### PR TITLE
`update-report`: fix unset cask repo variable error

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -136,7 +136,9 @@ module Homebrew
     updated_taps = []
     Tap.each do |tap|
       next unless tap.git?
-      next if tap.core_tap? && ENV["HOMEBREW_INSTALL_FROM_API"].present? && args.preinstall?
+      if (tap.core_tap? || tap == "homebrew/cask") && ENV["HOMEBREW_INSTALL_FROM_API"].present? && args.preinstall?
+        next
+      end
 
       if ENV["HOMEBREW_MIGRATE_LINUXBREW_FORMULAE"].present? && tap.core_tap? &&
          Settings.read("linuxbrewmigrated") != "true"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before, when an automatic `brew update` was run when `HOMEBREW_INSTALL_FROM_API` was set, the following error would be thrown if `update-report` was called:

```console
$ brew install foo
Updating Homebrew...
Error: HOMEBREW_UPDATE_BEFORE_HOMEBREW_HOMEBREW_CASK is unset!
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:305:in `initialize'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:164:in `new'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:164:in `block in update_report'
/usr/local/Homebrew/Library/Homebrew/tap.rb:662:in `block (2 levels) in each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:661:in `each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:661:in `block in each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:660:in `each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:660:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:137:in `update_report'
/usr/local/Homebrew/Library/Homebrew/brew.rb:129:in `<main>'
```

Because automatic `brew updates` with `HOMEBREW_INSTALL_FROM_API` don't actually update the cask tap, this variable was never set. The cask tap should have been automatically skipped by the reporter like is done for `homebrew/core`, but I forgot to add it to the conditional.
