### PR TITLE
Force UTF-8 encoding of lsb_release output

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -12,7 +12,7 @@ module OS
     def os_version
       if which("lsb_release")
         lsb_info = Utils.popen_read("lsb_release", "-a")
-        description = lsb_info[/^Description:\s*(.*)$/, 1]
+        description = lsb_info[/^Description:\s*(.*)$/, 1].force_encoding("UTF-8")
         codename = lsb_info[/^Codename:\s*(.*)$/, 1]
         if codename.blank? || (codename == "n/a")
           description


### PR DESCRIPTION
It's possible that the output may be encoded ASCII-8BIT, which cannot be automatically encoded to UTF-8 by Ruby's JSON library.

In this particular case, elementaryOS 6.1 returns `Jólnir` as a part of the lsb_release Description field.
Ruby's IO.popen would return this whole output in ASCII-8BIT.
When this description field was passed to homebrew-bundle to be written in a JSON lockfile,
Ruby throws an exception because it could not automatically reencode from ASCII-8BIT to UTF-8.

This may actually affect other output of the calls to the underlying `Utils.popen_read` but this may be the first thing to trigger it since
JSON requires UTF-8 output and nothing else using that function may require UTF-8.

Fixes #12689 12689
Fixes Homebrew/homebrew-bundle#1043

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I verified this works on my own installation. I'll add some tests if maintainers think this is an acceptable way to fix this.