### PR TITLE
formula_installer: add `tap_audit_exception` stub

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1196,6 +1196,12 @@ class FormulaInstaller
     super
   end
 
+  # This is a stub for calls made to this method at install time.
+  # Exceptions are correctly identified when doing `brew audit`.
+  def tap_audit_exception(*)
+    true
+  end
+
   def self.locked
     @locked ||= []
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`FormulaInstaller` calls `audit_installed` at install time, which
invokes methods in `FormulaCellarChecks`. One of these methods makes a
call to `tap_audit_exception` (cf. #11750), but this method isn't
visible in `FormulaInstaller`.

Instead of trying to replicate the logic of `tap_audit_exception` in
`FormulaAuditor` (or trying to initialise an instance of one to make the
call to `FormulaAuditor`'s implementation of it), let's just implement a
stub that assumes an exception always exists.

I'll need to think a bit about whether this is the right fix for this,
but currently the missing method error is blocking PRs in Homebrew/core,
so let's go with this for now. [1]

[1] e.g. Homebrew/homebrew-core#81388, Homebrew/homebrew-core#81582