### PR TITLE
`brew bump`: don't use Repology for versioned formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -105,7 +105,12 @@ module Homebrew
           Repology::HOMEBREW_CASK
         end
 
-        package_data = Repology.single_package_query(name, repository: repository)
+        package_data = if formula_or_cask.is_a?(Formula) && formula_or_cask.versioned_formula?
+          nil
+        else
+          Repology.single_package_query(name, repository: repository)
+        end
+
         retrieve_and_display_info_and_open_pr(
           formula_or_cask,
           name,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR proposes to avoid checking Repology for versioned formulae when `brew bump`ing them. 

Currently, `brew bump`'s Repology output for a versioned formula shows the latest version for the corresponding non-versioned formula. This leads to incorrect PRs like https://github.com/Homebrew/homebrew-core/pull/94115, https://github.com/Homebrew/homebrew-core/pull/94113, https://github.com/Homebrew/homebrew-core/pull/94110, etc. For example:

```
➜ brew bump traefik@1
==> traefik@1
Current formula version:  1.7.34
Latest livecheck version: 1.7.34
Latest Repology version:  2.6.0
Open pull requests:       none
```

With these changes, we have:

```
➜ brew bump traefik@1
==> traefik@1
Current formula version:  1.7.34
Latest livecheck version: 1.7.34
Latest Repology version:  not found
Open pull requests:       none
```

The message could probably improved/changed from "not found" for this particular case. I think it's fine to skip Repology altogether because:

* They don't list the versioned formula separately for Homebrew's case (see e.g. https://repology.org/project/traefik/versions, the page contains both `traefik` and `traefik@1`).
* Other distributions that have versioned formulae may not use the same name (e.g. Scoop uses `traefik1`) and searching through all these may be wasteful or include different packages.

This would only be a problem for formulae like `openssl` where we have only versioned formulae, but there are very few of these, they're usually very popular (Python, OpenSSL, etc.) and `livecheck` is probably sufficient.