### PR TITLE
formula_cellar_checks: handle universal binaries in `check_binary_arches`

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -330,7 +330,8 @@ module FormulaCellarChecks
     end
     mismatches -= compatible_universal_binaries
 
-    universal_binaries_expected = tap_audit_exception(:universal_binary_allowlist, formula.name)
+    universal_binaries_expected =
+      formula.tap.present? && tap_audit_exception(:universal_binary_allowlist, formula.name)
     return if mismatches.empty? && universal_binaries_expected
 
     s = ""

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -330,9 +330,10 @@ module FormulaCellarChecks
     end
     mismatches -= compatible_universal_binaries
 
-    universal_binaries_expected = true
     universal_binaries_expected = if formula.tap.present? && formula.tap.core_tap?
       tap_audit_exception(:universal_binary_allowlist, formula.name)
+    else
+      true
     end
     return if mismatches.empty? && universal_binaries_expected
 

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -339,7 +339,7 @@ module FormulaCellarChecks
 
     s = ""
 
-    if mismatches.any?
+    if mismatches.present?
       s += <<~EOS
         Binaries built for an incompatible architecture were installed into #{formula}'s prefix.
         The offending files are:
@@ -347,7 +347,7 @@ module FormulaCellarChecks
       EOS
     end
 
-    if compatible_universal_binaries.any? && !universal_binaries_expected
+    if compatible_universal_binaries.present? && !universal_binaries_expected
       s += <<~EOS
         Unexpected universal binaries were found.
         The offending files are:

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -325,10 +325,9 @@ module FormulaCellarChecks
     end
     return if mismatches.empty?
 
-    compatible_universal_binaries = mismatches.select do |file|
+    compatible_universal_binaries, mismatches = mismatches.partition do |file|
       file.arch == :universal && file.archs.include?(Hardware::CPU.arch)
     end
-    mismatches -= compatible_universal_binaries
 
     universal_binaries_expected = if formula.tap.present? && formula.tap.core_tap?
       tap_audit_exception(:universal_binary_allowlist, formula.name)

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -323,14 +323,15 @@ module FormulaCellarChecks
     mismatches = keg.binary_executable_or_library_files.reject do |file|
       file.arch == Hardware::CPU.arch
     end
+    return if mismatches.empty?
 
     compatible_universal_binaries = mismatches.select do |file|
       file.arch == :universal && file.archs.include?(Hardware::CPU.arch)
     end
     mismatches -= compatible_universal_binaries
 
-    return if mismatches.empty? && compatible_universal_binaries.empty?
-    return if mismatches.empty? && tap_audit_exception(:universal_binary_allowlist, formula.name)
+    universal_binaries_expected = tap_audit_exception(:universal_binary_allowlist, formula.name)
+    return if mismatches.empty? && universal_binaries_expected
 
     s = ""
 
@@ -342,7 +343,7 @@ module FormulaCellarChecks
       EOS
     end
 
-    unless compatible_universal_binaries.empty?
+    if !compatible_universal_binaries.empty? && !universal_binaries_expected
       s += <<~EOS
         Unexpected universal binaries were found.
         The offending files are:

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -330,13 +330,15 @@ module FormulaCellarChecks
     end
     mismatches -= compatible_universal_binaries
 
-    universal_binaries_expected =
-      formula.tap.present? && tap_audit_exception(:universal_binary_allowlist, formula.name)
+    universal_binaries_expected = true
+    universal_binaries_expected = if formula.tap.present? && formula.tap.core_tap?
+      tap_audit_exception(:universal_binary_allowlist, formula.name)
+    end
     return if mismatches.empty? && universal_binaries_expected
 
     s = ""
 
-    unless mismatches.empty?
+    if mismatches.any?
       s += <<~EOS
         Binaries built for an incompatible architecture were installed into #{formula}'s prefix.
         The offending files are:
@@ -344,7 +346,7 @@ module FormulaCellarChecks
       EOS
     end
 
-    if !compatible_universal_binaries.empty? && !universal_binaries_expected
+    if compatible_universal_binaries.any? && !universal_binaries_expected
       s += <<~EOS
         Unexpected universal binaries were found.
         The offending files are:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally? ~(In progress...)~

-----

The `check_binary_arches` audit will fail any formula that produces
universal binaries. We have a handful of formulae in Homebrew/core that
do this (see any formula that does `ENV.permit_arch_flags`, for
example). Moreover, some third party taps may have their own formulae
that build universal binaries.

I've updated the check so that it ignores a formula that produces
universal binaries whenever the formula is in the appropriate allowlist.
We'll need to create one in Homebrew/core for the handful of formulae
that do (expectedly) build universal binaries.

If we don't want to maintain an allowlist, we can easily modify this to
pass over any formulae that builds compatible universal binaries.

I've also fixed the spacing of the error this audit produces whenever
there is more than one file that fails the audit.