### PR TITLE
os: add `uname` method

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -39,8 +39,8 @@ module OS
   #
   # @api public
   sig { returns(String) }
-  def self.uname
-    @uname ||= Utils.safe_popen_read("uname", "-s").chomp
+  def self.kernel_name
+    @kernel_name ||= Utils.safe_popen_read("uname", "-s").chomp
   end
 
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -40,7 +40,7 @@ module OS
   # @api public
   sig { returns(String) }
   def self.uname
-    @uname ||= Utils.safe_popen_read("uname").chomp
+    @uname ||= Utils.safe_popen_read("uname", "-s").chomp
   end
 
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -35,6 +35,14 @@ module OS
     @kernel_version ||= Version.new(Utils.safe_popen_read("uname", "-r").chomp)
   end
 
+  # Get the kernel name.
+  #
+  # @api public
+  sig { returns(String) }
+  def self.uname
+    @uname ||= Utils.safe_popen_read("uname").chomp
+  end
+
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]
 
   CI_GLIBC_VERSION = "2.23"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will allow us to replace code like
```ruby
os = if OS.mac?
  "Darwin"
else
  "Linux"
end
```
with a call to `OS.uname`. Doing
```bash
rg '= (if )?OS\.(mac|linux)\?'
```
returns about 70 matches, so there are probably at least a handful of
formulae that could be simplified by this.

Idea for a follow-up: add an audit that disallows hardcoding `/[Dd]arwin/` or `/[Ll]inux/` in string literals.