### PR TITLE
Allow casks to be installed using the `cask-source` API

### DIFF
--- a/Library/Homebrew/api/cask-source.rb
+++ b/Library/Homebrew/api/cask-source.rb
@@ -1,0 +1,28 @@
+# typed: false
+# frozen_string_literal: true
+
+module Homebrew
+  module API
+    # Helper functions for using the cask source API.
+    #
+    # @api private
+    module CaskSource
+      class << self
+        extend T::Sig
+
+        sig { params(token: String).returns(Hash) }
+        def fetch(token)
+          Homebrew::API.fetch "cask-source/#{token}.rb", json: false
+        end
+
+        sig { params(token: String).returns(T::Boolean) }
+        def available?(token)
+          fetch token
+          true
+        rescue ArgumentError
+          false
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -20,7 +20,7 @@ module Cask
     extend Searchable
     include Metadata
 
-    attr_reader :token, :sourcefile_path, :config, :default_config
+    attr_reader :token, :sourcefile_path, :source, :config, :default_config
 
     def self.each(&block)
       return to_enum unless block
@@ -38,9 +38,10 @@ module Cask
       @tap
     end
 
-    def initialize(token, sourcefile_path: nil, tap: nil, config: nil, &block)
+    def initialize(token, sourcefile_path: nil, source: nil, tap: nil, config: nil, &block)
       @token = token
       @sourcefile_path = sourcefile_path
+      @source = source
       @tap = tap
       @block = block
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -6,6 +6,7 @@ require "cask/config"
 require "cask/dsl"
 require "cask/metadata"
 require "searchable"
+require "api"
 
 module Cask
   # An instance of a cask.
@@ -130,14 +131,21 @@ module Cask
         return []
       end
 
+      latest_version = if ENV["HOMEBREW_JSON_CORE"].present? &&
+                          (latest_cask_version = Homebrew::API::Versions.latest_cask_version(token))
+        DSL::Version.new latest_cask_version.to_s
+      else
+        version
+      end
+
       installed = versions
       current   = installed.last
 
       # not outdated unless there is a different version on tap
-      return [] if current == version
+      return [] if current == latest_version
 
       # collect all installed versions that are different than tap version and return them
-      installed.reject { |v| v == version }
+      installed.reject { |v| v == latest_version }
     end
 
     def outdated_info(greedy, verbose, json, greedy_latest, greedy_auto_updates)

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -40,7 +40,7 @@ module Cask
       private
 
       def cask(header_token, **options, &block)
-        Cask.new(header_token, **options, config: @config, &block)
+        Cask.new(header_token, source: content, **options, config: @config, &block)
       end
     end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -399,10 +399,10 @@ module Cask
     def save_caskfile
       old_savedir = @cask.metadata_timestamped_path
 
-      return unless @cask.sourcefile_path
+      return if @cask.source.blank?
 
       savedir = @cask.metadata_subdir("Casks", timestamp: :now, create: true)
-      FileUtils.copy @cask.sourcefile_path, savedir
+      (savedir/"#{@cask.token}.rb").write @cask.source
       old_savedir&.rmtree
     end
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -155,7 +155,7 @@ module Homebrew
     end
 
     begin
-      formulae, casks = args.named.to_formulae_and_casks(prefer_loading_from_json: true)
+      formulae, casks = args.named.to_formulae_and_casks(prefer_loading_from_api: true)
                             .partition { |formula_or_cask| formula_or_cask.is_a?(Formula) }
     rescue FormulaOrCaskUnavailableError, Cask::CaskUnavailableError => e
       retry if Tap.install_default_cask_tap_if_necessary(force: args.cask?)

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -85,6 +85,9 @@ module Homebrew
   def reinstall
     args = reinstall_args.parse
 
+    # We need to use the bottle API instead of just using the formula file
+    # from an installed keg because it will not contain bottle information.
+    # As a consequence, `brew reinstall` will also upgrade outdated formulae
     if ENV["HOMEBREW_JSON_CORE"].present?
       args.named.each do |name|
         formula = Formulary.factory(name)

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -648,7 +648,8 @@ EOS
     # HOMEBREW_UPDATE_PREINSTALL wasn't modified in subshell.
     # shellcheck disable=SC2031
     if [[ -n "${HOMEBREW_JSON_CORE}" ]] && [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
-       [[ "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core" ]]
+       [[ "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core" ||
+          "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" ]]
     then
       continue
     fi

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -225,6 +225,15 @@ module Homebrew
   def upgrade_outdated_casks(casks, args:)
     return false if args.formula?
 
+    if ENV["HOMEBREW_JSON_CORE"].present?
+      casks = casks.map do |cask|
+        next cask if cask.tap.present? && cask.tap != "homebrew/cask"
+        next cask unless Homebrew::API::CaskSource.available?(cask.token)
+
+        Cask::CaskLoader.load Homebrew::API::CaskSource.fetch(cask.token)
+      end
+    end
+
     Cask::Cmd::Upgrade.upgrade_casks(
       *casks,
       force:          args.force?,

--- a/Library/Homebrew/extend/os/mac/tap.rb
+++ b/Library/Homebrew/extend/os/mac/tap.rb
@@ -4,7 +4,7 @@
 class Tap
   def self.install_default_cask_tap_if_necessary(force: false)
     return false if default_cask_tap.installed?
-
+    return false if ENV["HOMEBREW_JSON_CORE"].present?
     return false if !force && Tap.untapped_official_taps.include?(default_cask_tap.name)
 
     default_cask_tap.install

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -14,6 +14,12 @@ describe Homebrew::API do
   end
 
   describe "::fetch" do
+    it "fetches a text file" do
+      mock_curl_output stdout: text
+      fetched_text = described_class.fetch("foo.txt", json: false)
+      expect(fetched_text).to eq text
+    end
+
     it "fetches a JSON file" do
       mock_curl_output stdout: json
       fetched_json = described_class.fetch("foo.json")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR allows casks to be installed using the `cask-source` API when `HOMEBREW_JSON_CORE` is set.

Now that this applies to casks, I think it may make more sense for the environment variable to be named `HOMEBREW_INSTALL_FROM_API` (or similar). Thoughts? This should be a simple change (just replace all occurrences) so I'll do this in a separate PR.

In only somewhat major change is that casks now have `Cask::Cask#source` method that returns the source code of the cask (or `nil` if it wasn't set, although I don't know of a situation where this would happen because all casks loaded with `Cask::CaskLoader` should have it set).

-----

The biggest issue I'm currently having is that checking whether a cask is outdated can be a bit problematic because casks can have different `version`s based on the operating system (e.g. [`onyx`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/onyx.rb)). Because the `versions` API is generated on a runner with macOS 10.15.7. This means that for casks like `onyx`, the version listed in `/api/versions-casks-json` is only the Catalina version. Therefore, `Cask::Cask#outdated?` return `true` for `onyx` on my Big Sur machine prompting me to upgrade the cask. Yet, when I run `brew upgrade`, it uses the source which defines a newer version (because it now knows I'm on Big Sur). This means I'm in a cycle where it installs the correct version of the cask, prompts me to upgrade, then upgrades to the exact same version.

Any ideas on how to move forward here? I'm wondering if we need to refine the `versions` API to include information for every (supported at a minimum) OS. This would also require some work to change how `MacOS.version` works (unless we actually want to run the versions API generator on every OS.

I wonder if in Homebrew/formulae.brew.sh we could override the `MacOS.version` method to manually override an check each OS option. Is that the best way to move forward here?
