### PR TITLE
curl: echo any cookies received on a redirect

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -33,6 +33,9 @@ module Utils
       # do not load .curlrc unless requested (must be the first argument)
       args << "--disable" unless Homebrew::EnvConfig.curlrc?
 
+      # echo any cookies received on a redirect
+      args << "--cookie-jar" << "/dev/null"
+
       args << "--globoff"
 
       args << "--show-error"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Using a browser or `wget`, opening https://www.crushftp.com/early10/CrushFTP10.zip sets some cookies and then redirects to https://www.crushftp.com/CrushFTP10.zip

Using `curl` or attempting to directly download https://www.crushftp.com/CrushFTP10.zip fails because it requires the cookies that are set by https://www.crushftp.com/early10/CrushFTP10.zip

As seen in https://github.com/Homebrew/homebrew-cask/pull/109237, these cookies can be set for `brew install` but `brew audit` still fails. This can be fixed by adding `--cookie-jar /dev/null` to the `curl` arguments, which makes the cookies persist even after a redirect.

Additionally, I've added a `retry` to `download_strategy.rb` that makes it unnecessary to set cookies in https://github.com/Homebrew/homebrew-cask/pull/109237.