### PR TITLE
remove on_os from formula

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -64,7 +64,6 @@ class Formula
   include Utils::Shebang
   include Utils::Shell
   include Context
-  include OnOS # TODO: 3.3.0: deprecate OnOS usage in instance methods.
   extend Enumerable
   extend Forwardable
   extend Cachable
@@ -3065,7 +3064,7 @@ class Formula
       block ||= case only_if
       when :clt_installed
         lambda do |_|
-          on_macos do
+          if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
               The bottle needs the Apple Command Line Tools to be installed.
                 You can install them, if desired, with:

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1542,12 +1542,8 @@ describe Formula do
         attr_reader :test
 
         def install
-          on_macos do
-            @test = 1
-          end
-          on_linux do
-            @test = 2
-          end
+          @test = 1 if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
+          @test = 2 if OS.linux?
         end
       end.new
     end
@@ -1565,12 +1561,8 @@ describe Formula do
         attr_reader :test
 
         def install
-          on_macos do
-            @test = 1
-          end
-          on_linux do
-            @test = 2
-          end
+          @test = 1 if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
+          @test = 2 if OS.linux?
         end
       end.new
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
remove `os_os` methods from `formula.rb` because of # TODO