### PR TITLE
Revert "remove on_os from formula"

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -64,6 +64,7 @@ class Formula
   include Utils::Shebang
   include Utils::Shell
   include Context
+  include OnOS # TODO: 3.3.0: deprecate OnOS usage in instance methods.
   extend Enumerable
   extend Forwardable
   extend Cachable
@@ -3064,7 +3065,7 @@ class Formula
       block ||= case only_if
       when :clt_installed
         lambda do |_|
-          if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
+          on_macos do
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
               The bottle needs the Apple Command Line Tools to be installed.
                 You can install them, if desired, with:

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1542,8 +1542,12 @@ describe Formula do
         attr_reader :test
 
         def install
-          @test = 1 if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
-          @test = 2 if OS.linux?
+          on_macos do
+            @test = 1
+          end
+          on_linux do
+            @test = 2
+          end
         end
       end.new
     end
@@ -1561,8 +1565,12 @@ describe Formula do
         attr_reader :test
 
         def install
-          @test = 1 if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
-          @test = 2 if OS.linux?
+          on_macos do
+            @test = 1
+          end
+          on_linux do
+            @test = 2
+          end
         end
       end.new
     end


### PR DESCRIPTION
This is causing `post_install` failures. Spotted in
Homebrew/homebrew-core#91763.

This reverts commit fc7462acd5ffb7cc393d2b56b989e96112ade896.