### PR TITLE
cli/parser: allow commands that look like options

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -264,6 +264,7 @@ module Homebrew
         remaining = []
 
         argv, non_options = split_non_options(argv)
+        allow_commands = Array(@named_args_type).include?(:command)
 
         while i < argv.count
           begin
@@ -279,7 +280,7 @@ module Homebrew
               i += 1
             end
           rescue OptionParser::InvalidOption
-            if ignore_invalid_options
+            if ignore_invalid_options || (allow_commands && Commands.path(arg))
               remaining << arg
             else
               $stderr.puts generate_help_text

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -559,5 +559,19 @@ describe Homebrew::CLI::Parser do
         Homebrew::CLI::MaxNamedArgumentsError, /This command does not take more than 1 formula or cask argument/
       )
     end
+
+    it "accepts commands with :command" do
+      parser = described_class.new do
+        named_args :command
+      end
+      expect { parser.parse(["--prefix", "--version"]) }.not_to raise_error
+    end
+
+    it "doesn't accept invalid options with :command" do
+      parser = described_class.new do
+        named_args :command
+      end
+      expect { parser.parse(["--not-a-command"]) }.to raise_error(OptionParser::InvalidOption, /--not-a-command/)
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes `brew command --cache`, which used to print `Error: invalid option: --cache` instead of the path to the `--cache` command.