### PR TITLE
brew: add `DBUS_SESSION_BUS_ADDRESS` copy

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -64,7 +64,7 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
-for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH TMUX
+for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH TMUX DBUS_SESSION_BUS_ADDRESS
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will support https://github.com/Homebrew/homebrew-services/pull/350 so systemd can use `DBUS_SESSION_BUS_ADDRESS`