### PR TITLE
Revamp APIs around bottle specifications

### DIFF
--- a/Library/Homebrew/extend/os/linux/software_spec.rb
+++ b/Library/Homebrew/extend/os/linux/software_spec.rb
@@ -3,8 +3,9 @@
 
 class BottleSpecification
   extend T::Sig
-  sig { returns(T::Boolean) }
-  def skip_relocation?
+
+  sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
+  def skip_relocation?(tag: Utils::Bottles.tag)
     false
   end
 end

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -41,11 +41,10 @@ module Utils
 
         return if tag_version.blank?
 
-        keys.find do |key|
-          key_tag = Tag.from_symbol(key)
-          next if key_tag.arch != tag.arch
+        tags.find do |candidate|
+          next if candidate.arch != tag.arch
 
-          key_tag.to_macos_version <= tag_version
+          candidate.to_macos_version <= tag_version
         rescue MacOSVersionError
           false
         end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2034,17 +2034,17 @@ class Formula
       "root_url" => bottle_spec.root_url,
       "files"    => {},
     }
-    bottle_spec.collector.each_key do |os|
-      collector_os = bottle_spec.collector[os]
-      os_cellar = collector_os[:cellar]
+    bottle_spec.collector.each_tag do |tag|
+      tag_spec = bottle_spec.collector.specification_for(tag)
+      os_cellar = tag_spec.cellar
       os_cellar = os_cellar.inspect if os_cellar.is_a?(Symbol)
 
-      checksum = collector_os[:checksum].hexdigest
-      filename = Bottle::Filename.create(self, os, bottle_spec.rebuild)
+      checksum = tag_spec.checksum.hexdigest
+      filename = Bottle::Filename.create(self, tag, bottle_spec.rebuild)
       path, = Utils::Bottles.path_resolved_basename(bottle_spec.root_url, name, checksum, filename)
       url = "#{bottle_spec.root_url}/#{path}"
 
