### PR TITLE
formula_auditor: use brewed curl for homepage check when needed

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -412,11 +412,21 @@ module Homebrew
 
       return unless DevelopmentTools.curl_handles_most_https_certificates?
 
+      use_homebrew_curl = false
+      %w[Stable HEAD].each do |name|
+        spec_name = name.downcase.to_sym
+        next unless (spec = formula.send(spec_name))
+
+        use_homebrew_curl = spec.using == :homebrew_curl
+        break if use_homebrew_curl
+      end
+
       if (http_content_problem = curl_check_http_content(homepage,
                                                          "homepage URL",
-                                                         user_agents:   [:browser, :default],
-                                                         check_content: true,
-                                                         strict:        @strict))
+                                                         user_agents:       [:browser, :default],
+                                                         check_content:     true,
+                                                         strict:            @strict,
+                                                         use_homebrew_curl: use_homebrew_curl))
         problem http_content_problem
       end
     end


### PR DESCRIPTION
If the download url is using brewed curl, use that too for the homepage check.
Ideally one would introduce the "using: :homebrew_curl" stanza for the homepage
line in the DSL, but it is easier to implicitely use the same logic
for homepages and url's and define the "using:" only once.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
