### PR TITLE
resource_auditor: add audit for HEAD default branch

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -523,9 +523,15 @@ module Homebrew
         spec_name = name.downcase.to_sym
         next unless (spec = formula.send(spec_name))
 
+        except = @except.to_a
+        if spec_name == :head &&
+           tap_audit_exception(:head_non_default_branch_allowlist, formula.name, spec.specs[:branch])
+          except << "head_branch"
+        end
+
         ra = ResourceAuditor.new(
           spec, spec_name,
-          online: @online, strict: @strict, only: @only, except: @except
+          online: @online, strict: @strict, only: @only, except: except
         ).audit
         ra.problems.each do |message|
           problem "#{name}: #{message}"

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -127,7 +127,7 @@ module Homebrew
     def audit_head_branch
       return unless @online
       return unless @strict
-      return unless spec_name == :head
+      return if spec_name != :head
       return unless Utils::Git.remote_exists?(url)
 
       branch = Utils.popen_read("git", "ls-remote", "--symref", url, "HEAD")

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -125,18 +125,17 @@ module Homebrew
     end
 
     def audit_head_branch
-      return if !@online || !@strict || spec_name != :head || !Utils::Git.remote_exists?(url)
+      return unless @online
+      return unless @strict
+      return unless spec_name == :head
+      return unless Utils::Git.remote_exists?(url)
 
       branch = Utils.popen_read("git", "ls-remote", "--symref", url, "HEAD")
                     .match(%r{ref: refs/heads/(.*?)\s+HEAD})[1]
 
-      return if branch == "master" && specs[:branch].blank? || branch == specs[:branch]
+      return if branch == specs[:branch]
 
-      if branch == "master"
-        problem "Remove `branch: \"#{specs[:branch]}\"`"
-      else
-        problem "Use `branch: \"#{branch}\"` to specify the correct default branch"
-      end
+      problem "Use `branch: \"#{branch}\"` to specify the default branch"
     end
 
     def problem(text)

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -124,6 +124,21 @@ module Homebrew
       end
     end
 
+    def audit_head_branch
+      return if !@online || !@strict || spec_name != :head || !Utils::Git.remote_exists?(url)
+
+      branch = Utils.popen_read("git", "ls-remote", "--symref", url, "HEAD")
+                    .match(%r{ref: refs/heads/(.*?)\s+HEAD})[1]
+
+      return if branch == "master" && specs[:branch].blank? || branch == specs[:branch]
+
+      if branch == "master"
+        problem "Remove `branch: \"#{specs[:branch]}\"`"
+      else
+        problem "Use `branch: \"#{branch}\"` to specify the correct default branch"
+      end
+    end
+
     def problem(text)
       @problems << text
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds an audit to ensure that the correct default branch for a Git repository is specified for `head` when using `--strict --online`. For `main` and other alternatives, we need to explicitly specify the default branch using `branch:`, as the default is `master`.

Adding an audit will ensure this is checked in PRs to add new formulae.

I haven't written a test for this audit as it would require network access (and use a real repository URL), but I'd be happy to add one if that's preferable.

(CC @vladimyr)