### PR TITLE
.github/ISSUE_TEMPLATE/bug.yml: add instructions for mirror sites bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,7 +25,7 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
-        - label: I have unset `HOMEBREW_{BOTTLE,ARTIFACT}_DOMAIN` and `HOMEBREW_{BREW,CORE}_GIT_REMOTE` and am still able to reproduce this issue.
+        - label: I have not set `HOMEBREW_BOTTLE_DOMAIN`, `HOMEBREW_ARTIFACT_DOMAIN`, `HOMEBREW_BREW_GIT_REMOTE`, or `HOMEBREW_CORE_GIT_REMOTE`  and am still able to reproduce this issue.
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,6 +11,9 @@ body:
       label: "`brew config` output"
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: If you are using `HOMEBREW_BOTTLE_DOMAIN` or `HOMEBREW_ARTIFACT_DOMAIN` to configure Homebrew mirrors, please first try unsetting those variables. If this bug is related to mirror sites themselves, please report the bug to the respective mirror sites. See https://github.com/Homebrew/discussions/discussions/1917 for more information.
   - type: textarea
     attributes:
       render: shell

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,9 +11,6 @@ body:
       label: "`brew config` output"
     validations:
       required: true
-  - type: markdown
-    attributes:
-      value: If you are using `HOMEBREW_BOTTLE_DOMAIN` or `HOMEBREW_ARTIFACT_DOMAIN` to configure Homebrew mirrors, please first try unsetting those variables. If this bug is related to mirror sites themselves, please report the bug to the respective mirror sites. See https://github.com/Homebrew/discussions/discussions/1917 for more information.
   - type: textarea
     attributes:
       render: shell
@@ -28,6 +25,11 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
+        - label: I have unset `HOMEBREW_{BOTTLE,ARTIFACT}_DOMAIN` and `HOMEBREW_{BREW,CORE}_GIT_REMOTE` to use official upstreams when reporting this bug.
+          required: true
+  - type: markdown
+    attributes:
+      value: If this bug is related to mirror sites, please refer to https://github.com/Homebrew/discussions/discussions/1917 for more information, and report bugs to respective mirror maintainers.
   - type: textarea
     attributes:
       label: What were you trying to do (and why)?

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,7 +25,7 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
-        - label: I have not set `HOMEBREW_BOTTLE_DOMAIN`, `HOMEBREW_ARTIFACT_DOMAIN`, `HOMEBREW_BREW_GIT_REMOTE`, or `HOMEBREW_CORE_GIT_REMOTE`  and am still able to reproduce this issue.
+        - label: I have not set `HOMEBREW_BOTTLE_DOMAIN`, `HOMEBREW_ARTIFACT_DOMAIN`, `HOMEBREW_BREW_GIT_REMOTE`, or `HOMEBREW_CORE_GIT_REMOTE` and am still able to reproduce this issue.
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,7 +25,7 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
-        - label: I have unset `HOMEBREW_{BOTTLE,ARTIFACT}_DOMAIN` and `HOMEBREW_{BREW,CORE}_GIT_REMOTE` to use official upstreams when reporting this bug.
+        - label: I have unset `HOMEBREW_{BOTTLE,ARTIFACT}_DOMAIN` and `HOMEBREW_{BREW,CORE}_GIT_REMOTE` and am still able to reproduce this issue.
           required: true
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -29,7 +29,7 @@ body:
           required: true
   - type: markdown
     attributes:
-      value: If this bug is related to mirror sites, please refer to https://github.com/Homebrew/discussions/discussions/1917 for more information, and report bugs to respective mirror maintainers.
+      value: If this bug is related to mirror sites, please refer to [this disucssion](https://github.com/Homebrew/discussions/discussions/1917) for more information, and report bugs to respective mirror maintainers.
   - type: textarea
     attributes:
       label: What were you trying to do (and why)?

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,11 +25,6 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
-        - label: I have not set `HOMEBREW_BOTTLE_DOMAIN`, `HOMEBREW_ARTIFACT_DOMAIN`, `HOMEBREW_BREW_GIT_REMOTE`, or `HOMEBREW_CORE_GIT_REMOTE` and am still able to reproduce this issue.
-          required: true
-  - type: markdown
-    attributes:
-      value: If this bug is related to mirror sites, please refer to [this disucssion](https://github.com/Homebrew/discussions/discussions/1917) for more information, and report bugs to respective mirror maintainers.
   - type: textarea
     attributes:
       label: What were you trying to do (and why)?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,3 +13,6 @@ contact_links:
   - name: New issue on Homebrew/linuxbrew-core
     url: https://github.com/Homebrew/linuxbrew-core/issues/new/choose
     about: On Linux? Having a `brew` problem with a `brew install` or `brew upgrade` of a single formula/package? Report it to Homebrew/linuxbrew-core (the Linux core tap/repository).
+  - name: Get help from Homebrew mirror maintainers
+    url: https://github.com/Homebrew/discussions/discussions/1917
+    about: Slow download speed? Homebrew mirror not working as expected? Please take a look at the mirror list and contact respective mirror maintainers.


### PR DESCRIPTION
… reporting

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] (Not applicable) Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Regarding previous discussions on mirror sites https://github.com/Homebrew/discussions/discussions/1906, we have created a discussion https://github.com/Homebrew/discussions/discussions/1917 for mirror maintainers to update mirror information. And then, in this PR, we modified the issue templates to remind our users to see if the issue is related to the mirror sites. Now users could post issues to the best-fit place when they find Homebrew mirrors are not working.

cc @MikeMcQuaid for review, thanks!