### PR TITLE
Apache: Extend `URL_MATCH_REGEX`

### DIFF
--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -7,14 +7,15 @@ module Homebrew
       # The {Apache} strategy identifies versions of software at apache.org
       # by checking directory listing pages.
       #
-      # Apache URLs start with `https://www.apache.org/dyn/closer.lua?path=`.
-      # The `path` parameter takes one of the following formats:
+      # Apache URLs start with `https://www.apache.org/dyn/` and include
+      # a `filename` or `path` query string parameter where the value is a
+      # path to a file. The path takes one of the following formats:
       #
       # * `example/1.2.3/example-1.2.3.tar.gz`
       # * `example/example-1.2.3/example-1.2.3.tar.gz`
       # * `example/example-1.2.3-bin.tar.gz`
       #
-      # When the `path` contains a version directory (e.g. `/1.2.3/`,
+      # When the path contains a version directory (e.g. `/1.2.3/`,
       # `/example-1.2.3/`, etc.), the default regex matches numeric versions
       # in directory names. Otherwise, the default regex matches numeric
       # versions in filenames.
@@ -26,7 +27,7 @@ module Homebrew
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
           ^https?://www\.apache\.org
-          /dyn/.+path=
+          /dyn/.+(?:path|filename)=
           (?<path>.+?)/      # Path to directory of files or version directories
           (?<prefix>[^/]*?)  # Any text in filename or directory before version
           v?\d+(?:\.\d+)+    # The numeric version

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -7,11 +7,23 @@ describe Homebrew::Livecheck::Strategy::Apache do
   subject(:apache) { described_class }
 
   let(:apache_urls) {
-    {
+    urls = {
       version_dir:          "https://www.apache.org/dyn/closer.lua?path=abc/1.2.3/def-1.2.3.tar.gz",
       name_and_version_dir: "https://www.apache.org/dyn/closer.lua?path=abc/def-1.2.3/ghi-1.2.3.tar.gz",
       name_dir_bin:         "https://www.apache.org/dyn/closer.lua?path=abc/def/ghi-1.2.3-bin.tar.gz",
     }
+
+    # Add mirrors.cgi test URLs using the same paths
+    urls.clone.each do |key, url|
+      next unless url.include?("/closer.lua?path=")
+
+      urls["mirrors_#{key}".to_sym] = url.sub(
+        "/closer.lua?path=",
+        "/mirrors/mirrors.cgi?action=download&filename=",
+      )
+    end
+
+    urls
   }
   let(:non_apache_url) { "https://brew.sh/test" }
 
@@ -34,9 +46,7 @@ describe Homebrew::Livecheck::Strategy::Apache do
 
   describe "::match?" do
     it "returns true for an Apache URL" do
-      expect(apache.match?(apache_urls[:version_dir])).to be true
-      expect(apache.match?(apache_urls[:name_and_version_dir])).to be true
-      expect(apache.match?(apache_urls[:name_dir_bin])).to be true
+      apache_urls.each_value { |url| expect(apache.match?(url)).to be true }
     end
 
     it "returns false for a non-Apache URL" do
@@ -46,9 +56,10 @@ describe Homebrew::Livecheck::Strategy::Apache do
 
   describe "::generate_input_values" do
     it "returns a hash containing url and regex for an Apache URL" do
-      expect(apache.generate_input_values(apache_urls[:version_dir])).to eq(generated[:version_dir])
-      expect(apache.generate_input_values(apache_urls[:name_and_version_dir])).to eq(generated[:name_and_version_dir])
-      expect(apache.generate_input_values(apache_urls[:name_dir_bin])).to eq(generated[:name_dir_bin])
+      apache_urls.each do |key, url|
+        generated_key = key.to_s.start_with?("mirrors_") ? key.to_s.delete_prefix("mirrors_").to_sym : key
+        expect(apache.generate_input_values(url)).to eq(generated[generated_key])
+      end
     end
 
     it "returns an empty hash for a non-Apache URL" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`apache-pulsar` is the only formula in homebrew/core using an Apache URL that doesn't follow the prevailing `/dyn/closer.lua?path=...` format. The `Apache` strategy doesn't match the formula's current `stable` URL (`https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.8.0/apache-pulsar-2.8.0-src.tar.gz`) and livecheck ends up checking the Git tags from `head` instead. We prefer to align the check with the `stable` URL whenever possible, so it's appropriate to extend the `Apache` strategy to address this.

It's been suggested in Homebrew/homebrew-core#87587 that we should simply update the URL to use the prevailing format (i.e., `https://www.apache.org/dyn/closer.lua?path=pulsar/pulsar-2.8.0/apache-pulsar-2.8.0-src.tar.gz` does work). However, the [first-party download page](https://pulsar.apache.org/en/download/) uses the `mirrors.cgi` URL, so it's possible for the URL to switch back to the format that the `Apache` strategy doesn't support (e.g., if someone copies the URL from the page and uses it in a version bump).

We could potentially add an audit to enforce the `closer.lua` URL format for Apache URLs but I think there's value in extending the `Apache` strategy to support the `mirrors.cgi` URL format regardless.