### PR TITLE
rubocops/uses_from_macos: remove versioned aliases.

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -81,11 +81,9 @@ module RuboCop
           groff
           gzip
           openssl
-          openssl@1.1
           perl
           php
           python
-          python@3
           rsync
           vim
           xz


### PR DESCRIPTION
It makes more sense to use the unversioned formulae with `uses_from_macos` because macOS isn't shipping multiple versions of this.

If you wish to e.g. pin to a specific version you can do that by specifying the dependency directly in an `os_linux` block.