### PR TITLE
api: fix generic api path functions

### DIFF
--- a/Library/Homebrew/api/analytics.rb
+++ b/Library/Homebrew/api/analytics.rb
@@ -7,19 +7,19 @@ module Homebrew
     #
     # @api private
     module Analytics
-      extend T::Sig
+      class << self
+        extend T::Sig
 
-      module_function
+        sig { returns(String) }
+        def analytics_api_path
+          "analytics"
+        end
+        alias generic_analytics_api_path analytics_api_path
 
-      sig { returns(String) }
-      def analytics_api_path
-        "analytics"
-      end
-      alias generic_analytics_api_path analytics_api_path
-
-      sig { params(category: String, days: T.any(Integer, String)).returns(Hash) }
-      def fetch(category, days)
-        Homebrew::API.fetch "#{analytics_api_path}/#{category}/#{days}d.json"
+        sig { params(category: String, days: T.any(Integer, String)).returns(Hash) }
+        def fetch(category, days)
+          Homebrew::API.fetch "#{analytics_api_path}/#{category}/#{days}d.json"
+        end
       end
     end
   end

--- a/Library/Homebrew/api/bottle.rb
+++ b/Library/Homebrew/api/bottle.rb
@@ -9,84 +9,84 @@ module Homebrew
     #
     # @api private
     module Bottle
-      extend T::Sig
+      class << self
+        extend T::Sig
 
-      module_function
+        sig { returns(String) }
+        def bottle_api_path
+          "bottle"
+        end
+        alias generic_bottle_api_path bottle_api_path
 
