### PR TITLE
deps: add `--graph` and `--dot` switches

### DIFF
--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -3,6 +3,8 @@
 
 # An adapter for casks to provide dependency information in a formula-like interface.
 class CaskDependent
+  attr_reader :cask
+
   def initialize(cask)
     @cask = cask
   end

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -43,6 +43,11 @@ module Homebrew
       switch "--tree",
              description: "Show dependencies as a tree. When given multiple formula arguments, "\
                           "show individual trees for each formula."
+      switch "--graph",
+             description: "Show dependencies as a directed graph."
+      switch "--dot",
+             depends_on:  "--graph",
+             description: "Show text-based graph description in DOT format."
       switch "--annotate",
              description: "Mark any build, test, optional, or recommended dependencies as "\
                           "such in the output."
@@ -62,6 +67,7 @@ module Homebrew
              depends_on:  "--installed",
              description: "Treat all named arguments as casks."
 
+      conflicts "--tree", "--graph"
       conflicts "--installed", "--all"
       conflicts "--formula", "--cask"
       formula_options
@@ -80,12 +86,13 @@ module Homebrew
 
     @use_runtime_dependencies = installed && recursive &&
                                 !args.tree? &&
+                                !args.graph? &&
                                 !args.include_build? &&
                                 !args.include_test? &&
                                 !args.include_optional? &&
                                 !args.skip_recommended?
 
-    if args.tree?
+    if args.tree? || args.graph?
       dependents = if args.named.present?
         sorted_dependents(args.named.to_formulae_and_casks)
       elsif args.installed?
@@ -99,6 +106,16 @@ module Homebrew
         end
       else
         raise FormulaUnspecifiedError
+      end
+
+      if args.graph?
+        dot_code = dot_code(dependents, recursive: recursive, args: args)
+        if args.dot?
+          puts dot_code
+        else
+          exec_browser "https://dreampuf.github.io/GraphvizOnline/##{ERB::Util.url_encode(dot_code)}"
+        end
+        return
       end
 
       puts_deps_tree dependents, recursive: recursive, args: args
@@ -200,6 +217,46 @@ module Homebrew
     end
   end
 