-      hash["files"][os] = {
+      hash["files"][tag.to_sym] = {
         "cellar" => os_cellar,
         "url"    => url,
         "sha256" => checksum,

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -150,13 +150,14 @@ class FormulaInstaller
       return false
     end
 
-    bottle = formula.bottle_specification
-    unless bottle.compatible_locations?
+    bottle = formula.bottle
+    if bottle && !bottle.compatible_locations?
       if output_warning
+        prefix = Pathname(bottle.cellar).parent
         opoo <<~EOS
           Building #{formula.full_name} from source as the bottle needs:
           - HOMEBREW_CELLAR: #{bottle.cellar} (yours is #{HOMEBREW_CELLAR})
-          - HOMEBREW_PREFIX: #{bottle.prefix} (yours is #{HOMEBREW_PREFIX})
+          - HOMEBREW_PREFIX: #{prefix} (yours is #{HOMEBREW_PREFIX})
         EOS
       end
       return false

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -386,7 +386,7 @@ describe "brew bottle" do
 
     describe "#merge_bottle_spec" do
       it "allows new bottle hash to be empty" do
-        valid_keys = [:root_url, :prefix, :cellar, :rebuild, :sha256]
+        valid_keys = [:root_url, :cellar, :rebuild, :sha256]
         old_spec = BottleSpecification.new
         old_spec.sha256(big_sur: "f59bc65c91e4e698f6f050e1efea0040f57372d4dcf0996cbb8f97ced320403b")
         expect { homebrew.merge_bottle_spec(valid_keys, old_spec, {}) }.not_to raise_error

--- a/Library/Homebrew/test/software_spec/bottle_spec.rb
+++ b/Library/Homebrew/test/software_spec/bottle_spec.rb
@@ -17,8 +17,8 @@ describe BottleSpecification do
 
       checksums.each_pair do |cat, digest|
         bottle_spec.sha256(cat => digest)
-        checksum, = bottle_spec.checksum_for(cat)
-        expect(Checksum.new(digest)).to eq(checksum)
+        tag_spec = bottle_spec.tag_specification_for(Utils::Bottles::Tag.from_symbol(cat))
+        expect(Checksum.new(digest)).to eq(tag_spec.checksum)
       end
     end
 
@@ -32,11 +32,11 @@ describe BottleSpecification do
 
       checksums.each do |checksum|
         bottle_spec.sha256(cellar: checksum[:cellar], checksum[:tag] => checksum[:digest])
-        digest, tag, cellar = bottle_spec.checksum_for(checksum[:tag])
-        expect(Checksum.new(checksum[:digest])).to eq(digest)
-        expect(checksum[:tag]).to eq(tag)
+        tag_spec = bottle_spec.tag_specification_for(Utils::Bottles::Tag.from_symbol(checksum[:tag]))
+        expect(Checksum.new(checksum[:digest])).to eq(tag_spec.checksum)
+        expect(checksum[:tag]).to eq(tag_spec.tag.to_sym)
         checksum[:cellar] ||= Homebrew::DEFAULT_CELLAR
-        expect(checksum[:cellar]).to eq(cellar)
+        expect(checksum[:cellar]).to eq(tag_spec.cellar)
       end
     end
   end

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -6,43 +6,50 @@ require "utils/bottles"
 describe Utils::Bottles::Collector do
   subject(:collector) { described_class.new }
 
-  describe "#fetch_checksum_for" do
+  let(:catalina) { Utils::Bottles::Tag.from_symbol(:catalina) }
+  let(:mojave) { Utils::Bottles::Tag.from_symbol(:mojave) }
+
+  describe "#specification_for" do
     it "returns passed tags" do
-      collector[:mojave] = { checksum: Checksum.new("foo_checksum"), cellar: "foo_cellar" }
-      collector[:catalina] = { checksum: Checksum.new("bar_checksum"), cellar: "bar_cellar" }
-      expect(collector.fetch_checksum_for(:catalina)).to eq(["bar_checksum", :catalina, "bar_cellar"])
+      collector.add(mojave, checksum: Checksum.new("foo_checksum"), cellar: "foo_cellar")
+      collector.add(catalina, checksum: Checksum.new("bar_checksum"), cellar: "bar_cellar")
+      spec = collector.specification_for(catalina)
+      expect(spec).not_to be_nil
+      expect(spec.tag).to eq(catalina)
+      expect(spec.checksum).to eq("bar_checksum")
+      expect(spec.cellar).to eq("bar_cellar")
     end
 
     it "returns nil if empty" do
-      expect(collector.fetch_checksum_for(:foo)).to be nil
+      expect(collector.specification_for(Utils::Bottles::Tag.from_symbol(:foo))).to be nil
     end
 
     it "returns nil when there is no match" do
-      collector[:catalina] = "foo"
-      expect(collector.fetch_checksum_for(:foo)).to be nil
+      collector.add(catalina, checksum: Checksum.new("bar_checksum"), cellar: "bar_cellar")
+      expect(collector.specification_for(Utils::Bottles::Tag.from_symbol(:foo))).to be nil
     end
 
     it "uses older tags when needed", :needs_macos do
-      collector[:mojave] = "foo"
-      expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:mojave))).to eq(:mojave)
-      expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:catalina))).to eq(:mojave)
+      collector.add(mojave, checksum: Checksum.new("foo_checksum"), cellar: "foo_cellar")
+      expect(collector.send(:find_matching_tag, mojave)).to eq(mojave)
+      expect(collector.send(:find_matching_tag, catalina)).to eq(mojave)
     end
 
     it "does not use older tags when requested not to", :needs_macos do
       allow(Homebrew::EnvConfig).to receive(:developer?).and_return(true)
       allow(Homebrew::EnvConfig).to receive(:skip_or_later_bottles?).and_return(true)
       allow(OS::Mac.version).to receive(:prerelease?).and_return(true)
