### PR TITLE
cpu: add AVX-512 and NEON helper functions

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -110,8 +110,21 @@ module Hardware
         @features ||= flags[1..].map(&:intern)
       end
 
-      %w[aes altivec avx avx2 lm ssse3 sse4_2].each do |flag|
+      %w[
+        aes
+        altivec
+        avx
+        avx2
+        avx512f
+        lm
+        ssse3
+        sse4_2
+      ].each do |flag|
         define_method("#{flag}?") { flags.include? flag }
+      end
+
+      def neon?
+        flags.include?("neon") || flags.include?("asimd")
       end
 
       def sse3?

--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -55,12 +55,15 @@ module Hardware
         sysctl_int("machdep.cpu.extmodel")
       end
 
-      def aes?
-        sysctl_bool("hw.optional.aes")
-      end
-
-      def altivec?
-        sysctl_bool("hw.optional.altivec")
+      %w[
+        aes
+        altivec
+        avx512f
+        neon
+        sse3
+        sse4_2
+      ].each do |flag|
+        define_method("#{flag}?") { sysctl_bool("hw.optional.#{flag}") }
       end
 
       def avx?
@@ -71,16 +74,8 @@ module Hardware
         sysctl_bool("hw.optional.avx2_0")
       end
 
-      def sse3?
-        sysctl_bool("hw.optional.sse3")
-      end
-
       def ssse3?
         sysctl_bool("hw.optional.supplementalsse3")
-      end
-
-      def sse4_2?
-        sysctl_bool("hw.optional.sse4_2")
       end
 
       # NOTE: this is more reliable than checking uname.


### PR DESCRIPTION
Add helper functions for AVX-512 and NEON extensions.

Note that AVX-512 is not a monolithic extension but rather a family of extensions, of which vendors can choose to implement some or all of them. We expose all of the individual extensions here so that each can be checked individually. `avx512f` is the "foundation" extension that is required for any other AVX-512 functionality, but it seems inaccurate to just have a single function `avx512?` that checks only this one extension. Similarly, it seems inaccurate to just have a single function `avx512?` that checks all of the extensions (in fact, AFAIK no single CPU currently implements all of the extensions).

NEON aka Advanced SIMD is an ARM extension analagous to Intel's SSE. Note that on Linux, the feature flag can be either `neon` or `asimd`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I'd appreciate someone validating that these helper functions work as expected. The AVX-512 sysctl entries are the only ones I found exposed on my system (all set to `0` since I'm on older hardware). [There's more extensions in the AVX-512 family](https://en.wikichip.org/wiki/x86/avx-512) but I'm not sure how many are exposed directly via sysctl.

The NEON helper may be unnecessary - it's supported on all Apple Silicon machines, and we don't officially support Linux on ARM. But from a readability/code meaning perspective, I think it makes more sense to enable NEON-specific functionality with `Hardware::CPU.neon?` rather than `Hardware::CPU.arm?` or `Hardware::CPU.arm? and OS.mac?` or `Hardware::CPU.arm? and Hardware::CPU.is_64_bit?` etc.
