### PR TITLE
bump: skip PR check if livecheck does not return a version

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -227,7 +227,8 @@ module Homebrew
     end
 
     livecheck_latest = livecheck_result(formula_or_cask)
-    pull_requests = if !args.no_pull_requests? && (args.named.present? || livecheck_latest != current_version)
+    pull_requests = if !args.no_pull_requests? && (args.named.present? ||
+                       (livecheck_latest.is_a?(Version) && livecheck_latest != current_version))
       retrieve_pull_requests(formula_or_cask, name)
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Further reduce unnecessary GitHub API calls during long `brew bump` runs by skipping formulae whose livecheck doesn't return a version.