-      collector[:mojave] = "foo"
-      expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:mojave))).to eq(:mojave)
-      expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:catalina))).to be_nil
+      collector.add(mojave, checksum: Checksum.new("foo_checksum"), cellar: "foo_cellar")
+      expect(collector.send(:find_matching_tag, mojave)).to eq(mojave)
+      expect(collector.send(:find_matching_tag, catalina)).to be_nil
     end
 
     it "ignores HOMEBREW_SKIP_OR_LATER_BOTTLES on release versions", :needs_macos do
       allow(Homebrew::EnvConfig).to receive(:skip_or_later_bottles?).and_return(true)
       allow(OS::Mac.version).to receive(:prerelease?).and_return(false)
-      collector[:mojave] = "foo"
-      expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:mojave))).to eq(:mojave)
-      expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:catalina))).to eq(:mojave)
+      collector.add(mojave, checksum: Checksum.new("foo_checksum"), cellar: "foo_cellar")
+      expect(collector.send(:find_matching_tag, mojave)).to eq(mojave)
+      expect(collector.send(:find_matching_tag, catalina)).to eq(mojave)
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Goals:

* Stronger typing (rather than passing around hashes everywhere)
* Less confusing names (e.g. `checksum_for` returning cellar information)
* Remove relics from old bottle spec DSL.

Additions:

* `BottleSpecification#tag_specification_for`
  - For a given tag, returns a new `TagSpecification` object containing the actual tag (since it may choose an older OS), the checksum and the cellar value.
* `Utils::Bottles::Collector#specification_for`
  - Backend for the above.
* Add `tag` parameter to `BottleSpecification#compatible_locations?` (default: tag for user's OS)
  - `Bottle#compatible_locations?` now uses this internally.
* Add `tag` parameter to `BottleSpecification#skip_relocation?` (default: tag for user's OS)
  - `Bottle#skip_relocation?` now uses this internally.
* `Utils::Bottles::Collector#tags`
  - Returns tags present in the collector
* `Utils::Bottles::Collector#each_tag`
  - For enumeration over the tags in the collector
* `Utils::Bottles::Collector#tag?`
  - Behaves just like `BottleSpecification#tag?` did (same parameters). Now a backend for that.
* `Utils::Bottles::Collector#add`
  - Pass in a tag, the checksum and the cellar and it'll create and store a `TagSpecification` object into the collector

Removals:

* `BottleSpecification#cellar`
  - Replacement: Use `BottleSpecification#tag_specification_for` and get the cellar value from that.
* `BottleSpecification#all_tags_cellar`
  - Always returned nil.
* `BottleSpecification#prefix`
  - Always returned `Homebrew::DEFAULT_PREFIX`.
* `Bottle#prefix`
  - As above.
* `BottleSpecification#checksum_for`
  - Replacement: `BottleSpecification#tag_specification_for`
* `Utils::Bottles::Collector#keys`
  - Replacement: `Utils::Bottles::Collector#tags` (returns `Util::Bottles::Tag`s rather than symbols)
* `Utils::Bottles::Collector#each_key`
  - Replacement: `Utils::Bottles::Collector#each_tag` (passes `Util::Bottles::Tag`s rather than symbols)
* `Utils::Bottles::Collector#key?`
  - Replacement: `Utils::Bottles::Collector#tag?` (takes a `Util::Bottles::Tag` rather than a symbol, and now also looks back for older OS versions or `:all` bottles like `BottleSpecification#tag?` did - if this is not desirable then search `Utils::Bottles::Collector#tags`)
* `Utils::Bottles::Collector#[]`
  - Replacement: `Utils::Bottles::Collector#specification_for` (returns `TagSpecifiation` object rather than a hash, and also looks back for older OS versions or `:all` bottles - if this is not desirable then search first if the tag exists in `Utils::Bottles::Collector#tags`)
* `Utils::Bottles::Collector#[]=`
  - Replacement: `Utils::Bottles::Collector#add` (pass in checksum and cellar as parameters rather than just passing a hash)
* `Utils::Bottles::Collector#dig`
  - Replacement: `Utils::Bottles::Collector#specification_for` (see `Utils::Bottles::Collector#[]` deprecation)


Newer APIs more strictly require `Utils::Bottles::Tag` rather than also allowing symbols.

The changes here hopefully fix #12068, but I haven't specifically tested that scenario yet.