+  def dot_code(dependents, recursive:, args:)
+    dep_graph = {}
+    dependents.each do |d|
+      graph_deps(d, dep_graph: dep_graph, recursive: recursive, args: args)
+    end
+
+    dot_code = dep_graph.map do |d, deps|
+      deps.map do |dep|
+        attributes = []
+        attributes << "style = dotted" if dep.build?
+        attributes << "arrowhead = empty" if dep.test?
+        if dep.optional?
+          attributes << "color = red"
+        elsif dep.recommended?
+          attributes << "color = green"
+        end
+        comment = " # #{dep.tags.map(&:inspect).join(", ")}" if dep.tags.any?
+        "  \"#{d}\" -> \"#{dep}\"#{" [#{attributes.join(", ")}]" if attributes.any?}#{comment}"
+      end
+    end.flatten.join("\n")
+    "digraph {\n#{dot_code}\n}"
+  end
+
+  def graph_deps(f, dep_graph:, recursive:, args:)
+    return if dep_graph.key?(f)
+
+    dependables = dependables(f, args: args)
+    dep_graph[f] = dependables
+    return unless recursive
+
+    dependables.each do |dep|
+      next unless dep.is_a? Dependency
+
+      graph_deps(Formulary.factory(dep.name),
+                 dep_graph: dep_graph,
+                 recursive: true,
+                 args:      args)
+    end
+  end
+
   def puts_deps_tree(dependents, args:, recursive: false)
     dependents.each do |d|
       puts d.full_name
@@ -208,18 +265,20 @@ module Homebrew
     end
   end
 
-  def recursive_deps_tree(f, dep_stack:, prefix:, recursive:, args:)
+  def dependables(f, args:)
     includes, ignores = args_includes_ignores(args)
-    dependables = @use_runtime_dependencies ? f.runtime_dependencies : f.deps
-    deps = reject_ignores(dependables, ignores, includes)
-    reqs = reject_ignores(f.requirements, ignores, includes)
-    dependables = reqs + deps
+    deps = @use_runtime_dependencies ? f.runtime_dependencies : f.deps
+    deps = reject_ignores(deps, ignores, includes)
+    reqs = reject_ignores(f.requirements, ignores, includes) if args.include_requirements?
+    reqs ||= []
+    reqs + deps
+  end
 
+  def recursive_deps_tree(f, dep_stack:, prefix:, recursive:, args:)
+    dependables = dependables(f, args: args)
     max = dependables.length - 1
     dep_stack.push f.name
     dependables.each_with_index do |dep, i|
-      next if !args.include_requirements? && dep.is_a?(Requirement)
-
       tree_lines = if i == max
         "└──"
       else

--- a/Library/Homebrew/utils/topological_hash.rb
+++ b/Library/Homebrew/utils/topological_hash.rb
@@ -20,7 +20,7 @@ module Utils
       packages = Array(packages)
 
       packages.each do |cask_or_formula|
-        next accumulator if accumulator.key?(cask_or_formula)
+        next if accumulator.key?(cask_or_formula)
 
         if cask_or_formula.is_a?(Cask::Cask)
           formula_deps = cask_or_formula.depends_on
@@ -39,9 +39,7 @@ module Utils
                                      .map { |c| Cask::CaskLoader.load(c, config: nil) }
         end
 
-        accumulator[cask_or_formula] ||= []
-        accumulator[cask_or_formula] += formula_deps
-        accumulator[cask_or_formula] += cask_deps
+        accumulator[cask_or_formula] = formula_deps + cask_deps
 
         graph_package_dependencies(formula_deps, accumulator)
         graph_package_dependencies(cask_deps, accumulator)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For example: [`brew deps --digraph watchman`](https://dreampuf.github.io/GraphvizOnline/#digraph%20%7B%0A%20%20%22watchman%22%20-%3E%20%22boost%22%0A%20%20%22watchman%22%20-%3E%20%22fmt%22%0A%20%20%22watchman%22%20-%3E%20%22folly%22%0A%20%20%22watchman%22%20-%3E%20%22gflags%22%0A%20%20%22watchman%22%20-%3E%20%22glog%22%0A%20%20%22watchman%22%20-%3E%20%22libevent%22%0A%20%20%22watchman%22%20-%3E%20%22openssl%401.1%22%0A%20%20%22watchman%22%20-%3E%20%22pcre%22%0A%20%20%22watchman%22%20-%3E%20%22python%403.10%22%0A%20%20%22boost%22%20-%3E%20%22icu4c%22%0A%20%20%22folly%22%20-%3E%20%22boost%22%0A%20%20%22folly%22%20-%3E%20%22double-conversion%22%0A%20%20%22folly%22%20-%3E%20%22fmt%22%0A%20%20%22folly%22%20-%3E%20%22gflags%22%0A%20%20%22folly%22%20-%3E%20%22glog%22%0A%20%20%22folly%22%20-%3E%20%22libevent%22%0A%20%20%22folly%22%20-%3E%20%22lz4%22%0A%20%20%22folly%22%20-%3E%20%22openssl%401.1%22%0A%20%20%22folly%22%20-%3E%20%22snappy%22%0A%20%20%22folly%22%20-%3E%20%22xz%22%0A%20%20%22folly%22%20-%3E%20%22zstd%22%0A%20%20%22glog%22%20-%3E%20%22gflags%22%0A%20%20%22libevent%22%20-%3E%20%22openssl%401.1%22%0A%20%20%22openssl%401.1%22%20-%3E%20%22ca-certificates%22%0A%20%20%22python%403.10%22%20-%3E%20%22gdbm%22%0A%20%20%22python%403.10%22%20-%3E%20%22mpdecimal%22%0A%20%20%22python%403.10%22%20-%3E%20%22openssl%401.1%22%0A%20%20%22python%403.10%22%20-%3E%20%22readline%22%0A%20%20%22python%403.10%22%20-%3E%20%22sqlite%22%0A%20%20%22python%403.10%22%20-%3E%20%22xz%22%0A%20%20%22sqlite%22%20-%3E%20%22readline%22%0A%7D)