### PR TITLE
repair to apply `--formula` and `--cask` options to `brew search  --desc`

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -78,7 +78,7 @@ module Homebrew
     string_or_regex = query_regexp(query)
 
     if args.desc?
-      search_descriptions(string_or_regex)
+      search_descriptions(string_or_regex, args)
     elsif args.pull_request?
       only = if args.open? && !args.closed?
         "open"

--- a/Library/Homebrew/extend/os/mac/search.rb
+++ b/Library/Homebrew/extend/os/mac/search.rb
@@ -7,10 +7,12 @@ require "cask/cask_loader"
 module Homebrew
   module Search
     module Extension
-      def search_descriptions(string_or_regex)
+      def search_descriptions(string_or_regex, args)
         super
 
         puts
+
+        return if args.formula?
 
         ohai "Casks"
         Cask::Cask.to_a.extend(Searchable)

--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -19,7 +19,9 @@ module Homebrew
       raise "#{query} is not a valid regex."
     end
 
-    def search_descriptions(string_or_regex)
+    def search_descriptions(string_or_regex, args)
+      return if args.cask?
+
       ohai "Formulae"
       CacheStoreDatabase.use(:descriptions) do |db|
         cache_store = DescriptionCacheStore.new(db)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
apply `formula` and `cask` options to `brew search --desc`, because `brew search --desc --formula` return `formula` and `cask` result.

Fixes https://github.com/Homebrew/brew/issues/11765