### PR TITLE
formula_support: deprecate `bottle :unneeded`/`:disabled` in 3.3.0

### DIFF
--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -69,6 +69,9 @@ class BottleDisableReason
   def initialize(type, reason)
     @type = type
     @reason = reason
+    # TODO: 3.3.0 should deprecate this behaviour as it was only needed for
+    # Homebrew/core (where we don't want unneeded or disabled bottles any more)
+    # odeprecated "bottle :#{@type}" if valid?
   end
 
   def unneeded?


### PR DESCRIPTION
We'll no longer need this DSL so let's move towards deprecation.