### PR TITLE
cleanup: allow users to specify formulae to skip cleaning

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -229,6 +229,10 @@ module Homebrew
                      "formulae.",
         boolean:     true,
       },
+      HOMEBREW_NO_CLEANUP_FORMULAE:           {
+        description: "A comma-separated list of formulae. Homebrew will refuse to clean up a " \
+                     "formula if it appears on this list.",
+      },
       HOMEBREW_NO_COLOR:                      {
         description:  "If set, do not print text with colour added.",
         default_text: "`$NO_COLOR`.",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). -- I tried, but I really don't grok RSpec.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This allows users to set `HOMEBREW_NO_CLEANUP_FORMULAE` to a
comma-separated list of formula that `brew` will refuse to clean with
`brew cleanup`.

We currently allow a less granular version of this with
`HOMEBREW_NO_INSTALL_CLEANUP`. All this changes is how much control
users have over what is and isn't cleaned.

Fixes #11924.