### PR TITLE
formula: allow optional output path in std_go_args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1528,9 +1528,9 @@ class Formula
   end
 
   # Standard parameters for Go builds.
-  sig { params(ldflags: T.nilable(String)).returns(T::Array[String]) }
-  def std_go_args(ldflags: nil)
-    args = ["-trimpath", "-o=#{bin/name}"]
+  sig { params(output: T.any(String, Pathname), ldflags: T.nilable(String)).returns(T::Array[String]) }
+  def std_go_args(output: bin/name, ldflags: nil)
+    args = ["-trimpath", "-o=#{output}"]
     args += ["-ldflags=#{ldflags}"] if ldflags
     args
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1528,10 +1528,13 @@ class Formula
   end
 
   # Standard parameters for Go builds.
-  sig { params(output: T.any(String, Pathname), ldflags: T.nilable(String)).returns(T::Array[String]) }
+  sig {
+    params(output:  T.any(String, Pathname),
+           ldflags: T.nilable(T.any(String, T::Array[String]))).returns(T::Array[String])
+  }
   def std_go_args(output: bin/name, ldflags: nil)
     args = ["-trimpath", "-o=#{output}"]
-    args += ["-ldflags=#{ldflags}"] if ldflags
+    args += ["-ldflags=#{Array(ldflags).join(" ")}"] if ldflags
     args
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We have a number of formulae (at least `archiver`, `buildkit`, `docker-ls`, `forcecli`, `go-jira`, `go-jsonnet`, but I have not finished looking) that build binaries that are not named the same as the formula.

Right now these formulae don't use `std_go_args` so that they can set a custom file output name with `-o`. Another option that I think I might've seen is specifying `std_go_args` and then adding an `-o=...` term anyways (the last value of this flag takes precedence).

This PR allows for the output file name to be specified if needed. The default is still `name`, so behavior should remain unchanged if this argument is not provided.

I picked the argument name `output` but am open to any other ideas if a different name would make more sense.