### PR TITLE
rubocops/urls: allow plain HTTP mirrors

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula.rb
+++ b/Library/Homebrew/rubocops/extend/formula.rb
@@ -35,14 +35,14 @@ module RuboCop
       # @param urls [Array] url/mirror method call nodes
       # @param regex [Regexp] pattern to match URLs
       def audit_urls(urls, regex)
-        urls.each do |url_node|
+        urls.each_with_index do |url_node, index|
           url_string_node = parameters(url_node).first
           url_string = string_content(url_string_node)
           match_object = regex_match_group(url_string_node, regex)
           next unless match_object
 
           offending_node(url_string_node.parent)
-          yield match_object, url_string
+          yield match_object, url_string, index
         end
       end
 

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -83,8 +83,14 @@ module RuboCop
                                                  %r{^http://(?:[^/]*\.)?archive\.org},
                                                  %r{^http://(?:[^/]*\.)?freedesktop\.org},
                                                  %r{^http://(?:[^/]*\.)?mirrorservice\.org/}])
-          audit_urls(urls, http_to_https_patterns) do |_, url|
-            problem "Please use https:// for #{url}"
+          audit_urls(urls, http_to_https_patterns) do |_, url, index|
+            # It's fine to have a plain HTTP mirror further down the mirror list.
+            https_url = url.dup.insert(4, "s")
+            https_index = nil
+            audit_urls(urls, https_url) do |_, _, found_https_index|
+              https_index = found_https_index
+            end
+            problem "Please use https:// for #{url}" if !https_index || https_index > index
           end
 
           apache_mirror_pattern = %r{^https?://(?:[^/]*\.)?apache\.org/dyn/closer\.(?:cgi|lua)\?path=/?(.*)}i


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For the sources which we mandate HTTPS for, allow a plain HTTP mirror to be used, as long as the HTTPS version is present and is higher in the mirror list.