### PR TITLE
linkage: display executables with missing rpath

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -451,6 +451,11 @@ class Pathname
   def dylib?
     false
   end
+
+  sig { returns(T::Array[String]) }
+  def rpaths
+    []
+  end
 end
 
 require "extend/os/pathname"

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -32,7 +32,7 @@ class LinkageChecker
     @unnecessary_deps = []
     @unwanted_system_dylibs = []
     @version_conflict_deps = []
-    @executables_missing_rpaths = []
+    @files_missing_rpaths = []
 
     check_dylibs(rebuild_cache: rebuild_cache)
   end
@@ -47,7 +47,7 @@ class LinkageChecker
     display_items "Undeclared dependencies with linkage", @undeclared_deps
     display_items "Dependencies with no linkage", @unnecessary_deps
     display_items "Unwanted system libraries", @unwanted_system_dylibs
-    display_items "Executables with missing rpath", @executables_missing_rpaths
+    display_items "Files with missing rpath", @files_missing_rpaths
   end
 
   def display_reverse_output
@@ -71,12 +71,12 @@ class LinkageChecker
     display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
     display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
     display_items "Undeclared dependencies with linkage", @undeclared_deps, puts_output: puts_output if strict
-    display_items "Executables with missing rpath", @executables_missing_rpaths, puts_output: puts_output
+    display_items "Files with missing rpath", @files_missing_rpaths, puts_output: puts_output
   end
 
   sig { params(strict: T::Boolean).returns(T::Boolean) }
   def broken_library_linkage?(strict: false)
-    issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps, @executables_missing_rpaths]
+    issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps, @files_missing_rpaths]
     issues << @undeclared_deps if strict
     [issues, unexpected_broken_dylibs, unexpected_present_dylibs].flatten.any?(&:present?)
   end
@@ -159,12 +159,12 @@ class LinkageChecker
       dylibs.each do |dylib|
         @reverse_links[dylib] << file
 
-        # Binary executables that link @rpath-prefixed dylibs must include at
+        # Files that link @rpath-prefixed dylibs must include at
         # least one rpath in order to resolve it.
         if !file_has_any_rpath_dylibs && (dylib.start_with? "@rpath/")
           file_has_any_rpath_dylibs = true
           pathname = Pathname(file)
-          @executables_missing_rpaths << file if pathname.binary_executable? && pathname.rpaths.empty?
+          @files_missing_rpaths << file if pathname.rpaths.empty?
         end
 
         next if checked_dylibs.include? dylib

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -86,10 +86,18 @@ module ELFShim
     elf_type == :executable
   end
 
+  # The runtime search path, such as:
+  # "/lib:/usr/lib:/usr/local/lib"
   def rpath
     return @rpath if defined? @rpath
 
     @rpath = rpath_using_patchelf_rb
+  end
+
+  # An array of runtime search path entries, such as:
+  # ["/lib", "/usr/lib", "/usr/local/lib"]
+  def rpaths
+    rpath.split(":")
   end
 
   def interpreter


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

An executable that links against `@rpath`-prefixed dylibs must include at least one `LC_RPATH`. This will prevent issues like the one resolved in https://github.com/Homebrew/homebrew-core/pull/91485.

Caveats:
1. This won't find executables that have only recursive dylib dependencies with @rpath prefixes.
1. This makes no attempt to resolve `@rpath`, `@executable_path` or `@loader_path` dylibs, or to verify the correctness of any `LC_RPATH` entries, or to otherwise simulate dlopen logic.
1. Weakly-linked dylibs are still excluded from the search for broken linkage.
1. I am not fluent in Ruby. 😊

The scope is narrow in order to focus on this particular problem. It is meant only as a sanity check.