### PR TITLE
Remove unknown YARD tags

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -30,7 +30,6 @@ module Superenv
   end
 
   # The location of Homebrew's shims on this OS.
-  # @public
   sig { returns(Pathname) }
   def self.shims_path
     HOMEBREW_SHIMS_PATH/"super"

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -5,7 +5,6 @@ module Superenv
   extend T::Sig
 
   # The location of Homebrew's shims on Linux.
-  # @public
   def self.shims_path
     HOMEBREW_SHIMS_PATH/"linux/super"
   end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -6,7 +6,6 @@ module Superenv
 
   class << self
     # The location of Homebrew's shims on macOS.
-    # @public
     def shims_path
       HOMEBREW_SHIMS_PATH/"mac/super"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`@public` is not a valid YARD [tag](https://www.rubydoc.info/gems/yard/file/docs/Tags.md)
Fixes https://github.com/Homebrew/rubydoc.brew.sh/runs/4369650006?check_suite_focus=true#step:7:8
cc @MikeMcQuaid 