### PR TITLE
install, upgrade: fix installation attempt check

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -314,10 +314,6 @@ module Homebrew
     def install_formula(formula_installer)
       f = formula_installer.formula
 
-      formula_installer.check_installation_already_attempted
-
-      f.print_tap_action
-
       upgrade = f.linked? && f.outdated? && !f.head? && !Homebrew::EnvConfig.no_install_upgrade?
 
       Upgrade.install_formula(formula_installer, upgrade: upgrade)

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -177,8 +177,6 @@ module Homebrew
         return
       end
 
-      formula_installer.check_installation_already_attempted
-
       install_formula(formula_installer, upgrade: true)
     rescue BuildError => e
       e.dump(verbose: verbose)
@@ -190,11 +188,15 @@ module Homebrew
     def install_formula(formula_installer, upgrade:)
       formula = formula_installer.formula
 
+      formula_installer.check_installation_already_attempted
+
       if upgrade
         print_upgrade_message(formula, formula_installer.options)
 
         kegs = outdated_kegs(formula)
         linked_kegs = kegs.select(&:linked?)
+      else
+        formula.print_tap_action
       end
 
       # first we unlink the currently active keg for this formula otherwise it is


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In #12024, I moved `rescue FormulaInstallationAlreadyAttemptedError` to `Upgrade.install_formula` but also should have moved `formula_installer.check_installation_already_attempted`