### PR TITLE
bug.yml: fix missing `label` property

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: New issue for Reproducible Bug
 description: "If you're sure it's reproducible and not just your machine: submit an issue so we can investigate."
-labels: bug
+labels: [bug]
 body:
   - type: markdown
     attributes:
@@ -19,6 +19,7 @@ body:
       required: true
   - type: checkboxes
     attributes:
+      label: Verification
       description: Please verify that you've followed these steps.
       options:
         - label: I ran `brew update` and am still able to reproduce my issue.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Submitting bug reports hasn't worked for a while because of the missing
`label`.

My editor complained about `labels` needing to be an array, so I've made
that one too. It was also complaining about the missing label property
for the checkboxes, so I guess it knows what it's talking about here.

See https://github.com/Homebrew/discussions/discussions/2526#discussioncomment-1731168