### PR TITLE
Patch neither glibc nor glibc@* using patchelf

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -6,7 +6,7 @@ require "compilers"
 class Keg
   def relocate_dynamic_linkage(relocation)
     # Patching the dynamic linker of glibc breaks it.
-    return if name == "glibc" || name.start_with?("glibc@")
+    return if name.match? Version.formula_optionally_versioned_regex(:glibc)
 
     # Patching patchelf fails with "Text file busy" or SIGBUS.
     return if name == "patchelf"

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -6,7 +6,7 @@ require "compilers"
 class Keg
   def relocate_dynamic_linkage(relocation)
     # Patching the dynamic linker of glibc breaks it.
-    return if name == "glibc"
+    return if name == "glibc" || name.start_with?("glibc@")
 
     # Patching patchelf fails with "Text file busy" or SIGBUS.
     return if name == "patchelf"


### PR DESCRIPTION
Patching the dynamic linker of Glibc breaks it.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

See PR
- https://github.com/Homebrew/homebrew-core/pull/92329