### PR TITLE
bump-cask-pr: use version substring before comma unless they match

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -173,6 +173,10 @@ module Homebrew
     branch_name = "bump-#{cask.token}"
     commit_message = "Update #{cask.token}"
     if new_version.present?
+      if new_version.before_comma != old_version.before_comma
+        new_version = new_version.before_comma
+        old_version = old_version.before_comma
+      end
       branch_name += "-#{new_version.tr(",:", "-")}"
       commit_message += " from #{old_version} to #{new_version}"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This shortens the commit message for cask bump PRs such that

```
Update dotnet from 5.0.10,0a1577a6-a7f1-4da0-ae64-9003ff8badb5:3b3a9291a0bdcb5591afab9e842272db to 5.0.11,f241f934-a4cc-400a-8d03-a5ab50c25fea:1c8600ad088a42b157c073454e80039a
```

becomes `Update dotnet from 5.0.10 to 5.0.11`