### PR TITLE
brew.sh: set HOMEBREW_FORCE_HOMEBREW_ON_LINUX when core repo is homeb…

### DIFF
--- a/Library/Homebrew/api/versions.rb
+++ b/Library/Homebrew/api/versions.rb
@@ -27,7 +27,9 @@ module Homebrew
 
         sig { params(name: String).returns(T.nilable(PkgVersion)) }
         def latest_formula_version(name)
-          versions = if OS.mac? || Homebrew::EnvConfig.force_homebrew_on_linux?
+          versions = if OS.mac? ||
+                        Homebrew::EnvConfig.force_homebrew_on_linux? ||
+                        Homebrew::EnvConfig.force_homebrew_core_repo_on_linux?
             formulae
           else
             linux

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -469,6 +469,17 @@ Your Git executable: $(unset git && type -p ${HOMEBREW_GIT})"
 
   HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION="2.13"
   unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
+
+  HOMEBREW_CORE_REPOSITORY_ORIGIN="$("${HOMEBREW_GIT}" -C "${HOMEBREW_CORE_REPOSITORY}" remote get-url origin)"
+  if [[ "${HOMEBREW_CORE_REPOSITORY_ORIGIN}" = "https://github.com/Homebrew/homebrew-core" ]]
+  then
+    # If the remote origin has been set to Homebrew/homebrew-core by the install script,
+    # then we are in the case of a new installation of brew, using Homebrew/homebrew-core as a Linux core repository.
+    # In that case, set HOMEBREW_FORCE_HOMEBREW_CORE_REPO_ON_LINUX=1 to set the right HOMEBREW_BOTTLE_DOMAIN below.
+    # TODO: Once the linuxbrew-core migration is done we will be able to clean this up and
+    # remove HOMEBREW_FORCE_HOMEBREW_CORE_REPO_ON_LINUX
+    export HOMEBREW_FORCE_HOMEBREW_CORE_REPO_ON_LINUX="1"
+  fi
 fi
 
 # A bug in the auto-update process prior to 3.1.2 means $HOMEBREW_BOTTLE_DOMAIN
@@ -484,7 +495,7 @@ then
   unset HOMEBREW_BOTTLE_DOMAIN
 fi
 
-if [[ -n "${HOMEBREW_MACOS}" || -n "${HOMEBREW_FORCE_HOMEBREW_ON_LINUX}" ]]
+if [[ -n "${HOMEBREW_MACOS}" || -n "${HOMEBREW_FORCE_HOMEBREW_ON_LINUX}" || -n "${HOMEBREW_FORCE_HOMEBREW_CORE_REPO_ON_LINUX}" ]]
 then
   HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"
 else
@@ -624,7 +635,7 @@ then
 fi
 export HOMEBREW_BREW_GIT_REMOTE
 
