### PR TITLE
livecheck: allow query parameter in electron_builder strategy url

### DIFF
--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -19,7 +19,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://.+/.+\.ya?ml$}i.freeze
+        URL_MATCH_REGEX = %r{^https?://.+/[^/]+\.ya?ml(?:\?[^/?]+)?$}i.freeze
 
         # Whether the strategy can be applied to the provided URL.
         #


### PR DESCRIPTION
This change allows a query parameter to be passed to a URL to a livecheck block using the `electron_builder` strategy.

This allows the livecheck in https://github.com/Homebrew/homebrew-cask/pull/109152 to return the correct version, as a query parameter of `noCache=true` or similar needs to be passed to consistently return the latest version.

There may be a better regex to allow the query parameter in the URL.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
