### PR TITLE
formula, cask: deprecate use of Enumerable methods e.g. `each`.

### DIFF
--- a/Library/Homebrew/compat/cask.rb
+++ b/Library/Homebrew/compat/cask.rb
@@ -6,8 +6,8 @@ module Cask
     extend Enumerable
 
     def self.each(&block)
-      # TODO: 3.4.0: odeprecated "`Enumerable` methods on `Cask::Cask`",
-      #              "`Cask::Cask.all` (but avoid looping over all casks, it's slow and insecure)"
+      odeprecated "`Enumerable` methods on `Cask::Cask`",
+                  "`Cask::Cask.all` (but avoid looping over all casks, it's slow and insecure)"
 
       return to_enum unless block
 

--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -5,8 +5,8 @@ class Formula
   extend Enumerable
 
   def self.each(&_block)
-    # TODO: 3.4.0: odeprecated "`Enumerable` methods on `Formula`",
-    #              "`Formula.all` (but avoid looping over all formulae, it's slow and insecure)"
+    odeprecated "`Enumerable` methods on `Formula`",
+                "`Formula.all` (but avoid looping over all formulae, it's slow and insecure)"
 
     files.each do |file|
       yield Formulary.factory(file)


### PR DESCRIPTION
Part of https://github.com/Homebrew/brew/issues/11292

Do not merge until the next tag will be 3.4.0.