### PR TITLE
missing_formula.rb: don't disable texlive

### DIFF
--- a/Library/Homebrew/extend/os/mac/missing_formula.rb
+++ b/Library/Homebrew/extend/os/mac/missing_formula.rb
@@ -18,19 +18,6 @@ module Homebrew
           <<~EOS
             Xcode can be installed from the App Store.
           EOS
-        when "tex", "tex-live", "texlive", "mactex", "latex"
-          <<~EOS
-            There are three versions of MacTeX.
-
-            Full installation:
-              brew install --cask mactex
-
-            Full installation without bundled applications:
-              brew install --cask mactex-no-gui
-
-            Minimal installation:
-              brew install --cask basictex
-          EOS
         else
           generic_disallowed_reason(name)
         end

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -18,7 +18,6 @@ describe Homebrew::MissingFormula do
     end
 
     it { is_expected.to disallow("gem") }
-    it("disallows LaTeX", :needs_macos) { is_expected.to disallow("latex") }
     it { is_expected.to disallow("pip") }
     it { is_expected.to disallow("pil") }
     it { is_expected.to disallow("macruby") }


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The reasons for disallowing `texlive` on macOS have been irrelevant for many years now and we have a PR to add it: https://github.com/Homebrew/homebrew-core/pull/83738.