### PR TITLE
formula_installer: always pre-install formulae required for fetching sources

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -305,10 +305,6 @@ jobs:
 
       - name: Install brew tests dependencies
         run: |
-          brew install subversion
-          brew sh -c "svn --homebrew=print-path"
-          which svn
-          which svnadmin
           brew install curl
           which curl
 

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -45,7 +45,7 @@ class DependencyCollector
   end
 
   def cache_key(spec)
-    if spec.is_a?(Resource) && spec.download_strategy == CurlDownloadStrategy
+    if spec.is_a?(Resource) && spec.download_strategy <= CurlDownloadStrategy
       File.extname(spec.url)
     else
       spec
@@ -148,7 +148,7 @@ class DependencyCollector
     strategy = spec.download_strategy
 
     if strategy <= HomebrewCurlDownloadStrategy
-      brewed_curl_dep_if_needed(tags)
+      @deps << brewed_curl_dep_if_needed(tags)
       parse_url_spec(spec.url, tags)
     elsif strategy <= CurlDownloadStrategy
       parse_url_spec(spec.url, tags)

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -763,10 +763,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
 
     args << "--ignore-externals" if ignore_externals
 
-    if meta[:trust_cert] == true
-      args << "--trust-server-cert"
-      args << "--non-interactive"
-    end
+    args.concat Utils::Svn.invalid_cert_flags if meta[:trust_cert] == true
 
     if target.directory?
       command! "svn", args: ["update", *args], chdir: target.to_s, timeout: timeout&.remaining

--- a/Library/Homebrew/extend/os/mac/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/mac/dependency_collector.rb
@@ -8,7 +8,7 @@ class DependencyCollector
   def git_dep_if_needed(tags); end
 
   def subversion_dep_if_needed(tags)
-    Dependency.new("subversion", tags) if MacOS.version >= :catalina
+    Dependency.new("subversion", tags)
   end
 
   def cvs_dep_if_needed(tags)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -215,6 +215,7 @@ class FormulaInstaller
     forbidden_license_check
 
     check_install_sanity
+    install_fetch_deps unless ignore_deps?
   end
 
   sig { void }
@@ -341,6 +342,19 @@ class FormulaInstaller
     raise CannotInstallFormulaError,
           "You must `brew unpin #{pinned_unsatisfied_deps * " "}` as installing " \
           "#{formula.full_name} requires the latest version of pinned dependencies"
