### PR TITLE
formulary: fix keg resolving not setting force_bottle

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -450,7 +450,7 @@ module Formulary
     keg = kegs.find(&:linked?) || kegs.find(&:optlinked?) || kegs.max_by(&:version)
 
     if keg
-      from_keg(keg, spec, alias_path: alias_path)
+      from_keg(keg, spec, alias_path: alias_path, force_bottle: force_bottle, flags: flags)
     else
       factory(rack.basename.to_s, spec || :stable, alias_path: alias_path, from: :rack,
               force_bottle: force_bottle, flags: flags)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`Formulary.from_keg` accepts a `force_bottle` but we were not passing it.
