### PR TITLE
utils/buildpulse: Move BuildPulse related function to Utils

### DIFF
--- a/Library/Homebrew/utils/buildpulse.rb
+++ b/Library/Homebrew/utils/buildpulse.rb
@@ -1,0 +1,43 @@
+# typed: true
+# frozen_string_literal: true
+
+module Utils
+  # Helper functions for BuildPulse integration
+  module Buildpulse
+    extend T::Sig
+
+    module_function
+
+    sig { returns(T::Boolean) }
+    def available?
+      return @available if defined?(@available)
+
+      @available = ENV["HOMEBREW_BUILDPULSE_ACCESS_KEY_ID"].present? &&
+                   ENV["HOMEBREW_BUILDPULSE_SECRET_ACCESS_KEY"].present? &&
+                   ENV["HOMEBREW_BUILDPULSE_ACCOUNT_ID"].present? &&
+                   ENV["HOMEBREW_BUILDPULSE_REPOSITORY_ID"].present?
+    end
+
+    sig { params(test_results_dir: T.any(String, Pathname)).void }
+    def upload_results(test_results_dir)
+      require "formula"
+
+      unless Formula["buildpulse-test-reporter"].any_version_installed?
+        ohai "Installing `buildpulse-test-reporter` for reporting test flakiness..."
+        with_env(HOMEBREW_NO_AUTO_UPDATE: "1", HOMEBREW_NO_BOOTSNAP: "1") do
+          safe_system HOMEBREW_BREW_FILE, "install", "buildpulse-test-reporter"
+        end
+      end
+
+      ENV["BUILDPULSE_ACCESS_KEY_ID"] = ENV["HOMEBREW_BUILDPULSE_ACCESS_KEY_ID"]
+      ENV["BUILDPULSE_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_BUILDPULSE_SECRET_ACCESS_KEY"]
+
+      ohai "Sending test results to BuildPulse"
+
+      safe_system Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
+                  "submit", test_results_dir.to_s,
+                  "--account-id", ENV["HOMEBREW_BUILDPULSE_ACCOUNT_ID"],
+                  "--repository-id", ENV["HOMEBREW_BUILDPULSE_REPOSITORY_ID"]
+    end
+  end
+end

--- a/Library/Homebrew/utils/buildpulse.rbi
+++ b/Library/Homebrew/utils/buildpulse.rbi
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Utils
+  module Buildpulse
+    include Kernel
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR moves all BuildPulse related functions to a module in Utils to make it possible to use them not only from Homebrew tests (I keep in mind using adding uploading test results from homebrew-test-bot)