### PR TITLE
Refactor #find_versions parameters in strategies

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -640,13 +640,12 @@ module Homebrew
 
         next if strategy.blank?
 
-        strategy_data = begin
-          strategy.find_versions(url, livecheck_regex, cask: cask, &livecheck_strategy_block)
-        rescue ArgumentError => e
-          raise unless e.message.include?("unknown keyword: cask")
-
-          odisabled "`def self.find_versions` in `#{strategy}` without a `cask` parameter"
-        end
+        strategy_data = strategy.find_versions(
+          url:   url,
+          regex: livecheck_regex,
+          cask:  cask,
+          &livecheck_strategy_block
+        )
         match_version_map = strategy_data[:matches]
         regex = strategy_data[:regex]
         messages = strategy_data[:messages]
@@ -711,7 +710,9 @@ module Homebrew
           version_info[:meta][:url][:symbol] = livecheck_url if livecheck_url.is_a?(Symbol) && livecheck_url_string
           version_info[:meta][:url][:original] = original_url
           version_info[:meta][:url][:processed] = url if url != original_url
-          version_info[:meta][:url][:strategy] = strategy_data[:url] if strategy_data[:url] != url
+          if strategy_data[:url].present? && strategy_data[:url] != url
+            version_info[:meta][:url][:strategy] = strategy_data[:url]
+          end
           version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data[:final_url]
 
           version_info[:meta][:strategy] = strategy.present? ? strategy_name : nil

--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -50,15 +50,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
@@ -73,7 +73,7 @@ module Homebrew
           # * `/href=["']?example-v?(\d+(?:\.\d+)+)-bin\.zip/i`
           regex ||= /href=["']?#{Regexp.escape(match[:prefix])}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -57,15 +57,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
@@ -84,7 +84,7 @@ module Homebrew
           # * `/href=.*?example-v?(\d+(?:\.\d+)+)\.t/i`
           regex ||= /href=.*?#{Regexp.escape(match[:prefix])}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -48,15 +48,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
@@ -68,7 +68,7 @@ module Homebrew
           # Example regex: `/href=.*?Brew[._-]v?(\d+(?:\.\d+)*)\.t/i`
           regex ||= /href=.*?#{match[:prefix]}[._-]v?(\d+(?:\.\d+)*)#{Regexp.escape(suffix)}/i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -59,20 +59,18 @@ module Homebrew
         # Checks the YAML content at the URL for new versions.
         #
         # @param url [String] the URL of the content to check
-        # @param regex [Regexp, nil] a regex used for matching versions
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: T::Hash[String, T.untyped]).returns(T.nilable(String))),
+            url:    String,
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(T.proc.params(arg0: T::Hash[String, T.untyped]).returns(T.nilable(String))),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
-          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if regex
+        def self.find_versions(url:, **unused, &block)
+          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if unused[:regex]
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, url: url }
 
           match_data.merge!(Strategy.page_content(url))
           content = match_data.delete(:content)

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -77,21 +77,23 @@ module Homebrew
 
         # Uses {UnversionedCaskChecker} on the provided cask to identify
         # versions from `plist` files.
+        #
+        # @param cask [Cask::Cask] the cask to check for version information
+        # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  Cask::Cask,
-            block: T.nilable(
+            cask:   Cask::Cask,
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: T::Hash[String, Item]).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask:, &block)
-          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if regex
+        def self.find_versions(cask:, **unused, &block)
+          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if unused[:regex]
           raise ArgumentError, "The #{T.must(name).demodulize} strategy only supports casks." unless T.unsafe(cask)
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {} }
 
           unversioned_cask_checker = UnversionedCaskChecker.new(cask)
           items = unversioned_cask_checker.all_versions.transform_values { |v| Item.new(bundle_version: v) }

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -122,16 +122,16 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:     String,
+            regex:   T.nilable(Regexp),
+            _unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:   T.nilable(
               T.proc.params(arg0: T::Array[String], arg1: T.nilable(Regexp))
                 .returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex = nil, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **_unused, &block)
           match_data = { matches: {}, regex: regex, url: url }
 
           tags_data = tag_info(url, regex)

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -65,15 +65,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.sub(/\.git$/i, "").match(URL_MATCH_REGEX)
 
           # Example URL: `https://github.com/example/example/releases/latest`
@@ -82,7 +82,7 @@ module Homebrew
           # The default regex is the same for all URLs using this strategy
           regex ||= %r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -53,15 +53,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           page_url = "https://download.gnome.org/sources/#{match[:package_name]}/cache.json"
@@ -71,7 +71,7 @@ module Homebrew
             # count on the delimiter between the package name and numeric
             # version being a hyphen and the file being a tarball.
             regex = /#{Regexp.escape(match[:package_name])}-(\d+(?:\.\d+)+)\.t/i
-            version_data = PageMatch.find_versions(page_url, regex, cask: cask, &block)
+            version_data = PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
 
             # Filter out unstable versions using the old version scheme where
             # the major version is below 40.
@@ -81,7 +81,7 @@ module Homebrew
 
             version_data
           else
