### PR TITLE
Fix `brew untap` with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -27,21 +27,23 @@ module Homebrew
     args.named.to_installed_taps.each do |tap|
       odie "Untapping #{tap} is not allowed" if tap.core_tap? && !Homebrew::EnvConfig.install_from_api?
 
-      installed_tap_formulae = Formula.installed.select { |formula| formula.tap == tap }
-      installed_tap_casks = Cask::Caskroom.casks.select { |cask| cask.tap == tap }
+      if !Homebrew::EnvConfig.install_from_api? || (!tap.core_tap? && tap != "homebrew/cask")
+        installed_tap_formulae = Formula.installed.select { |formula| formula.tap == tap }
+        installed_tap_casks = Cask::Caskroom.casks.select { |cask| cask.tap == tap }
 
-      if installed_tap_formulae.present? || installed_tap_casks.present?
-        installed_names = (installed_tap_formulae + installed_tap_casks.map(&:token)).join("\n")
-        if args.force? || Homebrew::EnvConfig.developer?
-          opoo <<~EOS
-            Untapping #{tap} even though it contains the following installed formulae or casks:
-            #{installed_names}
-          EOS
-        else
-          odie <<~EOS
-            Refusing to untap #{tap} because it contains the following installed formulae or casks:
-            #{installed_names}
-          EOS
+        if installed_tap_formulae.present? || installed_tap_casks.present?
+          installed_names = (installed_tap_formulae + installed_tap_casks.map(&:token)).join("\n")
+          if args.force? || Homebrew::EnvConfig.developer?
+            opoo <<~EOS
+              Untapping #{tap} even though it contains the following installed formulae or casks:
+              #{installed_names}
+            EOS
+          else
+            odie <<~EOS
+              Refusing to untap #{tap} because it contains the following installed formulae or casks:
+              #{installed_names}
+            EOS
+          end
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew untap` will complain if its run on a tap that has formulae/casks installed, so `homebrew/core` and `homebrew/cask` weren't able to be uninstalled with `brew untap` even with `HOMEBREW_INSTALL_FROM_API` set. This PR doesn't check for installed formulae/casks for `homebrew/core` and `homebrew/cask` with `HOMEBREW_INSTALL_FROM_API` set.

See https://github.com/Homebrew/discussions/discussions/2365#discussioncomment-1554969
