### PR TITLE
os/linux/elf: don't report missing libraries to dependents

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -133,8 +133,6 @@ module ELFShim
         match.captures.compact.first
       end.compact
       @dylibs = ldd_paths.select do |ldd_path|
-        next true unless ldd_path.start_with? "/"
-
         needed.include? File.basename(ldd_path)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, if a library was not found via `ldd` then all dependents of the broken formula in question also report that they are missing a library, even if the dependent doesn't explicitly define the library as "needed".

While this may sound useful, this is inconsistent to the behaviour on macOS and is confusing when (for example) `brew linkage --test codequery` reports missing libraries when `qt@5` is what actually has the broken library linkage and only `qt@5` requires a revision bump to fix.