### PR TITLE
cmd/shellenv.sh: make `brew shellenv` idempotent

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -15,31 +15,31 @@ homebrew-shellenv() {
       echo "set -gx HOMEBREW_PREFIX \"${HOMEBREW_PREFIX}\";"
       echo "set -gx HOMEBREW_CELLAR \"${HOMEBREW_CELLAR}\";"
       echo "set -gx HOMEBREW_REPOSITORY \"${HOMEBREW_REPOSITORY}\";"
-      [[ -n "${HOMEBREW_SHELLENV_SET}" ]] && return
+      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "set -q PATH; or set PATH ''; set -gx PATH \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\" \$PATH;"
       echo "set -q MANPATH; or set MANPATH ''; set -gx MANPATH \"${HOMEBREW_PREFIX}/share/man\" \$MANPATH;"
       echo "set -q INFOPATH; or set INFOPATH ''; set -gx INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH;"
-      echo "set -gx HOMEBREW_SHELLENV_SET 1;"
+      echo "set -q HOMEBREW_SHELLENV_SET; or set HOMEBREW_SHELLENV_SET ''; set -gx HOMEBREW_SHELLENV_SET \"${HOMEBREW_PREFIX}\" \$HOMEBREW_SHELLENV_SET;"
       ;;
     csh | -csh | tcsh | -tcsh)
       echo "setenv HOMEBREW_PREFIX ${HOMEBREW_PREFIX};"
       echo "setenv HOMEBREW_CELLAR ${HOMEBREW_CELLAR};"
       echo "setenv HOMEBREW_REPOSITORY ${HOMEBREW_REPOSITORY};"
-      [[ -n "${HOMEBREW_SHELLENV_SET}" ]] && return
+      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "setenv PATH ${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:\$PATH;"
       echo "setenv MANPATH ${HOMEBREW_PREFIX}/share/man\`[ \${?MANPATH} == 1 ] && echo \":\${MANPATH}\"\`:;"
       echo "setenv INFOPATH ${HOMEBREW_PREFIX}/share/info\`[ \${?INFOPATH} == 1 ] && echo \":\${INFOPATH}\"\`;"
-      echo "setenv HOMEBREW_SHELLENV_SET 1;"
+      echo "setenv HOMEBREW_SHELLENV_SET ${HOMEBREW_PREFIX}\`[ \${?HOMEBREW_SHELLENV_SET} == 1 ] && echo \":\${HOMEBREW_SHELLENV_SET}\"\`;"
       ;;
     *)
       echo "export HOMEBREW_PREFIX=\"${HOMEBREW_PREFIX}\";"
       echo "export HOMEBREW_CELLAR=\"${HOMEBREW_CELLAR}\";"
       echo "export HOMEBREW_REPOSITORY=\"${HOMEBREW_REPOSITORY}\";"
-      [[ -n "${HOMEBREW_SHELLENV_SET}" ]] && return
+      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "export PATH=\"${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin\${PATH+:\$PATH}\";"
       echo "export MANPATH=\"${HOMEBREW_PREFIX}/share/man\${MANPATH+:\$MANPATH}:\";"
       echo "export INFOPATH=\"${HOMEBREW_PREFIX}/share/info:\${INFOPATH:-}\";"
-      echo "export HOMEBREW_SHELLENV_SET=1;"
+      echo "export HOMEBREW_SHELLENV_SET=\"${HOMEBREW_PREFIX}\${HOMEBREW_SHELLENV_SET+:\$HOMEBREW_SHELLENV_SET}\";"
       ;;
   esac
 }

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -3,6 +3,7 @@
 #:  Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 #:
 #:  The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
+#:  The variable `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
 #:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 # HOMEBREW_CELLAR and HOMEBREW_PREFIX are set by extend/ENV/super.rb
@@ -10,29 +11,35 @@
 # shellcheck disable=SC2154
 homebrew-shellenv() {
   case "$(/bin/ps -p "${PPID}" -c -o comm=)" in
-    fish|-fish)
+    fish | -fish)
       echo "set -gx HOMEBREW_PREFIX \"${HOMEBREW_PREFIX}\";"
       echo "set -gx HOMEBREW_CELLAR \"${HOMEBREW_CELLAR}\";"
       echo "set -gx HOMEBREW_REPOSITORY \"${HOMEBREW_REPOSITORY}\";"
