### PR TITLE
Binary patching of build prefixes

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -183,4 +183,14 @@ class Keg
     # it's wrong. -O is a BSD-grep-only option.
     "-lrO"
   end
+
+  def egrep_args
+    grep_bin = "egrep"
+    grep_args = recursive_fgrep_args
+    [grep_bin, grep_args]
+  end
+
+  def codesign_patched_binary(binary_file)
+    apply_ad_hoc_signature(binary_file)
+  end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1230,6 +1230,10 @@ class FormulaInstaller
     keg = Keg.new(formula.prefix)
     skip_linkage = formula.bottle_specification.skip_relocation?
     keg.replace_placeholders_with_locations tab.changed_files, skip_linkage: skip_linkage
+
+    return if formula.bottle_specification.skip_prefix_relocation?
+
+    keg.relocate_build_prefix(keg, Utils::Bottles.tag.default_prefix, HOMEBREW_PREFIX)
   end
 
   sig { params(output: T.nilable(String)).void }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -8,6 +8,7 @@ class Keg
   LIBRARY_PLACEHOLDER = "@@HOMEBREW_LIBRARY@@"
   PERL_PLACEHOLDER = "@@HOMEBREW_PERL@@"
   JAVA_PLACEHOLDER = "@@HOMEBREW_JAVA@@"
+  BINARY_NULL_CHARACTER = "\x00"
 
   class Relocation
     extend T::Sig
@@ -163,6 +164,49 @@ class Keg
     changed_files
   end
 
+  def relocate_build_prefix(keg, old_prefix, new_prefix)
+    # Find binaries which match prefix strings.
+    string_matches = Set.new
+    keg.each_unique_file_matching(old_prefix) do |file|
+      string_matches << file
+    end
+
+    binary_string_matches = Set.new
+    keg.each_unique_binary_file do |file|
+      binary_string_matches << file if string_matches.include?(file)
+    end
+
+    # Only consider string matches which are binary files with null bytes, and remove any
+    # matches which are sharballs found by text_files.
+    binary_string_matches -= text_files
+
+    # Split binary by null characters into array and substitute new cellar for old cellar.
+    # Null padding is added if the new string is too short.
+    binary_string_matches.each do |binary_file|
+      binary_file.ensure_writable do
+        binary = File.binread binary_file
+        puts "Replacing build prefix in: #{binary_file}"
+        binary_strings = binary.split(BINARY_NULL_CHARACTER)
+        match_indices = binary_strings.each_index.select { |i| binary_strings[i].include?(old_prefix) }
+
+        # Only perform substitution on strings which match prefix regex.
+        match_indices.each do |i|
+          s = binary_strings[i]
+          binary_strings[i] = s.gsub(old_prefix, new_prefix).ljust(s.size, BINARY_NULL_CHARACTER)
+        end
+
+        # Add back null padding at the end of the binary if needed.
+        patched_binary = binary_strings.join(BINARY_NULL_CHARACTER).ljust(binary.size, BINARY_NULL_CHARACTER)
+        if patched_binary.size != binary.size
+          raise "Patching failed!  Original and patched binary sizes do not match."
+        end
+
+        binary_file.atomic_write patched_binary
+      end
+      codesign_patched_binary(binary_file)
+    end
+  end
+
   def detect_cxx_stdlibs(_options = {})
     []
   end
@@ -172,6 +216,14 @@ class Keg
     "-lr"
   end
   alias generic_recursive_fgrep_args recursive_fgrep_args
+
+  def egrep_args
+    grep_bin = "grep"
+    grep_args = recursive_fgrep_args
+    grep_args += "Pa"
+    [grep_bin, grep_args]
+  end
+  alias generic_egrep_args egrep_args
 
   def each_unique_file_matching(string)
     Utils.popen_read("fgrep", recursive_fgrep_args, string, to_s) do |io|
@@ -184,6 +236,26 @@ class Keg
         yield file if hardlinks.add? file.stat.ino
       end
     end
+  end
+
+  def each_unique_binary_file
+    grep_bin, grep_args = egrep_args
+
+    # An extra \ is needed for the null character when calling grep
+    Utils.popen_read(grep_bin, grep_args, "\\x00", to_s) do |io|
+      hardlinks = Set.new
+
+      until io.eof?
+        file = Pathname.new(io.readline.chomp)
+        next if file.symlink?
+
+        yield file if hardlinks.add? file.stat.ino
+      end
+    end
+  end
+
+  def codesign_patched_binary(_binary_file)
+    []
   end
 
   def lib

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -347,6 +347,11 @@ class Bottle
     @spec.compatible_locations?(tag: @tag)
   end
 
