### PR TITLE
dev-cmd/dispatch-build-bottle: Stop replacing `linuxbrew-core`

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -47,10 +47,6 @@ module Homebrew
     ref = "master"
     workflow = args.workflow || "dispatch-build-bottle.yml"
 
-    # Ensure we dispatch the bottle in homebrew/homebrew-core
-    # TODO: remove when core taps are merged
-    repo.gsub!("linux", "home") unless args.tap
-
     runners = if (macos = args.macos&.compact_blank) && macos.present?
       macos.map do |element|
         # We accept runner name syntax (11-arm64) or bottle syntax (arm64_big_sur)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The cores are now merged (:tada:), so the Linux core tap is `homebrew-core` not `linuxbrew-core`, everything core should have switched over, this should be safe to remove.