### PR TITLE
list: raise NoSuchKegError if formula exists but isn't installed

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -167,6 +167,8 @@ module Homebrew
           raise TapFormulaOrCaskUnavailableError.new(tap, short_name)
         end
 
+        raise NoSuchKegError, name if resolve_formula(name)
+
         raise FormulaOrCaskUnavailableError, name
       end
       private :load_formula_or_cask

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -132,7 +132,7 @@ module Homebrew
       system_command! "find", args:         args.named.to_default_kegs.map(&:to_s) + %w[-not -type d -print],
                               print_stdout: true
     else
-      kegs, casks = args.named.to_formulae_to_casks(method: :default_kegs)
+      kegs, casks = args.named.to_kegs_to_casks
 
       kegs.each { |keg| PrettyListing.new keg } if kegs.present?
       list_casks(casks, args: args) if casks.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Show a more accurate error message when running `brew list <formula>` with a non-installed formula.

Before:
```
$ brew list zorba
Error: No available formula or cask with the name "zorba". Did you mean zork?
```

After:
```
$ brew list zorba
Error: No such keg: /usr/local/Cellar/zorba
$ brew list does-not-exist
Error: No available formula with the name "does-not-exist".
```
