### PR TITLE
Fix `brew doctor` with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -884,9 +884,17 @@ module Homebrew
         kegs = Keg.all
 
         deleted_formulae = kegs.map do |keg|
-          next if !CoreTap.instance.installed? && EnvConfig.install_from_api? && Tab.for_keg(keg).tap.core_tap?
+          next if Formulary.tap_paths(keg.name).any?
 
-          keg.name if Formulary.tap_paths(keg.name).blank?
+          if !CoreTap.instance.installed? && EnvConfig.install_from_api?
+            # Formulae installed with HOMEBREW_INSTALL_FROM_API should not count as deleted formulae
+            # but may not have a tap listed in their tab
+            tap = Tab.for_keg(keg).tap
+            next if tap.present? && tap.core_tap?
+            next if tap.blank? && Homebrew::API::Bottle.available?(keg.name)
+          end
+
+          keg.name
         end.compact.uniq
 
         return if deleted_formulae.blank?

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -890,8 +890,7 @@ module Homebrew
             # Formulae installed with HOMEBREW_INSTALL_FROM_API should not count as deleted formulae
             # but may not have a tap listed in their tab
             tap = Tab.for_keg(keg).tap
-            next if tap.present? && tap.core_tap?
-            next if tap.blank? && Homebrew::API::Bottle.available?(keg.name)
+            next if (tap.blank? || tap.core_tap?) && Homebrew::API::Bottle.available?(keg.name)
           end
 
           keg.name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/12356

I could have sworn I fixed this in #12333 but I must have made some change and forgotten to test it out fully. Either way, this should fix the `check_deleted_formulae` check in `brew doctor` so that if `HOMEBREW_INSTALL_FROM_API` is set, kegs with their tap set to `homebrew/core` and kegs with a blank tap but which are available via the API won't be listed as being deleted.

This also raised another interesting issue which is that installing with `HOMEBREW_INSTALL_FROM_API` (when `homebrew/core` isn't tapped) leaves the `tap` entry in `INSTALL_RECEIPT.json` blank. This should probably be changed to be `homebrew/core`. However, since people have been using it, it's probably too late to not have the blank tap condition here.

I'm way too tired to think this through completely right now, though, so I'll just leave this as-is and maybe re-visit in the morning.
