### PR TITLE
brew.rb: solve `NameError` of `brew prof --stackprof`

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -51,8 +51,14 @@ module Homebrew
   end
 
   def setup_gem_environment!(gem_home: nil, gem_bindir: nil, setup_path: true)
+    # When `HOMEBREW_STACKPROF` is set, this method is called before `HOMEBREW_LIBRARY_PATH` is defined
+    library_path = if ENV["HOMEBREW_STACKPROF"]
+      "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
+    else
+      HOMEBREW_LIBRARY_PATH
+    end
     # Match where our bundler gems are.
-    gem_home ||= "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
+    gem_home ||= "#{library_path}/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
     Gem.paths = {
       "GEM_HOME" => gem_home,
       "GEM_PATH" => gem_home,

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -51,10 +51,10 @@ module Homebrew
   end
 
   def setup_gem_environment!(gem_home: nil, gem_bindir: nil, setup_path: true)
-    library_path = if !ENV["HOMEBREW_LIBRARY"].to_s.empty?
-      "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
-    else
+    library_path = if ENV["HOMEBREW_LIBRARY"].to_s.empty?
       HOMEBREW_LIBRARY_PATH
+    else
+      "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
     end
     # Match where our bundler gems are.
     gem_home ||= "#{library_path}/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -51,7 +51,7 @@ module Homebrew
   end
 
   def setup_gem_environment!(gem_home: nil, gem_bindir: nil, setup_path: true)
-    library_path = if ENV["HOMEBREW_LIBRARY"].present?
+    library_path = if !ENV["HOMEBREW_LIBRARY"].to_s.empty?
       "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
     else
       HOMEBREW_LIBRARY_PATH

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -51,12 +51,9 @@ module Homebrew
   end
 
   def setup_gem_environment!(gem_home: nil, gem_bindir: nil, setup_path: true)
-    # When `HOMEBREW_STACKPROF` is set, this method is called before `HOMEBREW_LIBRARY_PATH` is defined
-    library_path = if ENV["HOMEBREW_STACKPROF"]
-      "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
-    else
-      HOMEBREW_LIBRARY_PATH
-    end
+    raise "HOMEBREW_LIBRARY was not exported!" unless ENV["HOMEBREW_LIBRARY"]
+
+    library_path = "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
     # Match where our bundler gems are.
     gem_home ||= "#{library_path}/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
     Gem.paths = {

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -51,9 +51,11 @@ module Homebrew
   end
 
   def setup_gem_environment!(gem_home: nil, gem_bindir: nil, setup_path: true)
-    raise "HOMEBREW_LIBRARY was not exported!" unless ENV["HOMEBREW_LIBRARY"]
-
-    library_path = "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
+    library_path = if ENV["HOMEBREW_LIBRARY"].present?
+      "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"
+    else
+      HOMEBREW_LIBRARY_PATH
+    end
     # Match where our bundler gems are.
     gem_home ||= "#{library_path}/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
     Gem.paths = {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`brew prof info  -v  -d --stackprof` causes `NameError` of `HOMEBREW_LIBRARY_PATH`
 because in the case of `brew.rb info`, `HOMEBREW_LIBRARY_PATH`  is not the environment variable but the `Homebrew` module constant.

```bash
brew prof info  -v  -d --stackprof
/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby /usr/local/Homebrew/Library/Homebrew/brew.rb info
Traceback (most recent call last):
	1: from /usr/local/Homebrew/Library/Homebrew/brew.rb:6:in `<main>'
/usr/local/Homebrew/Library/Homebrew/utils/gems.rb:55:in `setup_gem_environment!': uninitialized constant Homebrew::HOMEBREW_LIBRARY_PATH (NameError)
Did you mean?  Homebrew::HOMEBREW_BUNDLER_VERSION
stackprof --d3-flamegraph prof/stackprof.dump > prof/d3-flamegraph.html
/usr/bin/open prof/d3-flamegraph.html
```