### PR TITLE
README: add DNSimple as a sponsor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Flaky test detection and tracking is provided by [BuildPulse](https://buildpulse
 
 [![BuildPulse](https://user-images.githubusercontent.com/2988/130445500-96f44c87-e7dd-4da0-9877-7e5b1618e144.png)](https://buildpulse.io)
 
+<https://brew.sh>'s DNS is [resolving with DNSimple](https://dnsimple.com/resolving/homebrew).
+
+[![DNSimple](https://cdn.dnsimple.com/assets/resolving-with-us/logo-light.png)](https://dnsimple.com/resolving/homebrew)
+
 Homebrew is generously supported by [Substack](https://github.com/substackinc), [Randy Reddig](https://github.com/ydnar), [embark-studios](https://github.com/embark-studios), [CodeCrafters](https://github.com/codecrafters-io) and many other users and organisations via [GitHub Sponsors](https://github.com/sponsors/Homebrew).
 
 [![Substack](https://github.com/substackinc.png?size=64)](https://github.com/substackinc)


### PR DESCRIPTION
They've provided our DNS for free for a while so let's give them a shout-out.