### PR TITLE
bump-revision: add --write switch

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -290,6 +290,9 @@ module Homebrew
 
       sig { returns(T.nilable(T::Array[String])) }
       def groups; end
+
+      sig { returns(T::Boolean) }
+      def write_only?; end
     end
   end
 end

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -18,8 +18,12 @@ module Homebrew
       EOS
       switch "-n", "--dry-run",
              description: "Print what would be done rather than doing it."
+      switch "--write-only",
+             description: "Make the expected file modifications without taking any Git actions."
       flag   "--message=",
              description: "Append <message> to the default commit message."
+
+      conflicts "--dry-run", "--write-only"
 
       named_args :formula, min: 1
     end
@@ -62,7 +66,7 @@ module Homebrew
       message = "#{formula.name}: revision bump #{args.message}"
       if args.dry_run?
         ohai "git commit --no-edit --verbose --message=#{message} -- #{formula.path}"
-      else
+      elsif !args.write_only?
         formula.path.parent.cd do
           safe_system "git", "commit", "--no-edit", "--verbose",
                       "--message=#{message}", "--", formula.path


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add a flag to write the changes made by `brew bump-revision` without committing them. This is the same concept as the `--write` switch in `brew bump-formula-pr`. This would be useful when we need to bump the revision but also do other things in the formula, such as migrating some dependencies.

While the changes work, I couldn't get `brew typecheck` to pass locally. I'm getting
```
dev-cmd/bump-revision.rb:70: Method write? does not exist on Homebrew::CLI::Args https://srb.help/7003
    70 |        unless args.write?
                       ^^^^^^^^^^^
```
I tried to update the RBI files but that didn't solve the issue. Actually, no change I made in the `bump_revision_args` block were reflected in the errors raised by `brew typecheck`.
