### PR TITLE
resource: add reference method for PatchResource

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -231,11 +231,14 @@ class Resource
 
   # A resource containing a patch.
   class PatchResource < Resource
+    extend T::Sig
+
     attr_reader :patch_files
 
     def initialize(&block)
       @patch_files = []
       @directory = nil
+      @reference = nil
       super "patch", &block
     end
 
@@ -245,10 +248,18 @@ class Resource
       @patch_files.uniq!
     end
 
+    sig { params(val: T.nilable(String)).returns(T.nilable(String)) }
     def directory(val = nil)
       return @directory if val.nil?
 
       @directory = val
+    end
+
+    sig { params(val: T.nilable(String)).returns(T.nilable(String)) }
+    def reference(val = nil)
+      return @reference if val.nil?
+
+      @reference = val
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
The idea is that comments like "can be removed after X is merged" can be a `reference`, where an audit can check if X is merged/closed/whatever.