### PR TITLE
formula: add a `time` method for use as the build time

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1551,6 +1551,18 @@ class Formula
     "@loader_path/../lib"
   end
 
+  # Creates a new `Time` object for use in the formula as the build time.
+  #
+  # @see https://www.rubydoc.info/stdlib/time/Time Time
+  sig { returns(Time) }
+  def time
+    if ENV["SOURCE_DATE_EPOCH"].present?
+      Time.at(ENV["SOURCE_DATE_EPOCH"].to_i).utc
+    else
+      Time.now.utc
+    end
+  end
+
   # an array of all core {Formula} names
   # @private
   def self.core_names


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A number of formulae use a variant of `Time.now` to generate the build
time of the formula. Let's define a method to make sure that:

1. it uses `SOURCE_DATE_EPOCH` whenever available; and,
2. it uses `utc`.

Both should help with build reproducibility.

See Homebrew/homebrew-core#80608.