### PR TITLE
typecheck: allow `typecheck` command to run on Apple Silicon

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -13,8 +13,6 @@ module Homebrew
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Check for typechecking errors using Sorbet.
-
-        Not (yet) working on Apple Silicon.
       EOS
       switch "--fix",
              description: "Automatically fix type errors."
@@ -44,11 +42,6 @@ module Homebrew
 
   sig { void }
   def typecheck
-    # TODO: update description above if removing this.
-    if Hardware::CPU.arm? || Hardware::CPU.in_rosetta2?
-      raise UsageError, "not (yet) working on Apple Silicon or Rosetta 2!"
-    end
-
     args = typecheck_args.parse
 
     Homebrew.install_bundler_gems!(groups: ["sorbet"])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Now that sorbet works on Apple Silicon, allow the `typecheck` command to run.

Thanks @Bo98!

Closes #10210