### PR TITLE
Add process_type to service DSL

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -13,6 +13,11 @@ module Homebrew
     RUN_TYPE_INTERVAL = "interval"
     RUN_TYPE_CRON = "cron"
 
+    PROCESS_TYPE_BACKGROUND = "background"
+    PROCESS_TYPE_STANDARD = "standard"
+    PROCESS_TYPE_INTERACTIVE = "interactive"
+    PROCESS_TYPE_ADAPTIVE = "adaptive"
+
     # sig { params(formula: Formula).void }
     def initialize(formula, &block)
       @formula = formula
@@ -119,6 +124,22 @@ module Homebrew
       end
     end
 
+    sig { params(type: T.nilable(String)).returns(T.nilable(String)) }
+    def process_type(type = nil)
+      case T.unsafe(type)
+      when nil
+        @process_type
+      when PROCESS_TYPE_BACKGROUND, PROCESS_TYPE_STANDARD, PROCESS_TYPE_INTERACTIVE, PROCESS_TYPE_ADAPTIVE
+        @process_type = type.to_s
+      when String
+        raise TypeError, "Service#process_type allows: "\
+                         "'#{PROCESS_TYPE_BACKGROUND}'/'#{PROCESS_TYPE_STANDARD}'/"\
+                         "'#{PROCESS_TYPE_INTERACTIVE}'/'#{PROCESS_TYPE_ADAPTIVE}'"
+      else
+        raise TypeError, "Service#process_type expects a String"
+      end
+    end
+
     sig { params(type: T.nilable(T.any(String, Symbol))).returns(T.nilable(String)) }
     def run_type(type = nil)
       case T.unsafe(type)
@@ -193,6 +214,7 @@ module Homebrew
       base[:KeepAlive] = @keep_alive if @keep_alive == true
       base[:LegacyTimers] = @macos_legacy_timers if @macos_legacy_timers == true
       base[:TimeOut] = @restart_delay if @restart_delay.present?
+      base[:ProcessType] = @process_type.capitalize if @process_type.present?
       base[:WorkingDirectory] = @working_dir if @working_dir.present?
       base[:RootDirectory] = @root_dir if @root_dir.present?
       base[:StandardInPath] = @input_path if @input_path.present?

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -76,6 +76,7 @@ describe Homebrew::Service do
         root_dir var
         working_dir var
         keep_alive true
+        process_type "interactive"
         restart_delay 30
         macos_legacy_timers true
       end
@@ -101,6 +102,8 @@ describe Homebrew::Service do
         \t<string>homebrew.mxcl.formula_name</string>
         \t<key>LegacyTimers</key>
         \t<true/>
+        \t<key>ProcessType</key>
+        \t<string>Interactive</string>
         \t<key>ProgramArguments</key>
         \t<array>
         \t\t<string>#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd</string>
@@ -165,6 +168,7 @@ describe Homebrew::Service do
         root_dir var
         working_dir var
         keep_alive true
+        process_type "interactive"
         restart_delay 30
         macos_legacy_timers true
       end


### PR DESCRIPTION
This enables services to be run with the "Interactive" `ProcessType` value; in particular, this avoids performance issues such as skipping when playing music in `mpd`. See this previous PR, which added `ProcessType` for the old `plist` method:
https://github.com/Homebrew/homebrew-core/pull/19410

The `ProcessType` plist key was lost in the conversion to the service DSL,
so this is just reinstating it:
https://github.com/Homebrew/homebrew-core/commit/483ad1fdfa29f10441b5de4386173e68f4b11555

I was experiencing music skipping in `mpd` and confirmed that adding the "Interactive" `ProcessType` in a custom plist resolved it.

The possible values are as described in the [launchd manpage](https://www.manpagez.com/man/5/launchd.plist/). I didn't see any [analogous options](https://www.freedesktop.org/software/systemd/man/systemd.service.html#) for `systemd` so there it's a no-op.

If and when this is merged I can submit a second PR to use it for the `mpd` formula.

-----
