### PR TITLE
exceptions: set backtrace for FormulaUnreadableError

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -208,6 +208,7 @@ class FormulaUnreadableError < FormulaUnavailableError
   def initialize(name, error)
     super(name)
     @formula_error = error
+    set_backtrace(error.backtrace)
   end
 end
 
@@ -257,6 +258,7 @@ class TapFormulaUnreadableError < TapFormulaUnavailableError
   def initialize(tap, name, error)
     super(tap, name)
     @formula_error = error
+    set_backtrace(error.backtrace)
   end
 end
 

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -4,7 +4,7 @@
 require "cli/named_args"
 
 def setup_unredable_formula(name)
-  error = FormulaUnreadableError.new(name, "testing")
+  error = FormulaUnreadableError.new(name, RuntimeError.new("testing"))
   allow(Formulary).to receive(:factory).with(name, force_bottle: false, flags: []).and_raise(error)
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The backtrace for the internal error for `FormulaUnreadableError` is the much more useful one.