### PR TITLE
os/mac/xcode: require Xcode 13.1 on Monterey

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -23,7 +23,7 @@ module OS
       def latest_version(macos: MacOS.version)
         latest_stable = "13.0"
         case macos
-        when "12" then "13.0"
+        when "12" then "13.1"
         when "11" then latest_stable
         when "10.15" then "12.4"
         when "10.14" then "11.3.1"
@@ -47,7 +47,7 @@ module OS
       sig { returns(String) }
       def minimum_version
         case MacOS.version
-        when "12" then "13.0"
+        when "12" then "13.1"
         when "11" then "12.2"
         when "10.15" then "11.0"
         when "10.14" then "10.2"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will be the first stable release with the macOS 12 SDK.

Unfortunately it's trickier to bump the CLT since version detection is less precise, but we have other diagnostics to cover this shortcoming.