### PR TITLE
upgrade: print (but don't raise) cask upgrade exceptions

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -74,7 +74,7 @@ module Cask
           binaries:            T.nilable(T::Boolean),
           quarantine:          T.nilable(T::Boolean),
           require_sha:         T.nilable(T::Boolean),
-        ).returns(T::Boolean)
+        ).void
       }
       def self.upgrade_casks(
         *casks,
@@ -117,7 +117,7 @@ module Cask
           outdated_casks -= manual_installer_casks
         end
 
-        return false if outdated_casks.empty?
+        return if outdated_casks.empty?
 
         if casks.empty? && !greedy
           if !greedy_auto_updates && !greedy_latest
@@ -135,14 +135,12 @@ module Cask
         verb = dry_run ? "Would upgrade" : "Upgrading"
         oh1 "#{verb} #{outdated_casks.count} outdated #{"package".pluralize(outdated_casks.count)}:"
 
-        caught_exceptions = []
-
         upgradable_casks = outdated_casks.map { |c| [CaskLoader.load(c.installed_caskfile), c] }
 
         puts upgradable_casks
           .map { |(old_cask, new_cask)| "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}" }
           .join("\n")
-        return true if dry_run
+        return if dry_run
 
         upgradable_casks.each do |(old_cask, new_cask)|
           upgrade_cask(
@@ -151,13 +149,8 @@ module Cask
             quarantine: quarantine, require_sha: require_sha
           )
         rescue => e
-          caught_exceptions << e.exception("#{new_cask.full_name}: #{e}")
-          next
+          ofail "#{new_cask.full_name}: #{e}"
         end
-
-        return true if caught_exceptions.empty?
-        raise MultipleCaskErrors, caught_exceptions if caught_exceptions.count > 1
-        raise caught_exceptions.first if caught_exceptions.count == 1
       end
 
       def self.upgrade_cask(

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -110,9 +110,9 @@ module Homebrew
     Homebrew.messages.display_messages(display_times: args.display_times?)
   end
 
-  sig { params(formulae: T::Array[Formula], args: CLI::Args).returns(T::Boolean) }
+  sig { params(formulae: T::Array[Formula], args: CLI::Args).void }
   def upgrade_outdated_formulae(formulae, args:)
-    return false if args.cask?
+    return if args.cask?
 
     if args.build_from_source? && !DevelopmentTools.installed?
       raise BuildFlagsError.new(["--build-from-source"], bottled: formulae.all?(&:bottled?))
@@ -140,7 +140,7 @@ module Homebrew
       end
     end
 
-    return false if outdated.blank?
+    return if outdated.blank?
 
     pinned = outdated.select(&:pinned?)
     outdated -= pinned
@@ -215,13 +215,11 @@ module Homebrew
       quiet:                      args.quiet?,
       verbose:                    args.verbose?,
     )
-
-    true
   end
 
-  sig { params(casks: T::Array[Cask::Cask], args: CLI::Args).returns(T::Boolean) }
+  sig { params(casks: T::Array[Cask::Cask], args: CLI::Args).void }
   def upgrade_outdated_casks(casks, args:)
-    return false if args.formula?
+    return if args.formula?
 
     if ENV["HOMEBREW_INSTALL_FROM_API"].present?
       casks = casks.map do |cask|

--- a/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
@@ -322,7 +322,7 @@ describe Cask::Cmd::Upgrade, :cask do
 
       expect {
         described_class.run("will-fail-if-upgraded")
-      }.to raise_error(Cask::CaskError).and output(output_reverted).to_stderr
+      }.to not_raise_error.and output(output_reverted).to_stderr
 
       expect(will_fail_if_upgraded).to be_installed
       expect(will_fail_if_upgraded_path).to be_a_file
@@ -340,7 +340,7 @@ describe Cask::Cmd::Upgrade, :cask do
 
       expect {
         described_class.run("bad-checksum")
-      }.to raise_error(ChecksumMismatchError).and(not_to_output(output_reverted).to_stderr)
+      }.to not_raise_error.and(not_to_output(output_reverted).to_stderr)
 
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory
@@ -385,7 +385,7 @@ describe Cask::Cmd::Upgrade, :cask do
 
       expect {
         described_class.run
-      }.to raise_error(Cask::MultipleCaskErrors)
+      }.to not_raise_error
 
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -280,6 +280,7 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :not_to_output, :output
+RSpec::Matchers.define_negated_matcher :not_raise_error, :raise_error
 RSpec::Matchers.alias_matcher :have_failed, :be_failed
 RSpec::Matchers.alias_matcher :a_string_containing, :include
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew upgrade` raises an error if any outdated cask fails to upgrade. This is bad because this makes `brew upgrade` exit early and prevents `Homebrew.messages.display_messages` from being called.

I fixed this by adding a `raise_exceptions` parameter so that:
- `brew upgrade` can set it to `false` to print the exceptions, and
- `upgrade_spec.rb` can set it to `true` for unit testing

I also changed the upgrade methods to `void` because their return values aren't used anymore.