+      [[ -n "${HOMEBREW_SHELLENV_SET}" ]] && return
       echo "set -q PATH; or set PATH ''; set -gx PATH \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\" \$PATH;"
       echo "set -q MANPATH; or set MANPATH ''; set -gx MANPATH \"${HOMEBREW_PREFIX}/share/man\" \$MANPATH;"
       echo "set -q INFOPATH; or set INFOPATH ''; set -gx INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH;"
+      echo "set -gx HOMEBREW_SHELLENV_SET 1;"
       ;;
-    csh|-csh|tcsh|-tcsh)
+    csh | -csh | tcsh | -tcsh)
       echo "setenv HOMEBREW_PREFIX ${HOMEBREW_PREFIX};"
       echo "setenv HOMEBREW_CELLAR ${HOMEBREW_CELLAR};"
       echo "setenv HOMEBREW_REPOSITORY ${HOMEBREW_REPOSITORY};"
+      [[ -n "${HOMEBREW_SHELLENV_SET}" ]] && return
       echo "setenv PATH ${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:\$PATH;"
       echo "setenv MANPATH ${HOMEBREW_PREFIX}/share/man\`[ \${?MANPATH} == 1 ] && echo \":\${MANPATH}\"\`:;"
       echo "setenv INFOPATH ${HOMEBREW_PREFIX}/share/info\`[ \${?INFOPATH} == 1 ] && echo \":\${INFOPATH}\"\`;"
+      echo "setenv HOMEBREW_SHELLENV_SET 1;"
       ;;
     *)
       echo "export HOMEBREW_PREFIX=\"${HOMEBREW_PREFIX}\";"
       echo "export HOMEBREW_CELLAR=\"${HOMEBREW_CELLAR}\";"
       echo "export HOMEBREW_REPOSITORY=\"${HOMEBREW_REPOSITORY}\";"
+      [[ -n "${HOMEBREW_SHELLENV_SET}" ]] && return
       echo "export PATH=\"${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin\${PATH+:\$PATH}\";"
       echo "export MANPATH=\"${HOMEBREW_PREFIX}/share/man\${MANPATH+:\$MANPATH}:\";"
       echo "export INFOPATH=\"${HOMEBREW_PREFIX}/share/info:\${INFOPATH:-}\";"
+      echo "export HOMEBREW_SHELLENV_SET=1;"
       ;;
   esac
 }

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -3,20 +3,23 @@
 #:  Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 #:
 #:  The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-#:  The variable `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
+#:  The variables and `HOMEBREW_SHELLENV_PREFIX` and `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
 #:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 # HOMEBREW_CELLAR and HOMEBREW_PREFIX are set by extend/ENV/super.rb
 # HOMEBREW_REPOSITORY is set by bin/brew
 # shellcheck disable=SC2154
 homebrew-shellenv() {
+  [[ "${HOMEBREW_SHELLENV_PREFIX}" == "${HOMEBREW_PREFIX}" ]] && return
+
   case "$(/bin/ps -p "${PPID}" -c -o comm=)" in
     fish | -fish)
       echo "set -gx HOMEBREW_PREFIX \"${HOMEBREW_PREFIX}\";"
       echo "set -gx HOMEBREW_CELLAR \"${HOMEBREW_CELLAR}\";"
       echo "set -gx HOMEBREW_REPOSITORY \"${HOMEBREW_REPOSITORY}\";"
-      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
+      echo "set -gx HOMEBREW_SHELLENV_PREFIX \"${HOMEBREW_PREFIX}\";"
       echo "set -q PATH; or set PATH ''; set -gx PATH \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\" \$PATH;"
+      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "set -q MANPATH; or set MANPATH ''; set -gx MANPATH \"${HOMEBREW_PREFIX}/share/man\" \$MANPATH;"
       echo "set -q INFOPATH; or set INFOPATH ''; set -gx INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH;"
       echo "set -q HOMEBREW_SHELLENV_SET; or set HOMEBREW_SHELLENV_SET ''; set -gx HOMEBREW_SHELLENV_SET \"${HOMEBREW_PREFIX}\" \$HOMEBREW_SHELLENV_SET;"
