### PR TITLE
language/python: create venvs with access to system site packages

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -218,7 +218,7 @@ module Language
         def create
           return if (@venv_root/"bin/python").exist?
 
-          @formula.system @python, "-m", "venv", @venv_root
+          @formula.system @python, "-m", "venv", "--system-site-packages", @venv_root
 
           # Robustify symlinks to survive python patch upgrades
           @venv_root.find do |f|

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -15,7 +15,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
   describe "#create" do
     it "creates a venv" do
-      expect(formula).to receive(:system).with("python", "-m", "venv", dir)
+      expect(formula).to receive(:system).with("python", "-m", "venv", "--system-site-packages", dir)
       virtualenv.create
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A user may wish to use two use two brew-installed Python packages
together. For example, one might want to `import numpy` when using
`jupyterlab` or `ptpython`.

Currently, the only ways to do this I'm aware of is with some hacking of
`PYTHONPATH` or the creation of `.pth` files in a formula's prefix.

A better solution is to allow the virtualenvs that `brew` creates to
have access to system site-packages by default, so that `import numpy`
inside `ptpython` or `jupyterlab` just works.

Partially resolves Homebrew/homebrew-core#76950.

-----

As a bonus, I think we should no longer need to resource `wheel` in any formula, since the `wheel` from the global environment which we ship with Python should be usable after this change.