### PR TITLE
keg: allow instantiating kegs not rooted in the cellar

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -165,9 +165,10 @@ class Keg
                  :to_s, :hash, :abv, :disk_usage, :file_count, :directory?, :exist?, :/,
                  :join, :rename, :find
 
-  def initialize(path)
+  def initialize(path, check_cellar: true)
     path = path.resolved_path if path.to_s.start_with?("#{HOMEBREW_PREFIX}/opt/")
-    raise "#{path} is not a valid keg" if path.parent.parent.realpath != HOMEBREW_CELLAR.realpath
+    keg_in_cellar = path.parent.parent.realpath == HOMEBREW_CELLAR.realpath
+    raise "#{path} is not a valid keg" if !keg_in_cellar && check_cellar
     raise "#{path} is not a directory" unless path.directory?
 
     @path = path


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I often download bottles directly from a GitHub workflow and unpack them
in a temporary directory. The `Keg` class provides a number of
convenience methods for examining the contents of unpacked bottles (e.g.
`Keg#mach_o_files`), so I often find myself temporarily commenting out
the check for a keg being rooted in the cellar.

It would simplify things a lot for me if I could just pass an extra
argument to `Keg.new` to skip checking for whether the `Keg` I'm trying
to instantiate is rooted in the cellar.