@@ -25,8 +28,9 @@ homebrew-shellenv() {
       echo "setenv HOMEBREW_PREFIX ${HOMEBREW_PREFIX};"
       echo "setenv HOMEBREW_CELLAR ${HOMEBREW_CELLAR};"
       echo "setenv HOMEBREW_REPOSITORY ${HOMEBREW_REPOSITORY};"
-      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
+      echo "setenv HOMEBREW_SHELLENV_PREFIX ${HOMEBREW_PREFIX};"
       echo "setenv PATH ${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:\$PATH;"
+      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "setenv MANPATH ${HOMEBREW_PREFIX}/share/man\`[ \${?MANPATH} == 1 ] && echo \":\${MANPATH}\"\`:;"
       echo "setenv INFOPATH ${HOMEBREW_PREFIX}/share/info\`[ \${?INFOPATH} == 1 ] && echo \":\${INFOPATH}\"\`;"
       echo "setenv HOMEBREW_SHELLENV_SET ${HOMEBREW_PREFIX}\`[ \${?HOMEBREW_SHELLENV_SET} == 1 ] && echo \":\${HOMEBREW_SHELLENV_SET}\"\`;"
@@ -35,8 +39,9 @@ homebrew-shellenv() {
       echo "export HOMEBREW_PREFIX=\"${HOMEBREW_PREFIX}\";"
       echo "export HOMEBREW_CELLAR=\"${HOMEBREW_CELLAR}\";"
       echo "export HOMEBREW_REPOSITORY=\"${HOMEBREW_REPOSITORY}\";"
-      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
+      echo "export HOMEBREW_SHELLENV_PREFIX=\"${HOMEBREW_PREFIX}\";"
       echo "export PATH=\"${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin\${PATH+:\$PATH}\";"
+      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "export MANPATH=\"${HOMEBREW_PREFIX}/share/man\${MANPATH+:\$MANPATH}:\";"
       echo "export INFOPATH=\"${HOMEBREW_PREFIX}/share/info:\${INFOPATH:-}\";"
       echo "export HOMEBREW_SHELLENV_SET=\"${HOMEBREW_PREFIX}\${HOMEBREW_SHELLENV_SET+:\$HOMEBREW_SHELLENV_SET}\";"

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -3,7 +3,7 @@
 #:  Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 #:
 #:  The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-#:  The variables and `HOMEBREW_SHELLENV_PREFIX` and `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
+#:  The variable `HOMEBREW_SHELLENV_PREFIX` will be exported to avoid adding duplicate entries to the environment variables.
 #:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 # HOMEBREW_CELLAR and HOMEBREW_PREFIX are set by extend/ENV/super.rb
@@ -19,10 +19,8 @@ homebrew-shellenv() {
       echo "set -gx HOMEBREW_REPOSITORY \"${HOMEBREW_REPOSITORY}\";"
       echo "set -gx HOMEBREW_SHELLENV_PREFIX \"${HOMEBREW_PREFIX}\";"
       echo "set -q PATH; or set PATH ''; set -gx PATH \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\" \$PATH;"
-      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "set -q MANPATH; or set MANPATH ''; set -gx MANPATH \"${HOMEBREW_PREFIX}/share/man\" \$MANPATH;"
       echo "set -q INFOPATH; or set INFOPATH ''; set -gx INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH;"
-      echo "set -q HOMEBREW_SHELLENV_SET; or set HOMEBREW_SHELLENV_SET ''; set -gx HOMEBREW_SHELLENV_SET \"${HOMEBREW_PREFIX}\" \$HOMEBREW_SHELLENV_SET;"
       ;;
     csh | -csh | tcsh | -tcsh)
       echo "setenv HOMEBREW_PREFIX ${HOMEBREW_PREFIX};"
@@ -30,10 +28,8 @@ homebrew-shellenv() {
       echo "setenv HOMEBREW_REPOSITORY ${HOMEBREW_REPOSITORY};"
       echo "setenv HOMEBREW_SHELLENV_PREFIX ${HOMEBREW_PREFIX};"
       echo "setenv PATH ${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:\$PATH;"
-      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "setenv MANPATH ${HOMEBREW_PREFIX}/share/man\`[ \${?MANPATH} == 1 ] && echo \":\${MANPATH}\"\`:;"
       echo "setenv INFOPATH ${HOMEBREW_PREFIX}/share/info\`[ \${?INFOPATH} == 1 ] && echo \":\${INFOPATH}\"\`;"
-      echo "setenv HOMEBREW_SHELLENV_SET ${HOMEBREW_PREFIX}\`[ \${?HOMEBREW_SHELLENV_SET} == 1 ] && echo \":\${HOMEBREW_SHELLENV_SET}\"\`;"
       ;;
     *)
       echo "export HOMEBREW_PREFIX=\"${HOMEBREW_PREFIX}\";"
@@ -41,10 +37,8 @@ homebrew-shellenv() {
       echo "export HOMEBREW_REPOSITORY=\"${HOMEBREW_REPOSITORY}\";"
       echo "export HOMEBREW_SHELLENV_PREFIX=\"${HOMEBREW_PREFIX}\";"
       echo "export PATH=\"${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin\${PATH+:\$PATH}\";"
-      [[ ":${HOMEBREW_SHELLENV_SET}:" == *":${HOMEBREW_PREFIX}:"* ]] && return
       echo "export MANPATH=\"${HOMEBREW_PREFIX}/share/man\${MANPATH+:\$MANPATH}:\";"
       echo "export INFOPATH=\"${HOMEBREW_PREFIX}/share/info:\${INFOPATH:-}\";"
-      echo "export HOMEBREW_SHELLENV_SET=\"${HOMEBREW_PREFIX}\${HOMEBREW_SHELLENV_SET+:\$HOMEBREW_SHELLENV_SET}\";"
       ;;
   esac
 }

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -305,9 +305,13 @@ module Homebrew
                      "useful to avoid long-running Homebrew commands being killed due to no output.",
         boolean:     true,
       },
+      HOMEBREW_SHELLENV_PREFIX:               {
+        description: "The lastest Homebrew prefix initialized by `brew shellenv`. If it is equal to " \
+                     "the current Homebrew prefix, `brew shellenv` will skip all export statements.",
+      },
       HOMEBREW_SHELLENV_SET:                  {
-        description: "A colon separated list of brew prefixes. If it is set and contains the current brew prefix, " \
-                     "`brew shellenv` skips export statements for paths.",
+        description: "A colon separated list of Homebrew prefixes. If it is set and contains the current " \
+                     "Homebrew prefix, `brew shellenv` will skip export statements for paths.",
       },
       all_proxy:                              {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -305,6 +305,10 @@ module Homebrew
                      "useful to avoid long-running Homebrew commands being killed due to no output.",
         boolean:     true,
       },
+      HOMEBREW_SHELLENV_SET:                  {
+        description: "If set, `brew shellenv` skips export statements for paths.",
+        boolean:     true,
+      },
       all_proxy:                              {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -306,8 +306,8 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_SHELLENV_SET:                  {
-        description: "If set, `brew shellenv` skips export statements for paths.",
-        boolean:     true,
+        description: "A colon separated list of brew prefixes. If it is set and contains the current brew prefix, " \
+                     "`brew shellenv` skips export statements for paths.",
       },
       all_proxy:                              {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -305,14 +305,6 @@ module Homebrew
                      "useful to avoid long-running Homebrew commands being killed due to no output.",
         boolean:     true,
       },
-      HOMEBREW_SHELLENV_PREFIX:               {
-        description: "The lastest Homebrew prefix initialized by `brew shellenv`. If it is equal to " \
-                     "the current Homebrew prefix, `brew shellenv` will skip all export statements.",
-      },
-      HOMEBREW_SHELLENV_SET:                  {
-        description: "A colon separated list of Homebrew prefixes. If it is set and contains the current " \
-                     "Homebrew prefix, `brew shellenv` will skip export statements for paths.",
-      },
       all_proxy:                              {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -565,7 +565,7 @@ The search for *`text`* is extended online to `homebrew/core` and `homebrew/cask
 Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 
 The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-The variable `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
+The variables and `HOMEBREW_SHELLENV_PREFIX` and `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
 Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 ### `tap` [*`options`*] [*`user`*`/`*`repo`*] [*`URL`*]
@@ -2088,8 +2088,11 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_VERBOSE_USING_DOTS`
   <br>If set, verbose output will print a `.` no more than once a minute. This can be useful to avoid long-running Homebrew commands being killed due to no output.
 
+- `HOMEBREW_SHELLENV_PREFIX`
+  <br>The lastest Homebrew prefix initialized by `brew shellenv`. If it is equal to the current Homebrew prefix, `brew shellenv` will skip all export statements.
+
 - `HOMEBREW_SHELLENV_SET`
-  <br>A colon separated list of brew prefixes. If it is set and contains the current brew prefix, `brew shellenv` skips export statements for paths.
+  <br>A colon separated list of Homebrew prefixes. If it is set and contains the current Homebrew prefix, `brew shellenv` will skip export statements for paths.
 
 - `all_proxy`
   <br>Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -565,6 +565,7 @@ The search for *`text`* is extended online to `homebrew/core` and `homebrew/cask
 Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 
 The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
+The variable `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
 Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 ### `tap` [*`options`*] [*`user`*`/`*`repo`*] [*`URL`*]
@@ -2086,6 +2087,9 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
 - `HOMEBREW_VERBOSE_USING_DOTS`
   <br>If set, verbose output will print a `.` no more than once a minute. This can be useful to avoid long-running Homebrew commands being killed due to no output.
+
+- `HOMEBREW_SHELLENV_SET`
+  <br>If set, `brew shellenv` skips export statements for paths.
 
 - `all_proxy`
   <br>Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2089,7 +2089,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set, verbose output will print a `.` no more than once a minute. This can be useful to avoid long-running Homebrew commands being killed due to no output.
 
 - `HOMEBREW_SHELLENV_SET`
-  <br>If set, `brew shellenv` skips export statements for paths.
+  <br>A colon separated list of brew prefixes. If it is set and contains the current brew prefix, `brew shellenv` skips export statements for paths.
 
 - `all_proxy`
   <br>Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -565,7 +565,7 @@ The search for *`text`* is extended online to `homebrew/core` and `homebrew/cask
 Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 
 The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-The variables and `HOMEBREW_SHELLENV_PREFIX` and `HOMEBREW_SHELLENV_SET` will be exported to avoid adding duplicate entries to the environment variables.
+The variable `HOMEBREW_SHELLENV_PREFIX` will be exported to avoid adding duplicate entries to the environment variables.
 Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 ### `tap` [*`options`*] [*`user`*`/`*`repo`*] [*`URL`*]
@@ -2087,12 +2087,6 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
 - `HOMEBREW_VERBOSE_USING_DOTS`
   <br>If set, verbose output will print a `.` no more than once a minute. This can be useful to avoid long-running Homebrew commands being killed due to no output.
-
-- `HOMEBREW_SHELLENV_PREFIX`
-  <br>The lastest Homebrew prefix initialized by `brew shellenv`. If it is equal to the current Homebrew prefix, `brew shellenv` will skip all export statements.
-
-- `HOMEBREW_SHELLENV_SET`
-  <br>A colon separated list of Homebrew prefixes. If it is set and contains the current Homebrew prefix, `brew shellenv` will skip export statements for paths.
 
 - `all_proxy`
   <br>Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -784,7 +784,7 @@ Search for \fItext\fR in the given database\.
 Print export statements\. When run in a shell, this installation of Homebrew will be added to your \fBPATH\fR, \fBMANPATH\fR, and \fBINFOPATH\fR\.
 .
 .P
-The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. The variable \fBHOMEBREW_SHELLENV_SET\fR will be exported to avoid adding duplicate entries to the environment variables\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
+The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. The variables and \fBHOMEBREW_SHELLENV_PREFIX\fR and \fBHOMEBREW_SHELLENV_SET\fR will be exported to avoid adding duplicate entries to the environment variables\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
 .
 .SS "\fBtap\fR [\fIoptions\fR] [\fIuser\fR\fB/\fR\fIrepo\fR] [\fIURL\fR]"
 Tap a formula repository\.
@@ -3040,10 +3040,16 @@ If set, always assume \fB\-\-debug\fR when running commands\.
 If set, verbose output will print a \fB\.\fR no more than once a minute\. This can be useful to avoid long\-running Homebrew commands being killed due to no output\.
 .
 .TP
+\fBHOMEBREW_SHELLENV_PREFIX\fR
+.
+.br
+The lastest Homebrew prefix initialized by \fBbrew shellenv\fR\. If it is equal to the current Homebrew prefix, \fBbrew shellenv\fR will skip all export statements\.
+.
+.TP
 \fBHOMEBREW_SHELLENV_SET\fR
 .
 .br
-A colon separated list of brew prefixes\. If it is set and contains the current brew prefix, \fBbrew shellenv\fR skips export statements for paths\.
+A colon separated list of Homebrew prefixes\. If it is set and contains the current Homebrew prefix, \fBbrew shellenv\fR will skip export statements for paths\.
 .
 .TP
 \fBall_proxy\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "July 2021" "Homebrew" "brew"
+.TH "BREW" "1" "August 2021" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)
@@ -3043,7 +3043,7 @@ If set, verbose output will print a \fB\.\fR no more than once a minute\. This c
 \fBHOMEBREW_SHELLENV_SET\fR
 .
 .br
-If set, \fBbrew shellenv\fR skips export statements for paths\.
+A colon separated list of brew prefixes\. If it is set and contains the current brew prefix, \fBbrew shellenv\fR skips export statements for paths\.
 .
 .TP
 \fBall_proxy\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -784,7 +784,7 @@ Search for \fItext\fR in the given database\.
 Print export statements\. When run in a shell, this installation of Homebrew will be added to your \fBPATH\fR, \fBMANPATH\fR, and \fBINFOPATH\fR\.
 .
 .P
-The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
+The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. The variable \fBHOMEBREW_SHELLENV_SET\fR will be exported to avoid adding duplicate entries to the environment variables\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
 .
 .SS "\fBtap\fR [\fIoptions\fR] [\fIuser\fR\fB/\fR\fIrepo\fR] [\fIURL\fR]"
 Tap a formula repository\.
@@ -3038,6 +3038,12 @@ If set, always assume \fB\-\-debug\fR when running commands\.
 .
 .br
 If set, verbose output will print a \fB\.\fR no more than once a minute\. This can be useful to avoid long\-running Homebrew commands being killed due to no output\.
+.
+.TP
+\fBHOMEBREW_SHELLENV_SET\fR
+.
+.br
+If set, \fBbrew shellenv\fR skips export statements for paths\.
 .
 .TP
 \fBall_proxy\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -784,7 +784,7 @@ Search for \fItext\fR in the given database\.
 Print export statements\. When run in a shell, this installation of Homebrew will be added to your \fBPATH\fR, \fBMANPATH\fR, and \fBINFOPATH\fR\.
 .
 .P
-The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. The variables and \fBHOMEBREW_SHELLENV_PREFIX\fR and \fBHOMEBREW_SHELLENV_SET\fR will be exported to avoid adding duplicate entries to the environment variables\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
+The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. The variable \fBHOMEBREW_SHELLENV_PREFIX\fR will be exported to avoid adding duplicate entries to the environment variables\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
 .
 .SS "\fBtap\fR [\fIoptions\fR] [\fIuser\fR\fB/\fR\fIrepo\fR] [\fIURL\fR]"
 Tap a formula repository\.
@@ -3038,18 +3038,6 @@ If set, always assume \fB\-\-debug\fR when running commands\.
 .
 .br
 If set, verbose output will print a \fB\.\fR no more than once a minute\. This can be useful to avoid long\-running Homebrew commands being killed due to no output\.
-.
-.TP
-\fBHOMEBREW_SHELLENV_PREFIX\fR
-.
-.br
-The lastest Homebrew prefix initialized by \fBbrew shellenv\fR\. If it is equal to the current Homebrew prefix, \fBbrew shellenv\fR will skip all export statements\.
-.
-.TP
-\fBHOMEBREW_SHELLENV_SET\fR
-.
-.br
-A colon separated list of Homebrew prefixes\. If it is set and contains the current Homebrew prefix, \fBbrew shellenv\fR will skip export statements for paths\.
 .
 .TP
 \fBall_proxy\fR


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Make `brew shellenv` idempotent. This implementation simply a new environment variable `HOMEBREW_SHELLENV_SET` to avoid duplicate initialization.

```console
$ /home/linuxbrew/.linuxbrew/bin/brew shellenv
export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew";
export HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar";
export HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew";
export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin${PATH+:$PATH}";
export MANPATH="/home/linuxbrew/.linuxbrew/share/man${MANPATH+:$MANPATH}:";
export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:${INFOPATH:-}";
export HOMEBREW_SHELLENV_SET="/home/linuxbrew/.linuxbrew${HOMEBREW_SHELLENV_SET+:$HOMEBREW_SHELLENV_SET}";

$ eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

$ /home/linuxbrew/.linuxbrew/bin/brew shellenv
export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew";
export HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar";
export HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew";
```

I make `HOMEBREW_SHELLENV_SET` a colon separated list of brew prefixes rather than a constant to handle multi-instance of brew installation.

It has several limitations, but I think it doesn't matter. For example, it can not handle file redirection (`[ ! -t 1 ]` can not work):

```console
$ eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

$ brew shellenv >> my_shell_profile

$ cat my_shell_profile
export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew";
export HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar";
export HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew";

$ HOMEBREW_SHELLENV_SET='' brew shellenv >> my_shell_profile

$ cat my_shell_profile
export HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew";
export HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar";
export HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew/Homebrew";
export PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin${PATH+:$PATH}";
export MANPATH="/home/linuxbrew/.linuxbrew/share/man${MANPATH+:$MANPATH}:";
export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:${INFOPATH:-}";
HOMEBREW_SHELLENV_SET="/home/linuxbrew/.linuxbrew${HOMEBREW_SHELLENV_SET+:$HOMEBREW_SHELLENV_SET}";
```

Resolves Homebrew/install#559.