### PR TITLE
audit: gitlab prerelease check keep time/zone

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -74,7 +74,7 @@ module SharedAudits
     release = gitlab_release_data(user, repo, tag)
     return unless release
 
-    return if Date.parse(release["released_at"]) <= Date.today
+    return if DateTime.parse(release["released_at"]) <= DateTime.now
 
     exception, version = if formula
       [tap_audit_exception(:gitlab_prerelease_allowlist, formula.tap, formula.name), formula.version]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Not sure if this check does anything with change, or if it is a no-op.

The existing check has a problem where CI runner timezone can impact behavior of prerelease output. `Date.parse` will ignore the time/timezone and parse the date portion.

For example, https://github.com/Homebrew/homebrew-core/pull/83805