### PR TITLE
system_config: fix clang version output on Linux

### DIFF
--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -7,7 +7,7 @@ module SystemConfig
   class << self
     include SystemCommand::Mixin
 
-    undef describe_homebrew_ruby
+    undef describe_homebrew_ruby, describe_clang
 
     def describe_homebrew_ruby
       s = describe_homebrew_ruby_version
@@ -17,6 +17,13 @@ module SystemConfig
       else
         "#{s} => #{RUBY_PATH}"
       end
+    end
+
+    def describe_clang
+      return "N/A" if clang.null?
+
+      clang_build_info = clang_build.null? ? "(parse error)" : clang_build
+      "#{clang} build #{clang_build_info}"
     end
 
     def xcode

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -76,8 +76,11 @@ module SystemConfig
     def describe_clang
       return "N/A" if clang.null?
 
-      clang_build_info = clang_build.null? ? "(parse error)" : clang_build
-      "#{clang} build #{clang_build_info}"
+      if clang_build.null?
+        clang.to_s
+      else
+        "#{clang} build #{clang_build}"
+      end
     end
 
     def describe_path(path)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If you have Homebrew LLVM installed on Linux, `brew config` will show

    Clang: 12.0.1 build (parse error)

because Homebrew LLVM does not give a build number. Some (but not all) installations
from the system package manager do have this information, so let's show
it if it's available but skip complaining if not.

I've kept the original code for macOS because we always expect Apple's
build number to show there.