### PR TITLE
Bypass searching for open Issues when failing to install a formula without a tap

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -61,7 +61,9 @@ module GitHub
     end
   end
 
-  def issues_for_formula(name, tap: CoreTap.instance, tap_remote_repo: tap.full_name, state: nil)
+  def issues_for_formula(name, tap: CoreTap.instance, tap_remote_repo: tap&.full_name, state: nil)
+    return [] unless tap_remote_repo
+
     search_issues(name, repo: tap_remote_repo, state: state, in: "title")
   end
 


### PR DESCRIPTION
Given a formula with a broken build, if you install it locally with `brew install path/to/formula.rb`, when the build fails, Homebrew will attempt to [search for open issues on the tap](https://github.com/Homebrew/brew/blob/073c4177b5d2f3c869181fb6eaab2bfa33d368ce/Library/Homebrew/exceptions.rb#L489); but in this case `formula.tap` is `nil` and `tap.full_name` would raise a `NoMethodError` yielding this output:

```
$ brew install ./erg.rb
Error: Failed to load cask: ./erg.rb
Cask 'erg' is unreadable: wrong constant name #<Class:0x00007fd89b246cd0>
Warning: Treating ./erg.rb as a formula.
==> Downloading https://github.com/square/erg/archive/v1.1.1.tar.gz
Already downloaded: /Users/lail/Library/Caches/Homebrew/downloads/54e3fce84302901d76d50b53aa7fe760cfcf81c9842a232d6b29e771de6ec9c5--erg-1.1.1.tar.gz
Warning: Cannot verify integrity of '54e3fce84302901d76d50b53aa7fe760cfcf81c9842a232d6b29e771de6ec9c5--erg-1.1.1.tar.gz'.
No checksum was provided for this resource.
For your reference, the checksum is:
  sha256 "8dbcff3dfd67b8f6e8f2dfd4f57cf818ce0cd6ce4b52566611e698fc8778507f"
==> go get github.com/square/erg
Last 15 lines from /Users/lail/Library/Logs/Homebrew/erg/01.go:
2021-12-02 16:45:31 +0000

go
get
github.com/square/erg

go: downloading github.com/square/erg v1.2.1
go: downloading vbom.ml/util v0.0.3
go: downloading vbom.ml/util/sortorder v1.0.2
go: downloading github.com/square/grange v0.0.0-20201015231752-48d66acdd125
go: downloading github.com/deckarep/golang-set v0.0.0-20170202203032-fc8930a5e645
go: downloading github.com/fvbommel/sortorder v1.0.1
go: downloading github.com/orcaman/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6
github.com/square/erg imports
	vbom.ml/util/sortorder: cannot find module providing package vbom.ml/util/sortorder

Do not report this issue to Homebrew/brew or Homebrew/core!

/usr/local/Homebrew/Library/Homebrew/utils/github.rb:64:in `issues_for_formula': undefined method `full_name' for nil:NilClass (NoMethodError)
	from /usr/local/Homebrew/Library/Homebrew/exceptions.rb:489:in `fetch_issues'
	from /usr/local/Homebrew/Library/Homebrew/exceptions.rb:485:in `issues'
	from /usr/local/Homebrew/Library/Homebrew/exceptions.rb:539:in `dump'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:155:in `rescue in <main>'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:143:in `<main>'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2306:in `block in system': Failed executing: go get github.com/square/erg (BuildError)
	from /usr/local/Homebrew/Library/Homebrew/formula.rb:2242:in `open'
	from /usr/local/Homebrew/Library/Homebrew/formula.rb:2242:in `system'
	from /Users/lail/Code/homebrew-formulas/erg.rb:13:in `install'
	from /usr/local/Homebrew/Library/Homebrew/build.rb:172:in `block (3 levels) in install'
	from /usr/local/Homebrew/Library/Homebrew/utils.rb:588:in `with_env'
	from /usr/local/Homebrew/Library/Homebrew/build.rb:134:in `block (2 levels) in install'
	from /usr/local/Homebrew/Library/Homebrew/formula.rb:1297:in `block in brew'
	from /usr/local/Homebrew/Library/Homebrew/formula.rb:2472:in `block (2 levels) in stage'
	from /usr/local/Homebrew/Library/Homebrew/utils.rb:588:in `with_env'
	from /usr/local/Homebrew/Library/Homebrew/formula.rb:2471:in `block in stage'
	from /usr/local/Homebrew/Library/Homebrew/resource.rb:126:in `block (2 levels) in unpack'
	from /usr/local/Homebrew/Library/Homebrew/download_strategy.rb:115:in `chdir'
	from /usr/local/Homebrew/Library/Homebrew/download_strategy.rb:115:in `chdir'
	from /usr/local/Homebrew/Library/Homebrew/download_strategy.rb:102:in `stage'
	from /usr/local/Homebrew/Library/Homebrew/resource.rb:122:in `block in unpack'
	from /usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `block in run'
	from /usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `chdir'
	from /usr/local/Homebrew/Library/Homebrew/mktemp.rb:63:in `run'
	from /usr/local/Homebrew/Library/Homebrew/resource.rb:208:in `mktemp'
	from /usr/local/Homebrew/Library/Homebrew/resource.rb:121:in `unpack'
	from /usr/local/Homebrew/Library/Homebrew/resource.rb:96:in `stage'
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/2.6.0/forwardable.rb:230:in `stage'
	from /usr/local/Homebrew/Library/Homebrew/formula.rb:2451:in `stage'
	from /usr/local/Homebrew/Library/Homebrew/formula.rb:1290:in `brew'
	from /usr/local/Homebrew/Library/Homebrew/build.rb:129:in `block in install'
	from /usr/local/Homebrew/Library/Homebrew/utils.rb:588:in `with_env'
	from /usr/local/Homebrew/Library/Homebrew/build.rb:124:in `install'
	from /usr/local/Homebrew/Library/Homebrew/build.rb:224:in `<main>'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
