### PR TITLE
Fix typo in docs/Manpage.md

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -592,7 +592,7 @@ The search for *`text`* is extended online to `homebrew/core` and `homebrew/cask
 Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 
 The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-To help guarantee idempotence, this command produces no output when Homebrew's `bin` and `sbin` directores are first and second
+To help guarantee idempotence, this command produces no output when Homebrew's `bin` and `sbin` directories are first and second
 respectively in your `PATH`. Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`,
 `~/.bash_profile`, or `~/.zprofile`) with: `eval "$(brew shellenv)"`
 


### PR DESCRIPTION
Simple typofix in docs/Manpage.md

595: directores -> directories

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
