### PR TITLE
GitHub/API: Don't ask for a PAT if one already exists

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -50,7 +50,7 @@ module GitHub
         @github_message = github_message
         super <<~EOS
           GitHub API Error: #{github_message}
-          Try again in #{pretty_ratelimit_reset(reset)}#{!API.credentials ? ", or:\n" + CREATE_GITHUB_PAT_MESSAGE : ""}
+          Try again in #{pretty_ratelimit_reset(reset)}#{API.credentials ? "" : ", or:\n#{CREATE_GITHUB_PAT_MESSAGE}"}
         EOS
       end
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -48,9 +48,10 @@ module GitHub
     class RateLimitExceededError < Error
       def initialize(reset, github_message)
         @github_message = github_message
+        new_PAT_message = API.credentials ? "" : ", or:\n#{CREATE_GITHUB_PAT_MESSAGE}"
         super <<~EOS
           GitHub API Error: #{github_message}
-          Try again in #{pretty_ratelimit_reset(reset)}#{API.credentials ? "" : ", or:\n#{CREATE_GITHUB_PAT_MESSAGE}"}
+          Try again in #{pretty_ratelimit_reset(reset)}#{new_PAT_message}
         EOS
       end
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -50,8 +50,7 @@ module GitHub
         @github_message = github_message
         super <<~EOS
           GitHub API Error: #{github_message}
-          Try again in #{pretty_ratelimit_reset(reset)}, or:
-          #{CREATE_GITHUB_PAT_MESSAGE}
+          Try again in #{pretty_ratelimit_reset(reset)}#{!API.credentials ? ", or:\n" + CREATE_GITHUB_PAT_MESSAGE : ""}
         EOS
       end
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -48,7 +48,7 @@ module GitHub
     class RateLimitExceededError < Error
       def initialize(reset, github_message)
         @github_message = github_message
-        new_pat_message = API.credentials ? "" : ", or:\n#{CREATE_GITHUB_PAT_MESSAGE}"
+        new_pat_message = ", or:\n#{CREATE_GITHUB_PAT_MESSAGE}" if API.credentials.blank?
         super <<~EOS
           GitHub API Error: #{github_message}
           Try again in #{pretty_ratelimit_reset(reset)}#{new_pat_message}

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -21,7 +21,7 @@ module GitHub
         #{ALL_SCOPES_URL}
       #{Utils::Shell.set_variable_in_profile("HOMEBREW_GITHUB_API_TOKEN", "your_token_here")}
   EOS
-  GITHUB_PERSONAL_ACCESS_TOKEN_REGEX = /^(?:[a-f0-9]{40}|ghp_\w{36,251})$/.freeze
+  GITHUB_PERSONAL_ACCESS_TOKEN_REGEX = /^(?:[a-f0-9]{40}|gh[po]_\w{36,251})$/.freeze
 
   # Helper functions to access the GitHub API.
   #

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -48,10 +48,10 @@ module GitHub
     class RateLimitExceededError < Error
       def initialize(reset, github_message)
         @github_message = github_message
-        new_PAT_message = API.credentials ? "" : ", or:\n#{CREATE_GITHUB_PAT_MESSAGE}"
+        new_pat_message = API.credentials ? "" : ", or:\n#{CREATE_GITHUB_PAT_MESSAGE}"
         super <<~EOS
           GitHub API Error: #{github_message}
-          Try again in #{pretty_ratelimit_reset(reset)}#{new_PAT_message}
+          Try again in #{pretty_ratelimit_reset(reset)}#{new_pat_message}
         EOS
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When using the GitHub API, if the API request limit is exceeded, the user would be prompted to create an API token even if one already exists. This will change it only ask for a new API token if one doesn't already exist.

Also, support for `gho_` tokens are added as the GitHub command line tool (`gh`) uses OAuth and may place that token in the keychain for git to use, and then subsequently being retrieved by Homebrew via `git credential-osxkeychain get`.