### PR TITLE
formula: fix `latest_version_installed?` for `HOMEBREW_JSON_CORE`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -520,8 +520,8 @@ class Formula
   # exists and is not empty.
   # @private
   def latest_version_installed?
-    latest_prefix = if ENV["HOMEBREW_JSON_CORE"].present?
-      prefix BottleAPI.latest_pkg_version(name)
+    latest_prefix = if ENV["HOMEBREW_JSON_CORE"].present? && (latest_pkg_version = BottleAPI.latest_pkg_version(name))
+      prefix latest_pkg_version
     else
       latest_installed_prefix
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/11715

If `HOMEBREW_JSON_CORE` is set, `brew cleanup` fails:

```console
$ brew cleanup
Error: no implicit conversion of nil into String
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/pathname.rb:350:in `initialize'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/pathname.rb:350:in `new'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/pathname.rb:350:in `+'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2351:in `versioned_prefix'
/usr/local/Homebrew/Library/Homebrew/formula.rb:597:in `prefix'
/usr/local/Homebrew/Library/Homebrew/formula.rb:524:in `latest_version_installed?'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2257:in `eligible_kegs_for_cleanup'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:237:in `cleanup_formula'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:190:in `block in clean!'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:189:in `each'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:189:in `clean!'
/usr/local/Homebrew/Library/Homebrew/cmd/cleanup.rb:58:in `cleanup'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```

This is because the updates to `Formula#latest_version_installed?` from #11715 did not handle the case where a formula wasn't found in the `/api/versions.json` file (which would happen for any non-core formula.

Now, if the formula isn't listed, default back to the old way of using `latest_installed_prefix` (which is still done if `HOMEBREW_JSON_CORE` is unset.
