### PR TITLE
Add support for private registry

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -390,7 +390,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
       resolved_url, _, url_time, _, is_redirection =
         resolve_url_basename_time_file_size(url, timeout: end_time&.remaining!)
-      meta[:headers].delete_if { |header| header[0].start_with?("Authorization") } if is_redirection
+      # Authorization is no longer valid after redirects
+      meta[:headers].delete_if { |header| header.first&.start_with?("Authorization") } if is_redirection
 
       fresh = if cached_location.exist? && url_time
         url_time <= cached_location.mtime

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -566,8 +566,8 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
   def initialize(url, name, version, **meta)
     meta ||= {}
     meta[:headers] ||= []
-    token = ENV.fetch("HOMEBREW_REGISTRY_ACCESS_TOKEN", "QQ==")
-    meta[:headers] << ["Authorization: Bearer #{token}"]
+    token = Homebrew::EnvConfig.artifact_domain ? ENV.fetch("HOMEBREW_REGISTRY_ACCESS_TOKEN", "") : "QQ=="
+    meta[:headers] << ["Authorization: Bearer #{token}"] unless token.empty?
     super(url, name, version, meta)
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -449,7 +449,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     return @resolved_info_cache[url] if @resolved_info_cache.include?(url)
 
     if (domain = Homebrew::EnvConfig.artifact_domain)
-      url = url.sub(%r{^((ht|f)tps?://)?}, "#{domain.chomp("/")}/")
+      url = url.sub(%r{^((ht|f)tps?://ghcr.io/)?}, "#{domain.chomp("/")}/")
     end
 
     out, _, status= curl_output("--location", "--silent", "--head", "--request", "GET", url.to_s, timeout: timeout)
@@ -528,6 +528,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   def _curl_args
     args = []
 
+    args += ["-L"] if Homebrew::EnvConfig.artifact_domain
+
     args += ["-b", meta.fetch(:cookies).map { |k, v| "#{k}=#{v}" }.join(";")] if meta.key?(:cookies)
 
     args += ["-e", meta.fetch(:referer)] if meta.key?(:referer)
@@ -564,7 +566,8 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
   def initialize(url, name, version, **meta)
     meta ||= {}
     meta[:headers] ||= []
-    meta[:headers] << ["Authorization: Bearer QQ=="]
+    token = ENV.fetch("HOMEBREW_REGISTRY_ACCESS_TOKEN", "QQ==")
+    meta[:headers] << ["Authorization: Bearer #{token}"]
     super(url, name, version, meta)
   end
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -170,9 +170,8 @@ module Homebrew
         description: "Use this GitHub personal access token when accessing the GitHub Packages Registry "\
                      "(where bottles may be stored).",
       },
-      HOMEBREW_REGISTRY_ACCESS_TOKEN:         {
-        description: "Use this bearer token for authenticating with a private registry proxying GitHub "\
-                     "Packages Registry.",
+      HOMEBREW_DOCKER_REGISTRY_TOKEN:         {
+        description: "Use this bearer token for authenticating with a Docker registry proxying GitHub Packages.",
       },
       HOMEBREW_GITHUB_PACKAGES_USER:          {
         description: "Use this username when accessing the GitHub Packages Registry (where bottles may be stored).",

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -170,6 +170,10 @@ module Homebrew
         description: "Use this GitHub personal access token when accessing the GitHub Packages Registry "\
                      "(where bottles may be stored).",
       },
+      HOMEBREW_REGISTRY_ACCESS_TOKEN:         {
+        description: "Use this bearer token for authenticating with a private registry proxying GitHub "\
+                     "Packages Registry.",
+      },
       HOMEBREW_GITHUB_PACKAGES_USER:          {
         description: "Use this username when accessing the GitHub Packages Registry (where bottles may be stored).",
       },

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -15,7 +15,7 @@ class GitHubPackages
   URL_DOMAIN = "ghcr.io"
   URL_PREFIX = "https://#{URL_DOMAIN}/v2/"
   DOCKER_PREFIX = "docker://#{URL_DOMAIN}/"
-  private_constant :URL_DOMAIN
+  public_constant :URL_DOMAIN
   private_constant :URL_PREFIX
   private_constant :DOCKER_PREFIX
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Supersedes https://github.com/Homebrew/brew/pull/11339
Partially addresses https://github.com/Homebrew/brew/issues/11287

Allow using a private registry mirroring the common URL for blobs and bottles (https://ghcr.io/v2/homebrew/core). This feature worked before when the Homebrew packages registry was Bintray and this PR makes sure it works as before.

Usage example with Artifactory:
1. Create a remote Docker repository in Artifactory proxies https://ghcr.io. In my example, I named it `brew-remote`.
2. Populate `HOMEBREW_REGISTRY_ACCESS_TOKEN` environment variable with Artifactory access token and HOMEBREW_ARTIFACT_DOMAIN with a URL to Artifactory repository:
```
export HOMEBREW_REGISTRY_ACCESS_TOKEN=<artifactory-access-token>
export HOMEBREW_ARTIFACT_DOMAIN=http://127.0.0.1:8081/artifactory/brew-remote
```

3. Run brew install:
```
brew install jfrog-cli
```
> ==> Downloading https://ghcr.io/v2/homebrew/core/jfrog-cli/manifests/2.0.1
==> Downloading from http://127.0.0.1:8081/artifactory/brew-remote/v2/homebrew/core/jfrog-cli/manifests/2.0.1
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/jfrog-cli/blobs/sha256:484e41483de267892b3b87aceb84d5040cd66df4db4ced30de419f8e32011a84
==> Downloading from http://127.0.0.1:8081/artifactory/brew-remote/v2/homebrew/core/jfrog-cli/blobs/sha256:484e41483de267892b3b87aceb84d5040cd66df4db4ced30de419f8e32011a84
######################################################################## 100.0%
==> Pouring jfrog-cli--2.0.1.big_sur.bottle.tar.gz
==> Caveats
zsh completions have been installed to:
  /Users/yahavi/code/brew/share/zsh/site-functions
==> Summary
🍺  /Users/yahavi/code/brew/Cellar/jfrog-cli/2.0.1: 7 files, 19.2MB