### PR TITLE
Enables bump-formula-pr with GHES by setting HOMEBREW_GITHUB_API_URL

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -162,6 +162,10 @@ module Homebrew
                      "of Ruby is new enough.",
         boolean:     true,
       },
+      HOMEBREW_GITHUB_API_URL:                   {
+        description: "Use this URL for accessing the GitHub API, such as https://git.example.com/api/v3" \
+                     "for a GitHub Enterprise Server. ",
+      },
       HOMEBREW_GITHUB_API_TOKEN:                 {
         description: "Use this personal access token for the GitHub API, for features such as " \
                      "`brew search`. You can create one at <https://github.com/settings/tokens>. If set, " \

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -146,9 +146,22 @@ class Tap
 
     return unless remote
 
-    @remote_repo ||= remote.delete_prefix("https://github.com/")
-                           .delete_prefix("git@github.com:")
-                           .delete_suffix(".git")
+    path_base = nil
+    begin
+      path_base = URI.parse(remote).path.delete_prefix("/")
+    rescue URI::InvalidURIError
+      # probably SSH
+      # consider using vendoring uri-ssh_git
+      # path_base = URI::SshGit.parse(remote).path
+      path_base = remote.split(":", 2).last
+    end
+
+    unless path_base
+      opoo "Cannot determine the remote repo based on the remote URL"
+      return
+    end
+
+    @remote_repo ||= path_base.delete_suffix(".git")
   end
 
   # The default remote path to this {Tap}.

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -248,6 +248,26 @@ describe Tap do
       allow(Utils::Git).to receive(:available?).and_return(false)
       expect(homebrew_foo_tap.remote_repo).to be nil
     end
+
+    it "returns the expected repo even when it's not github.com and it's ssh" do
+      services_tap = described_class.new("Homebrew", "services")
+      services_tap.path.mkpath
+      services_tap.path.cd do
+        system "git", "init"
+        system "git", "remote", "add", "origin", "git@git.example.com:testbrew/homebrew-house.git"
+      end
+      expect(services_tap.remote_repo).to eq("testbrew/homebrew-house")
+    end
+
+    it "returns the expected repo even when it's not github.com and it's https" do
+      services_tap = described_class.new("Homebrew", "services")
+      services_tap.path.mkpath
+      services_tap.path.cd do
+        system "git", "init"
+        system "git", "remote", "add", "origin", "https://git.example.com/testbrew/badlynamed-house.git"
+      end
+      expect(services_tap.remote_repo).to eq("testbrew/badlynamed-house")
+    end
   end
 
   specify "Git variant" do

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -5,7 +5,8 @@ require "tempfile"
 require "utils/shell"
 
 module GitHub
-  API_URL = "https://api.github.com"
+  PUBLIC_GITHUB_API_URL = "https://api.github.com"
+  API_URL = ENV.fetch("HOMEBREW_GITHUB_API_URL", PUBLIC_GITHUB_API_URL).freeze
   API_MAX_PAGES = 50
   API_MAX_ITEMS = 5000
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Set HOMEBREW_GITHUB_API_URL to https://git.example.com/api/v3 and `bump-formula-pr` will submit to a GitHub Enterprise Server instance. This change has _only_ been live-tested with that command and no others.

A part of this is reducing the assumption that a tap is on GitHub.com and doing our best to make an effort to support GHES.

Opportunities for improvement:

* The `ALL_SCOPES_URL` in `utils/github/api.rb` and some other places where `github.com/*` is hardcoded becomes a lie when `HOMEBREW_GITHUB_API_URL` is set. Determining that dynamically would be cool.
* It'd be really cool to have bump-formula-pr and friends _just work_ without having to set the URL. This would necessitate determining if a tap is backed by GitHub/GHES on-demand or at tap time. This _could_ enable a future of supporting some other major git hosting platforms (e.g. GitLab, Gitea, BitBucket) used for private taps to give them a built-in workflow for update automation.