### PR TITLE
brews.sh: change HOMEBREW_MINIMUM_CURL_VERSION only for debian 7

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -412,7 +412,7 @@ else
 
   # This is set by the user environment.
   # shellcheck disable=SC2154
-  if [[ -n "${HOMEBREW_FORCE_HOMEBREW_ON_LINUX}" && -n "${HOMEBREW_ON_DEBIAN7}" ]]
+  if [[ -n "${HOMEBREW_ON_DEBIAN7}" ]]
   then
     # Special version for our debian 7 docker container used to build patchelf and binutils
     HOMEBREW_MINIMUM_CURL_VERSION="7.25.0"


### PR DESCRIPTION
I am not sure why we also checked for HOMEBREW_FORCE_HOMEBREW_ON_LINUX.
If the minimum curl version needs to be changed, we should introduce
specific env variables for each case that needs it, instead of
asking for HOMEBREW_FORCE_HOMEBREW_ON_LINUX to be set too (which is not the case
in the linuxbrew-core repo for example)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
