### PR TITLE
Replace Nokogiri with REXML

### DIFF
--- a/Library/Homebrew/bundle_version.rb
+++ b/Library/Homebrew/bundle_version.rb
@@ -30,15 +30,15 @@ module Homebrew
 
     sig { params(package_info_path: Pathname).returns(T.nilable(T.attached_class)) }
     def self.from_package_info(package_info_path)
-      Homebrew.install_bundler_gems!
-      require "nokogiri"
+      require "rexml/document"
 
-      xml = Nokogiri::XML(package_info_path.read)
+      xml = REXML::Document.new(package_info_path.read)
 
-      bundle_id = xml.xpath("//pkg-info//bundle-version//bundle").first&.attr("id")
-      return unless bundle_id
+      bundle_version_bundle = xml.get_elements("//pkg-info//bundle-version//bundle").first
+      bundle_id = bundle_version_bundle["id"] if bundle_version_bundle
+      return if bundle_id.blank?
 
-      bundle = xml.xpath("//pkg-info//bundle").find { |b| b["id"] == bundle_id }
+      bundle = xml.get_elements("//pkg-info//bundle").find { |b| b["id"] == bundle_id }
       return unless bundle
 
       short_version = bundle["CFBundleShortVersionString"]

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -176,13 +176,13 @@ module Homebrew
 
             distribution_path = extract_dir/"Distribution"
             if distribution_path.exist?
-              Homebrew.install_bundler_gems!
-              require "nokogiri"
+              require "rexml/document"
 
-              xml = Nokogiri::XML(distribution_path.read)
+              xml = REXML::Document.new(distribution_path.read)
 
-              product_version = xml.xpath("//installer-gui-script//product").first&.attr("version")
-              return product_version if product_version
+              product = xml.get_elements("//installer-gui-script//product").first
+              product_version = product["version"] if product
+              return product_version if product_version.present?
             end
 
             opoo "#{pkg_path.basename} contains multiple packages: #{packages}" if packages.count != 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to #11599, where I said I would replace use of `nokogiri` for XML parsing with `rexml` in parts of brew outside of the `Sparkle` livecheck strategy. These changes are generally a straightforward shift from `nokogiri` methods to `rexml` methods.

One notable difference is that `rexml` requires you to access attribute values using square bracket syntax instead of a method (like `#attr` in `nokogiri`).`rexml` has an `#attribute` method but it returns the full attribute (e.g., `a="b"`). We can't use a safe navigation operator in this context, so it was necessary to create an intermediate variable to be able to guard against `nil` values.

If we had more code doing this, I would say that we could probably just extend `rexml` to add an `attr` method that's just a wrapper for the square bracket syntax. This would allow us to use the safe navigation operator but I'm not sure if it's worth deviating from `rexml`'s established API.

---

I'm not familiar with the `BundleVersion` and `UnversionedCaskChecker` classes but I've tried to exercise this using livecheck's `ExtractPlist` and `Sparkle` strategies, which use one or both of these classes. The output from checking casks that use these strategies was the same with and without these changes.

The other area where `UnversionedCaskChecker` is used is in the `brew bump-unversioned-casks` dev-cmd. I let this run for a few casks and it seemed to work as expected. I don't anticipate this introducing any issues but it wouldn't hurt for some homebrew/cask folks to test this out, as I'm not as knowledgeable about that side of Homebrew.