### PR TITLE
Handle `depends_on "homebrew/core/foo"` for `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -44,11 +44,6 @@ class Dependency
     formula = Formulary.factory(name)
     formula.build = BuildOptions.new(options, formula.options)
     formula
-  rescue CoreTapFormulaUnavailableError
-    raise if !Homebrew::EnvConfig.install_from_api? || !Homebrew::API::Bottle.available?(name)
-
-    Homebrew::API::Bottle.fetch_bottles(name)
-    retry
   end
 
   def unavailable_core_formula?

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -44,6 +44,11 @@ class Dependency
     formula = Formulary.factory(name)
     formula.build = BuildOptions.new(options, formula.options)
     formula
+  rescue CoreTapFormulaUnavailableError
+    raise if !Homebrew::EnvConfig.install_from_api? || !Homebrew::API::Bottle.available?(name)
+
+    Homebrew::API::Bottle.fetch_bottles(name)
+    retry
   end
 
   def unavailable_core_formula?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -212,6 +212,11 @@ class FormulaInstaller
   def verify_deps_exist
     begin
       compute_dependencies
+    rescue CoreTapFormulaUnavailableError => e
+      raise unless Homebrew::API::Bottle.available? e.name
+
+      Homebrew::API::Bottle.fetch_bottles(e.name)
+      retry
     rescue TapFormulaUnavailableError => e
       raise if e.tap.installed? || e.tap.core_tap?
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -218,7 +218,7 @@ class FormulaInstaller
       Homebrew::API::Bottle.fetch_bottles(e.name)
       retry
     rescue TapFormulaUnavailableError => e
-      raise if e.tap.installed? || e.tap.core_tap?
+      raise if e.tap.installed?
 
       e.tap.install
       retry

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -213,7 +213,7 @@ class FormulaInstaller
     begin
       compute_dependencies
     rescue TapFormulaUnavailableError => e
-      raise if e.tap.installed?
+      raise if e.tap.installed? || e.tap.core_tap?
 
       e.tap.install
       retry

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -343,7 +343,9 @@ module Formulary
     rescue FormulaClassUnavailableError => e
       raise TapFormulaClassUnavailableError.new(tap, name, e.path, e.class_name, e.class_list), "", e.backtrace
     rescue FormulaUnavailableError => e
-      raise CoreTapFormulaUnavailableError.new(name), "", e.backtrace if tap.core_tap?
+      if tap.core_tap? && Homebrew::EnvConfig.install_from_api?
+        raise CoreTapFormulaUnavailableError.new(name), "", e.backtrace
+      end
 
       raise TapFormulaUnavailableError.new(tap, name), "", e.backtrace
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -535,6 +535,13 @@ module Formulary
     when URL_START_REGEX
       return FromUrlLoader.new(ref)
     when HOMEBREW_TAP_FORMULA_REGEX
+      # If `homebrew/core` is specified and not installed, check whether the formula is already installed.
+      if ref.start_with?("homebrew/core/") && !CoreTap.instance.installed? && Homebrew::EnvConfig.install_from_api?
+        name = ref.split("/", 3).last
+        possible_keg_formula = Pathname.new("#{HOMEBREW_PREFIX}/opt/#{name}/.brew/#{name}.rb")
+        return FormulaLoader.new(name, possible_keg_formula) if possible_keg_formula.file?
+      end
+
       return TapLoader.new(ref, from: from)
     end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -343,6 +343,8 @@ module Formulary
     rescue FormulaClassUnavailableError => e
       raise TapFormulaClassUnavailableError.new(tap, name, e.path, e.class_name, e.class_list), "", e.backtrace
     rescue FormulaUnavailableError => e
+      raise CoreTapFormulaUnavailableError.new(name), "", e.backtrace if tap.core_tap?
+
       raise TapFormulaUnavailableError.new(tap, name), "", e.backtrace
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

See https://github.com/Homebrew/brew/issues/12326

Before, third-party formulae that had a `depends_on "homebrew/core/foo"` line wouldn't work as expected. This PR fixes the way that they are handled.

- Now, `homebrew/core` won't be automatically tapped
- Dependencies can be installed correctly

-----

I don't think this is fully correct yet. At the moment, any time `Dependency#to_formula` is called on a core formula that isn't installed already, its bottle will be downloaded. I'm not 100% sure that this is what we want, though, because there may be some cases where we'd rather it to just fail. I thought this through more clearly a while back but I can't remember exactly what I decided.

Also, this means that bottles will be downloaded unecessarily for core formulae that _are_ installed. For example, if a formula has `depends_on "homebrew/core/hello"` and `hello` is installed, installing that formula will download the `hello` bottle even though it doesn't need to install `hello`. Later, it realizes this and doesn't both using the downloaded bottle. It seems like `Formulary.factory` needs to be trained so that if it gets a ref like `homebrew/core/foo`, it should first look for any installed formulae with that name that have `homebrew/core` set as its tap (in it's tab).
