### PR TITLE
mktemp: delete invalid default prefix argument

### DIFF
--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -11,7 +11,7 @@ class Mktemp
   # Path to the tmpdir used in this run, as a {Pathname}.
   attr_reader :tmpdir
 
-  def initialize(prefix = name, opts = {})
+  def initialize(prefix, opts = {})
     @prefix = prefix
     @retain = opts[:retain]
     @quiet = false


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`Mktemp` does not have a method named `name`. This was probably pasted from `Formula` where the `mktemp` method also has a `prefix` parameter that defaults to `name`.