### PR TITLE
cask/dsl/caveats: add `:requires_rosetta`

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -127,6 +127,17 @@ module Cask
         end
       end
 
+      caveat :requires_rosetta do
+        next unless Hardware::CPU.arm?
+
+        <<~EOS
+          #{@cask} is built for Intel macOS and so requires Rosetta 2 to be installed.
+          You can install Rosetta 2 with:
+            softwareupdate --install-rosetta --agree-to-license
+          Note that it is very difficult to remove Rosetta 2 once it is installed.
+        EOS
+      end
+
       caveat :logout do
         <<~EOS
           You must log out and log back in for the installation of #{@cask} to take effect.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some casks will fail to install with a `Bad CPU type in executable`
error on Apple Silicon. See Homebrew/homebrew-cask#118638.

This error can be quite confusing, so let's add a way to help users know
that they need to install Rosetta to use or even install a cask.
