### PR TITLE
Fix brew outdated --cask --json --greedy

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -150,8 +150,7 @@ module Homebrew
       else
         c = formula_or_cask
 
-        c.outdated_info(args.greedy?, verbose?, true, greedy_latest:       args.greedy_latest?,
-                                                      greedy_auto_updates: args.greedy_auto_updates?)
+        c.outdated_info(args.greedy?, verbose?, true, args.greedy_latest?, args.greedy_auto_updates?)
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix this:
```console
$ sw_vers
ProductName:	macOS
ProductVersion:	11.5
BuildVersion:	20G71
$ brew outdated --cask --json --greedy
Error: wrong number of arguments (given 4, expected 5)
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/cask/cask.rb:143:in `outdated_info'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:153:in `block in json_info'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:134:in `map'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:134:in `json_info'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:72:in `outdated'
/usr/local/Homebrew/Library/Homebrew/brew.rb:131:in `<main>'
```