### PR TITLE
Mirror `--write-only`  behaviour to cask, fix incorrect arg reference

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -22,8 +22,9 @@ module Homebrew
       EOS
       switch "-n", "--dry-run",
              description: "Print what would be done rather than doing it."
-      switch "--write",
+      switch "--write-only",
              description: "Make the expected file modifications without taking any Git actions."
+      switch "--write", hidden: true
       switch "--commit",
              depends_on:  "--write",
              description: "When passed with `--write`, generate a new commit after writing changes "\
@@ -60,6 +61,8 @@ module Homebrew
 
   def bump_cask_pr
     args = bump_cask_pr_args.parse
+
+    odeprecated "`brew bump-cask-pr --write`", "`brew bump-cask-pr --write-only`" if args.write?
 
     # This will be run by `brew style` later so run it first to not start
     # spamming during normal output.

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -488,7 +488,7 @@ module GitHub
       changed_files = [sourcefile_path]
       changed_files += additional_files if additional_files.present?
 
-      if args.dry_run? || (args.write? && !args.commit?)
+      if args.dry_run? || (args.write_only? && !args.commit?)
         remote_url = if args.no_fork?
           Utils.popen_read("git", "remote", "get-url", "--push", "origin").chomp
         else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes #12268 and also mirrors the same behaviour of deprecating `--write` in favour of `--write-only` to cask.

CC: @Moisan 