### PR TITLE
utils/shfmt.sh: improve shell formatter usage

### DIFF
--- a/Library/Homebrew/utils/shfmt.sh
+++ b/Library/Homebrew/utils/shfmt.sh
@@ -227,11 +227,11 @@ no_forbidden_styles() {
 align_multiline_if_condition() {
   local line
   local lastline=''
-  local base_indent=''  # indents before `if`
-  local extra_indent='' # 2 extra spaces for `elif`
+  local base_indent=''       # indents before `if`
+  local elif_extra_indent='' # 2 extra spaces for `elif`
   local multiline_if_then_begin_regex='^( *)(el)?if '
   local multiline_if_then_end_regex='^(.*)\; (then( *#.*)?)$'
-  local within_test_regex='^( *)(((! )?-[fdLrwxeszn] )|([^\[]+ == ))'
+  local within_test_regex='^( *)(((! )?-[fdLrwxeszn] )|([^\[]+ (==|!=|=~) ))'
 
   trim() {
     [[ "$1" =~ [^[:space:]](.*[^[:space:]])? ]]
@@ -241,7 +241,7 @@ align_multiline_if_condition() {
   if [[ "$1" =~ ${multiline_if_then_begin_regex} ]]
   then
     base_indent="${BASH_REMATCH[1]}"
-    [[ -n "${BASH_REMATCH[2]}" ]] && extra_indent='  '
+    [[ -n "${BASH_REMATCH[2]}" ]] && elif_extra_indent='  ' # 2 extra spaces for `elif`
     echo "$1"
     shift
   fi
@@ -257,9 +257,14 @@ align_multiline_if_condition() {
     fi
     if [[ "${line}" =~ ${within_test_regex} ]]
     then
-      echo "${base_indent}${extra_indent}      $(trim "${line}")"
+      # Add 3 extra spaces (6 spaces in total) to multiline test conditions
+      # before:                   after:
+      #   if [[ -n ... ||           if [[ -n ... ||
+      #     -n ... ]]                     -n ... ]]
+      #   then                      then
+      echo "${base_indent}${elif_extra_indent}      $(trim "${line}")"
     else
-      echo "${base_indent}${extra_indent}   $(trim "${line}")"
+      echo "${base_indent}${elif_extra_indent}   $(trim "${line}")"
     fi
   done
 

--- a/Library/Homebrew/utils/shfmt.sh
+++ b/Library/Homebrew/utils/shfmt.sh
@@ -292,6 +292,7 @@ wrap_then_do() {
   local -a processed=()
   local -a buffer=()
   local line
+  local singleline_if_then_fi_regex='^( *)if (.+)\; then (.+)\; fi( *#.*)?$'
   local singleline_if_then_regex='^( *)(el)?if (.+)\; (then( *#.*)?)$'
   local singleline_for_do_regex='^( *)(for|while) (.+)\; (do( *#.*)?)$'
   local multiline_if_then_begin_regex='^( *)(el)?if '
@@ -301,7 +302,10 @@ wrap_then_do() {
   do
     if [[ "${#buffer[@]}" == 0 ]]
     then
-      if [[ "${line}" =~ ${singleline_if_then_regex} ]]
+      if [[ "${line}" =~ ${singleline_if_then_fi_regex} ]]
+      then
+        processed+=("${line}")
+      elif [[ "${line}" =~ ${singleline_if_then_regex} ]]
       then
         processed+=("${BASH_REMATCH[1]}${BASH_REMATCH[2]}if ${BASH_REMATCH[3]}")
         processed+=("${BASH_REMATCH[1]}${BASH_REMATCH[4]}")

--- a/Library/Homebrew/utils/shfmt.sh
+++ b/Library/Homebrew/utils/shfmt.sh
@@ -229,8 +229,8 @@ align_multiline_if_condition() {
   local lastline=''
   local base_indent=''  # indents before `if`
   local extra_indent='' # 2 extra spaces for `elif`
-  local multiline_if_begin_regex='^( *)(el)?if '
-  local multiline_then_end_regex='^(.*)\; (then( *#.*)?)$'
+  local multiline_if_then_begin_regex='^( *)(el)?if '
+  local multiline_if_then_end_regex='^(.*)\; (then( *#.*)?)$'
   local within_test_regex='^( *)(((! )?-[fdLrwxeszn] )|([^\[]+ == ))'
 
   trim() {
@@ -238,7 +238,7 @@ align_multiline_if_condition() {
     printf "%s" "${BASH_REMATCH[0]}"
   }
 
-  if [[ "$1" =~ ${multiline_if_begin_regex} ]]
+  if [[ "$1" =~ ${multiline_if_then_begin_regex} ]]
   then
     base_indent="${BASH_REMATCH[1]}"
     [[ -n "${BASH_REMATCH[2]}" ]] && extra_indent='  '
@@ -250,7 +250,7 @@ align_multiline_if_condition() {
   do
     line="$1"
     shift
-    if [[ "${line}" =~ ${multiline_then_end_regex} ]]
+    if [[ "${line}" =~ ${multiline_if_then_end_regex} ]]
     then
       line="${BASH_REMATCH[1]}"
       lastline="${base_indent}${BASH_REMATCH[2]}"
@@ -287,24 +287,24 @@ wrap_then_do() {
   local -a processed=()
   local -a buffer=()
   local line
-  local singleline_then_regex='^( *)(el)?if (.+)\; (then( *#.*)?)$'
-  local singleline_do_regex='^( *)(for|while) (.+)\; (do( *#.*)?)$'
-  local multiline_if_begin_regex='^( *)(el)?if '
-  local multiline_then_end_regex='^(.*)\; (then( *#.*)?)$'
+  local singleline_if_then_regex='^( *)(el)?if (.+)\; (then( *#.*)?)$'
+  local singleline_for_do_regex='^( *)(for|while) (.+)\; (do( *#.*)?)$'
+  local multiline_if_then_begin_regex='^( *)(el)?if '
+  local multiline_if_then_end_regex='^(.*)\; (then( *#.*)?)$'
 
   while IFS='' read -r line
   do
     if [[ "${#buffer[@]}" == 0 ]]
     then
-      if [[ "${line}" =~ ${singleline_then_regex} ]]
+      if [[ "${line}" =~ ${singleline_if_then_regex} ]]
       then
         processed+=("${BASH_REMATCH[1]}${BASH_REMATCH[2]}if ${BASH_REMATCH[3]}")
         processed+=("${BASH_REMATCH[1]}${BASH_REMATCH[4]}")
-      elif [[ "${line}" =~ ${singleline_do_regex} ]]
+      elif [[ "${line}" =~ ${singleline_for_do_regex} ]]
       then
         processed+=("${BASH_REMATCH[1]}${BASH_REMATCH[2]} ${BASH_REMATCH[3]}")
         processed+=("${BASH_REMATCH[1]}${BASH_REMATCH[4]}")
-      elif [[ "${line}" =~ ${multiline_if_begin_regex} ]]
+      elif [[ "${line}" =~ ${multiline_if_then_begin_regex} ]]
       then
         buffer=("${line}")
       else
@@ -312,7 +312,7 @@ wrap_then_do() {
       fi
     else
       buffer+=("${line}")
-      if [[ "${line}" =~ ${multiline_then_end_regex} ]]
+      if [[ "${line}" =~ ${multiline_if_then_end_regex} ]]
       then
         while IFS='' read -r line
         do
@@ -351,7 +351,7 @@ format() {
       return 1
     fi
 
-    tempfile="$(dirname "${file}")/.${file##*/}.temp"
+    tempfile="$(dirname "${file}")/.${file##*/}.formatted~"
     cp -af "${file}" "${tempfile}"
   fi
   trap 'rm -f "${tempfile}" 2>/dev/null' RETURN
@@ -396,6 +396,8 @@ format() {
     then
       cp -af "${tempfile}" "${file}"
     else
+      # Show a linebreak between outputs
+      [[ "${RETCODE}" != 0 ]] && onoe
       # Show differences
       "${DIFF}" "${DIFF_ARGS[@]}" "${file}" "${tempfile}" 1>&2
     fi
@@ -434,7 +436,6 @@ do
       4) onoe "${0##*/}: Fixable bad styles detected in file \"${file}\", run \`brew style --fix\` to apply. Formatter exited with code 4." ;;
       *) onoe "${0##*/}: Failed to format file \"${file}\". Formatter exited with code ${retcode}." ;;
     esac
-    onoe
     RETCODE=1
   fi
 done


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Copyed from output of https://github.com/Homebrew/brew/runs/4175574091 (false positive):

```diff
*** /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/vendor-install.sh	2021-11-11 08:16:31.123776054 +0000
--- /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/.vendor-install.sh.temp	2021-11-11 08:18:29.438048778 +0000
***************
*** 17,19 ****
    if [[ "${HOMEBREW_PROCESSOR}" == "Intel" &&
!         "$(sysctl -n machdep.cpu.brand_string)" != "Apple"* ]] ||
       # Handle the case where /usr/local/bin/brew is run under arm64.
--- 17,19 ----
    if [[ "${HOMEBREW_PROCESSOR}" == "Intel" &&
!      "$(sysctl -n machdep.cpu.brand_string)" != "Apple"* ]] ||
       # Handle the case where /usr/local/bin/brew is run under arm64.
shfmt.sh: Fixable bad styles detected in file "/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/vendor-install.sh", run `brew style --fix` to apply. Formatter exited with code 4.
```

Changes:

1. Add `!=` and `=~` to `within_test_regex`. Treat:
    - `-n ...`, `! -x ...` and similar
    - `... == ...`
    - `... != ...` (new)
    - `... =~ ...` (new)
    as test conditions and add 3 extra spaces for them. Fix false positive in the above GitHub Action result.

    BTW, I suggest always add double brackets if we can when using multiline `if` conditions:

    ```bash
    if [[ -n ... ||
          -n ... ]]
    then
      ...
    fi

    # Change to:
    if [[ -n ... ]] ||
       [[ -n ... ]]
    then
      ...
    fi

    # Exceptional case
    if [[ -n ... ||
          -n ... ]] &&
       [[ ... ]]
    then
      ...
    fi
    ```

2. Rename the temporary file from `.<filename>.temp` to `.<filename>.formatted~`.

3. Allow single-line `if` block `if ...; then ...; fi` in one line. (Current regex treats single-line `if` block as the beginning of a multi-line `if` condition rather than a completed block).
