### PR TITLE
feat: support user-configured Google Analytics reporting

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -11,6 +11,10 @@ module Homebrew
     module_function
 
     ENVS = {
+      HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID:    {
+        description: "Additional Google Analytics tracking ID to emit user behaviour analytics to. " \
+                     "For more information, see: <https://docs.brew.sh/Analytics>",
+      },
       HOMEBREW_ARCH:                              {
         description: "Linux only: Pass this value to a type name representing the compiler's `-march` option.",
         default:     "native",

--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -64,12 +64,17 @@ setup-analytics() {
   if [[ -n "${HOMEBREW_LINUX}" ]]
   then
     # For Homebrew on Linux's analytics.
-    HOMEBREW_ANALYTICS_ID="UA-76492262-1"
+    HOMEBREW_ANALYTICS_IDS="UA-76492262-1"
   else
     # Otherwise, fall back to Homebrew's analytics.
-    HOMEBREW_ANALYTICS_ID="UA-76679469-1"
+    HOMEBREW_ANALYTICS_IDS="UA-76679469-1"
   fi
 
-  export HOMEBREW_ANALYTICS_ID
+  if [[ -n "${HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID}" ]]
+  then
+    HOMEBREW_ANALYTICS_IDS="${HOMEBREW_ANALYTICS_IDS},${HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID}"
+  fi
+
+  export HOMEBREW_ANALYTICS_IDS
   export HOMEBREW_ANALYTICS_USER_UUID
 }


### PR DESCRIPTION
Allow users to set a custom Google Analytics tracking ID to report user behaviour via new environment variable: `$HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID`.

If provided, this tracking ID will be used _in addition to_ the default tracking
ID used by <https://brew.sh/analytics/>.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
