### PR TITLE
livecheck: allow inheriting from a formula/cask

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -18,11 +18,49 @@ class Livecheck
 
   def initialize(formula_or_cask)
     @formula_or_cask = formula_or_cask
+    @referenced_cask_name = nil
+    @referenced_formula_name = nil
     @regex = nil
     @skip = false
     @skip_msg = nil
     @strategy = nil
     @url = nil
+  end
+
+  # Sets the `@referenced_cask_name` instance variable to the provided `String`
+  # or returns the `@referenced_cask_name` instance variable when no argument
+  # is provided. Inherited livecheck values from the referenced cask
+  # (e.g. regex) can be overridden in the livecheck block.
+  #
+  # @param cask_name [String] name of cask to inherit livecheck info from
+  # @return [String, nil]
+  def cask(cask_name = nil)
+    case cask_name
+    when nil
+      @referenced_cask_name
+    when String
+      @referenced_cask_name = cask_name
+    else
+      raise TypeError, "Livecheck#cask expects a String"
+    end
+  end
+
+  # Sets the `@referenced_formula_name` instance variable to the provided
+  # `String` or returns the `@referenced_formula_name` instance variable when
+  # no argument is provided. Inherited livecheck values from the referenced
+  # formula (e.g. regex) can be overridden in the livecheck block.
+  #
+  # @param formula_name [String] name of formula to inherit livecheck info from
+  # @return [String, nil]
+  def formula(formula_name = nil)
+    case formula_name
+    when nil
+      @referenced_formula_name
+    when String
+      @referenced_formula_name = formula_name
+    else
+      raise TypeError, "Livecheck#formula expects a String"
+    end
   end
 
   # Sets the `@regex` instance variable to the provided `Regexp` or returns the
