### PR TITLE
Restore original TTY state after Sandbox

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -130,6 +130,10 @@ class Sandbox
         end
 
         if $stdin.tty?
+          # If stdin is a TTY, use io.raw to set stdin to a raw, passthrough
+          # mode while we copy the input/output of the process spawned in the
+          # PTY. After we've finished copying to/from the PTY process, io.raw
+          # will restore the stdin TTY to its original state.
           $stdin.raw(&write_to_pty)
         else
           write_to_pty.call

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -115,20 +115,18 @@ class Sandbox
         end
 
         write_to_pty = proc do
-          begin
-            # Update the window size whenever the parent terminal's window size changes.
-            old_winch = trap(:WINCH, &winch)
-            winch.call(nil)
+          # Update the window size whenever the parent terminal's window size changes.
+          old_winch = trap(:WINCH, &winch)
+          winch.call(nil)
 
-            stdin_thread = Thread.new { IO.copy_stream($stdin, w) }
+          stdin_thread = Thread.new { IO.copy_stream($stdin, w) }
 
-            r.each_char { |c| print(c) }
+          r.each_char { |c| print(c) }
 
-            Process.wait(pid)
-          ensure
-            stdin_thread&.kill
-            trap(:WINCH, old_winch)
-          end
+          Process.wait(pid)
+        ensure
+          stdin_thread&.kill
+          trap(:WINCH, old_winch)
         end
 
         if $stdin.tty?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/11984

This PR switches from the current method of using `raw!` and then `cooked!` to reset the Sandbox TTY to just using `raw` which automatically restores the original TTY state (and also is the recommended method in the [docs](https://docs.ruby-lang.org/en/2.2.0/IO.html#method-i-raw)). Using this approach the TTY state should always be properly restored, including the `echonl` and `istrip` flags that are not currently reset in all cases.