### PR TITLE
test/cmd/services_spec: fix test.

### DIFF
--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -6,7 +6,7 @@ describe "brew services", :integration_test, :needs_macos, :needs_network do
     setup_remote_tap "homebrew/services"
 
     expect { brew "services", "list" }
-      .to output("Warning: No services available to control with `brew services`\n").to_stderr
+      .to not_to_output.to_stderr
       .and not_to_output.to_stdout
       .and be_a_success
   end


### PR DESCRIPTION
Was broken by https://github.com/Homebrew/homebrew-services/pull/443