### PR TITLE
commands: remove `diy`, add `lc` alias for `livecheck`

### DIFF
--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -21,13 +21,13 @@ module Commands
     "uninstal"    => "uninstall",
     "rm"          => "uninstall",
     "remove"      => "uninstall",
-    "configure"   => "diy",
     "abv"         => "info",
     "dr"          => "doctor",
     "--repo"      => "--repository",
     "environment" => "--env",
     "--config"    => "config",
     "-v"          => "--version",
+    "lc"          => "livecheck",
     "tc"          => "typecheck",
   }.freeze
 

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1167,6 +1167,32 @@ _brew_irb() {
   esac
 }
 
+_brew_lc() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "${cur}" in
+    -*)
+      __brewcomp "
+      --all
+      --cask
+      --debug
+      --formula
+      --full-name
+      --help
+      --installed
+      --json
+      --newer-only
+      --quiet
+      --tap
+      --verbose
+      "
+      return
+      ;;
+    *)
+  esac
+  __brew_complete_formulae
+  __brew_complete_casks
+}
+
 _brew_leaves() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -2433,6 +2459,7 @@ _brew() {
     install) _brew_install ;;
     install-bundler-gems) _brew_install_bundler_gems ;;
     irb) _brew_irb ;;
+    lc) _brew_lc ;;
     leaves) _brew_leaves ;;
     link) _brew_link ;;
     linkage) _brew_linkage ;;

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -846,6 +846,23 @@ __fish_brew_complete_arg 'irb' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'irb' -l verbose -d 'Make some output more verbose'
 
 
+__fish_brew_complete_cmd 'lc' 'Check for newer versions of formulae and/or casks from upstream'
+__fish_brew_complete_arg 'lc' -l all -d 'Check all available formulae/casks'
+__fish_brew_complete_arg 'lc' -l cask -d 'Only check casks'
+__fish_brew_complete_arg 'lc' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'lc' -l formula -d 'Only check formulae'
+__fish_brew_complete_arg 'lc' -l full-name -d 'Print formulae/casks with fully-qualified names'
+__fish_brew_complete_arg 'lc' -l help -d 'Show this message'
+__fish_brew_complete_arg 'lc' -l installed -d 'Check formulae/casks that are currently installed'
+__fish_brew_complete_arg 'lc' -l json -d 'Output information in JSON format'
+__fish_brew_complete_arg 'lc' -l newer-only -d 'Show the latest version only if it\'s newer than the formula/cask'
+__fish_brew_complete_arg 'lc' -l quiet -d 'Suppress warnings, don\'t print a progress bar for JSON output'
+__fish_brew_complete_arg 'lc' -l tap -d 'Check formulae/casks within the given tap, specified as user`/`repo'
+__fish_brew_complete_arg 'lc' -l verbose -d 'Make some output more verbose'
+__fish_brew_complete_arg 'lc; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'lc; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+
+
 __fish_brew_complete_cmd 'leaves' 'List installed formulae that are not dependencies of another installed formula'
 __fish_brew_complete_arg 'leaves' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'leaves' -l help -d 'Show this message'

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -26,7 +26,6 @@ command
 commands
 completions
 config
-configure
 create
 deps
 desc
@@ -48,6 +47,7 @@ info
 install
 install-bundler-gems
 irb
+lc
 leaves
 link
 linkage

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -22,13 +22,13 @@ __brew_list_aliases() {
     uninstal uninstall
     rm uninstall
     remove uninstall
-    configure diy
     abv info
     dr doctor
     '--repo' '--repository'
     environment '--env'
     '--config' config
     '-v' '--version'
+    lc livecheck
     tc typecheck
   )
   echo "${aliases}"
@@ -1032,6 +1032,27 @@ _brew_irb() {
     '--pry[Use Pry instead of IRB. Implied if `HOMEBREW_PRY` is set]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]'
+}
+
+# brew lc
+_brew_lc() {
+  _arguments \
+    '(--tap --installed)--all[Check all available formulae/casks]' \
+    '(--json)--debug[Display any debugging information]' \
+    '--full-name[Print formulae/casks with fully-qualified names]' \
+    '--help[Show this message]' \
+    '(--tap --all)--installed[Check formulae/casks that are currently installed]' \
+    '(--debug)--json[Output information in JSON format]' \
+    '--newer-only[Show the latest version only if it'\''s newer than the formula/cask]' \
+    '--quiet[Suppress warnings, don'\''t print a progress bar for JSON output]' \
+    '(--all --installed)--tap[Check formulae/casks within the given tap, specified as user`/`repo]' \
+    '--verbose[Make some output more verbose]' \
+    - formula \
+    '(--cask)--formula[Only check formulae]' \
+    '*::formula:__brew_formulae' \
+    - cask \
+    '(--formula)--cask[Only check casks]' \
+    '*::cask:__brew_casks'
 }
 
 # brew leaves

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1131,7 +1131,7 @@ provided, check all kegs. Raises an error if run on uninstalled formulae.
 * `--cached`:
   Print the cached linkage values stored in `HOMEBREW_CACHE`, set by a previous `brew linkage` run.
 
-### `livecheck` [*`options`*] [*`formula`*|*`cask`* ...]
+### `livecheck`, `lc` [*`options`*] [*`formula`*|*`cask`* ...]
 
 Check for newer versions of formulae and/or casks from upstream.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1588,7 +1588,7 @@ For every library that a keg references, print its dylib path followed by the bi
 \fB\-\-cached\fR
 Print the cached linkage values stored in \fBHOMEBREW_CACHE\fR, set by a previous \fBbrew linkage\fR run\.
 .
-.SS "\fBlivecheck\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
+.SS "\fBlivecheck\fR, \fBlc\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Check for newer versions of formulae and/or casks from upstream\.
 .
 .P


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally? (Ran `brew tests --online`, all checks passed.)

-----

This PR makes two minor changes:
* It removes the default alias for `brew diy` (`configure`) which no longer exists.
* It adds `lc` as a default alias for `livecheck`, similar to `tc` for `typecheck`. The reason I'm proposing this (rather than using `brew alias` just for myself) is because there are 7 `l*` commands and 4 `li*` commands, so at least 4 characters (i.e. `liv<TAB>`) are required to autocomplete to `livecheck`. I think users of `livecheck` would like having a short alias like `lc`, which is convenient and unambiguous (to my knowledge).