### PR TITLE
upgrade: list upgradeable dependencies on dry run

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -133,7 +133,7 @@ module Cask
         end
 
         verb = dry_run ? "Would upgrade" : "Upgrading"
-        oh1 "#{verb} #{outdated_casks.count} #{"outdated package".pluralize(outdated_casks.count)}:"
+        oh1 "#{verb} #{outdated_casks.count} outdated #{"package".pluralize(outdated_casks.count)}:"
 
         caught_exceptions = []
 

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -154,10 +154,10 @@ module Homebrew
       @cleaned_up_paths = Set.new
     end
 
-    def self.install_formula_clean!(f)
+    def self.install_formula_clean!(f, dry_run: false)
       return if Homebrew::EnvConfig.no_install_cleanup?
 
-      cleanup = Cleanup.new
+      cleanup = Cleanup.new(dry_run: dry_run)
       if cleanup.periodic_clean_due?
         cleanup.periodic_clean!
       elsif f.latest_version_installed? && !cleanup.skip_clean_formula?(f)
@@ -187,8 +187,12 @@ module Homebrew
     def periodic_clean!
       return false unless periodic_clean_due?
 
-      ohai "`brew cleanup` has not been run in #{CLEANUP_DEFAULT_DAYS} days, running now..."
-      clean!(quiet: true, periodic: true)
+      if dry_run?
+        ohai "Would run `brew cleanup` which has not been run in the last #{CLEANUP_DEFAULT_DAYS} days"
+      else
+        ohai "`brew cleanup` has not been run in the last #{CLEANUP_DEFAULT_DAYS} days, running now..."
+        clean!(quiet: true, periodic: true)
+      end
     end
 
     def clean!(quiet: false, periodic: false)

--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -19,6 +19,8 @@ module Homebrew
       switch "-f", "--force",
              description: "Treat installed <formula> and provided <formula> as if they are from "\
                           "the same taps and migrate them anyway."
+      switch "-n", "--dry-run",
+             description: "Show what would be migrated, but do not actually migrate anything."
 
       named_args :installed_formula, min: 1
     end
@@ -35,8 +37,7 @@ module Homebrew
         odie "#{rack} is a symlink" if rack.symlink?
       end
 
-      migrator = Migrator.new(f, force: args.force?)
-      migrator.migrate
+      Migrator.migrate_if_needed(f, force: args.force?, dry_run: args.dry_run?)
     end
   end
 end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -187,21 +187,20 @@ module Homebrew
       puts formulae_upgrades.join("\n")
     end
 
