### PR TITLE
keg_relocate: fall back to formula when tab is missing

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -499,6 +499,7 @@ class Keg
   def runtime_dependencies
     Keg.cache[:runtime_dependencies] ||= {}
     Keg.cache[:runtime_dependencies][path] ||= tab.runtime_dependencies
+    Keg.cache[:runtime_dependencies][path] ||= to_formula.runtime_dependencies(read_from_tab: false)
   end
 
   def aliases

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -133,9 +133,16 @@ class Keg
 
   def openjdk_dep_name_if_applicable
     deps = runtime_dependencies
+    deps ||= to_formula.deps # the tab is missing, so fall back to the formula
     return if deps.blank?
 
-    dep_names = deps.map { |d| d["full_name"] }
+    # TODO: Remove this when we support fetching bottle manifests from non-ghcr.io domains.
+    dep_names = case deps.first
+    when Hash then deps.map { |d| d["full_name"] }
+    when Dependency then deps.map(&:name)
+    else odie "Unrecognised dependency array!"
+    end
+
     dep_names.find { |d| d.match? Version.formula_optionally_versioned_regex(:openjdk) }
   end
 

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -133,16 +133,9 @@ class Keg
 
   def openjdk_dep_name_if_applicable
     deps = runtime_dependencies
-    deps ||= to_formula.deps.reject(&:build?).reject(&:test?) # the tab is missing, so fall back to the formula
     return if deps.blank?
 
-    # TODO: Remove this when we support fetching bottle manifests from non-ghcr.io domains.
-    dep_names = case deps.first
-    when Hash then deps.map { |d| d["full_name"] }
-    when Dependency then deps.map(&:name)
-    else odie "Unrecognised dependency array!"
-    end
-
+    dep_names = deps.map { |d| d["full_name"] }
     dep_names.find { |d| d.match? Version.formula_optionally_versioned_regex(:openjdk) }
   end
 

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -133,7 +133,7 @@ class Keg
 
   def openjdk_dep_name_if_applicable
     deps = runtime_dependencies
-    deps ||= to_formula.deps # the tab is missing, so fall back to the formula
+    deps ||= to_formula.deps.reject(&:build?).reject(&:test?) # the tab is missing, so fall back to the formula
     return if deps.blank?
 
     # TODO: Remove this when we support fetching bottle manifests from non-ghcr.io domains.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Installing Java-dependent formulae from third-party taps and bottle
mirrors can, for a variety of reasons, result in the tab going missing.
See Homebrew/discussions#2530.

One result of this is that kegs are not relocated correctly, and this
produces confusing errors for users at runtime. Let's fix that by
falling back to the formula for dependency information when we need to.