### PR TITLE
sorbet/rbi/upstream.rbi: remove old workaround

### DIFF
--- a/Library/Homebrew/sorbet/rbi/upstream.rbi
+++ b/Library/Homebrew/sorbet/rbi/upstream.rbi
@@ -21,14 +21,3 @@ class Module
   end
   def define_method(arg0, arg1=T.unsafe(nil), &blk); end
 end
-
-class Pathname
-  # https://github.com/sorbet/sorbet/pull/4660
-  sig do
-    params(
-        consider_symlink: T::Boolean,
-    )
-    .returns(Pathname)
-  end
-  def cleanpath(consider_symlink=T.unsafe(nil)); end
-end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This was merged upstream a while ago.
