### PR TITLE
fetch: fix `--bottle-tag` when unbottled on host system

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -160,6 +160,9 @@ module Homebrew
       def minor?; end
 
       sig { returns(T.nilable(String)) }
+      def bottle_tag; end
+
+      sig { returns(T.nilable(String)) }
       def tag; end
 
       sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -24,6 +24,8 @@ module Homebrew
              description: "Show the cache file used when building from source."
       switch "--force-bottle",
              description: "Show the cache file used when pouring a bottle."
+      flag "--bottle-tag",
+           description: "Show the cache file used when pouring a bottle for the given tag."
       switch "--HEAD",
              description: "Show the cache file used when building from HEAD."
       switch "--formula",
@@ -31,7 +33,7 @@ module Homebrew
       switch "--cask",
              description: "Only show cache files for casks."
 
-      conflicts "--build-from-source", "--force-bottle", "--HEAD", "--cask"
+      conflicts "--build-from-source", "--force-bottle", "--bottle-tag", "--HEAD", "--cask"
       conflicts "--formula", "--cask"
 
       named_args [:formula, :cask]
@@ -61,7 +63,7 @@ module Homebrew
   sig { params(formula: Formula, args: CLI::Args).void }
   def print_formula_cache(formula, args:)
     if fetch_bottle?(formula, args: args)
-      puts formula.bottle.cached_download
+      puts formula.bottle_for_tag(args.bottle_tag).cached_download
     elsif args.HEAD?
       puts formula.head.cached_download
     else

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -6,7 +6,9 @@ module Utils
     class << self
       undef tag
 
-      def tag
+      def tag(symbol = nil)
+        return Utils::Bottles::Tag.from_symbol(symbol) if symbol.present?
+
         Utils::Bottles::Tag.new(system: MacOS.version.to_sym, arch: Hardware::CPU.arch)
       end
     end

--- a/Library/Homebrew/fetch.rb
+++ b/Library/Homebrew/fetch.rb
@@ -11,6 +11,7 @@ module Homebrew
       bottle = f.bottle
 
       return true if args.force_bottle? && bottle.present?
+      return true if args.bottle_tag.present? && f.bottled?(args.bottle_tag)
 
       bottle.present? &&
         f.pour_bottle? &&

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -373,7 +373,7 @@ class Formula
   # @private
   sig { params(tag: T.nilable(String)).returns(T.nilable(Bottle)) }
   def bottle_for_tag(tag = nil)
-    Bottle.new(self, bottle_specification, tag) if bottled?
+    Bottle.new(self, bottle_specification, tag) if bottled?(tag)
   end
 
   # The description of the software.

--- a/Library/Homebrew/formula.rbi
+++ b/Library/Homebrew/formula.rbi
@@ -7,8 +7,8 @@ class Formula
   def bottle_disabled?; end
   def bottle_disable_reason; end
   def bottle_defined?; end
-  def bottle_tag?; end
-  def bottled?; end
+  def bottle_tag?(tag = nil); end
+  def bottled?(tag = nil); end
   def bottle_specification; end
   def downloader; end
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -93,13 +93,13 @@ class SoftwareSpec
     !bottle_specification.collector.keys.empty?
   end
 
-  def bottle_tag?
-    bottle_specification.tag?(Utils::Bottles.tag)
+  def bottle_tag?(tag = nil)
+    bottle_specification.tag?(Utils::Bottles.tag(tag))
   end
 
-  def bottled?
-    bottle_tag? && \
-      (bottle_specification.compatible_locations? || owner.force_bottle)
+  def bottled?(tag = nil)
+    bottle_tag?(tag) && \
+      (tag.present? || bottle_specification.compatible_locations? || owner.force_bottle)
   end
 
   def bottle(disable_type = nil, disable_reason = nil, &block)
@@ -306,12 +306,7 @@ class Bottle
     @resource.specs[:bottle] = true
     @spec = spec
 
-    bottle_tag = if tag.present?
-      Utils::Bottles::Tag.from_symbol(tag)
-    else
-      Utils::Bottles.tag
-    end
-    checksum, tag, cellar = spec.checksum_for(bottle_tag)
+    checksum, tag, cellar = spec.checksum_for(Utils::Bottles.tag(tag))
 
     @prefix = spec.prefix
     @tag = tag

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -11,7 +11,9 @@ module Utils
     class << self
       extend T::Sig
 
-      def tag
+      def tag(symbol = nil)
+        return Tag.from_symbol(symbol) if symbol.present?
+
         @tag ||= Tag.new(system: T.must(ENV["HOMEBREW_SYSTEM"]).downcase.to_sym,
                          arch:   T.must(ENV["HOMEBREW_PROCESSOR"]).downcase.to_sym)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This can be tested by opening a formula, deleting/commenting out the bottle sha256 for your macOS version, and then running `brew fetch --bottle-tag=<different macOS tag> <formula name>` 