### PR TITLE
brew.sh: remove annoying prompts when homebrew/core not tapped

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -347,7 +347,7 @@ export HOMEBREW_COMMAND_DEPTH="$((HOMEBREW_COMMAND_DEPTH + 1))"
 # This is set by the user environment.
 # shellcheck disable=SC2154
 if [[ -n "${HOMEBREW_FORCE_BREWED_CURL}" && -x "${HOMEBREW_PREFIX}/opt/curl/bin/curl" ]] &&
-   "${HOMEBREW_PREFIX}/opt/curl/bin/curl" --version >/dev/null
+   "${HOMEBREW_PREFIX}/opt/curl/bin/curl" --version &>/dev/null
 then
   HOMEBREW_CURL="${HOMEBREW_PREFIX}/opt/curl/bin/curl"
 elif [[ -n "${HOMEBREW_DEVELOPER}" && -x "${HOMEBREW_CURL_PATH}" ]]
@@ -360,7 +360,7 @@ fi
 # This is set by the user environment.
 # shellcheck disable=SC2154
 if [[ -n "${HOMEBREW_FORCE_BREWED_GIT}" && -x "${HOMEBREW_PREFIX}/opt/git/bin/git" ]] &&
-   "${HOMEBREW_PREFIX}/opt/git/bin/git" --version >/dev/null
+   "${HOMEBREW_PREFIX}/opt/git/bin/git" --version &>/dev/null
 then
   HOMEBREW_GIT="${HOMEBREW_PREFIX}/opt/git/bin/git"
 elif [[ -n "${HOMEBREW_DEVELOPER}" && -x "${HOMEBREW_GIT_PATH}" ]]
@@ -518,7 +518,7 @@ Your Git executable: $(unset git && type -p ${HOMEBREW_GIT})"
   HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION="2.13"
   unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
 
-  HOMEBREW_CORE_REPOSITORY_ORIGIN="$("${HOMEBREW_GIT}" -C "${HOMEBREW_CORE_REPOSITORY}" remote get-url origin)"
+  HOMEBREW_CORE_REPOSITORY_ORIGIN="$("${HOMEBREW_GIT}" -C "${HOMEBREW_CORE_REPOSITORY}" remote get-url origin 2>/dev/null)"
   if [[ "${HOMEBREW_CORE_REPOSITORY_ORIGIN}" == "https://github.com/Homebrew/homebrew-core" ]]
   then
     # If the remote origin has been set to Homebrew/homebrew-core by the install script,

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -78,17 +78,6 @@ You may need to install your own Ruby using your system package manager, a PPA, 
 
 Homebrew does not currently support 32-bit x86 platforms. It would be possible for Homebrew to work on 32-bit x86 platforms with some effort. An interested and dedicated person could maintain a fork of Homebrew to develop support for 32-bit x86.
 
-## Alternative Installation
-
-Extract or `git clone` Homebrew wherever you want. Use `/home/linuxbrew/.linuxbrew` if possible (to enable the use of binary packages).
-
-```sh
-git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew
-mkdir ~/.linuxbrew/bin
-ln -s ~/.linuxbrew/Homebrew/bin/brew ~/.linuxbrew/bin
-eval "$(~/.linuxbrew/bin/brew shellenv)"
-```
-
 ## Homebrew on Linux Community
 
 - [@HomebrewOnLinux on Twitter](https://twitter.com/HomebrewOnLinux)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -53,6 +53,20 @@ here. *Pick another prefix at your peril!*
 mkdir homebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C homebrew
 ```
 
+or
+
+```sh
+git clone https://github.com/Homebrew/brew homebrew
+```
+
+then
+
+```sh
+eval "$(homebrew/bin/brew shellenv)"
+brew update --force --quiet
+chmod -R go-w "$(brew --prefix)/share/zsh"
+```
+
 ### Multiple installations
 
 Create a Homebrew installation wherever you extract the tarball. Whichever `brew` command is called is where the packages will be installed. You can use this as you see fit, e.g. a system set of libs in the default prefix and tweaked formulae for development in `~/homebrew`.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In the installer ([Homebrew/install](https://github.com/Homebrew/install)), we only officially support three default prefixes (`/usr/local`, `/opt/homebrew` and `/home/linuxbrew/.linuxbrew`). The prefix `~/.linuxbrew` is only available in interactive mode. Discussed in Homebrew/install#582 and Homebrew/install#583, we would not support the non-default prefixes in our official installer (including `~/.linuxbrew` https://github.com/Homebrew/install/pull/583#issuecomment-927826916).

For users who wants non-default prefixes or don't have `sudo` privillages, they should use the [Untar-anywhere](https://docs.brew.sh/Installation#untar-anywhere) / [Alternative-installation](https://docs.brew.sh/Homebrew-on-Linux#alternative-installation) methed (https://github.com/Homebrew/install/pull/583#discussion_r716672112).

```console
$ git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew
Cloning into '/home/PanXuehai/.linuxbrew/Homebrew'...
...

$ mkdir ~/.linuxbrew/bin
$ ln -s ~/.linuxbrew/Homebrew/bin/brew ~/.linuxbrew/bin
$ eval "$(~/.linuxbrew/bin/brew shellenv)"

$ brew update
fatal: cannot change to '/home/PanXuehai/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core': No such file or directory
Already up-to-date.

$ brew update --force --quiet  
fatal: cannot change to '/home/PanXuehai/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core': No such file or directory
fatal: cannot change to '/home/PanXuehai/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core': No such file or directory
fatal: cannot change to '/home/PanXuehai/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core': No such file or directory
HOMEBREW_CORE_GIT_REMOTE set: using https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/linuxbrew-core.git for Homebrew/core Git remote URL.
==> Tapping homebrew/core
Cloning into '/home/PanXuehai/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core'...
...
Already up-to-date.
```

This PR removes the annoying error messages above on Linux and updates the document.