### PR TITLE
update-python-resources: skip dependencies of excluded packages

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -288,15 +288,16 @@ module PyPI
   end
 
   def json_to_packages(json_tree, main_package, exclude_packages)
-    return [] if json_tree.nil?
+    return [] if json_tree.blank?
 
     json_tree.flat_map do |package_json|
       package = Package.new("#{package_json["name"]}==#{package_json["version"]}")
-      [package] + if package == main_package || exclude_packages.exclude?(package)
+      dependencies = if package == main_package || exclude_packages.exclude?(package)
         json_to_packages(package_json["dependencies"], main_package, exclude_packages)
       else
         []
       end
+      [package] + dependencies
     end
   end
 end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -94,10 +94,16 @@ module PyPI
       @name.tr("_", "-").casecmp(other.name.tr("_", "-")).zero?
     end
 
-    # Compare only names so we can use .include? on a Package array
+    # Compare only names so we can use .include? and .uniq on a Package array
     sig { params(other: Package).returns(T::Boolean) }
     def ==(other)
       same_package?(other)
+    end
+    alias eql? ==
+
+    sig { returns(Integer) }
+    def hash
+      @name.tr("_", "-").downcase.hash
     end
 
     sig { params(other: Package).returns(T.nilable(Integer)) }
@@ -212,7 +218,8 @@ module PyPI
     odie '"pipgrip" must be installed (`brew install pipgrip`)' unless @pipgrip_installed
 
     ohai "Retrieving PyPI dependencies for \"#{input_packages.join(" ")}\"..." if !print_only && !silent
-    command = [Formula["pipgrip"].opt_bin/"pipgrip", "--json", "--no-cache-dir", *input_packages.map(&:to_s)]
+    command =
+      [Formula["pipgrip"].opt_bin/"pipgrip", "--json", "--tree", "--no-cache-dir", *input_packages.map(&:to_s)]
     pipgrip_output = Utils.popen_read(*command)
     unless $CHILD_STATUS.success?
       odie <<~EOS
@@ -222,9 +229,7 @@ module PyPI
       EOS
     end
 
-    found_packages = JSON.parse(pipgrip_output).to_h.map do |new_name, new_version|
-      Package.new("#{new_name}==#{new_version}")
-    end
+    found_packages = json_to_packages(JSON.parse(pipgrip_output), main_package, exclude_packages).uniq
 
     new_resource_blocks = ""
     found_packages.sort.each do |package|
@@ -280,5 +285,18 @@ module PyPI
     end
 
     true
+  end
+
+  def json_to_packages(json_tree, main_package, exclude_packages)
+    return [] if json_tree.nil?
+
+    json_tree.flat_map do |package_json|
+      package = Package.new("#{package_json["name"]}==#{package_json["version"]}")
+      [package] + if package == main_package || exclude_packages.exclude?(package)
+        json_to_packages(package_json["dependencies"], main_package, exclude_packages)
+      else
+        []
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For example, this makes excluding `ipython` from `jupyterlab` also exclude unused dependencies, not just `ipython`.

`pipgrip --tree jupyterlab`

<details>

