### PR TITLE
Do not pass -Wl,-headerpad_max_install_names on linux

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -55,8 +55,6 @@ module Stdenv
     # Os is the default Apple uses for all its stuff so let's trust them
     define_cflags "-Os #{SAFE_CFLAGS_FLAGS}"
 
-    append "LDFLAGS", "-Wl,-headerpad_max_install_names"
-
     send(compiler)
 
     return unless cc&.match?(GNU_GCC_REGEXP)

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -16,6 +16,8 @@ module Stdenv
       bottle_arch: bottle_arch, testing_formula: testing_formula
     )
 
+    append "LDFLAGS", "-Wl,-headerpad_max_install_names"
+
     # sed is strict, and errors out when it encounters files with
     # mixed character sets
     delete("LC_ALL")


### PR DESCRIPTION
One of the more curious bugs, if you use `-Wl,-headerpad_max_install_names` on linux, it tries to link a library named `eaderpath_max_install_names` in, which causes all kinds of weird havoc.

Most notably, gtester inside glib fails to run for bizarre reasons. `-Wl,-headerpad_max_install_names` is not an option anywhere outside macos anyway, so move it to macos only and avoid the heartache of extremely weird bugs.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
