### PR TITLE
service: launch only once

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -303,7 +303,7 @@ module Homebrew
       }
 
       base[:KeepAlive] = @keep_alive if @keep_alive == true
-      base[:LaunchOnlyOnce] = @launch_only_once if @launch_only_once == false
+      base[:LaunchOnlyOnce] = @launch_only_once if @launch_only_once == true
       base[:LegacyTimers] = @macos_legacy_timers if @macos_legacy_timers == true
       base[:TimeOut] = @restart_delay if @restart_delay.present?
       base[:ProcessType] = @process_type.to_s.capitalize if @process_type.present?

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -334,11 +334,14 @@ module Homebrew
         WantedBy=multi-user.target
 
         [Service]
-        Type=simple
-        ExecStart=#{command.join(" ")}
       EOS
 
+      # command needs to be first because it initializes all other values
+      cmd = command.join(" ")
+
       options = []
+      options << "Type=#{@launch_only_once == true ? "oneshot" : "simple"}"
+      options << "ExecStart=#{cmd}"
       options << "Restart=always" if @keep_alive == true
       options << "RestartSec=#{restart_delay}" if @restart_delay.present?
       options << "WorkingDirectory=#{@working_dir}" if @working_dir.present?

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -112,6 +112,18 @@ module Homebrew
       end
     end
 
+    sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
+    def launch_only_once(value = nil)
+      case T.unsafe(value)
+      when nil
+        @launch_only_once
+      when true, false
+        @launch_only_once = value
+      else
+        raise TypeError, "Service#launch_only_once expects a Boolean"
+      end
+    end
+
     sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
     def restart_delay(value = nil)
       case T.unsafe(value)
@@ -291,6 +303,7 @@ module Homebrew
       }
 
       base[:KeepAlive] = @keep_alive if @keep_alive == true
+      base[:LaunchOnlyOnce] = @launch_only_once if @launch_only_once == false
       base[:LegacyTimers] = @macos_legacy_timers if @macos_legacy_timers == true
       base[:TimeOut] = @restart_delay if @restart_delay.present?
       base[:ProcessType] = @process_type.to_s.capitalize if @process_type.present?

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -102,6 +102,7 @@ describe Homebrew::Service do
         root_dir var
         working_dir var
         keep_alive true
+        launch_only_once true
         process_type :interactive
         restart_delay 30
         interval 5
@@ -127,6 +128,8 @@ describe Homebrew::Service do
         \t<true/>
         \t<key>Label</key>
         \t<string>homebrew.mxcl.formula_name</string>
+        \t<key>LaunchOnlyOnce</key>
+        \t<true/>
         \t<key>LegacyTimers</key>
         \t<true/>
         \t<key>ProcessType</key>

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -291,10 +291,11 @@ describe Homebrew::Service do
       expect(unit).to eq(unit_expect.strip)
     end
 
-    it "returns valid partial unit" do
+    it "returns valid partial oneshot unit" do
       f.class.service do
         run opt_bin/"beanstalkd"
         run_type :immediate
+        launch_only_once true
       end
 
       unit = f.service.to_systemd_unit
@@ -306,10 +307,10 @@ describe Homebrew::Service do
         WantedBy=multi-user.target
 
         [Service]
-        Type=simple
+        Type=oneshot
         ExecStart=#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd
       EOS
-      expect(unit).to eq(unit_expect)
+      expect(unit).to eq(unit_expect.strip)
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds a MacOS launchctl configuration to services that allows providing the `LaunchOnlyOnce` boolean flag.

```
     LaunchOnlyOnce <boolean>
     This optional key specifies whether the job can only be run once and only once.  In other words, if the job cannot be safely
     respawned without a full machine reboot, then set this key to be true.
```

**NOTE**: this is MacOS only, if there's a way to provide this for systemd that'd be awesome!

Issue: https://github.com/abiosoft/colima/issues/96