### PR TITLE
dev-cmd/bottle: don't gen `all` bottles if a bottle spec already exists

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -624,10 +624,19 @@ module Homebrew
       bottle.root_url bottle_hash["bottle"]["root_url"]
       bottle.rebuild bottle_hash["bottle"]["rebuild"]
 
+      path = HOMEBREW_REPOSITORY/bottle_hash["formula"]["path"]
+      formula = Formulary.factory(path)
+      old_bottle_spec = formula.bottle_specification
+      old_bottle_spec_matches = old_bottle_spec &&
+                                bottle_hash["formula"]["pkg_version"] == formula.pkg_version.to_s &&
+                                bottle.rebuild  != old_bottle_spec.rebuild &&
+                                bottle.root_url == old_bottle_spec.root_url &&
+                                old_bottle_spec.collector.tags.present?
+
       # if all the cellars and checksums are the same: we can create an
       # `all: $SHA256` bottle.
       tag_hashes = bottle_hash["bottle"]["tags"].values
-      all_bottle = (tag_hashes.count > 1) && tag_hashes.uniq do |tag_hash|
+      all_bottle = !old_bottle_spec_matches && (tag_hashes.count > 1) && tag_hashes.uniq do |tag_hash|
         "#{tag_hash["cellar"]}-#{tag_hash["sha256"]}"
       end.count == 1
 
@@ -652,14 +661,7 @@ module Homebrew
         next
       end
 
-      path = HOMEBREW_REPOSITORY/bottle_hash["formula"]["path"]
-      formula = Formulary.factory(path)
-      old_bottle_spec = formula.bottle_specification
-
-      no_bottle_changes = if old_bottle_spec &&
-                             bottle_hash["formula"]["pkg_version"] == formula.pkg_version.to_s &&
-                             bottle.rebuild  != old_bottle_spec.rebuild &&
-                             bottle.root_url == old_bottle_spec.root_url
+      no_bottle_changes = if old_bottle_spec_matches
         bottle.collector.tags.all? do |tag|
           tag_spec = bottle.collector.specification_for(tag)
           next false if tag_spec.blank?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hopefully fixes the issue seen in https://github.com/Homebrew/homebrew-core/commit/d42d3a9ee407e487c4e474d8918e31f8010e2efb.