### PR TITLE
GitHubPackages: fix dry_run with keep_old

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -263,7 +263,9 @@ class GitHubPackages
     root.mkpath
 
     if keep_old
-      download(user, token, skopeo, image_uri, root, dry_run: dry_run)
+      # Always pass false to dry_run because we'll need this metadata
+      # for later parts of the keep_old workflow to succeed.
+      download(user, token, skopeo, image_uri, root, dry_run: false)
     else
       write_image_layout(root)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

These two options aren't being treated as mutually exclusive, but they de facto are. For `keep_old` to work, it needs a copy of the metadata fetched by this call to `download`. If we pass along the `dry_run` status to it, we won't fetch the metadata and a later call within the `if keep_old` block that begins on line 294 will fail because it tries to read the JSON metadata file we didn't actually fetch.

My understanding is that fetching the metadata here is safe. For that reason, I think it's better for us to always read here even when performing a dry run in order to ensure it's possible to do a dry run of the `keep_old` workflow. 