### PR TITLE
sandbox: fallback to tput for winsize

### DIFF
--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -34,7 +34,8 @@ describe Sandbox, :needs_macos do
     it "complains on failure" do
       ENV["HOMEBREW_VERBOSE"] = "1"
 
-      expect(Utils).to receive(:popen_read).and_return("foo")
+      allow(Utils).to receive(:popen_read).and_call_original
+      allow(Utils).to receive(:popen_read).with("syslog", any_args).and_return("foo")
 
       expect { sandbox.exec "false" }
         .to raise_error(ErrorDuringExecution)
@@ -49,7 +50,8 @@ describe Sandbox, :needs_macos do
         Mar 17 02:55:06 sandboxd[342]: Python(49765) deny file-write-unlink /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/errors.pyc
         bar
       EOS
-      expect(Utils).to receive(:popen_read).and_return(with_bogus_error)
+      allow(Utils).to receive(:popen_read).and_call_original
+      allow(Utils).to receive(:popen_read).with("syslog", any_args).and_return(with_bogus_error)
 
       expect { sandbox.exec "false" }
         .to raise_error(ErrorDuringExecution)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should improve compatibility with some tests sensitive to the terminal size in the non-tty (CI) environment, such as `oakc`.