### PR TITLE
cmd/uses: add `--skip-recursive-build-dependents` flag

### DIFF
--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -38,6 +38,9 @@ module Homebrew
              description: "Include all formulae that specify <formula> as `:optional` type dependency."
       switch "--skip-recommended",
              description: "Skip all formulae that specify <formula> as `:recommended` type dependency."
+      switch "--skip-recursive-build-dependents",
+             depends_on:  "--recursive",
+             description: "Skip dependents of a build dependent."
       switch "--formula", "--formulae",
              description: "Include only formulae."
       switch "--cask", "--casks",
@@ -82,7 +85,7 @@ module Homebrew
   def intersection_of_dependents(use_runtime_dependents, used_formulae, args:)
     recursive = args.recursive?
     show_formulae_and_casks = !args.formula? && !args.cask?
-    includes, ignores = args_includes_ignores(args)
+    includes, ignores = args_includes_ignores(args, uses: true)
 
     deps = []
     if use_runtime_dependents
@@ -114,7 +117,7 @@ module Homebrew
   def select_used_dependents(dependents, used_formulae, recursive, includes, ignores)
     dependents.select do |d|
       deps = if recursive
-        recursive_includes(Dependency, d, includes, ignores)
+        recursive_includes(Dependency, d, includes, ignores, used_formulae)
       else
         reject_ignores(d.deps, ignores, includes)
       end

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -7,7 +7,7 @@ require "cask_dependent"
 #
 # @api private
 module DependenciesHelpers
-  def args_includes_ignores(args)
+  def args_includes_ignores(args, uses: false)
     includes = []
     ignores = []
 
@@ -30,11 +30,12 @@ module DependenciesHelpers
     end
 
     ignores << "recommended?" if args.skip_recommended?
+    ignores << "recursive-build?" if uses && args.skip_recursive_build_dependents?
 
     [includes, ignores]
   end
 
-  def recursive_includes(klass, root_dependent, includes, ignores)
+  def recursive_includes(klass, root_dependent, includes, ignores, used_formulae = [])
     raise ArgumentError, "Invalid class argument: #{klass}" if klass != Dependency && klass != Requirement
 
     cache_key = "recursive_includes_#{includes}_#{ignores}"
@@ -47,7 +48,8 @@ module DependenciesHelpers
       elsif dep.build? || dep.test?
         keep = false
         keep ||= dep.test? && includes.include?("test?") && dependent == root_dependent
-        keep ||= dep.build? && includes.include?("build?")
+        keep ||= dep.build? && includes.include?("build?") &&
+                 (ignores.exclude?("recursive-build?") || used_formulae.include?(dep.to_formula))
         klass.prune unless keep
       end
 

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -44,8 +44,9 @@ module DependenciesHelpers
   )
     raise ArgumentError, "Invalid class argument: #{klass}" if klass != Dependency && klass != Requirement
 
-    cache_key = +"recursive_includes_#{includes}_#{ignores}"
-    cache_key << "_no_recursive_build_#{used_formulae.join("_")}" if skip_recursive_build_dependents
+    cache_key = +"recursive_includes_#{includes.join("_")}_#{ignores.join("_")}"
+    cache_key << "_#{root_dependent}" if includes.include?("test?")
+    cache_key << "_#{root_dependent}_no_recursive_build_#{used_formulae.join("_")}" if skip_recursive_build_dependents
     cache_key.freeze
 
     klass.expand(root_dependent, cache_key: cache_key) do |dependent, dep|

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -54,9 +54,14 @@ module DependenciesHelpers
       elsif dep.build? || dep.test?
         keep = false
         keep ||= dep.test? && includes.include?("test?") && dependent == root_dependent
-        keep ||= dep.build? && includes.include?("build?") &&
-                 (!skip_recursive_build_dependents || used_formulae.include?(dep.to_formula))
+        keep ||= dep.build? && includes.include?("build?")
         klass.prune unless keep
