### PR TITLE
disable: allow to disable due to checksum mismatch

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -16,6 +16,10 @@ module DeprecateDisable
     unsupported:         "is not supported upstream",
     deprecated_upstream: "is deprecated upstream",
     versioned_formula:   "is a versioned formula",
+    checksum_mismatch:   "was built with an initially released source file that had "\
+                         "a different checksum than the current one. " \
+                         "Upstream's repository might have been compromised. " \
+                         "We can re-package this once upstream has confirmed that they retagged their release",
   }.freeze
 
   def deprecate_disable_info(formula)


### PR DESCRIPTION
The rationale is that a checksum mismatch is a huge security issue.
This means that the current source file, but maybe the initial one,
might have been compromised.

In the case upstream does not respond quickly to clarify what happened,
or fails to respond, we can now rev-bump the formula, disable and unbottle it,
making sure we stop delivering the potentially malicious code

Further improvements:
- Add the url of the project in the error message to redirect users to
the closed pull request where we disabled this, to centralize the discussion
and avoid the opening of multiple new issues
- Add a warning on brew-update that something is fishy upstream

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
