### PR TITLE
edit: update $HOMEBREW_BAT_CONFIG_PATH default

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -31,7 +31,7 @@ module Homebrew
       },
       HOMEBREW_BAT_CONFIG_PATH:                   {
         description:  "Use this as the `bat` configuration file.",
-        default_text: "`$HOME/.bat/config`.",
+        default_text: "`$HOME/.config/bat/config`.",
       },
       HOMEBREW_BOOTSNAP:                          {
         description: "If set, use Bootsnap to speed up repeated `brew` calls. "\


### PR DESCRIPTION
Fix #11974
brew use bat's default config path not $HOMEBREW_BAT_CONFIG_PATH

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
