### PR TITLE
install: fix `HEAD` installations with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -98,7 +98,8 @@ module Homebrew
         if verbose?
           outdated_kegs = f.outdated_kegs(fetch_head: args.fetch_HEAD?)
 
-          current_version = if ENV["HOMEBREW_INSTALL_FROM_API"].present? && (f.core_formula? || f.tap.blank?)
+          current_version = if !f.head? && ENV["HOMEBREW_INSTALL_FROM_API"].present? &&
+                               (f.core_formula? || f.tap.blank?)
             Homebrew::API::Versions.latest_formula_version(f.name)&.to_s || f.pkg_version.to_s
           elsif f.alias_changed? && !f.latest_formula.latest_version_installed?
             latest = f.latest_formula

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -160,6 +160,7 @@ module Homebrew
 
     if ENV["HOMEBREW_INSTALL_FROM_API"].present?
       formulae_to_install.map! do |formula|
+        next formula if formula.head?
         next formula if formula.tap.present? && !formula.core_formula?
         next formula unless Homebrew::API::Bottle.available?(formula.name)
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -79,10 +79,6 @@ class Formula
 
   # The path to the alias that was used to identify this {Formula}.
   # e.g. `/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/another-name-for-this-formula`
-  attr_reader :bottle_path
-
-  # The path to the alias that was used to identify this {Formula}.
-  # e.g. `/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/another-name-for-this-formula`
   attr_reader :alias_path
 
   # The name of the alias that was used to identify this {Formula}.
@@ -312,18 +308,12 @@ class Formula
     full_name_with_optional_tap(installed_alias_name)
   end
 
-  def prefix_formula_file
-    return unless prefix.directory?
-
-    prefix/".brew/#{name}.rb"
-  end
-
   # The path that was specified to find this formula.
   def specified_path
     default_specified_path = alias_path || path
 
-    return default_specified_path if default_specified_path.present? && default_specified_path.exist?
-    return local_bottle_path if local_bottle_path.present? && local_bottle_path.exist?
+    return default_specified_path if default_specified_path.presence&.exist?
+    return local_bottle_path if local_bottle_path.presence&.exist?
 
     default_specified_path
   end

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -287,7 +287,7 @@ module FormulaCellarChecks
   def check_cpuid_instruction(formula)
     return unless formula.prefix.directory?
     # TODO: add methods to `utils/ast` to allow checking for method use
-    return unless formula.prefix_formula_file.read.include? "ENV.runtime_cpu_detection"
+    return unless (formula.prefix/".brew/#{formula.name}.rb").read.include? "ENV.runtime_cpu_detection"
     # Checking for `cpuid` only makes sense on Intel:
     # https://en.wikipedia.org/wiki/CPUID
     return unless Hardware::CPU.intel?

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -287,7 +287,7 @@ module FormulaCellarChecks
   def check_cpuid_instruction(formula)
     return unless formula.prefix.directory?
     # TODO: add methods to `utils/ast` to allow checking for method use
-    return unless formula.path.read.include? "ENV.runtime_cpu_detection"
+    return unless formula.prefix_formula_file.read.include? "ENV.runtime_cpu_detection"
     # Checking for `cpuid` only makes sense on Intel:
     # https://en.wikipedia.org/wiki/CPUID
     return unless Hardware::CPU.intel?

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -41,7 +41,7 @@ class Tab < OpenStruct
       "source"                  => {
         "path"         => formula.specified_path.to_s,
         "tap"          => formula.tap&.name,
-        "tap_git_head" => formula.tap&.git_head,
+        "tap_git_head" => nil, # Filled in later if possible
         "spec"         => formula.active_spec_sym.to_s,
         "versions"     => {
           "stable"         => formula.stable&.version.to_s,
@@ -51,6 +51,9 @@ class Tab < OpenStruct
       },
       "built_on"                => DevelopmentTools.build_system_info,
     }
+
+    # We can only get `tap_git_head` if the tap is installed locally
+    attributes["source"]["tap_git_head"] = formula.tap.git_head if formula.tap&.installed?
 
     new(attributes)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR should fix the issues that `HOMEBREW_INSTALL_FROM_API` brought to HEAD formulae. Now, `brew install --HEAD`, `brew outdated --fetch-HEAD`, `brew upgrade --fetch-HEAD` should all work as expected.

CC @carlocab (if you could confirm that this fixes your issue I'd appreciate it, sorry I didn't get to fixing it earlier)
