### PR TITLE
Print warning if given old short name of renamed formula

### DIFF
--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -29,7 +29,9 @@ module Homebrew
   def migrate
     args = migrate_args.parse
 
-    args.named.to_resolved_formulae.each do |f|
+    args.named.to_default_kegs.each do |keg|
+      f = Formulary.from_keg(keg)
+
       if f.oldname
         rack = HOMEBREW_CELLAR/f.oldname
         raise NoSuchKegError, f.oldname if !rack.exist? || rack.subdirs.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For example, this makes `brew info ark` print `Warning: Use velero instead of deprecated ark` 

`brew info homebrew/core/ark` already prints this message because the string `homebrew/core/ark` matches the regex that maps to `TapLoader`, which is where the message is printed from.