### PR TITLE
brew.sh: alias `which` as `type -P`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -137,6 +137,12 @@ git() {
   "${HOMEBREW_LIBRARY}/Homebrew/shims/scm/git" "$@"
 }
 
+# Search given executable in PATH (remove dependency for `which` command)
+which() {
+  # Alias to Bash built-in command `type -P`
+  type -P "$@"
+}
+
 numeric() {
   # Condense the exploded argument into a single return value.
   # shellcheck disable=SC2086,SC2183

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,27 +1,5 @@
 export HOMEBREW_REQUIRED_RUBY_VERSION=2.6.3
 
-# Search given executable in all PATH entries (remove dependency for `which` command)
-which_all() {
-  if [[ $# -ne 1 ]]
-  then
-    return 1
-  fi
-
-  local executable entries entry retcode=1
-  IFS=':' read -r -a entries <<< "${PATH}"  # `readarray -d ':' -t` seems not applicable on WSL Bash
-  for entry in "${entries[@]}"
-  do
-    executable="${entry}/$1"
-    if [[ -x "${executable}" ]]
-    then
-      echo "${executable}"
-      retcode=0  # present
-    fi
-  done
-
-  return "${retcode}"
-}
-
 # HOMEBREW_LIBRARY is from the user environment
 # shellcheck disable=SC2154
 test_ruby() {
@@ -46,13 +24,18 @@ find_ruby() {
     local ruby_exec
     while read -r ruby_exec
     do
-      if test_ruby "${ruby_exec}"; then
+      if test_ruby "${ruby_exec}"
+      then
         echo "${ruby_exec}"
         break
       fi
     done < <(
-      which_all ruby
-      PATH="${HOMEBREW_PATH}" which_all ruby
+      # function which() is set by brew.sh
+      # it's aliased to `type -P`
+      # shellcheck disable=SC2230
+      which -a ruby
+      # shellcheck disable=SC2230
+      PATH="${HOMEBREW_PATH}" which -a ruby
     )
   fi
 }

--- a/bin/brew
+++ b/bin/brew
@@ -7,6 +7,12 @@ if ! [[ -d "${PWD}" ]]; then
   exit 1
 fi
 
+# Fail fast with concise message when not using bash
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "Error: Bash is required to run brew." >&2
+  exit 1
+fi
+
 quiet_cd() {
   cd "$@" &>/dev/null || return
 }

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -16,7 +16,7 @@ it does it too. You have to confirm everything it will do before it starts.
 * Command Line Tools (CLT) for Xcode: `xcode-select --install`,
   [developer.apple.com/downloads](https://developer.apple.com/downloads) or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
-* A Bourne-compatible shell for installation (e.g. `bash` or `zsh`) <sup>[4](#4)</sup>
+* The Bourne-again shell for installation (i.e. `bash`) <sup>[4](#4)</sup>
 
 ## Git Remote Mirroring
 
@@ -75,5 +75,5 @@ Apple Developer account on older versions of Mac OS X. Sign up for free
 [here](https://developer.apple.com/register/index.action).
 
 <a name="4"><sup>4</sup></a> The one-liner installation method found on
-[brew.sh](https://brew.sh) requires a Bourne-compatible shell (e.g. bash or
-zsh). Notably, fish, tcsh and csh will not work.
+[brew.sh](https://brew.sh) requires the Bourne-again shell, i.e. bash.
+Notably, zsh, fish, tcsh and csh will not work.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Implement `which` in a more elegant way using the `bash` built-in command `type -P`. We define the function `which` in `brew.sh` to avoid using the `/usr/bin/which` by mistake.

BTW, `type -P` command is only available in `bash`, and `zsh` does not support `type -P`. Besides, the behaviors of `type -p` on `bash` and `zsh` are different.

On `bash`:

```console
$ type -ap python3
/home/linuxbrew/.linuxbrew/bin/python3
/usr/bin/python3

$ type -aP python3
/home/linuxbrew/.linuxbrew/bin/python3
/usr/bin/python3
```

On `zsh`:

```console
$ type -ap python3
python3 is /home/linuxbrew/.linuxbrew/bin/python3
python3 is /usr/bin/python3

$ type -aP python3
type: bad option: -P
```

We need `bash` to run `brew`.

Ref #12027, Homebrew/install#575.