### PR TITLE
Utils::Git: Add `ls-remote` methods

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -20,6 +20,13 @@ module Homebrew
       # are ignored.
       DEFAULT_PRIORITY = 5
 
+      DEFAULT_SYSTEM_COMMAND_OPTIONS = {
+        print_stdout: false,
+        print_stderr: false,
+        debug:        false,
+        verbose:      false,
+      }.freeze
+
       # cURL's default `--connect-timeout` value can be up to two minutes, so
       # we need to use a more reasonable duration (in seconds) to avoid a
       # lengthy wait when a connection can't be established.
@@ -59,16 +66,12 @@ module Homebrew
       ] + DEFAULT_CURL_ARGS).freeze
 
       # Baseline `curl` options used in {Strategy} methods.
-      DEFAULT_CURL_OPTIONS = {
-        print_stdout:    false,
-        print_stderr:    false,
-        debug:           false,
-        verbose:         false,
+      DEFAULT_CURL_OPTIONS = DEFAULT_SYSTEM_COMMAND_OPTIONS.merge({
         timeout:         CURL_PROCESS_TIMEOUT,
         connect_timeout: CURL_CONNECT_TIMEOUT,
         max_time:        CURL_MAX_TIME,
         retries:         0,
-      }.freeze
+      }).freeze
 
       # HTTP response head(s) and body are typically separated by a double
       # `CRLF` (whereas HTTP header lines are separated by a single `CRLF`).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It was suggested in https://github.com/Homebrew/brew/pull/12276#discussion_r733800461 that we could benefit from having some methods in `Utils::Git` that use `git ls-remote`. This PR covers the following changes:

* Add a generic `Git#ls-remote` method to run `git ls-remote` and return the output (or errors).
* Add a `Git#remote_head` method that can be used to identify which branch is `HEAD` (useful for `ResourceAuditor`).
  * Good `#remote_head` output is like: `{ branch: "main", commit: "890190c0f30b36512835c846be004b0253b062ad" }`.
* Add a `Git#remote_tags` method that fetches tags and the corresponding commits (useful for livecheck's `Git` strategy and elsewhere).
  * Good `#remote_tags` output is like: `{ tags: { "1.2.3" => "ed9942fbd1ec4243f0a92ab8f9b2411c8b1fb091", ... } }`
* Modify `Git#available?` and `Git#version` to accept `**options`, so we can provide arguments to `SystemCommand`. Without this, `#version` will print the command as debug output and this is a nuisance within the context of livecheck (where we carefully control the debug output and need to pass `debug: false` to `SystemCommand` to avoid unnecessary output like this).
* Modify `ResourceAuditor#audit_head_branch` to use `#remote_head`. In the process, the `Git#remote_exists?` check becomes unnecessary (`#remote_head` will return a hash with errors if remote doesn't exist), so we can reduce this to one execution of `git ls-remote`.
* Move the `SystemCommand` options in `Livecheck::Strategy::DEFAULT_CURL_OPTIONS` into its own hash, so we can easily use this anywhere in livecheck where `SystemCommand` is used.
* Modify livecheck's `Git` strategy to use `#remote_tags`. We previously talked about replacing `Open3#capture3` with `SystemCommand` in this context. At the time, `SystemCommand` didn't support a `debug` option (needed to prevent debug output from printing) but I resolved that in a later PR (#10066). I had some local stashed changes to update the `Git` strategy's `#tag_info` method to use `SystemCommand` but the switch to `#remote_tags` ends up achieving the same goal. [This also allows us to switch the strategy to `typed: true`, as it was only `typed: false` to avoid a bug in Sorbet's type signature for `Open3#capture3`.]
  * I plan to create a follow-up PR sometime in the future to modify the `Git` strategy to properly handle the commit hashes for tags, so we can surface the original tag/commit information in the JSON output. This information is necessary to be able to create an automated version bump for a formula that uses `tag`/`revision` in `stable`.
* Update the tests for `Git#remote_exists?` to use slightly better throwaway names like `not-a-repo`/`remote_exists-test` instead of `blah`/`hey` (which aren't clear about their intention).