### PR TITLE
Output environment variable hints.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -230,7 +230,16 @@ EOS
 # exceeds 3 seconds.
 update-preinstall-timer() {
   sleep 3
-  echo 'Updating Homebrew...' >&2
+  # Outputting a command but don't want to run it, hence single quotes.
+  # shellcheck disable=SC2016
+  echo 'Running `brew update --preinstall`...' >&2
+  if [[ -z "${HOMEBREW_NO_ENV_HINTS}" && -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
+  then
+    # shellcheck disable=SC2016
+    echo 'Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with' >&2
+    # shellcheck disable=SC2016
+    echo 'HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).' >&2
+  fi
 }
 
 # These variables are set from various Homebrew scripts.

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -162,8 +162,19 @@ module Homebrew
         cleanup.periodic_clean!
       elsif f.latest_version_installed? && !cleanup.skip_clean_formula?(f)
         ohai "Running `brew cleanup #{f}`..."
+        puts_no_install_cleanup_disable_message_if_not_already!
         cleanup.cleanup_formula(f)
       end
+    end
+
+    def self.puts_no_install_cleanup_disable_message_if_not_already!
+      return if Homebrew::EnvConfig.no_env_hints?
+      return if Homebrew::EnvConfig.no_install_cleanup?
+      return if @puts_no_install_cleanup_disable_message_if_not_already
+
+      puts "Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP."
+      puts "Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`)."
+      @puts_no_install_cleanup_disable_message_if_not_already = true
     end
 
     def skip_clean_formula?(f)
@@ -194,6 +205,7 @@ module Homebrew
         ohai "`brew cleanup` has not been run in the last #{CLEANUP_DEFAULT_DAYS} days, running now..."
       end
 
+      Cleanup.puts_no_install_cleanup_disable_message_if_not_already!
       return if dry_run?
 
       clean!(quiet: true, periodic: true)

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -257,6 +257,10 @@ module Homebrew
                      "\n\n    *Note:* Will only try to print emoji on OS X Lion or newer.",
         boolean:     true,
       },
+      HOMEBREW_NO_ENV_HINTS:                   {
+        description: "If set, do not print any hints about changing Homebrew's behaviour with environment variables.",
+        boolean:     true,
+      },
       HOMEBREW_NO_GITHUB_API:                  {
         description: "If set, do not use the GitHub API, e.g. for searches or fetching relevant issues " \
                      "after a failed install.",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2095,6 +2095,9 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
     *Note:* Will only try to print emoji on OS X Lion or newer.
 
+- `HOMEBREW_NO_ENV_HINTS`
+  <br>If set, do not print any hints about changing Homebrew's behaviour with environment variables.
+
 - `HOMEBREW_NO_GITHUB_API`
   <br>If set, do not use the GitHub API, e.g. for searches or fetching relevant issues after a failed install.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3041,6 +3041,12 @@ If set, do not print \fBHOMEBREW_INSTALL_BADGE\fR on a successful build\.
 \fINote:\fR Will only try to print emoji on OS X Lion or newer\.
 .
 .TP
+\fBHOMEBREW_NO_ENV_HINTS\fR
+.
+.br
+If set, do not print any hints about changing Homebrew\'s behaviour with environment variables\.
+.
+.TP
 \fBHOMEBREW_NO_GITHUB_API\fR
 .
 .br


### PR DESCRIPTION
Output hints for disabling automatic `brew update`, `brew cleanup` and `brew upgrade`/`brew reinstall` of dependents. Also provide a `HOMEBREW_NO_ENV_HINTS` to disable this messaging.

Extracted from https://github.com/Homebrew/brew/pull/12413.

@Homebrew/maintainers interested again in your thoughts on this implementation. Since the last one I've added:
- some warnings when these variables are set
- the `HOMEBREW_NO_ENV_HINTS` variable