### PR TITLE
docs/Xcode: fix CLT method name

### DIFF
--- a/docs/Xcode.md
+++ b/docs/Xcode.md
@@ -3,7 +3,7 @@
 ## Supported Xcode versions
 
 Homebrew supports and recommends the latest Xcode and/or Command Line
-Tools available for your platform (see `OS::Mac::Xcode.latest_version` and `OS::Mac::CLT.latest_version` in [`Library/Homebrew/os/mac/xcode.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/os/mac/xcode.rb)).
+Tools available for your platform (see `OS::Mac::Xcode.latest_version` and `OS::Mac::CLT.latest_clang_version` in [`Library/Homebrew/os/mac/xcode.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/os/mac/xcode.rb)).
 
 ## Updating for new Xcode releases
 
@@ -12,5 +12,5 @@ updated:
 
 * In [`Library/Homebrew/os/mac/xcode.rb`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/os/mac/xcode.rb)
   * `OS::Mac::Xcode.latest_version`
-  * `OS::Mac::CLT.latest_version`
+  * `OS::Mac::CLT.latest_clang_version`
   * `OS::Mac::Xcode.detect_version_from_clang_version`


### PR DESCRIPTION
This PR is mostly an excuse to test `setup-homebrew`.