### PR TITLE
upgrade: don't upgrade unbottled dependents of upgraded formulae

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -285,7 +285,7 @@ module Homebrew
       if skipped_dependents.present?
         opoo <<~EOS
           The following dependents of upgraded formulae are outdated but will not
-          be upgraded:
+          be upgraded because they are not bottled:
             #{skipped_dependents * "\n  "}
         EOS
       end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -276,6 +276,20 @@ module Homebrew
         installed_formulae.flat_map(&:runtime_installed_formula_dependents)
                           .uniq
                           .select(&:outdated?)
+
+      # Ensure we never attempt a source build for outdated dependents of upgraded formulae.
+      outdated_dependents, skipped_dependents = outdated_dependents.partition do |dependent|
+        dependent.bottled? && dependent.deps.all?(&:bottled?)
+      end
+
+      if skipped_dependents.present?
+        opoo <<~EOS
+          The following dependents of upgraded formulae are outdated but will not
+          be upgraded:
+            #{skipped_dependents * "\n  "}
+        EOS
+      end
+
       return if outdated_dependents.blank? && already_broken_dependents.blank?
 
       outdated_dependents -= installed_formulae if dry_run


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We upgrade dependents of upgraded formulae to make sure that an upgrade
doesn't break anything. However, this reasoning applies only when a
dependent is bottled, since attempting a source build is just as likely
to break things, if not more.

I've opted not to restrict this to, say, users only on outdated versions
of macOS in order to cleanly handle other cases where this change should
also apply: Linux, or current versions of macOS in a non-default prefix.