### PR TITLE
bump-cask-pr: avoid replacing sha256 twice on multilang cask

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -153,7 +153,7 @@ module Homebrew
       end
     end
 
-    if new_hash.present?
+    if new_hash.present? && cask.language.blank?
       hash_regex = old_hash == :no_check ? ":no_check" : "[\"']#{Regexp.escape(old_hash.to_s)}[\"']"
 
       replacement_pairs << [

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -153,7 +153,7 @@ module Homebrew
       end
     end
 
-    if new_hash.present? && cask.language.blank?
+    if new_hash.present? && cask.language.blank? # avoid repeated replacement for multilanguage cask
       hash_regex = old_hash == :no_check ? ":no_check" : "[\"']#{Regexp.escape(old_hash.to_s)}[\"']"
 
       replacement_pairs << [

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -145,8 +145,6 @@ module Homebrew
         end
 
         cask.languages.each do |language|
-          next if language == cask.language
-
           lang_config = tmp_config.merge(Cask::Config.new(explicit: { languages: [language] }))
           replacement_pairs << fetch_cask(tmp_contents, config: lang_config)
         end


### PR DESCRIPTION
this script always get `inreplace failed` on cask like firefox because the
default sha256 is replaced twice

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
