### PR TITLE
Fix typo in brew doctor completion function name

### DIFF
--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -162,7 +162,7 @@ function __fish_brew_suggest_commands -d "Lists all commands names, including al
     end
 end
 
-function __fish_brew_suggest_diagnostic_check -d "List available diagnostic checks"
+function __fish_brew_suggest_diagnostic_checks -d "List available diagnostic checks"
     brew doctor --list-checks
 end
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -149,7 +149,7 @@ function __fish_brew_suggest_commands -d "Lists all commands names, including al
     end
 end
 
-function __fish_brew_suggest_diagnostic_checks -d "List available diagnostic checks"
+function __fish_brew_suggest_diagnostic_check -d "List available diagnostic checks"
     brew doctor --list-checks
 end
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -149,7 +149,7 @@ function __fish_brew_suggest_commands -d "Lists all commands names, including al
     end
 end
 
-function __fish_brew_suggest_diagnostic_check -d "List available diagnostic checks"
+function __fish_brew_suggest_diagnostic_checks -d "List available diagnostic checks"
     brew doctor --list-checks
 end
 


### PR DESCRIPTION
Wherever in the file the function __fish_brew_suggest_diagnostic_checks is called, the name has a trailing 's' (plural 'checks'), whereas the function definition uses 'check' in singular. Changing the function name to match the callsites.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally? (1085 files inspected, no offenses detected)
- [x] Have you successfully run `brew typecheck` with your changes locally? (No errors! Great job.)
- [x] Have you successfully run `brew tests` with your changes locally? (3385 examples, 0 failures, 49 pendings)

-----
Closes #11676