### PR TITLE
ResourceAuditor: Skip branch error when using tag

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -143,6 +143,7 @@ module Homebrew
       return unless @strict
       return if spec_name != :head
       return unless Utils::Git.remote_exists?(url)
+      return if specs[:tag].present?
 
       branch = Utils.popen_read("git", "ls-remote", "--symref", url, "HEAD")
                     .match(%r{ref: refs/heads/(.*?)\s+HEAD})[1]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `arangodb` formula contains the following `resource` block:

```ruby
resource "starter" do
  url "https://github.com/arangodb-helper/arangodb.git",
      tag:      "0.15.1",
      revision: "3c27ad4cfb89e96db551445212f78706b7263851"
end
```

Running `brew audit --strict --online arangodb` produces the following error:

```
arangodb:
  * HEAD resource "starter": Use `branch: "master"` to specify the default branch
Error: 1 problem in 1 formula detected
```

As discussed in Homebrew/homebrew-core#87645, this seems like a bug. `branch` and `tag` should probably be considered mutually exclusive in terms of this audit (i.e., a tag references a commit which exists on a branch but the tag exists irrespective of branches).

With this in mind, this PR is an attempt to address this issue. Feel free to suggest an alternative approach or correct my understanding if any of this isn't true.