### PR TITLE
Wrap mac 'brew info' multi-word service command parameters in single quotes

### DIFF
--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -38,8 +38,8 @@ class Caveats
     if f.plist_manual || f.service?
       command = if f.service?
         f.service.command
-         .map { |arg| (arg =~ /\s/) ? "'#{arg}'" : arg } # wrap multi-word arguments in quotes
-         .join(" ")
+          .map { |arg| (arg =~ /\s/) ? "'#{arg}'" : arg } # wrap multi-word arguments in quotes
+          .join(" ")
       else
         f.plist_manual
       end

--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -37,7 +37,7 @@ class Caveats
 
     if f.plist_manual || f.service?
       command = if f.service?
-        f.service.command.join(" ")
+        f.service.command.map{ |arg| "'#{arg}'" }.join(" ")
       else
         f.plist_manual
       end

--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -37,9 +37,14 @@ class Caveats
 
     if f.plist_manual || f.service?
       command = if f.service?
-        f.service.command
-         .map { |arg| (arg =~ /\s/) ? "'#{arg}'" : arg } # wrap multi-word arguments in quotes
-         .join(" ")
+        f.service
+         .command
+         .map do |arg|
+           next arg unless arg.match?(/\s/)
+
+           # quote multi-word arguments
+           "'#{arg}'"
+         end.join(" ")
       else
         f.plist_manual
       end

--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -37,7 +37,9 @@ class Caveats
 
     if f.plist_manual || f.service?
       command = if f.service?
-        f.service.command.map { |arg| "'#{arg}'" }.join(" ")
+        f.service.command
+         .map { |arg| (arg =~ /\s/) ? "'#{arg}'" : arg } # wrap multi-word arguments in quotes
+         .join(" ")
       else
         f.plist_manual
       end

--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -38,8 +38,8 @@ class Caveats
     if f.plist_manual || f.service?
       command = if f.service?
         f.service.command
-          .map { |arg| (arg =~ /\s/) ? "'#{arg}'" : arg } # wrap multi-word arguments in quotes
-          .join(" ")
+         .map { |arg| (arg =~ /\s/) ? "'#{arg}'" : arg } # wrap multi-word arguments in quotes
+         .join(" ")
       else
         f.plist_manual
       end

--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -37,7 +37,7 @@ class Caveats
 
     if f.plist_manual || f.service?
       command = if f.service?
-        f.service.command.map{ |arg| "'#{arg}'" }.join(" ")
+        f.service.command.map { |arg| "'#{arg}'" }.join(" ")
       else
         f.plist_manual
       end

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -124,7 +124,21 @@ describe Caveats do
         caveats = described_class.new(f).caveats
 
         expect(f.service?).to eq(true)
-        expect(caveats).to include("'#{f.bin}/php' 'test'")
+        expect(caveats).to include("#{f.bin}/php test")
+        expect(caveats).to include("background service")
+      end
+
+      it "wraps multi-word service parameters" do
+        f = formula do
+          url "foo-1.0"
+          service do
+            run [bin/"nginx", "-g", "daemon off;"]
+          end
+        end
+        caveats = described_class.new(f).caveats
+
+        expect(f.service?).to eq(true)
+        expect(caveats).to include("#{f.bin}/nginx -g 'daemon off;'")
         expect(caveats).to include("background service")
       end
 

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -124,7 +124,7 @@ describe Caveats do
         caveats = described_class.new(f).caveats
 
         expect(f.service?).to eq(true)
-        expect(caveats).to include("#{f.bin}/php test")
+        expect(caveats).to include("'#{f.bin}/php' 'test'")
         expect(caveats).to include("background service")
       end
 


### PR DESCRIPTION
This might be an oversimplification, but should resolve issues with multi-word arguments, eg:

> Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/nginx/bin/nginx -g daemon off;

fails, but 

> Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/nginx/bin/nginx -g 'daemon off;'

succeeds

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
