### PR TITLE
Use --insecure to download `ca-certificates` source where necessary

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -544,6 +544,15 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += [meta[:header], meta[:headers]].flatten.compact.flat_map { |h| ["--header", h.strip] }
 
+    if meta[:insecure]
+      unless @insecure_warning_shown
+        opoo "Using --insecure with curl to download `ca-certificates` " \
+             "because we need it installed to download securely."
+        @insecure_warning_shown = true
+      end
+      args += ["--insecure"] if meta[:insecure]
+    end
+
     args
   end
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -310,8 +310,8 @@ class Bottle
   def initialize(formula, spec, tag = nil)
     @name = formula.name
     @resource = Resource.new
-    @resource.owner = formula
     @resource.specs[:bottle] = true
+    @resource.owner = formula
     @spec = spec
 
     tag_spec = spec.tag_specification_for(Utils::Bottles.tag(tag))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We've not been able to provide a HTTP mirror for this, so the second best solution is to pass `--insecure` while downloading, so it can indeed be downloaded when system CA certs are broken.