### PR TITLE
download_strategy: fix error when using custom headers with a redirect

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -391,7 +391,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       resolved_url, _, url_time, _, is_redirection =
         resolve_url_basename_time_file_size(url, timeout: end_time&.remaining!)
       # Authorization is no longer valid after redirects
-      meta[:headers]&.delete_if { |header| header.first&.start_with?("Authorization") } if is_redirection
+      meta[:headers]&.delete_if { |header| header.start_with?("Authorization") } if is_redirection
 
       fresh = if cached_location.exist? && url_time
         url_time <= cached_location.mtime
@@ -569,7 +569,7 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
     meta ||= {}
     meta[:headers] ||= []
     token = Homebrew::EnvConfig.artifact_domain ? Homebrew::EnvConfig.docker_registry_token : "QQ=="
-    meta[:headers] << ["Authorization: Bearer #{token}"] if token.present?
+    meta[:headers] << "Authorization: Bearer #{token}" if token.present?
     super(url, name, version, meta)
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`meta[:headers]` should be an array of strings - not an array of arrays of strings.
