### PR TITLE
Strategy: Add --silent flag to DEFAULT_CURL_ARGS

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -39,6 +39,9 @@ module Homebrew
       DEFAULT_CURL_ARGS = [
         # Follow redirections to handle mirrors, relocations, etc.
         "--location",
+        # Avoid progress bar text, so we can reliably identify `curl` error
+        # messages in output
+        "--silent",
       ].freeze
 
       # `curl` arguments used in `Strategy#page_headers` method.
@@ -46,8 +49,7 @@ module Homebrew
         # We only need the response head (not the body)
         "--head",
         # Some servers may not allow a HEAD request, so we use GET
-        "--request", "GET",
-        "--silent"
+        "--request", "GET"
       ] + DEFAULT_CURL_ARGS).freeze
 
       # `curl` arguments used in `Strategy#page_content` method.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a recreation of #12647, as I was encountering persistent CI failures that I didn't think were related to the committed changes (based on what I saw in testing). Digging into this further, it turned out that the failures were, in fact, due to the `#curl_args` commit where I used `#uniq` on the returned array. My intention was to avoid having options duplicated between `args` and `extra_args` (e.g., including `--silent` twice), simply for the sake of tidiness, but this approach causes problems because some options can be used more than once (e.g., `--header`).

Unfortunately, I modified the related branch, so I couldn't re-open the previous PR. That said, this PR is the same as the last one but I've dropped the `#curl_args` commit.

---

Currently, only `Livecheck::Strategy::PAGE_HEADERS_CURL_ARGS` uses the `--silent` option and `PAGE_CONTENT_CURL_ARGS` does not (though there's no intention behind this omission). However, the `#page_content` method should also use the `--silent` flag, to prevent progress bar text (`#=#=#`, etc.) from appearing in output.

This is an issue because the regex that's used to identify `curl` error messages in `stderr` (`^curl:.+$/`) will fail if leading progress bar text is present. This leads to an ambiguous "cURL failed without a detectable error" message instead of the actual error message(s) from `curl`.

This PR addresses the issue by adding `--silent` to `Livecheck::Strategy::DEFAULT_CURL_ARGS`, which both `PAGE_HEADERS_CURL_ARGS` and `PAGE_CONTENT_CURL_ARGS` inherit.