### PR TITLE
utils/github/actions: make `file` a mandatory argument

### DIFF
--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -9,25 +9,31 @@ describe GitHub::Actions::Annotation do
   describe "#new" do
     it "fails when the type is wrong" do
       expect {
-        described_class.new(:fatal, message)
+        described_class.new(:fatal, message, file: "file.txt")
       }.to raise_error(ArgumentError)
     end
   end
 
   describe "#to_s" do
     it "escapes newlines" do
-      annotation = described_class.new(:warning, <<~EOS)
+      annotation = described_class.new(:warning, <<~EOS, file: "file.txt")
         lorem
         ipsum
       EOS
 
-      expect(annotation.to_s).to eq "::warning::lorem%0Aipsum%0A"
+      expect(annotation.to_s).to eq "::warning file=file.txt::lorem%0Aipsum%0A"
     end
 
     it "allows specifying the file" do
       annotation = described_class.new(:warning, "lorem ipsum", file: "file.txt")
 
       expect(annotation.to_s).to eq "::warning file=file.txt::lorem ipsum"
+    end
+
+    it "allows specifying the title" do
+      annotation = described_class.new(:warning, "lorem ipsum", file: "file.txt", title: "foo")
+
+      expect(annotation.to_s).to eq "::warning file=file.txt,title=foo::lorem ipsum"
     end
 
     it "allows specifying the file and line" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

An annotation is pretty useless if you don't specify a file to place the
annotation on, so let's just require it.