### PR TITLE
dev-cmd/bump-formula-pr: fix for undetectable version

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -408,7 +408,7 @@ module Homebrew
     resource.owner = Resource.new(formula.name)
     forced_version = new_version && new_version != resource.version
     resource.version = new_version if forced_version
-    odie "No `--version=` argument specified!" if resource.version.blank?
+    odie "Couldn't identify version, specify it using `--version=`." if resource.version.blank?
     [resource.fetch, forced_version]
   end
 

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -436,6 +436,9 @@ module Homebrew
       specs[:tag] = tag if tag.present?
       version = Version.detect(url, **specs)
     end
+
+    return if version.null?
+
     check_throttle(formula, version)
     check_closed_pull_requests(formula, tap_remote_repo, args: args, version: version)
   end


### PR DESCRIPTION
Currently, `brew bump-formula-pr` errors out without a proper message
when `--version` isn't specified and the formula's version cannot be parsed
from the URL. We fix this by returning early from `check_new_version` when the
detected version is Version::NULL.

See https://github.com/Homebrew/homebrew-core/pull/93497#issuecomment-1017968277 for context.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?