### PR TITLE
Update documentation on deprecating and disabling formulae

### DIFF
--- a/docs/Deprecating-Disabling-and-Removing-Formulae.md
+++ b/docs/Deprecating-Disabling-and-Removing-Formulae.md
@@ -18,6 +18,11 @@ A formula should be deprecated to indicate to users that the formula should not 
 
 The most common reasons for deprecation are when the upstream project is deprecated, unmaintained, or archived.
 
+Formulae with dependents should **not** be deprecated unless the formula:
+
+- does not build on any of our supported platforms; or,
+- has outstanding CVEs.
+
 To deprecate a formula, add a `deprecate!` call. This call should include a deprecation date (in the ISO 8601 format) and a deprecation reason:
 
 ```ruby
@@ -40,6 +45,8 @@ The most common reasons for disabling a formula are:
 - it has been deprecated for a long time
 - the upstream repository has been removed
 - the project has no license
+
+Formulae should not be disabled without a reasonable deprecation period unless the circumstances are exceptional (e.g. the formula does not build). How long a reasonable period is depends on the formula's usage statistics. Popular formulae should have longer deprecation periods. We should aim to have a formula deprecated for at least three months before disabling it.
 
 **Note: disabled formulae in homebrew/core will be automatically removed one year after their disable date**
 

--- a/docs/Deprecating-Disabling-and-Removing-Formulae.md
+++ b/docs/Deprecating-Disabling-and-Removing-Formulae.md
@@ -18,11 +18,11 @@ A formula should be deprecated to indicate to users that the formula should not 
 
 The most common reasons for deprecation are when the upstream project is deprecated, unmaintained, or archived.
 
-Formulae with dependents should **not** be deprecated unless:
+Formulae with dependents should **only** be deprecated if any of the below are true:
 
-- all of its dependents are also deprecated;
-- the formula does not build on any of our supported platforms; or,
-- the formula has outstanding CVEs.
+- its dependents are all deprecated
+- the formula does not build on any of our supported macOS versions and on Linux
+- the formula has outstanding CVEs
 
 To deprecate a formula, add a `deprecate!` call. This call should include a deprecation date (in the ISO 8601 format) and a deprecation reason:
 
@@ -47,7 +47,7 @@ The most common reasons for disabling a formula are:
 - the upstream repository has been removed
 - the project has no license
 
-Formulae should not be disabled without a reasonable deprecation period unless the circumstances are exceptional (e.g. the formula does not build). How long a reasonable period is depends on the formula's usage statistics. Popular formulae should have longer deprecation periods. We should aim to have a formula deprecated for at least three months before disabling it.
+Formulae should not be disabled without a deprecation period of at least three months unless the circumstances are exceptional (e.g. the formula does not build on any supported macOS version or Linux). How long a reasonable period is depends on the formula's usage statistics. Popular formulae should have longer deprecation periods.
 
 **Note: disabled formulae in homebrew/core will be automatically removed one year after their disable date**
 

--- a/docs/Deprecating-Disabling-and-Removing-Formulae.md
+++ b/docs/Deprecating-Disabling-and-Removing-Formulae.md
@@ -18,7 +18,7 @@ A formula should be deprecated to indicate to users that the formula should not 
 
 The most common reasons for deprecation are when the upstream project is deprecated, unmaintained, or archived.
 
-Formulae with dependents should **only** be deprecated if any of the below are true:
+Formulae with dependents may be deprecated only if at least one of the following are true:
 
 - its dependents are all deprecated
 - the formula does not build on any of our supported macOS versions and on Linux
@@ -47,7 +47,7 @@ The most common reasons for disabling a formula are:
 - the upstream repository has been removed
 - the project has no license
 
-Formulae should not be disabled without a deprecation period of at least three months unless the circumstances are exceptional (e.g. the formula does not build on any supported macOS version or Linux). How long a reasonable period is depends on the formula's usage statistics. Popular formulae should have longer deprecation periods.
+Formulae should not be disabled without a deprecation period of at least three months unless the circumstances are exceptional (e.g. the formula does not build on any supported macOS version or Linux). Popular formulae should have longer deprecation periods. The popularity of a formula should be based on our analytics data.
 
 **Note: disabled formulae in homebrew/core will be automatically removed one year after their disable date**
 

--- a/docs/Deprecating-Disabling-and-Removing-Formulae.md
+++ b/docs/Deprecating-Disabling-and-Removing-Formulae.md
@@ -18,10 +18,11 @@ A formula should be deprecated to indicate to users that the formula should not 
 
 The most common reasons for deprecation are when the upstream project is deprecated, unmaintained, or archived.
 
-Formulae with dependents should **not** be deprecated unless the formula:
+Formulae with dependents should **not** be deprecated unless:
 
-- does not build on any of our supported platforms; or,
-- has outstanding CVEs.
+- all of its dependents are also deprecated;
+- the formula does not build on any of our supported platforms; or,
+- the formula has outstanding CVEs.
 
 To deprecate a formula, add a `deprecate!` call. This call should include a deprecation date (in the ISO 8601 format) and a deprecation reason:
 


### PR DESCRIPTION
This is based on the discussion at Homebrew/homebrew-core#91368.

A few reasons why we don't want to deprecate formulae that have
dependents:

1. This results in displaying warning messages to (at least some) users
   that they can't do anything about.
2. `test-bot` does not test deprecated formulae, so we risk breaking
   dependent formulae when one of its dependencies is not tested.
3. It is much harder to commit to a disable date for formulae with
   dependents because we don't know when we'll be able to wean
   dependents off of a deprecated formula.

I think it's important to have a disable date in mind when we deprecate
formulae. Otherwise, we might end up leaving formulae deprecated
indefinitely. This is bad because it teaches users to not take
deprecation warnings seriously.