### PR TITLE
workflows/triage: fix concurrency.

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,7 +14,7 @@ on:
 
 permissions: {}
 
-concurrency: triage-${{ github.ref }}
+concurrency: triage-${{ github.head_ref }}
 
 jobs:
   review:


### PR DESCRIPTION
`github.ref` is always `master` for `pull_request_target` jobs so this needs to use `github.head_ref` instead to get the actual pull request branch.