### PR TITLE
cmd/info: include aliases in info output

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -315,6 +315,8 @@ module Homebrew
 
     puts "From: #{Formatter.url(github_info(f))}"
 
+    puts "Also known as: #{f.aliases.join(", ")}" unless f.aliases.empty?
+
     puts "License: #{SPDX.license_expression_to_string f.license}" if f.license.present?
 
     unless f.deps.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?

  I realize this says to file an issue first, but the patch is small, so I figure discussion can just happen here instead.
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).

   I can't seem to find any tests that check `brew info` output. If someone can point me to an example, I can add something for this.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I ran `brew info npm`, which resolved to the node formula, which is great, but there was no mention of npm there, which is slightly confusing.

So this adds an `Also known as` section to `brew info` which includes all aliases of the formula:

```shell
$ brew info npm
node: stable 17.2.0 (bottled), HEAD
Platform built on V8 to build network applications
https://nodejs.org/
/usr/local/Cellar/node/17.2.0 (2,018 files, 45.8MB) *
  Poured from bottle on 2021-12-04 at 21:38:51
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/node.rb
Also known as: nodejs, node@17, node.js, npm
License: MIT
==> Dependencies
Build: pkg-config ✔, python@3.9 ✔
Required: brotli ✔, c-ares ✔, icu4c ✔, libnghttp2 ✔, libuv ✔, openssl@1.1 ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Analytics
install: 326,191 (30 days), 1,341,692 (90 days), 4,747,131 (365 days)
install-on-request: 263,498 (30 days), 1,082,913 (90 days), 3,712,755 (365 days)
build-error: 4,744 (30 days)
```

This is in line with what https://formulae.brew.sh shows.
