### PR TITLE
move `require 'formula'`

### DIFF
--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "formula"
 require "tab"
 require "diagnostic"
 require "cli/parser"
@@ -33,6 +32,7 @@ module Homebrew
     return unless HOMEBREW_CELLAR.exist?
 
     ff = if args.no_named?
+      require "formula"
       Formula.installed.sort
     else
       args.named.to_resolved_formulae.sort

--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "extend/ENV"
-require "formula"
 require "cli/parser"
 
 module Homebrew
@@ -33,8 +32,10 @@ module Homebrew
     args = sh_args.parse
 
     ENV.activate_extensions!(env: args.env)
-
-    ENV.deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? } if superenv?(args.env)
+    if superenv?(args.env)
+      require "formula"
+      ENV.deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? }
+    end
     ENV.setup_build_environment
     if superenv?(args.env)
       # superenv stopped adding brew's bin but generally users will want it


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
move `require 'formula'` because `Formula` is only used once for a specific condition.