### PR TITLE
Fix error message duplication for installation from URL

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -45,6 +45,8 @@ class KegUnspecifiedError < UsageError
   end
 end
 
+class UnsupportedInstallationMethod < RuntimeError; end
+
 class MultipleVersionsInstalledError < RuntimeError; end
 
 class NotAKegError < RuntimeError; end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -274,12 +274,14 @@ module Formulary
 
     def load_file(flags:, ignore_errors:)
       if %r{githubusercontent.com/[\w-]+/[\w-]+/[a-f0-9]{40}(?:/Formula)?/(?<formula_name>[\w+-.@]+).rb} =~ url
-        raise UsageError, "Installation of #{formula_name} from a GitHub commit URL is unsupported! " \
-                          "`brew extract #{formula_name}` to a stable tap on GitHub instead."
+        raise UnsupportedInstallationMethod,
+              "Installation of #{formula_name} from a GitHub commit URL is unsupported! " \
+              "`brew extract #{formula_name}` to a stable tap on GitHub instead."
       elsif url.match?(%r{^(https?|ftp)://})
-        raise UsageError, "Non-checksummed download of #{name} formula file from an arbitrary URL is unsupported! ",
-              "`brew extract` or `brew create` and `brew tap-new` to create a "\
-              "formula file in a tap on GitHub instead."
+        raise UnsupportedInstallationMethod,
+              "Non-checksummed download of #{name} formula file from an arbitrary URL is unsupported! " \
+              "`brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap " \
+              "on GitHub instead."
       end
       HOMEBREW_CACHE_FORMULA.mkpath
       FileUtils.rm_f(path)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before:
```
$ brew install https://raw.githubusercontent.com/nginx/homebrew-unit/master/Formula/unit.rb
`brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.: Invalid usage: Non-checksummed download of unit formula file from an arbitrary URL is unsupported!  (UsageError)
`brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.: Invalid usage: Non-checksummed download of unit formula file from an arbitrary URL is unsupported!  (UsageError)
```

After:
```
$ brew install https://raw.githubusercontent.com/nginx/homebrew-unit/master/Formula/unit.rb
Error: Invalid usage: Non-checksummed download of unit formula file from an arbitrary URL is unsupported! `brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.
```


