### PR TITLE
Add cask renames

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -58,6 +58,7 @@ module Cask
       check_missing_verified
       check_no_match
       check_generic_artifacts
+      check_token_rename
       check_token_valid
       check_token_bad_words
       check_token_conflicts
@@ -474,6 +475,13 @@ module Cask
       rescue Locale::ParserError
         add_error "Locale '#{language}' is invalid."
       end
+    end
+
+    def check_token_rename
+      return unless cask.tap
+      return unless (new_token = cask.tap.cask_renames[cask.token])
+
+      add_error "#{cask.token} is reserved as the old token of #{new_token}"
     end
 
     def check_token_conflicts

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -38,14 +38,7 @@ module Cask
 
       Pathname.glob(path.join("*")).sort.select(&:directory?).map do |path|
         token = path.basename.to_s
-
-        if (tap_path = CaskLoader.tap_paths(token).first)
-          CaskLoader::FromTapPathLoader.new(tap_path).load(config: config)
-        elsif (caskroom_path = Pathname.glob(path.join(".metadata/*/*/*/*.rb")).first)
-          CaskLoader::FromPathLoader.new(caskroom_path).load(config: config)
-        else
-          CaskLoader.load(token, config: config)
-        end
+        CaskLoader.load(token, config: config, warn_renamed: false)
       end
     end
   end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -259,10 +259,8 @@ module Cask
 
     # @api public
     def staged_path
-      return @staged_path if @staged_path
-
       cask_version = version || :unknown
-      @staged_path = caskroom_path.join(cask_version.to_s)
+      caskroom_path.join(cask_version.to_s)
     end
 
     # @api public

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -88,8 +88,7 @@ module Cask
       raise e
     end
 
-    def install
-      start_time = Time.now
+    def install(print_heading: true, start_time: Time.now)
       odebug "Cask::Installer#install"
 
       old_config = @cask.config
@@ -107,7 +106,7 @@ module Cask
 
       backup if force? && @cask.staged_path.exist? && @cask.metadata_versioned_path.exist?
 
-      oh1 "Installing Cask #{Formatter.identifier(@cask)}"
+      oh1 "Installing Cask #{Formatter.identifier(@cask)}" if print_heading
       opoo "macOS's Gatekeeper has been disabled for this Cask" unless quarantine?
       stage
 
@@ -388,8 +387,8 @@ module Cask
       @cask.config_path.atomic_write(@cask.config.to_json)
     end
 
-    def uninstall
-      oh1 "Uninstalling Cask #{Formatter.identifier(@cask)}"
+    def uninstall(print_heading: true)
+      oh1 "Uninstalling Cask #{Formatter.identifier(@cask)}" if print_heading
       uninstall_artifacts(clear: true)
       remove_config_file if !reinstall? && !upgrade?
       purge_versioned_files

--- a/Library/Homebrew/cask/metadata.rb
+++ b/Library/Homebrew/cask/metadata.rb
@@ -10,7 +10,7 @@ module Cask
     TIMESTAMP_FORMAT = "%Y%m%d%H%M%S.%L"
 
     def metadata_main_container_path
-      @metadata_main_container_path ||= caskroom_path.join(METADATA_SUBDIR)
+      caskroom_path.join(METADATA_SUBDIR)
     end
 
     def metadata_versioned_path(version: self.version)

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -65,15 +65,17 @@ module Homebrew
         [:switch, "--keep-tmp", {
           description: "Retain the temporary files created during installation.",
         }],
-        [:switch, "--display-times", {
-          env:         :display_install_times,
-          description: "Print install times for each package at the end of the run.",
-        }],
       ].each do |options|
         send(*options)
         conflicts "--cask", options[-2]
       end
+
+      switch "--display-times",
+             env:         :display_install_times,
+             description: "Print install times for each package at the end of the run."
+
       formula_options
