### PR TITLE
cmd/autoremove recognize cask dependencies

### DIFF
--- a/Library/Homebrew/cmd/autoremove.rb
+++ b/Library/Homebrew/cmd/autoremove.rb
@@ -36,6 +36,10 @@ module Homebrew
     removable_formulae = get_removable_formulae(Formula.installed)
     return if removable_formulae.blank?
 
+    if Cask::Caskroom.casks.present?
+      removable_formulae -= Cask::Caskroom.casks.flat_map { |cask| cask.depends_on[:formula] }
+                                          .compact.map { |formula| Formula[formula] }
+    end
     formulae_names = removable_formulae.map(&:full_name).sort
 
     verb = args.dry_run? ? "Would uninstall" : "Uninstalling"

--- a/Library/Homebrew/cmd/autoremove.rb
+++ b/Library/Homebrew/cmd/autoremove.rb
@@ -36,9 +36,10 @@ module Homebrew
     removable_formulae = get_removable_formulae(Formula.installed)
     return if removable_formulae.blank?
 
-    if Cask::Caskroom.casks.present?
-      removable_formulae -= Cask::Caskroom.casks.flat_map { |cask| cask.depends_on[:formula] }
-                                          .compact.map { |formula| Formula[formula] }
+    if (casks = Cask::Caskroom.casks.presence)
+      removable_formulae -= casks.flat_map { |cask| cask.depends_on[:formula] }
+                                 .compact
+                                 .map { |formula| Formula[formula] }
     end
     formulae_names = removable_formulae.map(&:full_name).sort
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes https://github.com/Homebrew/brew/issues/11417

Remove cask dependent formulae from `removable_formulae` in `cmd/autoremove`.