### PR TITLE
remove useless `require 'formula'`

### DIFF
--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "formula"
 require "cli/parser"
 
 module Homebrew

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "formula"
 require "cli/parser"
 
 module Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
remove `require "formula"` because it is not needed to execute the commands.