### PR TITLE
formula: add `deuniversalize_machos` method

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -4,7 +4,9 @@
 class Formula
   undef shared_library
   undef rpath
+  undef deuniversalize_machos
 
+  sig { params(name: String, version: T.nilable(T.any(String, Integer))).returns(String) }
   def shared_library(name, version = nil)
     suffix = if version == "*" || (name == "*" && version.blank?)
       "{,.*}"
@@ -14,9 +16,13 @@ class Formula
     "#{name}.so#{suffix}"
   end
 
+  sig { returns(String) }
   def rpath
     "'$ORIGIN/../lib'"
   end
+
+  sig { params(targets: T.nilable(T.any(Pathname, String))).void }
+  def deuniversalize_machos(*targets); end
 
   class << self
     undef ignore_missing_libraries

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1594,12 +1594,12 @@ class Formula
       end
     end
 
-    targets.each { |t| extract_slice_from(Pathname.new(t), Hardware::CPU.arch) }
+    targets.each { |t| extract_macho_slice_from(Pathname.new(t), Hardware::CPU.arch) }
   end
 
   # @private
   sig { params(file: Pathname, arch: T.nilable(Symbol)).void }
-  def extract_slice_from(file, arch = Hardware::CPU.arch)
+  def extract_macho_slice_from(file, arch = Hardware::CPU.arch)
     odebug "Extracting #{arch} slice from #{file}"
     file.ensure_writable do
       macho = MachO::FatFile.new(file)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1582,6 +1582,21 @@ class Formula
     end
   end
 
+  sig { params(targets: T.nilable(T.any(Pathname, String))).void }
+  def deuniversalize_machos(*targets)
+    if targets.blank?
+      targets = any_installed_keg.mach_o_files.select do |file|
+        file.arch == :universal && file.archs.include?(Hardware::CPU.arch)
+      end
+    end
+
+    targets.each do |t|
+      macho = MachO::FatFile.new(t)
+      native_slice = macho.extract(Hardware::CPU.arch)
+      native_slice.write t
+    end
+  end
+
   # an array of all core {Formula} names
   # @private
   def self.core_names

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1588,6 +1588,7 @@ class Formula
   # universal binaries in a {Formula}'s {Keg}.
   sig { params(targets: T.nilable(T.any(Pathname, String))).void }
   def deuniversalize_machos(*targets)
+    targets = nil if targets.blank?
     targets ||= any_installed_keg.mach_o_files.select do |file|
       file.arch == :universal && file.archs.include?(Hardware::CPU.arch)
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1588,10 +1588,8 @@ class Formula
   # universal binaries in a {Formula}'s {Keg}.
   sig { params(targets: T.nilable(T.any(Pathname, String))).void }
   def deuniversalize_machos(*targets)
-    if targets.blank?
-      targets = any_installed_keg.mach_o_files.select do |file|
-        file.arch == :universal && file.archs.include?(Hardware::CPU.arch)
-      end
+    targets ||= any_installed_keg.mach_o_files.select do |file|
+      file.arch == :universal && file.archs.include?(Hardware::CPU.arch)
     end
 
     targets.each { |t| extract_macho_slice_from(Pathname.new(t), Hardware::CPU.arch) }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1605,6 +1605,7 @@ class Formula
       macho = MachO::FatFile.new(file)
       native_slice = macho.extract(Hardware::CPU.arch)
       native_slice.write file
+      MachO.codesign! file if Hardware::CPU.arm?
     rescue MachO::MachOBinaryError
       onoe "#{file} is not a universal binary"
       raise


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This method takes an optional array of `Pathnames`s or `Strings`s and
extracts the native slice from the specified universal binary. If no
parameter is supplied, this is done on all compatible universal binaries
in a formula's keg.

`deuniversalize_machos` is a no-op on Linux.

I still need to look into a) error handling, and b) whether using this
method requires codesigning on ARM.

I've also added signatures to the methods in `extend/os/linux/formula`.