### PR TITLE
mac/formula_cellar_checks: check for flat namespace libraries

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -41,7 +41,7 @@ module FormulaCellarChecks
       These object files were linked against the deprecated system OpenSSL or
       the system's private LibreSSL.
       Adding `depends_on "openssl"` to the formula may help.
-        #{system_openssl * "\n "}
+        #{system_openssl * "\n  "}
     EOS
   end
 
@@ -97,10 +97,10 @@ module FormulaCellarChecks
       next true unless file.dylib?
 
       macho = MachO.open(file)
-      if file.universal?
+      if MachO::Utils.fat_magic?(macho.magic)
         macho.machos.map(&:header).all? { |h| h.flag? :MH_TWOLEVEL }
       else
-        macho.header.flag?(:MH_TWOLEVEL)
+        macho.header.flag? :MH_TWOLEVEL
       end
     end
     return if flat_namespace_files.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There are at least five instances where a formula has libraries compiled
with `-flat_namespace` due to a bug in detecting the macOS version (cf.
Homebrew/homebrew-core#87103, Homebrew/homebrew-core#85974,
Homebrew/homebrew-core#85973).

I think it makes sense to check for this more generally. It is
sometimes intentional, so I've added a check for an allowlist for
those instances. Running this on the current `util-linux` bottle
produces

    ❯ brew audit --strict util-linux
    util-linux:
      * Libraries were compiled with a flat namespace.
        This can cause linker errors due to name collisions, and
        is often due to a bug in detecting the macOS version.
          /usr/local/Cellar/util-linux/2.37.2/lib/libblkid.1.dylib
          /usr/local/Cellar/util-linux/2.37.2/lib/libfdisk.1.dylib
          /usr/local/Cellar/util-linux/2.37.2/lib/libsmartcols.1.dylib
          /usr/local/Cellar/util-linux/2.37.2/lib/libuuid.1.dylib
    Error: 1 problem in 1 formula detected

Some things that still need to be done here:
- ~fix this check for universal binaries~
- check if we want to restrict this audit to newer versions of macOS
- ~fix false positives (try `brew audit --strict llvm` and compare the~
  ~output of `otool -hV` on the identified files)~

While we're here, let's fix the formatting of the output of these other
audits (cf. #12217).

-----

Here's some background on flat vs two-level namespaces: https://developer.apple.com/library/archive/documentation/Porting/Conceptual/PortingUnix/compiling/compiling.html#//apple_ref/doc/uid/TP40002850-BCIHJBBF