### PR TITLE
Improvements to JSON bottle handling

### DIFF
--- a/Library/Homebrew/bottle_api.rb
+++ b/Library/Homebrew/bottle_api.rb
@@ -74,6 +74,7 @@ module BottleAPI
       existing_formula = begin
         Formulary.factory dep_hash["name"]
       rescue FormulaUnavailableError
+        # The formula might not exist if it's not installed and homebrew/core isn't tapped
         nil
       end
 

--- a/Library/Homebrew/bottle_api.rb
+++ b/Library/Homebrew/bottle_api.rb
@@ -66,7 +66,7 @@ module BottleAPI
     hash = fetch(name)
     bottle_tag = Utils::Bottles.tag.to_s
 
-    odie "No bottle available for current OS" unless hash["bottles"].key? bottle_tag
+    odie "No bottle available for current OS" if !hash["bottles"].key?(bottle_tag) && !hash["bottles"].key?("all")
 
     download_bottle(hash, bottle_tag)
 
@@ -94,6 +94,7 @@ module BottleAPI
   sig { params(hash: Hash, tag: Symbol).void }
   def download_bottle(hash, tag)
     bottle = hash["bottles"][tag]
+    bottle ||= hash["bottles"]["all"]
     return if bottle.blank?
 
     sha256 = bottle["sha256"] || checksum_from_url(bottle["url"])

--- a/Library/Homebrew/bottle_api.rb
+++ b/Library/Homebrew/bottle_api.rb
@@ -71,6 +71,14 @@ module BottleAPI
     download_bottle(hash, bottle_tag)
 
     hash["dependencies"].each do |dep_hash|
+      existing_formula = begin
+        Formulary.factory dep_hash["name"]
+      rescue FormulaUnavailableError
+        nil
+      end
+
+      next if existing_formula.present? && existing_formula.latest_version_installed?
+
       download_bottle(dep_hash, bottle_tag)
     end
   end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -253,10 +253,7 @@ module Homebrew
       s += " (bottled)" if bottle_exists
       specs << s
     elsif (stable = f.stable)
-      latest_version = BottleAPI.latest_pkg_version(f.name).version if ENV["HOMEBREW_JSON_CORE"].present?
-      latest_version ||= stable.version
-
-      s = "stable #{latest_version}"
+      s = "stable #{stable.version}"
       s += " (bottled)" if stable.bottled? && f.pour_bottle?
       specs << s
     end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -244,7 +244,13 @@ module Homebrew
     specs = []
 
     if (stable = f.stable)
-      s = "stable #{stable.version}"
+      latest_version = if ENV["HOMEBREW_JSON_CORE"].present?
+        BottleAPI.latest_pkg_version(f.name).version || stable.version
+      else
+        stable.version
+      end
+
+      s = "stable #{latest_version}"
       s += " (bottled)" if stable.bottled? && f.pour_bottle?
       specs << s
     end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -244,11 +244,8 @@ module Homebrew
     specs = []
 
     if (stable = f.stable)
-      latest_version = if ENV["HOMEBREW_JSON_CORE"].present?
-        BottleAPI.latest_pkg_version(f.name).version || stable.version
-      else
-        stable.version
-      end
+      latest_version = BottleAPI.latest_pkg_version(f.name).version if ENV["HOMEBREW_JSON_CORE"].present?
+      latest_version ||= stable.version
 
       s = "stable #{latest_version}"
       s += " (bottled)" if stable.bottled? && f.pour_bottle?

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -243,7 +243,16 @@ module Homebrew
   def info_formula(f, args:)
     specs = []
 
-    if (stable = f.stable)
+    if ENV["HOMEBREW_JSON_CORE"].present? && BottleAPI.bottle_available?(f.name)
+      info = BottleAPI.fetch(f.name)
+
+      latest_version = info["pkg_version"].split("_").first
+      bottle_exists = info["bottles"].key?(Utils::Bottles.tag.to_s) || info["bottles"].key?("all")
+
+      s = "stable #{latest_version}"
+      s += " (bottled)" if bottle_exists
+      specs << s
+    elsif (stable = f.stable)
       latest_version = BottleAPI.latest_pkg_version(f.name).version if ENV["HOMEBREW_JSON_CORE"].present?
       latest_version ||= stable.version
 

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -471,7 +471,7 @@ EOS
      [[ -d "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core" ]]
   then
     safe_cd "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core"
-    echo "HOMEBREW_CORE_GIT_REMOTE set: using ${HOMEBREW_CORE_GIT_REMOTE} for Homebrew/brew Git remote."
+    echo "HOMEBREW_CORE_GIT_REMOTE set: using ${HOMEBREW_CORE_GIT_REMOTE} for Homebrew/core Git remote."
     git remote set-url origin "${HOMEBREW_CORE_GIT_REMOTE}"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     git fetch --force origin refs/heads/master:refs/remotes/origin/master
@@ -498,6 +498,12 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
+    if [[ -n "${HOMEBREW_JSON_CORE}" ]] && [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
+       [[ "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core" ]]
+    then
+      continue
+    fi
+
     [[ -d "${DIR}/.git" ]] || continue
     cd "${DIR}" || continue
 
@@ -639,6 +645,14 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
+    # HOMEBREW_UPDATE_PREINSTALL wasn't modified in subshell.
+    # shellcheck disable=SC2031
+    if [[ -n "${HOMEBREW_JSON_CORE}" ]] && [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
+       [[ "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core" ]]
+    then
+      continue
+    fi
+
     [[ -d "${DIR}/.git" ]] || continue
     cd "${DIR}" || continue
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -520,7 +520,13 @@ class Formula
   # exists and is not empty.
   # @private
   def latest_version_installed?
-    (dir = latest_installed_prefix).directory? && !dir.children.empty?
+    latest_prefix = if ENV["HOMEBREW_JSON_CORE"].present?
+      prefix BottleAPI.latest_pkg_version(name)
+    else
+      latest_installed_prefix
+    end
+
+    (dir = latest_prefix).directory? && !dir.children.empty?
   end
 
   # If at least one version of {Formula} is installed.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/11648

This PR does three things to improve the way JSON bottles are handled:

1. `BottleAPI::fetch_bottles` only downloads dependency bottles if no up-to-date version of the formula is installed locally. This means we don't need to spend time downloading bottles for all dependencies if they will never be used.
2. Automatic Homebrew updates (i.e. `brew update --preinstall`), no longer fetches `homebrew/core` (as long as `HOMEBREW_JSON_CORE` is set). Running `brew update` manually _will_ still fetch `homebrew/core`.
3. `brew info` now shows the most recent version information if `HOMEBREW_JSON_CORE` is set rather than the version that exists in the tap.
