### PR TITLE
Bypass setting environment variables for the MacOS SDK when it is nil

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -66,7 +66,7 @@ module Stdenv
     else
       MacOS.sdk(version)
     end
-    return if !MacOS.sdk_root_needed? && sdk&.source != :xcode
+    return unless (MacOS.sdk_root_needed? || sdk&.source == :xcode) && sdk
 
     Homebrew::Diagnostic.checks(:fatal_setup_build_environment_checks)
     sdk = sdk.path

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -106,7 +106,7 @@ module Superenv
   # @private
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
     sdk = formula ? MacOS.sdk_for_formula(formula) : MacOS.sdk
-    if MacOS.sdk_root_needed? || sdk&.source == :xcode
+    if (MacOS.sdk_root_needed? || sdk&.source == :xcode) && sdk
       Homebrew::Diagnostic.checks(:fatal_setup_build_environment_checks)
       self["HOMEBREW_SDKROOT"] = sdk.path
 


### PR DESCRIPTION
Resolves
```
Error: An exception occurred within a child process:
  NoMethodError: undefined method `path' for nil:NilClass
Did you mean?  paths
```

which occurs in `setup_build_environment` when `MacOS.sdk_root_needed?` returns `true` and  `MacOS::CLTSDKLocator#sdk_if_applicable(MacOS.version)` returns `nil`.

* * *

This was partially resolved by https://github.com/Homebrew/brew/pull/7694, but it's still possible to bypass the guard clauses in that PR and call `sdk.path` when `sdk` is nil.

* * *

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
