### PR TITLE
dev-cmd/bump-cask-pr: Load the cask object, not temporary file contents

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -127,7 +127,7 @@ module Homebrew
                                                         read_only_run: true,
                                                         silent:        true)
 
-        tmp_cask = Cask::CaskLoader.load(tmp_contents)
+        tmp_cask = Cask::CaskLoader.load(cask)
         tmp_config = cask.config
         tmp_url = tmp_cask.url.to_s
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #11633.
- With `Cask::CaskLoader.load(tmp_contents)` we were trying to find a Cask that was a string of updated file contents, not an actual Cask with all its attributes. This led to errors like:

```
$ brew bump-cask-pr --version=3003.1  smillerdev/saltstack/saltstack
Error: Cask 'i)
  end

  conflicts_with cask: ["saltstack-3001", "saltstack-3000"]

  pkg "salt-#{version}-py3-x86_64.pkg"

  uninstall pkgutil: "com.saltstack.salt"
end
' is unavailable: No Cask with this name exists.
```