-      sig { returns(String) }
-      def bottle_api_path
-        "bottle"
-      end
-      alias generic_bottle_api_path bottle_api_path
+        GITHUB_PACKAGES_SHA256_REGEX = %r{#{GitHubPackages::URL_REGEX}.*/blobs/sha256:(?<sha256>\h{64})$}.freeze
 
-      GITHUB_PACKAGES_SHA256_REGEX = %r{#{GitHubPackages::URL_REGEX}.*/blobs/sha256:(?<sha256>\h{64})$}.freeze
-
-      sig { params(name: String).returns(Hash) }
-      def fetch(name)
-        Homebrew::API.fetch "#{bottle_api_path}/#{name}.json"
-      end
-
-      sig { params(name: String).returns(T::Boolean) }
-      def available?(name)
-        fetch name
-        true
-      rescue ArgumentError
-        false
-      end
-
-      sig { params(name: String).void }
-      def fetch_bottles(name)
-        hash = fetch(name)
-        bottle_tag = Utils::Bottles.tag.to_s
-
-        if !hash["bottles"].key?(bottle_tag) && !hash["bottles"].key?("all")
-          odie "No bottle available for #{name} on the current OS"
+        sig { params(name: String).returns(Hash) }
+        def fetch(name)
+          Homebrew::API.fetch "#{bottle_api_path}/#{name}.json"
         end
 
-        download_bottle(hash, bottle_tag)
+        sig { params(name: String).returns(T::Boolean) }
+        def available?(name)
+          fetch name
+          true
+        rescue ArgumentError
+          false
+        end
 
-        hash["dependencies"].each do |dep_hash|
-          existing_formula = begin
-            Formulary.factory dep_hash["name"]
-          rescue FormulaUnavailableError
-            # The formula might not exist if it's not installed and homebrew/core isn't tapped
-            nil
+        sig { params(name: String).void }
+        def fetch_bottles(name)
+          hash = fetch(name)
+          bottle_tag = Utils::Bottles.tag.to_s
+
+          if !hash["bottles"].key?(bottle_tag) && !hash["bottles"].key?("all")
+            odie "No bottle available for #{name} on the current OS"
           end
 
-          next if existing_formula.present? && existing_formula.latest_version_installed?
+          download_bottle(hash, bottle_tag)
 
-          download_bottle(dep_hash, bottle_tag)
+          hash["dependencies"].each do |dep_hash|
+            existing_formula = begin
+              Formulary.factory dep_hash["name"]
+            rescue FormulaUnavailableError
+              # The formula might not exist if it's not installed and homebrew/core isn't tapped
+              nil
+            end
+
+            next if existing_formula.present? && existing_formula.latest_version_installed?
+
+            download_bottle(dep_hash, bottle_tag)
+          end
         end
-      end
 
-      sig { params(url: String).returns(T.nilable(String)) }
-      def checksum_from_url(url)
-        match = url.match GITHUB_PACKAGES_SHA256_REGEX
-        return if match.blank?
+        sig { params(url: String).returns(T.nilable(String)) }
+        def checksum_from_url(url)
+          match = url.match GITHUB_PACKAGES_SHA256_REGEX
+          return if match.blank?
 
-        match[:sha256]
-      end
+          match[:sha256]
+        end
 
-      sig { params(hash: Hash, tag: Symbol).void }
-      def download_bottle(hash, tag)
-        bottle = hash["bottles"][tag]
-        bottle ||= hash["bottles"]["all"]
-        return if bottle.blank?
+        sig { params(hash: Hash, tag: Symbol).void }
+        def download_bottle(hash, tag)
+          bottle = hash["bottles"][tag]
+          bottle ||= hash["bottles"]["all"]
+          return if bottle.blank?
 
-        sha256 = bottle["sha256"] || checksum_from_url(bottle["url"])
-        bottle_filename = ::Bottle::Filename.new(hash["name"], hash["pkg_version"], tag, hash["rebuild"])
+          sha256 = bottle["sha256"] || checksum_from_url(bottle["url"])
+          bottle_filename = ::Bottle::Filename.new(hash["name"], hash["pkg_version"], tag, hash["rebuild"])
 
-        resource = Resource.new hash["name"]
-        resource.url bottle["url"]
-        resource.sha256 sha256
-        resource.version hash["pkg_version"]
-        resource.downloader.resolved_basename = bottle_filename
+          resource = Resource.new hash["name"]
+          resource.url bottle["url"]
+          resource.sha256 sha256
+          resource.version hash["pkg_version"]
+          resource.downloader.resolved_basename = bottle_filename
 
-        resource.fetch
+          resource.fetch
 
-        # Map the name of this formula to the local bottle path to allow the
-        # formula to be loaded by passing just the name to `Formulary::factory`.
-        Formulary.map_formula_name_to_local_bottle_path hash["name"], resource.downloader.cached_location
+          # Map the name of this formula to the local bottle path to allow the
+          # formula to be loaded by passing just the name to `Formulary::factory`.
+          Formulary.map_formula_name_to_local_bottle_path hash["name"], resource.downloader.cached_location
+        end
       end
     end
   end

--- a/Library/Homebrew/api/bottle.rb
+++ b/Library/Homebrew/api/bottle.rb
@@ -66,7 +66,7 @@ module Homebrew
           match[:sha256]
         end
 
-        sig { params(hash: Hash, tag: Symbol).void }
+        sig { params(hash: Hash, tag: String).void }
         def download_bottle(hash, tag)
           bottle = hash["bottles"][tag]
           bottle ||= hash["bottles"]["all"]

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -7,13 +7,13 @@ module Homebrew
     #
     # @api private
     module Cask
-      extend T::Sig
+      class << self
+        extend T::Sig
 
-      module_function
-
-      sig { params(name: String).returns(Hash) }
-      def fetch(name)
-        Homebrew::API.fetch "cask/#{name}.json"
+        sig { params(name: String).returns(Hash) }
+        def fetch(name)
+          Homebrew::API.fetch "cask/#{name}.json"
+        end
       end
     end
   end

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -7,19 +7,19 @@ module Homebrew
     #
     # @api private
     module Formula
-      extend T::Sig
+      class << self
+        extend T::Sig
 
-      module_function
+        sig { returns(String) }
+        def formula_api_path
+          "formula"
+        end
+        alias generic_formula_api_path formula_api_path
 
-      sig { returns(String) }
-      def formula_api_path
-        "formula"
-      end
-      alias generic_formula_api_path formula_api_path
-
-      sig { params(name: String).returns(Hash) }
-      def fetch(name)
-        Homebrew::API.fetch "#{formula_api_path}/#{name}.json"
+        sig { params(name: String).returns(Hash) }
+        def fetch(name)
+          Homebrew::API.fetch "#{formula_api_path}/#{name}.json"
+        end
       end
     end
   end

--- a/Library/Homebrew/api/versions.rb
+++ b/Library/Homebrew/api/versions.rb
@@ -7,45 +7,45 @@ module Homebrew
     #
     # @api private
     module Versions
-      extend T::Sig
+      class << self
+        extend T::Sig
 
-      module_function
-
-      def formulae
-        # The result is cached by Homebrew::API.fetch
-        Homebrew::API.fetch "versions-formulae.json"
-      end
-
-      def linux
-        # The result is cached by Homebrew::API.fetch
-        Homebrew::API.fetch "versions-linux.json"
-      end
-
-      def casks
-        # The result is cached by Homebrew::API.fetch
-        Homebrew::API.fetch "versions-casks.json"
-      end
-
-      sig { params(name: String).returns(T.nilable(PkgVersion)) }
-      def latest_formula_version(name)
-        versions = if OS.mac? || Homebrew::EnvConfig.force_homebrew_on_linux?
-          formulae
-        else
-          linux
+        def formulae
+          # The result is cached by Homebrew::API.fetch
+          Homebrew::API.fetch "versions-formulae.json"
         end
 
-        return unless versions.key? name
+        def linux
+          # The result is cached by Homebrew::API.fetch
+          Homebrew::API.fetch "versions-linux.json"
+        end
 
-        version = Version.new(versions[name]["version"])
-        revision = versions[name]["revision"]
-        PkgVersion.new(version, revision)
-      end
+        def casks
+          # The result is cached by Homebrew::API.fetch
+          Homebrew::API.fetch "versions-casks.json"
+        end
 
-      sig { params(token: String).returns(T.nilable(Version)) }
-      def latest_cask_version(token)
-        return unless casks.key? token
+        sig { params(name: String).returns(T.nilable(PkgVersion)) }
+        def latest_formula_version(name)
+          versions = if OS.mac? || Homebrew::EnvConfig.force_homebrew_on_linux?
+            formulae
+          else
+            linux
+          end
 
-        Version.new(casks[token]["version"])
+          return unless versions.key? name
+
+          version = Version.new(versions[name]["version"])
+          revision = versions[name]["revision"]
+          PkgVersion.new(version, revision)
+        end
+
+        sig { params(token: String).returns(T.nilable(Version)) }
+        def latest_cask_version(token)
+          return unless casks.key? token
+
+          Version.new(casks[token]["version"])
+        end
       end
     end
   end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -190,7 +190,7 @@ module Utils
       def formula_output(f, args:)
         return if Homebrew::EnvConfig.no_analytics? || Homebrew::EnvConfig.no_github_api?
 
-        json = Homebrew::API::Formula.fetch f
+        json = Homebrew::API::Formula.fetch f.name
         return if json.blank? || json["analytics"].blank?
 
         get_analytics(json, args: args)
@@ -202,7 +202,7 @@ module Utils
       def cask_output(cask, args:)
         return if Homebrew::EnvConfig.no_analytics? || Homebrew::EnvConfig.no_github_api?
 
-        json = Homebrew::API::Cask.fetch cask
+        json = Homebrew::API::Cask.fetch cask.token
         return if json.blank? || json["analytics"].blank?
 
         get_analytics(json, args: args)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/11831
Fixes https://github.com/Homebrew/brew/pull/11831#issuecomment-895408324

It seems that using `alias` inside of a module that uses `module_function` does not work. Instead, define the functions directly within the module's metaclass. This means that the `alias` call actually works and the aliased functions can actually be called.

TBH I don't totally understand why `module_function` doesn't work as I thought it just copied all of the methods over to the metaclass. I still don't really understand metaclasses, though, so there might be a good reason.

Here's a model of what happened before:

```ruby
module Foo
  module_function

  def bar
    "Hello, world!"
  end
  alias hello bar
end

Foo.bar   # => "Hello, world!"
Foo.hello # => NoMethodError: undefined method `hello' for Foo:Module
```

And after this PR:

```ruby
module Foo
  class << self
    def bar
      "Hello, world!"
    end
    alias hello bar
  end
end

Foo.bar   # => "Hello, world!"
Foo.hello # => "Hello, world!"
```
