### PR TITLE
fix duplicate keg names in `Keg.all` names

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -877,12 +877,12 @@ module Homebrew
       end
 
       def check_deleted_formula
-        kegs = Keg.all
-        deleted_formulae = []
-        kegs.each do |keg|
-          keg_name = keg.name
-          deleted_formulae << keg_name if Formulary.tap_paths(keg_name).blank?
-        end
+        keg_names = Keg.all.map(&:name).uniq
+
+        deleted_formulae = keg_names.map do |keg_name|
+          keg_name if Formulary.tap_paths(keg_name).blank?
+        end.compact
+
         return if deleted_formulae.blank?
 
         <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
repair `Diagnostic#Checks::check_deleted_formula` because `Keg. all` names will have duplicate names if we have installed the same software with different versions.