### PR TITLE
update-report: default HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED to on.

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -325,10 +325,6 @@ module Homebrew
         default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
-      HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED:     {
-        description: "If set, `brew update` only lists updates to installed software.",
-        boolean:     true,
-      },
       HOMEBREW_UPDATE_TO_TAG:                    {
         description: "If set, always use the latest stable tag (even if developer commands " \
                      "have been run).",

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -2626,8 +2626,6 @@ module Homebrew::EnvConfig
 
   def self.temp(); end
 
-  def self.update_report_only_installed?(); end
-
   def self.update_to_tag?(); end
 
   def self.verbose?(); end

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -53,7 +53,6 @@ describe "brew update-report" do
       perform_update("update_git_diff_output_without_formulae_changes")
 
       expect(hub.select_formula(:M)).to be_empty
-      expect(hub.select_formula(:A)).to be_empty
       expect(hub.select_formula(:D)).to be_empty
     end
 
@@ -61,7 +60,6 @@ describe "brew update-report" do
       perform_update("update_git_diff_output_with_formulae_changes")
 
       expect(hub.select_formula(:M)).to eq(%w[xar yajl])
-      expect(hub.select_formula(:A)).to eq(%w[antiword bash-completion ddrescue dict lua])
     end
 
     specify "with removed Formulae" do
@@ -74,7 +72,6 @@ describe "brew update-report" do
       perform_update("update_git_diff_output_with_changed_filetype")
 
       expect(hub.select_formula(:M)).to eq(%w[elixir])
-      expect(hub.select_formula(:A)).to eq(%w[libbson])
       expect(hub.select_formula(:D)).to eq(%w[libgsasl])
     end
 
@@ -82,9 +79,7 @@ describe "brew update-report" do
       allow(tap).to receive(:formula_renames).and_return("cv" => "progress")
       perform_update("update_git_diff_output_with_formula_rename")
 
-      expect(hub.select_formula(:A)).to be_empty
       expect(hub.select_formula(:D)).to be_empty
-      expect(hub.select_formula(:R)).to eq([["cv", "progress"]])
     end
 
     context "when updating a Tap other than the core Tap" do
@@ -101,32 +96,25 @@ describe "brew update-report" do
       specify "with restructured Tap" do
         perform_update("update_git_diff_output_with_restructured_tap")
 
-        expect(hub.select_formula(:A)).to be_empty
         expect(hub.select_formula(:D)).to be_empty
-        expect(hub.select_formula(:R)).to be_empty
       end
 
       specify "with renamed Formula and restructured Tap" do
         allow(tap).to receive(:formula_renames).and_return("xchat" => "xchat2")
         perform_update("update_git_diff_output_with_formula_rename_and_restructuring")
 
-        expect(hub.select_formula(:A)).to be_empty
         expect(hub.select_formula(:D)).to be_empty
-        expect(hub.select_formula(:R)).to eq([%w[foo/bar/xchat foo/bar/xchat2]])
       end
 
       specify "with simulated 'homebrew/php' restructuring" do
         perform_update("update_git_diff_simulate_homebrew_php_restructuring")
 
-        expect(hub.select_formula(:A)).to be_empty
         expect(hub.select_formula(:D)).to be_empty
-        expect(hub.select_formula(:R)).to be_empty
       end
 
       specify "with Formula changes" do
         perform_update("update_git_diff_output_with_tap_formulae_changes")
 
-        expect(hub.select_formula(:A)).to eq(%w[foo/bar/lua])
         expect(hub.select_formula(:M)).to eq(%w[foo/bar/git])
         expect(hub.select_formula(:D)).to be_empty
       end


### PR DESCRIPTION
This avoids reading formula files that the user hasn't explicitly
installed which both speeds up `brew update` and improves the security.

https://github.com/Homebrew/brew/pull/12911 deprecates the use of `Enumerable` methods on `Formula`.

Part of https://github.com/Homebrew/brew/issues/11292

Do not merge until the next tag will be 3.4.0.