### PR TITLE
`resolve_latest_keg` should return the latest HEAD keg when no stable kegs exist

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -324,7 +324,11 @@ module Homebrew
         # Return keg if it is the only installed keg
         return kegs if kegs.length == 1
 
-        kegs.reject { |k| k.version.head? }.max_by(&:version)
+        eligible_kegs = kegs.reject { |k| k.version.head? }
+        # Use HEAD kegs if there are no stable kegs
+        eligible_kegs = kegs if eligible_kegs.blank?
+
+        eligible_kegs.max_by(&:version)
       end
 
       def resolve_default_keg(name)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -324,11 +324,11 @@ module Homebrew
         # Return keg if it is the only installed keg
         return kegs if kegs.length == 1
 
-        eligible_kegs = kegs.reject { |k| k.version.head? }
-        # Use HEAD kegs if there are no stable kegs
-        eligible_kegs = kegs if eligible_kegs.blank?
+        stable_kegs = kegs.reject { |k| k.version.head? }
 
-        eligible_kegs.max_by(&:version)
+        return kegs.max_by { |keg| Tab.for_keg(keg).source_modified_time } if stable_kegs.blank?
+
+        stable_kegs.max_by(&:version)
       end
 
       def resolve_default_keg(name)

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -223,12 +223,14 @@ describe Homebrew::CLI::NamedArgs do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath
       (HOMEBREW_CELLAR/"foo/2.0").mkpath
       (HOMEBREW_CELLAR/"bar/1.0").mkpath
+      (HOMEBREW_CELLAR/"baz/HEAD-1").mkpath
+      (HOMEBREW_CELLAR/"baz/HEAD-2").mkpath
     end
 
     it "resolves the latest kegs with #resolve_latest_keg" do
-      latest_kegs = described_class.new("foo", "bar").to_latest_kegs
-      expect(latest_kegs.map(&:name)).to eq ["foo", "bar"]
-      expect(latest_kegs.map { |k| k.version.version.to_s }).to eq ["2.0", "1.0"]
+      latest_kegs = described_class.new("foo", "bar", "baz").to_latest_kegs
+      expect(latest_kegs.map(&:name)).to eq ["foo", "bar", "baz"]
+      expect(latest_kegs.map { |k| k.version.version.to_s }).to eq ["2.0", "1.0", "HEAD-1"]
     end
 
     it "when there are no matching kegs returns an empty array" do

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -223,14 +223,16 @@ describe Homebrew::CLI::NamedArgs do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath
       (HOMEBREW_CELLAR/"foo/2.0").mkpath
       (HOMEBREW_CELLAR/"bar/1.0").mkpath
-      (HOMEBREW_CELLAR/"baz/HEAD-1").mkpath
-      (HOMEBREW_CELLAR/"baz/HEAD-2").mkpath
+      head1 = (HOMEBREW_CELLAR/"baz/HEAD-1").mkpath
+      head2 = HOMEBREW_CELLAR/"baz/HEAD-2"
+      head2.mkpath
+      (head2/"INSTALL_RECEIPT.json").write (TEST_FIXTURE_DIR/"receipt.json").read
     end
 
     it "resolves the latest kegs with #resolve_latest_keg" do
       latest_kegs = described_class.new("foo", "bar", "baz").to_latest_kegs
       expect(latest_kegs.map(&:name)).to eq ["foo", "bar", "baz"]
-      expect(latest_kegs.map { |k| k.version.version.to_s }).to eq ["2.0", "1.0", "HEAD-1"]
+      expect(latest_kegs.map { |k| k.version.version.to_s }).to eq ["2.0", "1.0", "HEAD-2"]
     end
 
     it "when there are no matching kegs returns an empty array" do

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -223,7 +223,7 @@ describe Homebrew::CLI::NamedArgs do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath
       (HOMEBREW_CELLAR/"foo/2.0").mkpath
       (HOMEBREW_CELLAR/"bar/1.0").mkpath
-      head1 = (HOMEBREW_CELLAR/"baz/HEAD-1").mkpath
+      (HOMEBREW_CELLAR/"baz/HEAD-1").mkpath
       head2 = HOMEBREW_CELLAR/"baz/HEAD-2"
       head2.mkpath
       (head2/"INSTALL_RECEIPT.json").write (TEST_FIXTURE_DIR/"receipt.json").read

--- a/Library/Homebrew/test/support/fixtures/receipt.json
+++ b/Library/Homebrew/test/support/fixtures/receipt.json
@@ -15,6 +15,7 @@
     "bin/foo"
   ],
   "time": 1403827774,
+  "source_modified_time": 1628303333,
   "HEAD": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
   "alias_path": "/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/test-formula",
   "stdlib": "libcxx",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Closes #11741.

Currently, `resolve_latest_keg` has the following behavior:
- If only one keg exists (HEAD or stable), return that keg.
- Otherwise, return the latest stable keg.

This behavior doesn't handle the case where there are multiple HEAD kegs, but no stable kegs. This PR adds the following behavior to `resolve_latest_keg`:
- If there are HEAD kegs but no stable kegs, return the latest HEAD keg.