### PR TITLE
release_notes: use `safe_popen_read`.

### DIFF
--- a/Library/Homebrew/release_notes.rb
+++ b/Library/Homebrew/release_notes.rb
@@ -14,7 +14,7 @@ module ReleaseNotes
       .returns(String)
   }
   def generate_release_notes(start_ref, end_ref, markdown: false)
-    Utils.popen_read(
+    Utils.safe_popen_read(
       "git", "-C", HOMEBREW_REPOSITORY, "log", "--pretty=format:'%s >> - %b%n'", "#{start_ref}..#{end_ref}"
     ).lines.map do |s|
       matches = s.match(%r{.*Merge pull request #(?<pr>\d+) from (?<user>[^/]+)/[^>]*>> - (?<body>.*)})


### PR DESCRIPTION
Otherwise if `git log` fails (e.g. due to missing `origin/HEAD` in my case) then it will generate a release with empty release notes.