### PR TITLE
docs: cask-cookbook update livecheck blocks

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -748,6 +748,8 @@ If the version depends on multiple header fields, a block can be specified, e.g.
 strategy :header_match do |headers|
   v = headers["content-disposition"][/MyApp-(\d+(?:\.\d+)*)\.zip/i, 1]
   id = headers["location"][%r{/(\d+)/download$}i, 1]
+  next if v.blank? || id.blank?
+  
   "#{v},#{id}"
 end
 ```
@@ -757,6 +759,8 @@ Similarly, the `:page_match` strategy can also be used for more complex versions
 ```ruby
 strategy :page_match do |page|
   match = page.match(%r{href=.*?/(\d+)/MyApp-(\d+(?:\.\d+)*)\.zip}i)
+  next if match.blank?
+  
   "#{match[2]},#{match[1]}"
 end
 ```


### PR DESCRIPTION
This change causes `livecheck` to return a nicer error if no match is found from the regex.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