```
jupyterlab (3.2.3)
├── ipython (7.29.0)
│   ├── appnope (0.1.2)
│   ├── backcall (0.2.0)
│   ├── decorator (5.1.0)
│   ├── jedi>=0.16 (0.18.0)
│   │   └── parso<0.9.0,>=0.8.0 (0.8.2)
│   ├── matplotlib-inline (0.1.3)
│   │   └── traitlets (5.1.1)
│   ├── pexpect>4.3 (4.8.0)
│   │   └── ptyprocess>=0.5 (0.7.0)
│   ├── pickleshare (0.7.5)
│   ├── prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 (3.0.22)
│   │   └── wcwidth (0.2.5)
│   ├── pygments (2.10.0)
│   ├── setuptools>=18.5 (58.5.3)
│   └── traitlets>=4.2 (5.1.1)
├── jinja2>=2.1 (3.0.3)
│   └── markupsafe>=2.0 (2.0.1)
├── jupyter-core (4.9.1)
│   └── traitlets (5.1.1)
├── jupyter-server~=1.4 (1.11.2)
│   ├── anyio<4,>=3.1.0 (3.3.4)
│   │   ├── idna>=2.8 (3.3)
│   │   └── sniffio>=1.1 (1.2.0)
│   ├── argon2-cffi (21.1.0)
│   │   └── cffi>=1.0.0 (1.15.0)
│   │       └── pycparser (2.21)
│   ├── ipython-genutils (0.2.0)
│   ├── jinja2 (3.0.3)
│   │   └── markupsafe>=2.0 (2.0.1)
│   ├── jupyter-client>=6.1.1 (7.0.6)
│   │   ├── entrypoints (0.3)
│   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   └── traitlets (5.1.1)
│   │   ├── nest-asyncio>=1.5 (1.5.1)
│   │   ├── python-dateutil>=2.1 (2.8.2)
│   │   │   └── six>=1.5 (1.16.0)
│   │   ├── pyzmq>=13 (22.3.0)
│   │   ├── tornado>=4.1 (6.1)
│   │   └── traitlets (5.1.1)
│   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   └── traitlets (5.1.1)
│   ├── nbconvert (6.3.0)
│   │   ├── bleach (4.1.0)
│   │   │   ├── packaging (21.2)
│   │   │   │   └── pyparsing<3,>=2.0.2 (2.4.7)
│   │   │   ├── six>=1.9.0 (1.16.0)
│   │   │   └── webencodings (0.5.1)
│   │   ├── defusedxml (0.7.1)
│   │   ├── entrypoints>=0.2.2 (0.3)
│   │   ├── jinja2>=2.4 (3.0.3)
│   │   │   └── markupsafe>=2.0 (2.0.1)
│   │   ├── jupyter-core (4.9.1)
│   │   │   └── traitlets (5.1.1)
│   │   ├── jupyterlab-pygments (0.1.2)
│   │   │   └── pygments<3,>=2.4.1 (2.10.0)
│   │   ├── mistune<2,>=0.8.1 (0.8.4)
│   │   ├── nbclient<0.6.0,>=0.5.0 (0.5.8)
│   │   │   ├── jupyter-client>=6.1.5 (7.0.6)
│   │   │   │   ├── entrypoints (0.3)
│   │   │   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   ├── nest-asyncio>=1.5 (1.5.1)
│   │   │   │   ├── python-dateutil>=2.1 (2.8.2)
│   │   │   │   │   └── six>=1.5 (1.16.0)
│   │   │   │   ├── pyzmq>=13 (22.3.0)
│   │   │   │   ├── tornado>=4.1 (6.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   ├── nbformat>=5.0 (5.1.3)
│   │   │   │   ├── ipython-genutils (0.2.0)
│   │   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   └── traitlets>=4.1 (5.1.1)
│   │   │   ├── nest-asyncio (1.5.1)
│   │   │   └── traitlets>=4.2 (5.1.1)
│   │   ├── nbformat>=4.4 (5.1.3)
│   │   │   ├── ipython-genutils (0.2.0)
│   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   └── traitlets>=4.1 (5.1.1)
│   │   ├── pandocfilters>=1.4.1 (1.5.0)
│   │   ├── pygments>=2.4.1 (2.10.0)
│   │   ├── testpath (0.5.0)
│   │   └── traitlets>=5.0 (5.1.1)
│   ├── nbformat (5.1.3)
│   │   ├── ipython-genutils (0.2.0)
│   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   ├── jupyter-core (4.9.1)
│   │   │   └── traitlets (5.1.1)
│   │   └── traitlets>=4.1 (5.1.1)
│   ├── prometheus-client (0.12.0)
│   ├── pyzmq>=17 (22.3.0)
│   ├── send2trash (1.8.0)
│   ├── terminado>=0.8.3 (0.12.1)
│   │   ├── ptyprocess (0.7.0)
│   │   └── tornado>=4 (6.1)
│   ├── tornado>=6.1.0 (6.1)
│   ├── traitlets>=4.2.1 (5.1.1)
│   └── websocket-client (1.2.1)
├── jupyterlab-server~=2.3 (2.8.2)
│   ├── babel (2.9.1)
│   │   └── pytz>=2015.7 (2021.3)
│   ├── entrypoints>=0.2.2 (0.3)
│   ├── jinja2>=2.10 (3.0.3)
│   │   └── markupsafe>=2.0 (2.0.1)
│   ├── json5 (0.9.6)
│   ├── jsonschema>=3.0.1 (4.2.1)
│   │   ├── attrs>=17.4.0 (21.2.0)
│   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   ├── jupyter-server~=1.4 (1.11.2)
│   │   ├── anyio<4,>=3.1.0 (3.3.4)
│   │   │   ├── idna>=2.8 (3.3)
│   │   │   └── sniffio>=1.1 (1.2.0)
│   │   ├── argon2-cffi (21.1.0)
│   │   │   └── cffi>=1.0.0 (1.15.0)
│   │   │       └── pycparser (2.21)
│   │   ├── ipython-genutils (0.2.0)
│   │   ├── jinja2 (3.0.3)
│   │   │   └── markupsafe>=2.0 (2.0.1)
│   │   ├── jupyter-client>=6.1.1 (7.0.6)
│   │   │   ├── entrypoints (0.3)
│   │   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   ├── nest-asyncio>=1.5 (1.5.1)
│   │   │   ├── python-dateutil>=2.1 (2.8.2)
│   │   │   │   └── six>=1.5 (1.16.0)
│   │   │   ├── pyzmq>=13 (22.3.0)
│   │   │   ├── tornado>=4.1 (6.1)
│   │   │   └── traitlets (5.1.1)
│   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   └── traitlets (5.1.1)
│   │   ├── nbconvert (6.3.0)
│   │   │   ├── bleach (4.1.0)
│   │   │   │   ├── packaging (21.2)
│   │   │   │   │   └── pyparsing<3,>=2.0.2 (2.4.7)
│   │   │   │   ├── six>=1.9.0 (1.16.0)
│   │   │   │   └── webencodings (0.5.1)
│   │   │   ├── defusedxml (0.7.1)
│   │   │   ├── entrypoints>=0.2.2 (0.3)
│   │   │   ├── jinja2>=2.4 (3.0.3)
│   │   │   │   └── markupsafe>=2.0 (2.0.1)
│   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   ├── jupyterlab-pygments (0.1.2)
│   │   │   │   └── pygments<3,>=2.4.1 (2.10.0)
│   │   │   ├── mistune<2,>=0.8.1 (0.8.4)
│   │   │   ├── nbclient<0.6.0,>=0.5.0 (0.5.8)
│   │   │   │   ├── jupyter-client>=6.1.5 (7.0.6)
│   │   │   │   │   ├── entrypoints (0.3)
│   │   │   │   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   │   ├── nest-asyncio>=1.5 (1.5.1)
│   │   │   │   │   ├── python-dateutil>=2.1 (2.8.2)
│   │   │   │   │   │   └── six>=1.5 (1.16.0)
│   │   │   │   │   ├── pyzmq>=13 (22.3.0)
│   │   │   │   │   ├── tornado>=4.1 (6.1)
│   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   ├── nbformat>=5.0 (5.1.3)
│   │   │   │   │   ├── ipython-genutils (0.2.0)
│   │   │   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   │   └── traitlets>=4.1 (5.1.1)
│   │   │   │   ├── nest-asyncio (1.5.1)
│   │   │   │   └── traitlets>=4.2 (5.1.1)
│   │   │   ├── nbformat>=4.4 (5.1.3)
│   │   │   │   ├── ipython-genutils (0.2.0)
│   │   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   └── traitlets>=4.1 (5.1.1)
│   │   │   ├── pandocfilters>=1.4.1 (1.5.0)
│   │   │   ├── pygments>=2.4.1 (2.10.0)
│   │   │   ├── testpath (0.5.0)
│   │   │   └── traitlets>=5.0 (5.1.1)
│   │   ├── nbformat (5.1.3)
│   │   │   ├── ipython-genutils (0.2.0)
│   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   └── traitlets>=4.1 (5.1.1)
│   │   ├── prometheus-client (0.12.0)
│   │   ├── pyzmq>=17 (22.3.0)
│   │   ├── send2trash (1.8.0)
│   │   ├── terminado>=0.8.3 (0.12.1)
│   │   │   ├── ptyprocess (0.7.0)
│   │   │   └── tornado>=4 (6.1)
│   │   ├── tornado>=6.1.0 (6.1)
│   │   ├── traitlets>=4.2.1 (5.1.1)
│   │   └── websocket-client (1.2.1)
│   ├── packaging (21.2)
│   │   └── pyparsing<3,>=2.0.2 (2.4.7)
│   └── requests (2.26.0)
│       ├── certifi>=2017.4.17 (2021.10.8)
│       ├── charset-normalizer~=2.0.0 (2.0.7)
│       ├── idna<4,>=2.5 (3.3)
│       └── urllib3<1.27,>=1.21.1 (1.26.7)
├── nbclassic~=0.2 (0.3.4)
│   ├── jupyter-server~=1.8 (1.11.2)
│   │   ├── anyio<4,>=3.1.0 (3.3.4)
│   │   │   ├── idna>=2.8 (3.3)
│   │   │   └── sniffio>=1.1 (1.2.0)
│   │   ├── argon2-cffi (21.1.0)
│   │   │   └── cffi>=1.0.0 (1.15.0)
│   │   │       └── pycparser (2.21)
│   │   ├── ipython-genutils (0.2.0)
│   │   ├── jinja2 (3.0.3)
│   │   │   └── markupsafe>=2.0 (2.0.1)
│   │   ├── jupyter-client>=6.1.1 (7.0.6)
│   │   │   ├── entrypoints (0.3)
│   │   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   ├── nest-asyncio>=1.5 (1.5.1)
│   │   │   ├── python-dateutil>=2.1 (2.8.2)
│   │   │   │   └── six>=1.5 (1.16.0)
│   │   │   ├── pyzmq>=13 (22.3.0)
│   │   │   ├── tornado>=4.1 (6.1)
│   │   │   └── traitlets (5.1.1)
│   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   └── traitlets (5.1.1)
│   │   ├── nbconvert (6.3.0)
│   │   │   ├── bleach (4.1.0)
│   │   │   │   ├── packaging (21.2)
│   │   │   │   │   └── pyparsing<3,>=2.0.2 (2.4.7)
│   │   │   │   ├── six>=1.9.0 (1.16.0)
│   │   │   │   └── webencodings (0.5.1)
│   │   │   ├── defusedxml (0.7.1)
│   │   │   ├── entrypoints>=0.2.2 (0.3)
│   │   │   ├── jinja2>=2.4 (3.0.3)
│   │   │   │   └── markupsafe>=2.0 (2.0.1)
│   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   ├── jupyterlab-pygments (0.1.2)
│   │   │   │   └── pygments<3,>=2.4.1 (2.10.0)
│   │   │   ├── mistune<2,>=0.8.1 (0.8.4)
│   │   │   ├── nbclient<0.6.0,>=0.5.0 (0.5.8)
│   │   │   │   ├── jupyter-client>=6.1.5 (7.0.6)
│   │   │   │   │   ├── entrypoints (0.3)
│   │   │   │   │   ├── jupyter-core>=4.6.0 (4.9.1)
│   │   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   │   ├── nest-asyncio>=1.5 (1.5.1)
│   │   │   │   │   ├── python-dateutil>=2.1 (2.8.2)
│   │   │   │   │   │   └── six>=1.5 (1.16.0)
│   │   │   │   │   ├── pyzmq>=13 (22.3.0)
│   │   │   │   │   ├── tornado>=4.1 (6.1)
│   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   ├── nbformat>=5.0 (5.1.3)
│   │   │   │   │   ├── ipython-genutils (0.2.0)
│   │   │   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   │   └── traitlets>=4.1 (5.1.1)
│   │   │   │   ├── nest-asyncio (1.5.1)
│   │   │   │   └── traitlets>=4.2 (5.1.1)
│   │   │   ├── nbformat>=4.4 (5.1.3)
│   │   │   │   ├── ipython-genutils (0.2.0)
│   │   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   │   └── traitlets (5.1.1)
│   │   │   │   └── traitlets>=4.1 (5.1.1)
│   │   │   ├── pandocfilters>=1.4.1 (1.5.0)
│   │   │   ├── pygments>=2.4.1 (2.10.0)
│   │   │   ├── testpath (0.5.0)
│   │   │   └── traitlets>=5.0 (5.1.1)
│   │   ├── nbformat (5.1.3)
│   │   │   ├── ipython-genutils (0.2.0)
│   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│   │   │   ├── jupyter-core (4.9.1)
│   │   │   │   └── traitlets (5.1.1)
│   │   │   └── traitlets>=4.1 (5.1.1)
│   │   ├── prometheus-client (0.12.0)
│   │   ├── pyzmq>=17 (22.3.0)
│   │   ├── send2trash (1.8.0)
│   │   ├── terminado>=0.8.3 (0.12.1)
│   │   │   ├── ptyprocess (0.7.0)
│   │   │   └── tornado>=4 (6.1)
│   │   ├── tornado>=6.1.0 (6.1)
│   │   ├── traitlets>=4.2.1 (5.1.1)
│   │   └── websocket-client (1.2.1)
│   └── notebook<7 (6.4.5)
│       ├── argon2-cffi (21.1.0)
│       │   └── cffi>=1.0.0 (1.15.0)
│       │       └── pycparser (2.21)
│       ├── ipykernel (6.5.0)
│       │   ├── appnope (0.1.2)
│       │   ├── debugpy<2.0,>=1.0.0 (1.5.1)
│       │   ├── ipython<8.0,>=7.23.1 (7.29.0)
│       │   │   ├── appnope (0.1.2)
│       │   │   ├── backcall (0.2.0)
│       │   │   ├── decorator (5.1.0)
│       │   │   ├── jedi>=0.16 (0.18.0)
│       │   │   │   └── parso<0.9.0,>=0.8.0 (0.8.2)
│       │   │   ├── matplotlib-inline (0.1.3)
│       │   │   │   └── traitlets (5.1.1)
│       │   │   ├── pexpect>4.3 (4.8.0)
│       │   │   │   └── ptyprocess>=0.5 (0.7.0)
│       │   │   ├── pickleshare (0.7.5)
│       │   │   ├── prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 (3.0.22)
│       │   │   │   └── wcwidth (0.2.5)
│       │   │   ├── pygments (2.10.0)
│       │   │   ├── setuptools>=18.5 (58.5.3)
│       │   │   └── traitlets>=4.2 (5.1.1)
│       │   ├── jupyter-client<8.0 (7.0.6)
│       │   │   ├── entrypoints (0.3)
│       │   │   ├── jupyter-core>=4.6.0 (4.9.1)
│       │   │   │   └── traitlets (5.1.1)
│       │   │   ├── nest-asyncio>=1.5 (1.5.1)
│       │   │   ├── python-dateutil>=2.1 (2.8.2)
│       │   │   │   └── six>=1.5 (1.16.0)
│       │   │   ├── pyzmq>=13 (22.3.0)
│       │   │   ├── tornado>=4.1 (6.1)
│       │   │   └── traitlets (5.1.1)
│       │   ├── matplotlib-inline<0.2.0,>=0.1.0 (0.1.3)
│       │   │   └── traitlets (5.1.1)
│       │   ├── tornado<7.0,>=4.2 (6.1)
│       │   └── traitlets<6.0,>=5.1.0 (5.1.1)
│       ├── ipython-genutils (0.2.0)
│       ├── jinja2 (3.0.3)
│       │   └── markupsafe>=2.0 (2.0.1)
│       ├── jupyter-client>=5.3.4 (7.0.6)
│       │   ├── entrypoints (0.3)
│       │   ├── jupyter-core>=4.6.0 (4.9.1)
│       │   │   └── traitlets (5.1.1)
│       │   ├── nest-asyncio>=1.5 (1.5.1)
│       │   ├── python-dateutil>=2.1 (2.8.2)
│       │   │   └── six>=1.5 (1.16.0)
│       │   ├── pyzmq>=13 (22.3.0)
│       │   ├── tornado>=4.1 (6.1)
│       │   └── traitlets (5.1.1)
│       ├── jupyter-core>=4.6.1 (4.9.1)
│       │   └── traitlets (5.1.1)
│       ├── nbconvert (6.3.0)
│       │   ├── bleach (4.1.0)
│       │   │   ├── packaging (21.2)
│       │   │   │   └── pyparsing<3,>=2.0.2 (2.4.7)
│       │   │   ├── six>=1.9.0 (1.16.0)
│       │   │   └── webencodings (0.5.1)
│       │   ├── defusedxml (0.7.1)
│       │   ├── entrypoints>=0.2.2 (0.3)
│       │   ├── jinja2>=2.4 (3.0.3)
│       │   │   └── markupsafe>=2.0 (2.0.1)
│       │   ├── jupyter-core (4.9.1)
│       │   │   └── traitlets (5.1.1)
│       │   ├── jupyterlab-pygments (0.1.2)
│       │   │   └── pygments<3,>=2.4.1 (2.10.0)
│       │   ├── mistune<2,>=0.8.1 (0.8.4)
│       │   ├── nbclient<0.6.0,>=0.5.0 (0.5.8)
│       │   │   ├── jupyter-client>=6.1.5 (7.0.6)
│       │   │   │   ├── entrypoints (0.3)
│       │   │   │   ├── jupyter-core>=4.6.0 (4.9.1)
│       │   │   │   │   └── traitlets (5.1.1)
│       │   │   │   ├── nest-asyncio>=1.5 (1.5.1)
│       │   │   │   ├── python-dateutil>=2.1 (2.8.2)
│       │   │   │   │   └── six>=1.5 (1.16.0)
│       │   │   │   ├── pyzmq>=13 (22.3.0)
│       │   │   │   ├── tornado>=4.1 (6.1)
│       │   │   │   └── traitlets (5.1.1)
│       │   │   ├── nbformat>=5.0 (5.1.3)
│       │   │   │   ├── ipython-genutils (0.2.0)
│       │   │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│       │   │   │   │   ├── attrs>=17.4.0 (21.2.0)
│       │   │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│       │   │   │   ├── jupyter-core (4.9.1)
│       │   │   │   │   └── traitlets (5.1.1)
│       │   │   │   └── traitlets>=4.1 (5.1.1)
│       │   │   ├── nest-asyncio (1.5.1)
│       │   │   └── traitlets>=4.2 (5.1.1)
│       │   ├── nbformat>=4.4 (5.1.3)
│       │   │   ├── ipython-genutils (0.2.0)
│       │   │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│       │   │   │   ├── attrs>=17.4.0 (21.2.0)
│       │   │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│       │   │   ├── jupyter-core (4.9.1)
│       │   │   │   └── traitlets (5.1.1)
│       │   │   └── traitlets>=4.1 (5.1.1)
│       │   ├── pandocfilters>=1.4.1 (1.5.0)
│       │   ├── pygments>=2.4.1 (2.10.0)
│       │   ├── testpath (0.5.0)
│       │   └── traitlets>=5.0 (5.1.1)
│       ├── nbformat (5.1.3)
│       │   ├── ipython-genutils (0.2.0)
│       │   ├── jsonschema!=2.5.0,>=2.4 (4.2.1)
│       │   │   ├── attrs>=17.4.0 (21.2.0)
│       │   │   └── pyrsistent!=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0 (0.18.0)
│       │   ├── jupyter-core (4.9.1)
│       │   │   └── traitlets (5.1.1)
│       │   └── traitlets>=4.1 (5.1.1)
│       ├── prometheus-client (0.12.0)
│       ├── pyzmq>=17 (22.3.0)
│       ├── send2trash>=1.5.0 (1.8.0)
│       ├── terminado>=0.8.3 (0.12.1)
│       │   ├── ptyprocess (0.7.0)
│       │   └── tornado>=4 (6.1)
│       ├── tornado>=6.1 (6.1)
│       └── traitlets>=4.2.1 (5.1.1)
├── packaging (21.2)
│   └── pyparsing<3,>=2.0.2 (2.4.7)
└── tornado>=6.1.0 (6.1)
```

</details>