### PR TITLE
Livecheck: Avoid duplicate URLs

### DIFF
--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -44,6 +44,15 @@ describe Homebrew::Livecheck do
     RUBY
   end
 
+  let(:f_duplicate_urls) do
+    formula("test_duplicate_urls") do
+      desc "Test formula with a duplicate URL"
+      homepage "https://github.com/Homebrew/brew.git"
+      url "https://brew.sh/test-0.0.1.tgz"
+      head "https://github.com/Homebrew/brew.git"
+    end
+  end
+
   describe "::resolve_livecheck_reference" do
     context "when a formula/cask has a livecheck block without formula/cask methods" do
       it "returns [nil, []]" do
@@ -144,6 +153,7 @@ describe Homebrew::Livecheck do
     it "returns the list of URLs to check" do
       expect(livecheck.checkable_urls(f)).to eq([stable_url, head_url, homepage_url])
       expect(livecheck.checkable_urls(c)).to eq([cask_url, homepage_url])
+      expect(livecheck.checkable_urls(f_duplicate_urls)).to eq([stable_url, head_url])
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Some formulae/casks contain duplicate checkable URLs or contain URLs that become duplicates after `#preprocess_url` is used. With the former, a formula's `stable` and `head` URLs can be the same if they both use the Git repository. With the latter, a formula's `homepage` and `stable` URLs are different but `#preprocess_url` can return the same Git repository URL for each (which can also be a duplicate of the `head` URL).

The `fabric-completion` formula is a worst case scenario, as it contains both of these conditions but the repository has no tags. By default, livecheck would needlessly check the repository three times (i.e., no versions are found so livecheck tries the next URL, which happens to be the same URL). [That said, I added a `skip` `livecheck` block in the past when I noticed this issue.]

This PR avoids duplicate URLs in `#checkable_urls` and keeps track of checked URLs in `#latest_version` to avoid a duplicate caused by `#preprocess_url`. This should effectively resolve the issue of checking the same URL more than once for a given formula/cask. Checking the same URL only once across all the formulae/casks in a given livecheck run will be handled in a later PR (though I've done most of the groundwork already in previous PRs).