### PR TITLE
rubocops/text: forbid "go get" only in install method

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -57,8 +57,10 @@ module RuboCop
             problem %q(use "xcodebuild *args" instead of "system 'xcodebuild', *args")
           end
 
-          find_method_with_args(body_node, :system, "go", "get") do
-            problem "Do not use `go get`. Please ask upstream to implement Go vendoring"
+          if (method_node = find_method_def(body_node, :install))
+            find_method_with_args(method_node, :system, "go", "get") do
+              problem "Do not use `go get`. Please ask upstream to implement Go vendoring"
+            end
           end
 
           find_method_with_args(body_node, :system, "dep", "ensure") do |d|


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Idea from here: https://github.com/Homebrew/homebrew-core/pull/89377#discussion_r748841562

This is not tested though.