### PR TITLE
Add missing `--formulae/--casks` aliases for `--formula/--cask`

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -28,9 +28,9 @@ module Homebrew
            description: "Show the cache file used when pouring a bottle for the given tag."
       switch "--HEAD",
              description: "Show the cache file used when building from HEAD."
-      switch "--formula",
+      switch "--formula", "--formulae",
              description: "Only show cache files for formulae."
-      switch "--cask",
+      switch "--cask", "--casks",
              description: "Only show cache files for casks."
 
       conflicts "--build-from-source", "--force-bottle", "--bottle-tag", "--HEAD", "--cask"

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -24,9 +24,9 @@ module Homebrew
              description: "List only the names of outdated kegs (takes precedence over `--verbose`)."
       switch "-v", "--verbose",
              description: "Include detailed version information."
-      switch "--formula",
+      switch "--formula", "--formulae",
              description: "List only outdated formulae."
-      switch "--cask",
+      switch "--cask", "--casks",
              description: "List only outdated casks."
       flag   "--json",
              description: "Print output in JSON format. There are two versions: `v1` and `v2`. " \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The commands affected by this are: `brew --cache` and `brew outdated`