### PR TITLE
reinstall: add support for the --git option

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -57,6 +57,9 @@ module Homebrew
           env:         :display_install_times,
           description: "Print install times for each formula at the end of the run.",
         }],
+        [:switch, "-g", "--git", {
+          description: "Create a Git repository, useful for creating patches to the software.",
+        }],
       ].each do |options|
         send(*options)
         conflicts "--cask", options[-2]
@@ -108,6 +111,7 @@ module Homebrew
         debug:                      args.debug?,
         quiet:                      args.quiet?,
         verbose:                    args.verbose?,
+        git:                        args.git?,
       )
       Cleanup.install_formula_clean!(formula)
     end

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -19,7 +19,8 @@ module Homebrew
     force: false,
     debug: false,
     quiet: false,
-    verbose: false
+    verbose: false,
+    git: false
   )
     if formula.opt_prefix.directory?
       keg = Keg.new(formula.opt_prefix.resolved_path)
@@ -44,6 +45,7 @@ module Homebrew
         build_bottle:               tab&.built_bottle?,
         force_bottle:               force_bottle,
         build_from_source_formulae: build_from_source_formulae,
+        git:                        git,
         interactive:                interactive,
         keep_tmp:                   keep_tmp,
         force:                      force,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
`Error: Invalid usage: not (yet) working on Apple Silicon or Rosetta 2!`
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This Pull request adds the `-g` or `--git` option to the `brew reinstall` command.

I've had several instances where I do this:
```
brew install flashrom
brew install flashrom --build-from-source
brew test flashrom
brew reinstall flashrom --build-from-source --git --debug
# ugh.
brew uninstall flashrom
brew install flashrom --build-from-source --git --debug
```

I've found it very useful to when doing a `reinstall` to be able to pass the git option to avoid the uninstall:
```
brew install flashrom
brew install flashrom --build-from-source
brew test flashrom
brew reinstall flashrom --build-from-source --git --debug
brew test flashrom
```

I'm going to fire up a clean install to test this on intel.