### PR TITLE
Sourceforge: Do not modify RSS URLs

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -68,7 +68,11 @@ module Homebrew
         def self.find_versions(url, regex, cask: nil, &block)
           match = url.match(URL_MATCH_REGEX)
 
-          page_url = "https://sourceforge.net/projects/#{match[:project_name]}/rss"
+          page_url = if url.match?(%r{/rss(?:/?$|\?)})
+            url
+          else
+            "https://sourceforge.net/projects/#{match[:project_name]}/rss"
+          end
 
           # It may be possible to improve the default regex but there's quite a
           # bit of variation between projects and it can be challenging to


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This allows a `livecheck` block to check the RSS feed for a given path in a SourceForge project (e.g., `https://sourceforge.net/projects/example/rss?path=/directory`).

For example, the check for `ttfautohint` is currently failing because it's part of the `freetype` project and the latest `stable` archive for `ttfautohint` has been pushed out of the main RSS feed. Restricting the RSS feed to only the `ttfautohint` directory works as expected but, without this modification, the `Sourceforge` strategy currently modifies the URL back to the main RSS URL.

We can simply use `strategy :page_match` in a `livecheck` block (as we've been doing) but I figured it would be better to address this issue, so we don't have to override the strategy in these instances. If/when this is merged, I'll create follow-up PRs in homebrew/core to update 11 related formulae to use the `Sourceforge` strategy in this fashion (I have the related changes finished and stashed locally).