### PR TITLE
sandbox: start sandbox in a pseudoterminal

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -97,15 +97,17 @@ class Sandbox
     seatbelt.close
     @start = Time.now
 
-    $stdin.raw!
+    $stdin.raw! if $stdin.tty?
     stdin_thread = T.let(nil, T.nilable(Thread))
 
     begin
       command = [SANDBOX_EXEC, "-f", seatbelt.path, *args]
       # Start sandbox in a pseudoterminal to prevent access of the parent terminal.
       T.unsafe(PTY).spawn(*command) do |r, w, pid|
-        w.winsize = $stdout.winsize
-        trap(:WINCH) { w.winsize = $stdout.winsize }
+        if $stdout.tty?
+          w.winsize = $stdout.winsize
+          trap(:WINCH) { w.winsize = $stdout.winsize }
+        end
         stdin_thread = Thread.new { IO.copy_stream($stdin, w) }
         r.each_char { |c| print(c) }
         Process.wait(pid)
@@ -116,7 +118,7 @@ class Sandbox
       raise
     ensure
       stdin_thread&.kill
-      $stdin.cooked!
+      $stdin.cooked! if $stdin.tty?
 
       seatbelt.unlink
       sleep 0.1 # wait for a bit to let syslog catch up the latest events.

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -102,6 +102,7 @@ class Sandbox
 
     begin
       command = [SANDBOX_EXEC, "-f", seatbelt.path, *args]
+      # Start sandbox in a pseudoterminal to prevent access of the parent terminal.
       T.unsafe(PTY).spawn(*command) do |r, w, pid|
         w.winsize = $stdout.winsize
         trap(:WINCH) { w.winsize = $stdout.winsize }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This disconnects the sandbox from directly accessing the parent terminal.

Due to the wide range of formulae we have and how some of the tests we have can be pretty picky on the terminal, particularly for those that do things like manually setting `TERM`, changing the `winsize` or doing some fancy things in `expect`, I can't give 100% assurances this will be regression free but it does seem the work on a couple that I tried. It's very much possible nothing will break and I'm being overly cautious - there's just too much variation for me to guarantee anything.

**In the event someone feels the need to revert this quickly, but the only thing breaking is (multiple) tests, I suggest a partial revert by adding a kwarg to conditionally disable this for tests (but not builds/postinstall) should time allow.**