### PR TITLE
Add flag `--overwrite` to `brew install` to govern the keg-linking step

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -16,7 +16,7 @@ Lint/NestedMethodDefinition:
 Metrics/AbcSize:
   Max: 280
 Metrics/BlockLength:
-  Max: 103
+  Max: 106
   Exclude:
     # TODO: extract more of the bottling logic
     - "dev-cmd/bottle.rb"

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -22,6 +22,7 @@ module Homebrew
 
   sig { returns(CLI::Parser) }
   def install_args
+    # rubocop:disable Metrics/BlockLength
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Install a <formula> or <cask>. Additional options specific to a <formula> may be
@@ -112,6 +113,9 @@ module Homebrew
         [:switch, "-g", "--git", {
           description: "Create a Git repository, useful for creating patches to the software.",
         }],
+        [:switch, "--overwrite", {
+          description: "Delete files that already exist in the prefix while linking.",
+        }],
       ].each do |*args, **options|
         send(*args, **options)
         conflicts "--cask", args.last
@@ -132,6 +136,7 @@ module Homebrew
 
       named_args [:formula, :cask], min: 1
     end
+    # rubocop:enable Metrics/BlockLength
   end
 
   def install
@@ -226,6 +231,7 @@ module Homebrew
       interactive:                args.interactive?,
       keep_tmp:                   args.keep_tmp?,
       force:                      args.force?,
+      overwrite:                  args.overwrite?,
       debug:                      args.debug?,
       quiet:                      args.quiet?,
       verbose:                    args.verbose?,

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -22,7 +22,6 @@ module Homebrew
 
   sig { returns(CLI::Parser) }
   def install_args
-    # rubocop:disable Metrics/BlockLength
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Install a <formula> or <cask>. Additional options specific to a <formula> may be
@@ -136,7 +135,6 @@ module Homebrew
 
       named_args [:formula, :cask], min: 1
     end
-    # rubocop:enable Metrics/BlockLength
   end
 
   def install

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -38,7 +38,7 @@ class FormulaInstaller
 
   attr_predicate :installed_as_dependency?, :installed_on_request?
   attr_predicate :show_summary_heading?, :show_header?
-  attr_predicate :force_bottle?, :ignore_deps?, :only_deps?, :interactive?, :git?, :force?, :keep_tmp?
+  attr_predicate :force_bottle?, :ignore_deps?, :only_deps?, :interactive?, :git?, :force?, :overwrite?, :keep_tmp?
   attr_predicate :verbose?, :debug?, :quiet?
 
   # TODO: Remove when removed from `test-bot`.
@@ -64,6 +64,7 @@ class FormulaInstaller
     cc: nil,
     options: Options.new,
     force: false,
+    overwrite: false,
     debug: false,
     quiet: false,
     verbose: false
@@ -71,6 +72,7 @@ class FormulaInstaller
     @formula = formula
     @env = env
     @force = force
+    @overwrite = overwrite
     @keep_tmp = keep_tmp
     @link_keg = !formula.keg_only? || link_keg
     @show_header = show_header
@@ -951,7 +953,7 @@ class FormulaInstaller
 
     unless link_keg
       begin
-        keg.optlink(verbose: verbose?)
+        keg.optlink(verbose: verbose?, overwrite: overwrite?)
       rescue Keg::LinkError => e
         ofail "Failed to create #{formula.opt_prefix}"
         puts "Things that depend on #{formula.full_name} will probably not build."
@@ -982,7 +984,7 @@ class FormulaInstaller
     backup_dir = HOMEBREW_CACHE/"Backup"
 
     begin
-      keg.link(verbose: verbose?)
+      keg.link(verbose: verbose?, overwrite: overwrite?)
     rescue Keg::ConflictError => e
       conflict_file = e.dst
       if formula.link_overwrite?(conflict_file) && !link_overwrite_backup.key?(conflict_file)

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -268,6 +268,7 @@ module Homebrew
       interactive: false,
       keep_tmp: false,
       force: false,
+      overwrite: false,
       debug: false,
       quiet: false,
       verbose: false
@@ -291,6 +292,7 @@ module Homebrew
           interactive:                interactive,
           keep_tmp:                   keep_tmp,
           force:                      force,
+          overwrite:                  overwrite,
           debug:                      debug,
           quiet:                      quiet,
           verbose:                    verbose,


### PR DESCRIPTION
Allows you to avoid the `Keg::ConflictError` recommending that you invoke `brew link --overwrite` in scenarios when you know that that's how you'd proceed anyway.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I didn't see a test in [formula_spec.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/formula_spec.rb) that exercised the `Keg::ConflictError` error — that I could copy and adapt. [keg_spec.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/keg_spec.rb) already covers the logic of the `overwrite` option.

I validated this change by doing:
```
brew uninstall git
touch /usr/local/bin/git
brew install --overwrite git
```
