### PR TITLE
Curl: Fix #curl_args options

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -27,7 +27,7 @@ module Homebrew
       return cache[endpoint] if cache.present? && cache.key?(endpoint)
 
       api_url = "#{API_DOMAIN}/#{endpoint}"
-      output = Utils::Curl.curl_output("--fail", "--max-time", "5", api_url)
+      output = Utils::Curl.curl_output("--fail", api_url, max_time: 5)
       raise ArgumentError, "No file found at #{Tty.underline}#{api_url}#{Tty.reset}" unless output.success?
 
       cache[endpoint] = if json

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -558,7 +558,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   end
 
   def curl(*args, **options)
-    args << "--connect-timeout" << "15" unless mirrors.empty?
+    options[:connect_timeout] = 15 unless mirrors.empty?
     super(*_curl_args, *args, **_curl_opts, **command_output_options, **options)
   end
 end

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -39,8 +39,6 @@ module Homebrew
       DEFAULT_CURL_ARGS = [
         # Follow redirections to handle mirrors, relocations, etc.
         "--location",
-        "--connect-timeout", CURL_CONNECT_TIMEOUT,
-        "--max-time", CURL_MAX_TIME
       ].freeze
 
       # `curl` arguments used in `Strategy#page_headers` method.
@@ -62,12 +60,14 @@ module Homebrew
 
       # Baseline `curl` options used in {Strategy} methods.
       DEFAULT_CURL_OPTIONS = {
-        print_stdout: false,
-        print_stderr: false,
-        debug:        false,
-        verbose:      false,
-        timeout:      CURL_PROCESS_TIMEOUT,
-        retries:      0,
+        print_stdout:    false,
+        print_stderr:    false,
+        debug:           false,
+        verbose:         false,
+        timeout:         CURL_PROCESS_TIMEOUT,
+        connect_timeout: CURL_CONNECT_TIMEOUT,
+        max_time:        CURL_MAX_TIME,
+        retries:         0,
       }.freeze
 
       # HTTP response head(s) and body are typically separated by a double

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -67,7 +67,7 @@ module Homebrew
         debug:        false,
         verbose:      false,
         timeout:      CURL_PROCESS_TIMEOUT,
-        retry:        false,
+        retries:      0,
       }.freeze
 
       # HTTP response head(s) and body are typically separated by a double

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -5,10 +5,10 @@ require "utils/curl"
 
 describe "Utils::Curl" do
   describe "curl_args" do
-    let(:args) { "foo" }
+    let(:args) { ["foo"] }
     let(:user_agent_string) { "Lorem ipsum dolor sit amet" }
 
-    it "returns --disable as the first argument when HOMEBREW_CURLRC is not set" do
+    it "returns `--disable` as the first argument when HOMEBREW_CURLRC is not set" do
       # --disable must be the first argument according to "man curl"
       expect(curl_args(*args).first).to eq("--disable")
     end
@@ -16,6 +16,26 @@ describe "Utils::Curl" do
     it "doesn't return `--disable` as the first argument when HOMEBREW_CURLRC is set" do
       ENV["HOMEBREW_CURLRC"] = "1"
       expect(curl_args(*args).first).not_to eq("--disable")
+    end
+
+    it "uses `--connect-timeout` when `:connect_timeout` is Numeric" do
+      expect(curl_args(*args, connect_timeout: 123).join(" ")).to include("--connect-timeout 123")
+      expect(curl_args(*args, connect_timeout: 123.4).join(" ")).to include("--connect-timeout 123.4")
+      expect(curl_args(*args, connect_timeout: 123.4567).join(" ")).to include("--connect-timeout 123.457")
+    end
+
+    it "errors when `:connect_timeout` is not Numeric" do
+      expect { curl_args(*args, connect_timeout: "test") }.to raise_error(TypeError)
+    end
+
+    it "uses `--max-time` when `:max_time` is Numeric" do
+      expect(curl_args(*args, max_time: 123).join(" ")).to include("--max-time 123")
+      expect(curl_args(*args, max_time: 123.4).join(" ")).to include("--max-time 123.4")
+      expect(curl_args(*args, max_time: 123.4567).join(" ")).to include("--max-time 123.457")
+    end
+
+    it "errors when `:max_time` is not Numeric" do
+      expect { curl_args(*args, max_time: "test") }.to raise_error(TypeError)
     end
 
     it "uses `--retry 3` when HOMEBREW_CURL_RETRIES is unset" do
@@ -27,12 +47,27 @@ describe "Utils::Curl" do
       expect(curl_args(*args).join(" ")).to include("--retry 10")
     end
 
-    it "doesn't use `--retry` when `:retry` == `false`" do
-      expect(curl_args(*args, retry: false).join(" ")).not_to include("--retry")
+    it "uses `--retry` when `:retries` is a positive Integer" do
+      expect(curl_args(*args, retries: 5).join(" ")).to include("--retry 5")
     end
 
