### PR TITLE
Apache: Support additional mirror/backup URLs

### DIFF
--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -7,13 +7,17 @@ module Homebrew
       # The {Apache} strategy identifies versions of software at apache.org
       # by checking directory listing pages.
       #
-      # Apache URLs start with `https://www.apache.org/dyn/` and include
+      # Most Apache URLs start with `https://www.apache.org/dyn/` and include
       # a `filename` or `path` query string parameter where the value is a
       # path to a file. The path takes one of the following formats:
       #
       # * `example/1.2.3/example-1.2.3.tar.gz`
       # * `example/example-1.2.3/example-1.2.3.tar.gz`
       # * `example/example-1.2.3-bin.tar.gz`
+      #
+      # This strategy also handles a few common mirror/backup URLs where the
+      # path is provided outside of a query string parameter (e.g.
+      # `https://archive.apache.org/dist/example/1.2.3/example-1.2.3.tar.gz`).
       #
       # When the path contains a version directory (e.g. `/1.2.3/`,
       # `/example-1.2.3/`, etc.), the default regex matches numeric versions
@@ -26,8 +30,11 @@ module Homebrew
 
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
-          ^https?://www\.apache\.org
-          /dyn/.+(?:path|filename)=
+          ^https?://
+          (?:www\.apache\.org/dyn/.+(?:path|filename)=/?|
+          archive\.apache\.org/dist/|
+          dlcdn\.apache\.org/|
+          downloads\.apache\.org/)
           (?<path>.+?)/      # Path to directory of files or version directories
           (?<prefix>[^/]*?)  # Any text in filename or directory before version
           v?\d+(?:\.\d+)+    # The numeric version

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -7,28 +7,30 @@ describe Homebrew::Livecheck::Strategy::Apache do
   subject(:apache) { described_class }
 
   let(:apache_urls) {
-    urls = {
-      version_dir:          "https://www.apache.org/dyn/closer.lua?path=abc/1.2.3/def-1.2.3.tar.gz",
-      name_and_version_dir: "https://www.apache.org/dyn/closer.lua?path=abc/def-1.2.3/ghi-1.2.3.tar.gz",
-      name_dir_bin:         "https://www.apache.org/dyn/closer.lua?path=abc/def/ghi-1.2.3-bin.tar.gz",
+    {
+      version_dir:                    "https://www.apache.org/dyn/closer.lua?path=abc/1.2.3/def-1.2.3.tar.gz",
+      version_dir_root:               "https://www.apache.org/dyn/closer.lua?path=/abc/1.2.3/def-1.2.3.tar.gz",
+      name_and_version_dir:           "https://www.apache.org/dyn/closer.lua?path=abc/def-1.2.3/ghi-1.2.3.tar.gz",
+      name_dir_bin:                   "https://www.apache.org/dyn/closer.lua?path=abc/def/ghi-1.2.3-bin.tar.gz",
+      archive_version_dir:            "https://archive.apache.org/dist/abc/1.2.3/def-1.2.3.tar.gz",
+      archive_name_and_version_dir:   "https://archive.apache.org/dist/abc/def-1.2.3/ghi-1.2.3.tar.gz",
+      archive_name_dir_bin:           "https://archive.apache.org/dist/abc/def/ghi-1.2.3-bin.tar.gz",
+      dlcdn_version_dir:              "https://dlcdn.apache.org/abc/1.2.3/def-1.2.3.tar.gz",
+      dlcdn_name_and_version_dir:     "https://dlcdn.apache.org/abc/def-1.2.3/ghi-1.2.3.tar.gz",
+      dlcdn_name_dir_bin:             "https://dlcdn.apache.org/abc/def/ghi-1.2.3-bin.tar.gz",
+      downloads_version_dir:          "https://downloads.apache.org/abc/1.2.3/def-1.2.3.tar.gz",
+      downloads_name_and_version_dir: "https://downloads.apache.org/abc/def-1.2.3/ghi-1.2.3.tar.gz",
+      downloads_name_dir_bin:         "https://downloads.apache.org/abc/def/ghi-1.2.3-bin.tar.gz",
+      mirrors_version_dir:            "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=abc/1.2.3/def-1.2.3.tar.gz",
+      mirrors_version_dir_root:       "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=/abc/1.2.3/def-1.2.3.tar.gz",
+      mirrors_name_and_version_dir:   "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=abc/def-1.2.3/ghi-1.2.3.tar.gz",
+      mirrors_name_dir_bin:           "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=abc/def/ghi-1.2.3-bin.tar.gz",
     }
-
-    # Add mirrors.cgi test URLs using the same paths
-    urls.clone.each do |key, url|
-      next unless url.include?("/closer.lua?path=")
-
-      urls["mirrors_#{key}".to_sym] = url.sub(
-        "/closer.lua?path=",
-        "/mirrors/mirrors.cgi?action=download&filename=",
-      )
-    end
-
-    urls
   }
   let(:non_apache_url) { "https://brew.sh/test" }
 
   let(:generated) {
-    {
+    values = {
       version_dir:          {
         url:   "https://archive.apache.org/dist/abc/",
         regex: %r{href=["']?v?(\d+(?:\.\d+)+)/}i,
@@ -42,6 +44,22 @@ describe Homebrew::Livecheck::Strategy::Apache do
         regex: /href=["']?ghi-v?(\d+(?:\.\d+)+)-bin\.t/i,
       },
     }
+    values[:version_dir_root] = values[:version_dir]
+    values[:archive_version_dir] = values[:version_dir]
+    values[:archive_name_and_version_dir] = values[:name_and_version_dir]
+    values[:archive_name_dir_bin] = values[:name_dir_bin]
+    values[:dlcdn_version_dir] = values[:version_dir]
+    values[:dlcdn_name_and_version_dir] = values[:name_and_version_dir]
+    values[:dlcdn_name_dir_bin] = values[:name_dir_bin]
+    values[:downloads_version_dir] = values[:version_dir]
+    values[:downloads_name_and_version_dir] = values[:name_and_version_dir]
+    values[:downloads_name_dir_bin] = values[:name_dir_bin]
+    values[:mirrors_version_dir] = values[:version_dir]
+    values[:mirrors_version_dir_root] = values[:version_dir_root]
+    values[:mirrors_name_and_version_dir] = values[:name_and_version_dir]
+    values[:mirrors_name_dir_bin] = values[:name_dir_bin]
+
+    values
   }
 
   describe "::match?" do
@@ -57,8 +75,7 @@ describe Homebrew::Livecheck::Strategy::Apache do
   describe "::generate_input_values" do
     it "returns a hash containing url and regex for an Apache URL" do
       apache_urls.each do |key, url|
-        generated_key = key.to_s.start_with?("mirrors_") ? key.to_s.delete_prefix("mirrors_").to_sym : key
-        expect(apache.generate_input_values(url)).to eq(generated[generated_key])
+        expect(apache.generate_input_values(url)).to eq(generated[key])
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `stable` URL for the `apache-spark` formula is currently `https://dlcdn.apache.org/spark/spark-3.2.0/spark-3.2.0-bin-hadoop3.2.tgz`. The path in this URL is one of the expected formats that we see in URLs that the `Apache` strategy already supports (albeit not in the form of a query string parameter).

The `stable` archive from `dlcdn.apache.org` is also available using the typical `https://www.apache.org/dyn/closer.lua?path=spark/spark-3.2.0/spark-3.2.0-bin-hadoop3.2.tgz` URL and the formula already uses `https://archive.apache.org/dist/spark/spark-3.2.0/spark-3.2.0-bin-hadoop3.2.tgz` as the mirror.

With that in mind, the `Apache` strategy can easily support `dlcdn.apache.org` URLs through a simple change to the `URL_MATCH_REGEX`. This PR makes this change and expands related tests.

Past that, though `archive.apache.org` URLs aren't likely to appear as a `stable` URL (usually they're a `mirror`), I added support in `URL_MATCH_REGEX` as well.