### PR TITLE
pr-upload: deprecate `--github-org=`

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -30,8 +30,7 @@ module Homebrew
              description: "Skip running `brew bottle` before uploading."
       flag   "--committer=",
              description: "Specify a committer name and email in `git`'s standard author format."
-      flag   "--github-org=",
-             description: "Upload to the specified GitHub organisation's GitHub Packages (default: `homebrew`)."
+      flag   "--github-org=", hidden: true
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--root-url-using=",
@@ -90,6 +89,8 @@ module Homebrew
 
   def pr_upload
     args = pr_upload_args.parse
+
+    # odeprecated "`brew pr-upload --github-org`", "`brew pr-upload` without `--github-org`" if args.github_org
 
     json_files = Dir["*.bottle.json"]
     odie "No bottle JSON files found in the current working directory" if json_files.blank?
@@ -158,8 +159,7 @@ module Homebrew
       github_releases = GitHubReleases.new
       github_releases.upload_bottles(bottles_hash)
     elsif github_packages?(bottles_hash)
-      github_org = args.github_org || "homebrew"
-      github_packages = GitHubPackages.new(org: github_org)
+      github_packages = GitHubPackages.new
       github_packages.upload_bottles(bottles_hash,
                                      keep_old:      args.keep_old?,
                                      dry_run:       args.dry_run?,

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -33,20 +33,6 @@ class GitHubPackages
     "Macintosh" => "darwin",
   }.freeze
 
-  sig { returns(String) }
-  def inspect
-    "#<GitHubPackages: org=#{@github_org}>"
-  end
-
-  sig { params(org: T.nilable(String)).void }
-  def initialize(org: "homebrew")
-    @github_org = org
-
-    raise UsageError, "Must set a GitHub organisation!" unless @github_org
-
-    ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if @github_org == "homebrew" && !OS.mac?
-  end
-
   sig {
     params(
       bottles_hash:  T::Hash[String, T.untyped],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The environment variable `HOMEBREW_FORCE_HOMEBREW_ON_LINUX` is not used anymore (1cc7ca3), so let's deprecate <code>&#8209;&#8209;github&#8209;org</code>. This doesn't affect bottle uploads because the GitHub org is already inferred from `root_url`.