### PR TITLE
Allow passing a regex in all livecheck `strategy` blocks

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -626,13 +626,10 @@ module Homebrew
         end
 
         if livecheck_strategy.present?
-          if livecheck_strategy == :page_match && (livecheck_regex.blank? && livecheck_strategy_block.blank?)
-            odebug "#{strategy_name} strategy requires a regex or block"
-            next
-          elsif livecheck_url.blank?
+          if livecheck_url.blank?
             odebug "#{strategy_name} strategy requires a URL"
             next
-          elsif strategies.exclude?(strategy)
+          elsif livecheck_strategy != :page_match && strategies.exclude?(strategy)
             odebug "#{strategy_name} strategy does not apply to this URL"
             next
           end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -658,9 +658,13 @@ module Homebrew
         end
 
         if debug
-          puts "URL (strategy):   #{strategy_data[:url]}" if strategy_data[:url] != url
-          puts "URL (final):      #{strategy_data[:final_url]}" if strategy_data[:final_url]
-          puts "Regex (strategy): #{strategy_data[:regex].inspect}" if strategy_data[:regex] != livecheck_regex
+          if strategy_data[:url].present? && strategy_data[:url] != url
+            puts "URL (strategy):   #{strategy_data[:url]}"
+          end
+          puts "URL (final):      #{strategy_data[:final_url]}" if strategy_data[:final_url].present?
+          if strategy_data[:regex].present? && strategy_data[:regex] != livecheck_regex
+            puts "Regex (strategy): #{strategy_data[:regex].inspect}"
+          end
           puts "Cached?:          Yes" if strategy_data[:cached] == true
         end
 

--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -93,9 +93,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -96,9 +96,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -80,9 +80,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -40,12 +40,7 @@ module Homebrew
           params(
             content: String,
             regex:   T.nilable(Regexp),
-            block:   T.nilable(
-              T.proc.params(
-                arg0: T::Hash[String, T.untyped],
-                arg1: T.nilable(Regexp),
-              ).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Array[String])
         }
         def self.versions_from_content(content, regex = nil, &block)
@@ -54,7 +49,10 @@ module Homebrew
           yaml = YAML.safe_load(content)
           return [] if yaml.blank?
 
-          return Strategy.handle_block_return(yield(yaml, regex)) if block
+          if block
+            block_return_value = regex.present? ? yield(yaml, regex) : yield(yaml)
+            return Strategy.handle_block_return(block_return_value)
+          end
 
           version = yaml["version"]
           version.present? ? [version] : []
@@ -69,12 +67,7 @@ module Homebrew
             url:     String,
             regex:   T.nilable(Regexp),
             _unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:   T.nilable(
-              T.proc.params(
-                arg0: T::Hash[String, T.untyped],
-                arg1: T.nilable(Regexp),
-              ).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **_unused, &block)

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -63,16 +63,14 @@ module Homebrew
           params(
             items: T::Hash[String, Item],
             regex: T.nilable(Regexp),
-            block: T.nilable(
-              T.proc.params(
-                arg0: T::Hash[String, Item],
-                arg1: T.nilable(Regexp),
-              ).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block: T.untyped,
           ).returns(T::Array[String])
         }
         def self.versions_from_items(items, regex = nil, &block)
-          return Strategy.handle_block_return(yield(items, regex)) if block
+          if block
+            block_return_value = regex.present? ? yield(items, regex) : yield(items)
+            return Strategy.handle_block_return(block_return_value)
+          end
 
           items.map do |_key, item|
             item.bundle_version.nice_version
