### PR TITLE
dependabot.yml: lockfile-only versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       interval: weekly
     allow:
       - dependency-type: all
+    versioning-strategy: lockfile-only
 
   - package-ecosystem: bundler
     directory: /Library/Homebrew
@@ -25,3 +26,4 @@ updates:
       - dependency-type: all
     ignore:
       - dependency-name: sorbet-runtime
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is documented as being the default but it doesn't seem to be that way. 🤷‍♂️ 