### PR TITLE
extract: ignore syntax errors during load

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -226,6 +226,6 @@ module Homebrew
     contents = Utils::Git.last_revision_of_file(repo, file, before_commit: rev)
     contents.gsub!("@url=", "url ")
     contents.gsub!("require 'brewkit'", "require 'formula'")
-    with_monkey_patch { Formulary.from_contents(name, file, contents) }
+    with_monkey_patch { Formulary.from_contents(name, file, contents, ignore_errors: true) }
   end
 end

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -14,9 +14,17 @@ describe "brew extract" do
       core_tap = CoreTap.new
       core_tap.path.cd do
         system "git", "init"
-        formula_file = setup_test_formula "testball"
+        # Start with deprecated bottle syntax
+        setup_test_formula "testball", bottle_block: <<~EOS
+
+          bottle do
+            cellar :any
+          end
+        EOS
         system "git", "add", "--all"
         system "git", "commit", "-m", "testball 0.1"
+        # Replace with a valid formula for the next version
+        formula_file = setup_test_formula "testball"
         contents = File.read(formula_file)
         contents.gsub!("testball-0.1", "testball-0.2")
         File.write(formula_file, contents)


### PR DESCRIPTION
Deprecated syntax can happen when stepping back in time, so we shouldn't start by blocking everything that doesn't meet current Homebrew syntax standards. Closes #11593.

Before:
```bash
$ brew extract -d -v --version=14.15.1 node@14 gromgit/tmp
==> Searching repository history
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
==> Trying 14.17.3 from revision f90d04c against desired 14.15.1
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
[...]
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
==> Trying 14.15.4 from revision e2c833d against desired 14.15.1
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
Error: node@14: Calling `cellar` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the homebrew/core tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb:14

/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formulary.rb:84:in `rescue in block in load_formula'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formulary.rb:77:in `block in load_formula'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formulary.rb:90:in `load_formula'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formulary.rb:383:in `klass'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formulary.rb:180:in `get_formula'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formulary.rb:496:in `from_contents'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/extract.rb:229:in `block in formula_at_revision'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/extract.rb:38:in `with_monkey_patch'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/extract.rb:229:in `formula_at_revision'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/extract.rb:158:in `block in extract'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/extract.rb:138:in `loop'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/extract.rb:138:in `extract'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```
After:
```bash
$ brew extract -d -v --version=14.15.1 node@14 gromgit/tmp
==> Searching repository history
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
==> Trying 14.17.3 from revision f90d04c against desired 14.15.1
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
[...]
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
==> Trying 14.15.4 from revision e2c833d against desired 14.15.1
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
==> Trying 14.15.4 from revision 700c6c1 against desired 14.15.1
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
[...]
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
==> Trying 14.15.2 from revision 6102dd7 against desired 14.15.1
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node@14.rb
==> Writing formula for node from revision bccda0e to:
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/gromgit/homebrew-tmp/Formula/node@14.15.1.rb
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
