### PR TITLE
os/mac/keg: use `MachOFile#delete_rpath` instead of `MachO::Tools`

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -54,20 +54,12 @@ class Keg
           change_install_name(bad_name, new_name, file) unless new_name == bad_name
         end
 
-        # Keep track of the rpath counts for deletion of duplicates.
-        # We need to track this here since we cache the MachO data [0]
-        # and this cache is not updated after modification with #delete_rpath.
-        #
-        # [0] See os/mac/mach.rb.
-        rpath_count = Hash.new { |h, k| h[k] = file.rpaths.count(k) }
-
         each_linkage_for(file, :rpaths) do |bad_name|
           # Strip duplicate rpaths and rpaths rooted in the build directory.
           next if !bad_name.start_with?(HOMEBREW_TEMP.to_s) &&
                   !bad_name.start_with?(HOMEBREW_TEMP.realpath.to_s) &&
-                  (rpath_count[bad_name] == 1)
+                  (file.rpaths.count(bad_name) == 1)
 
-          rpath_count[bad_name] -= 1
           delete_rpath(bad_name, file)
         end
       end

--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -52,7 +52,7 @@ class Keg
 
   def delete_rpath(rpath, file)
     odebug "Deleting rpath #{rpath} in #{file}"
-    MachO::Tools.delete_rpath(file, rpath, strict: false)
+    file.delete_rpath(rpath, strict: false)
     apply_ad_hoc_signature(file)
   rescue MachO::MachOError
     onoe <<~EOS

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -57,6 +57,13 @@ module MachOShim
   end
   private :mach_data
 
+  # TODO: See if the `#write!` call can be delayed until
+  # we know we're not making any changes to the rpaths.
+  def delete_rpath(rpath, **options)
+    macho.delete_rpath(rpath, options)
+    macho.write!
+  end
+
   def dynamically_linked_libraries(except: :none)
     lcs = macho.dylib_load_commands.reject { |lc| lc.type == except }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will allow us to avoid keeping track of the number of `RPATH`s
while trying to delete duplicates.

See discussion at #12745.