### PR TITLE
dev-cmd/unbottled: don't skip non-core formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -123,8 +123,6 @@ module Homebrew
     uses_hash = {}
 
     all_formulae.each do |f|
-      next unless f.core_formula?
-
       deps = f.recursive_dependencies do |_, dep|
         Dependency.prune if dep.optional?
       end.map(&:to_formula)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Related to Homebrew/homebrew-test-bot#705, and I believe this doesn't conflict with #12325, which also modifies `dev-cmd/unbottled`. This allows the `brew unbottled` command to work for formulae in 3rd-party taps.

## Before

~~~
$ brew unbottled osrf/simulation/gazebo9
==> Populating dependency tree...
==> :catalina bottle status
gazebo9: ready to bottle
~~~

## After

~~~
$ brew unbottled osrf/simulation/gazebo9
==> Populating dependency tree...
==> :catalina bottle status
gazebo9: unbottled deps: ignition-cmake0 ignition-math4
~~~