### PR TITLE
formula_cellar_checks: fix edge case handling in `check_binary_arches`

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -341,6 +341,8 @@ module FormulaCellarChecks
     mismatches_expected = formula.tap.blank? || tap_audit_exception(:mismatched_binary_allowlist, formula.name)
     return if compatible_universal_binaries.empty? && mismatches_expected
 
+    return if universal_binaries_expected && mismatches_expected
+
     s = ""
 
     if mismatches.present? && !mismatches_expected


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, if formula `foo` ships both universal and non-native
binaries and `foo` is on both allowlists, then `brew audit --strict`
errors out with an empty error message:

    ❯ brew audit --strict foo
    foo:
      *
    Error: 1 problem in 1 formula detected

Let's fix this (admittedly obscure) corner case by returning early when
a formula is present on both allowlists.