+  # Should the build prefix be relocated?
+  def skip_prefix_relocation?
+    @spec.skip_prefix_relocation?(tag: @tag)
+  end
+
   # Does the bottle need to be relocated?
   def skip_relocation?
     @spec.skip_relocation?(tag: @tag)
@@ -473,6 +478,8 @@ class Bottle
 end
 
 class BottleSpecification
+  RELOCATABLE_CELLARS = [:any, :any_skip_relocation].freeze
+
   extend T::Sig
 
   attr_rw :rebuild
@@ -513,7 +520,30 @@ class BottleSpecification
       tag.default_cellar
     end
 
-    return true if [:any, :any_skip_relocation].include?(cellar)
+    return true if RELOCATABLE_CELLARS.include?(cellar)
+
+    prefix = Pathname(cellar).parent.to_s
+
+    cellar_relocatable = cellar.size >= HOMEBREW_CELLAR.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"]
+    prefix_relocatable = prefix.size >= HOMEBREW_PREFIX.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"]
+
+    compatible_cellar = cellar == HOMEBREW_CELLAR.to_s || cellar_relocatable
+    compatible_prefix = prefix == HOMEBREW_PREFIX.to_s || prefix_relocatable
+
+    compatible_cellar && compatible_prefix
+  end
+
+  # Should the build prefix for the {Bottle} this {BottleSpecification} belongs to be relocated?
+  sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
+  def skip_prefix_relocation?(tag: Utils::Bottles.tag)
+    spec = collector.specification_for(tag)
+    cellar = if spec.present?
+      spec.cellar
+    else
+      tag.default_cellar
+    end
+
+    return true if RELOCATABLE_CELLARS.include?(cellar)
 
     prefix = Pathname(cellar).parent.to_s
 


### PR DESCRIPTION
To-do list:

- [x] Add a test that raises an error if the patched binary is not the same number of bytes as the original.
- [ ] ~~Add a test that raises an error if there are any binaries (including those which are not ELF/MachO files) which still contain prefix references.~~
- [x] Fix the Linux test bottle so it doesn't throw an error when trying to see if it has a cellar.
- [x] Refactor `skip_prefix_relocation` to more closely resemble `compatible_location?` and use `spec.cellar == HOMEBREW_CELLAR.to_us` instead of `Homebrew.default_prefix?`
- [x] Test this locally on macOS Intel in the prefix `/opt/hb`.

-----

This PR implements part 1 of https://github.com/Homebrew/brew/issues/10846.  The goal here is replace references to the build prefix in a binary with users's prefix if the new prefix is of equal or shorter length to the build prefix.  If the prefix is shorter, strings which contain it are padded with null characters to make it the same length as the build prefix.

There are several things which I think need to be added to this PR, for which feedback would be greatly appreciated:
1) Proper error handling.  There are at least two scenarios where we might want raise an exception:<br>
a) The patched binary is not the same length as the original.  The way the code is written right now makes this unlikely, but we still might want something in case of a weird fluke.<br>
b) There should probably be an exception raised if, after patching, references to the build prefix still exist in binaries in the keg.<br>
Given that this is an experimental feature which must be enabled with the environment variable `HOMEBREW_RELOCATE_BUILD_PREFIX`, I think for now exceptions we raise from this should just halt the bottle pouring and tell the user to unset that variable and build the formula from source.

2) I'd like to get some more clarification on two scenarios where a bottle is not relocatable which don't seem to be related to build prefix references in binaries:
   ```
   if keg_contain?(HOMEBREW_LIBRARY.to_s, keg, ignores, formula_and_runtime_deps_names, args: args)
      relocatable = false
   end
   ```
   This looks it is checking for references to HOMEBREW_LIBRARY, which is being pulled from the environment and not something baked in to the bottle.  I'm not sure under what scenario this reference would show up in a keg (even if only in text files), but it doesn't seem like something that can be fixed with binary patching.
   ```
   relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg, args: args)
   ```
   This also appears to be an issue that is unrelated to build prefix references in binaries.  I'm also unsure of the circumstances under which this occurs.

In terms of testing, I've tried about a dozen non-relocatable formulae (and a few relocatable ones to make sure they're ignored) on Linux, and so far the binary strings look to be properly replaced and the formulae work with `brew test`.  I will have to set up a second Homebrew install in `/opt/hb` on my Intel MacBook for macOS testing because my main installation is in `/usr/local`.   I have tried manually running the core patching code on some binaries in `irb` on macOS, and it doesn't throw any errors.  

Ideally we could automate testing of all non-relocatable bottles on each platform in a shorter, non-default prefix (i.e. `/opt/hb`), but I'm not sure how practical that is right now.  As a starting point it would be great to test some of the most popular non-relocatable formulae.