### PR TITLE
Revert "formula: remove `OnOS`."

### DIFF
--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -2,18 +2,6 @@
 # frozen_string_literal: true
 
 class Formula
-  extend OnOS
-
-  def on_macos(&block)
-    odeprecated "`on_macos do` inside `Formula` methods", "`if OS.mac?`"
-    super
-  end
-
-  def on_linux(&block)
-    odeprecated "`on_linux do` inside `Formula` methods", "`if OS.linux?`"
-    super
-  end
-
   extend Enumerable
 
   def self.each(&_block)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -64,6 +64,7 @@ class Formula
   include Utils::Shebang
   include Utils::Shell
   include Context
+  include OnOS # TODO: 3.4.0: odeprecate OnOS usage in instance methods.
   extend Forwardable
   extend Cachable
   extend Predicable

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -64,7 +64,7 @@ class Formula
   include Utils::Shebang
   include Utils::Shell
   include Context
-  include OnOS # TODO: 3.4.0: odeprecate OnOS usage in instance methods.
+  include OnOS
   extend Forwardable
   extend Cachable
   extend Predicable

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1534,4 +1534,50 @@ describe Formula do
       expect(f.any_installed_version).to eq(PkgVersion.parse("1.0_1"))
     end
   end
+
+  describe "#on_macos", :needs_macos do
+    let(:f) do
+      Class.new(Testball) do
+        @test = 0
+        attr_reader :test
+
+        def install
+          on_macos do
+            @test = 1
+          end
+          on_linux do
+            @test = 2
+          end
+        end
+      end.new
+    end
+
+    it "only calls code within on_macos" do
+      f.brew { f.install }
+      expect(f.test).to eq(1)
+    end
+  end
+
+  describe "#on_linux", :needs_linux do
+    let(:f) do
+      Class.new(Testball) do
+        @test = 0
+        attr_reader :test
+
+        def install
+          on_macos do
+            @test = 1
+          end
+          on_linux do
+            @test = 2
+          end
+        end
+      end.new
+    end
+
+    it "only calls code within on_linux" do
+      f.brew { f.install }
+      expect(f.test).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Reverts Homebrew/brew#12912

CC @carlocab FYI

We still need this for e.g. `test do` blocks.