### PR TITLE
style: add shfmt exit status to `brew style`

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -65,12 +65,16 @@ module Homebrew
         run_shellcheck(shell_files, output_type)
       end
 
-      run_shfmt(shell_files, fix: fix) if ruby_files.none? || shell_files.any?
+      shfmt_result = if ruby_files.any? && shell_files.none?
+        true
+      else
+        run_shfmt(shell_files, fix: fix)
+      end
 
       if output_type == :json
         Offenses.new(rubocop_result + shellcheck_result)
       else
-        rubocop_result && shellcheck_result
+        rubocop_result && shellcheck_result && shfmt_result
       end
     end
 

--- a/Library/Homebrew/utils/shfmt.sh
+++ b/Library/Homebrew/utils/shfmt.sh
@@ -49,6 +49,7 @@ do
   SHFMT_ARGS+=("${arg}")
   shift
 done
+unset arg
 
 FILES=()
 for file in "$@"
@@ -66,6 +67,7 @@ do
     exit 1
   fi
 done
+unset file
 
 if [[ "${#FILES[@]}" == 0 ]]
 then
@@ -76,6 +78,32 @@ fi
 ### Custom shell script styling
 ###
 
+# Check for specific patterns and prompt messages if detected
+no_forbidden_patten() {
+  local file="$1"
+  local tempfile="$2"
+  local subject="$3"
+  local message="$4"
+  local regex_pos="$5"
+  local regex_neg="${6:-}"
+  local line
+  local num=0
+  local retcode=0
+
+  while IFS='' read -r line
+  do
+    num="$((num + 1))"
+    if [[ "${line}" =~ ${regex_pos} ]] &&
+       [[ -z "${regex_neg}" || ! "${line}" =~ ${regex_neg} ]]
+    then
+      onoe "${subject} detected at \"${file}\", line ${num}."
+      [[ -n "${message}" ]] && onoe "${message}"
+      retcode=1
+    fi
+  done <"${file}"
+  return "${retcode}"
+}
+
 # Check pattern:
 # '^\t+'
 #
@@ -84,22 +112,12 @@ fi
 no_tabs() {
   local file="$1"
   local tempfile="$2"
-  local line
-  local num=0
-  local retcode=0
-  local regex_pos='^[[:space:]]+'
-  local regex_neg='^ +'
 
-  while IFS='' read -r line
-  do
-    num="$((num + 1))"
-    if [[ "${line}" =~ ${regex_pos} && ! "${line}" =~ ${regex_neg} ]]
-    then
-      onoe "Indent by tab detected at \"${file}\", line ${num}."
-      retcode=1
-    fi
-  done <"${file}"
-  return "${retcode}"
+  no_forbidden_patten "${file}" "${tempfile}" \
+    "Indent with tab" \
+    'Replace tabs with 2 spaces instead.' \
+    '^[[:space:]]+' \
+    '^ +'
 }
 
 # Check pattern:
@@ -116,18 +134,10 @@ no_tabs() {
 no_multiline_for_statements() {
   local file="$1"
   local tempfile="$2"
-  local line
-  local num=0
-  local retcode=0
   local regex='^ *for [_[:alnum:]]+ in .*\\$'
-
-  while IFS='' read -r line
-  do
-    num="$((num + 1))"
-    if [[ "${line}" =~ ${regex} ]]
-    then
-      onoe "Multiline for statement detected at \"${file}\", line ${num}."
-      cat >&2 <<EOMSG
+  local message
+  message="$(
+    cat <<EOMSG
 Use the followings instead (keep for statements only one line):
   ARRAY=(
     ...
@@ -137,10 +147,12 @@ Use the followings instead (keep for statements only one line):
     ...
   done
 EOMSG
-      retcode=1
-    fi
-  done <"${file}"
-  return "${retcode}"
+  )"
+
+  no_forbidden_patten "${file}" "${tempfile}" \
+    "Multiline for statement" \
+    "${message}" \
+    "${regex}"
 }
 
 # Check pattern:
@@ -155,32 +167,26 @@ EOMSG
 no_IFS_newline() {
   local file="$1"
   local tempfile="$2"
-  local line
-  local num=0
-  local retcode=0
   local regex="^[^#]*IFS=\\\$'\\\\n'"
-
-  while IFS='' read -r line
-  do
-    num="$((num + 1))"
-    if [[ "${line}" =~ ${regex} ]]
-    then
-      onoe "Pattern \`IFS=\$'\\n'\` detected at \"${file}\", line ${num}."
-      cat >&2 <<EOMSG
+  local message
+  message="$(
+    cat <<EOMSG
 Use the followings instead:
   while IFS='' read -r line
   do
     ...
   done < <(command)
 EOMSG
-      retcode=1
-    fi
-  done <"${file}"
-  return "${retcode}"
+  )"
+
+  no_forbidden_patten "${file}" "${tempfile}" \
+    "Pattern \`IFS=\$'\\n'\`" \
+    "${message}" \
+    "${regex}"
 }
 
 # Combine all forbidden styles
-no_forbiddens() {
+no_forbidden_styles() {
   local file="$1"
   local tempfile="$2"
 
@@ -304,15 +310,14 @@ align_multiline_switch_cases() {
 
 format() {
   local file="$1"
+  local tempfile
   if [[ ! -f "${file}" || ! -r "${file}" ]]
   then
     onoe "File \"${file}\" is not readable."
     return 1
   fi
 
-  # shellcheck disable=SC2155
-  local tempfile="$(dirname "${file}")/.${file##*/}.temp"
-
+  tempfile="$(dirname "${file}")/.${file##*/}.temp"
   trap 'rm -f "${tempfile}" 2>/dev/null' RETURN
   cp -af "${file}" "${tempfile}"
 
@@ -325,15 +330,12 @@ format() {
   # Format with `shfmt` first
   if ! "${SHFMT}" -w "${SHFMT_ARGS[@]}" "${tempfile}"
   then
-    onoe "Failed to run \`shfmt\`"
+    onoe "Failed to run \`shfmt\` for file \"${file}\"."
     return 1
   fi
 
-  # Fail fast when forbidden patterns detected
-  if ! no_forbiddens "${file}" "${tempfile}"
-  then
-    return 2
-  fi
+  # Fail fast when forbidden styles detected
+  ! no_forbidden_styles "${file}" "${tempfile}" && return 2
 
   # Tweak it with custom shell script styles
   wrap_then_do "${file}" "${tempfile}"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I refactor some functions in `utils/shfmt.sh` in #12044 to reuse code fragments and improve code readability.

And adding exit code of `run_shfmt` to `brew style` is needed in CI tests.