### PR TITLE
cxxstdlib: delete unused CompatibilityError class

### DIFF
--- a/Library/Homebrew/cxxstdlib.rb
+++ b/Library/Homebrew/cxxstdlib.rb
@@ -7,18 +7,6 @@ require "compilers"
 class CxxStdlib
   extend T::Sig
 
-  include CompilerConstants
-
-  # Error for when a formula's dependency was built with a different C++ standard library.
-  class CompatibilityError < StandardError
-    def initialize(formula, dep, stdlib)
-      super <<~EOS
-        #{formula.full_name} dependency #{dep.name} was built with a different C++ standard
-        library (#{stdlib.type_string} from #{stdlib.compiler}). This may cause problems at runtime.
-      EOS
-    end
-  end
-
   def self.create(type, compiler)
     raise ArgumentError, "Invalid C++ stdlib type: #{type}" if type && [:libstdcxx, :libcxx].exclude?(type)
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As of 04abc51, `CompatibilityError` and `include CompilerConstants` can be deleted.