### PR TITLE
ENV/super: enable deterministic archive generation

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -127,6 +127,12 @@ module Superenv
     # The tools in /usr/bin proxy to the active developer directory.
     # This means we can use them for any combination of CLT and Xcode.
     self["HOMEBREW_PREFER_CLT_PROXIES"] = "1"
+
+    # Deterministic timestamping.
+    # This can work on older Xcode versions, but they contain some bugs.
+    # Notably, Xcode 10.2 fixes issues where ZERO_AR_DATE affected file mtimes.
+    # Xcode 11.0 contains fixes for lldb reading things built with ZERO_AR_DATE.
+    self["ZERO_AR_DATE"] = "1" if MacOS::Xcode.version >= "11.0" || MacOS::CLT.version >= "11.0"
   end
 
   def no_weak_imports


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

By "archive" I mean the generation of `.a` files, like static libraries.

`ZERO_AR_DATE` tells Apple's tools to set the timestamp within these archives to 0.