### PR TITLE
Strategy: Improve curl error message finding

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -247,10 +247,8 @@ module Homebrew
           return data
         end
 
-        /^(?<error_msg>curl: \(\d+\) .+)/ =~ stderr
-        {
-          messages: [error_msg.presence || "cURL failed without an error"],
-        }
+        error_msgs = stderr&.scan(/^curl:.+$/)
+        { messages: error_msgs.presence || ["cURL failed without a detectable error"] }
       end
 
       # Handles the return value from a `strategy` block in a `livecheck`


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When I originally migrated livecheck to `curl`, the errors we were encountering typically started with `curl: ` and a number in parentheses before the error message (e.g., `curl: (60) SSL certificate problem: certificate has expired`). However, `curl` produces some errors that don't adhere to this format.

In some cases, the error message doesn't include a leading number in parentheses. Additionally, some errors can include multiple messages. For example:

```
curl: option --something: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
```

With this in mind, it's necessary to loosen the regex that's used to identify curl error messages and to use `#scan` to collect all of the error message lines in `stderr`. Otherwise we incorrectly miss certain error messages and get the fallback `cURL failed without an error` message, which we shouldn't see.

---

For what it's worth, I encountered this shortcoming as part of implementing support for specifying `curl` args in a `livecheck` block. I'll be creating a PR for that work soon but I wanted to extract this commit from that branch beforehand, to simplify the forthcoming PR.