### PR TITLE
os/mac/pkgconfig/12: update version info

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/12/expat.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/12/expat.pc
@@ -5,7 +5,7 @@ libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: expat
-Version: 2.2.8
+Version: 2.4.1
 Description: expat XML parser
 URL: http://www.libexpat.org
 Libs: -L${libdir} -lexpat

--- a/Library/Homebrew/os/mac/pkgconfig/12/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/12/libcurl.pc
@@ -5,11 +5,11 @@
 #                            | (__| |_| |  _ <| |___
 #                             \___|\___/|_| \_\_____|
 #
-# Copyright (C) 2001 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+# Copyright (C) 2001 - 2020, Daniel Stenberg, <daniel@haxx.se>, et al.
 #
 # This software is licensed as described in the file COPYING, which
 # you should have received as part of this distribution. The terms
-# are also available at https://curl.haxx.se/docs/copyright.html.
+# are also available at https://curl.se/docs/copyright.html.
 #
 # You may opt to use, copy, modify, merge, publish, distribute and/or sell
 # copies of the Software, and permit persons to whom the Software is
@@ -28,13 +28,13 @@ prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
-supported_protocols="DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
-supported_features="AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO MultiSSL NTLM NTLM_WB SSL libz HTTP2 UnixSockets HTTPS-proxy"
+supported_protocols="DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS LDAP LDAPS MQTT POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
+supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM NTLM_WB SPNEGO SSL UnixSockets"
 
 Name: libcurl
-URL: https://curl.haxx.se/
+URL: https://curl.se/
 Description: Library to transfer files with ftp, http, etc.
-Version: 7.64.1
+Version: 7.77.0
 Libs: -L${libdir} -lcurl
 Libs.private: -lldap -lz
 Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/12/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/12/sqlite3.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 
 Name: SQLite
 Description: SQL database engine
-Version: 3.32.3
+Version: 3.36.0
 Libs: -L${libdir} -lsqlite3
 Libs.private:
 Cflags:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These still had Big Sur version info. Updated to match the version info as of SDK build 21A5304f.

Needed for `brew tests` to pass on Monterey.