### PR TITLE
Fix `brew services` test

### DIFF
--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -6,8 +6,8 @@ describe "brew services", :integration_test, :needs_macos, :needs_network do
     setup_remote_tap "homebrew/services"
 
     expect { brew "services", "list" }
-      .to output("Warning: No services available to control with `brew services`\n").to_stderr
+      .to be_a_success
+      .and not_to_output.to_stderr
       .and not_to_output.to_stdout
-      .and be_a_success
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/Homebrew/homebrew-services/pull/443 changed `brew services list` so that it no longer outputs a warning without TTY. This broke the test here and this is blocking Homebrew/brew CI now.

I just changed the test to check that there's no stderr or stdout output and the command succeeds. I think this should be enough to check the same thing that was being checked before. We may even want to consider just removing this integration test since its slow and I'm not really sure what it's checking since it's not checking any `brew services` functionality. I guess it's possible that its purpose is to check running an external command so I'll leave it for now.
