### PR TITLE
Add helpful error message when attempting to run `brew cask`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -121,7 +121,7 @@ begin
     possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
     if !possible_tap || possible_tap.installed? || Tap.untapped_official_taps.include?(possible_tap.name)
-      if cmd == 'cask' # Check for cask explicitly because it's very common in old guides
+      if cmd == "cask" # Check for cask explicitly because it's very common in old guides
         odie "`brew cask <command>` is no longer supported. Use `brew <command> --cask` instead."
       end
       odie "Unknown command: #{cmd}"

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -121,9 +121,8 @@ begin
     possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
     if !possible_tap || possible_tap.installed? || Tap.untapped_official_taps.include?(possible_tap.name)
-      if cmd == "cask" # Check for cask explicitly because it's very common in old guides
-        odie "`brew cask <command>` is no longer supported. Use `brew <command> --cask` instead."
-      end
+      # Check for cask explicitly because it's very common in old guides
+      odie "`brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead." if cmd == "cask"
       odie "Unknown command: #{cmd}"
     end
 

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -86,6 +86,10 @@ begin
   require "commands"
   require "settings"
 
+  # Print an error message and exit if the command is no longer supported
+  unsupported_cmd_message = Commands.unsupported_cmd?(cmd)
+  odie unsupported_cmd_message if unsupported_cmd_message
+
   internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd) if cmd
 
   unless internal_cmd

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -86,10 +86,6 @@ begin
   require "commands"
   require "settings"
 
-  # Print an error message and exit if the command is no longer supported
-  unsupported_cmd_message = Commands.unsupported_cmd?(cmd)
-  odie unsupported_cmd_message if unsupported_cmd_message
-
   internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd) if cmd
 
   unless internal_cmd
@@ -125,6 +121,9 @@ begin
     possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
     if !possible_tap || possible_tap.installed? || Tap.untapped_official_taps.include?(possible_tap.name)
+      if cmd == 'cask' # Check for cask explicitly because it's very common in old guides
+        odie "`brew cask <command>` is no longer supported. Use `brew <command> --cask` instead."
+      end
       odie "Unknown command: #{cmd}"
     end
 

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -30,6 +30,13 @@ module Commands
     "lc"          => "livecheck",
     "tc"          => "typecheck",
   }.freeze
+  HOMEBREW_UNSUPPORTED_COMMAND_MESSAGES = {
+    "cask" => "`brew cask <command>` is no longer supported. Use `brew <command> --cask` instead.",
+  }.freeze
+
+  def unsupported_cmd?(cmd)
+    HOMEBREW_UNSUPPORTED_COMMAND_MESSAGES.fetch(cmd, nil)
+  end
 
   def valid_internal_cmd?(cmd)
     require?(HOMEBREW_CMD_PATH/cmd)

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -30,13 +30,6 @@ module Commands
     "lc"          => "livecheck",
     "tc"          => "typecheck",
   }.freeze
-  HOMEBREW_UNSUPPORTED_COMMAND_MESSAGES = {
-    "cask" => "`brew cask <command>` is no longer supported. Use `brew <command> --cask` instead.",
-  }.freeze
-
-  def unsupported_cmd?(cmd)
-    HOMEBREW_UNSUPPORTED_COMMAND_MESSAGES.fetch(cmd, nil)
-  end
 
   def valid_internal_cmd?(cmd)
     require?(HOMEBREW_CMD_PATH/cmd)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
  - I may have missed some, as there are 26 pages of results for `
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
  - I couldn't think of any general enough tests for this that don't basically just duplicate the logic, but I'm open to writing one if needed.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
  - I get some nondeterministic errors both with my code and with the current master code, that differ between runs. This may relate at least in part to me running this on an M1 mac. Some errors were timeouts. Wasn't able to check/compare many times because it takes about 5 minutes to run the full suite.
  - EDIT: But the CI tests pass! 🎉 

-----

This adds a simple check: if the command being used is `brew cask`, it exits early with a helpful error message instructing them to use `brew <command> --cask` instead.

Fixes #12707

See https://github.com/Homebrew/discussions/discussions/902 for related discussion & motivation for this issue