-    it "uses `--retry 3` when `:retry` == `true`" do
-      expect(curl_args(*args, retry: true).join(" ")).to include("--retry 3")
+    it "doesn't use `--retry` when `:retries` is nil or a non-positive Integer" do
+      expect(curl_args(*args, retries: nil).join(" ")).not_to include("--retry")
+      expect(curl_args(*args, retries: 0).join(" ")).not_to include("--retry")
+      expect(curl_args(*args, retries: -1).join(" ")).not_to include("--retry")
+    end
+
+    it "errors when `:retries` is not Numeric" do
+      expect { curl_args(*args, retries: "test") }.to raise_error(TypeError)
+    end
+
+    it "uses `--retry-max-time` when `:retry_max_time` is Numeric" do
+      expect(curl_args(*args, retry_max_time: 123).join(" ")).to include("--retry-max-time 123")
+      expect(curl_args(*args, retry_max_time: 123.4).join(" ")).to include("--retry-max-time 123")
+    end
+
+    it "errors when `:retry_max_time` is not Numeric" do
+      expect { curl_args(*args, retry_max_time: "test") }.to raise_error(TypeError)
     end
 
     it "uses HOMEBREW_USER_AGENT_FAKE_SAFARI when `:user_agent` is `:browser` or `:fake`" do
@@ -51,6 +86,12 @@ describe "Utils::Curl" do
     it "uses provided user agent string when `:user_agent` is a `String`" do
       expect(curl_args(*args, user_agent: user_agent_string).join(" "))
         .to include("--user-agent #{user_agent_string}")
+    end
+
+    it "errors when `:user_agent` is not a String or supported Symbol" do
+      expect { curl_args(*args, user_agent: :an_unsupported_symbol) }
+        .to raise_error(TypeError, ":user_agent must be :browser/:fake, :default, or a String")
+      expect { curl_args(*args, user_agent: 123) }.to raise_error(TypeError)
     end
 
     it "uses `--fail` unless `:show_output` is `true`" do

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -214,8 +214,13 @@ module Utils
       if url != secure_url
         user_agents.each do |user_agent|
           secure_details = begin
-            curl_http_content_headers_and_checksum(secure_url, specs: specs, hash_needed: true,
-                                                   user_agent: user_agent, use_homebrew_curl: use_homebrew_curl)
+            curl_http_content_headers_and_checksum(
+              secure_url,
+              specs:             specs,
+              hash_needed:       true,
+              use_homebrew_curl: use_homebrew_curl,
+              user_agent:        user_agent,
+            )
           rescue Timeout::Error
             next
           end
@@ -231,8 +236,13 @@ module Utils
       details = nil
       user_agents.each do |user_agent|
         details =
-          curl_http_content_headers_and_checksum(url, specs: specs, hash_needed: hash_needed,
-                                                 user_agent: user_agent, use_homebrew_curl: use_homebrew_curl)
+          curl_http_content_headers_and_checksum(
+            url,
+            specs:             specs,
+            hash_needed:       hash_needed,
+            use_homebrew_curl: use_homebrew_curl,
+            user_agent:        user_agent,
+          )
         break if http_status_ok?(details[:status])
       end
 
@@ -297,16 +307,21 @@ module Utils
       "The #{url_type} #{url} may be able to use HTTPS rather than HTTP. Please verify it in a browser."
     end
 
-    def curl_http_content_headers_and_checksum(url, specs: {}, hash_needed: false,
-                                               user_agent: :default, use_homebrew_curl: false)
+    def curl_http_content_headers_and_checksum(
+      url, specs: {}, hash_needed: false,
+      use_homebrew_curl: false, user_agent: :default
+    )
       file = Tempfile.new.tap(&:close)
 
       specs = specs.flat_map { |option, argument| ["--#{option.to_s.tr("_", "-")}", argument] }
-      max_time = hash_needed ? "600" : "25"
+      max_time = hash_needed ? 600 : 25
       output, _, status = curl_output(
-        *specs, "--dump-header", "-", "--output", file.path, "--location",
-        "--connect-timeout", "15", "--max-time", max_time, "--retry-max-time", max_time, url,
-        user_agent: user_agent, use_homebrew_curl: use_homebrew_curl
+        *specs, "--dump-header", "-", "--output", file.path, "--location", url,
+        use_homebrew_curl: use_homebrew_curl,
+        connect_timeout:   15,
+        max_time:          max_time,
+        retry_max_time:    max_time,
+        user_agent:        user_agent
       )
 
       status_code = :unknown


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Utils::Curl#curl_args` seems like it intends to accept `:connect_timeout`, `:max_time`, and `:retry_max_time` options but the code that adds arguments for these values uses variables that aren't defined in this scope (`connect_timeout`, `max_time`, and `retry_max_time` respectively). The related code gives an error like ```NameError (undefined local variable or method `connect_timeout' for main:Object)``` when these options are provided to `#curl_args`.

~This PR updates this code to use the `options` value for each of these, so this will work as intended. This also modifies the inline conditions to ensure these values are numeric, as a non-numeric value would cause `#round` (and `curl`) to error.~

After discussion, this PR updates `#curl_args` to use named parameters instead of `**options`, which resolves the undefined variable issue. This also updates related code in Homebrew/brew to use these parameters instead of passing related args like `--connect-timeout`.

---

Just as an aside, I've extracted this commit from a local branch that I'll be creating a PR for soon. At the moment, I'm working on creating PRs for necessary changes that aren't strictly topical, as a way of simplifying the forthcoming PR.