### PR TITLE
utils/git: require formula.

### DIFF
--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -123,6 +123,7 @@ module Utils
     end
 
     def setup_gpg!
+      require "formula"
       return unless Formula["gnupg"].optlinked?
 
       ENV["PATH"] = PATH.new(ENV["PATH"])


### PR DESCRIPTION
This is currently causing `brew vendor-gems` to fail.