### PR TITLE
cmd/search: add repology

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -15,7 +15,8 @@ module Homebrew
   extend Search
 
   PACKAGE_MANAGERS = {
-    macports: ->(query) { "https://www.macports.org/ports.php?by=name&substr=#{query}" },
+    repology: ->(query) { "https://repology.org/projects/?search=#{query}" },
+    macports: ->(query) { "https://ports.macports.org/search/?q=#{query}" },
     fink:     ->(query) { "https://pdb.finkproject.org/pdb/browse.php?summary=#{query}" },
     opensuse: ->(query) { "https://software.opensuse.org/search?q=#{query}" },
     fedora:   ->(query) { "https://apps.fedoraproject.org/packages/s/#{query}" },
@@ -53,7 +54,7 @@ module Homebrew
       package_manager_switches = PACKAGE_MANAGERS.keys.map { |name| "--#{name}" }
       package_manager_switches.each do |s|
         switch s,
-               description: "Search for <text> in the given package manager's list."
+               description: "Search for <text> in the given database's or package manager's list."
       end
 
       conflicts "--desc", "--pull-request"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally? In progress...

-----

I often find myself checking Repology to quickly reference how other
package managers handle certain things, so it seems useful to be able to
do so with `brew search`.

While we're here, let's fix the query URL for MacPorts.