### PR TITLE
Only use patchelf.rb

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -8,7 +8,7 @@ class Keg
     # Patching the dynamic linker of glibc breaks it.
     return if name == "glibc"
 
-    # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
+    # Patching patchelf fails with "Text file busy" or SIGBUS.
     return if name == "patchelf"
 
     old_prefix, new_prefix = relocation.replacement_pair_for(:prefix)
@@ -79,14 +79,6 @@ class Keg
       elf_files << pn
     end
     elf_files
-  end
-
-  def self.relocation_formulae
-    @relocation_formulae ||= if HOMEBREW_PATCHELF_RB_WRITE
-      []
-    else
-      ["patchelf"]
-    end.freeze
   end
 
   def self.bottle_dependencies

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -134,7 +134,4 @@ require "official_taps"
 require "tap"
 require "tap_constants"
 
-# Enables `patchelf.rb` write support.
-HOMEBREW_PATCHELF_RB_WRITE = ENV["HOMEBREW_NO_PATCHELF_RB_WRITE"].blank?.freeze
-
 require "compat/late" unless Homebrew::EnvConfig.no_compat?

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -101,11 +101,7 @@ module ELFShim
   def patch!(interpreter: nil, rpath: nil)
     return if interpreter.blank? && rpath.blank?
 
-    if HOMEBREW_PATCHELF_RB_WRITE
-      save_using_patchelf_rb interpreter, rpath
-    else
-      save_using_patchelf interpreter, rpath
-    end
+    save_using_patchelf_rb interpreter, rpath
   end
 
   def dynamic_elf?
@@ -157,16 +153,6 @@ module ELFShim
     end
   end
   private_constant :Metadata
-
-  def save_using_patchelf(new_interpreter, new_rpath)
-    patchelf = DevelopmentTools.locate "patchelf"
-    odie "Could not locate `patchelf`; please run `brew install patchelf`" if patchelf.blank?
-    args = []
-    args << "--set-interpreter" << new_interpreter if new_interpreter.present?
-    args << "--force-rpath" << "--set-rpath" << new_rpath if new_rpath.present?
-
-    Homebrew.safe_system(patchelf, *args, to_s)
-  end
 
   def save_using_patchelf_rb(new_interpreter, new_rpath)
     patcher = patchelf_patcher

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -8,19 +8,6 @@ describe "brew bottle" do
   it_behaves_like "parseable arguments"
 
   it "builds a bottle for the given Formula", :integration_test do
-    # create stub patchelf
-    if OS.linux?
-      setup_test_formula "patchelf"
-      patchelf = HOMEBREW_CELLAR/"patchelf/1.0/bin/patchelf"
-      patchelf.dirname.mkpath
-      patchelf.write <<~EOS
-        #!/bin/sh
-        exit 0
-      EOS
-      FileUtils.chmod "+x", patchelf
-      FileUtils.ln_s patchelf, HOMEBREW_PREFIX/"bin/patchelf"
-    end
-
     install_test_formula "testball", build_bottle: true
 
     # `brew bottle` should not fail with dead symlink

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -25,8 +25,6 @@ describe FormulaInstaller do
     stub_formula_loader formula
     stub_formula_loader formula("gcc") { url "gcc-1.0" }
     stub_formula_loader formula("gcc@5") { url "gcc-5.0" }
-    stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
-    allow(Formula["patchelf"]).to receive(:latest_version_installed?).and_return(true)
 
     fi = FormulaInstaller.new(formula)
     fi.fetch

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -143,8 +143,6 @@ describe Formulary do
         allow(described_class).to receive(:loader_for).and_call_original
         stub_formula_loader formula("gcc") { url "gcc-1.0" }
         stub_formula_loader formula("gcc@5") { url "gcc-5.0" }
-        stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
-        allow(Formula["patchelf"]).to receive(:latest_version_installed?).and_return(true)
       end
 
       let(:installed_formula) { described_class.factory(formula_path) }

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -43,11 +43,6 @@ describe Pathname do
   end
 
   describe "#patch!" do
-    # testing only patchelf.rb as HOMEBREW_PREFIX is different for tests,
-    # and DevelopmentTools.locate fails to locate patchelf
-    # TODO: use stub_const("HOMEBREW_PATCHELF_RB_WRITE", true) in tests instead.
-    HOMEBREW_PATCHELF_RB_WRITE = true
-
     let(:placeholder_prefix) { "@@HOMEBREW_PREFIX@@" }
     let(:short_prefix) { "/home/dwarf" }
     let(:standard_prefix) { "/home/linuxbrew/.linuxbrew" }

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -163,7 +163,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
 
         # something here
       RUBY
-    when "foo", "gnupg", "patchelf"
+    when "foo", "gnupg"
       content = <<~RUBY
         url "https://brew.sh/#{name}-1.0"
       RUBY


### PR DESCRIPTION
Remove support for using the `patchelf` formula for writing as it's been off by default for a long time now.