### PR TITLE
formula: make each instance have separate spec references

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -262,7 +262,7 @@ class Formula
   end
 
   def spec_eval(name)
-    spec = self.class.send(name)
+    spec = self.class.send(name).dup
     return unless spec.url
 
     spec.owner = self
@@ -1449,9 +1449,9 @@ class Formula
 
   # @private
   def ==(other)
-    instance_of?(other.class) &&
+    self.class == other.class &&
       name == other.name &&
-      active_spec == other.active_spec
+      active_spec_sym == other.active_spec_sym
   end
   alias eql? ==
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -567,6 +567,14 @@ describe Formula do
     expect(f.class.head).to be_kind_of(SoftwareSpec)
   end
 
+  specify "instance specs have different references" do
+    f = Testball.new
+    f2 = Testball.new
+
+    expect(f.stable.owner).to equal(f)
+    expect(f2.stable.owner).to equal(f2)
+  end
+
   specify "incomplete instance specs are not accessible" do
     f = formula do
       url "foo-1.0"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes `SoftwareSpec#owner` being mixed up if there are multiple formula references. See the test case for an example.
This in turn fixes `--force-bottle` not working in some scenarios like `brew reinstall`.

`--force-bottle` bug reported to me via email.