### PR TITLE
tap_auditor: use short names when checking exception lists

### DIFF
--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -15,12 +15,15 @@ module Homebrew
     def initialize(tap, strict:)
       @name                      = tap.name
       @path                      = tap.path
-      @formula_names             = tap.formula_names
       @cask_tokens               = tap.cask_tokens
       @tap_audit_exceptions      = tap.audit_exceptions
       @tap_style_exceptions      = tap.style_exceptions
       @tap_pypi_formula_mappings = tap.pypi_formula_mappings
       @problems                  = []
+
+      @formula_names = tap.formula_names.map do |formula_name|
+        formula_name.split("/").last
+      end
     end
 
     sig { void }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For core formulae, `Formula#full_name` is the same as `Formulae#name`, but this is not true for other taps. The formula names that need to go in the exception lists are the short names (because this is what we compare them to during the audit and changing this adds backwards incompatibility). I think this makes sense because the lists are per-tap so short names are sufficient.

`TapAuditor` also checks to make sure that every formula listed in an exception list actually exists in that tap. This is done by comparing each entry to `Tap#formula_names`. There is a problem here because `Tap#formula_names` returns the full name of each formula in the tap. For core formulae, `Formula#full_name` is the same as `Formulae#name`, but this is not true for other taps. Therefore, adding an audit exception using the short name will fail the audit checking that it exists in the tap. For example, `btb/open-watcom/open-watcom-v2` (from `formula_names`) is not the same as `open-watcom-v2` (from the exception list).

See https://github.com/Homebrew/discussions/discussions/2005#discussioncomment-1203817 or https://github.com/btb/homebrew-open-watcom/pull/9
