### PR TITLE
formula_cellar_checks: fix cpuid instruction check on Mojave

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -345,10 +345,15 @@ module FormulaCellarChecks
 
   def cpuid_instruction?(file, objdump = "objdump")
     @instruction_column_index ||= {}
-    @instruction_column_index[objdump] ||= if Utils.popen_read(objdump, "--version").include? "LLVM"
-      1 # `llvm-objdump` or macOS `objdump`
-    else
-      2 # GNU binutils `objdump`
+    @instruction_column_index[objdump] ||= begin
+      objdump_version = Utils.popen_read(objdump, "--version")
+
+      if (objdump_version.match?(/^Apple LLVM/) && MacOS.version <= :mojave) ||
+         objdump_version.exclude?("LLVM")
+        2 # Mojave `objdump` or GNU Binutils `objdump`
+      else
+        1 # `llvm-objdump` or Catalina+ `objdump`
+      end
     end
 
     has_cpuid_instruction = false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The output format of `objdump` on Mojave is different from newer
versions of macOS, so I've adjusted the relevant audit to account for
this difference.