### PR TITLE
unpack_strategy/tar: fix zst subextraction

### DIFF
--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -30,7 +30,7 @@ module UnpackStrategy
       FileUtils.cp path, unpack_dir/basename, preserve: true
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "unzstd",
-                      args:    [*quiet_flags, "-T0", "--", unpack_dir/basename],
+                      args:    [*quiet_flags, "-T0", "--rm", "--", unpack_dir/basename],
                       env:     { "PATH" => PATH.new(Formula["zstd"].opt_bin, ENV["PATH"]) },
                       verbose: verbose
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Before extracting `.tar.zst` file (and some other file formats), we copy it to an extraction directory: https://github.com/Homebrew/brew/blob/9b42a104ee51fd2c45f91a72fc18bbad73b1aa5a/Library/Homebrew/unpack_strategy/zstd.rb#L29-L30

After extracting it, we have two files in the directory — `.tar` and original `.tar.zst`. 
Current logic assumes that the first file in this directory is `.tar` file:
https://github.com/Homebrew/brew/blob/9b42a104ee51fd2c45f91a72fc18bbad73b1aa5a/Library/Homebrew/unpack_strategy/tar.rb#L62-L65
But it's not always true for `Pathname#children`; thus in some cases, we're trying to untar the original file (`.tar.zst`) instead of `.tar` (like in https://github.com/Homebrew/homebrew-core/pull/86195).

~~This PR makes sure we're trying to untar exactly the `.tar` file.~~
This PR makes sure we're having only one file in the directory for untar.