### PR TITLE
os/mac/diagnostic: check min CLT version on env setup

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -70,6 +70,7 @@ module Homebrew
 
       def fatal_setup_build_environment_checks
         %w[
+          check_clt_minimum_version
           check_if_supported_sdk_available
         ].freeze
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This covers the case where the user has CLT 12.0-12.4 on Big Sur and is setting up the build env via non-build-from-source means (e.g. `bottle :unneeded`). We no longer support those versions of the CLT and they will throw errors if used.