### PR TITLE
adds an option to skip unversioned casks in outdated and upgrade command

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -113,16 +113,16 @@ module Cask
       @caskroom_path ||= Caskroom.path.join(token)
     end
 
-    def outdated?(greedy: false)
-      !outdated_versions(greedy: greedy).empty?
+    def outdated?(greedy: false, skip_unversioned: false)
+      !outdated_versions(greedy: greedy, skip_unversioned: skip_unversioned).empty?
     end
 
-    def outdated_versions(greedy: false)
+    def outdated_versions(greedy: false, skip_unversioned: false)
       # special case: tap version is not available
       return [] if version.nil?
 
       if greedy
-        return versions if version.latest?
+        return versions if version.latest? && !skip_unversioned
       elsif auto_updates
         return []
       end
@@ -137,10 +137,10 @@ module Cask
       installed.reject { |v| v == version }
     end
 
-    def outdated_info(greedy, verbose, json)
+    def outdated_info(greedy, verbose, json, skip_unversioned)
       return token if !verbose && !json
 
-      installed_versions = outdated_versions(greedy: greedy).join(", ")
+      installed_versions = outdated_versions(greedy: greedy, skip_unversioned: skip_unversioned).join(", ")
 
       if json
         {

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -113,16 +113,20 @@ module Cask
       @caskroom_path ||= Caskroom.path.join(token)
     end
 
-    def outdated?(greedy: false, skip_unversioned: false)
-      !outdated_versions(greedy: greedy, skip_unversioned: skip_unversioned).empty?
+    def outdated?(greedy: false, greedy_latest: false, greedy_auto_updates: false)
+      !outdated_versions(greedy: greedy, greedy_latest: greedy_latest, greedy_auto_updates: greedy_auto_updates).empty?
     end
 
-    def outdated_versions(greedy: false, skip_unversioned: false)
+    def outdated_versions(greedy: false, greedy_latest: false, greedy_auto_updates: false)
       # special case: tap version is not available
       return [] if version.nil?
 
-      if greedy
-        return versions if version.latest? && !skip_unversioned
+      if greedy || greedy_latest && greedy_auto_updates
+        return versions if version.latest?
+      elsif greedy_auto_updates && auto_updates
+        return versions if version.latest?
+      elsif greedy_latest && version.latest?
+        return versions
       elsif auto_updates
         return []
       end
@@ -137,10 +141,10 @@ module Cask
       installed.reject { |v| v == version }
     end
 
-    def outdated_info(greedy, verbose, json, skip_unversioned)
+    def outdated_info(greedy, verbose, json, greedy_latest, greedy_auto_updates)
       return token if !verbose && !json
 
-      installed_versions = outdated_versions(greedy: greedy, skip_unversioned: skip_unversioned).join(", ")
+      installed_versions = outdated_versions(greedy: greedy, greedy_latest: greedy_latest, greedy_auto_updates: greedy_auto_updates).join(", ")
 
       if json
         {

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -114,7 +114,8 @@ module Cask
     end
 
     def outdated?(greedy: false, greedy_latest: false, greedy_auto_updates: false)
-      !outdated_versions(greedy: greedy, greedy_latest: greedy_latest, greedy_auto_updates: greedy_auto_updates).empty?
+      !outdated_versions(greedy: greedy, greedy_latest: greedy_latest,
+                         greedy_auto_updates: greedy_auto_updates).empty?
     end
 
     def outdated_versions(greedy: false, greedy_latest: false, greedy_auto_updates: false)
@@ -144,7 +145,8 @@ module Cask
     def outdated_info(greedy, verbose, json, greedy_latest, greedy_auto_updates)
       return token if !verbose && !json
 
-      installed_versions = outdated_versions(greedy: greedy, greedy_latest: greedy_latest, greedy_auto_updates: greedy_auto_updates).join(", ")
+      installed_versions = outdated_versions(greedy: greedy, greedy_latest: greedy_latest,
+                                             greedy_auto_updates: greedy_auto_updates).join(", ")
 
       if json
         {

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -122,9 +122,7 @@ module Cask
       # special case: tap version is not available
       return [] if version.nil?
 
-      if greedy || greedy_latest && greedy_auto_updates
-        return versions if version.latest?
-      elsif greedy_auto_updates && auto_updates
+      if greedy || greedy_latest && greedy_auto_updates || greedy_auto_updates && auto_updates
         return versions if version.latest?
       elsif greedy_latest && version.latest?
         return versions

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -122,7 +122,7 @@ module Cask
       # special case: tap version is not available
       return [] if version.nil?
 
-      if greedy || greedy_latest && greedy_auto_updates || greedy_auto_updates && auto_updates
+      if greedy || (greedy_latest && greedy_auto_updates) || (greedy_auto_updates && auto_updates)
         return versions if version.latest?
       elsif greedy_latest && version.latest?
         return versions

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -46,34 +46,34 @@ module Cask
         verbose = ($stdout.tty? || args.verbose?) && !args.quiet?
         self.class.upgrade_casks(
           *casks,
-          force:            args.force?,
-          greedy:           args.greedy?,
-          greedy_latest: args.greedy_latest,
+          force:               args.force?,
+          greedy:              args.greedy?,
+          greedy_latest:       args.greedy_latest,
           greedy_auto_updates: args.greedy_auto_updates,
-          dry_run:          args.dry_run?,
-          binaries:         args.binaries?,
-          quarantine:       args.quarantine?,
-          require_sha:      args.require_sha?,
-          skip_cask_deps:   args.skip_cask_deps?,
-          verbose:          verbose,
-          args:             args,
+          dry_run:             args.dry_run?,
+          binaries:            args.binaries?,
+          quarantine:          args.quarantine?,
+          require_sha:         args.require_sha?,
+          skip_cask_deps:      args.skip_cask_deps?,
+          verbose:             verbose,
+          args:                args,
         )
       end
 
       sig {
         params(
-          casks:            Cask,
-          args:             Homebrew::CLI::Args,
-          force:            T.nilable(T::Boolean),
-          greedy:           T.nilable(T::Boolean),
-          greedy_latest: T.nilable(T::Boolean),
+          casks:               Cask,
+          args:                Homebrew::CLI::Args,
+          force:               T.nilable(T::Boolean),
+          greedy:              T.nilable(T::Boolean),
+          greedy_latest:       T.nilable(T::Boolean),
           greedy_auto_updates: T.nilabel(T::Boolean),
-          dry_run:          T.nilable(T::Boolean),
-          skip_cask_deps:   T.nilable(T::Boolean),
-          verbose:          T.nilable(T::Boolean),
-          binaries:         T.nilable(T::Boolean),
-          quarantine:       T.nilable(T::Boolean),
-          require_sha:      T.nilable(T::Boolean),
+          dry_run:             T.nilable(T::Boolean),
+          skip_cask_deps:      T.nilable(T::Boolean),
+          verbose:             T.nilable(T::Boolean),
+          binaries:            T.nilable(T::Boolean),
+          quarantine:          T.nilable(T::Boolean),
+          require_sha:         T.nilable(T::Boolean),
         ).returns(T::Boolean)
       }
       def self.upgrade_casks(
@@ -95,7 +95,8 @@ module Cask
 
         outdated_casks = if casks.empty?
           Caskroom.casks(config: Config.from_args(args)).select do |cask|
-            cask.outdated?(greedy: greedy, greedy_latest: args.greedy_latest?, greedy_auto_updates: args.greedy_auto_updates?)
+            cask.outdated?(greedy: greedy, greedy_latest: args.greedy_latest?,
+                           greedy_auto_updates: args.greedy_auto_updates?)
           end
         else
           casks.select do |cask|

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -121,7 +121,8 @@ module Cask
 
         if casks.empty? && !greedy
           if !args.greedy_auto_updates? && !args.greedy_latest?
-            ohai "Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them."
+            ohai "Casks with 'auto_updates true' or 'version :latest'
+            will not be upgraded; pass `--greedy` to upgrade them."
           end
           if args.greedy_auto_updates? && !args.greedy_latest?
             ohai "Casks with 'version :latest' will not be upgraded; pass `--greedy-latest` to upgrade them."

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -48,8 +48,8 @@ module Cask
           *casks,
           force:               args.force?,
           greedy:              args.greedy?,
-          greedy_latest:       args.greedy_latest,
-          greedy_auto_updates: args.greedy_auto_updates,
+          greedy_latest:       args.greedy_latest?,
+          greedy_auto_updates: args.greedy_auto_updates?,
           dry_run:             args.dry_run?,
           binaries:            args.binaries?,
           quarantine:          args.quarantine?,
@@ -67,7 +67,7 @@ module Cask
           force:               T.nilable(T::Boolean),
           greedy:              T.nilable(T::Boolean),
           greedy_latest:       T.nilable(T::Boolean),
-          greedy_auto_updates: T.nilabel(T::Boolean),
+          greedy_auto_updates: T.nilable(T::Boolean),
           dry_run:             T.nilable(T::Boolean),
           skip_cask_deps:      T.nilable(T::Boolean),
           verbose:             T.nilable(T::Boolean),
@@ -120,7 +120,9 @@ module Cask
         return false if outdated_casks.empty?
 
         if casks.empty? && !greedy
-          ohai "Casks with 'auto_updates' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them."
+          ohai "Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them." if !args.greedy_auto_updates? && !args.greedy_latest?
+          ohai "Casks with 'version :latest' will not be upgraded; pass `--greedy-latest` to upgrade them." if args.greedy_auto_updates? && !args.greedy_latest?
+          ohai "Casks with 'auto_updates true' will not be upgraded; pass `--greedy-auto-updates` to upgrade them." if !args.greedy_auto_updates? && args.greedy_latest?
         end
 
         verb = dry_run ? "Would upgrade" : "Upgrading"

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -120,9 +120,15 @@ module Cask
         return false if outdated_casks.empty?
 
         if casks.empty? && !greedy
-          ohai "Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them." if !args.greedy_auto_updates? && !args.greedy_latest?
-          ohai "Casks with 'version :latest' will not be upgraded; pass `--greedy-latest` to upgrade them." if args.greedy_auto_updates? && !args.greedy_latest?
-          ohai "Casks with 'auto_updates true' will not be upgraded; pass `--greedy-auto-updates` to upgrade them." if !args.greedy_auto_updates? && args.greedy_latest?
+          if !args.greedy_auto_updates? && !args.greedy_latest?
+            ohai "Casks with 'auto_updates true' or 'version :latest' will not be upgraded; pass `--greedy` to upgrade them."
+          end
+          if args.greedy_auto_updates? && !args.greedy_latest?
+            ohai "Casks with 'version :latest' will not be upgraded; pass `--greedy-latest` to upgrade them."
+          end
+          if !args.greedy_auto_updates? && args.greedy_latest?
+            ohai "Casks with 'auto_updates true' will not be upgraded; pass `--greedy-auto-updates` to upgrade them."
+          end
         end
 
         verb = dry_run ? "Would upgrade" : "Upgrading"

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -21,7 +21,7 @@ module Cask
         }],
         [:switch, "--skip-unversioned", {
           description: "Skip casks with `version :latest`.",
-        }]
+        }],
       ].freeze
 
       sig { returns(Homebrew::CLI::Parser) }
