### PR TITLE
Fix duplicate formulae in search results

### DIFF
--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -87,7 +87,7 @@ module Homebrew
                 .search(string_or_regex)
                 .sort
 
-      results += Formula.fuzzy_search(string_or_regex)
+      results |= Formula.fuzzy_search(string_or_regex)
 
       results.map do |name|
         formula, canonical_full_name = begin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/11606.
Currently the search can return duplicate formulae due to https://github.com/Homebrew/brew/pull/11565. Because in [this line](https://github.com/homebrew/brew/blob/master/Library/Homebrew/search.rb#L90) the results of `fuzzy_search` are simply appended, formulae can be added a second time to the result list.
This PR changes this by adding the additional results, only if they're not already in the list.

Before:
```
brew search delta
==> Formulae
delta                               git-delta                           xdelta                              zdelta                              zdelta                              xdelta
==> Casks
deltachat                                                                                                   deltawalker
```
After:
```
$ brew search delta   
==> Formulae
delta                                                 git-delta                                             xdelta                                                zdelta
==> Casks
deltachat                                                                                                   deltawalker
```