### PR TITLE
install: Allow brew to install ARM packages even if terminal running in rosetta

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -13,7 +13,7 @@ module Hardware
       def type
         case sysctl_int("hw.cputype")
         when MachO::Headers::CPU_TYPE_I386
-          :intel
+          in_rosetta2? ? :arm : :intel
         when MachO::Headers::CPU_TYPE_ARM64
           :arm
         else

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -31,18 +31,8 @@ module Homebrew
     end
 
     def check_prefix
-      if (Hardware::CPU.intel? || Hardware::CPU.in_rosetta2?) &&
-         HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX
-        if Hardware::CPU.in_rosetta2?
-          odie <<~EOS
-            Cannot install under Rosetta 2 in ARM default prefix (#{HOMEBREW_PREFIX})!
-            To rerun under ARM use:
-                arch -arm64 brew install ...
-            To install under x86_64, install Homebrew into #{HOMEBREW_DEFAULT_PREFIX}.
-          EOS
-        else
-          odie "Cannot install on Intel processor in ARM default prefix (#{HOMEBREW_PREFIX})!"
-        end
+      if Hardware::CPU.intel? && HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX
+        odie "Cannot install on Intel processor in ARM default prefix (#{HOMEBREW_PREFIX})!"
       elsif Hardware::CPU.arm? && HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX
         odie <<~EOS
           Cannot install in Homebrew on ARM processor in Intel default prefix (#{HOMEBREW_PREFIX})!


### PR DESCRIPTION
If terminal is running in rosetta, it's still ok to install
ARM programs, as rosetta will happily run native executables
in subprocesses. See #10313 for discussion.

This allows brew to work out-of-box on M1 macs in terminal emulators that
are currently running in rosetta (eg alacritty, kitty)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
   - I am happy with existing test coverage on install, but would be open to adding tests with some assistance from maintainers
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
