### PR TITLE
shebang: raise error if no rewriting

### DIFF
--- a/Library/Homebrew/test/utils/shebang_spec.rb
+++ b/Library/Homebrew/test/utils/shebang_spec.rb
@@ -1,0 +1,30 @@
+# typed: false
+# frozen_string_literal: true
+
+require "utils/shebang"
+
+describe Utils::Shebang do
+  let(:file) { Tempfile.new("shebang") }
+
+  before do
+    file.write "#!/usr/bin/python"
+    file.flush
+  end
+
+  after { file.unlink }
+
+  describe "rewrite_shebang" do
+    it "rewrites a shebang" do
+      rewrite_info = Utils::Shebang::RewriteInfo.new(/^#!.*python$/, 25, "new_shebang")
+      described_class.rewrite_shebang rewrite_info, file
+      expect(File.read(file)).to eq "#!new_shebang"
+    end
+
+    it "raises an error if no rewriting occurs" do
+      rewrite_info = Utils::Shebang::RewriteInfo.new(/^#!.*perl$/, 25, "new_shebang")
+      expect {
+        described_class.rewrite_shebang rewrite_info, file
+      }.to raise_error("No matching files found to rewrite shebang")
+    end
+  end
+end

--- a/Library/Homebrew/utils/shebang.rb
+++ b/Library/Homebrew/utils/shebang.rb
@@ -34,13 +34,17 @@ module Utils
     # @api public
     sig { params(rewrite_info: RewriteInfo, paths: T::Array[T.any(String, Pathname)]).void }
     def rewrite_shebang(rewrite_info, *paths)
+      found = T.let(false, T::Boolean)
       paths.each do |f|
         f = Pathname(f)
         next unless f.file?
         next unless rewrite_info.regex.match?(f.read(rewrite_info.max_length))
 
         Utils::Inreplace.inreplace f.to_s, rewrite_info.regex, "#!#{rewrite_info.replacement}"
+        found = true
       end
+
+      raise "No matching files found to rewrite shebang" unless found
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In https://github.com/Homebrew/homebrew-core/pull/94202, we encountered a bug where `rewrite_shebang` wasn't actually rewriting any shebang due to a misspelled filename. This change prevents this class of bugs by erroring when no replacement occurs.

This is my first PR here, so any feedback is greatly appreciated 😄 