### PR TITLE
bump-formula-pr: use default remote if forcing Homebrew on Linux

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -87,7 +87,9 @@ module Homebrew
   def use_correct_linux_tap(formula, args:)
     default_origin_branch = formula.tap.path.git_origin_branch
 
-    return formula.tap.remote_repo, "origin", default_origin_branch, "-" if !OS.linux? || !formula.tap.core_tap?
+    if !OS.linux? || !formula.tap.core_tap? || Homebrew::EnvConfig.force_homebrew_on_linux?
+      return formula.tap.remote_repo, "origin", default_origin_branch, "-"
+    end
 
     tap_remote_repo = formula.tap.full_name.gsub("linuxbrew", "homebrew")
     homebrew_core_url = "https://github.com/#{tap_remote_repo}"


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If one sets `HOMEBREW_FORCE_HOMEBREW_ON_LINUX` it is unnecessary to specially create new remote to check out `homebrew/core`, it should already be the default.