### PR TITLE
cask/installer.rb: Reinstate checking deps before installing

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -70,10 +70,9 @@ module Cask
       odebug "Cask::Installer#fetch"
 
       verify_has_sha if require_sha? && !force?
+      satisfy_dependencies
 
       download(quiet: quiet, timeout: timeout)
-
-      satisfy_dependencies
     end
 
     def stage


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Essentially reinstates 3fdab5a24d (#8572), which was undone by 712a95fdd (#10864) and the related fallout.

I'm not sure if it was intentional or not, but I couldn't find any comments referencing it in any of the mishegas (#10898, #10913, #10919, #10922, #10923), so I thought perhaps it was simply missed.  As someone on an older system, it would be awful nice to have!