@@ -43,32 +43,32 @@ module Cask
         verbose = ($stdout.tty? || args.verbose?) && !args.quiet?
         self.class.upgrade_casks(
           *casks,
-          force:          args.force?,
-          greedy:         args.greedy?,
+          force:            args.force?,
+          greedy:           args.greedy?,
           skip_unversioned: args.skip_unversioned?,
-          dry_run:        args.dry_run?,
-          binaries:       args.binaries?,
-          quarantine:     args.quarantine?,
-          require_sha:    args.require_sha?,
-          skip_cask_deps: args.skip_cask_deps?,
-          verbose:        verbose,
-          args:           args,
+          dry_run:          args.dry_run?,
+          binaries:         args.binaries?,
+          quarantine:       args.quarantine?,
+          require_sha:      args.require_sha?,
+          skip_cask_deps:   args.skip_cask_deps?,
+          verbose:          verbose,
+          args:             args,
         )
       end
 
       sig {
         params(
-          casks:          Cask,
-          args:           Homebrew::CLI::Args,
-          force:          T.nilable(T::Boolean),
-          greedy:         T.nilable(T::Boolean),
+          casks:            Cask,
+          args:             Homebrew::CLI::Args,
+          force:            T.nilable(T::Boolean),
+          greedy:           T.nilable(T::Boolean),
           skip_unversioned: T.nilable(T::Boolean),
-          dry_run:        T.nilable(T::Boolean),
-          skip_cask_deps: T.nilable(T::Boolean),
-          verbose:        T.nilable(T::Boolean),
-          binaries:       T.nilable(T::Boolean),
-          quarantine:     T.nilable(T::Boolean),
-          require_sha:    T.nilable(T::Boolean),
+          dry_run:          T.nilable(T::Boolean),
+          skip_cask_deps:   T.nilable(T::Boolean),
+          verbose:          T.nilable(T::Boolean),
+          binaries:         T.nilable(T::Boolean),
+          quarantine:       T.nilable(T::Boolean),
+          require_sha:      T.nilable(T::Boolean),
         ).returns(T::Boolean)
       }
       def self.upgrade_casks(

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -19,6 +19,9 @@ module Cask
         [:switch, "--greedy", {
           description: "Also include casks with `auto_updates true` or `version :latest`.",
         }],
+        [:switch, "--skip-unversioned", {
+          description: "Skip casks with `version :latest`.",
+        }]
       ].freeze
 
       sig { returns(Homebrew::CLI::Parser) }
