### PR TITLE
Formula: Allow configuration of std_cargo_args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1479,9 +1479,9 @@ class Formula
   end
 
   # Standard parameters for cargo builds.
-  sig { returns(T::Array[T.any(String, Pathname)]) }
-  def std_cargo_args
-    ["--locked", "--root", prefix, "--path", "."]
+  sig { params(root: String, path: String).returns(T::Array[T.any(String, Pathname)]) }
+  def std_cargo_args(root: prefix, path: ".")
+    ["--locked", "--root", root, "--path", path]
   end
 
   # Standard parameters for CMake builds.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A few Rust-related formulae in homebrew/core need to override aspects of `std_cargo_args` and this is currently more painful than it needs to be.

`git-series` can't use the `--locked` flag until the next version is released and this has been the case since late 2019. As it stands, it uses manually-defined args instead of `std_cargo_args`: `system "cargo", "install", "--root", prefix, "--path", "."`

`gnirehtet` sets different `--root` and `--path` values, so it also uses manually-defined args: `system "cargo", "install", "--locked", "--root", libexec, "--path", "relay-rust"`

These two formulae don't inherit from `std_cargo_args`, so the formulae would need to be manually updated if/when that array is updated in the future.

---

`dprint` takes a different approach, doing a naive substitution of the current `--path` value (`.`) with the desired path:

```ruby
# replace `--path` arg with `./crates/dprint`
args = std_cargo_args.map { |s| s == "." ? "./crates/dprint" : s }
system "cargo", "install", *args
```

However, as described in [a recent `gping` PR comment](https://github.com/Homebrew/homebrew-core/pull/81535#issuecomment-882959415), this could fail if `std_cargo_args` is updated to include more than one `.` argument value or if the default `--path` value changes from `.`. I suggested a potentially less fragile (but verbose) modification of this approach for `gping`:

```ruby
# Replace `--path` value with `./gping`
args = std_cargo_args.clone
args.each_with_index do |s, i|
  next if s != "--path" || i + 1 >= args.length

  args[i+1] = "./gping"
end
```

---

Long story short, there are shortcomings to these approaches and trying to create something more robust ends up being verbose. This latter approach isn't something that we want to duplicate in other formulae but it seems inevitable that another formulae will need to modify the default `std_cargo_args` values in the future.

`std_cargo_args` is implemented as a method, so it struck me that we could simply allow for something like `std_cargo_args(path: "./gping")`, which is comparatively terse and doesn't require us to go through gyrations to replace default argument values.

With that in mind, this PR modifies `std_cargo_args` to allow for optional named arguments to control the default values. This allows `std_cargo_args` to be adapted to each of the situations described above in a clear and comparatively elegant fashion:

* ~~`git-series`: `system "cargo", "install", *std_cargo_args(locked: false)`~~
* `gnirehtet`: `system "cargo", "install", *std_cargo_args(root: libexec, path: "relay-rust")`
* `dprint`: `system "cargo", "install", *std_cargo_args(path: "./crates/dprint")`
* `gping`: `system "cargo", "install", *std_cargo_args(path: "./gping")`

As you would expect, `system "cargo", "install", *std_cargo_args` continues to work as expected, so no changes will need to be made to other formulae.

---

One thing to note about this PR is that there currently aren't any `std_cargo_args` tests. Testing this would seemingly require hardcoding the expected values and the tests would need to be updated if/when the array values are updated in the future. If that's fine and to be expected, I'll modify this to add tests that exercises this method.