### PR TITLE
formula_auditor: disallow external tap dependencies in core

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -289,6 +289,13 @@ module Homebrew
 
           next unless @core_tap
 
+          unless dep_f.tap.core_tap?
+            problem <<~EOS
+              Dependency '#{dep.name}' is not in homebrew/core. Formulae in homebrew/core
+              should not have dependencies in external taps.
+            EOS
+          end
+
           # we want to allow uses_from_macos for aliases but not bare dependencies
           if self.class.aliases.include?(dep.name) && spec.uses_from_macos_names.exclude?(dep.name)
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Occasionally, we get PRs that attempt to add a dependency on a formula
in an external tap in homebrew/core (e.g. Homebrew/homebrew-core#94791).

We don't actually have an audit that disallows that. We should have one.
