### PR TITLE
Cask::Audit: Handle referenced cask in livecheck

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -553,11 +553,24 @@ module Cask
     def check_livecheck_version
       return unless appcast?
 
+      referenced_cask, = Homebrew::Livecheck.resolve_livecheck_reference(cask)
+
+      # Respect skip conditions for a referenced cask
+      if referenced_cask
+        skip_info = Homebrew::Livecheck::SkipConditions.referenced_skip_information(
+          referenced_cask,
+          Homebrew::Livecheck.cask_name(cask),
+        )
+      end
+
       # Respect cask skip conditions (e.g. discontinued, latest, unversioned)
-      skip_info = Homebrew::Livecheck::SkipConditions.skip_information(cask)
+      skip_info ||= Homebrew::Livecheck::SkipConditions.skip_information(cask)
       return :skip if skip_info.present?
 
-      latest_version = Homebrew::Livecheck.latest_version(cask)&.fetch(:latest)
+      latest_version = Homebrew::Livecheck.latest_version(
+        cask,
+        referenced_formula_or_cask: referenced_cask,
+      )&.fetch(:latest)
       if cask.version.to_s == latest_version.to_s
         if cask.appcast
           add_error "Version '#{latest_version}' was automatically detected by livecheck; " \

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -421,8 +421,20 @@ describe Cask::Audit, :cask do
         it { is_expected.not_to fail_with(message) }
       end
 
+      context "when the Cask has a livecheck block referencing a Cask using skip" do
+        let(:cask_token) { "livecheck/livecheck-skip-reference" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+
       context "when the Cask is discontinued" do
         let(:cask_token) { "livecheck/discontinued" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+
+      context "when the Cask has a livecheck block referencing a discontinued Cask" do
+        let(:cask_token) { "livecheck/discontinued-reference" }
 
         it { is_expected.not_to fail_with(message) }
       end
@@ -433,8 +445,20 @@ describe Cask::Audit, :cask do
         it { is_expected.not_to fail_with(message) }
       end
 
+      context "when the Cask has a livecheck block referencing a Cask where version is :latest" do
+        let(:cask_token) { "livecheck/version-latest-reference" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+
       context "when url is unversioned" do
         let(:cask_token) { "livecheck/url-unversioned" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+
+      context "when the Cask has a livecheck block referencing a Cask with an unversioned url" do
+        let(:cask_token) { "livecheck/url-unversioned-reference" }
 
         it { is_expected.not_to fail_with(message) }
       end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/discontinued-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/discontinued-reference.rb
@@ -1,0 +1,18 @@
+cask "discontinued-reference" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/discontinued-#{version}.dmg"
+  name "Discontinued Reference"
+  desc "Cask for testing a livecheck reference to a discontinued cask"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/discontinued"
+
+  livecheck do
+    cask "livecheck/discontinued"
+  end
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip-reference.rb
@@ -1,0 +1,18 @@
+cask "livecheck-skip-reference" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-skip-#{version}.dmg"
+  name "Skip Reference"
+  desc "Cask for testing a livecheck reference to a cask with a #skip livecheck block"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-skip"
+
+  livecheck do
+    cask "livecheck/livecheck-skip"
+  end
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/url-unversioned-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/url-unversioned-reference.rb
@@ -1,0 +1,18 @@
+cask "url-unversioned-reference" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/url-unversioned.dmg"
+  name "Unversioned URL Reference"
+  desc "Cask for testing a livecheck reference to a cask with an unversioned URL"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/url-unversioned"
+
+  livecheck do
+    cask "livecheck/url-unversioned"
+  end
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/version-latest-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/version-latest-reference.rb
@@ -1,0 +1,18 @@
+cask "version-latest-reference" do
+  version :latest
+  sha256 :no_check
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/version-latest.dmg"
+  name "Version Latest Reference"
+  desc "Cask for testing a livecheck reference to a cask where version is :latest"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/version-latest"
+
+  livecheck do
+    cask "livecheck/version-latest"
+  end
+
+  app "TestCask.app"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Cask::Audit#check_livecheck_version` was never updated to handle a referenced cask in a `livecheck` block (e.g., `cask "other-cask"`). As a result, this audit will wrongly give an error like `Version '1.2.3' differs from '' retrieved by livecheck.` in this scenario (e.g., Homebrew/homebrew-cask#113621, Homebrew/homebrew-cask#113622).

This PR ensures that a referenced cask is handled by the audit and it won't error when the referenced check provides a good version. I'll have to remember to keep this logic up to date when related changes are made in livecheck, like we do with `#livecheck_result` in `brew bump`.