### PR TITLE
formula_installer: fix error if a compatible bottle was not found

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -63,7 +63,7 @@ module Homebrew
   sig { params(formula: Formula, args: CLI::Args).void }
   def print_formula_cache(formula, args:)
     if fetch_bottle?(formula, args: args)
-      puts formula.bottle_for_tag(args.bottle_tag).cached_download
+      puts formula.bottle_for_tag(args.bottle_tag&.to_sym).cached_download
     elsif args.HEAD?
       puts formula.head.cached_download
     else

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -93,7 +93,7 @@ module Homebrew
           begin
             f.clear_cache if args.force?
             f.fetch_bottle_tab
-            fetch_formula(f.bottle_for_tag(args.bottle_tag), args: args)
+            fetch_formula(f.bottle_for_tag(args.bottle_tag&.to_sym), args: args)
           rescue Interrupt
             raise
           rescue => e

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -371,7 +371,7 @@ class Formula
 
   # The Bottle object for given tag.
   # @private
-  sig { params(tag: T.nilable(String)).returns(T.nilable(Bottle)) }
+  sig { params(tag: T.nilable(Symbol)).returns(T.nilable(Bottle)) }
   def bottle_for_tag(tag = nil)
     Bottle.new(self, bottle_specification, tag) if bottled?(tag)
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -150,8 +150,10 @@ class FormulaInstaller
       return false
     end
 
-    bottle = formula.bottle
-    if bottle && !bottle.compatible_locations?
+    bottle = formula.bottle_for_tag(Utils::Bottles.tag.to_sym)
+    return false if bottle.nil?
+
+    unless bottle.compatible_locations?
       if output_warning
         prefix = Pathname(bottle.cellar).parent
         opoo <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`Formula#bottle` has a quirk where it returns nil if a bottle with an incompatible location is found, while `bottle_for_tag` does not do this.

Fixes #12099.