### PR TITLE
formula_auditor: allow uses_from_macos for aliases.

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -263,7 +263,9 @@ module Homebrew
 
           next unless @core_tap
 
-          if self.class.aliases.include?(dep.name)
+          # we want to allow uses_from_macos for aliases but not bare dependencies
+          if self.class.aliases.include?(dep.name) &&
+             (spec.uses_from_macos_elements.blank? || spec.uses_from_macos_elements.exclude?(dep.name))
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 


### PR DESCRIPTION
This will enable https://github.com/Homebrew/homebrew-core/pull/84910 which will enable https://github.com/Homebrew/brew/pull/12008.