### PR TITLE
Fix analytics_spec.rb test to pass when run from M1

### DIFF
--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -11,11 +11,13 @@ describe Utils::Analytics do
         described_class.clear_os_arch_prefix_ci
       end
 
+      ci = ", CI" if ENV["CI"]
+
       it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix on intel" do
         allow(Hardware::CPU).to receive(:type).and_return(:intel)
         allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(false)
         allow(Homebrew).to receive(:default_prefix?).and_return(false)
-        expected = "#{OS_VERSION}, #{described_class.custom_prefix_label}"
+        expected = "#{OS_VERSION}, #{described_class.custom_prefix_label}#{ci}"
         expect(described_class.os_arch_prefix_ci).to eq expected
       end
 
@@ -23,7 +25,7 @@ describe Utils::Analytics do
         allow(Hardware::CPU).to receive(:type).and_return(:arm)
         allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(false)
         allow(Homebrew).to receive(:default_prefix?).and_return(false)
-        expected = "#{OS_VERSION}, ARM, #{described_class.custom_prefix_label}"
+        expected = "#{OS_VERSION}, ARM, #{described_class.custom_prefix_label}#{ci}"
         expect(described_class.os_arch_prefix_ci).to eq expected
       end
 
@@ -31,7 +33,7 @@ describe Utils::Analytics do
         allow(Hardware::CPU).to receive(:type).and_return(:intel)
         allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(true)
         allow(Homebrew).to receive(:default_prefix?).and_return(false)
-        expected = "#{OS_VERSION}, Rosetta, #{described_class.custom_prefix_label}"
+        expected = "#{OS_VERSION}, Rosetta, #{described_class.custom_prefix_label}#{ci}"
         expect(described_class.os_arch_prefix_ci).to eq expected
       end
 

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -14,7 +14,9 @@ describe Utils::Analytics do
       it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix" do
         allow(Hardware::CPU).to receive(:type).and_return(:intel)
         allow(Homebrew).to receive(:default_prefix?).and_return(false)
-        expect(described_class.os_arch_prefix_ci).to include("#{OS_VERSION}, #{described_class.custom_prefix_label}")
+        arch = ", #{described_class.arch_label}" if described_class.arch_label.present?
+        expected = "#{OS_VERSION}#{arch}, #{described_class.custom_prefix_label}"
+        expect(described_class.os_arch_prefix_ci).to include(expected)
       end
 
       it "does not include prefix when HOMEBREW_PREFIX is the default prefix" do

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -11,12 +11,28 @@ describe Utils::Analytics do
         described_class.clear_os_arch_prefix_ci
       end
 
-      it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix" do
+      it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix on intel" do
         allow(Hardware::CPU).to receive(:type).and_return(:intel)
+        allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(false)
         allow(Homebrew).to receive(:default_prefix?).and_return(false)
-        arch = ", #{described_class.arch_label}" if described_class.arch_label.present?
-        expected = "#{OS_VERSION}#{arch}, #{described_class.custom_prefix_label}"
-        expect(described_class.os_arch_prefix_ci).to include(expected)
+        expected = "#{OS_VERSION}, #{described_class.custom_prefix_label}"
+        expect(described_class.os_arch_prefix_ci).to eq expected
+      end
+
+      it 'returns OS_VERSION, "ARM" and prefix when HOMEBREW_PREFIX is a custom prefix on arm' do
+        allow(Hardware::CPU).to receive(:type).and_return(:arm)
+        allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(false)
+        allow(Homebrew).to receive(:default_prefix?).and_return(false)
+        expected = "#{OS_VERSION}, ARM, #{described_class.custom_prefix_label}"
+        expect(described_class.os_arch_prefix_ci).to eq expected
+      end
+
+      it 'returns OS_VERSION, "Rosetta" and prefix when HOMEBREW_PREFIX is a custom prefix using Rosetta' do
+        allow(Hardware::CPU).to receive(:type).and_return(:intel)
+        allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(true)
+        allow(Homebrew).to receive(:default_prefix?).and_return(false)
+        expected = "#{OS_VERSION}, Rosetta, #{described_class.custom_prefix_label}"
+        expect(described_class.os_arch_prefix_ci).to eq expected
       end
 
       it "does not include prefix when HOMEBREW_PREFIX is the default prefix" do

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -11,7 +11,7 @@ describe Utils::Analytics do
         described_class.clear_os_arch_prefix_ci
       end
 
-      ci = ", CI" if ENV["CI"]
+      let(:ci) { ", CI" if ENV["CI"] }
 
       it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix on intel" do
         allow(Hardware::CPU).to receive(:type).and_return(:intel)
@@ -21,7 +21,7 @@ describe Utils::Analytics do
         expect(described_class.os_arch_prefix_ci).to eq expected
       end
 
-      it 'returns OS_VERSION, "ARM" and prefix when HOMEBREW_PREFIX is a custom prefix on arm' do
+      it "returns OS_VERSION, ARM and prefix when HOMEBREW_PREFIX is a custom prefix on arm" do
         allow(Hardware::CPU).to receive(:type).and_return(:arm)
         allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(false)
         allow(Homebrew).to receive(:default_prefix?).and_return(false)
@@ -29,7 +29,7 @@ describe Utils::Analytics do
         expect(described_class.os_arch_prefix_ci).to eq expected
       end
 
-      it 'returns OS_VERSION, "Rosetta" and prefix when HOMEBREW_PREFIX is a custom prefix using Rosetta' do
+      it "returns OS_VERSION, Rosetta and prefix when HOMEBREW_PREFIX is a custom prefix on Rosetta", :needs_macos do
         allow(Hardware::CPU).to receive(:type).and_return(:intel)
         allow(Hardware::CPU).to receive(:in_rosetta2?).and_return(true)
         allow(Homebrew).to receive(:default_prefix?).and_return(false)

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "November 2021" "Homebrew" "brew"
+.TH "BREW" "1" "December 2021" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)


### PR DESCRIPTION
On M1 running from a rosetta terminal - the code puts a ", Rosetta" in the analytics string.
Can repro by running from a rosetta emulated terminal (eg alacritty). This fixes it!

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
