### PR TITLE
Dockerfile: remove extraneous permission modification commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,4 @@ RUN cd /home/linuxbrew/.linuxbrew \
   && brew cleanup \
   && { git -C /home/linuxbrew/.linuxbrew/Homebrew config --unset gc.auto; true; } \
   && { git -C /home/linuxbrew/.linuxbrew/Homebrew config --unset homebrew.devcmdrun; true; } \
-  && rm -rf ~/.cache \
-  && chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
-  && chmod -R g+w,o-w /home/linuxbrew/.linuxbrew
+  && rm -rf ~/.cache


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

```
Dockerfile: remove extraneous permission modification commands

These are no longer necessary due to the fact that the second `RUN`
instruction runs as the `linuxbrew` user (as of commit
77afe94446e78e688ebde7a5e2b1249fc0a4afcd).
```

-----

# THIS PR DEPENDS ON ~#11815~. DO NOT MERGE UNTIL IT IS MARKED READY