### PR TITLE
dispatch-build-bottle: rename --wheezy to --linux-wheezy

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -103,7 +103,7 @@ module Homebrew
       def linux_self_hosted?; end
 
       sig { returns(T::Boolean) }
-      def wheezy?; end
+      def linux_wheezy?; end
 
       sig { returns(T::Boolean) }
       def total?; end

--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -29,7 +29,7 @@ module Homebrew
              description: "Dispatch bottle for Linux (using GitHub runners)."
       switch "--linux-self-hosted",
              description: "Dispatch bottle for Linux (using self-hosted runner)."
-      switch "--wheezy",
+      switch "--linux-wheezy",
              description: "Use Debian Wheezy container for building the bottle on Linux."
 
       conflicts "--macos", "--linux", "--linux-self-hosted"
@@ -83,7 +83,7 @@ module Homebrew
       # These cannot be passed as nil to GitHub API
       inputs[:issue] = args.issue if args.issue
       inputs[:upload] = args.upload?.to_s if args.upload?
-      inputs[:wheezy] = args.wheezy?.to_s if args.wheezy?
+      inputs[:wheezy] = args.linux_wheezy?.to_s if args.linux_wheezy?
 
       ohai "Dispatching #{tap} bottling request of formula \"#{formula.name}\" for #{runner}"
       GitHub.workflow_dispatch_event(user, repo, workflow, ref, inputs)


### PR DESCRIPTION
@MikeMcQuaid asked to rename this flag.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----