### PR TITLE
Revert "rubocops: allow uses_from_macos `openssl@3`"

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -82,7 +82,6 @@ module RuboCop
           gzip
           openssl
           openssl@1.1
-          openssl@3
           perl
           php
           python

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -7,7 +7,7 @@ shared_examples "formulae exist" do |array|
       core_tap = Pathname("#{HOMEBREW_LIBRARY_PATH}/../Taps/homebrew/homebrew-core")
       formula_path = core_tap/"Formula/#{f}.rb"
       alias_path = core_tap/"Aliases/#{f}"
-      expect(formula_path.exist? || alias_path.exist? || f.start_with?("openssl")).to be true
+      expect(formula_path.exist? || alias_path.exist?).to be true
     end
   end
 end


### PR DESCRIPTION
Reverts Homebrew/brew#11994