### PR TITLE
dev-cmd/bottle: fix pkg_version comparison on merge

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -626,9 +626,15 @@ module Homebrew
 
       path = HOMEBREW_REPOSITORY/bottle_hash["formula"]["path"]
       formula = Formulary.factory(path)
+
       old_bottle_spec = formula.bottle_specification
+      old_pkg_version = formula.pkg_version
+      FormulaVersions.new(formula).formula_at_revision("origin/HEAD") do |upstream_f|
+        old_pkg_version = upstream_f.pkg_version
+      end
+
       old_bottle_spec_matches = old_bottle_spec &&
-                                bottle_hash["formula"]["pkg_version"] == formula.pkg_version.to_s &&
+                                bottle_hash["formula"]["pkg_version"] == old_pkg_version.to_s &&
                                 bottle.root_url == old_bottle_spec.root_url &&
                                 old_bottle_spec.collector.tags.present?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`bottle_hash["formula"]["pkg_version"] == formula.pkg_version.to_s` was always true in a version bump PR merge, as `formula` referred to the formula file post-bump. To fix this, check the latest origin/HEAD.

Should fix https://github.com/Homebrew/brew/pull/12387#issuecomment-962745603.
