### PR TITLE
Gnu: Update generated URL to use HTTPS

### DIFF
--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -64,7 +64,7 @@ module Homebrew
           return values if match.blank?
 
           # The directory listing page for the project's files
-          values[:url] = "http://ftp.gnu.org/gnu/#{match[:project_name]}/"
+          values[:url] = "https://ftp.gnu.org/gnu/#{match[:project_name]}/"
 
           regex_name = Regexp.escape(T.must(match[:project_name])).gsub("\\-", "-")
 

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -19,15 +19,15 @@ describe Homebrew::Livecheck::Strategy::Gnu do
   let(:generated) {
     {
       no_version_dir: {
-        url:   "http://ftp.gnu.org/gnu/abc/",
+        url:   "https://ftp.gnu.org/gnu/abc/",
         regex: %r{href=.*?abc[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i,
       },
       software_page:  {
-        url:   "http://ftp.gnu.org/gnu/abc/",
+        url:   "https://ftp.gnu.org/gnu/abc/",
         regex: %r{href=.*?abc[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i,
       },
       subdomain:      {
-        url:   "http://ftp.gnu.org/gnu/abc/",
+        url:   "https://ftp.gnu.org/gnu/abc/",
         regex: %r{href=.*?abc[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i,
       },
       savannah:       {},


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`ftp.gnu.org` supports HTTPS (and URLs in formulae use it) but the `Gnu` strategy's generated URL only uses HTTP instead. This PR updates the URL in `Gnu#generate_input_values` to use HTTPS.