### PR TITLE
Add `--print-path` flag to `brew edit`

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -296,6 +296,9 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def custom_remote?; end
+
+      sig { returns(T::Boolean) }
+      def print_path?; end
     end
   end
 end

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -186,10 +186,6 @@ module Homebrew
         to_formulae_to_casks(only: only, method: :resolve)
       end
 
-      def to_formulae_paths
-        to_paths(only: :formula)
-      end
-
       # Keep existing paths and try to convert others to tap, formula or cask paths.
       # If a cask and formula with the same name exist, includes both their paths
       # unless `only` is specified.

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -21,6 +21,8 @@ module Homebrew
              description: "Treat all named arguments as formulae."
       switch "--cask", "--casks",
              description: "Treat all named arguments as casks."
+      switch "--print-path",
+             description: "Print the file path to be edited, without opening an editor."
 
       conflicts "--formula", "--cask"
 
@@ -57,6 +59,11 @@ module Homebrew
                           "Run #{Formatter.identifier("brew create --set-name #{path.basename} $URL")} " \
                           "to create a new formula!"
       end.presence
+    end
+
+    if args.print_path?
+      paths.each(&method(:puts))
+      return
     end
 
     exec_editor(*paths)

--- a/Library/Homebrew/dev-cmd/formula.rb
+++ b/Library/Homebrew/dev-cmd/formula.rb
@@ -23,6 +23,13 @@ module Homebrew
   def formula
     args = formula_args.parse
 
-    args.named.to_formulae_paths.each(&method(:puts))
+    formula_paths = args.named.to_paths(only: :formula).select(&:exist?)
+    if formula_paths.blank? && args.named
+                                   .to_paths(only: :cask)
+                                   .select(&:exist?)
+                                   .present?
+      odie "Found casks but did not find formulae!"
+    end
+    formula_paths.each(&method(:puts))
   end
 end


### PR DESCRIPTION
Add a `--print-path` flag to `brew edit`, in order to print the source `.rb`
file of both casks and formulae. In order to prevent faulty reporting, `brew
formula $SOME_CASK` will now error out if a cask matches, but a formula does
not.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Per prior discussions on #12231 and #12230