### PR TITLE
tap: handle `TapCoreRemoteMismatchError` when tapping the core tap without a URL

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -762,8 +762,8 @@ class CoreTap < Tap
 
   # CoreTap never allows shallow clones (on request from GitHub).
   def install(quiet: false, clone_target: nil, force_auto_update: nil, custom_remote: false)
-    remote = Homebrew::EnvConfig.core_git_remote
-    requested_remote = clone_target || default_remote
+    remote = Homebrew::EnvConfig.core_git_remote # set by HOMEBREW_CORE_GIT_REMOTE
+    requested_remote = clone_target || remote
 
     # The remote will changed again on `brew update` since remotes for Homebrew/core are mismatched
     raise TapCoreRemoteMismatchError.new(name, remote, requested_remote) if requested_remote != remote


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Handle `TapCoreRemoteMismatchError` on `brew tap homebrew/core` without a URL while `HOMEBREW_CORE_GIT_REMOTE` set.

```console
$ rm -rf "$(brew --repo homebrew/core)"

$ export HOMEBREW_CORE_GIT_REMOTE="https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/linuxbrew-core.git"

$ brew tap homebrew/core  # tap without a URL while `HOMEBREW_CORE_GIT_REMOTE` set
Updating Homebrew...
Error: Tap homebrew/core remote does mot match HOMEBREW_CORE_GIT_REMOTE.
https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/linuxbrew-core.git != https://github.com/Homebrew/linuxbrew-core
Please set HOMEBREW_CORE_GIT_REMOTE="https://github.com/Homebrew/linuxbrew-core" and run `brew update` instead.
Error: Failure while executing; `/home/PanXuehai/Projects/brew/bin/brew tap homebrew/core` exited with 1.
Error: Tap homebrew/core remote does mot match HOMEBREW_CORE_GIT_REMOTE.
https://mirrors.tuna.tsinghua.edu.cn/git/homebrew/linuxbrew-core.git != https://github.com/Homebrew/linuxbrew-core
Please set HOMEBREW_CORE_GIT_REMOTE="https://github.com/Homebrew/linuxbrew-core" and run `brew update` instead.
```