### PR TITLE
dev-cmd/cat: auto-install `bat` when running `brew cat ...` with `HOMEBREW_BAT` set

### DIFF
--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cli/parser"
+require "formula"
 
 module Homebrew
   extend T::Sig
@@ -31,8 +32,16 @@ module Homebrew
 
     cd HOMEBREW_REPOSITORY
     pager = if Homebrew::EnvConfig.bat?
+      unless Formula["bat"].any_version_installed?
+        # The user might want to capture the output of `brew cat ...`
+        # Redirect stdout to stderr
+        redirect_stdout($stderr) do
+          ohai "Installing `bat` for displaying <formula>/<cask> source..."
+          safe_system HOMEBREW_BREW_FILE, "install", "bat"
+        end
+      end
       ENV["BAT_CONFIG_PATH"] = Homebrew::EnvConfig.bat_config_path
-      "#{HOMEBREW_PREFIX}/bin/bat"
+      Formula["bat"].opt_bin/"bat"
     else
       "cat"
     end

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "cli/parser"
-require "formula"
 
 module Homebrew
   extend T::Sig
@@ -32,6 +31,8 @@ module Homebrew
 
     cd HOMEBREW_REPOSITORY
     pager = if Homebrew::EnvConfig.bat?
+      require "formula"
+
       unless Formula["bat"].any_version_installed?
         # The user might want to capture the output of `brew cat ...`
         # Redirect stdout to stderr

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -437,19 +437,21 @@ module Kernel
     $stderr = old
   end
 
-  def nostdout
+  def nostdout(&block)
     if verbose?
       yield
     else
-      begin
-        out = $stdout.dup
-        $stdout.reopen(File::NULL)
-        yield
-      ensure
-        $stdout.reopen(out)
-        out.close
-      end
+      redirect_stdout(File::NULL, &block)
     end
+  end
+
+  def redirect_stdout(file)
+    out = $stdout.dup
+    $stdout.reopen(file)
+    yield
+  ensure
+    $stdout.reopen(out)
+    out.close
   end
 
   def paths


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Fallback to `cat` when `HOMEBREW_BAT` set but `bat` is not installed.

```console
$ brew uninstall bat
$ export HOMEBREW_CAT=1
$ brew cat bat      
Error: Failure while executing; `/home/linuxbrew/.linuxbrew/bin/bat /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/bat.rb` exited with 1.
```

This version:

```console
$ brew cat bat
Warning: Command `bat` is not installed, falling back to `cat`.
class Bat < Formula
  desc "Clone of cat(1) with syntax highlighting and Git integration"
...
```