### PR TITLE
dev-cmd/bump-formula-pr: fix undefined method null error

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -435,9 +435,8 @@ module Homebrew
       specs = {}
       specs[:tag] = tag if tag.present?
       version = Version.detect(url, **specs)
+      return if version.null?
     end
-
-    return if version.null?
 
     check_throttle(formula, version)
     check_closed_pull_requests(formula, tap_remote_repo, args: args, version: version)


### PR DESCRIPTION
Fix a regression from 8b1fcc7c5c18ec970c30e712ab283d7703694523.
Only if `version.nil?` is `Version.detect` used, so we can
only use `version.null?` after that. (Otherwise, it's a string.)

```
Error: undefined method `null?' for "X.Y.Z":String
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:440:in `check_new_version'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:131:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
