### PR TITLE
Adapt DNSimple logo to system appearance

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Flaky test detection and tracking is provided by [BuildPulse](https://buildpulse
 
 <https://brew.sh>'s DNS is [resolving with DNSimple](https://dnsimple.com/resolving/homebrew).
 
-[![DNSimple](https://cdn.dnsimple.com/assets/resolving-with-us/logo-light.png)](https://dnsimple.com/resolving/homebrew)
+[![DNSimple](https://cdn.dnsimple.com/assets/resolving-with-us/logo-light.png)](https://dnsimple.com/resolving/homebrew#gh-light-mode-only)
+[![DNSimple](https://cdn.dnsimple.com/assets/resolving-with-us/logo-dark.png)](https://dnsimple.com/resolving/homebrew#gh-dark-mode-only)
 
 Homebrew is generously supported by [Substack](https://github.com/substackinc), [Randy Reddig](https://github.com/ydnar), [embark-studios](https://github.com/embark-studios), [CodeCrafters](https://github.com/codecrafters-io) and many other users and organisations via [GitHub Sponsors](https://github.com/sponsors/Homebrew).
 


### PR DESCRIPTION
Follow-up to #12731

This adds DNSimple's dark mode logo and sets up the README to [switch between using the light and dark logos based on the GitHub theme](https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/).

Before on dark mode:

<img width="394" alt="Screen Shot 2022-01-17 at 12 54 24 PM" src="https://user-images.githubusercontent.com/32525609/149818034-7ef152e7-c521-4075-870d-acfed1b39738.png">

After on dark mode:

<img width="380" alt="Screen Shot 2022-01-17 at 12 54 45 PM" src="https://user-images.githubusercontent.com/32525609/149818059-79354440-4f5b-4689-a995-443aac45abbb.png">

It would probably also be good to do this for MacStadium and maybe Substack, but I don't know where the right images would be located.