### PR TITLE
formula_auditor: add audit for formulae with synced versions

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -118,6 +118,31 @@ module Homebrew
       @aliases ||= Formula.aliases + Formula.tap_aliases
     end
 
+    SYNCED_VERSIONS_FORMULAE_FILE = "synced_versions_formulae.json"
+
+    def audit_synced_versions_formulae
+      synced_versions_formulae_file = formula.tap.path/SYNCED_VERSIONS_FORMULAE_FILE
+      return unless synced_versions_formulae_file.file?
+
+      name = formula.name
+      version = formula.version
+
+      synced_versions_formulae = JSON.parse(synced_versions_formulae_file.read)
+      synced_versions_formulae.each do |synced_version_formulae|
+        next unless synced_version_formulae.include? name
+
+        synced_version_formulae.each do |synced_formula|
+          next if synced_formula == name
+
+          if (synced_version = Formulary.factory(synced_formula).version) != version
+            problem "Version of `#{synced_formula}` (#{synced_version}) should match version of `#{name}` (#{version})"
+          end
+        end
+
+        break
+      end
+    end
+
     def audit_formula_name
       name = formula.name
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We have a bunch of formulae in homebrew-core that are supposed to be updated simultaneously (like `git` and `git-gui`, `python@3.9` and `python-tk@3.9` and recently added `libnghttp2` and `nghttp2`) and usually, we keep this requirement as a comment in formulae and check it manually during a PR review.

I propose adding a list (`synced_versions_formulae.json`) of such formulae to homebrew-core and an audit for checking those particular formulae have the same version.

The current version of `synced_versions_formulae.json` will look like this:
```json
[
  ["cmake", "cmake-docs"],
  ["etl", "synfig"],
  ["fizz", "folly", "wangle", "watchman"],
  ["git", "git-credential-libsecret", "git-gui"],
  ["ilmbase", "openexr@2"],
  ["imath", "openexr"],
  ["libnghttp2", "nghttp2"],
  ["libqalculate", "qalculate-gtk"],
  ["mame", "rom-tools"],
  ["moarvm", "nqp", "rakudo"],
  ["python@3.10", "python-tk@3.10"],
  ["python@3.9", "python-tk@3.9"]
]
```