@@ -109,6 +147,8 @@ class Livecheck
   # @return [Hash]
   def to_hash
     {
+      "cask"     => @referenced_cask_name,
+      "formula"  => @referenced_formula_name,
       "regex"    => @regex,
       "skip"     => @skip,
       "skip_msg" => @skip_msg,

--- a/Library/Homebrew/rubocops/livecheck.rb
+++ b/Library/Homebrew/rubocops/livecheck.rb
@@ -50,6 +50,10 @@ module RuboCop
           skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.present?
 
+          formula_node = find_every_method_call_by_name(livecheck_node, :formula).first
+          cask_node = find_every_method_call_by_name(livecheck_node, :cask).first
+          return if formula_node.present? || cask_node.present?
+
           livecheck_url = find_every_method_call_by_name(livecheck_node, :url).first
           return if livecheck_url.present?
 

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -44,6 +44,15 @@ describe Homebrew::Livecheck do
     RUBY
   end
 
+  describe "::resolve_livecheck_reference" do
+    context "when a formula/cask has a livecheck block without formula/cask methods" do
+      it "returns [nil, []]" do
+        expect(livecheck.resolve_livecheck_reference(f)).to eq([nil, []])
+        expect(livecheck.resolve_livecheck_reference(c)).to eq([nil, []])
+      end
+    end
+  end
+
   describe "::formula_name" do
     it "returns the name of the formula" do
       expect(livecheck.formula_name(f)).to eq("test")

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -28,6 +28,40 @@ describe Livecheck do
   end
   let(:livecheckable_c) { described_class.new(c) }
 
+  describe "#formula" do
+    it "returns nil if not set" do
+      expect(livecheckable_f.formula).to be nil
+    end
+
+    it "returns the String if set" do
+      livecheckable_f.formula("other-formula")
+      expect(livecheckable_f.formula).to eq("other-formula")
+    end
+
+    it "raises a TypeError if the argument isn't a String" do
+      expect {
+        livecheckable_f.formula(123)
+      }.to raise_error(TypeError, "Livecheck#formula expects a String")
+    end
+  end
+
+  describe "#cask" do
+    it "returns nil if not set" do
+      expect(livecheckable_c.cask).to be nil
+    end
+
+    it "returns the String if set" do
+      livecheckable_c.cask("other-cask")
+      expect(livecheckable_c.cask).to eq("other-cask")
+    end
+
+    it "raises a TypeError if the argument isn't a String" do
+      expect {
+        livecheckable_c.cask(123)
+      }.to raise_error(TypeError, "Livecheck#cask expects a String")
+    end
+  end
+
   describe "#regex" do
     it "returns nil if not set" do
       expect(livecheckable_f.regex).to be nil
@@ -128,6 +162,8 @@ describe Livecheck do
     it "returns a Hash of all instance variables" do
       expect(livecheckable_f.to_hash).to eq(
         {
+          "cask"     => nil,
+          "formula"  => nil,
           "regex"    => nil,
           "skip"     => false,
           "skip_msg" => nil,

--- a/docs/Brew-Livecheck.md
+++ b/docs/Brew-Livecheck.md
@@ -96,6 +96,18 @@ end
 
 If tags include the software name as a prefix (e.g. `example-1.2.3`), it's easy to modify the regex accordingly: `/^example[._-]v?(\d+(?:\.\d+)+)$/i`
 
+### Referenced formula/cask
+
+A formula/cask can use the same check as another by using `formula` or `cask`.
+
+```ruby
+livecheck do
+  formula "another-formula"
+end
+```
+
+The referenced formula/cask should be in the same tap, as a reference to a formula/cask from another tap will generate an error if the user doesn't already have it tapped.
+
 ### `strategy` blocks
 
 If the upstream version format needs to be manipulated to match the formula/cask format, a `strategy` block can be used instead of a `regex`.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I took a brief detour today to expand the `livecheck` block DSL to allow us to inherit livecheck information from another formula/cask (e.g., `url`, `regex`, etc.). This should work as expected for referenced formulae/casks regardless of whether they contain a `livecheck` block or simply use livecheck's default.

For example, we have various formulae in homebrew/core that use the same check as `sqlite` (e.g., `dbhash`, `lemon`, `sqldiff`, `sqlite-analyzer`) and we simply duplicate these `livecheck` blocks. If a change is made to the `sqlite` formula's `livecheck` block, it has to be manually replicated in each of the related formulae. Ideally, a change in the `sqlite` `livecheck` block would automatically be reflected in the related formulae and that's part of the goal of this feature. If/when this feature is merged, the duplicate `livecheck` blocks can be replaced with:

```ruby
livecheck do
  formula "sqlite"
end
```

The way this is implemented, livecheck values that are inherited from another formula/cask (e.g., `regex`) can be overridden by supplying a value in the `livecheck` block. For example, you can inherit a `url`, `strategy` block, etc. from another formula/cask and override only the `regex`:

```ruby
livecheck do
  formula "other-formula"
  regex(/href=.*?something[._-]v?(\d+(?:\.\d+)+)\.t/i)
end
```

---

One thing to note, I've implemented this such that it should correctly handle recursive situations. For example, a formula/cask contains a `livecheck` block that references another formula/cask which contains a `livecheck` block that references another formula/cask, etc. In this situation, livecheck will resolve the links to the final formula/cask and use that as the referenced formula/cask.

The debug output prints the references like so (where `a2ps` is using `formula "a52dec"` and `a52dec` is using `cask "0-ad"`):

```
Formula:          a2ps
Livecheckable?:   Yes
Formula Ref:      a52dec
Cask Ref:         0-ad

URL:              https://play0ad.com/download/mac/
Strategy:         PageMatch
Regex:            /href=.*?0ad[._-]v?(.*?)-osx64\.dmg/i

Matched Versions:
0.0.24b-alpha
a2ps : 4.14 ==> 0.0.24b-alpha
```

The references are also surfaced in the verbose JSON output like so:

```json
[
  {
    "formula": "a2ps",
    "version": {
      "current": "4.14",
      "latest": "0.0.24b-alpha",
      "outdated": false,
      "newer_than_upstream": true
    },
    "meta": {
      "livecheckable": true,
      "references": [
        {
          "formula": "a52dec"
        },
        {
          "cask": "0-ad"
        }
      ],
      "url": {
        "original": "https://play0ad.com/download/mac/"
      },
      "strategy": "PageMatch",
      "strategies": [
        "PageMatch"
      ],
      "regex": "/href=.*?0ad[._-]v?(.*?)-osx64\\.dmg/i"
    }
  }
]
```

---

I'm working on another part of livecheck at the moment but this has been an itch that I've wanted to scratch for a while and it came up again today, so I figured I would finally take care of it.

Looking forward, I intend to factor this information into future caching behavior (i.e., avoiding multiple checks to the same source in a given run) when I finish implementing that. There are a few other things in the pipeline before that but I figured I would mention it in case someone gets a similar idea after looking at this.

Lastly, I've disabled the `Metrics/ModuleLength` rubocop for the `Livecheck` module and I've disabled `Metrics/BlockLength` in a couple areas. These changes pushed these areas just over the limits and I don't think it makes sense to refactor livecheck in this PR. I intend to do some refactoring in the future to address this situation but I don't think the length cops should hold us up in this PR.