### PR TITLE
Modernize swift scripts in Library/Homebrew/cask/utils

### DIFF
--- a/Library/Homebrew/cask/utils/quarantine.swift
+++ b/Library/Homebrew/cask/utils/quarantine.swift
@@ -2,46 +2,53 @@
 
 import Foundation
 
-struct swifterr: TextOutputStream {
-  public static var stream = swifterr()
-  mutating func write(_ string: String) { fputs(string, stderr) }
+struct SwiftErr: TextOutputStream {
+    public static var stream = SwiftErr()
+    
+    mutating func write(_ string: String) {
+        fputs(string, stderr)
+    }
 }
 
-if #available(macOS 10.10, *) {
-  if (CommandLine.arguments.count < 4) {
+// Make sure the user is on macOS 10.10 or newer
+guard #available(macOS 10.10, *) else {
+    print("Homebrew Quarantine: user must be on macOS 10.10 or newer.", to: &SwiftErr.stream)
+    exit(5)
+}
+
+
+// TODO: tell which arguments have to be provided
+guard CommandLine.arguments.count >= 4 else {
     exit(2)
-  }
+}
 
-  let dataLocationUrl: NSURL = NSURL.init(fileURLWithPath: CommandLine.arguments[1])
+var dataLocationURL = URL(fileURLWithPath: CommandLine.arguments[1])
 
-  var errorBag: NSError?
-
-  let quarantineProperties: [String: Any] = [
+let quarantineProperties: [String: Any] = [
     kLSQuarantineAgentNameKey as String: "Homebrew Cask",
     kLSQuarantineTypeKey as String: kLSQuarantineTypeWebDownload,
     kLSQuarantineDataURLKey as String: CommandLine.arguments[2],
     kLSQuarantineOriginURLKey as String: CommandLine.arguments[3]
-  ]
+]
 
-  if (dataLocationUrl.checkResourceIsReachableAndReturnError(&errorBag)) {
-    do {
-      try dataLocationUrl.setResourceValue(
-        quarantineProperties as NSDictionary,
-        forKey: URLResourceKey.quarantinePropertiesKey
-        )
+// Check for if the data location URL is reachable
+do {
+    let isDataLocationURLReachable = try dataLocationURL.checkResourceIsReachable()
+    guard isDataLocationURLReachable else {
+        print("URL \(dataLocationURL.path) is not reachable. Not proceeding.", to: &SwiftErr.stream)
+        exit(1)
     }
-    catch {
-      print(error.localizedDescription, to: &swifterr.stream)
-      exit(1)
-    }
-  }
-  else {
-    print(errorBag!.localizedDescription, to: &swifterr.stream)
-    exit(3)
-  }
-
-  exit(0)
+} catch {
+    print(error.localizedDescription, to: &SwiftErr.stream)
+    exit(1)
 }
-else {
-  exit(5)
+
+// Quarantine the file
+do {
+    var resourceValues = URLResourceValues()
+    resourceValues.quarantineProperties = quarantineProperties
+    try dataLocationURL.setResourceValues(resourceValues)
+} catch {
+    print(error.localizedDescription, to: &SwiftErr.stream)
+    exit(1)
 }

--- a/Library/Homebrew/cask/utils/trash.swift
+++ b/Library/Homebrew/cask/utils/trash.swift
@@ -4,28 +4,32 @@ import Foundation
 
 extension FileHandle : TextOutputStream {
   public func write(_ string: String) {
-    self.write(string.data(using: .utf8)!)
+      if let data = string.data(using: .utf8) { self.write(data) }
   }
 }
 
 var stderr = FileHandle.standardError
 
-let manager: FileManager = FileManager()
+let manager = FileManager.default
 
 var success = true
 
-for item in CommandLine.arguments[1...] {
-  do {
-    let path: URL = URL(fileURLWithPath: item)
-    var trashedPath: NSURL!
-    try manager.trashItem(at: path, resultingItemURL: &trashedPath)
-    print((trashedPath as URL).path, terminator: ":")
-  } catch {
-    print(item, terminator: ":", to: &stderr)
-    success = false
-  }
+// The command line arguments given but without the script's name
+let CMDLineArgs = Array(CommandLine.arguments.dropFirst())
+
+for item in CMDLineArgs {
+    do {
+        let url = URL(fileURLWithPath: item)
+        var trashedPath: NSURL!
+        try manager.trashItem(at: url, resultingItemURL: &trashedPath)
+        print((trashedPath as URL).path, terminator: ":")
+        success = true
+    } catch {
+        print(item, terminator: ":", to: &stderr)
+        success = false
+    }
 }
 
 guard success else {
-  exit(1)
+    exit(1)
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The following PR modernizes the swift scripts in Library/Homebrew/cask/utils (trash.swift and quarantine.swift), by using features that are Swift-like, such as guard statements. 

The functionality and usage of the 2 scripts remains the same  