### PR TITLE
install, upgrade: don't print message if formula already installed

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -289,6 +289,8 @@ module Homebrew
     def install_formula(formula_installer, only_deps: false)
       f = formula_installer.formula
 
+      formula_installer.prelude
+
       f.print_tap_action
 
       if f.linked_keg.directory?
@@ -315,8 +317,6 @@ module Homebrew
           Upgrade.print_upgrade_message(f, formula_installer.options)
         end
       end
-
-      formula_installer.prelude
 
       kegs.each(&:unlink) if kegs.present?
 

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -165,11 +165,11 @@ module Homebrew
       if dry_run
         print_dry_run_dependencies(formula, formula_installer.compute_dependencies)
         return
-      else
-        print_upgrade_message(formula, formula_installer.options)
       end
 
       formula_installer.prelude
+
+      print_upgrade_message(formula, formula_installer.options)
 
       # first we unlink the currently active keg for this formula otherwise it is
       # possible for the existing build to interfere with the build we are about to


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix for #11900

The `prelude` method checks if the formula has already been installed, so it should be invoked before printing any install or upgrade messages.