### PR TITLE
Formula: Allow `cargo build` when building libraries

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -70,7 +70,9 @@ module RuboCop
             problem "use \"dep\", \"ensure\", \"-vendor-only\""
           end
 
-          find_method_with_args(body_node, :system, "cargo", "build") do
+          find_method_with_args(body_node, :system, "cargo", "build") do |m|
+            next if parameters_passed?(m, /--lib/)
+
             problem "use \"cargo\", \"install\", *std_cargo_args"
           end
 

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -205,6 +205,19 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
+    it "doesn't reports an offense if `cargo build` is executed with --lib" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          def install
+            system "cargo", "build", "--lib"
+          end
+        end
+      RUBY
+    end
+
     it "reports an offense if `make` calls are not separated" do
       expect_offense(<<~RUBY)
         class Foo < Formula


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

When building Rust packages that provide libraries but no executable binaries, `cargo install` doesn't do anything; you need to use `cargo build` and install any libraries manually. See e.g. rust-lang/cargo#8294.

Unfortunately, Homebrew's Rubocop "use `"cargo", "install", *std_cargo_args`" rule, as currently written, blocks all invocations of `cargo build`. This is blocking homebrew/homebrew-core#94091 and will prevent formulas for being created for any library-only Rust packages that use `cargo` to build.

This commit changes that rule to allow invocations of `cargo build` that use the `--lib` argument (`--lib` specifies to Cargo that a package's library targets should be built). This will enable library packages to be built, while retaining the "use `"cargo", "install", *std_cargo_args`" message for the more common case when a Rust package provides executable binaries.