### PR TITLE
rubocops/lines: allow `OS.foo?` in `service` blocks

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -354,7 +354,7 @@ module RuboCop
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           no_on_os_method_names = [:install, :post_install].freeze
-          no_on_os_block_names = [:test].freeze
+          no_on_os_block_names = [:service, :test].freeze
           [[:on_macos, :mac?], [:on_linux, :linux?]].each do |on_method_name, if_method_name|
             if_method_and_class = "if OS.#{if_method_name}"
             no_on_os_method_names.each do |formula_method_name|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These seem more natural, and I don't think we need to be able to mock
service blocks on other OSs.

See Homebrew/homebrew-core#90091.