### PR TITLE
unversioned_cask_checker: check for versions in qlplugins

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -91,7 +91,7 @@ module Homebrew
 
     unversioned_cask_checker = UnversionedCaskChecker.new(cask)
 
-    if !unversioned_cask_checker.single_app_cask? && !unversioned_cask_checker.single_pkg_cask?
+    if !unversioned_cask_checker.single_app_cask? && !unversioned_cask_checker.single_pkg_cask? && !unversioned_cask_checker.single_qlplugin_cask?
       opoo "Skipping, not a single-app or PKG cask."
       return
     end

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -91,7 +91,9 @@ module Homebrew
 
     unversioned_cask_checker = UnversionedCaskChecker.new(cask)
 
-    if !unversioned_cask_checker.single_app_cask? && !unversioned_cask_checker.single_pkg_cask? && !unversioned_cask_checker.single_qlplugin_cask?
+    if !unversioned_cask_checker.single_app_cask? &&
+       !unversioned_cask_checker.single_pkg_cask? &&
+       !unversioned_cask_checker.single_qlplugin_cask?
       opoo "Skipping, not a single-app or PKG cask."
       return
     end

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -122,8 +122,8 @@ module Homebrew
 
     sig { returns(T.nilable(String)) }
     def guess_cask_version
-      if apps.empty? && pkgs.empty?
-        opoo "Cask #{cask} does not contain any apps or PKG installers."
+      if apps.empty? && pkgs.empty? && qlplugins.empty?
+        opoo "Cask #{cask} does not contain any apps, qlplugins or PKG installers."
         return
       end
 

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -88,7 +88,7 @@ module Homebrew
 
         installer.extract_primary_container(to: dir)
 
-        info_plist_paths = (apps.concat(qlplugins)).flat_map do |artifact|
+        info_plist_paths = apps.concat(qlplugins).flat_map do |artifact|
           top_level_info_plists(Pathname.glob(dir/"**"/artifact.source.basename/"Contents"/"Info.plist")).sort
         end
 

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -47,6 +47,11 @@ module Homebrew
     end
 
     sig { returns(T::Boolean) }
+    def single_qlplugin_cask?
+      qlplugins.count == 1
+    end
+
+    sig { returns(T::Boolean) }
     def single_pkg_cask?
       pkgs.count == 1
     end
@@ -83,8 +88,8 @@ module Homebrew
 
         installer.extract_primary_container(to: dir)
 
-        info_plist_paths = (apps + qlplugins).flat_map do |app|
-          top_level_info_plists(Pathname.glob(dir/"**"/app.source.basename/"Contents"/"Info.plist")).sort
+        info_plist_paths = (apps.concat(qlplugins)).flat_map do |artifact|
+          top_level_info_plists(Pathname.glob(dir/"**"/artifact.source.basename/"Contents"/"Info.plist")).sort
         end
 
         info_plist_paths.each(&parse_info_plist)

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -83,18 +83,8 @@ module Homebrew
 
         installer.extract_primary_container(to: dir)
 
-        info_plist_paths = []
-
-        apps.flat_map do |app|
-          top_level_info_plists(Pathname.glob(dir/"**"/app.source.basename/"Contents"/"Info.plist"))
-            .sort
-            .each { |match| info_plist_paths.push(match) }
-        end
-
-        qlplugins.flat_map do |qlplugin|
-          top_level_info_plists(Pathname.glob(dir/"**"/qlplugin.source.basename/"Contents"/"Info.plist"))
-            .sort
-            .each { |match| info_plist_paths.push(match) }
+        info_plist_paths = (apps + qlplugins).flat_map do |app|
+          top_level_info_plists(Pathname.glob(dir/"**"/app.source.basename/"Contents"/"Info.plist")).sort
         end
 
         info_plist_paths.each(&parse_info_plist)

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -31,6 +31,11 @@ module Homebrew
       @apps ||= @cask.artifacts.select { |a| a.is_a?(Cask::Artifact::App) }
     end
 
+    sig { returns(T::Array[Cask::Artifact::Qlplugin]) }
+    def qlplugins
+      @qlplugins ||= @cask.artifacts.select { |a| a.is_a?(Cask::Artifact::Qlplugin) }
+    end
+
     sig { returns(T::Array[Cask::Artifact::Pkg]) }
     def pkgs
       @pkgs ||= @cask.artifacts.select { |a| a.is_a?(Cask::Artifact::Pkg) }
@@ -78,8 +83,18 @@ module Homebrew
 
         installer.extract_primary_container(to: dir)
 
-        info_plist_paths = apps.flat_map do |app|
-          top_level_info_plists(Pathname.glob(dir/"**"/app.source.basename/"Contents"/"Info.plist")).sort
+        info_plist_paths = []
+
+        apps.flat_map do |app|
+          top_level_info_plists(Pathname.glob(dir/"**"/app.source.basename/"Contents"/"Info.plist"))
+            .sort
+            .each {|match| info_plist_paths.push(match)}
+        end
+
+        qlplugins.flat_map do |qlplugin|
+          top_level_info_plists(Pathname.glob(dir/"**"/qlplugin.source.basename/"Contents"/"Info.plist"))
+            .sort
+            .each {|match| info_plist_paths.push(match)}
         end
 
         info_plist_paths.each(&parse_info_plist)

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -88,13 +88,13 @@ module Homebrew
         apps.flat_map do |app|
           top_level_info_plists(Pathname.glob(dir/"**"/app.source.basename/"Contents"/"Info.plist"))
             .sort
-            .each {|match| info_plist_paths.push(match)}
+            .each { |match| info_plist_paths.push(match) }
         end
 
         qlplugins.flat_map do |qlplugin|
           top_level_info_plists(Pathname.glob(dir/"**"/qlplugin.source.basename/"Contents"/"Info.plist"))
             .sort
-            .each {|match| info_plist_paths.push(match)}
+            .each { |match| info_plist_paths.push(match) }
         end
 
         info_plist_paths.each(&parse_info_plist)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [] Have you successfully run `brew tests` with your changes locally?

-----

Adds the ability for unversioned_cask_checker to look inside `info.plist` files within quick look plugins.
This also allows the extract_plist livecheck strategy to look inside the plugin file also.