### PR TITLE
Recommend interactive usage of `fish_add_path`

### DIFF
--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -98,7 +98,7 @@ describe Utils::Shell do
       ENV["SHELL"] = "/usr/local/bin/fish"
       ENV["fish_user_paths"] = "/some/path"
       expect(described_class.prepend_path_in_profile(path))
-        .to eq("echo 'fish_add_path #{path}' >> #{shell_profile}")
+        .to eq("fish_add_path #{path}")
     end
   end
 end

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -78,7 +78,7 @@ module Utils
       when :csh, :tcsh
         "echo 'setenv PATH #{csh_quote(path)}:$PATH' >> #{profile}"
       when :fish
-        "echo 'fish_add_path #{sh_quote(path)}' >> #{profile}"
+        "fish_add_path #{sh_quote(path)}"
       end
     end
 


### PR DESCRIPTION
Since the `fish_add_path` command modifies a universal Fish variable (which is automatically persisted to a file) it's unnecessary to run it again every time a new shell is opened.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?