### PR TITLE
fix: Allow specifying `:revision` for resources downloaded from Git repos whose default branch is not named `master`

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1078,17 +1078,17 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
 
   sig { returns(String) }
   def default_refspec
-    default_branch.yield_self do |branch|
-      if branch
-        "+refs/heads/#{branch}:refs/remotes/origin/#{branch}"
-      else
-        super
-      end
+    if default_branch
+      "+refs/heads/#{default_branch}:refs/remotes/origin/#{default_branch}"
+    else
+      super
     end
   end
 
   sig { returns(String) }
   def default_branch
+    return @default_branch if defined?(@default_branch)
+
     command! "git",
              args:  ["remote", "set-head", "origin", "--auto"],
              chdir: cached_location
@@ -1097,7 +1097,7 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
                       args:  ["symbolic-ref", "refs/remotes/origin/HEAD"],
                       chdir: cached_location
 
-    result.stdout[%r{^refs/remotes/origin/(.*)$}, 1]
+    @default_branch = result.stdout[%r{^refs/remotes/origin/(.*)$}, 1]
   end
 end
 


### PR DESCRIPTION
### Problem
Given a repo that does not have branch named `master`;
Given a formula that specifies `:revision` like this:
```ruby
class Example < Formula
  stable do
    url "https://github.com/user/example.git", revision: "e8b123de62e0faec283c3253c6ea5495a332007e"
  end
end
```


When Homebrew's cached location did not exist, it would execute this:
```
git clone https://github.com/user/example.git /path/to/cache
```
Which would work fine.


And when its cached location did exist, Homebrew would execute this:
```
git -C /path/to/cache config remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
git -C /path/to/cache fetch origin
```
Which would always fail with `fatal: couldn't find remote ref refs/heads/master`.


### Solution
This commit changes the value for `remote.origin.fetch` to `+refs/heads/*:refs/remotes/origin/*` (which is [Git's default value for the refspec](https://git-scm.com/book/en/v2/Git-Internals-The-Refspec) anyway).

This may increase the latency of `git fetch origin` for formulae that use `:revision` because Git will now fetch all remote refs; but it does have the advantage of not being broken 🙂

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
