### PR TITLE
install, upgrade: fetch each formula only once

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -114,6 +114,15 @@ class FormulaInstaller
     @installed = Set.new
   end
 
+  def self.fetched
+    @fetched ||= Set.new
+  end
+
+  sig { void }
+  def self.clear_fetched
+    @fetched = Set.new
+  end
+
   sig { returns(T::Boolean) }
   def build_from_source?
     @build_from_source_formulae.include?(formula.full_name)
@@ -1141,6 +1150,8 @@ class FormulaInstaller
 
   sig { void }
   def fetch
+    return if self.class.fetched.include?(formula)
+
     fetch_dependencies
 
     return if only_deps?
@@ -1152,6 +1163,8 @@ class FormulaInstaller
       formula.resources.each(&:fetch)
     end
     downloader.fetch
+
+    self.class.fetched << formula
   end
 
   def downloader

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -204,6 +204,7 @@ RSpec.configure do |config|
     Requirement.clear_cache
     FormulaInstaller.clear_attempted
     FormulaInstaller.clear_installed
+    FormulaInstaller.clear_fetched
 
     TEST_DIRECTORIES.each(&:mkpath)
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This prevents output spam that results from `fetch_dependencies`. For example, `aom` depends on `jpeg-xl` which depends on `openexr`. When all three formulae are outdated and about to be upgraded, `openexr` gets fetched three times: once for `aom`, once more for `jpeg-xl`, and again for itself. 