### PR TITLE
vendor-install: handle native ARM running under Rosetta

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -6,6 +6,7 @@
 # Doesn't need a default case because we don't support other OSs
 # shellcheck disable=SC2249
 HOMEBREW_PROCESSOR="$(uname -m)"
+HOMEBREW_PHYSICAL_PROCESSOR="${HOMEBREW_PROCESSOR}"
 HOMEBREW_SYSTEM="$(uname -s)"
 case "${HOMEBREW_SYSTEM}" in
   Darwin) HOMEBREW_MACOS="1" ;;
@@ -17,12 +18,19 @@ esac
 # same file under the native architecture
 # These variables are set from the user environment.
 # shellcheck disable=SC2154
-if [[ "${HOMEBREW_CHANGE_ARCH_TO_ARM}" == "1" ]] &&
-   [[ "${HOMEBREW_MACOS}" == "1" ]] &&
-   [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]] &&
-   [[ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" == "1" ]]
+if [[ "${HOMEBREW_MACOS}" == "1" ]] &&
+   [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]
 then
-  exec arch -arm64e "${HOMEBREW_BREW_FILE}" "$@"
+  # used in vendor-install.sh
+  # shellcheck disable=SC2034
+  HOMEBREW_PHYSICAL_PROCESSOR="arm64"
+  HOMEBREW_ROSETTA="$(sysctl -n sysctl.proc_translated)"
+
+  if [[ "${HOMEBREW_CHANGE_ARCH_TO_ARM}" == "1" ]] &&
+     [[ "${HOMEBREW_ROSETTA}" == "1" ]]
+  then
+    exec arch -arm64e "${HOMEBREW_BREW_FILE}" "$@"
+  fi
 fi
 
 # Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -13,11 +13,6 @@ case "${HOMEBREW_SYSTEM}" in
   Linux) HOMEBREW_LINUX="1" ;;
 esac
 
-# If we're running under macOS Rosetta 2, and it was requested by setting
-# HOMEBREW_CHANGE_ARCH_TO_ARM (for example in CI), then we re-exec this
-# same file under the native architecture
-# These variables are set from the user environment.
-# shellcheck disable=SC2154
 if [[ "${HOMEBREW_MACOS}" == "1" ]] &&
    [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]
 then
@@ -26,6 +21,11 @@ then
   HOMEBREW_PHYSICAL_PROCESSOR="arm64"
   HOMEBREW_ROSETTA="$(sysctl -n sysctl.proc_translated)"
 
+  # If we're running under macOS Rosetta 2, and it was requested by setting
+  # HOMEBREW_CHANGE_ARCH_TO_ARM (for example in CI), then we re-exec this
+  # same file under the native architecture
+  # These variables are set from the user environment.
+  # shellcheck disable=SC2154
   if [[ "${HOMEBREW_CHANGE_ARCH_TO_ARM}" == "1" ]] &&
      [[ "${HOMEBREW_ROSETTA}" == "1" ]]
   then

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -22,8 +22,7 @@ then
   then
     ruby_FILENAME="portable-ruby-2.6.8.yosemite.bottle.tar.gz"
     ruby_SHA="0cb1cc7af109437fe0e020c9f3b7b95c3c709b140bde9f991ad2c1433496dd42"
-  elif [[ "$(sysctl -n machdep.cpu.brand_string)" == "Apple"* ]]
-  then
+  else
     ruby_FILENAME="portable-ruby-2.6.8.arm64_big_sur.bottle.tar.gz"
     ruby_SHA="f2d5cab5a4dd49e5b3de780a3cd0a1f61642fea247d1c25aa40cd43f1be290b5"
   fi

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -14,7 +14,8 @@ VENDOR_DIR="${HOMEBREW_LIBRARY}/Homebrew/vendor"
 # Built from https://github.com/Homebrew/homebrew-portable-ruby.
 if [[ -n "${HOMEBREW_MACOS}" ]]
 then
-  if [[ "${HOMEBREW_PROCESSOR}" == "Intel" ]] ||
+  if [[ "${HOMEBREW_PROCESSOR}" == "Intel" &&
+        "$(sysctl -n machdep.cpu.brand_string)" != "Apple"* ]] ||
      # Handle the case where /usr/local/bin/brew is run under arm64.
      # It's a x86_64 installation there (we refuse to install arm64 binaries) so
      # use a x86_64 Portable Ruby.

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -23,7 +23,7 @@ then
   then
     ruby_FILENAME="portable-ruby-2.6.8.yosemite.bottle.tar.gz"
     ruby_SHA="0cb1cc7af109437fe0e020c9f3b7b95c3c709b140bde9f991ad2c1433496dd42"
-  elif [[ "${HOMEBREW_PROCESSOR}" == "arm64" ]]
+  elif [[ "$(sysctl -n machdep.cpu.brand_string)" == "Apple"* ]]
   then
     ruby_FILENAME="portable-ruby-2.6.8.arm64_big_sur.bottle.tar.gz"
     ruby_SHA="f2d5cab5a4dd49e5b3de780a3cd0a1f61642fea247d1c25aa40cd43f1be290b5"

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -14,15 +14,16 @@ VENDOR_DIR="${HOMEBREW_LIBRARY}/Homebrew/vendor"
 # Built from https://github.com/Homebrew/homebrew-portable-ruby.
 if [[ -n "${HOMEBREW_MACOS}" ]]
 then
-  if [[ "$(sysctl -n machdep.cpu.brand_string)" != "Apple"* ]] ||
+  if [[ "${HOMEBREW_PHYSICAL_PROCESSOR}" == "x86_64" ]] ||
      # Handle the case where /usr/local/bin/brew is run under arm64.
      # It's a x86_64 installation there (we refuse to install arm64 binaries) so
      # use a x86_64 Portable Ruby.
-     [[ "${HOMEBREW_PROCESSOR}" == "arm64" && "${HOMEBREW_PREFIX}" == "/usr/local" ]]
+     [[ "${HOMEBREW_PHYSICAL_PROCESSOR}" == "arm64" && "${HOMEBREW_PREFIX}" == "/usr/local" ]]
   then
     ruby_FILENAME="portable-ruby-2.6.8.yosemite.bottle.tar.gz"
     ruby_SHA="0cb1cc7af109437fe0e020c9f3b7b95c3c709b140bde9f991ad2c1433496dd42"
-  else
+  elif [[ "${HOMEBREW_PHYSICAL_PROCESSOR}" == "arm64" ]]
+  then
     ruby_FILENAME="portable-ruby-2.6.8.arm64_big_sur.bottle.tar.gz"
     ruby_SHA="f2d5cab5a4dd49e5b3de780a3cd0a1f61642fea247d1c25aa40cd43f1be290b5"
   fi

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -14,8 +14,7 @@ VENDOR_DIR="${HOMEBREW_LIBRARY}/Homebrew/vendor"
 # Built from https://github.com/Homebrew/homebrew-portable-ruby.
 if [[ -n "${HOMEBREW_MACOS}" ]]
 then
-  if [[ "${HOMEBREW_PROCESSOR}" == "Intel" &&
-        "$(sysctl -n machdep.cpu.brand_string)" != "Apple"* ]] ||
+  if [[ "$(sysctl -n machdep.cpu.brand_string)" != "Apple"* ]] ||
      # Handle the case where /usr/local/bin/brew is run under arm64.
      # It's a x86_64 installation there (we refuse to install arm64 binaries) so
      # use a x86_64 Portable Ruby.


### PR DESCRIPTION
Since `HOMEBREW_PROCESSOR` is populated using `uname -m`, this will
register as `Intel` even when a native ARM install is running under
Rosetta.

Let's work around this by checking `sysctl -n machdep.cpu.brand_string`.
On my Intel machine:

    ❯ sysctl -n machdep.cpu.brand_string
    Intel(R) Core(TM) i3-1000NG4 CPU @ 1.10GHz

On Apple Silicon:

    brew@HMBRW-A-001-M1-001 ~ % sysctl -n machdep.cpu.brand_string
    Apple M1
    brew@HMBRW-A-001-M1-001 ~ % arch -x86_64 sysctl -n machdep.cpu.brand_string
    Apple M1

The case of a Rosetta installation of Homebrew is already handled below
the proposed change.

Fixes Homebrew/discussions#2434.
