### PR TITLE
development_tools: add type signatures

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -38,19 +38,6 @@ class DevelopmentTools
       installation_instructions
     end
 
-    # TODO: This method appears to be unused. Can it be deleted?
-    sig { returns(T.nilable(String)) }
-    def default_cc
-      cc = DevelopmentTools.locate "cc"
-      return if cc.nil?
-
-      begin
-        cc.realpath.basename.to_s
-      rescue
-        nil
-      end
-    end
-
     sig { returns(Symbol) }
     def default_compiler
       :clang
@@ -126,7 +113,7 @@ class DevelopmentTools
       {
         "os"         => ENV["HOMEBREW_SYSTEM"],
         "os_version" => OS_VERSION,
-        "cpu_family" => Hardware::CPU.family,
+        "cpu_family" => Hardware::CPU.family.to_s,
       }
     end
     alias generic_build_system_info build_system_info

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -108,7 +108,7 @@ class DevelopmentTools
       true
     end
 
-    sig { returns(T::Hash[String, T.untyped]) }
+    sig { returns(T::Hash[String, T.nilable(String)]) }
     def build_system_info
       {
         "os"         => ENV["HOMEBREW_SYSTEM"],

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -5,6 +5,7 @@ class DevelopmentTools
   class << self
     extend T::Sig
 
+    sig { params(tool: String).returns(T.nilable(Pathname)) }
     def locate(tool)
       (@locate ||= {}).fetch(tool) do |key|
         @locate[key] = if (path = HOMEBREW_PREFIX/"bin/#{tool}").executable?
@@ -20,6 +21,7 @@ class DevelopmentTools
       :gcc
     end
 
+    sig { returns(T::Hash[String, T.untyped]) }
     def build_system_info
       generic_build_system_info.merge({
         "glibc_version"     => OS::Linux::Glibc.version,

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -21,11 +21,11 @@ class DevelopmentTools
       :gcc
     end
 
-    sig { returns(T::Hash[String, T.untyped]) }
+    sig { returns(T::Hash[String, T.nilable(String)]) }
     def build_system_info
       generic_build_system_info.merge({
-        "glibc_version"     => OS::Linux::Glibc.version,
-        "oldest_cpu_family" => Hardware.oldest_cpu,
+        "glibc_version"     => OS::Linux::Glibc.version.to_s.presence,
+        "oldest_cpu_family" => Hardware.oldest_cpu.to_s,
       })
     end
   end

--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -64,7 +64,7 @@ class DevelopmentTools
       EOS
     end
 
-    sig { returns(T::Hash[String, T.untyped]) }
+    sig { returns(T::Hash[String, T.nilable(String)]) }
     def build_system_info
       build_info = {
         "xcode"          => MacOS::Xcode.version.to_s.presence,

--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -12,6 +12,7 @@ class DevelopmentTools
     undef installed?, default_compiler, curl_handles_most_https_certificates?,
           subversion_handles_most_https_certificates?
 
+    sig { params(tool: String).returns(T.nilable(Pathname)) }
     def locate(tool)
       (@locate ||= {}).fetch(tool) do |key|
         @locate[key] = if (located_tool = generic_locate(tool))
@@ -26,6 +27,7 @@ class DevelopmentTools
     # Checks if the user has any developer tools installed, either via Xcode
     # or the CLT. Convenient for guarding against formula builds when building
     # is impossible.
+    sig { returns(T::Boolean) }
     def installed?
       MacOS::Xcode.installed? || MacOS::CLT.installed?
     end
@@ -62,6 +64,7 @@ class DevelopmentTools
       EOS
     end
 
+    sig { returns(T::Hash[String, T.untyped]) }
     def build_system_info
       build_info = {
         "xcode"          => MacOS::Xcode.version.to_s.presence,

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -18,8 +18,8 @@ module SharedEnvExtension
   def no_weak_imports_support?
     return false unless compiler == :clang
 
-    return false if MacOS::Xcode.version && MacOS::Xcode.version < "8.0"
-    return false if MacOS::CLT.version && MacOS::CLT.version < "8.0"
+    return false if !MacOS::Xcode.version.null? && MacOS::Xcode.version < "8.0"
+    return false if !MacOS::CLT.version.null? && MacOS::CLT.version < "8.0"
 
     true
   end

--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -4,7 +4,12 @@
 module Hardware
   extend T::Sig
   sig { params(version: T.nilable(Version)).returns(Symbol) }
-  def self.oldest_cpu(version = MacOS.version)
+  def self.oldest_cpu(version = nil)
+    version = if version
+      MacOS::Version.new(version.to_s)
+    else
+      MacOS.version
+    end
     if CPU.arch == :arm64
       :arm_vortex_tempest
     # TODO: this cannot be re-enabled until either Rosetta 2 supports AVX

--- a/Library/Homebrew/os/linux/glibc.rb
+++ b/Library/Homebrew/os/linux/glibc.rb
@@ -11,6 +11,7 @@ module OS
 
       module_function
 
+      sig { returns(Version) }
       def system_version
         @system_version ||= begin
           version = Utils.popen_read("/usr/bin/ldd", "--version")[/ (\d+\.\d+)/, 1]
@@ -22,6 +23,7 @@ module OS
         end
       end
 
+      sig { returns(Version) }
       def version
         @version ||= begin
           version = Utils.popen_read(HOMEBREW_PREFIX/"opt/glibc/bin/ldd", "--version")[/ (\d+\.\d+)/, 1]
@@ -38,6 +40,7 @@ module OS
         Version.new(ENV.fetch("HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION"))
       end
 
+      sig { returns(T::Boolean) }
       def below_minimum_version?
         system_version < minimum_version
       end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -75,6 +75,7 @@ module OS
       languages.first
     end
 
+    sig { returns(String) }
     def active_developer_dir
       @active_developer_dir ||= Utils.popen_read("/usr/bin/xcode-select", "-print-path").strip
     end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -178,6 +178,7 @@ module OS
       paths.uniq
     end
 
+    sig { params(ids: String).returns(T.nilable(Pathname)) }
     def app_with_bundle_id(*ids)
       path = mdfind(*ids)
              .reject { |p| p.include?("/Backups.backupdb/") }
@@ -185,6 +186,7 @@ module OS
       Pathname.new(path) if path.present?
     end
 
+    sig { params(ids: String).returns(T::Array[String]) }
     def mdfind(*ids)
       (@mdfind ||= {}).fetch(ids) do
         @mdfind[ids] = Utils.popen_read("/usr/bin/mdfind", mdfind_query(*ids)).split("\n")
@@ -197,6 +199,7 @@ module OS
       end
     end
 
+    sig { params(ids: String).returns(String) }
     def mdfind_query(*ids)
       ids.map! { |id| "kMDItemCFBundleIdentifier == #{id}" }.join(" || ")
     end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -24,16 +24,19 @@ module OS
 
     # This can be compared to numerics, strings, or symbols
     # using the standard Ruby Comparable methods.
+    sig { returns(Version) }
     def version
       @version ||= full_version.strip_patch
     end
 
     # This can be compared to numerics, strings, or symbols
     # using the standard Ruby Comparable methods.
+    sig { returns(Version) }
     def full_version
       @full_version ||= Version.new((ENV["HOMEBREW_MACOS_VERSION"]).chomp)
     end
 
+    sig { params(version: Version).void }
     def full_version=(version)
       @full_version = Version.new(version.chomp)
       @version = nil

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -9,11 +9,21 @@ module OS
     #
     # @api private
     class SDK
+      extend T::Sig
+
       # 11.x SDKs are explicitly excluded - we want the MacOSX11.sdk symlink instead.
       VERSIONED_SDK_REGEX = /MacOSX(10\.\d+|\d+)\.sdk$/.freeze
 
-      attr_reader :version, :path, :source
+      sig { returns(OS::Mac::Version) }
+      attr_reader :version
 
+      sig { returns(Pathname) }
+      attr_reader :path
+
+      sig { returns(Symbol) }
+      attr_reader :source
+
+      sig { params(version: OS::Mac::Version, path: T.any(String, Pathname), source: Symbol).void }
       def initialize(version, path, source)
         @version = version
         @path = Pathname.new(path)
@@ -25,8 +35,14 @@ module OS
     #
     # @api private
     class BaseSDKLocator
+      extend T::Sig
+      extend T::Helpers
+
+      abstract!
+
       class NoSDKError < StandardError; end
 
+      sig { params(v: OS::Mac::Version).returns(SDK) }
       def sdk_for(v)
         sdk = all_sdks.find { |s| s.version == v }
         raise NoSDKError if sdk.nil?
@@ -34,6 +50,7 @@ module OS
         sdk
       end
 
+      sig { returns(T::Array[SDK]) }
       def all_sdks
         return @all_sdks if @all_sdks
 
@@ -62,6 +79,7 @@ module OS
         @all_sdks
       end
 
+      sig { params(v: T.nilable(OS::Mac::Version)).returns(T.nilable(SDK)) }
       def sdk_if_applicable(v = nil)
         sdk = begin
           if v.blank?
@@ -81,20 +99,20 @@ module OS
         sdk
       end
 
-      def source
-        nil
-      end
+      sig { abstract.returns(Symbol) }
+      def source; end
 
       private
 
-      def sdk_prefix
-        ""
-      end
+      sig { abstract.returns(String) }
+      def sdk_prefix; end
 
+      sig { returns(T.nilable(SDK)) }
       def latest_sdk
         all_sdks.max_by(&:version)
       end
 
+      sig { params(sdk_path: Pathname).returns(T.nilable(OS::Mac::Version)) }
       def read_sdk_version(sdk_path)
         sdk_settings = sdk_path/"SDKSettings.json"
         sdk_settings_string = sdk_settings.read if sdk_settings.exist?
@@ -129,13 +147,14 @@ module OS
     class XcodeSDKLocator < BaseSDKLocator
       extend T::Sig
 
-      sig { returns(Symbol) }
+      sig { override.returns(Symbol) }
       def source
         :xcode
       end
 
       private
 
+      sig { override.returns(String) }
       def sdk_prefix
         @sdk_prefix ||= begin
           # Xcode.prefix is pretty smart, so let's look inside to find the sdk
@@ -155,7 +174,7 @@ module OS
     class CLTSDKLocator < BaseSDKLocator
       extend T::Sig
 
-      sig { returns(Symbol) }
+      sig { override.returns(Symbol) }
       def source
         :clt
       end
@@ -169,6 +188,7 @@ module OS
       # separate package, so we can't rely on their being present.
       # This will only look up SDKs on Xcode 10 or newer, and still
       # return nil SDKs for Xcode 9 and older.
+      sig { override.returns(String) }
       def sdk_prefix
         @sdk_prefix ||= if CLT.provides_sdk?
           "#{CLT::PKG_PATH}/SDKs"

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module OS
@@ -89,6 +89,7 @@ module OS
 
       # Returns a Pathname object corresponding to Xcode.app's Developer
       # directory or nil if Xcode.app is not installed.
+      sig { returns(Pathname) }
       def prefix
         @prefix ||=
           begin
@@ -109,6 +110,7 @@ module OS
         Pathname("#{prefix}/Toolchains/XcodeDefault.xctoolchain")
       end
 
+      sig { returns(T.nilable(Pathname)) }
       def bundle_path
         # Use the default location if it exists.
         return DEFAULT_BUNDLE_PATH if DEFAULT_BUNDLE_PATH.exist?
@@ -124,18 +126,22 @@ module OS
         !prefix.nil?
       end
 
+      sig { returns(XcodeSDKLocator) }
       def sdk_locator
         @sdk_locator ||= XcodeSDKLocator.new
       end
 
+      sig { params(v: T.nilable(MacOS::Version)).returns(T.nilable(SDK)) }
       def sdk(v = nil)
         sdk_locator.sdk_if_applicable(v)
       end
 
+      sig { params(v: T.nilable(MacOS::Version)).returns(T.nilable(Pathname)) }
       def sdk_path(v = nil)
         sdk(v)&.path
       end
 
+      sig { returns(String) }
       def installation_instructions
         if OS::Mac.version.prerelease?
           <<~EOS
@@ -163,6 +169,7 @@ module OS
         end
       end
 
+      sig { returns(::Version) }
       def version
         # may return a version string
         # that is guessed based on the compiler, so do not
@@ -174,6 +181,7 @@ module OS
         end
       end
 
+      sig { returns(T.nilable(String)) }
       def detect_version
         # This is a separate function as you can't cache the value out of a block
         # if return is used in the middle, which we do many times in here.
@@ -231,6 +239,7 @@ module OS
         end
       end
 
+      sig { returns(T::Boolean) }
       def default_prefix?
         prefix.to_s == "/Applications/Xcode.app/Contents/Developer"
       end
@@ -255,26 +264,32 @@ module OS
         !version.null?
       end
 
+      sig { returns(T::Boolean) }
       def separate_header_package?
         version >= "10" && MacOS.version >= "10.14"
       end
 
+      sig { returns(T::Boolean) }
       def provides_sdk?
         version >= "8"
       end
 
+      sig { returns(CLTSDKLocator) }
       def sdk_locator
         @sdk_locator ||= CLTSDKLocator.new
       end
 
+      sig { params(v: T.nilable(MacOS::Version)).returns(T.nilable(SDK)) }
       def sdk(v = nil)
         sdk_locator.sdk_if_applicable(v)
       end
 
+      sig { params(v: T.nilable(MacOS::Version)).returns(T.nilable(Pathname)) }
       def sdk_path(v = nil)
         sdk(v)&.path
       end
 
+      sig { returns(String) }
       def installation_instructions
         if MacOS.version == "10.14"
           # This is not available from `xcode-select`
@@ -344,6 +359,7 @@ module OS
         end
       end
 
+      sig { returns(T::Boolean) }
       def below_minimum_version?
         return false unless installed?
 
@@ -358,11 +374,13 @@ module OS
         ::Version.new(clang_version) < latest_clang_version
       end
 
+      sig { returns(T.nilable(String)) }
       def detect_clang_version
         version_output = Utils.popen_read("#{PKG_PATH}/usr/bin/clang", "--version")
         version_output[/clang-(\d+\.\d+\.\d+(\.\d+)?)/, 1]
       end
 
+      sig { returns(T.nilable(String)) }
       def detect_version_from_clang_version
         detect_clang_version&.sub(/^(\d+)0(\d)\./, "\\1.\\2.")
       end
@@ -370,6 +388,7 @@ module OS
       # Version string (a pretty long one) of the CLT package.
       # Note that the different ways of installing the CLTs lead to different
       # version numbers.
+      sig { returns(::Version) }
       def version
         if @version ||= detect_version
           ::Version.new @version
@@ -378,8 +397,9 @@ module OS
         end
       end
 
+      sig { returns(T.nilable(String)) }
       def detect_version
-        version = nil
+        version = T.let(nil, T.nilable(String))
         [EXECUTABLE_PKG_ID, MAVERICKS_NEW_PKG_ID].each do |id|
           next unless File.exist?("#{PKG_PATH}/usr/bin/clang")
 

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -91,6 +91,9 @@ module OS
       # directory or nil if Xcode.app is not installed.
       sig { returns(T.nilable(Pathname)) }
       def prefix
+        return @prefix if defined?(@prefix)
+
+        @prefix = T.let(@prefix, T.nilable(Pathname))
         @prefix ||=
           begin
             dir = MacOS.active_developer_dir

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -89,7 +89,7 @@ module OS
 
       # Returns a Pathname object corresponding to Xcode.app's Developer
       # directory or nil if Xcode.app is not installed.
-      sig { returns(Pathname) }
+      sig { returns(T.nilable(Pathname)) }
       def prefix
         @prefix ||=
           begin

--- a/Library/Homebrew/os/mac/xcode.rbi
+++ b/Library/Homebrew/os/mac/xcode.rbi
@@ -1,0 +1,9 @@
+# typed: strict
+
+module OS
+  module Mac
+    module Xcode
+      include Kernel
+    end
+  end
+end

--- a/Library/Homebrew/sorbet/rbi/upstream.rbi
+++ b/Library/Homebrew/sorbet/rbi/upstream.rbi
@@ -21,3 +21,14 @@ class Module
   end
   def define_method(arg0, arg1=T.unsafe(nil), &blk); end
 end
+
+class Pathname
+  # https://github.com/sorbet/sorbet/pull/4660
+  sig do
+    params(
+        consider_symlink: T::Boolean,
+    )
+    .returns(Pathname)
+  end
+  def cleanpath(consider_symlink=T.unsafe(nil)); end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

```
Redefining the existing method DevelopmentTools.custom_installation_instructions as a method alias https://srb.help/5037
    35 |    alias custom_installation_instructions installation_instructions
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```diff
-alias custom_installation_instructions installation_instructions
+def custom_installation_instructions
+  installation_instructions
+end
```

-----

```
Expected T::Boolean but found T.nilable(Pathname) for method result type https://srb.help/7005
    29 |    end
            ^^^
```

```diff
 def installed?
-  locate("clang") || locate("gcc")
+  locate("clang").present? || locate("gcc").present?
 end
```

-----

```
This code is unreachable https://srb.help/7006
    21 |    return false if MacOS::Xcode.version && MacOS::Xcode.version < "8.0"
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

This code is unreachable https://srb.help/7006
    22 |    return false if MacOS::CLT.version && MacOS::CLT.version < "8.0"
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```diff
-return false if MacOS::Xcode.version && MacOS::Xcode.version < "8.0"
-return false if MacOS::CLT.version && MacOS::CLT.version < "8.0"
+return false if !MacOS::Xcode.version.null? && MacOS::Xcode.version < "8.0"
+return false if !MacOS::CLT.version.null? && MacOS::CLT.version < "8.0"
```