### PR TITLE
PageMatch#find_versions: Fix return conditions

### DIFF
--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -90,7 +90,7 @@ module Homebrew
         }
         def self.find_versions(url:, regex:, provided_content: nil, **_unused, &block)
           match_data = { matches: {}, regex: regex, url: url }
-          return match_data if url.blank? || regex.blank?
+          return match_data if url.blank? || (regex.blank? && block.blank?)
 
           content = if provided_content.is_a?(String)
             match_data[:cached] = true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Casks with a `livecheck` block using `PageMatch` but not using `#regex` are currently failing (see #11882) because I recently introduced code in `PageMatch#find_versions` that returns early when a regex isn't provided. I had tested this change on homebrew/core, where all the related `strategy` blocks use `#regex` and pass it into the `strategy` block (i.e., `do |page, regex|`), but I didn't test it on homebrew/cask.

This PR fixes the issue by updating the condition to require either a regex or `strategy` block. I'll create a follow-up PR to add a related test and maybe modify `PageMatch#find_versions`'s parameters (making `regex` nilable again) but I wanted to push out this fix in the interim time.