### PR TITLE
.vscode: auto fix shell script code style on save or on demand

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,6 +5,7 @@
     "rebornix.ruby",
     "wingrunr21.vscode-ruby",
     "timonwong.shellcheck",
-    "foxundermoon.shell-format"
+    "foxundermoon.shell-format",
+    "editorconfig.editorconfig"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,9 @@
     "--external-sources",
     "--source-path=${workspaceFolder}/Library"
   ],
-  "shellformat.flag": "-i 2 -ci"
+  "shellformat.effectLanguages": [
+    "shellscript"
+  ],
+  "shellformat.path": "${workspaceFolder}/Library/Homebrew/utils/shfmt.sh",
+  "shellformat.flag": "-i 2 -ci -ln bash"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,11 @@
     "shellscript"
   ],
   "shellformat.path": "${workspaceFolder}/Library/Homebrew/utils/shfmt.sh",
-  "shellformat.flag": "-i 2 -ci -ln bash"
+  "shellformat.flag": "-i 2 -ci -ln bash",
+  "[shellscript]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.shellcheck": true,
+    }
+  }
 }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Apply autofix by from `shellcheck` and customized `shfmt` (`utils/shfmt.sh`) on save or on demand for shell scripts on VS Code.

Screencast:

![screencast](https://user-images.githubusercontent.com/16078332/140750029-ec8f36b0-36c1-4a04-adc3-d93a6b36d138.gif)