### PR TITLE
cmd/vendor-install.sh: allow download vendors from `HOMEBREW_ARTIFACT_DOMAIN` and `HOMEBREW_BOTTLE_DOMAIN`

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -37,7 +37,7 @@ then
   ruby_URLs=()
   if [[ -n "${HOMEBREW_ARTIFACT_DOMAIN}" ]]
   then
-    ruby_URLs+=("${HOMEBREW_ARTIFACT_DOMAIN}/bottles-portable-ruby/${ruby_FILENAME}")
+    ruby_URLs+=("${HOMEBREW_ARTIFACT_DOMAIN}/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:${ruby_SHA}")
   fi
   if [[ -n "${HOMEBREW_BOTTLE_DOMAIN}" ]]
   then


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

PR #11070 drops the support for users to download `portable-ruby` from `HOMEBREW_BOTTLE_DOMAIN`. Users cannot use geolocalized mirrors to speed up downloading and only packages host on GitHub are supported. (Ref https://github.com/tuna/issues/issues/1224#issuecomment-917467113 and https://github.com/tuna/mirror-web/pull/292#issuecomment-917622256)

This PR takes the URL from `HOMEBREW_ARTIFACT_DOMAIN` back and adds the URL from `HOMEBREW_ARTIFACT_DOMAIN` (as documented for this environment variable).

This implementation may be a bit tricky to use the `eval` statement to expand an array from the name.

```bash
# Expand the name to an array of variables
# The array name must be "${VENDOR_NAME}_URLs"! Otherwise substitution errors will occur!
read -r -a VENDOR_URLs <<< "$(eval "echo "\$\{${VENDOR_NAME}_URLs[@]\}"")"
```

------

Some tests:

- Unset `HOMEBREW_ARTIFACT_DOMAIN` and `HOMEBREW_BOTTLE_DOMAIN`:

```console
$ brew cleanup -s --prune 0
Removing: /home/PanXuehai/.cache/Homebrew/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz... (10.4MB)

$ unset HOMEBREW_{ARTIFACT,BOTTLE}_DOMAIN

$ brew vendor-install ruby 
==> Downloading https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:97e639a64dcec285392b53ad804b5334c324f1d2a8bdc2b5087b8bf8051e332f
################################################################################ 100.0%
==> Pouring portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
```

- Invalid `HOMEBREW_ARTIFACT_DOMAIN` and `HOMEBREW_BOTTLE_DOMAIN`:

```console
$ brew cleanup -s --prune 0
Removing: /home/PanXuehai/.cache/Homebrew/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz... (10.4MB)

$ export HOMEBREW_ARTIFACT_DOMAIN="https://localhost:10000"  # a invalid URL
$ export HOMEBREW_BOTTLE_DOMAIN="https://localhost:20000"  # a invalid URL

$ brew vendor-install ruby 
==> Downloading https://localhost:10000/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to localhost:10000

==> Downloading https://localhost:20000/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to localhost:20000

==> Downloading https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:97e639a64dcec285392b53ad804b5334c324f1d2a8bdc2b5087b8bf8051e332f
################################################################################ 100.0%
==> Pouring portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
```

- Valid `HOMEBREW_BOTTLE_DOMAIN`:

```console
$ brew cleanup -s --prune 0
Removing: /home/PanXuehai/.cache/Homebrew/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz... (10.4MB)

$ export HOMEBREW_ARTIFACT_DOMAIN="https://localhost:10000"  # a invalid URL
$ export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.tuna.tsinghua.edu.cn/linuxbrew-bottles"

$ brew vendor-install ruby 
==> Downloading https://localhost:10000/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to localhost:10000

==> Downloading https://mirrors.tuna.tsinghua.edu.cn/linuxbrew-bottles/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
################################################################################ 100.0%
==> Pouring portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz

$ brew vendor-install ruby
==> Downloading https://localhost:10000/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
Already downloaded: /home/PanXuehai/.cache/Homebrew/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
==> Pouring portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz

$ unset HOMEBREW_ARTIFACT_DOMAIN

$ brew vendor-install ruby
==> Downloading https://mirrors.tuna.tsinghua.edu.cn/linuxbrew-bottles/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
Already downloaded: /home/PanXuehai/.cache/Homebrew/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
==> Pouring portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz

$ brew cleanup -s --prune 0
Removing: /home/PanXuehai/.cache/Homebrew/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz... (10.4MB)

$ brew vendor-install ruby 
==> Downloading https://mirrors.tuna.tsinghua.edu.cn/linuxbrew-bottles/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
################################################################################ 100.0%
==> Pouring portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
```

- All fails:

```console
$ brew cleanup -s --prune 0
Removing: /home/PanXuehai/.cache/Homebrew/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz... (10.4MB)

$ export HOMEBREW_ARTIFACT_DOMAIN="https://localhost:10000"  # a invalid URL
$ export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.tuna.tsinghua.edu.cn/linuxbrew-bottles"

$ export http_proxy="http://localhost:20000"  # a invalid Proxy
$ export https_proxy="http://localhost:20000"  # a invalid Proxy

$ brew vendor-install ruby 
==> Downloading https://localhost:10000/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
curl: (7) Failed to connect to localhost port 20000: Connection refused

==> Downloading https://mirrors.tuna.tsinghua.edu.cn/linuxbrew-bottles/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
curl: (7) Failed to connect to localhost port 20000: Connection refused

==> Downloading https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:97e639a64dcec285392b53ad804b5334c324f1d2a8bdc2b5087b8bf8051e332f
curl: (7) Failed to connect to localhost port 20000: Connection refused

==> Downloading https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.6.3_2/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
curl: (7) Failed to connect to localhost port 20000: Connection refused

Error: Failed to download ruby from the following locations:
  - https://localhost:10000/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
  - https://mirrors.tuna.tsinghua.edu.cn/linuxbrew-bottles/bottles-portable-ruby/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz
  - https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:97e639a64dcec285392b53ad804b5334c324f1d2a8bdc2b5087b8bf8051e332f
  - https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.6.3_2/portable-ruby-2.6.3_2.x86_64_linux.bottle.tar.gz

Do not file an issue on GitHub about this; you will need to figure out for
yourself what issue with your internet connection restricts your access to
GitHub (used for Homebrew updates and binary packages).
```