### PR TITLE
workflows: reduce GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ on:
   release:
     types:
       - published
+permissions:
+  contents: read
 jobs:
   ubuntu:
     if: startsWith(github.repository, 'Homebrew/')

--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -8,6 +8,8 @@ on:
       - Library/Homebrew/extend/os/diagnostic.rb
       - Library/Homebrew/extend/os/mac/diagnostic.rb
       - Library/Homebrew/os/mac/xcode.rb
+permissions:
+  contents: read
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -10,6 +10,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tapioca:
     if: github.repository == 'Homebrew/brew'

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -7,6 +7,8 @@ on:
       - master
   schedule:
     - cron: "0 0 * * *"
+permissions:
+  contents: read
 jobs:
   spdx:
     if: github.repository == 'Homebrew/brew'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -12,6 +12,8 @@ on:
   schedule:
     - cron: "0 */3 * * *" # every 3 hours
 
+permissions:
+
 concurrency: triage-${{ github.ref }}
 
 jobs:

--- a/.github/workflows/update-man-completions.yml
+++ b/.github/workflows/update-man-completions.yml
@@ -18,6 +18,9 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-manpage:
     runs-on: ubuntu-latest

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -8,6 +8,10 @@ on:
         description: Pull request number
         required: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   vendor-gems:
     if: >


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

All of these could potentially be `write` in some scenario (e.g. vendor gem update). This is unnecessary so it's best play a bit safer and reduce these to the minimum possible permissions.

Tests workflow might need tweaking but I think the rest are correct.