### PR TITLE
`brew pr-pull`: handle label for merging without bottles

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -291,7 +291,10 @@ module Homebrew
 
   def formulae_need_bottles?(tap, original_commit, user, repo, pr, args:)
     return if args.dry_run?
-    return false if GitHub.pull_request_labels(user, repo, pr).include? "CI-syntax-only"
+
+    labels = GitHub.pull_request_labels(user, repo, pr)
+
+    return false if labels.include?("CI-syntax-only") || labels.include?("CI-no-bottles")
 
     changed_formulae(tap, original_commit).any? do |f|
       !f.bottle_unneeded? && !f.bottle_disabled?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a `--no-bottle` option to `pr-pull` and `pr-publish`. This can be convenient when we want to rebase and merge a PR (and ensure commits are signed) without downloading bottles.

A use case for this would include PRs such as Homebrew/homebrew-core#80302 where we didn't add the syntax only label, since some of the changes weren't autocorrected and modified logic in e.g. `test` blocks.

Signatures do not persist when using the GitHub UI "Rebase and merge" button, and `--no-upload` would still download the bottles. This option prevents downloading the bottles when we simply want to rebase and merge.