-    unless args.dry_run?
-      Upgrade.upgrade_formulae(
-        formulae_to_install,
-        flags:                      args.flags_only,
-        installed_on_request:       args.named.present?,
-        force_bottle:               args.force_bottle?,
-        build_from_source_formulae: args.build_from_source_formulae,
-        interactive:                args.interactive?,
-        keep_tmp:                   args.keep_tmp?,
-        force:                      args.force?,
-        debug:                      args.debug?,
-        quiet:                      args.quiet?,
-        verbose:                    args.verbose?,
-      )
-    end
+    Upgrade.upgrade_formulae(
+      formulae_to_install,
+      flags:                      args.flags_only,
+      dry_run:                    args.dry_run?,
+      installed_on_request:       args.named.present?,
+      force_bottle:               args.force_bottle?,
+      build_from_source_formulae: args.build_from_source_formulae,
+      interactive:                args.interactive?,
+      keep_tmp:                   args.keep_tmp?,
+      force:                      args.force?,
+      debug:                      args.debug?,
+      quiet:                      args.quiet?,
+      verbose:                    args.verbose?,
+    )
 
     Upgrade.check_installed_dependents(
       formulae_to_install,

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -110,10 +110,14 @@ class Migrator
     true
   end
 
-  def self.migrate_if_needed(formula, force:)
+  def self.migrate_if_needed(formula, force:, dry_run: false)
     return unless Migrator.needs_migration?(formula)
 
     begin
+      if dry_run
+        ohai "Would migrate #{formula.oldname} to #{formula.name}"
+        return
+      end
       migrator = Migrator.new(formula, force: force)
       migrator.migrate
     rescue => e

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1419,6 +1419,7 @@ _brew_migrate() {
     -*)
       __brewcomp "
       --debug
+      --dry-run
       --force
       --help
       --quiet

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -997,6 +997,7 @@ __fish_brew_complete_arg 'man' -l verbose -d 'Make some output more verbose'
 
 __fish_brew_complete_cmd 'migrate' 'Migrate renamed packages to new names, where formula are old names of packages'
 __fish_brew_complete_arg 'migrate' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'migrate' -l dry-run -d 'Show what would be migrated, but do not actually migrate anything'
 __fish_brew_complete_arg 'migrate' -l force -d 'Treat installed formula and provided formula as if they are from the same taps and migrate them anyway'
 __fish_brew_complete_arg 'migrate' -l help -d 'Show this message'
 __fish_brew_complete_arg 'migrate' -l quiet -d 'Make some output more quiet'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1221,6 +1221,7 @@ _brew_man() {
 _brew_migrate() {
   _arguments \
     '--debug[Display any debugging information]' \
+    '--dry-run[Show what would be migrated, but do not actually migrate anything]' \
     '--force[Treat installed formula and provided formula as if they are from the same taps and migrate them anyway]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -417,13 +417,15 @@ if no formula is provided.
 * `-n`, `--max-count`:
   Print only a specified number of commits.
 
-### `migrate` [*`--force`*] *`installed_formula`* [...]
+### `migrate` [*`--force`*] [*`--dry-run`*] *`installed_formula`* [...]
 
 Migrate renamed packages to new names, where *`formula`* are old names of
 packages.
 
 * `-f`, `--force`:
   Treat installed *`formula`* and provided *`formula`* as if they are from the same taps and migrate them anyway.
+* `-n`, `--dry-run`:
+  Show what would be migrated, but do not actually migrate anything.
 
 ### `missing` [*`--hide`*`=`] [*`formula`* ...]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -578,12 +578,16 @@ Print only one commit\.
 \fB\-n\fR, \fB\-\-max\-count\fR
 Print only a specified number of commits\.
 .
-.SS "\fBmigrate\fR [\fI\-\-force\fR] \fIinstalled_formula\fR [\.\.\.]"
+.SS "\fBmigrate\fR [\fI\-\-force\fR] [\fI\-\-dry\-run\fR] \fIinstalled_formula\fR [\.\.\.]"
 Migrate renamed packages to new names, where \fIformula\fR are old names of packages\.
 .
 .TP
 \fB\-f\fR, \fB\-\-force\fR
 Treat installed \fIformula\fR and provided \fIformula\fR as if they are from the same taps and migrate them anyway\.
+.
+.TP
+\fB\-n\fR, \fB\-\-dry\-run\fR
+Show what would be migrated, but do not actually migrate anything\.
 .
 .SS "\fBmissing\fR [\fI\-\-hide\fR\fB=\fR] [\fIformula\fR \.\.\.]"
 Check the given \fIformula\fR kegs for missing dependencies\. If no \fIformula\fR are provided, check all kegs\. Will exit with a non\-zero status if any kegs are found to be missing dependencies\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, a dry run of `brew upgrade` only lists which dependents of the given packages will be auto-upgraded. This adds a list of dependencies to be auto-upgraded to the output.

Before:
```
$ brew upgrade -n nghttp2 harfbuzz
==> Would upgrade 2 outdated packages:
nghttp2 1.43.0 -> 1.44.0
harfbuzz 2.8.1 -> 2.9.0
==> Would upgrade 4 dependents:
unbound 1.13.1 -> 1.13.2, gnupg 2.3.1_1 -> 2.3.2, pango 1.48.5 -> 1.48.9, gtk+3 3.24.29 -> 3.24.30
==> No currently broken dependents found!
Warning: If they are broken by the upgrade they will also be upgraded or reinstalled.
```

After:
```
$ brew upgrade -n nghttp2 harfbuzz
==> Would upgrade 2 outdated packages:
nghttp2 1.43.0 -> 1.44.0
harfbuzz 2.8.1 -> 2.9.0
==> Would upgrade 3 dependencies for nghttp2:
openssl@1.1 1.1.1k -> 1.1.1l, cmake 3.21.1 -> 3.21.2, c-ares 1.17.1 -> 1.17.2
==> Would upgrade 4 dependencies for harfbuzz:
openssl@1.1 1.1.1k -> 1.1.1l, meson 0.59.0 -> 0.59.1, freetype 2.10.4 -> 2.11.0, glib 2.68.3 -> 2.68.4
==> Would upgrade 4 dependents:
unbound 1.13.1 -> 1.13.2, gnupg 2.3.1_1 -> 2.3.2, pango 1.48.5 -> 1.48.9, gtk+3 3.24.29 -> 3.24.30
==> No currently broken dependents found!
Warning: If they are broken by the upgrade they will also be upgraded or reinstalled.
```