### PR TITLE
cmd/doctor: repair `xattr` not find

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -31,7 +31,7 @@ module Cask
     def check_quarantine_support
       odebug "Checking quarantine support"
 
-      if !system_command(xattr, args:[ "-h" ], print_stderr: false).success?
+      if !system_command(xattr, args: ["-h"], print_stderr: false).success?
         odebug "There's no working version of `xattr` on this system."
         :xattr_broken
       elsif swift.nil?

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -31,7 +31,7 @@ module Cask
     def check_quarantine_support
       odebug "Checking quarantine support"
 
-      if !system_command(xattr, print_stderr: false).success?
+      if !system_command(xattr, args:[ "-h" ], print_stderr: false).success?
         odebug "There's no working version of `xattr` on this system."
         :xattr_broken
       elsif swift.nil?

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1000,7 +1000,7 @@ module Homebrew
       end
 
       def check_cask_xattr
-        result = system_command "/usr/bin/xattr", args: [ "-h" ]
+        result = system_command "/usr/bin/xattr", args: ["-h"]
 
         return if result.status.success?
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1000,7 +1000,7 @@ module Homebrew
       end
 
       def check_cask_xattr
-        result = system_command "/usr/bin/xattr"
+        result = system_command "/usr/bin/xattr", args: [ "-h" ]
 
         return if result.status.success?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
There is a problem with the current way of checking`xattr` command, which is simply running `xattr` no args and checking if it prints an error. But on macOS 12 beta3, the `xattr` command with no args would print an error, so the `-h` command is appended to fix this check.

This type of detection does not affect the previous version and does not require additional unit tests.