### PR TITLE
Cleanup developer mode handling in `brew.{sh,rb}`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -86,44 +86,7 @@ begin
   require "commands"
   require "settings"
 
-  if cmd
-    internal_cmd = Commands.valid_internal_cmd?(cmd)
-    internal_cmd ||= begin
-      internal_dev_cmd = Commands.valid_internal_dev_cmd?(cmd)
-      if internal_dev_cmd && !Homebrew::EnvConfig.developer?
-        if ENV["HOMEBREW_DEV_CMD_RUN"].blank?
-          opoo <<~MESSAGE
-            #{Tty.bold}#{cmd}#{Tty.reset} is a developer command, so
-            Homebrew's developer mode has been automatically turned on.
-            To turn developer mode off, run #{Tty.bold}brew developer off#{Tty.reset}
-
-          MESSAGE
-        end
-
-        Homebrew::Settings.write "devcmdrun", true
-        ENV["HOMEBREW_DEV_CMD_RUN"] = "1"
-      end
-      internal_dev_cmd
-    end
-  end
-
-  developer_mode = if cmd == "developer" && ARGV.include?("on")
-    true
-  elsif cmd == "developer" && ARGV.include?("off")
-    false
-  else
-    Homebrew::EnvConfig.developer? || Homebrew::Settings.read("devcmdrun") == "true"
-  end
-
-  if internal_dev_cmd && Homebrew::EnvConfig.install_from_api?
-    odie "Developer commands cannot be run while HOMEBREW_INSTALL_FROM_API is set!"
-  elsif Homebrew::EnvConfig.install_from_api? && developer_mode
-    opoo <<~MESSAGE
-      Developers should not have HOMEBREW_INSTALL_FROM_API set!
-      Please unset HOMEBREW_INSTALL_FROM_API or turn developer mode off by running:
-        brew developer off
-    MESSAGE
-  end
+  internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd) if cmd
 
   unless internal_cmd
     # Add contributed commands to PATH before checking.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Per https://github.com/Homebrew/brew/pull/12305, I've cleaned up the handling of developer mode and moved everything that relates to `brew.sh`. Previously, almost all of this logic was duplicated and handled by both `brew.sh` (for shell commands) and `brew.rb` (for ruby commands). Now, it's all handled in one spot (in `brew.sh`). The downside of this is that the bash code is a bit trickier to read but I've done my best to make it as clean as possible.

Note that some new variables are needed and, because they're all similarly named, I've added comments to try to explain what each is for.
- `HOMEBREW_DEVELOPER` is still the same
- `HOMEBREW_DEV_CMD_RUN` is still the same (set if a user has run or is running a developer command and does not have `HOMEBREW_DEVELOPER` set)
- `HOMEBREW_DEVELOPER_COMMAND` is new and is set if the _current command_ is a developer command (regardless of previous developer mode status)
    - This is used to block all developer commands from being run with `HOMEBREW_INSTALL_FROM_API`, to determine whether `HOMEBREW_DEVELOPER_MODE` should be set, and to show a warning when first enabling developer mode.
- `HOMEBREW_DEVELOPER_MODE` is new and is set if developer mode is currently on (whether that is because of `HOMEBREW_DEVELOPER` is set, a developer command has been/is currently being run, or `brew developer on` is being run)
    - This is used to display a warning if developer mode is enabled and `HOMEBREW_INSTALL_FROM_API` is set but the current command isn't a developer command.
