### PR TITLE
Provide a way for regular users to ignore xcode check

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -134,7 +134,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI providers
         # Homebrew/brew is currently using.
-        return if ENV["GITHUB_ACTIONS"]
+        return if ENV["GITHUB_ACTIONS"] || ENV["SKIP_XCODE_UP_TO_DATE_CHECK"]
 
         message = <<~EOS
           Your Xcode (#{MacOS::Xcode.version}) is outdated.
@@ -161,7 +161,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI providers
         # Homebrew/brew is currently using.
-        return if ENV["GITHUB_ACTIONS"]
+        return if ENV["GITHUB_ACTIONS"] || ENV["SKIP_XCODE_UP_TO_DATE_CHECK"]
 
         <<~EOS
           A newer Command Line Tools release is available.
@@ -171,6 +171,8 @@ module Homebrew
 
       def check_xcode_minimum_version
         return unless MacOS::Xcode.below_minimum_version?
+
+        return if ENV["SKIP_XCODE_UP_TO_DATE_CHECK"]
 
         xcode = MacOS::Xcode.version.to_s
         xcode += " => #{MacOS::Xcode.prefix}" unless MacOS::Xcode.default_prefix?


### PR DESCRIPTION
In some corporations folks run vendored versions of xcode where updating
to the latest version of xcode is simply not possible with the toolchain
they are working with. Given there is already a way to bypass the xcode
check in github actions, there should be a reasonable way for most users
to bypass the check too if they would like knowing the risks it may
entail.

There is already a rather widely shared solution similar to this:
https://stackoverflow.com/a/56252549

However this is brittle and is prone to reverting if a brew update is
run (which the default brew configuration will do when installing a new
package https://github.com/Homebrew/brew/issues/9285)

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
