### PR TITLE
Rename `HOMEBREW_JSON_CORE` to `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -149,7 +149,7 @@ module Cask
         return []
       end
 
-      latest_version = if ENV["HOMEBREW_JSON_CORE"].present? &&
+      latest_version = if ENV["HOMEBREW_INSTALL_FROM_API"].present? &&
                           (latest_cask_version = Homebrew::API::Versions.latest_cask_version(token))
         DSL::Version.new latest_cask_version.to_s
       else

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -94,7 +94,7 @@ module Homebrew
         unreadable_error = nil
 
         if only != :cask
-          if prefer_loading_from_api && ENV["HOMEBREW_JSON_CORE"].present? &&
+          if prefer_loading_from_api && ENV["HOMEBREW_INSTALL_FROM_API"].present? &&
              Homebrew::API::Bottle.available?(name)
             Homebrew::API::Bottle.fetch_bottles(name)
           end
@@ -133,7 +133,7 @@ module Homebrew
         end
 
         if only != :formula
-          if prefer_loading_from_api && ENV["HOMEBREW_JSON_CORE"].present? &&
+          if prefer_loading_from_api && ENV["HOMEBREW_INSTALL_FROM_API"].present? &&
              Homebrew::API::CaskSource.available?(name)
             contents = Homebrew::API::CaskSource.fetch(name)
           end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -244,7 +244,7 @@ module Homebrew
   def info_formula(f, args:)
     specs = []
 
-    if ENV["HOMEBREW_JSON_CORE"].present? && Homebrew::API::Bottle.available?(f.name)
+    if ENV["HOMEBREW_INSTALL_FROM_API"].present? && Homebrew::API::Bottle.available?(f.name)
       info = Homebrew::API::Bottle.fetch(f.name)
 
       latest_version = info["pkg_version"].split("_").first

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -98,7 +98,7 @@ module Homebrew
         if verbose?
           outdated_kegs = f.outdated_kegs(fetch_head: args.fetch_HEAD?)
 
-          current_version = if ENV["HOMEBREW_JSON_CORE"].present? && (f.core_formula? || f.tap.blank?)
+          current_version = if ENV["HOMEBREW_INSTALL_FROM_API"].present? && (f.core_formula? || f.tap.blank?)
             Homebrew::API::Versions.latest_formula_version(f.name)&.to_s || f.pkg_version.to_s
           elsif f.alias_changed? && !f.latest_formula.latest_version_installed?
             latest = f.latest_formula

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -88,7 +88,7 @@ module Homebrew
     # We need to use the bottle API instead of just using the formula file
     # from an installed keg because it will not contain bottle information.
     # As a consequence, `brew reinstall` will also upgrade outdated formulae
-    if ENV["HOMEBREW_JSON_CORE"].present?
+    if ENV["HOMEBREW_INSTALL_FROM_API"].present?
       args.named.each do |name|
         formula = Formulary.factory(name)
         next unless formula.any_version_installed?

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -25,7 +25,7 @@ module Homebrew
     args = untap_args.parse
 
     args.named.to_installed_taps.each do |tap|
-      odie "Untapping #{tap} is not allowed" if tap.core_tap? && ENV["HOMEBREW_JSON_CORE"].blank?
+      odie "Untapping #{tap} is not allowed" if tap.core_tap? && ENV["HOMEBREW_INSTALL_FROM_API"].blank?
 
       installed_tap_formulae = Formula.installed.select { |formula| formula.tap == tap }
       installed_tap_casks = Cask::Caskroom.casks.select { |cask| cask.tap == tap }

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -102,7 +102,7 @@ module Homebrew
     updated_taps = []
     Tap.each do |tap|
       next unless tap.git?
-      next if tap.core_tap? && ENV["HOMEBREW_JSON_CORE"].present? && args.preinstall?
+      next if tap.core_tap? && ENV["HOMEBREW_INSTALL_FROM_API"].present? && args.preinstall?
 
       begin
         reporter = Reporter.new(tap)
@@ -208,7 +208,7 @@ module Homebrew
 
   def install_core_tap_if_necessary
     return if ENV["HOMEBREW_UPDATE_TEST"]
-    return if ENV["HOMEBREW_JSON_CORE"].present?
+    return if ENV["HOMEBREW_INSTALL_FROM_API"].present?
 
     core_tap = CoreTap.instance
     return if core_tap.installed?

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -498,7 +498,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -n "${HOMEBREW_JSON_CORE}" ]] && [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
+    if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] && [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
        [[ "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core" ]]
     then
       continue
@@ -647,7 +647,7 @@ EOS
   do
     # HOMEBREW_UPDATE_PREINSTALL wasn't modified in subshell.
     # shellcheck disable=SC2031
-    if [[ -n "${HOMEBREW_JSON_CORE}" ]] && [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
+    if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] && [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
        [[ "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core" ||
           "${DIR}" = "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" ]]
     then

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -160,7 +160,7 @@ module Homebrew
       puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 
-    if ENV["HOMEBREW_JSON_CORE"].present?
+    if ENV["HOMEBREW_INSTALL_FROM_API"].present?
       formulae_to_install.map! do |formula|
         next formula if formula.tap.present? && !formula.core_formula?
         next formula unless Homebrew::API::Bottle.available?(formula.name)
@@ -225,7 +225,7 @@ module Homebrew
   def upgrade_outdated_casks(casks, args:)
     return false if args.formula?
 
-    if ENV["HOMEBREW_JSON_CORE"].present?
+    if ENV["HOMEBREW_INSTALL_FROM_API"].present?
       casks = casks.map do |cask|
         next cask if cask.tap.present? && cask.tap != "homebrew/cask"
         next cask unless Homebrew::API::CaskSource.available?(cask.token)

--- a/Library/Homebrew/extend/os/mac/tap.rb
+++ b/Library/Homebrew/extend/os/mac/tap.rb
@@ -4,7 +4,7 @@
 class Tap
   def self.install_default_cask_tap_if_necessary(force: false)
     return false if default_cask_tap.installed?
-    return false if ENV["HOMEBREW_JSON_CORE"].present?
+    return false if ENV["HOMEBREW_INSTALL_FROM_API"].present?
     return false if !force && Tap.untapped_official_taps.include?(default_cask_tap.name)
 
     default_cask_tap.install

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -520,7 +520,7 @@ class Formula
   # exists and is not empty.
   # @private
   def latest_version_installed?
-    latest_prefix = if ENV["HOMEBREW_JSON_CORE"].present? &&
+    latest_prefix = if ENV["HOMEBREW_INSTALL_FROM_API"].present? &&
                        (latest_pkg_version = Homebrew::API::Versions.latest_formula_version(name))
       prefix latest_pkg_version
     else
@@ -1340,7 +1340,7 @@ class Formula
     Formula.cache[:outdated_kegs][cache_key] ||= begin
       all_kegs = []
       current_version = T.let(false, T::Boolean)
-      latest_version = if ENV["HOMEBREW_JSON_CORE"].present? && (core_formula? || tap.blank?)
+      latest_version = if ENV["HOMEBREW_INSTALL_FROM_API"].present? && (core_formula? || tap.blank?)
         Homebrew::API::Versions.latest_formula_version(name) || pkg_version
       else
         pkg_version

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -361,7 +361,9 @@ module Formulary
     end
 
     def get_formula(*)
-      raise CoreTapFormulaUnavailableError, name if !CoreTap.instance.installed? && ENV["HOMEBREW_JSON_CORE"].present?
+      if !CoreTap.instance.installed? && ENV["HOMEBREW_INSTALL_FROM_API"].present?
+        raise CoreTapFormulaUnavailableError, name
+      end
 
       raise FormulaUnavailableError, name
     end
@@ -397,7 +399,7 @@ module Formulary
   )
     raise ArgumentError, "Formulae must have a ref!" unless ref
 
-    if ENV["HOMEBREW_JSON_CORE"].present? &&
+    if ENV["HOMEBREW_INSTALL_FROM_API"].present? &&
        @formula_name_local_bottle_path_map.present? &&
        @formula_name_local_bottle_path_map.key?(ref)
       ref = @formula_name_local_bottle_path_map[ref]
@@ -429,7 +431,9 @@ module Formulary
   # @param formula_name the formula name string to map.
   # @param local_bottle_path a path pointing to the target bottle archive.
   def self.map_formula_name_to_local_bottle_path(formula_name, local_bottle_path)
-    raise UsageError, "HOMEBREW_JSON_CORE not set but required for #{__method__}!" if ENV["HOMEBREW_JSON_CORE"].blank?
+    if ENV["HOMEBREW_INSTALL_FROM_API"].blank?
+      raise UsageError, "HOMEBREW_INSTALL_FROM_API not set but required for #{__method__}!"
+    end
 
     @formula_name_local_bottle_path_map ||= {}
     @formula_name_local_bottle_path_map[formula_name] = Pathname(local_bottle_path).realpath

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -735,7 +735,7 @@ class CoreTap < Tap
 
   def self.ensure_installed!
     return if instance.installed?
-    return if ENV["HOMEBREW_JSON_CORE"].present?
+    return if ENV["HOMEBREW_INSTALL_FROM_API"].present?
 
     safe_system HOMEBREW_BREW_FILE, "tap", instance.name
   end
@@ -752,7 +752,7 @@ class CoreTap < Tap
   # @private
   sig { params(manual: T::Boolean).void }
   def uninstall(manual: false)
-    raise "Tap#uninstall is not available for CoreTap" if ENV["HOMEBREW_JSON_CORE"].blank?
+    raise "Tap#uninstall is not available for CoreTap" if ENV["HOMEBREW_INSTALL_FROM_API"].blank?
 
     super
   end

--- a/Library/Homebrew/test/api/bottle_spec.rb
+++ b/Library/Homebrew/test/api/bottle_spec.rb
@@ -64,7 +64,7 @@ describe Homebrew::API::Bottle do
 
   describe "::fetch_bottles" do
     before do
-      ENV["HOMEBREW_JSON_CORE"] = "1"
+      ENV["HOMEBREW_INSTALL_FROM_API"] = "1"
       allow(described_class).to receive(:fetch).and_return bottle_hash
     end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -216,12 +216,12 @@ describe Formulary do
         described_class.factory("formula-to-map")
       }.to raise_error(FormulaUnavailableError)
 
-      ENV["HOMEBREW_JSON_CORE"] = nil
+      ENV["HOMEBREW_INSTALL_FROM_API"] = nil
       expect {
         described_class.map_formula_name_to_local_bottle_path "formula-to-map", formula_path
-      }.to raise_error(UsageError, /HOMEBREW_JSON_CORE not set/)
+      }.to raise_error(UsageError, /HOMEBREW_INSTALL_FROM_API not set/)
 
-      ENV["HOMEBREW_JSON_CORE"] = "1"
+      ENV["HOMEBREW_INSTALL_FROM_API"] = "1"
       described_class.map_formula_name_to_local_bottle_path "formula-to-map", formula_path
 
       expect(described_class.factory("formula-to-map")).to be_kind_of(Formula)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/11859

Now that this variable allows formulae _and_ casks to be installed from the API, the old name doesn't quite fit.

I'd like to do this now before I ask maintainers to start to try this stuff out so that no one (except me) has to make any changes to their environments. Since this is currently undocumented, it shouldn't be a big issue for us.
