### PR TITLE
update-report: still report homebrew/core changes if they are updated

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -102,7 +102,7 @@ module Homebrew
     updated_taps = []
     Tap.each do |tap|
       next unless tap.git?
-      next if tap.core_tap? && ENV["HOMEBREW_JSON_CORE"].present?
+      next if tap.core_tap? && ENV["HOMEBREW_JSON_CORE"].present? && args.preinstall?
 
       begin
         reporter = Reporter.new(tap)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/11729

We also need to check whether it's a preinstall update (i.e. that `--preinstall` was passed). Otherwise, homebrew/core will still be updated and its updates won't be listed in the output because they'll be ignored by `HOMEBREW_JSON_CORE` presence.
