### PR TITLE
ENV/super: add `shims_path` helper method.

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -29,6 +29,13 @@ module Superenv
     base.run_time_deps = []
   end
 
+  # The location of Homebrew's shims on this OS.
+  # @public
+  sig { returns(Pathname) }
+  def self.shims_path
+    HOMEBREW_SHIMS_PATH/"super"
+  end
+
   # @private
   sig { returns(T.nilable(Pathname)) }
   def self.bin; end

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -4,9 +4,15 @@
 module Superenv
   extend T::Sig
 
+  # The location of Homebrew's shims on Linux.
+  # @public
+  def self.shims_path
+    HOMEBREW_SHIMS_PATH/"linux/super"
+  end
+
   # @private
   def self.bin
-    (HOMEBREW_SHIMS_PATH/"linux/super").realpath
+    shims_path.realpath
   end
 
   # @private

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -5,13 +5,19 @@ module Superenv
   extend T::Sig
 
   class << self
+    # The location of Homebrew's shims on macOS.
+    # @public
+    def shims_path
+      HOMEBREW_SHIMS_PATH/"mac/super"
+    end
+
     undef bin
 
     # @private
     def bin
       return unless DevelopmentTools.installed?
 
-      (HOMEBREW_SHIMS_PATH/"mac/super").realpath
+      shims_path.realpath
     end
   end
 


### PR DESCRIPTION
This allows us to stop repeatedly hardcoding this on macOS/Linux in formulae.