### PR TITLE
brew.rb: remove gem setup for stackprof

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 if ENV["HOMEBREW_STACKPROF"]
-  require_relative "utils/gems"
-  Homebrew.setup_gem_environment!
   require "stackprof"
   StackProf.start(mode: :wall, raw: true)
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`GEM_HOME` and `GEM_PATH` are already set here, so setting up the gem environment here is not necessary and causes issues due to the assumption that `standalone/load_path` is run first. This fixes stackprof not working.

This could be refined further so that we don't allow `GEM_*` bleeding and instead insert the relevant directory into the load path via a Ruby command arg (like we do for intergration tests), to ensure better consistency in runtime behaviour between `brew prof` runs and regular env-filtered runs. That is however an extension of this PR rather than an alternative solution.

Closes https://github.com/Homebrew/brew/pull/11799
