### PR TITLE
dependency_collector: add depends_on :swift

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -127,10 +127,16 @@ class DependencyCollector
     when :linux         then LinuxRequirement.new(tags)
     when :macos         then MacOSRequirement.new(tags)
     when :maximum_macos then MacOSRequirement.new(tags, comparator: "<=")
+    when :swift         then parse_swift_spec(tags)
     when :xcode         then XcodeRequirement.new(tags)
     else
       raise ArgumentError, "Unsupported special dependency #{spec.inspect}"
     end
+  end
+
+  def parse_swift_spec(tags)
+    tags.delete(:build_if_macos)
+    Dependency.new("swift", tags)
   end
 
   def parse_class_spec(spec, tags)

--- a/Library/Homebrew/extend/os/mac/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/mac/dependency_collector.rb
@@ -3,7 +3,8 @@
 
 class DependencyCollector
   undef git_dep_if_needed, subversion_dep_if_needed, cvs_dep_if_needed,
-        xz_dep_if_needed, unzip_dep_if_needed, bzip2_dep_if_needed
+        xz_dep_if_needed, unzip_dep_if_needed, bzip2_dep_if_needed,
+        parse_swift_spec
 
   def git_dep_if_needed(tags); end
 
@@ -20,4 +21,20 @@ class DependencyCollector
   def unzip_dep_if_needed(tags); end
 
   def bzip2_dep_if_needed(tags); end
+
+  private
+
+  def parse_swift_spec(tags)
+    min_xcode_version = MacOS::Xcode.minimum_version_for_swift(tags.shift) if tags.first.to_s.match?(/(\d\.)+\d/)
+
+    tags << :build if tags.delete(:build_if_macos)
+
+    if min_xcode_version && Version.new(MacOS::Xcode.latest_version) < Version.new(min_xcode_version)
+      # We're on an older OS where we can't update Xcode to get a new enough Swift.
+      Dependency.new("swift", tags)
+    else
+      tags.unshift(min_xcode_version) if min_xcode_version
+      XcodeRequirement.new(tags)
+    end
+  end
 end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -234,6 +234,30 @@ module OS
       def default_prefix?
         prefix.to_s == "/Applications/Xcode.app/Contents/Developer"
       end
+
+      sig { params(swift_version: String).returns(String) }
+      def minimum_version_for_swift(swift_version)
+        # https://swiftversion.net
+        case swift_version
+        when "5.4" then "12.5"
+        when "5.3" then "12.0"
+        when "5.2" then "11.4"
+        when "5.1" then "11.0"
+        when "5.0" then "10.2"
+        when "4.2" then "10.0"
+        when "4.1" then "9.3"
+        when "4.0" then "9.0"
+        when "3.1" then "8.3"
+        when "3.0" then "8.0"
+        when "2.2" then "7.3"
+        when "2.1" then "7.1"
+        when "2.0" then "7.0"
+        when "1.2" then "6.3"
+        when "1.1" then "6.1"
+        when "1.0" then "6.0.1"
+        else raise "Unknown Swift version #{swift_version}"
+        end
+      end
     end
 
     # Helper module for querying macOS Command Line Tools information.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This has _not_ been tested yet. I've opened this for review on the approach taken.

Example usage:

```ruby
depends_on :swift => "5.4"
```

This is mapped to:

```ruby
depends_on :xcode => ["12.5", :build]
```

on macOS and

```ruby
depends_on "swift"
```

on Linux.

Versionless `depends_on :swift` means versionless `depends_on :xcode => :build` on macOS.