### PR TITLE
rubocops/lines: recommend on_os/OS.os? based on context.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -64,7 +64,7 @@ class Formula
   include Utils::Shebang
   include Utils::Shell
   include Context
-  include OnOS
+  include OnOS # TODO: 3.3.0: deprecate OnOS usage in instance methods.
   extend Enumerable
   extend Forwardable
   extend Cachable

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -69,7 +69,7 @@ class BottleDisableReason
   def initialize(type, reason)
     @type = type
     @reason = reason
-    # TODO: 3.3.0 should deprecate this behaviour as it was only needed for
+    # TODO: 3.3.0: deprecate this behaviour as it was only needed for
     # Homebrew/core (where we don't want unneeded or disabled bottles any more)
     # odeprecated "bottle :#{@type}" if valid?
   end

--- a/Library/Homebrew/rubocops/shared/helper_functions.rb
+++ b/Library/Homebrew/rubocops/shared/helper_functions.rb
@@ -113,8 +113,10 @@ module RuboCop
         nil
       end
 
-      # Sets the given node as the offending node when required in custom cops.
-      def offending_node(node)
+      # Gets/sets the given node as the offending node when required in custom cops.
+      def offending_node(node = nil)
+        return @offensive_node if node.nil?
+
         @offensive_node = node
       end
 

--- a/Library/Homebrew/test/rubocops/text/on_os_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_os_conditionals_spec.rb
@@ -1,0 +1,86 @@
+# typed: false
+# frozen_string_literal: true
+
+require "rubocops/lines"
+
+describe RuboCop::Cop::FormulaAudit::OSConditionals do
+  subject(:cop) { described_class.new }
+
+  context "when auditing OS conditionals" do
+    it "reports an offense when `OS.linux?` is used on Formula class" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          if OS.linux?
+             ^^^^^^^^^ Don't use 'if OS.linux?', use 'on_linux do' instead.
+            url 'https://brew.sh/linux-1.0.tgz'
+          else
+            url 'https://brew.sh/linux-1.0.tgz'
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when `OS.mac?` is used on Formula class" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          if OS.mac?
+             ^^^^^^^ Don't use 'if OS.mac?', use 'on_macos do' instead.
+            url 'https://brew.sh/mac-1.0.tgz'
+          else
+            url 'https://brew.sh/linux-1.0.tgz'
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when `on_macos` is used in install method" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          def install
+            on_macos do
+            ^^^^^^^^ Don't use 'on_macos' in 'def install', use 'if OS.mac?' instead.
+              true
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when `on_linux` is used in install method" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          def install
+            on_linux do
+            ^^^^^^^^ Don't use 'on_linux' in 'def install', use 'if OS.linux?' instead.
+              true
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when `on_macos` is used in test block" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          test do
+            on_macos do
+            ^^^^^^^^ Don't use 'on_macos' in 'test do', use 'if OS.mac?' instead.
+              true
+            end
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Recommend the use of `on_macos` and `on_linux` unless we're in `def install`, `def post_install` or `test do` in which case recommend `OS.mac?` and `OS.linux?` instead.

TODO: 
- [x] add autocorrection, tests
- [x] fix homebrew/core

Fixes https://github.com/Homebrew/brew/issues/11687