### PR TITLE
utils/pypi respect ignore_non_pypi_packages

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -203,7 +203,7 @@ module PyPI
     end
 
     formula.resources.each do |resource|
-      if !(ignore_non_pypi_packages || print_only) && !resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
+      if !ignore_non_pypi_packages && !print_only && !resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
         odie "\"#{formula.name}\" contains non-PyPI resources. Please update the resources manually."
       end
     end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -203,7 +203,7 @@ module PyPI
     end
 
     formula.resources.each do |resource|
-      if !print_only && !resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
+      if !(ignore_non_pypi_packages || print_only) && !resource.url.start_with?(PYTHONHOSTED_URL_PREFIX)
         odie "\"#{formula.name}\" contains non-PyPI resources. Please update the resources manually."
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Elsewhere on this file, the ignore_non_pypi_packages flag is used
to continue to make progress despite the existence of non-pypi resources

There is one check in the update_python_resources function that
will always `odie` if there is a non-pypi resource. This prevents
`brew bump-forumla-pr` from being run on formulas that contain
both pypi and non-pypi resources.

This PR modifies said check to not call `odie` when such resources
are encountered