### PR TITLE
Style: fix mac?/linux? checks on Linux in "simulate Mac" mode

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -373,7 +373,7 @@ module RuboCop
           end
 
           [:mac?, :linux?].each do |method_name|
-            next if formula_tap != "homebrew-core" || file_path&.include?("linuxbrew")
+            next if formula_tap != "homebrew-core" || formula_tap == "linuxbrew-core"
 
             find_instance_method_call(body_node, "OS", method_name) do |check|
               problem "Don't use #{check.source}; homebrew/core only supports macOS"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We already disabled this check on Linux back in 2018, and since homebrew/core runs its style checks in Linux, it means we de facto haven't been running this in CI for several years.

As of Homebrew/homebrew-core#84025 and another similar PR, we now have several of these `OS.mac?` checks in homebrew/core. My understanding is that's valid now, since we're merging Homebrew and Linuxbrew core. For that reason, this check is no longer relevant and we should kill it off.

refs https://github.com/Homebrew/actions/pull/213