### PR TITLE
rubocops: silence parser warning

### DIFF
--- a/Library/Homebrew/rubocops/all.rb
+++ b/Library/Homebrew/rubocops/all.rb
@@ -6,7 +6,11 @@ require "active_support/core_ext/array/conversions"
 require "rubocop-performance"
 require "rubocop-rails"
 require "rubocop-rspec"
-require "rubocop-sorbet"
+
+require_relative "../warnings"
+Warnings.ignore :parser_syntax do
+  require "rubocop-sorbet"
+end
 
 require_relative "io_read"
 require_relative "shell_commands"

--- a/Library/Homebrew/rubocops/extend/formula.rb
+++ b/Library/Homebrew/rubocops/extend/formula.rb
@@ -1,15 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-# Silence compatibility warning.
-begin
-  old_verbosity = $VERBOSE
-  $VERBOSE = nil
-  require "parser/current"
-ensure
-  $VERBOSE = old_verbosity
-end
-
 require "extend/string"
 require "rubocops/shared/helper_functions"
 

--- a/Library/Homebrew/rubocops/shared/helper_functions.rb
+++ b/Library/Homebrew/rubocops/shared/helper_functions.rb
@@ -3,6 +3,11 @@
 
 require "rubocop"
 
+require_relative "../../warnings"
+Warnings.ignore :parser_syntax do
+  require "parser/current"
+end
+
 module RuboCop
   module Cop
     # Helper functions for cops.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The warning appeared again after load ordering changes caused by gem updates (`rubocop-sorbet` now loads `parser/current`).