### PR TITLE
rubocops/lines: disallow `pyoxidizer` as a build/runtime dependency

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -211,6 +211,32 @@ module RuboCop
         end
       end
 
+      # This cop makes sure that formulae do not depend on `pyoxidizer` at build-time
+      # or run-time.
+      #
+      # @api private
+      class PyoxidizerCheck < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          # Disallow use of PyOxidizer as a dependency in core
+          return unless formula_tap == "homebrew-core"
+
+          find_method_with_args(body_node, :depends_on, "pyoxidizer") do
+            problem "Formulae in homebrew/core should not use '#{@offensive_node.source}'."
+          end
+
+          [
+            :build,
+            [:build],
+            [:build, :test],
+            [:test, :build],
+          ].each do |type|
+            find_method_with_args(body_node, :depends_on, "pyoxidizer" => type) do
+              problem "Formulae in homebrew/core should not use '#{@offensive_node.source}'."
+            end
+          end
+        end
+      end
+
       # This cop makes sure that the safe versions of `popen_*` calls are used.
       #
       # @api private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

PyOxidizer downloads pre-built versions of Rust and Python, and embeds
this Python into the binaries it produces.

This goes against a number of our packaging policies, so let's make sure
formulae in Homebrew/core don't do this.

See Homebrew/homebrew-core#90025.