### PR TITLE
edit: enable Sublime Text project view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,5 +194,7 @@
 # Unignore tests' bundle config
 !/Library/Homebrew/test/.bundle/config
 
-# Unignore vscode configuration
+# Unignore editor configuration
+!/.sublime
+/.sublime/homebrew.sublime-workspace
 !/.vscode

--- a/.sublime/homebrew.sublime-project
+++ b/.sublime/homebrew.sublime-project
@@ -1,0 +1,28 @@
+{
+	"folders":
+	[
+		{
+			"//": "Generated based on the contents of our .gitignore",
+			"path": "..",
+			"folder_exclude_patterns": [
+				"Caskroom",
+				"Cellar",
+				"Frameworks",
+				"bin",
+				"etc",
+				"include",
+				"lib",
+				"opt",
+				"sbin",
+				"share",
+				"var",
+				"Library/Homebrew/LinkedKegs",
+				"Library/Homebrew/Aliases"
+			],
+			"follow_symlinks": true
+		}
+	],
+    "settings": {
+        "tab_size": 2
+    }
+}

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -40,16 +40,24 @@ module Homebrew
       EOS
     end
 
-    paths = args.named.to_paths.select do |path|
-      next path if path.exist?
+    paths = if args.named.empty?
+      # Sublime requires opting into the project editing path,
+      # as opposed to VS Code which will infer from the .vscode path
+      if which_editor == "subl"
+        ["--project", "#{HOMEBREW_REPOSITORY}/.sublime/homebrew.sublime-project"]
+      else
+        # If no formulae are listed, open the project root in an editor.
+        [HOMEBREW_REPOSITORY]
+      end
+    else
+      args.named.to_paths.select do |path|
+        next path if path.exist?
 
-      raise UsageError, "#{path} doesn't exist on disk. " \
-                        "Run #{Formatter.identifier("brew create --set-name #{path.basename} $URL")} " \
-                        "to create a new formula!"
-    end.presence
-
-    # If no formulae are listed, open the project root in an editor.
-    paths ||= [HOMEBREW_REPOSITORY]
+        raise UsageError, "#{path} doesn't exist on disk. " \
+                          "Run #{Formatter.identifier("brew create --set-name #{path.basename} $URL")} " \
+                          "to create a new formula!"
+      end.presence
+    end
 
     exec_editor(*paths)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Code very similar to this was removed in c6b6fc678e66668b08d31e7a55950768e0e4d687 because we had, at the time, moved away from the model where the Homebrew prefix was the repository. Now that we've actually moved back to that model, we've re-inherited exactly the same problems that inspired the original code.

In place of the original code, which specified the list of files to open in `cmd/edit`, this PR adds a Sublime Text project file and opens that with `brew edit` instead. That limits the code changes significantly, with the majority of the diff being indent-related. I've left a comment at the top of the Sublime project file to indicate how it was authored.

A similar PR to this was previously open in #10710. This version addresses Mike's comments in the original version.