### PR TITLE
dev-cmd/typecheck: `error-white-list` renamed to `isolate-error-code`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -98,9 +98,6 @@ Naming/InclusiveLanguage:
     blacklist:
       AllowedRegex:
         - "--listBlacklist" # Used in formula `xmlsectool`
-    whitelist:
-      AllowedRegex:
-        - "--repo-whitelist" # Used in formula `atlantis`
 
 Naming/MethodName:
   IgnoredPatterns:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -100,8 +100,7 @@ Naming/InclusiveLanguage:
         - "--listBlacklist" # Used in formula `xmlsectool`
     whitelist:
       AllowedRegex:
-        - "--error-white-list" # For an option passed to `srb` in dev-cmd/typecheck.rb
-        - "--repo-whitelist"   # Used in formula `atlantis`
+        - "--repo-whitelist" # Used in formula `atlantis`
 
 Naming/MethodName:
   IgnoredPatterns:

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -67,7 +67,8 @@ module Homebrew
         if args.suggest_typed?
           result = system_command(
             "bundle",
-            args:         ["exec", "--", "srb", "tc", "--suggest-typed", "--typed=strict", "--error-white-list=7022"],
+            args:         ["exec", "--", "srb", "tc", "--suggest-typed", "--typed=strict",
+                           "--isolate-error-code=7022"],
             print_stderr: false,
           )
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
 
- It was renamed in https://github.com/sorbet/sorbet/commit/4ea6842988c6ec33dc8a39439b7b1d4742921f0e which is included in the ancient version we're using.
