### PR TITLE
New allow list: mismatched_binary_allowlist

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -338,9 +338,12 @@ module FormulaCellarChecks
     end
     return if mismatches.empty? && universal_binaries_expected
 
+    mismatches_expected = formula.tap.blank? || tap_audit_exception(:mismatched_binary_allowlist, formula.name)
+    return if compatible_universal_binaries.empty? && mismatches_expected
+
     s = ""
 
-    if mismatches.present?
+    if mismatches.present? && !mismatches_expected
       s += <<~EOS
         Binaries built for a non-native architecture were installed into #{formula}'s prefix.
         The offending files are:


### PR DESCRIPTION
This is needed by [Lima](https://github.com/Homebrew/homebrew-core/pull/82723), which installs non-native binaries for supporting ARM-on-Intel / Intel-on-ARM emulation.

See https://github.com/Homebrew/homebrew-core/pull/82723#issuecomment-893232417


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
