### PR TITLE
GitHub.create_bump_pr: don't leak GitHub token if set via environment variable

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -53,10 +53,10 @@ class SystemCommand
     each_output_line do |type, line|
       case type
       when :stdout
-        $stdout << line if print_stdout?
+        $stdout << redact_secrets(line, @secrets) if print_stdout?
         @output << [:stdout, line]
       when :stderr
-        $stderr << line if print_stderr?
+        $stderr << redact_secrets(line, @secrets) if print_stderr?
         @output << [:stderr, line]
       end
     end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -5,11 +5,15 @@ require "uri"
 require "utils/github/actions"
 require "utils/github/api"
 
+require "system_command"
+
 # Wrapper functions for the GitHub API.
 #
 # @api private
 module GitHub
   extend T::Sig
+
+  include SystemCommand::Mixin
 
   module_function
 
@@ -530,7 +534,8 @@ module GitHub
                     "--", *changed_files
         return if args.commit?
 
-        safe_system "git", "push", "--set-upstream", remote_url, "#{branch}:#{branch}"
+        system_command!("git", args:         ["push", "--set-upstream", remote_url, "#{branch}:#{branch}"],
+                               print_stdout: true)
         safe_system "git", "checkout", "--quiet", previous_branch
         pr_message = <<~EOS
           #{pr_message}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When `HOMEBREW_GITHUB_API_TOKEN` is set and user runs `brew bump-{cask,formula}-pr`, the GitHub token is printed on the console in Git push output.

`SystemCommand` uses `redact_secrets` already; this PR adds secret redaction to stdout/stderr as well, and then changes `GitHub.create_bump_pr` to use `system_command!` for executing the Git push.

Some questions to consider:
- Do we want to switch over all of the stuff in `create_bump_pr` (or all functions in `utils/github.rb`) to use `system_command[!]` instead? Any particular reason to prefer one of `system_command[!]` or `[safe_]system` over another here?
- Do we want to have a flag to toggle secret redaction for stdout/stderr (is there a case where we do need to print secret stuff to stdout/stderr with `SystemCommand`)? If so, what should the default behavior be?

Ideally the test cases would also try printing a secret to stderr and verifying that this is correctly redacted; if someone knows of an easy way to print to stderr, we can probably add this (I don't think `system_command` supports Bash redirections).