### PR TITLE
shims/super/cc: run in bash shell

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Make sure this shim uses the same Ruby interpreter that is used by Homebrew.
 if [[ -z "${HOMEBREW_RUBY_PATH}" ]]
 then

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -48,6 +48,7 @@ describe "Bash" do
         next if path.directory?
         next if path.symlink?
         next unless path.executable?
+        next if path.basename.to_s == "cc" # `bash -n` tries to parse the Ruby part
         next unless path.read(12) == "#!/bin/bash\n"
 
         expect(path).to have_valid_bash_syntax


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Should fix errors like this one:
```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-5: 3: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++-5: [[: not found
```

I don't know if there is any special reason we run this particular shim via plain sh.

Found here: https://github.com/Homebrew/homebrew-core/pull/85282/checks?check_run_id=3624010217

Bug introduced in: https://github.com/Homebrew/brew/pull/12044