### PR TITLE
repair cask formulae autoremove

### DIFF
--- a/Library/Homebrew/cmd/autoremove.rb
+++ b/Library/Homebrew/cmd/autoremove.rb
@@ -36,9 +36,10 @@ module Homebrew
     removable_formulae = get_removable_formulae(Formula.installed)
 
     if (casks = Cask::Caskroom.casks.presence)
-      removable_formulae -= casks.flat_map { |cask| cask.depends_on[:formula] }
-                                 .compact
-                                 .map { |formula| Formula[formula] }
+      cask_formulae = casks.flat_map { |cask| cask.depends_on[:formula] }
+                           .compact
+                           .map { |formula| Formula[formula] }
+      removable_formulae -= [*cask_formulae, *cask_formulae.flat_map(&:runtime_formula_dependencies)]
     end
     return if removable_formulae.blank?
 

--- a/Library/Homebrew/cmd/autoremove.rb
+++ b/Library/Homebrew/cmd/autoremove.rb
@@ -36,10 +36,10 @@ module Homebrew
     removable_formulae = get_removable_formulae(Formula.installed)
 
     if (casks = Cask::Caskroom.casks.presence)
-      cask_formulae = casks.flat_map { |cask| cask.depends_on[:formula] }
-                           .compact
-                           .map { |formula| Formula[formula] }
-      removable_formulae -= [*cask_formulae, *cask_formulae.flat_map(&:runtime_formula_dependencies)]
+      removable_formulae -= casks.flat_map { |cask| cask.depends_on[:formula] }
+                                 .compact
+                                 .map { |f| Formula[f] }
+                                 .flat_map { |f| [f, *f.runtime_formula_dependencies].compact }
     end
     return if removable_formulae.blank?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Closes https://github.com/Homebrew/brew/issues/12660

`autoremove` not only cask's formulae but also cask's formulae's formulae