### PR TITLE
rubocops: fix `OnOs` block checks.

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -404,18 +404,15 @@ module RuboCop
             no_on_os_block_names.each do |formula_block_name|
               block_node = find_block(body_node, formula_block_name)
               next unless block_node
-              next unless method_called_in_block?(block_node, on_method_name)
+              next unless block_method_called_in_block?(block_node, on_method_name)
 
               problem "Don't use '#{on_method_name}' in '#{formula_block_name} do', " \
                       "use '#{if_method_and_class}' instead." do |corrector|
-                block_node = offending_node.parent
-                next if block_node.type != :block
-
                 # TODO: could fix corrector to handle this but punting for now.
-                next if block_node.single_line?
+                next if offending_node.single_line?
 
-                source_range = offending_node.source_range.join(offending_node.parent.loc.begin)
-                corrector.replace(source_range, if_method_and_class)
+                source_range = offending_node.send_node.source_range.join(offending_node.body.source_range.begin)
+                corrector.replace(source_range, "#{if_method_and_class}\n")
               end
             end
 

--- a/Library/Homebrew/rubocops/shared/helper_functions.rb
+++ b/Library/Homebrew/rubocops/shared/helper_functions.rb
@@ -285,10 +285,10 @@ module RuboCop
         nil
       end
 
-      # Check if a method is called inside a block.
-      def method_called_in_block?(node, method_name)
-        block_body = node.children[2]
-        block_body.each_child_node(:send) do |call_node|
+      # Check if a block method is called inside a block.
+      def block_method_called_in_block?(node, method_name)
+        node.body.each_child_node do |call_node|
+          next if !call_node.block_type? && !call_node.send_type?
           next unless call_node.method_name == method_name
 
           @offensive_node = call_node


### PR DESCRIPTION
This wasn't correctly flagging the use of `on_os` in `test do` as invalid.