### PR TITLE
dev-cmd/pr-publish: pass `--autosquash` by default

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -31,7 +31,7 @@ module Homebrew
              description: "Instruct `brew pr-publish` to automatically reformat and reword commits "\
                           "in the pull request to our preferred format."
       switch "--no-autosquash",
-             description: "Instruct `brew pr-publish` to skip automatically reformattin and rewording commits "\
+             description: "Instruct `brew pr-publish` to skip automatically reformatting and rewording commits "\
                           "in the pull request to the preferred format."
       switch "--ignore-failures",
              description: "Include pull requests that have failing status checks."

--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -30,7 +30,7 @@ module Homebrew
       switch "--autosquash",
              description: "Instruct `brew pr-publish` to automatically reformat and reword commits "\
                           "in the pull request to our preferred format."
-      switch "--no_autosquash",
+      switch "--no-autosquash",
              description: "Instruct `brew pr-publish` to skip automatically reformattin and rewording commits "\
                           "in the pull request to the preferred format."
       switch "--ignore-failures",
@@ -43,7 +43,7 @@ module Homebrew
   def pr_automerge
     args = pr_automerge_args.parse
 
-    odeprecated "`brew pr-publish --autosquash`" if args.autosquash?
+    odeprecated "`brew pr-automerge --autosquash`" if args.autosquash?
 
     without_labels = args.without_labels || [
       "do not merge",

--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -30,6 +30,9 @@ module Homebrew
       switch "--autosquash",
              description: "Instruct `brew pr-publish` to automatically reformat and reword commits "\
                           "in the pull request to our preferred format."
+      switch "--no_autosquash",
+             description: "Instruct `brew pr-publish` to skip automatically reformattin and rewording commits "\
+                          "in the pull request to the preferred format."
       switch "--ignore-failures",
              description: "Include pull requests that have failing status checks."
 
@@ -39,6 +42,8 @@ module Homebrew
 
   def pr_automerge
     args = pr_automerge_args.parse
+
+    odeprecated "`brew pr-publish --autosquash`" if args.autosquash?
 
     without_labels = args.without_labels || [
       "do not merge",
@@ -71,7 +76,7 @@ module Homebrew
 
     publish_args = ["pr-publish"]
     publish_args << "--tap=#{tap}" if tap
-    publish_args << "--autosquash" if args.autosquash?
+    publish_args << "--autosquash" unless args.no_autosquash?
     if args.publish?
       safe_system HOMEBREW_BREW_FILE, *publish_args, *pr_urls
     else

--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -43,7 +43,7 @@ module Homebrew
   def pr_automerge
     args = pr_automerge_args.parse
 
-    odeprecated "`brew pr-automerge --autosquash`" if args.autosquash?
+    odeprecated "`brew pr-automerge --autosquash`", "`brew pr-automerge`" if args.autosquash?
 
     without_labels = args.without_labels || [
       "do not merge",

--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -76,7 +76,7 @@ module Homebrew
 
     publish_args = ["pr-publish"]
     publish_args << "--tap=#{tap}" if tap
-    publish_args << "--autosquash" unless args.no_autosquash?
+    publish_args << "--no-autosquash" if args.no_autosquash?
     if args.publish?
       safe_system HOMEBREW_BREW_FILE, *publish_args, *pr_urls
     else

--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -43,7 +43,7 @@ module Homebrew
     workflow = args.workflow || "publish-commit-bottles.yml"
     ref = args.branch || "master"
 
-    odeprecated "`brew pr-publish --autosquash`" if args.autosquash?
+    odeprecated "`brew pr-publish --autosquash`", "`brew pr-publish`" if args.autosquash?
 
     extra_args = []
     extra_args << "--autosquash" unless args.no_autosquash?

--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -19,6 +19,9 @@ module Homebrew
       switch "--autosquash",
              description: "If supported on the target tap, automatically reformat and reword commits "\
                           "in the pull request to our preferred format."
+      switch "--no-autosquash",
+             description: "Skip automatically reformatting and rewording commits in the pull request "\
+                          "to the preferred format, even if supported on the target tap."
       flag   "--branch=",
              description: "Branch to publish to (default: `master`)."
       flag   "--message=",
@@ -40,8 +43,10 @@ module Homebrew
     workflow = args.workflow || "publish-commit-bottles.yml"
     ref = args.branch || "master"
 
+    odeprecated "`brew pr-publish --autosquash`" if args.autosquash?
+
     extra_args = []
-    extra_args << "--autosquash" if args.autosquash?
+    extra_args << "--autosquash" unless args.no_autosquash?
     extra_args << "--message='#{args.message}'" if args.message.presence
     dispatch_args = extra_args.join " "
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It's too easy to forget to, and the consequences of forgetting to pass
`--autosquash` are worse (i.e. almost always permanent) than forgetting
to pass `--no-autosquash` (i.e. just do `pr-publish --no-autosquash`
when your command fails).

See the discussion at Homebrew/homebrew-core#80717.