### PR TITLE
livecheck: allow nil return from strategy blocks

### DIFF
--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -52,7 +52,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -59,7 +59,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -50,7 +50,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -37,19 +37,24 @@ module Homebrew
         sig {
           params(
             content: String,
-            block:   T.nilable(T.proc.params(arg0: Hash).returns(String)),
+            block:   T.nilable(T.proc.params(arg0: T::Hash[String, T.untyped]).returns(T.nilable(String))),
           ).returns(T.nilable(String))
         }
         def self.version_from_content(content, &block)
           require "yaml"
 
-          return unless (yaml = YAML.safe_load(content))
+          yaml = YAML.safe_load(content)
+          return if yaml.blank?
 
           if block
-            value = block.call(yaml)
-            return value if value.is_a?(String)
-
-            raise TypeError, "Return value of `strategy :electron_builder` block must be a string."
+            case (value = block.call(yaml))
+            when String
+              return value
+            when nil
+              return
+            else
+              raise TypeError, "Return value of `strategy :electron_builder` block must be a string."
+            end
           end
 
           yaml["version"]
@@ -65,7 +70,7 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: Hash).returns(String)),
+            block: T.nilable(T.proc.params(arg0: T::Hash[String, T.untyped]).returns(T.nilable(String))),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -103,7 +103,7 @@ module Homebrew
             when String
               match_data[:matches][value] = Version.new(value)
             when Array
-              value.each do |tag|
+              value.compact.uniq.each do |tag|
                 match_data[:matches][tag] = Version.new(tag)
               end
             when nil

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -81,8 +81,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: T::Array[String])
-            .returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: T::Array[String]).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)
@@ -105,6 +106,8 @@ module Homebrew
               value.each do |tag|
                 match_data[:matches][tag] = Version.new(tag)
               end
+            when nil
+              return match_data
             else
               raise TypeError, "Return value of `strategy :git` block must be a string or array of strings."
             end

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -67,7 +67,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -55,7 +55,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -59,7 +59,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -52,7 +52,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -50,7 +50,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -46,7 +46,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -56,7 +56,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -62,7 +62,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -144,7 +144,7 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: Item).returns(String)),
+            block: T.nilable(T.proc.params(arg0: Item).returns(T.nilable(String))),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)
@@ -156,19 +156,20 @@ module Homebrew
           content = match_data.delete(:content)
 
           if (item = item_from_content(content))
-            match = if block
-              value = block.call(item)
-
-              unless T.unsafe(value).is_a?(String)
+            version = if block
+              case (value = block.call(item))
+              when String
+                value
+              when nil
+                return match_data
+              else
                 raise TypeError, "Return value of `strategy :sparkle` block must be a string."
               end
-
-              value
             else
               item.bundle_version&.nice_version
             end
 
-            match_data[:matches][match] = Version.new(match) if match
+            match_data[:matches][version] = Version.new(version) if version
           end
 
           match_data

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -85,7 +85,9 @@ module Homebrew
             url:   String,
             regex: T.nilable(Regexp),
             cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: String).returns(T.any(T::Array[String], String))),
+            block: T.nilable(
+              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url, regex, cask: nil, &block)

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -54,5 +54,14 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
 
       expect(version).to eq "1.2.4"
     end
+
+    it "allows a nil return from a strategy block" do
+      expect(electron_builder.version_from_content(electron_builder_yaml) { next }).to eq(nil)
+    end
+
+    it "errors on an invalid return type from a strategy block" do
+      expect { electron_builder.version_from_content(electron_builder_yaml) { 123 } }
+        .to raise_error(TypeError, "Return value of `strategy :electron_builder` block must be a string.")
+    end
   end
 end

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -72,8 +72,12 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
     end
 
     it "finds matching text in page content using a strategy block" do
-      expect(page_match.page_matches(page_content, regex) { |content| content.scan(regex).map(&:first).uniq })
+      expect(page_match.page_matches(page_content, regex) { |content, regex| content.scan(regex).map(&:first).uniq })
         .to eq(page_content_matches)
+    end
+
+    it "allows a nil return from a strategy block" do
+      expect(page_match.page_matches(page_content, regex) { next }).to eq([])
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR intends to simplify early returns in a `livecheck` block's `strategy` block. Acceptable return types differ between strategies and it's currently necessary to keep these in mind when using `next` to return early from a `strategy` block.

For example, `PageMatch` (and the strategies that use it internally) will accept a string or array of strings from a `strategy` block, so it's necessary to use something like `next ""` or `next []` when doing an early return.

A recent homebrew/cask PR got me thinking about this because it used a `HeaderMatch` `strategy` block, which can only return a string but will also accept `nil`. Handling a `nil` value means that we can use `next` (with no argument) to return early from a `strategy` block and have the strategy take care of what should happen with a `nil` value.

This behavior seems like an improvement over requiring everyone to remember acceptable return types for a given strategy when we simply want to do an early return. As such, this PR modifies all the strategies to allow for a `nil` return from a `strategy` block, so they can all use `next` for an early return without being required to supply a default value.

Existing enforcement of return types will continue to apply to non-`nil` return values. This PR tries to better align related logic across strategies, where possible. `HeaderMatch` was a notable exception and I've tried to bring that more in line with the others.

---

Past that, this also makes some related changes:

* I've modified the `Git` and `PageMatch` strategies to call `#compact` and `#uniq` on array values returned from a `strategy` block, so we don't have to duplicate this logic in every related `strategy` block. There are a handful of formulae/casks that call `#compact` in a `strategy` block before returning an array and doing this in the strategy itself will allow us to remove those calls and not have to worry about it in the future.
* I've refactored the default `HeaderMatch` logic that checks the `Content-Disposition` and `Location` headers for version information. The existing code was duplicated for each of these headers, so I restructured it to avoid the duplication and to make it easier to add additional headers to check in the future by simply updating an array. This isn't strictly related to this PR and I only added it here because I was already modifying the related code. If necessary, I can split this into a follow-up PR.