-            PageMatch.find_versions(page_url, regex, cask: cask, &block)
+            PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
           end
         end
       end

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -57,15 +57,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           # The directory listing page for the project's files
@@ -81,7 +81,7 @@ module Homebrew
           # Example regex: `%r{href=.*?example[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i`
           regex ||= %r{href=.*?#{match[:project_name]}[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -50,15 +50,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = File.basename(url).match(FILENAME_REGEX)
 
           # A page containing a directory listing of the latest source tarball
@@ -67,7 +67,7 @@ module Homebrew
           # Example regex: `%r{<h3>example-(.*?)/?</h3>}i`
           regex ||= %r{<h3>#{Regexp.escape(match[:package_name])}-(.*?)/?</h3>}i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -76,15 +76,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:     String,
+            regex:   T.nilable(Regexp),
+            _unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:   T.nilable(
               T.proc.params(arg0: T::Hash[String, String], arg1: T.nilable(Regexp)).returns(T.nilable(String)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **_unused, &block)
           match_data = { matches: {}, regex: regex, url: url }
 
           headers = Strategy.page_headers(url)

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -48,15 +48,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           # The main page for the project on Launchpad
@@ -65,7 +65,7 @@ module Homebrew
           # The default regex is the same for all URLs using this strategy
           regex ||= %r{class="[^"]*version[^"]*"[^>]*>\s*Latest version is (.+)\s*</}
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -44,15 +44,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           page_url = "https://www.npmjs.com/package/#{match[:package_name]}?activeTab=versions"
@@ -62,7 +62,7 @@ module Homebrew
           # * `%r{href=.*?/package/@example/example/v/(\d+(?:\.\d+)+)"}i`
           regex ||= %r{href=.*?/package/#{Regexp.escape(match[:package_name])}/v/(\d+(?:\.\d+)+)"}i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -81,14 +81,14 @@ module Homebrew
           params(
             url:              String,
             regex:            Regexp,
-            cask:             T.nilable(Cask::Cask),
             provided_content: T.nilable(String),
+            _unused:          T.nilable(T::Hash[Symbol, T.untyped]),
             block:            T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, provided_content: nil, &block)
+        def self.find_versions(url:, regex:, provided_content: nil, **_unused, &block)
           match_data = { matches: {}, regex: regex, url: url }
 
           content = if provided_content.is_a?(String)

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -54,15 +54,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = File.basename(url).match(FILENAME_REGEX)
 
           # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
@@ -77,7 +77,7 @@ module Homebrew
           re_suffix = Regexp.escape(suffix)
           regex ||= %r{href=.*?/packages.*?/#{re_package_name}[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)#{re_suffix}}i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -60,15 +60,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           match = url.match(URL_MATCH_REGEX)
 
           page_url = if url.match?(%r{/rss(?:/?$|\?)})
@@ -82,7 +82,7 @@ module Homebrew
           # create something that works for most URLs.
           regex ||= %r{url=.*?/#{Regexp.escape(match[:project_name])}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
 
-          PageMatch.find_versions(page_url, regex, cask: cask, &block)
+          PageMatch.find_versions(url: page_url, regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -166,16 +166,15 @@ module Homebrew
         # Checks the content at the URL for new versions.
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(T.proc.params(arg0: Item).returns(T.nilable(String))),
+            url:    String,
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(T.proc.params(arg0: Item).returns(T.nilable(String))),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
-          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if regex
+        def self.find_versions(url:, **unused, &block)
+          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if unused[:regex]
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, url: url }
 
           match_data.merge!(Strategy.page_content(url))
           content = match_data.delete(:content)

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -83,15 +83,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:   String,
-            regex: T.nilable(Regexp),
-            cask:  T.nilable(Cask::Cask),
-            block: T.nilable(
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:  T.nilable(
               T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url, regex, cask: nil, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           file_name = File.basename(url)
           match = file_name.match(FILENAME_REGEX)
 
@@ -105,7 +105,13 @@ module Homebrew
 
           # Use the cached page content to avoid duplicate fetches
           cached_content = @page_data[page_url]
-          match_data = PageMatch.find_versions(page_url, regex, provided_content: cached_content, cask: cask, &block)
+          match_data = PageMatch.find_versions(
+            url:              page_url,
+            regex:            regex,
+            provided_content: cached_content,
+            **unused,
+            &block
+          )
 
           # Cache any new page content
           @page_data[page_url] = match_data[:content] if match_data[:content].present?

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -106,7 +106,7 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
 
   describe "::find_versions?" do
     it "finds versions in provided_content" do
-      expect(page_match.find_versions(http_url, regex, provided_content: content))
+      expect(page_match.find_versions(url: http_url, regex: regex, provided_content: content))
         .to eq(find_versions_cached_return_hash)
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Livecheck's strategies all contain a `#find_versions` method that takes input (e.g., a `url`, `regex`, `cask`, etc.) and uses it to identify versions from a source. All of the strategies except for `ExtractPlist` expect that a URL will be provided. `ExtractPlist` is an exception (in many unfortunate ways), as it expects a cask instead of a URL.

When `ExtractPlist` was created, a `cask` parameter was added to every `#find_version` method. This is because livecheck uses all the possible arguments when it calls the method, regardless of the strategy (i.e., it doesn't cater the arguments to what the strategy expects). If a strategy didn't have the `cask` parameter but a named `cask` argument was provided, Ruby would give an error.

Ideally, a given `#find_versions` method should only be required to have parameters for what it actually uses and we shouldn't have to update every method if one strategy needs a new parameter. This PR aims to achieve this by removing unused parameters from `#find_versions` methods and including an `**unused` parameter in each, as the double splat will take care of any arguments that don't correspond to a named parameter for a given strategy.

For example, `ExtractPlist` has a named `cask:` parameter (since it's the only strategy that works with a cask) but all the others omit this. Instead of producing an error, the `cask` parameter is simply part of `unused` (i.e., `unused[:cask]`).

In general, this helps to minimize `#find_versions` parameters to only what's used. This will make it easier to add new strategies in the future, where a new parameter wouldn't need to be added to all other strategies. Besides that, this bit of clean up helps to make things a bit more manageable before I add a couple more parameters to most `#find_versions` methods in the near future.

---

As usual, I've done comparative before/after livecheck runs across first-party formulae/casks and I didn't see any regressions.