### PR TITLE
cmd/link: change `default_prefix?` check to `/usr/local` check

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -89,7 +89,7 @@ module Homebrew
       end
 
       if keg_only
-        if HOMEBREW_PREFIX.to_s == "/usr/local" && formula.present? && formula.keg_only_reason.by_macos?
+        if HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX && formula.present? && formula.keg_only_reason.by_macos?
           caveats = Caveats.new(formula)
           opoo <<~EOS
             Refusing to link macOS provided/shadowed software: #{keg.name}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Linking macOS-provided software breaks things only in `/usr/local`
prefixes, hence the `default_prefix?` check, which was included when our
only default prefix on macOS was `/usr/local`. Now that we install into
`/opt/homebrew` too, the default prefix check is needlessly restrictive.