### PR TITLE
cask: add `#csv` to version DSL

### DIFF
--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -133,6 +133,12 @@ module Cask
       end
 
       # @api public
+      sig { returns(T::Array[Version]) } # Only top-level T.self_type is supported https://sorbet.org/docs/self-type
+      def csv
+        split(",").map(&self.class.method(:new))
+      end
+
+      # @api public
       sig { returns(T.self_type) }
       def before_comma
         version { split(",", 2).first }
@@ -147,12 +153,14 @@ module Cask
       # @api public
       sig { returns(T.self_type) }
       def before_colon
+        # odeprecated "Cask::DSL::Version#before_colon", "Cask::DSL::Version#csv"
         version { split(":", 2).first }
       end
 
       # @api public
       sig { returns(T.self_type) }
       def after_colon
+        # odeprecated "Cask::DSL::Version#after_colon", "Cask::DSL::Version#csv"
         version { split(":", 2).second }
       end
 

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -140,6 +140,20 @@ describe Cask::DSL::Version, :cask do
                        "1.2.3-4,5:6" => "2.3-4"
     end
 
+    describe "#csv" do
+      subject { version.csv }
+
+      include_examples "expectations hash", :raw_version,
+                       :latest     => ["latest"],
+                       "latest"    => ["latest"],
+                       ""          => [],
+                       nil         => [],
+                       "1.2.3"     => ["1.2.3"],
+                       "1.2.3,"    => ["1.2.3"],
+                       ",abc"      => ["", "abc"],
+                       "1.2.3,abc" => ["1.2.3", "abc"]
+    end
+
     describe "#before_comma" do
       include_examples "version expectations hash", :before_comma,
                        "1.2.3"     => "1.2.3",

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -1268,7 +1268,7 @@ The examples above can become hard to read, however. Since many of these changes
 
 Similar to `dots_to_hyphens`, we provide all logical permutations of `{dots,hyphens,underscores}_to_{dots,hyphens,underscores}`. The same applies to `no_dots` in the form of `no_{dots,hyphens,underscores}`, with an extra `no_dividers` that applies all of those at once.
 
-Finally, there are `before_colon` and `after_colon` that act like their `comma` counterparts. These four are extra special to allow for otherwise complex cases, and should be used sparingly. There should be no more than one of `,` and `:` per `version`. Use `,` first, and `:` only if absolutely necessary.
+Finally, there is `csv` that returns an array of comma-separated values. `csv`, `before_comma` and `after_comma` are extra special to allow for otherwise complex cases, and should be used sparingly. There should be no more than two of `,` per `version`.
 
 ### Stanza: `zap`
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`csv` will replace `before_colon` and `after_colon` (https://github.com/Homebrew/homebrew-cask/issues/95207)

> Example:
>
> `version` | `version.csv[0]` | `version.csv[1]` | `version.csv[2]`
> -- | -- | -- | --
> `123,456,789` | `123` | `456` | `789`

> `:` is a special character, and (unless I’m misremembering) it has given us trouble in the past. It’s used in highly specific cases, and those can be handled by multiple `,`.