### PR TITLE
repology: always use Homebrew curl.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,6 +228,9 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.test-flags }}-parallel_runtime_rspec-${{ github.sha }}
           restore-keys: ${{ runner.os }}-${{ matrix.test-flags }}-parallel_runtime_rspec-
 
+      - name: Install brew tests dependencies
+        run: brew install curl
+
       - name: Run brew tests
         run: |
           # brew tests doesn't like world writable directories
@@ -303,13 +306,7 @@ jobs:
         run: brew readall --aliases
 
       - name: Install brew tests dependencies
-        run: |
-          brew install subversion
-          brew sh -c "svn --homebrew=print-path"
-          which svn
-          which svnadmin
-          brew install curl
-          which curl
+        run: brew install subversion curl
 
       - name: Create parallel test log directory
         run: mkdir tests

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -56,14 +56,12 @@ module Homebrew
 
     limit = args.limit.to_i if args.limit.present?
 
-    unless Utils::Curl.curl_supports_tls13?
-      begin
-        unless Pathname.new(ENV["HOMEBREW_BREWED_CURL_PATH"]).exist?
-          ensure_formula_installed!("curl", reason: "Repology queries")
-        end
-      rescue FormulaUnavailableError
-        opoo "A `curl` with TLS 1.3 support is required for Repology queries."
+    begin
+      unless Pathname.new(ENV["HOMEBREW_BREWED_CURL_PATH"]).exist?
+        ensure_formula_installed!("curl", reason: "Repology queries")
       end
+    rescue FormulaUnavailableError
+      opoo "A newer `curl` is required for Repology queries."
     end
 
     if formulae_and_casks.present?

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -6,7 +6,7 @@ require "cmd/shared_examples/args_parse"
 describe "brew bump" do
   it_behaves_like "parseable arguments"
 
-  describe "formula", :integration_test, :needs_network, :needs_tls13 do
+  describe "formula", :integration_test, :needs_network, :needs_homebrew_curl do
     it "returns data for single valid specified formula" do
       install_test_formula "testball"
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -169,11 +169,9 @@ RSpec.configure do |config|
                       .append(svnadmin.dirname)
   end
 
-  config.before(:each, :needs_tls13) do
-    unless curl_supports_tls13?
-      ENV["HOMEBREW_CURL"] = ENV["HOMEBREW_BREWED_CURL_PATH"]
-      skip "A `curl` with TLS 1.3 support is required." unless curl_supports_tls13?
-    end
+  config.before(:each, :needs_homebrew_curl) do
+    ENV["HOMEBREW_CURL"] = ENV["HOMEBREW_BREWED_CURL_PATH"]
+    skip "A `curl` with TLS 1.3 support is required." unless curl_supports_tls13?
   rescue FormulaUnavailableError
     skip "No `curl` formula is available."
   end

--- a/Library/Homebrew/test/utils/repology_spec.rb
+++ b/Library/Homebrew/test/utils/repology_spec.rb
@@ -4,7 +4,7 @@
 require "utils/repology"
 
 describe Repology do
-  describe "single_package_query", :needs_network, :needs_tls13 do
+  describe "single_package_query", :needs_network, :needs_homebrew_curl do
     it "returns nil for non-existent package" do
       response = described_class.single_package_query("invalidName", repository: "homebrew")
 
@@ -19,7 +19,7 @@ describe Repology do
     end
   end
 
-  describe "parse_api_response", :needs_network, :needs_tls13 do
+  describe "parse_api_response", :needs_network, :needs_homebrew_curl do
     it "returns a hash of data" do
       limit = 1
       start_with = "x"


### PR DESCRIPTION
This seems to be required even with TLSv1.3 support now.

Also, while we're here, improve the error handling/output.