### PR TITLE
Fix linuxbrew-core migration not applying to Linuxbrew/homebrew-core

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -554,7 +554,7 @@ Your Git executable: $(unset git && type -p ${HOMEBREW_GIT})"
   unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
 
   HOMEBREW_CORE_REPOSITORY_ORIGIN="$("${HOMEBREW_GIT}" -C "${HOMEBREW_CORE_REPOSITORY}" remote get-url origin 2>/dev/null)"
-  if [[ "${HOMEBREW_CORE_REPOSITORY_ORIGIN}" =~ /linuxbrew-core(\.git)?$ ]]
+  if [[ "${HOMEBREW_CORE_REPOSITORY_ORIGIN}" =~ (/linuxbrew|Linuxbrew/homebrew)-core(\.git)?$ ]]
   then
     # triggers migration code in update.sh
     # shellcheck disable=SC2034

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -827,7 +827,7 @@ class CoreTap < Tap
   # @private
   sig { returns(T::Boolean) }
   def linuxbrew_core?
-    remote_repo.to_s.end_with?("/linuxbrew-core")
+    remote_repo.to_s.end_with?("/linuxbrew-core") || remote_repo == "Linuxbrew/homebrew-core"
   end
 
   # @private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There's an even older remote we used, Linuxbrew/homebrew-core, which redirects to Homebrew/linuxbrew-core. Some users who installed a long time ago may still have Linuxbrew/homebrew-core as a git origin as we never migrated them to Homebrew/linuxbrew-core and simply relied on GitHub's redirect feature. Those users simply faced their linuxbrew-core install no longer receiving updates when we should have been migrating them.

See https://github.com/Homebrew/discussions/discussions/2624.