### PR TITLE
fetch: add --bottle-tag flag

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -20,6 +20,8 @@ module Homebrew
         Download a bottle (if available) or source packages for <formula>e
         and binaries for <cask>s. For files, also print SHA-256 checksums.
       EOS
+      flag "--bottle-tag",
+           description: "Download a bottle for given tag."
       switch "--HEAD",
              description: "Fetch HEAD version instead of stable version."
       switch "-f", "--force",
@@ -47,12 +49,13 @@ module Homebrew
       switch "--cask", "--casks",
              description: "Treat all named arguments as casks."
 
-      conflicts "--build-from-source", "--build-bottle", "--force-bottle"
+      conflicts "--build-from-source", "--build-bottle", "--force-bottle", "--bottle-tag"
       conflicts "--cask", "--HEAD"
       conflicts "--cask", "--deps"
       conflicts "--cask", "-s"
       conflicts "--cask", "--build-bottle"
       conflicts "--cask", "--force-bottle"
+      conflicts "--cask", "--bottle-tag"
       conflicts "--formula", "--cask"
 
       named_args [:formula, :cask], min: 1
@@ -90,7 +93,7 @@ module Homebrew
           begin
             f.clear_cache if args.force?
             f.fetch_bottle_tab
-            fetch_formula(f.bottle, args: args)
+            fetch_formula(f.bottle_for_tag(args.bottle_tag), args: args)
           rescue Interrupt
             raise
           rescue => e

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -368,6 +368,13 @@ class Formula
     @bottle ||= Bottle.new(self, bottle_specification) if bottled?
   end
 
+  # The Bottle object for given tag.
+  # @private
+  sig { params(tag: T.nilable(String)).returns(T.nilable(Bottle)) }
+  def bottle_for_tag(tag = nil)
+    Bottle.new(self, bottle_specification, tag) if bottled?
+  end
+
   # The description of the software.
   # @!method desc
   # @see .desc=

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -299,14 +299,19 @@ class Bottle
   def_delegators :resource, :url, :verify_download_integrity
   def_delegators :resource, :cached_download
 
-  def initialize(formula, spec)
+  def initialize(formula, spec, tag = nil)
     @name = formula.name
     @resource = Resource.new
     @resource.owner = formula
     @resource.specs[:bottle] = true
     @spec = spec
 
-    checksum, tag, cellar = spec.checksum_for(Utils::Bottles.tag)
+    bottle_tag = if tag.present?
+      Utils::Bottles::Tag.from_symbol(tag)
+    else
+      Utils::Bottles.tag
+    end
+    checksum, tag, cellar = spec.checksum_for(bottle_tag)
 
     @prefix = spec.prefix
     @tag = tag


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

It would be useful for maintainers to be able to easily fetch bottles for different OSes.

Not sure if the implementation itself is fine but it works.