### PR TITLE
Add HOMEBREW_SSH_CONFIG_PATH

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -794,6 +794,12 @@ fi
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/analytics.sh"
 setup-analytics
 
+# Use this configuration file instead of ~/.ssh/config when fetching git over SSH.
+if [[ -n "${HOMEBREW_SSH_CONFIG_PATH}" ]]
+then
+  export GIT_SSH_COMMAND="ssh -F${HOMEBREW_SSH_CONFIG_PATH}"
+fi
+
 if [[ -n "${HOMEBREW_BASH_COMMAND}" ]]
 then
   # source rather than executing directly to ensure the entire file is read into

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -455,7 +455,7 @@ EOS
   fi
 
   export GIT_TERMINAL_PROMPT="0"
-  export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
+  export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh} -oBatchMode=yes"
 
   if [[ -n "${HOMEBREW_GIT_NAME}" ]]
   then

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -282,6 +282,11 @@ module Homebrew
         description: "If set, running Homebrew on Linux will use homebrew-core instead of linuxbrew-core.",
         boolean:     true,
       },
+      HOMEBREW_SSH_CONFIG_PATH:                   {
+        description:  "If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching " \
+                      "`git` repos over `ssh`.",
+        default_text: "`$HOME/.ssh/config`",
+      },
       HOMEBREW_SKIP_OR_LATER_BOTTLES:             {
         description: "If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions " \
                      "of macOS. This is useful in development on new macOS versions.",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2086,6 +2086,11 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_FORCE_HOMEBREW_CORE_REPO_ON_LINUX`
   <br>If set, running Homebrew on Linux will use homebrew-core instead of linuxbrew-core.
 
+- `HOMEBREW_SSH_CONFIG_PATH`
+  <br>If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching `git` repos over `ssh`.
+
+  *Default:* `$HOME/.ssh/config`
+
 - `HOMEBREW_SKIP_OR_LATER_BOTTLES`
   <br>If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions of macOS. This is useful in development on new macOS versions.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3038,6 +3038,15 @@ If set, running Homebrew on Linux will simulate certain macOS code paths\. This 
 If set, running Homebrew on Linux will use homebrew\-core instead of linuxbrew\-core\.
 .
 .TP
+\fBHOMEBREW_SSH_CONFIG_PATH\fR
+.
+.br
+If set, Homebrew will use the given config file instead of \fB~/\.ssh/config\fR when fetching \fBgit\fR repos over \fBssh\fR\.
+.
+.IP
+\fIDefault:\fR \fB$HOME/\.ssh/config\fR
+.
+.TP
 \fBHOMEBREW_SKIP_OR_LATER_BOTTLES\fR
 .
 .br


### PR DESCRIPTION
**TL;DR: This allows specifying the path of an SSH config file that Homebrew should use instead of the default, `~/.ssh/config`, when fetching Git repos over SSH.**

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

### Backstory

My company has a similar environment to the one described in https://github.com/Homebrew/brew/pull/3493.

We need to supply `SSH_AUTH_SOCK` when cloning a private tap — but we've found that there are a number of ways engineers' `~/.ssh/config` can conflict with `SSH_AUTH_SOCK`. For example, if their Config includes `IdentitiesOnly yes`, a misconfigured `IdentityAgent`, or anything malformed, `SSH_AUTH_SOCK` alone won't guarantee access.

We're looking for a better way of temporarily asserting a pristine configuration in order to set up (or repair) our engineers' environments with a script.
