### PR TITLE
audit: fix brew audit for casks that require cookies

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -737,6 +737,7 @@ module Cask
 
       if cask.url && !cask.url.using
         check_url_for_https_availability(cask.url, "binary URL",
+                                         curl_args:   download.downloader.send(:_curl_args),
                                          user_agents: [cask.url.user_agent])
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The cask `adobe-acrobat-pro` requires cookies to access the download URL, which is making https://github.com/Homebrew/homebrew-cask/pull/109110 fail.