### PR TITLE
Fix installing from API with tap names

### DIFF
--- a/Library/Homebrew/api/bottle.rb
+++ b/Library/Homebrew/api/bottle.rb
@@ -22,6 +22,7 @@ module Homebrew
 
         sig { params(name: String).returns(Hash) }
         def fetch(name)
+          name = name.sub(%r{^homebrew/core/}, "")
           Homebrew::API.fetch "#{bottle_api_path}/#{name}.json"
         end
 
@@ -85,7 +86,9 @@ module Homebrew
 
           # Map the name of this formula to the local bottle path to allow the
           # formula to be loaded by passing just the name to `Formulary::factory`.
-          Formulary.map_formula_name_to_local_bottle_path hash["name"], resource.downloader.cached_location
+          [hash["name"], "homebrew/core/#{hash["name"]}"].each do |name|
+            Formulary.map_formula_name_to_local_bottle_path name, resource.downloader.cached_location
+          end
         end
       end
     end

--- a/Library/Homebrew/api/cask-source.rb
+++ b/Library/Homebrew/api/cask-source.rb
@@ -12,6 +12,7 @@ module Homebrew
 
         sig { params(token: String).returns(Hash) }
         def fetch(token)
+          token = token.sub(%r{^homebrew/cask/}, "")
           Homebrew::API.fetch "cask-source/#{token}.rb", json: false
         end
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -138,11 +138,12 @@ module Homebrew
     end
 
     args.named.each do |name|
-      next if EnvConfig.install_from_api?
       next if File.exist?(name)
-      next if name !~ HOMEBREW_TAP_FORMULA_REGEX && name !~ HOMEBREW_CASK_TAP_CASK_REGEX
+      next unless name =~ HOMEBREW_TAP_FORMULA_REGEX
 
       tap = Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))
+      next if (tap.core_tap? || tap == "homebrew/cask") && EnvConfig.install_from_api?
+
       tap.install unless tap.installed?
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/12333 (also there's a chance that this fixes https://github.com/Homebrew/brew/issues/12326)

This PR fixes `brew install` with `HOMEBREW_INSTALL_FROM_API` set so that it will work for `brew install homebrew/core/foo` and `brew install homebrew/cask/foo`.

I marked this as `critical` because it fixes a bug that was introduced in https://github.com/Homebrew/brew/pull/12333.