### PR TITLE
dev-cmd/extract: remove old DependencyCollector::Compat handling

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -28,13 +28,6 @@ def with_monkey_patch
     define_method(:parse_symbol_spec) { |*| }
   end
 
-  if defined?(DependencyCollector::Compat)
-    DependencyCollector::Compat.class_eval do
-      alias_method :old_parse_string_spec, :parse_string_spec if method_defined?(:parse_string_spec)
-      define_method(:parse_string_spec) { |*| }
-    end
-  end
-
   yield
 ensure
   BottleSpecification.class_eval do
@@ -62,15 +55,6 @@ ensure
     if method_defined?(:old_parse_symbol_spec)
       alias_method :parse_symbol_spec, :old_parse_symbol_spec
       undef :old_parse_symbol_spec
-    end
-  end
-
-  if defined?(DependencyCollector::Compat)
-    DependencyCollector::Compat.class_eval do
-      if method_defined?(:old_parse_string_spec)
-        alias_method :parse_string_spec, :old_parse_string_spec
-        undef :old_parse_string_spec
-      end
     end
   end
 end

--- a/Library/Homebrew/sorbet/rbi/todo.rbi
+++ b/Library/Homebrew/sorbet/rbi/todo.rbi
@@ -3,7 +3,6 @@
 
 # typed: strong
 module ::StackProf; end
-module DependencyCollector::Compat; end
 module T::InterfaceWrapper::Helpers; end
 module T::Private::Abstract::Hooks; end
 module T::Private::Methods::MethodHooks; end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This was needed as a temporary measure due to some dependency-related deprecation. `DependencyCollector::Compat` no longer exists so this monkey patch is never invoked and can be removed.