### PR TITLE
formula_installer: don't install bottle deps for `all` bottles

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -590,7 +590,9 @@ class FormulaInstaller
       end
     end
 
-    if pour_bottle && !Keg.bottle_dependencies.empty?
+    # We require some dependencies (glibc, GCC 5, etc.) if binaries were built.
+    # Native binaries shouldn't exist in cross-platform `all` bottles.
+    if pour_bottle && !formula.bottled?(:all) && !Keg.bottle_dependencies.empty?
       bottle_deps = if Keg.bottle_dependencies.exclude?(formula.name)
         Keg.bottle_dependencies
       elsif Keg.relocation_formulae.exclude?(formula.name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a bit of a hack but I'm not sure of a better alternative, though I suppose it's no different to the conditionals we have elsewhere. I want to install brewed `ca-certificates` in our Debian 7 image so that we can get Homebrew/portable-ruby CI functional again, but installing the bottle requires installing GCC 5 which we don't want on the image (and is not needed as there is no actual binaries in the bottle).

This PR will also fix an issue where a user on a system with broken certificates and no GCC 5 bottle available (e.g. ARM) will not be able to install our `ca-certificates` because it tries to fetch the GCC 5 source first.