@@ -42,6 +45,7 @@ module Cask
           *casks,
           force:          args.force?,
           greedy:         args.greedy?,
+          skip_unversioned: args.skip_unversioned?,
           dry_run:        args.dry_run?,
           binaries:       args.binaries?,
           quarantine:     args.quarantine?,
@@ -58,6 +62,7 @@ module Cask
           args:           Homebrew::CLI::Args,
           force:          T.nilable(T::Boolean),
           greedy:         T.nilable(T::Boolean),
+          skip_unversioned: T.nilable(T::Boolean),
           dry_run:        T.nilable(T::Boolean),
           skip_cask_deps: T.nilable(T::Boolean),
           verbose:        T.nilable(T::Boolean),
@@ -71,6 +76,7 @@ module Cask
         args:,
         force: false,
         greedy: false,
+        skip_unversioned: false,
         dry_run: false,
         skip_cask_deps: false,
         verbose: false,
@@ -83,7 +89,7 @@ module Cask
 
         outdated_casks = if casks.empty?
           Caskroom.casks(config: Config.from_args(args)).select do |cask|
-            cask.outdated?(greedy: greedy)
+            cask.outdated?(greedy: greedy, skip_unversioned: args.skip_unversioned?)
           end
         else
           casks.select do |cask|

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -19,8 +19,11 @@ module Cask
         [:switch, "--greedy", {
           description: "Also include casks with `auto_updates true` or `version :latest`.",
         }],
