### PR TITLE
Gemfile: restrict activesupport version range

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -33,7 +33,7 @@ group :sorbet, optional: true do
 end
 
 # vendored gems
-gem "activesupport"
+gem "activesupport", "< 7" # 7 requires Ruby 2.7
 gem "concurrent-ruby"
 gem "did_you_mean" # remove when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
 gem "mechanize"

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -201,7 +201,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (< 7)
   bootsnap
   byebug
   concurrent-ruby


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is mostly to prevent Dependabot picking 7.0 since that requires Ruby 2.7.