### PR TITLE
shims: make xcrun look at superenv bin first

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -123,10 +123,6 @@ module Superenv
       ENV["ac_have_clock_syscall"] = "no"
     end
 
-    # The tools in /usr/bin proxy to the active developer directory.
-    # This means we can use them for any combination of CLT and Xcode.
-    self["HOMEBREW_PREFER_CLT_PROXIES"] = "1"
-
     # Deterministic timestamping.
     # This can work on older Xcode versions, but they contain some bugs.
     # Notably, Xcode 10.2 fixes issues where ZERO_AR_DATE affected file mtimes.

--- a/Library/Homebrew/shims/mac/super/apr-1-config
+++ b/Library/Homebrew/shims/mac/super/apr-1-config
@@ -11,7 +11,7 @@ then
     --includes) echo "-isystem${HOMEBREW_SDKROOT}/usr/include/apr-1" ;;
     --apr-libtool) echo "glibtool" ;;
     *)
-      exec xcrun apr-1-config "$@"
+      exec /usr/bin/apr-1-config "$@"
       ;;
   esac
 else

--- a/Library/Homebrew/shims/mac/super/bsdmake
+++ b/Library/Homebrew/shims/mac/super/bsdmake
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-export HOMEBREW_CCCFG="O${HOMEBREW_CCCFG}"
-exec xcrun bsdmake "$@"

--- a/Library/Homebrew/shims/mac/super/make
+++ b/Library/Homebrew/shims/mac/super/make
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export HOMEBREW_CCCFG="O${HOMEBREW_CCCFG}"
-exec xcrun "make" "$@"
+exec env -u DEVELOPER_DIR /usr/bin/make "$@"

--- a/Library/Homebrew/shims/mac/super/mig
+++ b/Library/Homebrew/shims/mac/super/mig
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 pwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec xcrun mig -cc "${pwd}/cc" "$@"
+exec env -u DEVELOPER_DIR /usr/bin/mig -cc "${pwd}/cc" "$@"

--- a/Library/Homebrew/shims/mac/super/xcrun
+++ b/Library/Homebrew/shims/mac/super/xcrun
@@ -25,53 +25,94 @@ then
   exec /usr/bin/xcrun "$@"
 fi
 
-# shellcheck disable=SC2249
-case "$1" in
-  -*) exec /usr/bin/xcrun "$@" ;;
-esac
+allargs=("$@")
+mode="run"
+log=0
+while [[ $# -gt 0 ]]
+do
+  case "$1" in
+    -show-* | --show-* | -version | --version | -h | --h | -help | --help)
+      mode="show"
+      break 2
+      ;;
+    -f | --f | -find | --find)
+      mode="find"
+      shift
+      ;;
+    -r | --r | -run | --run)
+      mode="run"
+      shift
+      ;;
+    -l | --l | -log | --log)
+      log=1
+      shift
+      ;;
+    -sdk | --sdk | -toolchain | --toolchain)
+      shift
+      shift
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      program="$1"
+      shift
+      postargs=("$@")
+      break 2
+      ;;
+  esac
+done
 
-arg0="$1"
-shift
-
-exe="/usr/bin/${arg0}"
-if [[ -x "${exe}" ]]
+if [[ "${mode}" == "show" ]]
 then
-  if [[ -n "${HOMEBREW_PREFER_CLT_PROXIES}" ]]
+  exec /usr/bin/xcrun "${allargs[@]}"
+fi
+
+if [[ -z "${program}" ]]
+then
+  echo "Program name not passed." >&2
+  exit 1
+fi
+
+try_exe() {
+  if [[ -x "$1" ]]
   then
-    exec "${exe}" "$@"
-  elif [[ -z "${HOMEBREW_SDKROOT}" || ! -d "${HOMEBREW_SDKROOT}" ]]
-  then
-    exec "${exe}" "$@"
+    if [[ "${mode}" == "find" ]]
+    then
+      echo "$1"
+      exit 0
+    else
+      if [[ "${log}" == "1" ]]
+      then
+        echo "env" "SDKROOT=${SDKROOT}" "$1" "${postargs[@]}"
+      fi
+      exec "$1" "${postargs[@]}"
+    fi
   fi
-fi
+}
 
-SUPERBIN="$(cd "${0%/*}" && pwd -P)"
+superbin="$(cd "${0%/*}" && pwd -P)"
+try_exe "${superbin}/${program}"
 
-exe="$(/usr/bin/xcrun --find "${arg0}" 2>/dev/null)"
-if [[ -x "${exe}" && "${exe%/*}" != "${SUPERBIN}" ]]
-then
-  exec "${exe}" "$@"
-fi
+try_exe "/usr/bin/${program}"
+
+try_exe "$(/usr/bin/xcrun --find "${program}" 2>/dev/null)"
 
 old_IFS="${IFS}"
 IFS=':'
 for path in ${PATH}
 do
-  if [[ "${path}" == "${SUPERBIN}" ]]
+  if [[ "${path}" == "${superbin}" ]]
   then
     continue
   fi
 
-  exe="${path}/${arg0}"
-  if [[ -x "${exe}" ]]
-  then
-    exec "${exe}" "$@"
-  fi
+  try_exe "${path}/${program}"
 done
 IFS="${old_IFS}"
 
 echo >&2 "
-Failed to execute ${arg0} ${*}
+Failed to find ${program} ${*}
 
 Xcode and/or the CLT appear to be misconfigured. Try one or both of the following:
   xcodebuild -license

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -470,7 +470,7 @@ if __FILE__ == $PROGRAM_NAME
 
   args << { close_others: false }
   if mac?
-    exec "#{dirname}/xcrun", tool, *args
+    exec({"DEVELOPER_DIR" => nil}, "/usr/bin/#{tool}", *args)
   else
     paths = ENV["PATH"].split(":")
     paths = remove_superbin_from_path(paths)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This closes a superenv bypass where build systems using `xcrun clang` or `xcrun --find clang` returned the path directly to Xcode's clang. This meant formulae like `qt@5` has never used our superenv clang.

This does require a bit of arg parsing in our xcrun shim which is unfortunate (need to watch for changes to system xcrun - though the tool has been stable for a while), but necessary to replicate the behaviour of system xcrun.