+
       [
         [:switch, "--cask", "--casks", {
           description: "Treat all named arguments as casks. If no named arguments " \

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -21,6 +21,7 @@ class Tap
   TAP_DIRECTORY = (HOMEBREW_LIBRARY/"Taps").freeze
 
   HOMEBREW_TAP_FORMULA_RENAMES_FILE = "formula_renames.json"
+  HOMEBREW_TAP_CASK_RENAMES_FILE = "cask_renames.json"
   HOMEBREW_TAP_MIGRATIONS_FILE = "tap_migrations.json"
   HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR = "audit_exceptions"
   HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR = "style_exceptions"
@@ -28,6 +29,7 @@ class Tap
 
   HOMEBREW_TAP_JSON_FILES = %W[
     #{HOMEBREW_TAP_FORMULA_RENAMES_FILE}
+    #{HOMEBREW_TAP_CASK_RENAMES_FILE}
     #{HOMEBREW_TAP_MIGRATIONS_FILE}
     #{HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR}/*.json
     #{HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR}/*.json
@@ -614,6 +616,15 @@ class Tap
   # Hash with tap formula renames.
   def formula_renames
     @formula_renames ||= if (rename_file = path/HOMEBREW_TAP_FORMULA_RENAMES_FILE).file?
+      JSON.parse(rename_file.read)
+    else
+      {}
+    end
+  end
+
+  # Hash with tap cask renames.
+  def cask_renames
+    @cask_renames ||= if (rename_file = path/HOMEBREW_TAP_CASK_RENAMES_FILE).file?
       JSON.parse(rename_file.read)
     else
       {}

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -269,6 +269,7 @@ RSpec.configure do |config|
         CoreTap.instance.path/".git",
         CoreTap.instance.alias_dir,
         CoreTap.instance.path/"formula_renames.json",
+        CoreTap.instance.path/"cask_renames.json",
         CoreTap.instance.path/"tap_migrations.json",
         CoreTap.instance.path/"audit_exceptions",
         CoreTap.instance.path/"style_exceptions",

--- a/docs/Rename-A-Cask.md
+++ b/docs/Rename-A-Cask.md
@@ -1,0 +1,16 @@
+# Renaming a Cask
+
+Sometimes software and casks need to be renamed. To rename a cask
+you need to:
+
+1. Rename the casks file and its class to a new cask. The new name must meet all the usual rules of cask naming. Fix any test failures that may occur due to the stricter requirements for new casks than existing casks (i.e. `brew audit --online --new --cask` must pass for that cask).
+
+2. Create a pull request to the corresponding tap deleting the old cask file, adding the new cask file, and adding it to `cask_renames.json` with a commit message like `newack: renamed from ack`. Use the canonical name (e.g. `ack` instead of `user/repo/ack`).
+
+A `cask_renames.json` example for a cask rename:
+
+```json
+{
+  "ack": "newack"
+}
+```

--- a/docs/Rename-A-Formula.md
+++ b/docs/Rename-A-Formula.md
@@ -3,7 +3,7 @@
 Sometimes software and formulae need to be renamed. To rename a formula
 you need to:
 
-1. Rename the formula file and its class to a new formula. The new name must meet all the usual rules of formula naming. Fix any test failures that may occur due to the stricter requirements for new formulae than existing formulae (i.e. `brew audit --online --new-formula` must pass for that formula).
+1. Rename the formula file and its class to a new formula. The new name must meet all the usual rules of formula naming. Fix any test failures that may occur due to the stricter requirements for new formulae than existing formulae (i.e. `brew audit --online --new --formula` must pass for that formula).
 
 2. Create a pull request to the corresponding tap deleting the old formula file, adding the new formula file, and adding it to `formula_renames.json` with a commit message like `newack: renamed from ack`. Use the canonical name (e.g. `ack` instead of `user/repo/ack`).
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This adds support for `cask_renames.json` (`formula_renames.json` for casks).

Some notes:

- [`update-report` doesn't report cask renames, which I have started working on.](https://github.com/FnControlOption/brew/commit/da5bc7b8c925fba5ac8e7e9435d1bb2412dac50f)
- The documentation and tests so far are from https://github.com/Homebrew/brew/pull/12189
- There are probably some places that use `Formula#oldname` which I have ignored.

Affected homebrew-cask PRs:

- [110172: `youtube-dl-gui` was renamed to `open-video-downloader`](https://github.com/Homebrew/homebrew-cask/pull/110172)
- [114668: `alt-tab` should be renamed to `alttab`](https://github.com/Homebrew/homebrew-cask/pull/114668)