### PR TITLE
upgrade: use `greedy_*` method parameters

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -95,8 +95,8 @@ module Cask
 
         outdated_casks = if casks.empty?
           Caskroom.casks(config: Config.from_args(args)).select do |cask|
-            cask.outdated?(greedy: greedy, greedy_latest: args.greedy_latest?,
-                           greedy_auto_updates: args.greedy_auto_updates?)
+            cask.outdated?(greedy: greedy, greedy_latest: greedy_latest,
+                           greedy_auto_updates: greedy_auto_updates)
           end
         else
           casks.select do |cask|
@@ -120,14 +120,14 @@ module Cask
         return false if outdated_casks.empty?
 
         if casks.empty? && !greedy
-          if !args.greedy_auto_updates? && !args.greedy_latest?
-            ohai "Casks with 'auto_updates true' or 'version :latest'
-            will not be upgraded; pass `--greedy` to upgrade them."
+          if !greedy_auto_updates && !greedy_latest
+            ohai "Casks with 'auto_updates true' or 'version :latest' " \
+                 "will not be upgraded; pass `--greedy` to upgrade them."
           end
-          if args.greedy_auto_updates? && !args.greedy_latest?
+          if greedy_auto_updates && !greedy_latest
             ohai "Casks with 'version :latest' will not be upgraded; pass `--greedy-latest` to upgrade them."
           end
-          if !args.greedy_auto_updates? && args.greedy_latest?
+          if !greedy_auto_updates && greedy_latest
             ohai "Casks with 'auto_updates true' will not be upgraded; pass `--greedy-auto-updates` to upgrade them."
           end
         end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -234,15 +234,17 @@ module Homebrew
 
     Cask::Cmd::Upgrade.upgrade_casks(
       *casks,
-      force:          args.force?,
-      greedy:         args.greedy?,
-      dry_run:        args.dry_run?,
-      binaries:       args.binaries?,
-      quarantine:     args.quarantine?,
-      require_sha:    args.require_sha?,
-      skip_cask_deps: args.skip_cask_deps?,
-      verbose:        args.verbose?,
-      args:           args,
+      force:               args.force?,
+      greedy:              args.greedy?,
+      greedy_latest:       args.greedy_latest?,
+      greedy_auto_updates: args.greedy_auto_updates?,
+      dry_run:             args.dry_run?,
+      binaries:            args.binaries?,
+      quarantine:          args.quarantine?,
+      require_sha:         args.require_sha?,
+      skip_cask_deps:      args.skip_cask_deps?,
+      verbose:             args.verbose?,
+      args:                args,
     )
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `upgrade_casks` method already has parameters for `greedy_latest` and `greedy_auto_updates` but they were unused.