### PR TITLE
Add per-os versions to `Cask::Cask#to_h`

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -81,6 +81,21 @@ module Cask
                           .reverse
     end
 
+    def os_versions
+      @os_versions ||= begin
+        version_os_hash = {}
+        actual_version = MacOS.full_version.to_s
+
+        MacOS::Version::SYMBOLS.each do |os_name, os_version|
+          MacOS.full_version = os_version
+          version_os_hash[os_name] = CaskLoader.load(token).version
+        end
+
+        MacOS.full_version = actual_version
+        version_os_hash
+      end
+    end
+
     def full_name
       return token if tap.nil?
       return token if tap.user == "Homebrew"
@@ -181,6 +196,7 @@ module Cask
         "url"            => url,
         "appcast"        => appcast,
         "version"        => version,
+        "versions"       => os_versions,
         "installed"      => versions.last,
         "outdated"       => outdated?,
         "sha256"         => sha256,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a `versions` key to the cask JSON output. This key contains a hash mapping macOS versions to cask versions. Some casks, like [`onyx`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/onyx.rb), have different `version` stanzas based on the OS version.

Some things to note about the field. For now, it contains versions for all macOS versions present in [`OS::Mac::Versions::SYMBOLS`](https://github.com/Homebrew/brew/blob/216eb45a6fefad9dda0a41a8f56fd276c07e60f3/Library/Homebrew/os/mac/version.rb#L16-L25), even if the cask version matches the default. Instead, I could make it so the only versions that show in `versions` are the ones that don't match the default `version` field. Thoughts?

For some context, see https://github.com/Homebrew/brew/pull/11859