+
+        next unless skip_recursive_build_dependents
+        next unless dep.build?
+        next if dependent == root_dependent && used_formulae.include?(dep.to_formula)
+
+        klass.prune
       end
 
       # If a tap isn't installed, we can't find the dependencies of one of

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -44,7 +44,9 @@ module DependenciesHelpers
   )
     raise ArgumentError, "Invalid class argument: #{klass}" if klass != Dependency && klass != Requirement
 
-    cache_key = "recursive_includes_#{includes}_#{ignores}#{"_no_recursive_build" if skip_recursive_build_dependents}"
+    cache_key = +"recursive_includes_#{includes}_#{ignores}"
+    cache_key << "_no_recursive_build_#{used_formulae.join("_")}" if skip_recursive_build_dependents
+    cache_key.freeze
 
     klass.expand(root_dependent, cache_key: cache_key) do |dependent, dep|
       if dep.recommended?

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -15,7 +15,58 @@ describe "brew uses" do
     RUBY
 
     expect { brew "uses", "--recursive", "foo" }
-      .to output(/(bar\nbaz|baz\nbar)/).to_stdout
+      .to output("bar\nbaz\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "skips dependents of test dependents", :integration_test do
+    setup_test_formula "foo"
+    setup_test_formula "baz", <<~RUBY
+      url "https://brew.sh/baz-1.0"
+      depends_on "foo" => :test
+    RUBY
+    setup_test_formula "qux", <<~RUBY
+      url "https://brew.sh/qux-1.0"
+      depends_on "baz"
+    RUBY
+
+    expect { brew "uses", "--recursive", "--include-test", "foo" }
+      .to output("baz\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "prints build dependents when requested", :integration_test do
+    setup_test_formula "foo"
+    setup_test_formula "baz", <<~RUBY
+      url "https://brew.sh/baz-1.0"
+      depends_on "foo" => :build
+    RUBY
+    setup_test_formula "qux", <<~RUBY
+      url "https://brew.sh/qux-1.0"
+      depends_on "baz"
+    RUBY
+
+    expect { brew "uses", "--recursive", "--include-build", "foo" }
+      .to output("baz\nqux\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "skips dependents of build dependents when requested", :integration_test do
+    setup_test_formula "foo"
+    setup_test_formula "baz", <<~RUBY
+      url "https://brew.sh/baz-1.0"
+      depends_on "foo" => :build
+    RUBY
+    setup_test_formula "qux", <<~RUBY
+      url "https://brew.sh/qux-1.0"
+      depends_on "baz"
+    RUBY
+
+    expect { brew "uses", "--recursive", "--include-build", "--skip-recursive-build-dependents", "foo" }
+      .to output("baz\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We use `brew uses` to determine the list of dependent formulae to test
in `test-bot`. By default, we generate this list with the invocation

    brew uses --formula --include-build --include-test --recursive <formula>

This results in our testing formulae that do not need to be tested. As
an example, suppose `foo` is a build dependency of `bar`, and `baz`
depends on `bar`. Since we don't rebuild `bar` when testing `baz`, then
no changes in `foo` are relevant to `baz`, and any test result from
testing `baz` as a dependent of `foo` is not meaningful.

One instance where this is particularly wasteful is in `go` PRs. `envoy`
and `envoy@1.18` both declare a build dependency on `bazelisk`, which in
turn declares a build dependency on `go`. The two formulae also take
about four hours each to build.

Let's cut the CI time we spend testing formulae that don't need to be
tested by adding a `--skip-recursive-dependents` flag to `brew uses`.
Adding this flag will omit all dependents of a build dependent from the
output.

For reference, here is the list of formulae that are present without the
`--skip-recursive-build-depenents` flag but are no longer there with it:

arduino-cli
bat-extras
crun
envoy
envoy@1.18
kube-ps1
kubectx
kubernetes-cli
kubie
modd
newrelic-infra-agent
terraform@0.11