### PR TITLE
rubocops/text: remove `setuptools` audit

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -35,13 +35,6 @@ module RuboCop
             problem "Formulae in homebrew/core should use OpenBLAS as the default serial linear algebra library."
           end
 
-          if method_called_ever?(body_node, :virtualenv_create) ||
-             method_called_ever?(body_node, :virtualenv_install_with_resources)
-            find_method_with_args(body_node, :resource, "setuptools") do
-              problem "Formulae using virtualenvs do not need a `setuptools` resource."
-            end
-          end
-
           unless method_called_ever?(body_node, :go_resource)
             # processed_source.ast is passed instead of body_node because `require` would be outside body_node
             find_method_with_args(processed_source.ast, :require, "language/go") do

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -144,25 +144,6 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "reports an offense if formula uses virtualenv and also `setuptools` resource" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          url "https://brew.sh/foo-1.0.tgz"
-          homepage "https://brew.sh"
-
-          resource "setuptools" do
-          ^^^^^^^^^^^^^^^^^^^^^ Formulae using virtualenvs do not need a `setuptools` resource.
-            url "https://foo.com/foo.tar.gz"
-            sha256 "db0904a28253cfe53e7dedc765c71596f3c53bb8a866ae50123320ec1a7b73fd"
-          end
-
-          def install
-            virtualenv_create(libexec)
-          end
-        end
-      RUBY
-    end
-
     it "reports an offense if `Formula.factory(name)` is present" do
       expect_offense(<<~RUBY)
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This currently no longer applies, because we might sometimes need an
older `setuptools` than the one shipped with a Python formula.

This is needed for Homebrew/homebrew-core#93964.
