### PR TITLE
bottle.rb: add workaround to make gcc have cellar :any

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -441,6 +441,15 @@ module Homebrew
         # Ignore matches to source code, which is not required at run time.
         # These matches may be caused by debugging symbols.
         ignores = [%r{/include/|\.(c|cc|cpp|h|hpp)$}]
+
+        # GCC installation can be moved so long as the whole directory tree is moved together:
+        # https://gcc-help.gcc.gnu.narkive.com/GnwuCA7l/moving-gcc-from-the-installation-path-is-it-allowed.
+        begin
+          ignores << %r{#{Regexp.escape(cellar)}/gcc} if Formula["gcc"].versioned_formulae.map(&:name).include?(name)
+        rescue FormulaUnavailableError
+          nil
+        end
+
         any_go_deps = f.deps.any? do |dep|
           dep.name =~ Version.formula_optionally_versioned_regex(:go)
         end


### PR DESCRIPTION
…LINKS

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a followup to https://github.com/Homebrew/linuxbrew-core/pull/23361.  I followed the suggestion from @iMichka to add a regex to exclude the nonrelocatable strings inside the GCC formulae.  For many years `:any` was manually added to the GCC cellar block on Linux so we know it works.  This should guarantee this happens from now on.  