### PR TITLE
Dockerfile: run as user: linuxbrew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,11 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && localedef -i en_US -f UTF-8 en_US.UTF-8 \
   && useradd -m -s /bin/bash linuxbrew \
-  && echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+  && echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
+  && su - linuxbrew -c 'mkdir ~/.linuxbrew'
 
-COPY . /home/linuxbrew/.linuxbrew/Homebrew
+USER linuxbrew
+COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 WORKDIR /home/linuxbrew
 


### PR DESCRIPTION
```
Dockerfile: run as user: linuxbrew

This commit refactors the Dockerfile in order to resolve build errors
caused by attempting to execute `brew` commands as the root user. We
need to create the `/home/linuxbrew/.linuxbrew` folder prior to copying
the local directory into `/home/linuxbrew/.linuxbrew/Homebrew` (and
ensure the appropriate user owns it), as failing to do so will create
`/home/linuxbrew/.linuxbrew` with root user and group ownership, causing
the subsequent `mkdir` command called in the second `RUN` instruction to
fail.

closes #11802
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

There are additional improvements that the container image could still benefit from, namely:

* **Avoiding cloning `homebrew/homebrew-core` via `git`**. This causes the build to hang for some time (on the order of several minutes; I haven't timed it precisely). We could instead bring these source files in via an `ADD` instruction, pulling an archive from GitHub directly.
* **Reducing the image size**. The current image exceeds 1GiB in size. This is... huge. Drawbacks to an image as large as this include slower network transport (of the image, to/from registries), higher disk consumption, and higher CPU and memory requirements to run. This can be done by utilizing a smaller base image, and/or multi-stage builds, as well as performing optimization of the final image contents, ensuring that any unecessary artifacts are removed.
* **Improve the user experience**. Currently, users are required to type a command similar to `docker run --rm -v "$(pwd):/home/linuxbrew/.linuxbrew" homebrew/brew brew <command>`. This is a bit verbose, and also isn't ideal, as paths in `PWD` that are mounted into the container can overwrite preexisting paths within the container, and as with this repository (when running `brew {style,typecheck,tests}`), can potentially lead to lengthy runtimes due to re-fetching of the dependencies.

I will plan to submit PRs for the above recommendations over the next few weeks. I'd like to get it done sooner, but time constraints and my unfamiliarity with the internal architecture of `brew` will likely lead to me not being able to iterate on this right away.