### PR TITLE
PageMatch: Expand #find_versions tests

### DIFF
--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -44,20 +44,21 @@ module Homebrew
         # With either approach, an array of unique matches is returned.
         #
         # @param content [String] the page content to check
-        # @param regex [Regexp] a regex used for matching versions in the
+        # @param regex [Regexp, nil] a regex used for matching versions in the
         #   content
         # @return [Array]
         sig {
           params(
             content: String,
-            regex:   Regexp,
+            regex:   T.nilable(Regexp),
             block:   T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+              T.proc.params(arg0: String, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Array[String])
         }
         def self.versions_from_content(content, regex, &block)
           return Strategy.handle_block_return(block.call(content, regex)) if block
+          return [] if regex.blank?
 
           content.scan(regex).map do |match|
             case match
@@ -73,22 +74,22 @@ module Homebrew
         # regex for matching.
         #
         # @param url [String] the URL of the content to check
-        # @param regex [Regexp] a regex used for matching versions
+        # @param regex [Regexp, nil] a regex used for matching versions
         # @param provided_content [String, nil] page content to use in place of
         #   fetching via Strategy#page_content
         # @return [Hash]
         sig {
           params(
             url:              String,
-            regex:            Regexp,
+            regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             _unused:          T.nilable(T::Hash[Symbol, T.untyped]),
             block:            T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
+              T.proc.params(arg0: String, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex:, provided_content: nil, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, **_unused, &block)
           match_data = { matches: {}, regex: regex, url: url }
           return match_data if url.blank? || (regex.blank? && block.blank?)
 

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -108,6 +108,23 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
     it "finds versions in provided_content" do
       expect(page_match.find_versions(url: http_url, regex: regex, provided_content: content))
         .to eq(find_versions_cached_return_hash)
+
+      # NOTE: Ideally, a regex should always be provided to `#find_versions`
+      # for `PageMatch` but there are currently some `livecheck` blocks in
+      # casks where `#regex` isn't used and the regex only exists within a
+      # `strategy` block. This isn't ideal but, for the moment, we allow a
+      # `strategy` block to act as a substitution for a regex and we need to
+      # test this scenario to ensure it works.
+      #
+      # Under normal circumstances, a regex should be established in a
+      # `livecheck` block using `#regex` and passed into the `strategy` block
+      # using `do |page, regex|`. Hopefully over time we can address related
+      # issues and get to a point where regexes are always established using
+      # `#regex`.
+      expect(page_match.find_versions(url: http_url, provided_content: content) do |page|
+        page.scan(%r{href=.*?/homebrew[._-]v?(\d+(?:\.\d+)+)/?["' >]}i).map(&:first)
+      end)
+        .to eq(find_versions_cached_return_hash.merge({ regex: nil }))
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to #11888, where I modified the early return conditions for `PageMatch#find_versions` to allow a `strategy` block to [temporarily] act as a substitution for a `regex`. That PR was a fix for an issue affecting some casks that don't follow established patterns, so I wanted to get it merged quickly. This PR contains related changes that I would have handled in #11888 if I had more time.

This adds a test to ensure that `PageMatch#find_versions` works when a block is provided but a regex isn't. I've added comments to explain that this is temporary and the pattern in the test shouldn't be followed.

Similarly, I've updated related method signatures and documentation comments to reflect that the `regex` parameter is technically nilable for now. The method signature changes were required for this to pass.


## Looking forward

Existing cask `livecheck` blocks that don't use `#regex` to establish a regex and pass it into a `strategy` block should be updated to do so. This has long been the pattern in homebrew/core and homebrew/cask should be brought up to standard (in many other ways as well).

One challenge is that there are some cask `strategy` blocks that require more than one regex but `#regex` currently only works with one regex. With some of these `strategy` blocks, there's a clear primary regex that can be established using `#regex` and any secondary regexes can be inlined in the strategy block. We do this with a few complex `strategy` blocks in homebrew/core (e.g., `bash`).

The issue is that some of the cask `strategy` blocks with more than one regex don't have a primary regex that can be reasonably extracted into a `#regex` call. These exceptions would prevent us from eventually getting to a point where we standardize on always establishing regexes using `#regex` and passing it into a strategy block.

One solution to this could be to modify the `#regex` DSL to allow either a hash with `Regexp` values or an array of `Regexps`. These would both achieve the same purpose but there are benefits/detriments to each.

Either way, we would only allow a non-`Regexp` value when a `strategy` block is present (as the strategy wouldn't know what to do with a non-`Regexp` value by default). However, we want `#regex` to appear before `#strategy` in a `livecheck` block (to make it clear that it's the same regex being passed into the `strategy` block), so this would need to be enforced somewhere outside of the `#regex` DSL method.

Allowing for multiple regexes when using `#regex` would also let us avoid having to determine which regex is a primary regex and which are secondary. This is currently a bit subjective, so it would be nice to avoid this question entirely.

This shouldn't be difficult to implement, so I'll investigate it and work on creating a PR.