### PR TITLE
dev-cmd/bottle: fixup macOS symlink permissions.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -399,6 +399,8 @@ module Homebrew
         keg.find do |file|
           # Set the times for reproducible bottles.
           if file.symlink?
+            # Need to make symlink permissions consistent on macOS and Linux
+            system "chmod", "-h", "0777", file if OS.mac?
             File.lutime(tab.source_modified_time, tab.source_modified_time, file)
           else
             file.utime(tab.source_modified_time, tab.source_modified_time)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -400,7 +400,7 @@ module Homebrew
           # Set the times for reproducible bottles.
           if file.symlink?
             # Need to make symlink permissions consistent on macOS and Linux
-            system "chmod", "-h", "0777", file if OS.mac?
+            File.lchmod 0777, file if OS.mac?
             File.lutime(tab.source_modified_time, tab.source_modified_time, file)
           else
             file.utime(tab.source_modified_time, tab.source_modified_time)


### PR DESCRIPTION
These can be changed on macOS but not on Linux so we need to make them consistent in both places for `all:` bottles to have consistent checksums.

I investigated adding to `cleaner.rb` to fix these symlink permissions on installation but it seems it already happens by default when extracting so there's no need.