### PR TITLE
pr-{publish,pull}: autosquash by default

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -26,12 +26,13 @@ module Homebrew
       flag   "--branch=",
              description: "Branch to publish to (default: `master`)."
       flag   "--message=",
-             depends_on:  "--autosquash",
              description: "Message to include when autosquashing revision bumps, deletions, and rebuilds."
       flag   "--tap=",
              description: "Target tap repository (default: `homebrew/core`)."
       flag   "--workflow=",
              description: "Target workflow filename (default: `publish-commit-bottles.yml`)."
+
+      conflicts "--no-autosquash", "--message"
 
       named_args :pull_request, min: 1
     end
@@ -45,7 +46,7 @@ module Homebrew
     ref = args.branch || "master"
 
     extra_args = []
-    extra_args << "--autosquash" unless args.no_autosquash?
+    extra_args << "--no-autosquash" if args.no_autosquash?
     extra_args << "--message='#{args.message}'" if args.message.presence
     dispatch_args = extra_args.join " "
 

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -27,12 +27,17 @@ module Homebrew
       switch "-n", "--dry-run",
              description: "Print what would be done rather than doing it."
       switch "--clean",
+             depends_on:  "--no-autosquash",
              description: "Do not amend the commits from pull requests."
       switch "--keep-old",
              description: "If the formula specifies a rebuild version, " \
                           "attempt to preserve its value in the generated DSL."
       switch "--autosquash",
              description: "Automatically reformat and reword commits in the pull request to our "\
+                          "preferred format.",
+             replacement: "`--no-autosquash` to opt out"
+      switch "--no-autosquash",
+             description: "Skip automatically reformatting and rewording commits in the pull request to our "\
                           "preferred format."
       switch "--branch-okay",
              description: "Do not warn if pulling to a branch besides the repository default (useful for testing)."
@@ -45,7 +50,6 @@ module Homebrew
       flag   "--committer=",
              description: "Specify a committer name and email in `git`'s standard author format."
       flag   "--message=",
-             depends_on:  "--autosquash",
              description: "Message to include when autosquashing revision bumps, deletions, and rebuilds."
       flag   "--artifact=",
              description: "Download artifacts with the specified name (default: `bottles`)."
@@ -62,7 +66,7 @@ module Homebrew
       comma_array "--ignore-missing-artifacts=",
                   description: "Comma-separated list of workflows which can be ignored if they have not been run."
 
-      conflicts "--clean", "--autosquash"
+      conflicts "--no-autosquash", "--message"
 
       named_args :pull_request, min: 1
     end
@@ -366,7 +370,7 @@ module Homebrew
 
           unless args.no_commit?
             cherry_pick_pr!(user, repo, pr, path: tap.path, args: args)
-            if args.autosquash? && !args.dry_run?
+            if !args.no_autosquash? && !args.dry_run?
               autosquash!(original_commit, path: tap.path,
                           verbose: args.verbose?, resolve: args.resolve?, reason: args.message)
             end

--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -1,4 +1,4 @@
-# Adding Software to Homebrew
+# Adding Software To Homebrew
 
 Are you missing your favorite software in Homebrew? Then you're the perfect person to resolve this problem.
 
@@ -358,4 +358,3 @@ if you set the variable `HOMEBREW_NO_AUTO_UPDATE` then clean it up with:
 ```bash
 unset HOMEBREW_NO_AUTO_UPDATE
 ```
-


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows dispatching the publish workflow via the GitHub UI to have
the exact same behaviour as doing `brew pr-publish`.

Closes Homebrew/homebrew-core#94704.