@@ -89,12 +87,7 @@ module Homebrew
             cask:    Cask::Cask,
             regex:   T.nilable(Regexp),
             _unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:   T.nilable(
-              T.proc.params(
-                arg0: T::Hash[String, Item],
-                arg1: T.nilable(Regexp),
-              ).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(cask:, regex: nil, **_unused, &block)

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -62,13 +62,17 @@ module Homebrew
         sig {
           params(
             items: T::Hash[String, Item],
+            regex: T.nilable(Regexp),
             block: T.nilable(
-              T.proc.params(arg0: T::Hash[String, Item]).returns(T.any(String, T::Array[String], NilClass)),
+              T.proc.params(
+                arg0: T::Hash[String, Item],
+                arg1: T.nilable(Regexp),
+              ).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Array[String])
         }
-        def self.versions_from_items(items, &block)
-          return Strategy.handle_block_return(yield(items)) if block
+        def self.versions_from_items(items, regex = nil, &block)
+          return Strategy.handle_block_return(yield(items, regex)) if block
 
           items.map do |_key, item|
             item.bundle_version.nice_version
@@ -82,15 +86,21 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            cask:   Cask::Cask,
-            unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: T::Hash[String, Item]).returns(T.any(String, T::Array[String], NilClass)),
+            cask:    Cask::Cask,
+            regex:   T.nilable(Regexp),
+            _unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:   T.nilable(
+              T.proc.params(
+                arg0: T::Hash[String, Item],
+                arg1: T.nilable(Regexp),
+              ).returns(T.any(String, T::Array[String], NilClass)),
             ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(cask:, **unused, &block)
-          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if unused[:regex]
+        def self.find_versions(cask:, regex: nil, **_unused, &block)
+          if regex.present? && block.blank?
+            raise ArgumentError, "#{T.must(name).demodulize} only supports a regex when using a `strategy` block"
+          end
           raise ArgumentError, "The #{T.must(name).demodulize} strategy only supports casks." unless T.unsafe(cask)
 
           match_data = { matches: {} }
@@ -98,7 +108,7 @@ module Homebrew
           unversioned_cask_checker = UnversionedCaskChecker.new(cask)
           items = unversioned_cask_checker.all_versions.transform_values { |v| Item.new(bundle_version: v) }
 
-          versions_from_items(items, &block).each do |version_text|
+          versions_from_items(items, regex, &block).each do |version_text|
             match_data[:matches][version_text] = Version.new(version_text)
           end
 

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -86,14 +86,20 @@ module Homebrew
           params(
             tags:  T::Array[String],
             regex: T.nilable(Regexp),
-            block: T.nilable(
-              T.proc.params(arg0: T::Array[String], arg1: T.nilable(Regexp))
-                .returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block: T.untyped,
           ).returns(T::Array[String])
         }
         def self.versions_from_tags(tags, regex = nil, &block)
-          return Strategy.handle_block_return(yield(tags, regex || DEFAULT_REGEX)) if block
+          if block
+            block_return_value = if regex.present?
+              yield(tags, regex)
+            elsif block.arity == 2
+              yield(tags, DEFAULT_REGEX)
+            else
+              yield(tags)
+            end
+            return Strategy.handle_block_return(block_return_value)
+          end
 
           tags_only_debian = tags.all? { |tag| tag.start_with?("debian/") }
 
@@ -125,10 +131,7 @@ module Homebrew
             url:     String,
             regex:   T.nilable(Regexp),
             _unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:   T.nilable(
-              T.proc.params(arg0: T::Array[String], arg1: T.nilable(Regexp))
-                .returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **_unused, &block)

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -92,9 +92,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -82,9 +82,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -92,9 +92,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -78,9 +78,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -44,16 +44,14 @@ module Homebrew
           params(
             headers: T::Hash[String, String],
             regex:   T.nilable(Regexp),
-            block:   T.nilable(
-              T.proc.params(
-                arg0: T::Hash[String, String],
-                arg1: T.nilable(Regexp),
-              ).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Array[String])
         }
         def self.versions_from_headers(headers, regex = nil, &block)
-          return Strategy.handle_block_return(yield(headers, regex)) if block
+          if block
+            block_return_value = regex.present? ? yield(headers, regex) : yield(headers)
+            return Strategy.handle_block_return(block_return_value)
+          end
 
           DEFAULT_HEADERS_TO_CHECK.map do |header_name|
             header_value = headers[header_name]
@@ -79,9 +77,7 @@ module Homebrew
             url:     String,
             regex:   T.nilable(Regexp),
             _unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:   T.nilable(
-              T.proc.params(arg0: T::Hash[String, String], arg1: T.nilable(Regexp)).returns(T.nilable(String)),
-            ),
+            block:   T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **_unused, &block)

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -75,9 +75,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -73,9 +73,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -90,6 +90,10 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, provided_content: nil, **_unused, &block)
+          if regex.blank? && block.blank?
+            raise ArgumentError, "#{T.must(name).demodulize} requires a regex or `strategy` block"
+          end
+
           match_data = { matches: {}, regex: regex, url: url }
           return match_data if url.blank? || (regex.blank? && block.blank?)
 

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -51,13 +51,15 @@ module Homebrew
           params(
             content: String,
             regex:   T.nilable(Regexp),
-            block:   T.nilable(
-              T.proc.params(arg0: String, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Array[String])
         }
         def self.versions_from_content(content, regex, &block)
-          return Strategy.handle_block_return(yield(content, regex)) if block
+          if block
+            block_return_value = regex.present? ? yield(content, regex) : yield(content)
+            return Strategy.handle_block_return(block_return_value)
+          end
+
           return [] if regex.blank?
 
           content.scan(regex).map do |match|
@@ -84,9 +86,7 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             _unused:          T.nilable(T::Hash[Symbol, T.untyped]),
-            block:            T.nilable(
-              T.proc.params(arg0: String, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:            T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, provided_content: nil, **_unused, &block)

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -87,9 +87,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -92,9 +92,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -150,14 +150,17 @@ module Homebrew
         sig {
           params(
             content: String,
-            block:   T.nilable(T.proc.params(arg0: Item).returns(T.any(String, T::Array[String], NilClass))),
+            regex:   T.nilable(Regexp),
+            block:   T.nilable(
+              T.proc.params(arg0: Item, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Array[String])
         }
-        def self.versions_from_content(content, &block)
+        def self.versions_from_content(content, regex = nil, &block)
           item = item_from_content(content)
           return [] if item.blank?
 
-          return Strategy.handle_block_return(yield(item)) if block
+          return Strategy.handle_block_return(yield(item, regex)) if block
 
           version = item.bundle_version&.nice_version
           version.present? ? [version] : []
@@ -166,20 +169,25 @@ module Homebrew
         # Checks the content at the URL for new versions.
         sig {
           params(
-            url:    String,
-            unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(T.proc.params(arg0: Item).returns(T.nilable(String))),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            _unused: T.nilable(T::Hash[Symbol, T.untyped]),
+            block:   T.nilable(
+              T.proc.params(arg0: Item, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
+            ),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, **unused, &block)
-          raise ArgumentError, "The #{T.must(name).demodulize} strategy does not support a regex." if unused[:regex]
+        def self.find_versions(url:, regex: nil, **_unused, &block)
+          if regex.present? && block.blank?
+            raise ArgumentError, "#{T.must(name).demodulize} only supports a regex when using a `strategy` block"
+          end
 
           match_data = { matches: {}, url: url }
 
           match_data.merge!(Strategy.page_content(url))
           content = match_data.delete(:content)
 
-          versions_from_content(content, &block).each do |version_text|
+          versions_from_content(content, regex, &block).each do |version_text|
             match_data[:matches][version_text] = Version.new(version_text)
           end
 

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -151,16 +151,17 @@ module Homebrew
           params(
             content: String,
             regex:   T.nilable(Regexp),
-            block:   T.nilable(
-              T.proc.params(arg0: Item, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Array[String])
         }
         def self.versions_from_content(content, regex = nil, &block)
           item = item_from_content(content)
           return [] if item.blank?
 
-          return Strategy.handle_block_return(yield(item, regex)) if block
+          if block
+            block_return_value = regex.present? ? yield(item, regex) : yield(item)
+            return Strategy.handle_block_return(block_return_value)
+          end
 
           version = item.bundle_version&.nice_version
           version.present? ? [version] : []
@@ -172,9 +173,7 @@ module Homebrew
             url:     String,
             regex:   T.nilable(Regexp),
             _unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:   T.nilable(
-              T.proc.params(arg0: Item, arg1: T.nilable(Regexp)).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:   T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **_unused, &block)

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -114,9 +114,7 @@ module Homebrew
             url:    String,
             regex:  T.nilable(Regexp),
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
-            block:  T.nilable(
-              T.proc.params(arg0: String, arg1: Regexp).returns(T.any(String, T::Array[String], NilClass)),
-            ),
+            block:  T.untyped,
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **unused, &block)

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -25,6 +25,7 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
       releaseDate: '2000-01-01T00:00:00.000Z'
     EOS
   }
+  let(:mac_regex) { /Example[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i }
 
   let(:versions) { ["1.2.3"] }
 
@@ -57,6 +58,26 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
 
       # Returning an array of strings from block
       expect(electron_builder.versions_from_content(electron_builder_yaml) { versions }).to eq(versions)
+    end
+
+    it "returns an array of version strings when given YAML text, a regex, and a block" do
+      # Returning a string from block
+      expect(
+        electron_builder.versions_from_content(electron_builder_yaml, mac_regex) do |yaml, regex|
+          yaml["path"][regex, 1]
+        end,
+      ).to eq(versions)
+
+      # Returning an array of strings from block
+      expect(
+        electron_builder.versions_from_content(electron_builder_yaml, mac_regex) do |yaml, regex|
+          yaml["files"]&.map do |file|
+            next if file["url"].blank?
+
+            file["url"][regex, 1]
+          end
+        end,
+      ).to eq(versions)
     end
 
     it "allows a nil return from a block" do

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -41,6 +41,8 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
     EOS
   }
 
+  let(:title_regex) { /Version\s+v?(\d+(?:\.\d+)+)\s*$/i }
+
   let(:item) {
     Homebrew::Livecheck::Strategy::Sparkle::Item.new(
       title:          appcast_data[:title],
@@ -93,8 +95,24 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
         end,
       ).to eq([item.bundle_version.nice_version.sub("3", "4")])
 
-      # Returning an array of strings from block
+      # Returning an array of strings from block (unlikely to be used)
       expect(sparkle.versions_from_content(appcast_xml) { versions }).to eq(versions)
+    end
+
+    it "returns an array of version strings when given content, a regex, and a block" do
+      # Returning a string from block
+      expect(
+        sparkle.versions_from_content(appcast_xml, title_regex) do |item, regex|
+          item.title[regex, 1]
+        end,
+      ).to eq([item.bundle_version.short_version])
+
+      # Returning an array of strings from block (unlikely to be used)
+      expect(
+        sparkle.versions_from_content(appcast_xml, title_regex) do |item, regex|
+          [item.title[regex, 1]]
+        end,
+      ).to eq([item.bundle_version.short_version])
     end
 
     it "allows a nil return from a block" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR modifies cask-related livecheck strategies (i.e., `ElectronBuilder`, `ExtractPlist`, `Sparkle`) to allow passing a regex into a `strategy` block, when appropriate. These strategies were outliers that explicitly rejected a regex even if a `strategy` block was used, forcing any regex to be inlined in the `strategy` block (instead of being defined using `#regex`).

With these changes, all `strategy` blocks will be able to accept a regex, further simplifying the mental model. This also helps to better align the various `find_versions` and `versions_from_*` methods across strategies (this will be further improved in a later PR).