### PR TITLE
bump: fix tests

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -351,10 +351,11 @@ export HOMEBREW_COMMAND_DEPTH="$((HOMEBREW_COMMAND_DEPTH + 1))"
 setup_curl() {
   # This is set by the user environment.
   # shellcheck disable=SC2154
-  if [[ -n "${HOMEBREW_FORCE_BREWED_CURL}" && -x "${HOMEBREW_PREFIX}/opt/curl/bin/curl" ]] &&
-     "${HOMEBREW_PREFIX}/opt/curl/bin/curl" --version &>/dev/null
+  HOMEBREW_BREWED_CURL_PATH="${HOMEBREW_PREFIX}/opt/curl/bin/curl"
+  if [[ -n "${HOMEBREW_FORCE_BREWED_CURL}" && -x "${HOMEBREW_BREWED_CURL_PATH}" ]] &&
+     "${HOMEBREW_BREWED_CURL_PATH}" --version &>/dev/null
   then
-    HOMEBREW_CURL="${HOMEBREW_PREFIX}/opt/curl/bin/curl"
+    HOMEBREW_CURL="${HOMEBREW_BREWED_CURL_PATH}"
   elif [[ -n "${HOMEBREW_DEVELOPER}" && -x "${HOMEBREW_CURL_PATH}" ]]
   then
     HOMEBREW_CURL="${HOMEBREW_CURL_PATH}"
@@ -592,6 +593,7 @@ export HOMEBREW_CELLAR
 export HOMEBREW_SYSTEM
 export HOMEBREW_SYSTEM_CA_CERTIFICATES_TOO_OLD
 export HOMEBREW_CURL
+export HOMEBREW_BREWED_CURL_PATH
 export HOMEBREW_CURL_WARNING
 export HOMEBREW_SYSTEM_CURL_TOO_OLD
 export HOMEBREW_GIT

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -56,15 +56,14 @@ module Homebrew
 
     limit = args.limit.to_i if args.limit.present?
 
-    unless quiet_system(HOMEBREW_SHIMS_PATH/"shared/curl", "--tlsv1.3", "--head", "https://repology.org/")
+    unless Utils::Curl.curl_supports_tls13?
       begin
-        brewed_curl = Formula["curl"]
-        unless brewed_curl.any_version_installed?
+        unless Pathname.new(ENV["HOMEBREW_BREWED_CURL_PATH"]).exist?
           ohai "Installing `curl` for Repology queries..."
-          safe_system HOMEBREW_BREW_FILE, "install", "--formula", brewed_curl.full_name
+          safe_system HOMEBREW_BREW_FILE, "install", "--formula", Formula["curl"].full_name
         end
       rescue FormulaUnavailableError
-        opoo "A `curl` with TLS 1.3 support is required for Repology queries"
+        opoo "A `curl` with TLS 1.3 support is required for Repology queries."
       end
     end
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -170,12 +170,12 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :needs_tls13) do
-    begin
-      curl = Utils::Curl.curl_executable(use_homebrew_curl: OS.mac?)
-    rescue FormulaUnavailableError
-      skip "curl formula not available"
+    unless curl_supports_tls13?
+      ENV["HOMEBREW_CURL"] = ENV["HOMEBREW_BREWED_CURL_PATH"]
+      skip "A `curl` with TLS 1.3 support is required." unless curl_supports_tls13?
     end
-    skip "Requires curl with TLS 1.3 support." unless quiet_system curl, "--tlsv1.3", "--head", "https://brew.sh/"
+  rescue FormulaUnavailableError
+    skip "No `curl` formula is available."
   end
 
   config.before(:each, :needs_unzip) do

--- a/Library/Homebrew/test/utils/repology_spec.rb
+++ b/Library/Homebrew/test/utils/repology_spec.rb
@@ -22,7 +22,8 @@ describe Repology do
   describe "parse_api_response", :needs_network, :needs_tls13 do
     it "returns a hash of data" do
       limit = 1
-      response = described_class.parse_api_response(limit, repository: "homebrew")
+      start_with = "x"
+      response = described_class.parse_api_response(limit, start_with, repository: "homebrew")
 
       expect(response).not_to be_nil
       expect(response).to be_a(Hash)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -17,7 +17,7 @@ module Utils
     module_function
 
     def curl_executable(use_homebrew_curl: false)
-      return Formula["curl"].opt_bin/"curl" if use_homebrew_curl
+      return Pathname.new(ENV["HOMEBREW_BREWED_CURL_PATH"]) if use_homebrew_curl
 
       @curl_executable ||= HOMEBREW_SHIMS_PATH/"shared/curl"
     end
@@ -357,10 +357,11 @@ module Utils
       file.unlink
     end
 
-    def homebrew_curl_available?
-      Formulary.factory("curl").present?
-    rescue FormulaUnavailableError
-      false
+    def curl_supports_tls13?
+      @curl_supports_tls13 ||= Hash.new do |h, key|
+        h[key] = quiet_system(curl_executable, "--tlsv1.3", "--head", "https://brew.sh/")
+      end
+      @curl_supports_tls13[ENV["HOMEBREW_CURL"]]
     end
 
     def http_status_ok?(status)

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -19,7 +19,7 @@ module Repology
     last_package_in_response += "/" if last_package_in_response.present?
     url = "https://repology.org/api/v1/projects/#{last_package_in_response}?inrepo=#{repository}&outdated=1"
 
-    output, _errors, _status = curl_output(url.to_s, use_homebrew_curl: OS.mac?)
+    output, _errors, _status = curl_output(url.to_s, use_homebrew_curl: !curl_supports_tls13?)
     JSON.parse(output)
   end
 
@@ -27,7 +27,7 @@ module Repology
     url = "https://repology.org/tools/project-by?repo=#{repository}&" \
           "name_type=srcname&target_page=api_v1_project&name=#{name}"
 
-    output, _errors, _status = curl_output("--location", url.to_s, use_homebrew_curl: OS.mac?)
+    output, _errors, _status = curl_output("--location", url.to_s, use_homebrew_curl: !curl_supports_tls13?)
 
     begin
       data = JSON.parse(output)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
A follow-up to #12121:

- modifies Utils::Curl.curl_executable so it can find brewed curl from within a test environment
- consolidates testing for TLS 1.3 support in a Utils::Curl method, which dev-cmd/bump.rb, spec_helper.rb and Utils::Repology use to check if they should use brewed `curl` or not
- reduces repology_spec.rb test time by using `start_with` to fetch a smaller data set

This should allow the repology & bump tests to run in a macOS environment if `curl` is pre-installed.
