### PR TITLE
dev-cmd/bump: Ignore Repology if the livecheck uses `GithubLatest`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -269,6 +269,14 @@ module Homebrew
     EOS
 
     return unless args.open_pr?
+
+    if repology_latest > current_version &&
+       repology_latest > livecheck_latest &&
+       livecheck_strategy == "GithubLatest"
+      puts "#{title_name} was not bumped to the Repology version because that " \
+           "version is not the latest release on GitHub."
+    end
+
     return unless new_version
     return if pull_requests
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- I got frustrated when I fixed the build and test failures for https://github.com/Homebrew/homebrew-core/pull/95430 only to have the audit step say it was a pre-release.
- Repology can list versions that are GitHub pre-releases. Pre-release versions of software are things we don't generally want to ship: there's an audit specifically for that.
- This fixes `brew bump` to not mark a Repology version as the newest if the formula's livecheck strategy is `GithubLatest`. If the livecheck doesn't exist, or its update strategy is something other than `GithubLatest`, Repology's reported package version is respected.