### PR TITLE
git rm Library/.rubocop_cask.yml

### DIFF
--- a/Library/.rubocop_cask.yml
+++ b/Library/.rubocop_cask.yml
@@ -1,4 +1,0 @@
-# TODO: This file can be deleted once https://github.com/Homebrew/brew/pull/8542
-# is in a stable release and `rubocop.yml` has been removed from all cask taps.
-
-inherit_from: ./.rubocop.yml


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was a TODO from 2020 (2b029b2744c1a008b17c588313963051a291f13c). I can't find `.rubocop.yml` in any Cask taps in the Homebrew org anymore.
