### PR TITLE
Take `$HOMEBREW_DOCKER_REGISTRY_TOKEN` into account when installing portable-ruby

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -119,7 +119,7 @@ fetch() {
     --remote-time
     --location
     --user-agent "${HOMEBREW_USER_AGENT_CURL}"
-    --header "Authorization: Bearer QQ=="
+    --header "Authorization: Bearer ${HOMEBREW_DOCKER_REGISTRY_TOKEN:-QQ==}"
   )
 
   if [[ -n "${HOMEBREW_QUIET}" ]]


### PR DESCRIPTION
Extends what has been done in https://github.com/Homebrew/brew/pull/11766 to the portable-ruby installer;
because it was already taking `$HOMEBREW_ARTIFACT_DOMAIN` into account but not `$HOMEBREW_DOCKER_REGISTRY_TOKEN`, so we had 401 errors when installing homebrew.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
