### PR TITLE
BottleAPI: include formula name in error message

### DIFF
--- a/Library/Homebrew/bottle_api.rb
+++ b/Library/Homebrew/bottle_api.rb
@@ -66,7 +66,9 @@ module BottleAPI
     hash = fetch(name)
     bottle_tag = Utils::Bottles.tag.to_s
 
-    odie "No bottle available for current OS" if !hash["bottles"].key?(bottle_tag) && !hash["bottles"].key?("all")
+    if !hash["bottles"].key?(bottle_tag) && !hash["bottles"].key?("all")
+      odie "No bottle available for #{name} on the current OS"
+    end
 
     download_bottle(hash, bottle_tag)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I noticed that the error message when a bottle isn't available for the given OS could be improved by adding the name of the formula that's missing the bottle. Otherwise, if working with multiple formulae, it is not clear which is missing.
