### PR TITLE
Remove HOMEBREW_BOTTLE_DOMAIN

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -38,18 +38,6 @@ module Homebrew
                      "A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).",
         boolean:     true,
       },
-      HOMEBREW_BOTTLE_DOMAIN:                 {
-        description:  "Use this URL as the download mirror for bottles. " \
-                      "If bottles at that URL are temporarily unavailable, " \
-                      "the default bottle domain will be used as a fallback mirror. " \
-                      "For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to " \
-                      "download from the prefix `http://localhost:8080/`. " \
-                      "If bottles are not available at `HOMEBREW_BOTTLE_DOMAIN` " \
-                      "they will be downloaded from the default bottle domain.",
-        default_text: "macOS: `https://ghcr.io/v2/homebrew/core`, " \
-                      "Linux: `https://ghcr.io/v2/linuxbrew/core`.",
-        default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,
-      },
       HOMEBREW_BREW_GIT_REMOTE:               {
         description: "Use this URL as the Homebrew/brew `git`(1) remote.",
         default:     HOMEBREW_BREW_DEFAULT_GIT_REMOTE,

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -8331,8 +8331,6 @@ module Homebrew::EnvConfig
 
   def self.bootsnap?(); end
 
-  def self.bottle_domain(); end
-
   def self.brew_git_remote(); end
 
   def self.browser(); end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1878,11 +1878,6 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_BOOTSNAP`
   <br>If set, use Bootsnap to speed up repeated `brew` calls. A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).
 
-- `HOMEBREW_BOTTLE_DOMAIN`
-  <br>Use this URL as the download mirror for bottles. If bottles at that URL are temporarily unavailable, the default bottle domain will be used as a fallback mirror. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to download from the prefix `http://localhost:8080/`. If bottles are not available at `HOMEBREW_BOTTLE_DOMAIN` they will be downloaded from the default bottle domain.
-
-  *Default:* macOS: `https://ghcr.io/v2/homebrew/core`, Linux: `https://ghcr.io/v2/linuxbrew/core`.
-
 - `HOMEBREW_BREW_GIT_REMOTE`
   <br>Use this URL as the Homebrew/brew `git`(1) remote.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2644,15 +2644,6 @@ Use this as the \fBbat\fR configuration file\.
 If set, use Bootsnap to speed up repeated \fBbrew\fR calls\. A no\-op when using Homebrew\'s vendored, relocatable Ruby on macOS (as it doesn\'t work)\.
 .
 .TP
-\fBHOMEBREW_BOTTLE_DOMAIN\fR
-.
-.br
-Use this URL as the download mirror for bottles\. If bottles at that URL are temporarily unavailable, the default bottle domain will be used as a fallback mirror\. For example, \fBHOMEBREW_BOTTLE_DOMAIN=http://localhost:8080\fR will cause all bottles to download from the prefix \fBhttp://localhost:8080/\fR\. If bottles are not available at \fBHOMEBREW_BOTTLE_DOMAIN\fR they will be downloaded from the default bottle domain\.
-.
-.IP
-\fIDefault:\fR macOS: \fBhttps://ghcr\.io/v2/homebrew/core\fR, Linux: \fBhttps://ghcr\.io/v2/linuxbrew/core\fR\.
-.
-.TP
 \fBHOMEBREW_BREW_GIT_REMOTE\fR
 .
 .br


### PR DESCRIPTION
It no longer works under GitHub Packages and `HOMEBREW_ARTIFACT_DOMAIN` must be used instead.

Fixes https://github.com/Homebrew/brew/issues/11209