### PR TITLE
build: delete post_superenv_hacks

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -35,14 +35,6 @@ class Build
     end
   end
 
-  def post_superenv_hacks
-    # Only allow Homebrew-approved directories into the PATH, unless
-    # a formula opts-in to allowing the user's path.
-    return if !formula.env.userpaths? && reqs.none? { |rq| rq.env.userpaths? }
-
-    ENV.userpaths!
-  end
-
   def effective_build_options_for(dependent)
     args  = dependent.build.used_options
     args |= Tab.for_formula(dependent).used_options
@@ -92,7 +84,6 @@ class Build
         build_bottle: args.build_bottle?,
         bottle_arch:  args.bottle_arch,
       )
-      post_superenv_hacks
       reqs.each do |req|
         req.modify_build_environment(
           env: args.env, cc: args.cc, build_bottle: args.build_bottle?, bottle_arch: args.bottle_arch,

--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -29,11 +29,6 @@ class BuildEnvironment
     @settings.include? :std
   end
 
-  sig { returns(T::Boolean) }
-  def userpaths?
-    @settings.include? :userpaths
-  end
-
   # DSL for specifying build environment settings.
   module DSL
     extend T::Sig

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -4,8 +4,6 @@
 require "build_environment"
 
 describe BuildEnvironment do
-  alias_matcher :use_userpaths, :be_userpaths
-
   let(:env) { described_class.new }
 
   describe "#<<" do
@@ -31,39 +29,17 @@ describe BuildEnvironment do
     end
   end
 
-  describe "#userpaths?" do
-    it "returns true if the environment contains :userpaths" do
-      env << :userpaths
-      expect(env).to use_userpaths
-    end
-
-    it "returns false if the environment does not contain :userpaths" do
-      expect(env).not_to use_userpaths
-    end
-  end
-
   describe BuildEnvironment::DSL do
     subject(:build_environment_dsl) { double.extend(described_class) }
 
     context "with a single argument" do
       before do
         build_environment_dsl.instance_eval do
-          env :userpaths
-        end
-      end
-
-      its(:env) { is_expected.to use_userpaths }
-    end
-
-    context "with multiple arguments" do
-      before do
-        build_environment_dsl.instance_eval do
-          env :userpaths, :std
+          env :std
         end
       end
 
       its(:env) { is_expected.to be_std }
-      its(:env) { is_expected.to use_userpaths }
     end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Cleaned up `ENV.userpaths!` call that got missed.

- Deprecated https://github.com/Homebrew/brew/commit/d6957a3acb9b524d84c377028867aea2d7d1f0af
- Disabled https://github.com/Homebrew/brew/commit/d73351251cb90fcc353557e6dfd4497a6ad83aef
- Deleted https://github.com/Homebrew/brew/commit/30a65342e8ee21fb07908309fb76bd994f7ab773