-if [[ -n "${HOMEBREW_MACOS}" ]] || [[ -n "${HOMEBREW_FORCE_HOMEBREW_ON_LINUX}" ]]
+if [[ -n "${HOMEBREW_MACOS}" ]] || [[ -n "${HOMEBREW_FORCE_HOMEBREW_ON_LINUX}" ]]  || [[ -n "${HOMEBREW_FORCE_HOMEBREW_CORE_REPO_ON_LINUX}" ]]
 then
   HOMEBREW_CORE_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/homebrew-core"
 else

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -11,34 +11,34 @@ module Homebrew
     module_function
 
     ENVS = {
-      HOMEBREW_ARCH:                          {
+      HOMEBREW_ARCH:                              {
         description: "Linux only: Pass this value to a type name representing the compiler's `-march` option.",
         default:     "native",
       },
-      HOMEBREW_ARTIFACT_DOMAIN:               {
+      HOMEBREW_ARTIFACT_DOMAIN:                   {
         description: "Prefix all download URLs, including those for bottles, with this value. " \
                      "For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a " \
                      "formula with the URL `https://example.com/foo.tar.gz` to instead download from " \
                      "`http://localhost:8080/example.com/foo.tar.gz`.",
       },
-      HOMEBREW_AUTO_UPDATE_SECS:              {
+      HOMEBREW_AUTO_UPDATE_SECS:                  {
         description: "Automatically check for updates once per this seconds interval.",
         default:     300,
       },
-      HOMEBREW_BAT:                           {
+      HOMEBREW_BAT:                               {
         description: "If set, use `bat` for the `brew cat` command.",
         boolean:     true,
       },
-      HOMEBREW_BAT_CONFIG_PATH:               {
+      HOMEBREW_BAT_CONFIG_PATH:                   {
         description:  "Use this as the `bat` configuration file.",
         default_text: "`$HOME/.bat/config`.",
       },
-      HOMEBREW_BOOTSNAP:                      {
+      HOMEBREW_BOOTSNAP:                          {
         description: "If set, use Bootsnap to speed up repeated `brew` calls. "\
                      "A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).",
         boolean:     true,
       },
-      HOMEBREW_BOTTLE_DOMAIN:                 {
+      HOMEBREW_BOTTLE_DOMAIN:                     {
         description:  "Use this URL as the download mirror for bottles. " \
                       "If bottles at that URL are temporarily unavailable, " \
                       "the default bottle domain will be used as a fallback mirror. " \
@@ -50,79 +50,79 @@ module Homebrew
                       "Linux: `https://ghcr.io/v2/linuxbrew/core`.",
         default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,
       },
-      HOMEBREW_BREW_GIT_REMOTE:               {
+      HOMEBREW_BREW_GIT_REMOTE:                   {
         description: "Use this URL as the Homebrew/brew `git`(1) remote.",
         default:     HOMEBREW_BREW_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_BROWSER:                       {
+      HOMEBREW_BROWSER:                           {
         description:  "Use this as the browser when opening project homepages.",
         default_text: "`$BROWSER` or the OS's default browser.",
       },
-      HOMEBREW_CACHE:                         {
+      HOMEBREW_CACHE:                             {
         description:  "Use this directory as the download cache.",
         default_text: "macOS: `$HOME/Library/Caches/Homebrew`, " \
                       "Linux: `$XDG_CACHE_HOME/Homebrew` or `$HOME/.cache/Homebrew`.",
         default:      HOMEBREW_DEFAULT_CACHE,
       },
-      HOMEBREW_CASK_OPTS:                     {
+      HOMEBREW_CASK_OPTS:                         {
         description: "Append these options to all `cask` commands. All `--*dir` options, " \
                      "`--language`, `--require-sha`, `--no-quarantine` and `--no-binaries` are supported. " \
                      "For example, you might add something like the following to your " \
                      "`~/.profile`, `~/.bash_profile`, or `~/.zshenv`:\n\n" \
                      '    `export HOMEBREW_CASK_OPTS="--appdir=~/Applications --fontdir=/Library/Fonts"`',
       },
-      HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS:    {
+      HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS:        {
         description: "If set, `brew install`, `brew upgrade` and `brew reinstall` will cleanup all formulae " \
                      "when this number of days has passed.",
         default:     30,
       },
-      HOMEBREW_CLEANUP_MAX_AGE_DAYS:          {
+      HOMEBREW_CLEANUP_MAX_AGE_DAYS:              {
         description: "Cleanup all cached files older than this many days.",
         default:     120,
       },
-      HOMEBREW_COLOR:                         {
+      HOMEBREW_COLOR:                             {
         description: "If set, force colour output on non-TTY outputs.",
         boolean:     true,
       },
-      HOMEBREW_CORE_GIT_REMOTE:               {
+      HOMEBREW_CORE_GIT_REMOTE:                   {
         description:  "Use this URL as the Homebrew/homebrew-core `git`(1) remote.",
         default_text: "macOS: `https://github.com/Homebrew/homebrew-core`, " \
                       "Linux: `https://github.com/Homebrew/linuxbrew-core`.",
         default:      HOMEBREW_CORE_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_CURLRC:                        {
+      HOMEBREW_CURLRC:                            {
         description: "If set, do not pass `--disable` when invoking `curl`(1), which disables the " \
                      "use of `curlrc`.",
         boolean:     true,
       },
-      HOMEBREW_CURL_RETRIES:                  {
+      HOMEBREW_CURL_RETRIES:                      {
         description: "Pass the given retry count to `--retry` when invoking `curl`(1).",
         default:     3,
       },
-      HOMEBREW_CURL_VERBOSE:                  {
+      HOMEBREW_CURL_VERBOSE:                      {
         description: "If set, pass `--verbose` when invoking `curl`(1).",
         boolean:     true,
       },
-      HOMEBREW_DEVELOPER:                     {
+      HOMEBREW_DEVELOPER:                         {
         description: "If set, tweak behaviour to be more relevant for Homebrew developers (active or " \
                      "budding) by e.g. turning warnings into errors.",
         boolean:     true,
       },
-      HOMEBREW_DISABLE_LOAD_FORMULA:          {
+      HOMEBREW_DISABLE_LOAD_FORMULA:              {
         description: "If set, refuse to load formulae. This is useful when formulae are not trusted (such " \
                      "as in pull requests).",
         boolean:     true,
       },
-      HOMEBREW_DISPLAY:                       {
+      HOMEBREW_DISPLAY:                           {
         description:  "Use this X11 display when opening a page in a browser, for example with " \
                       "`brew home`. Primarily useful on Linux.",
         default_text: "`$DISPLAY`.",
       },
-      HOMEBREW_DISPLAY_INSTALL_TIMES:         {
+      HOMEBREW_DISPLAY_INSTALL_TIMES:             {
         description: "If set, print install times for each formula at the end of the run.",
         boolean:     true,
       },
-      HOMEBREW_EDITOR:                        {
+      HOMEBREW_EDITOR:                            {
         description:  "Use this editor when editing a single formula, or several formulae in the " \
                       "same directory." \
                       "\n\n    *Note:* `brew edit` will open all of Homebrew as discontinuous files " \
@@ -130,35 +130,35 @@ module Homebrew
                       "editors will do strange things in this case.",
         default_text: "`$EDITOR` or `$VISUAL`.",
       },
-      HOMEBREW_FAIL_LOG_LINES:                {
+      HOMEBREW_FAIL_LOG_LINES:                    {
         description: "Output this many lines of output on formula `system` failures.",
         default:     15,
       },
-      HOMEBREW_FORBIDDEN_LICENSES:            {
+      HOMEBREW_FORBIDDEN_LICENSES:                {
         description: "A space-separated list of licenses. Homebrew will refuse to install a " \
                      "formula if it or any of its dependencies has a license on this list.",
       },
-      HOMEBREW_FORCE_BREWED_CURL:             {
+      HOMEBREW_FORCE_BREWED_CURL:                 {
         description: "If set, always use a Homebrew-installed `curl`(1) rather than the system version. " \
                      "Automatically set if the system version of `curl` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_BREWED_GIT:              {
+      HOMEBREW_FORCE_BREWED_GIT:                  {
         description: "If set, always use a Homebrew-installed `git`(1) rather than the system version. " \
                      "Automatically set if the system version of `git` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_HOMEBREW_ON_LINUX:       {
+      HOMEBREW_FORCE_HOMEBREW_ON_LINUX:           {
         description: "If set, running Homebrew on Linux will use URLs for macOS. This is useful when merging " \
                      "pull requests for macOS while on Linux.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_VENDOR_RUBY:             {
+      HOMEBREW_FORCE_VENDOR_RUBY:                 {
         description: "If set, always use Homebrew's vendored, relocatable Ruby version even if the system version " \
                      "of Ruby is new enough.",
         boolean:     true,
       },
-      HOMEBREW_GITHUB_API_TOKEN:              {
+      HOMEBREW_GITHUB_API_TOKEN:                  {
         description: "Use this personal access token for the GitHub API, for features such as " \
                      "`brew search`. You can create one at <https://github.com/settings/tokens>. If set, " \
                      "GitHub will allow you a greater number of API requests. For more information, see: " \
@@ -166,43 +166,43 @@ module Homebrew
                      "\n\n    *Note:* Homebrew doesn't require permissions for any of the scopes, but some " \
                      "developer commands may require additional permissions.",
       },
-      HOMEBREW_GITHUB_PACKAGES_TOKEN:         {
+      HOMEBREW_GITHUB_PACKAGES_TOKEN:             {
         description: "Use this GitHub personal access token when accessing the GitHub Packages Registry "\
                      "(where bottles may be stored).",
       },
-      HOMEBREW_DOCKER_REGISTRY_TOKEN:         {
+      HOMEBREW_DOCKER_REGISTRY_TOKEN:             {
         description: "Use this bearer token for authenticating with a Docker registry proxying GitHub Packages.",
       },
-      HOMEBREW_GITHUB_PACKAGES_USER:          {
+      HOMEBREW_GITHUB_PACKAGES_USER:              {
         description: "Use this username when accessing the GitHub Packages Registry (where bottles may be stored).",
       },
-      HOMEBREW_GIT_EMAIL:                     {
+      HOMEBREW_GIT_EMAIL:                         {
         description: "Set the Git author and committer email to this value.",
       },
-      HOMEBREW_GIT_NAME:                      {
+      HOMEBREW_GIT_NAME:                          {
         description: "Set the Git author and committer name to this value.",
       },
-      HOMEBREW_INSTALL_BADGE:                 {
+      HOMEBREW_INSTALL_BADGE:                     {
         description:  "Print this text before the installation summary of each successful build.",
         default_text: 'The "Beer Mug" emoji.',
         default:      "🍺",
       },
-      HOMEBREW_INTERNET_ARCHIVE_KEY:          {
+      HOMEBREW_INTERNET_ARCHIVE_KEY:              {
         description: "Use this API key when accessing the Internet Archive S3 API, where bottles are stored. " \
                      "The format is access:secret. See https://archive.org/account/s3.php",
       },
-      HOMEBREW_LIVECHECK_WATCHLIST:           {
+      HOMEBREW_LIVECHECK_WATCHLIST:               {
         description: "Consult this file for the list of formulae to check by default when no formula argument " \
                      "is passed to `brew livecheck`.",
         default:     "$HOME/.brew_livecheck_watchlist",
       },
-      HOMEBREW_LOGS:                          {
+      HOMEBREW_LOGS:                              {
         description:  "Use this directory to store log files.",
         default_text: "macOS: `$HOME/Library/Logs/Homebrew`, " \
                       "Linux: `$XDG_CACHE_HOME/Homebrew/Logs` or `$HOME/.cache/Homebrew/Logs`.",
         default:      HOMEBREW_DEFAULT_LOGS,
       },
-      HOMEBREW_MAKE_JOBS:                     {
+      HOMEBREW_MAKE_JOBS:                         {
         description:  "Use this value as the number of parallel jobs to run when building with `make`(1).",
         default_text: "The number of available CPU cores.",
         default:      lambda {
@@ -211,86 +211,90 @@ module Homebrew
           Hardware::CPU.cores
         },
       },
-      HOMEBREW_NO_ANALYTICS:                  {
+      HOMEBREW_NO_ANALYTICS:                      {
         description: "If set, do not send analytics. For more information, see: <https://docs.brew.sh/Analytics>",
         boolean:     true,
       },
-      HOMEBREW_NO_AUTO_UPDATE:                {
+      HOMEBREW_NO_AUTO_UPDATE:                    {
         description: "If set, do not automatically update before running some commands e.g. " \
                      "`brew install`, `brew upgrade` and `brew tap`.",
         boolean:     true,
       },
-      HOMEBREW_NO_BOOTSNAP:                   {
+      HOMEBREW_NO_BOOTSNAP:                       {
         description: "If set, do not use Bootsnap to speed up repeated `brew` calls.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: {
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK:     {
         description: "If set, do not check for broken dependents after installing, upgrading or reinstalling " \
                      "formulae.",
         boolean:     true,
       },
-      HOMEBREW_NO_CLEANUP_FORMULAE:           {
+      HOMEBREW_NO_CLEANUP_FORMULAE:               {
         description: "A comma-separated list of formulae. Homebrew will refuse to clean up a " \
                      "formula if it appears on this list.",
       },
-      HOMEBREW_NO_COLOR:                      {
+      HOMEBREW_NO_COLOR:                          {
         description:  "If set, do not print text with colour added.",
         default_text: "`$NO_COLOR`.",
         boolean:      true,
       },
-      HOMEBREW_NO_COMPAT:                     {
+      HOMEBREW_NO_COMPAT:                         {
         description: "If set, disable all use of legacy compatibility code.",
         boolean:     true,
       },
-      HOMEBREW_NO_EMOJI:                      {
+      HOMEBREW_NO_EMOJI:                          {
         description: "If set, do not print `HOMEBREW_INSTALL_BADGE` on a successful build." \
                      "\n\n    *Note:* Will only try to print emoji on OS X Lion or newer.",
         boolean:     true,
       },
-      HOMEBREW_NO_GITHUB_API:                 {
+      HOMEBREW_NO_GITHUB_API:                     {
         description: "If set, do not use the GitHub API, e.g. for searches or fetching relevant issues " \
                      "after a failed install.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSECURE_REDIRECT:          {
+      HOMEBREW_NO_INSECURE_REDIRECT:              {
         description: "If set, forbid redirects from secure HTTPS to insecure HTTP." \
                      "\n\n    *Note:* While ensuring your downloads are fully secure, this is likely to cause " \
                      "from-source SourceForge, some GNU & GNOME-hosted formulae to fail to download.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALL_CLEANUP:            {
+      HOMEBREW_NO_INSTALL_CLEANUP:                {
         description: "If set, `brew install`, `brew upgrade` and `brew reinstall` will never automatically " \
                      "cleanup installed/upgraded/reinstalled formulae or all formulae every " \
                      "`HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` days.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALL_UPGRADE:            {
+      HOMEBREW_NO_INSTALL_UPGRADE:                {
         description: "If set, `brew install` will not automatically upgrade installed but outdated formulae",
         boolean:     true,
       },
-      HOMEBREW_PRY:                           {
+      HOMEBREW_PRY:                               {
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
-      HOMEBREW_SIMULATE_MACOS_ON_LINUX:       {
+      HOMEBREW_SIMULATE_MACOS_ON_LINUX:           {
         description: "If set, running Homebrew on Linux will simulate certain macOS code paths. This is useful " \
                      "when auditing macOS formulae while on Linux. Implies `HOMEBREW_FORCE_HOMEBREW_ON_LINUX`.",
         boolean:     true,
       },
-      HOMEBREW_SKIP_OR_LATER_BOTTLES:         {
+      HOMEBREW_FORCE_HOMEBREW_CORE_REPO_ON_LINUX: {
+        description: "If set, running Homebrew on Linux will use homebrew-core instead of linuxbrew-core.",
+        boolean:     true,
+      },
+      HOMEBREW_SKIP_OR_LATER_BOTTLES:             {
         description: "If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions " \
                      "of macOS. This is useful in development on new macOS versions.",
         boolean:     true,
       },
-      HOMEBREW_SORBET_RUNTIME:                {
+      HOMEBREW_SORBET_RUNTIME:                    {
         description: "If set, enable runtime typechecking using Sorbet.",
         boolean:     true,
       },
-      HOMEBREW_SVN:                           {
+      HOMEBREW_SVN:                               {
         description:  "Use this as the `svn`(1) binary.",
         default_text: "A Homebrew-built Subversion (if installed), or the system-provided binary.",
       },
-      HOMEBREW_TEMP:                          {
+      HOMEBREW_TEMP:                              {
         description:  "Use this path as the temporary directory for building packages. Changing " \
                       "this may be needed if your system temporary directory and Homebrew prefix are on " \
                       "different volumes, as macOS has trouble moving symlinks across volumes when the target " \
@@ -299,45 +303,45 @@ module Homebrew
         default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
-      HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED:  {
+      HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED:      {
         description: "If set, `brew update` only lists updates to installed software.",
         boolean:     true,
       },
-      HOMEBREW_UPDATE_TO_TAG:                 {
+      HOMEBREW_UPDATE_TO_TAG:                     {
         description: "If set, always use the latest stable tag (even if developer commands " \
                      "have been run).",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE:                       {
+      HOMEBREW_VERBOSE:                           {
         description: "If set, always assume `--verbose` when running commands.",
         boolean:     true,
       },
-      HOMEBREW_DEBUG:                         {
+      HOMEBREW_DEBUG:                             {
         description: "If set, always assume `--debug` when running commands.",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE_USING_DOTS:            {
+      HOMEBREW_VERBOSE_USING_DOTS:                {
         description: "If set, verbose output will print a `.` no more than once a minute. This can be " \
                      "useful to avoid long-running Homebrew commands being killed due to no output.",
         boolean:     true,
       },
-      all_proxy:                              {
+      all_proxy:                                  {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      ftp_proxy:                              {
+      ftp_proxy:                                  {
         description: "Use this FTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      http_proxy:                             {
+      http_proxy:                                 {
         description: "Use this HTTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      https_proxy:                            {
+      https_proxy:                                {
         description: "Use this HTTPS proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      no_proxy:                               {
+      no_proxy:                                   {
         description: "A comma-separated list of hostnames and domain names excluded " \
                      "from proxying by `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      SUDO_ASKPASS:                           {
+      SUDO_ASKPASS:                               {
         description: "If set, pass the `-A` option when calling `sudo`(8).",
       },
     }.freeze

--- a/Library/Homebrew/extend/os/linux/api/analytics.rb
+++ b/Library/Homebrew/extend/os/linux/api/analytics.rb
@@ -6,7 +6,9 @@ module Homebrew
     module Analytics
       class << self
         def analytics_api_path
-          return generic_analytics_api_path if Homebrew::EnvConfig.force_homebrew_on_linux?
+          return generic_analytics_api_path if
+            Homebrew::EnvConfig.force_homebrew_on_linux? ||
+            Homebrew::EnvConfig.force_homebrew_core_repo_on_linux?
 
           "analytics-linux"
         end

--- a/Library/Homebrew/extend/os/linux/api/bottle.rb
+++ b/Library/Homebrew/extend/os/linux/api/bottle.rb
@@ -6,7 +6,9 @@ module Homebrew
     module Bottle
       class << self
         def bottle_api_path
-          return generic_bottle_api_path if Homebrew::EnvConfig.force_homebrew_on_linux?
+          return generic_bottle_api_path if
+            Homebrew::EnvConfig.force_homebrew_on_linux? ||
+            Homebrew::EnvConfig.force_homebrew_core_repo_on_linux?
 
           "bottle-linux"
         end

--- a/Library/Homebrew/extend/os/linux/api/formula.rb
+++ b/Library/Homebrew/extend/os/linux/api/formula.rb
@@ -6,7 +6,9 @@ module Homebrew
     module Formula
       class << self
         def formula_api_path
-          return generic_formula_api_path if Homebrew::EnvConfig.force_homebrew_on_linux?
+          return generic_formula_api_path if
+            Homebrew::EnvConfig.force_homebrew_on_linux? ||
+            Homebrew::EnvConfig.force_homebrew_core_repo_on_linux?
 
           "formula-linux"
         end

--- a/Library/Homebrew/extend/os/linux/tap.rb
+++ b/Library/Homebrew/extend/os/linux/tap.rb
@@ -5,6 +5,8 @@ class CoreTap < Tap
   # @private
   def initialize
     super "Homebrew", "core"
-    @full_name = "Homebrew/linuxbrew-core" unless Homebrew::EnvConfig.force_homebrew_on_linux?
+    @full_name = "Homebrew/linuxbrew-core" if
+      !Homebrew::EnvConfig.force_homebrew_on_linux? &&
+      !Homebrew::EnvConfig.force_homebrew_core_repo_on_linux?
   end
 end

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -9817,6 +9817,8 @@ module Homebrew::EnvConfig
 
   def self.force_homebrew_on_linux?(); end
 
+  def self.force_homebrew_core_repo_on_linux?(); end
+
   def self.force_vendor_ruby?(); end
 
   def self.ftp_proxy(); end


### PR DESCRIPTION
…rew-core

See https://github.com/Homebrew/install/pull/571

When the install script sets as https://github.com/Homebrew/homebrew-core,
we need to use the homebrew-core bottle domain, and correctly set
the HOMEBREW_CORE_DEFAULT_GIT_REMOTE below.

This also fixes the brew doctor issue for new homebrew-core Linux installations

Warning: Suspicious https://github.com/Homebrew/linuxbrew-core git origin remote found.
The current git origin is:
  https://github.com/Homebrew/homebrew-core

With a non-standard origin, Homebrew won't update properly.
You can solve this by setting the origin remote:
  git -C "/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core" remote set-url origin https://github.com/Homebrew/linuxbrew-core

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
