### PR TITLE
`dev-cmd/audit`: fix cask arg handling

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -34,7 +34,6 @@ module Cask
       appcast = online if appcast.nil? # `appcast` is `nil` if neither `--appcast` nor `--no-appcast` are passed
       download = online if download.blank?
 
-      odie online
       # `new_cask` implies `token_conflicts`
       token_conflicts = new_cask if token_conflicts.blank?
 

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -27,15 +27,16 @@ module Cask
                    new_cask: nil)
 
       # `new_cask` implies `online` and `strict`
-      online = new_cask if online.nil?
-      strict = new_cask if strict.nil?
+      online = new_cask if online.blank?
+      strict = new_cask if strict.blank?
 
       # `online` implies `appcast` and `download`
-      appcast = online if appcast.nil?
-      download = online if download.nil?
+      appcast = online if appcast.nil? # `appcast` is `nil` if neither `--appcast` nor `--no-appcast` are passed
+      download = online if download.blank?
 
+      odie online
       # `new_cask` implies `token_conflicts`
-      token_conflicts = new_cask if token_conflicts.nil?
+      token_conflicts = new_cask if token_conflicts.blank?
 
       @cask = cask
       @appcast = appcast

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -27,15 +27,15 @@ module Cask
                    new_cask: nil)
 
       # `new_cask` implies `online` and `strict`
-      online = new_cask if online.blank?
-      strict = new_cask if strict.blank?
+      online = new_cask if online.nil?
+      strict = new_cask if strict.nil?
 
       # `online` implies `appcast` and `download`
-      appcast = online if appcast.nil? # `appcast` is `nil` if neither `--appcast` nor `--no-appcast` are passed
-      download = online if download.blank?
+      appcast = online if appcast.nil?
+      download = online if download.nil?
 
       # `new_cask` implies `token_conflicts`
-      token_conflicts = new_cask if token_conflicts.blank?
+      token_conflicts = new_cask if token_conflicts.nil?
 
       @cask = cask
       @appcast = appcast

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -211,7 +211,7 @@ module Homebrew
       Cask::Cmd::Audit.audit_casks(
         *audit_casks,
         download:              nil,
-        # No need for `|| nil` because this is a `--[no-]appcast` and automatically sets itself to `nil` if not passed
+        # No need for `|| nil` for `--[no-]appcast` because boolean switches are already `nil` if not passed
         appcast:               args.appcast?,
         online:                args.online? || nil,
         strict:                args.strict? || nil,

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -206,14 +206,17 @@ module Homebrew
       require "cask/cmd/abstract_command"
       require "cask/cmd/audit"
 
+      # For switches, we add `|| nil` so that `nil` will be passed instead of `false` if they aren't set.
+      # This way, we can distinguish between "not set" and "set to false".
       Cask::Cmd::Audit.audit_casks(
         *audit_casks,
         download:              nil,
+        # No need for `|| nil` because this is a `--[no-]appcast` and automatically sets itself to `nil` if not passed
         appcast:               args.appcast?,
-        online:                args.online?,
-        strict:                args.strict?,
-        new_cask:              args.new_cask?,
-        token_conflicts:       args.token_conflicts?,
+        online:                args.online? || nil,
+        strict:                args.strict? || nil,
+        new_cask:              args.new_cask? || nil,
+        token_conflicts:       args.token_conflicts? || nil,
         quarantine:            nil,
         any_named_args:        !no_named_args,
         language:              nil,

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "October 2021" "Homebrew" "brew"
+.TH "BREW" "1" "November 2021" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes an issue where `brew audit --cask --new-cask` did not run the [`check_token_conflicts`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/cask/audit.rb#L479) check as it should have. This was because at some point in the past, `args.token_conflicts?` started returning `true`/`false` instead of `true`/`nil`. Since `false.nil?` is `false` but `false.blank?` is `true`, this wasn't triggering properly. There are a few other implied audit rules that likely were affected as a result of this. that I've fixed here, too.
