### PR TITLE
Allow anonymous access in private registries

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -568,8 +568,7 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
   def initialize(url, name, version, **meta)
     meta ||= {}
     meta[:headers] ||= []
-    token = Homebrew::EnvConfig.docker_registry_token
-    token ||= "QQ=="
+    token = Homebrew::EnvConfig.artifact_domain ? Homebrew::EnvConfig.docker_registry_token : "QQ=="
     meta[:headers] << ["Authorization: Bearer #{token}"] if token.present?
     super(url, name, version, meta)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Followup https://github.com/Homebrew/brew/pull/11766

Currently when `HOMEBREW_ARTIFACT_DOMAIN` is configured and `HOMEBREW_DOCKER_REGISTRY_TOKEN` is not, a default `QQ==` access token is used to authenticate with private registries.
This PR change this behavior: If `HOMEBREW_ARTIFACT_DOMAIN` is configured, always use the token configured in `HOMEBREW_DOCKER_REGISTRY_TOKEN`, even if empty.