### PR TITLE
Use Homebrew/brew when checking `HOMEBREW_AUTO_UPDATE_SECS`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -183,11 +183,11 @@ update-preinstall() {
       HOMEBREW_AUTO_UPDATE_SECS="300"
     fi
 
-    # Skip auto-update if the core tap has been updated in the
+    # Skip auto-update if the repository has been updated in the
     # last $HOMEBREW_AUTO_UPDATE_SECS.
-    tap_fetch_head="${HOMEBREW_CORE_REPOSITORY}/.git/FETCH_HEAD"
-    if [[ -f "${tap_fetch_head}" &&
-          -n "$(find "${tap_fetch_head}" -type f -mtime -"${HOMEBREW_AUTO_UPDATE_SECS}"s 2>/dev/null)" ]]
+    repo_fetch_head="${HOMEBREW_REPOSITORY}/.git/FETCH_HEAD"
+    if [[ -f "${repo_fetch_head}" &&
+          -n "$(find "${repo_fetch_head}" -type f -mtime -"${HOMEBREW_AUTO_UPDATE_SECS}"s 2>/dev/null)" ]]
     then
       return
     fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When checking whether `HOMEBREW_AUTO_UPDATE_SECS` have passed since the latest fetch to determine whether to run a preinstall update or not, we currently check when `.git/FETCH_HEAD` in the homebrew/core tap was last updated. However, with `HOMEBREW_JSON_CORE`, homebrew/core won't be fetched on preinstall updates meaning its `FETCH_HEAD` file won't reflect new updates. THis means the modification time of `FETCH_HEAD` is not actually a measure of when the last update was run but is, instead, a measure of how long ago the user manually ran `brew update`. Additionally, if they untap homebrew/core, this check will never be hit.

Instead, check the homebrew/brew repo because it is necessary for all Homebrew installations and is really what's being updated here (i.e. not the taps).
