### PR TITLE
extract: remove bottle blocks

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -64,6 +64,8 @@ module Homebrew
 
   module_function
 
+  BOTTLE_BLOCK_REGEX = /  bottle do.+?end\n\n/m.freeze
+
   sig { returns(CLI::Parser) }
   def extract_args
     Homebrew::CLI::Parser.new do
@@ -184,7 +186,7 @@ module Homebrew
     result.sub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
 
     # Remove bottle blocks, they won't work.
-    result.sub!(/  bottle do.+?end\n\n/m, "") if destination_tap != source_tap
+    result.sub!(BOTTLE_BLOCK_REGEX, "")
 
     path = destination_tap.path/"Formula/#{name}@#{version.to_s.downcase}.rb"
     if path.exist?
@@ -210,6 +212,7 @@ module Homebrew
     contents = Utils::Git.last_revision_of_file(repo, file, before_commit: rev)
     contents.gsub!("@url=", "url ")
     contents.gsub!("require 'brewkit'", "require 'formula'")
+    contents.sub!(BOTTLE_BLOCK_REGEX, "")
     with_monkey_patch { Formulary.from_contents(name, file, contents, ignore_errors: true) }
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Attempting to extract Ghostscript 9.21 gives an error because it has the old bottle sha256 format.

```sh-session
> brew tap-new $USER/local-tap
> brew extract --version=9.21 ghostscript $USER/local-tap
Error: ghostscript: undefined method `[]' for nil:NilClass
```