### PR TITLE
Dockerfile: use relative paths when in the /home/linuxbrew directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,15 +37,22 @@ COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
 WORKDIR /home/linuxbrew
 
-# hadolint ignore=DL3003
-RUN cd /home/linuxbrew/.linuxbrew \
-  && mkdir -p bin etc include lib opt sbin share var/homebrew/linked Cellar \
-  && ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/ \
-  && git -C /home/linuxbrew/.linuxbrew/Homebrew remote set-url origin https://github.com/Homebrew/brew \
-  && git -C /home/linuxbrew/.linuxbrew/Homebrew fetch origin \
+RUN mkdir -p \
+     .linuxbrew/bin \
+     .linuxbrew/etc \
+     .linuxbrew/include \
+     .linuxbrew/lib \
+     .linuxbrew/opt \
+     .linuxbrew/sbin \
+     .linuxbrew/share \
+     .linuxbrew/var/homebrew/linked \
+     .linuxbrew/Cellar \
+  && ln -s ../Homebrew/bin/brew .linuxbrew/bin/brew \
+  && git -C .linuxbrew/Homebrew remote set-url origin https://github.com/Homebrew/brew \
+  && git -C .linuxbrew/Homebrew fetch origin \
   && HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
   && brew install-bundler-gems \
   && brew cleanup \
-  && { git -C /home/linuxbrew/.linuxbrew/Homebrew config --unset gc.auto; true; } \
-  && { git -C /home/linuxbrew/.linuxbrew/Homebrew config --unset homebrew.devcmdrun; true; } \
-  && rm -rf ~/.cache
+  && { git -C .linuxbrew/Homebrew config --unset gc.auto; true; } \
+  && { git -C .linuxbrew/Homebrew config --unset homebrew.devcmdrun; true; } \
+  && rm -rf .cache


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

```
Dockerfile: use relative paths when in the /home/linuxbrew directory

Because the `WORKDIR` instruction specifies the home directory of the
`linuxbrew` user, there is no need to use absolute paths to reference
paths within the home directory, nor is there a need to call `cd` (this
is actually an anti-pattern [0]) to move into a subdirectory before
creating folders.

[0]: https://github.com/hadolint/hadolint/wiki/DL3003
```

-----

# THIS PR DEPENDS ON ~#11815~ AND ~#11818~ . DO NOT MERGE UNTIL IT IS MARKED READY