### PR TITLE
autoremove: Return when not removing

### DIFF
--- a/Library/Homebrew/cmd/autoremove.rb
+++ b/Library/Homebrew/cmd/autoremove.rb
@@ -34,13 +34,14 @@ module Homebrew
     args = autoremove_args.parse
 
     removable_formulae = get_removable_formulae(Formula.installed)
-    return if removable_formulae.blank?
 
     if (casks = Cask::Caskroom.casks.presence)
       removable_formulae -= casks.flat_map { |cask| cask.depends_on[:formula] }
                                  .compact
                                  .map { |formula| Formula[formula] }
     end
+    return if removable_formulae.blank?
+
     formulae_names = removable_formulae.map(&:full_name).sort
 
     verb = args.dry_run? ? "Would uninstall" : "Uninstalling"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Checks if the removable formulae *after* removing cask dependancies, preventing output like this:
```
$ brew autoremove
==> Uninstalling 0 unneeded formulae:

```