### PR TITLE
.rubocop.yml: selectively enable Rails cops

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -202,26 +202,40 @@ Performance/Caller:
 Performance/MethodObjectAsBlock:
   Enabled: false
 
-# Cannot use ActiveSupport in RuboCops.
 Rails:
+  # Selectively enable what we want.
+  Enabled: false
+  # Cannot use ActiveSupport in RuboCops.
   Exclude:
     - "Homebrew/rubocops/**/*"
 
-# Skip these as they only apply to actual Rails and not our ActiveSupport usage.
-Rails/ArelStar:
-  Enabled: false
-Rails/Date:
-  Enabled: false
+# These relate to ActiveSupport and not other parts of Rails.
+Rails/ActiveSupportAliases:
+  Enabled: true
+Rails/Blank:
+  Enabled: true
 Rails/Delegate:
-  Enabled: false
-Rails/RakeEnvironment:
-  Enabled: false
-Rails/SkipsModelValidations:
-  Enabled: false
-Rails/Pluck:
-  Enabled: false
-Rails/TimeZone:
-  Enabled: false
+  Enabled: false # TODO
+Rails/DelegateAllowBlank:
+  Enabled: true
+Rails/ExpandedDateRange:
+  Enabled: true
+Rails/Inquiry:
+  Enabled: true
+Rails/NegateInclude:
+  Enabled: true
+Rails/PluralizationGrammar:
+  Enabled: true
+Rails/Presence:
+  Enabled: true
+Rails/Present:
+  Enabled: true
+Rails/RelativeDateConstant:
+  Enabled: true
+Rails/SafeNavigation:
+  Enabled: true
+Rails/SafeNavigationWithBlank:
+  Enabled: true
 
 # Don't allow cops to be disabled in casks and formulae.
 Style/DisableCopsWithinSourceCodeDirective:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some Rails cops use `ActiveRecordHelper` which contains a cache checksum that involves checksuming a Rails database schema. This involves an amount of file traversal as it tries to find this schema, which can be slow.

For _cached_ `brew style` runs on Homebrew/core, disabling these cops speeds up execution time by over 50%.