### PR TITLE
`Keg::Relocation`: allow `-F`, `-I`, `-L`, `-isystem` prefixes

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -12,7 +12,7 @@ class Keg
   class Relocation
     extend T::Sig
 
-    RELOCATABLE_PATH_REGEX_PREFIX = /(?<![a-zA-Z0-9])/.freeze
+    RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-I|-L|-isystem)|(?<![a-zA-Z0-9]))/.freeze
 
     def initialize
       @replacement_map = {}

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -12,7 +12,7 @@ class Keg
   class Relocation
     extend T::Sig
 
-    RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-I|-L|-isystem)|(?<![a-zA-Z0-9]))/.freeze
+    RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))/.freeze
 
     def initialize
       @replacement_map = {}

--- a/Library/Homebrew/test/keg_relocate/relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/relocation_spec.rb
@@ -12,8 +12,8 @@ describe Keg::Relocation do
   let(:cellar_placeholder) { "@@HOMEBREW_CELLAR@@" }
   let(:repository_placeholder) { "@@HOMEBREW_REPOSITORY@@" }
   let(:library_placeholder) { "@@HOMEBREW_LIBRARY@@" }
-  let(:escaped_prefix) { /(?<![a-zA-Z0-9])#{Regexp.escape(HOMEBREW_PREFIX)}/o }
-  let(:escaped_cellar) { /(?<![a-zA-Z0-9])#{HOMEBREW_CELLAR}/o }
+  let(:escaped_prefix) { /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))#{Regexp.escape(HOMEBREW_PREFIX)}/o }
+  let(:escaped_cellar) { /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))#{HOMEBREW_CELLAR}/o }
 
   def setup_relocation
     relocation = described_class.new
@@ -61,8 +61,8 @@ describe Keg::Relocation do
 
   specify "::path_to_regex" do
     expect(described_class.path_to_regex(prefix)).to eq escaped_prefix
-    expect(described_class.path_to_regex("foo.bar")).to eq(/(?<![a-zA-Z0-9])foo\.bar/)
+    expect(described_class.path_to_regex("foo.bar")).to eq(/(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))foo\.bar/)
     expect(described_class.path_to_regex(/#{cellar}/o)).to eq escaped_cellar
-    expect(described_class.path_to_regex(/foo.bar/)).to eq(/(?<![a-zA-Z0-9])foo.bar/)
+    expect(described_class.path_to_regex(/foo.bar/)).to eq(/(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))foo.bar/)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes an issue with keg relocation where something like `-I/usr/local/Cellar` would not be relocated (and also not deemed necessary of relocation) because of the `-I` prefix. Homebrew treats this as the path `I/usr/local/Cellar` which it determines isn't equal to the cellar path that needs relocation. This means that placeholders aren't placed in text files and also means that strings like that won't be detected to determine whether the bottle is relocatable.

Per suggestion from @carlocab, I've modified the path regex to allow for either `-I`, `-L`, or `-isystem` to appear in front of the path. `-B` was also suggested as a possible exception, but I left it off for now pending further discussion. Another option is to allow any `-\w+` prefixes, but this is harder to code (because you can't have wildcards in a negative lookbehind regex). I welcome further discussion about how best to handle these.
