### PR TITLE
os/linux: fix Version::NULL type mixup

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -40,11 +40,11 @@ module OS
     raise "Loaded OS::Linux on generic OS!" if ENV["HOMEBREW_TEST_GENERIC_OS"]
 
     def version
-      Version::NULL
+      ::Version::NULL
     end
 
     def full_version
-      Version::NULL
+      ::Version::NULL
     end
 
     def languages
@@ -71,7 +71,7 @@ module OS
       module_function
 
       def version
-        Version::NULL
+        ::Version::NULL
       end
 
       def installed?
@@ -83,7 +83,7 @@ module OS
       module_function
 
       def version
-        Version::NULL
+        ::Version::NULL
       end
 
       def installed?

--- a/Library/Homebrew/sorbet/rbi/todo.rbi
+++ b/Library/Homebrew/sorbet/rbi/todo.rbi
@@ -4,7 +4,6 @@
 # typed: strong
 module ::StackProf; end
 module DependencyCollector::Compat; end
-module OS::Mac::Version::NULL; end
 module T::InterfaceWrapper::Helpers; end
 module T::Private::Abstract::Hooks; end
 module T::Private::Methods::MethodHooks; end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Sorbet could end having both `os/mac` and `os/linux` in memory, so this return could have gotten mistaken for `MacOS::Version::NULL`. This shouldn't change a thing at runtime but clears up a TODO item in the Sorbet RBI.