### PR TITLE
extend/ENV/super: allow `O{1,0}` to accept a block

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -337,15 +337,25 @@ module Superenv
     append_to_cccfg "O"
   end
 
-  %w[O1 O0].each do |opt|
-    define_method opt do |&block|
-      if T.must(block)
-        with_env(HOMEBREW_OPTIMIZATION_LEVEL: opt) { block.call }
-      else
-        send(:[]=, "HOMEBREW_OPTIMIZATION_LEVEL", opt)
-      end
+  # rubocop: disable Naming/MethodName
+  sig { params(block: T.nilable(T.proc.void)).void }
+  def O0(&block)
+    if block
+      with_env(HOMEBREW_OPTIMIZATION_LEVEL: "O0", &block)
+    else
+      self["HOMEBREW_OPTIMIZATION_LEVEL"] = "O0"
     end
   end
+
+  sig { params(block: T.nilable(T.proc.void)).void }
+  def O1(&block)
+    if block
+      with_env(HOMEBREW_OPTIMIZATION_LEVEL: "O1", &block)
+    else
+      self["HOMEBREW_OPTIMIZATION_LEVEL"] = "O1"
+    end
+  end
+  # rubocop: enable Naming/MethodName
 end
 
 require "extend/os/extend/ENV/super"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -338,6 +338,7 @@ module Superenv
   end
 
   # rubocop: disable Naming/MethodName
+  # Fixes style error `Naming/MethodName: Use snake_case for method names.`
   sig { params(block: T.nilable(T.proc.void)).void }
   def O0(&block)
     if block

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -338,8 +338,12 @@ module Superenv
   end
 
   %w[O1 O0].each do |opt|
-    define_method opt do
-      send(:[]=, "HOMEBREW_OPTIMIZATION_LEVEL", opt)
+    define_method opt do |&block|
+      if block
+        with_env(HOMEBREW_OPTIMIZATION_LEVEL: opt) { block.call }
+      else
+        send(:[]=, "HOMEBREW_OPTIMIZATION_LEVEL", opt)
+      end
     end
   end
 end

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -339,7 +339,7 @@ module Superenv
 
   %w[O1 O0].each do |opt|
     define_method opt do |&block|
-      if block
+      if T.must(block)
         with_env(HOMEBREW_OPTIMIZATION_LEVEL: opt) { block.call }
       else
         send(:[]=, "HOMEBREW_OPTIMIZATION_LEVEL", opt)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This makes `ENV.O{1,0}` behave like `ENV.deparallelize`.

This should also allow us to build libgcrypt's jitter entropy collector,
which we currently disable because it interacts poorly with our compiler
shims. See #11201 for a previous attempt at this.