### PR TITLE
Allow linkage to libnss_files.so.2 on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -15,6 +15,7 @@ class LinkageChecker
     libm.so.6
     libmvec.so.1
     libnsl.so.1
+    libnss_files.so.2
     libpthread.so.0
     libresolv.so.2
     librt.so.1


### PR DESCRIPTION
libnss_nis.so.2 in glibc@2.13 has linkage to libnss_files.so.2.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix the error
```console
$ brew linkage --test glibc@2.13
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libnss_files.so.2
```
https://github.com/Homebrew/homebrew-core/runs/4676492184?check_suite_focus=true#step:7:67
