### PR TITLE
create(go): add `-s -w` ldflags to reduce the artifact size

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -166,7 +166,7 @@ module Homebrew
             system "shards", "build", "--release"
             bin.install "bin/#{name}"
         <% elsif mode == :go %>
-            system "go", "build", *std_go_args
+            system "go", "build", *std_go_args(ldflags: "-s -w")
         <% elsif mode == :meson %>
             mkdir "build" do
               system "meson", *std_meson_args, ".."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

It is consistent with the go formulae practices we are doing in the homebrew-core

This is [the article reference](https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/) for shrinking the binary (thanks @bayandin)