+  end
+
+  sig { void }
+  def install_fetch_deps
+    return if @compute_dependencies.blank?
+
+    compute_dependencies(use_cache: false) if @compute_dependencies.any? do |dep, options|
+      next false unless dep.tags == [:build, :test]
+
+      fetch_dependencies
+      install_dependency(dep, options)
+      true
+    end
   end
 
   def build_bottle_preinstall


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This fixes two similar issues:
- ever since the [Let's Encrypt CA expiry](https://github.com/Homebrew/brew/issues/12161), the built-in `svn` on macOS 10.14 and earlier is unable to access repositories hosted on SourceForge (i.e. svn.code.sf.net) and possibly others, so the `subversion` formula needs to always be installed before attempting to download and build from source any formula that gets its source from SVN. (Also, if a formula URL is marked with `trust_cert: true`, any unknown or outdated certificate errors will still be ignored.)
- macOS's built-in `curl` doesn't (yet) properly handle TLS 1.3 connections, so for installing from source any formulae using such sites (e.g. xiph.org) that are marked with `using: :homebrew_curl`, brewed `curl` needs to be installed first. 

<details>
  <summary>`svn` before:</summary>

```
% brew install -s acme
==> Downloading https://ghcr.io/v2/homebrew/core/subversion/manifests/1.14.1_4
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/subversion/blobs/sha256:34f8d1862f1480c068ff3798c8e1cd90f833b43c33d1731aca15f1d875b16834
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:34f8d1862f1480c068ff3798c8e1cd90f833b43c33d1731aca15f1d875b16834?se=2021-11-06T18%3A55%3A00Z&sig=6LIHuXbN%2B3UxpRLpjq4hFJQzouvAYhGAPR4j9iBtCN
######################################################################## 100.0%
==> Cloning https://svn.code.sf.net/p/acme-crossass/code-0/trunk
==> Checking out 266
You must: brew install svn
Error: acme: Failed to download resource "acme"
Failure while executing; `svn checkout https://svn.code.sf.net/p/acme-crossass/code-0/trunk /Users/serveradmin/Library/Caches/Homebrew/acme--svn --quiet -r 266` exited with 1. Here's the output:
You must: brew install svn
```
</details>

<details>
  <summary>`svn` after:</summary>

```
% brew install -s acme         
==> Downloading https://ghcr.io/v2/homebrew/core/subversion/manifests/1.14.1_4
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/a5926227bbead69887dfea12408cbd3c29e7280770ad0bd62320ef20525fd028--subversion-1.14.1_4.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/subversion/blobs/sha256:34f8d1862f1480c068ff3798c8e1cd90f833b43c33d1731aca15f1d875b16834
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/9ba0f1eb092b0a83dfa1bd0d8e31c9569b61f96a189d97a321820bf7c1b9e126--subversion--1.14.1_4.arm64_big_sur.bottle.tar.gz
==> Installing acme dependency: subversion
==> Pouring subversion--1.14.1_4.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/subversion/1.14.1_4: 234 files, 33.8MB
==> Cloning https://svn.code.sf.net/p/acme-crossass/code-0/trunk
==> Checking out 266
==> make -C src install BINDIR=/opt/homebrew/Cellar/acme/0.97/bin
🍺  /opt/homebrew/Cellar/acme/0.97: 26 files, 321.9KB, built in 2 seconds
```
</details>

<details>
  <summary>`curl` before:</summary>

```
% brew deps --tree --include-build libvorbis
libvorbis
├── pkg-config
└── libogg

% brew install -s libvorbis
==> Downloading https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/e163886f3d57674f022eb584f07ef6d71dbbf58fb39c481a2c516ce6bfd4af18--Example.ogg
==> Downloading https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz
Trying a mirror...
==> Downloading https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.tar.xz
Error: libvorbis: Failed to download resource "libvorbis"
Download failed: Homebrew-installed `curl` is not installed for: https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz
```
</details>

<details>
  <summary>`curl` after:</summary>

```
% brew deps --tree --include-build libvorbis
libvorbis
├── curl
│   ├── pkg-config
│   ├── brotli
│   │   └── cmake
│   ├── libidn2
│   │   ├── pkg-config
│   │   ├── gettext
│   │   └── libunistring
│   ├── libnghttp2
│   │   └── pkg-config
│   ├── libssh2
│   │   └── openssl@1.1
│   │       └── ca-certificates
│   ├── openldap
│   │   └── openssl@1.1
│   │       └── ca-certificates
│   ├── openssl@1.1
│   │   └── ca-certificates
│   ├── rtmpdump
│   │   └── openssl@1.1
│   │       └── ca-certificates
│   └── zstd
│       └── cmake
├── pkg-config
└── libogg

% brew install -s libvorbis
==> Downloading https://ghcr.io/v2/homebrew/core/rtmpdump/manifests/2.4.20151223_1
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/cc1598f2946e431654b278ceac5c9e7f21238bb5ed66d9e5c8640f9030a528cc--rtmpdump-2.4+20151223_1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/rtmpdump/blobs/sha256:67c47ecf95d2f4367685fb0ab04c913d55743e5bafccce721f665c6579f3b599
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/f27b0c32ba3ce61628afbe09b4850f065480f938e8d441591fddff48310d4780--rtmpdump--2.4+20151223_1.arm64_big_sur.bottle.tar.gz
==> Downloading https://ghcr.io/v2/homebrew/core/zstd/manifests/1.5.0
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/zstd/blobs/sha256:e8962c7923904213f312c86372b670b6b5a7ac7103ee63254ab3d1c349913246
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:e8962c7923904213f312c86372b670b6b5a7ac7103ee63254ab3d1c349913246?se=2021-11-06T20%3A10%3A00Z&sig=4vyBfrai281HLjH%2B4H9r9KdDBO5Iur3L%2BzBfaPtc
######################################################################## 100.0%
==> Downloading https://ghcr.io/v2/homebrew/core/curl/manifests/7.79.1_1
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/1778e02b2a4545c6f17f9db910fb589048c2fac70144a261fc05c670d2ccf598--curl-7.79.1_1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/curl/blobs/sha256:fb8bc11a92e6b9c69415ebcc0ac30a69d5fa7399ed48eda8f39acd08fb030f91
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/a72698a6aacff55c1e13fdb3d8b765dd82948b0f404f8de4be3c393f59285ecb--curl--7.79.1_1.arm64_big_sur.bottle.tar.gz
==> Installing libvorbis dependency: curl
==> Installing dependencies for curl: rtmpdump and zstd
==> Installing curl dependency: rtmpdump
==> Pouring rtmpdump--2.4+20151223_1.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/rtmpdump/2.4+20151223_1: 20 files, 711KB
==> Installing curl dependency: zstd
==> Pouring zstd--1.5.0.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/zstd/1.5.0: 31 files, 3.3MB
==> Installing curl
==> Pouring curl--7.79.1_1.arm64_big_sur.bottle.tar.gz
🍺  /opt/homebrew/Cellar/curl/7.79.1_1: 486 files, 4.0MB
==> Downloading https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/e163886f3d57674f022eb584f07ef6d71dbbf58fb39c481a2c516ce6bfd4af18--Example.ogg
==> Downloading https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz
######################################################################## 100.0%
==> ./configure --prefix=/opt/homebrew/Cellar/libvorbis/1.3.7
==> make install
🍺  /opt/homebrew/Cellar/libvorbis/1.3.7: 157 files, 2.4MB, built in 7 seconds
```
</details>

xref. Homebrew/homebrew-core#87527, #11724 (cask SVN dependencies not yet handled)