### PR TITLE
Strategy: Add --silent flag to DEFAULT_CURL_ARGS

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -39,6 +39,9 @@ module Homebrew
       DEFAULT_CURL_ARGS = [
         # Follow redirections to handle mirrors, relocations, etc.
         "--location",
+        # Avoid progress bar text, so we can reliably identify `curl` error
+        # messages in output
+        "--silent",
       ].freeze
 
       # `curl` arguments used in `Strategy#page_headers` method.
@@ -47,7 +50,6 @@ module Homebrew
         "--head",
         # Some servers may not allow a HEAD request, so we use GET
         "--request", "GET",
-        "--silent"
       ] + DEFAULT_CURL_ARGS).freeze
 
       # `curl` arguments used in `Strategy#page_content` method.

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -86,7 +86,7 @@ module Utils
 
       args << "--retry-max-time" << retry_max_time.round if retry_max_time.present?
 
-      args + extra_args
+      (args + extra_args).uniq
     end
 
     def curl_with_workarounds(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently, only `Livecheck::Strategy::PAGE_HEADERS_CURL_ARGS` uses the `--silent` option and `PAGE_CONTENT_CURL_ARGS` does not (though there's no intention behind this omission). However, the `#page_content` method should also use the `--silent` flag, to prevent progress bar text (`#=#=#`, etc.) from appearing in output.

This is an issue because the regex that's used to identify `curl` error messages in `stderr` (`^curl:.+$/`) will fail if leading progress bar text is present. This leads to an ambiguous "cURL failed without a detectable error" message instead of the actual error message(s) from `curl`.

This PR addresses the issue by adding `--silent` to `Livecheck::Strategy::DEFAULT_CURL_ARGS`, which both `PAGE_HEADERS_CURL_ARGS` and `PAGE_CONTENT_CURL_ARGS` inherit.

Besides that, this also ensures that the returned array from `#curl_args` is unique, as we can potentially end up with duplicate arguments from `extra_args`.

---

Another way of handling this is to add a `silent` option to `#curl_args` but I wasn't sure if a more broadly-applicable approach was desirable (we do seem to pass `--silent` as part of `extra_args` in a few other places in `brew`).

You can see how this could look on my [`curl-add-silent-option` branch](https://github.com/samford/brew/compare/master...curl-add-silent-option). If that approach is preferable, I'll update this PR accordingly.