-        [:switch, "--skip-unversioned", {
-          description: "Skip casks with `version :latest`.",
+        [:switch, "--greedy-latest", {
+          description: "Also include casks with `version :latest`.",
+        }],
+        [:switch, "--greedy-auto-updates", {
+          description: "Also include casks with `auto_updates true`.",
         }],
       ].freeze
 
@@ -45,7 +48,8 @@ module Cask
           *casks,
           force:            args.force?,
           greedy:           args.greedy?,
-          skip_unversioned: args.skip_unversioned?,
+          greedy_latest: args.greedy_latest,
+          greedy_auto_updates: args.greedy_auto_updates,
           dry_run:          args.dry_run?,
           binaries:         args.binaries?,
           quarantine:       args.quarantine?,
@@ -62,7 +66,8 @@ module Cask
           args:             Homebrew::CLI::Args,
           force:            T.nilable(T::Boolean),
           greedy:           T.nilable(T::Boolean),
-          skip_unversioned: T.nilable(T::Boolean),
+          greedy_latest: T.nilable(T::Boolean),
+          greedy_auto_updates: T.nilabel(T::Boolean),
           dry_run:          T.nilable(T::Boolean),
           skip_cask_deps:   T.nilable(T::Boolean),
           verbose:          T.nilable(T::Boolean),
@@ -76,7 +81,8 @@ module Cask
         args:,
         force: false,
         greedy: false,
-        skip_unversioned: false,
+        greedy_latest: false,
+        greedy_auto_updates: false,
         dry_run: false,
         skip_cask_deps: false,
         verbose: false,
@@ -89,7 +95,7 @@ module Cask
 
         outdated_casks = if casks.empty?
           Caskroom.casks(config: Config.from_args(args)).select do |cask|
-            cask.outdated?(greedy: greedy, skip_unversioned: args.skip_unversioned?)
+            cask.outdated?(greedy: greedy, greedy_latest: args.greedy_latest?, greedy_auto_updates: args.greedy_auto_updates?)
           end
         else
           casks.select do |cask|

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -197,7 +197,8 @@ module Homebrew
       if formula_or_cask.is_a?(Formula)
         formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
       else
-        formula_or_cask.outdated?(greedy: args.greedy?, greedy_latest: args.greedy_latest?, greedy_auto_updates: args.greedy_auto_updates?)
+        formula_or_cask.outdated?(greedy: args.greedy?, greedy_latest: args.greedy_latest?,
+                                  greedy_auto_updates: args.greedy_auto_updates?)
       end
     end
   end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -38,8 +38,11 @@ module Homebrew
       switch "--greedy",
              description: "Print outdated casks with `auto_updates` or `version :latest`."
 
-      switch "--skip-unversioned",
-             description: "Print outdated casks with `auto_updates` but no `version :latest`."
+      switch "--greedy-latest",
+             description: "Print outdated casks including those with `version :latest`."
+
+      switch "--greedy-auto-updates",
+             description: "Print outdated casks including those with `auto_updates`."
 
       conflicts "--quiet", "--verbose", "--json"
       conflicts "--formula", "--cask"
@@ -119,7 +122,7 @@ module Homebrew
       else
         c = formula_or_cask
 
-        puts c.outdated_info(args.greedy?, verbose?, false, args.skip_unversioned?)
+        puts c.outdated_info(args.greedy?, verbose?, false, args.greedy_latest?, args.greedy_auto_updates?)
       end
     end
   end
@@ -194,7 +197,7 @@ module Homebrew
       if formula_or_cask.is_a?(Formula)
         formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
       else
-        formula_or_cask.outdated?(greedy: args.greedy?, skip_unversioned: args.skip_unversioned?)
+        formula_or_cask.outdated?(greedy: args.greedy?, greedy_latest: args.greedy_latest?, greedy_auto_updates: args.greedy_auto_updates?)
       end
     end
   end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -147,8 +147,8 @@ module Homebrew
       else
         c = formula_or_cask
 
-        c.outdated_info(args.greedy?, verbose?, true, greedy_latest: args.greedy_latest?,
-          greedy_auto_updates: args.greedy_auto_updates?)
+        c.outdated_info(args.greedy?, verbose?, true, greedy_latest:       args.greedy_latest?,
+                                                      greedy_auto_updates: args.greedy_auto_updates?)
       end
     end
   end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -36,13 +36,13 @@ module Homebrew
                           "formula is outdated. Otherwise, the repository's HEAD will only be checked for "\
                           "updates when a new stable or development version has been released."
       switch "--greedy",
-             description: "Print outdated casks with `auto_updates` or `version :latest`."
+             description: "Print outdated casks with `auto_updates true` or `version :latest`."
 
       switch "--greedy-latest",
              description: "Print outdated casks including those with `version :latest`."
 
       switch "--greedy-auto-updates",
-             description: "Print outdated casks including those with `auto_updates`."
+             description: "Print outdated casks including those with `auto_updates true`."
 
       conflicts "--quiet", "--verbose", "--json"
       conflicts "--formula", "--cask"
@@ -147,7 +147,8 @@ module Homebrew
       else
         c = formula_or_cask
 
-        c.outdated_info(args.greedy?, verbose?, true)
+        c.outdated_info(args.greedy?, verbose?, true, greedy_latest: args.greedy_latest?,
+          greedy_auto_updates: args.greedy_auto_updates?)
       end
     end
   end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -38,6 +38,9 @@ module Homebrew
       switch "--greedy",
              description: "Print outdated casks with `auto_updates` or `version :latest`."
 
+      switch "--skip-unversioned",
+             description: "Print outdated casks with `auto_updates` but no `version :latest`."
+
       conflicts "--quiet", "--verbose", "--json"
       conflicts "--formula", "--cask"
 
@@ -116,7 +119,7 @@ module Homebrew
       else
         c = formula_or_cask
 
-        puts c.outdated_info(args.greedy?, verbose?, false)
+        puts c.outdated_info(args.greedy?, verbose?, false, args.skip_unversioned?)
       end
     end
   end
@@ -191,7 +194,7 @@ module Homebrew
       if formula_or_cask.is_a?(Formula)
         formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
       else
-        formula_or_cask.outdated?(greedy: args.greedy?)
+        formula_or_cask.outdated?(greedy: args.greedy?, skip_unversioned: args.skip_unversioned?)
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Adds an additional flag `--skip-unversioned` for running brew outdated or upgrade. It skips casks that are given `version :latest`

Some documentation updates including within the terminal command outputs would also require updating.

Some of the areas I have added the flag as parameters may be superfluous at the moment.