### PR TITLE
workflows: remove outdated Xcode switch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -267,9 +267,6 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Set up Xcode
-        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
-
       - run: brew test-bot --only-cleanup-before
 
       - run: brew config

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -26,16 +26,17 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
-      - name: Set up Xcode
-        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
+
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master
         with:
           username: BrewTestBot
+
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Check out pull request
         id: checkout
         run: |
@@ -48,6 +49,7 @@ jobs:
           echo "::set-output name=gem_name::${gem_name}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Vendor Gems
         env:
           GEM_NAME: ${{ steps.checkout.outputs.gem_name }}
@@ -61,6 +63,7 @@ jobs:
           else
             brew vendor-gems
           fi
+
       - name: Update RBI files
         env:
           GEM_NAME: ${{ steps.checkout.outputs.gem_name }}
@@ -77,6 +80,7 @@ jobs:
 
             git reset --hard
           fi
+
       - name: Push to pull request
         uses: Homebrew/actions/git-try-push@master
         with:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is no longer necessary and actually breaks things when run on `macos-11`.
