### PR TITLE
Set uses_from_macos_elements in all cases

### DIFF
--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -7,19 +7,21 @@ class SoftwareSpec
   undef uses_from_macos
 
   def uses_from_macos(deps, bounds = {})
-    @uses_from_macos_elements ||= []
-
     if deps.is_a?(Hash)
       bounds = deps.dup
-      deps = bounds.shift
+      deps = [bounds.shift].to_h
     end
 
+    @uses_from_macos_elements << deps
+
     bounds = bounds.transform_values { |v| MacOS::Version.from_symbol(v) }
-    if MacOS.version >= bounds[:since] ||
-       (Homebrew::EnvConfig.simulate_macos_on_linux? && !bounds.key?(:since))
-      @uses_from_macos_elements << deps
-    else
-      depends_on deps
-    end
+
+    # Linux simulating macOS. Assume oldest macOS version.
+    return if Homebrew::EnvConfig.simulate_macos_on_linux? && !bounds.key?(:since)
+
+    # macOS new enough for dependency to not be required.
+    return if MacOS.version >= bounds[:since]
+
+    depends_on deps
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1903,7 +1903,6 @@ class Formula
   # @private
   def to_hash
     dependencies = deps
-    uses_from_macos = uses_from_macos_elements || []
 
     hsh = {
       "name"                     => name,
@@ -1941,7 +1940,7 @@ class Formula
       "optional_dependencies"    => dependencies.select(&:optional?)
                                                 .map(&:name)
                                                 .uniq,
-      "uses_from_macos"          => uses_from_macos.uniq,
+      "uses_from_macos"          => uses_from_macos_elements.uniq,
       "requirements"             => [],
       "conflicts_with"           => conflicts.map(&:name),
       "caveats"                  => caveats&.gsub(HOMEBREW_PREFIX, "$(brew --prefix)"),

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -487,6 +487,9 @@ class Formula
   # Dependencies provided by macOS for the currently active {SoftwareSpec}.
   delegate uses_from_macos_elements: :active_spec
 
+  # Dependency names provided by macOS for the currently active {SoftwareSpec}.
+  delegate uses_from_macos_names: :active_spec
+
   # The {Requirement}s for the currently active {SoftwareSpec}.
   delegate requirements: :active_spec
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -264,7 +264,7 @@ module Homebrew
           next unless @core_tap
 
           # we want to allow uses_from_macos for aliases but not bare dependencies
-          if self.class.aliases.include?(dep.name) && spec.uses_from_macos_elements.exclude?(dep.name)
+          if self.class.aliases.include?(dep.name) && spec.uses_from_macos_names.exclude?(dep.name)
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -264,8 +264,7 @@ module Homebrew
           next unless @core_tap
 
           # we want to allow uses_from_macos for aliases but not bare dependencies
-          if self.class.aliases.include?(dep.name) &&
-             (spec.uses_from_macos_elements.blank? || spec.uses_from_macos_elements.exclude?(dep.name))
+          if self.class.aliases.include?(dep.name) && spec.uses_from_macos_elements.exclude?(dep.name)
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 

--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -13,7 +13,7 @@ module Language
       def detected_perl_shebang(formula = self)
         perl_path = if formula.deps.map(&:name).include? "perl"
           Formula["perl"].opt_bin/"perl"
-        elsif formula.uses_from_macos_elements.include? "perl"
+        elsif formula.uses_from_macos_names.include? "perl"
           "/usr/bin/perl#{MacOS.preferred_perl_version}"
         else
           raise ShebangDetectionError.new("Perl", "formula does not depend on Perl")

--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -11,10 +11,10 @@ module Language
       module_function
 
       def detected_perl_shebang(formula = self)
-        perl_path = if formula.uses_from_macos_elements&.include? "perl"
-          "/usr/bin/perl#{MacOS.preferred_perl_version}"
-        elsif formula.deps.map(&:name).include? "perl"
+        perl_path = if formula.deps.map(&:name).include? "perl"
           Formula["perl"].opt_bin/"perl"
+        elsif formula.uses_from_macos_elements.include? "perl"
+          "/usr/bin/perl#{MacOS.preferred_perl_version}"
         else
           raise ShebangDetectionError.new("Perl", "formula does not depend on Perl")
         end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -186,6 +186,10 @@ class SoftwareSpec
     depends_on(spec)
   end
 
+  def uses_from_macos_names
+    uses_from_macos_elements.flat_map { |e| e.is_a?(Hash) ? e.keys : e }
+  end
+
   def deps
     dependency_collector.deps
   end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -47,6 +47,7 @@ class SoftwareSpec
     @deprecated_options = []
     @build = BuildOptions.new(Options.create(@flags), options)
     @compiler_failures = []
+    @uses_from_macos_elements = []
     @bottle_disable_reason = nil
   end
 
@@ -178,7 +179,10 @@ class SoftwareSpec
   end
 
   def uses_from_macos(spec, _bounds = {})
-    spec = spec.dup.shift if spec.is_a?(Hash)
+    spec = [spec.dup.shift].to_h if spec.is_a?(Hash)
+
+    @uses_from_macos_elements << spec
+
     depends_on(spec)
   end
 

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -33,8 +33,8 @@ describe Formula do
 
       expect(f.class.stable.deps.first.name).to eq("foo")
       expect(f.class.head.deps.first.name).to eq("foo")
-      expect(f.class.stable.uses_from_macos_elements).to be_empty
-      expect(f.class.head.uses_from_macos_elements).to be_empty
+      expect(f.class.stable.uses_from_macos_elements).to eq(["foo"])
+      expect(f.class.head.uses_from_macos_elements).to eq(["foo"])
     end
   end
 

--- a/Library/Homebrew/test/os/mac/software_spec_spec.rb
+++ b/Library/Homebrew/test/os/mac/software_spec_spec.rb
@@ -23,7 +23,7 @@ describe SoftwareSpec do
       spec.uses_from_macos("foo", since: :high_sierra)
 
       expect(spec.deps.first.name).to eq("foo")
-      expect(spec.uses_from_macos_elements).to be_empty
+      expect(spec.uses_from_macos_elements).to eq(["foo"])
     end
 
     it "works with tags" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hopefully fixes CI. Kinda rushed this so not tested.

TODO: adjust any `uses_from_macos_elements` checks to also consider the case where the element is a hash (e.g. `"dep" => :build`).