### PR TITLE
install: fix --skip-cask-deps message

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -341,7 +341,7 @@ module Cask
       missing_formulae_and_casks.each do |cask_or_formula|
         if cask_or_formula.is_a?(Cask)
           if skip_cask_deps?
-            opoo "`--skip-cask-deps` is set; skipping installation of #{@cask}."
+            opoo "`--skip-cask-deps` is set; skipping installation of #{cask_or_formula}."
             next
           end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In the string ``"`--skip-cask-deps` is set; skipping installation of #{@cask}"``, `@cask` should be `cask_or_formula` because `cask_or_formula` is the dependency that's being skipped.