### PR TITLE
Revert "update-report: default HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED to on."

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -413,7 +413,7 @@ class Reporter
       renamed_formulae << [old_full_name, new_full_name]
     end
 
-    unless renamed_formulae.empty?
+    if renamed_formulae.present?
       @report[:A] -= renamed_formulae.map(&:last)
       @report[:D] -= renamed_formulae.map(&:first)
       @report[:R] = renamed_formulae.to_a
@@ -593,20 +593,21 @@ class ReporterHub
   private
 
   def dump_formula_report(key, title)
-    # TODO: 3.4.0: odisabled the old functionality and make this default
     only_installed = Homebrew::EnvConfig.update_report_only_installed?
 
     formulae = select_formula(key).sort.map do |name, new_name|
       # Format list items of renamed formulae
       case key
       when :R
-        name = pretty_installed(name) if installed?(name)
-        new_name = pretty_installed(new_name) if installed?(new_name)
-        "#{name} -> #{new_name}" unless only_installed
+        unless only_installed
+          name = pretty_installed(name) if installed?(name)
+          new_name = pretty_installed(new_name) if installed?(new_name)
+          "#{name} -> #{new_name}"
+        end
       when :A
-        name if !installed?(name) && !only_installed
+        name if !only_installed && !installed?(name)
       when :AC
-        name.split("/").last if !cask_installed?(name) && !only_installed
+        name.split("/").last if !only_installed && !cask_installed?(name)
       when :MC, :DC
         name = name.split("/").last
         if cask_installed?(name)

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -331,6 +331,9 @@ class Reporter
 
       if paths.any? { |p| tap.cask_file?(p) }
         case status
+        when "A"
+          # Have a dedicated report array for new casks.
+          @report[:AC] << tap.formula_file_to_name(src)
         when "D"
           # Have a dedicated report array for deleted casks.
           @report[:DC] << tap.formula_file_to_name(src)
@@ -410,13 +413,11 @@ class Reporter
       renamed_formulae << [old_full_name, new_full_name]
     end
 
-    if renamed_formulae.present?
+    unless renamed_formulae.empty?
       @report[:A] -= renamed_formulae.map(&:last)
       @report[:D] -= renamed_formulae.map(&:first)
+      @report[:R] = renamed_formulae.to_a
     end
-
-    # Only needed additions for calculating deletions correctly based on renames.
-    @report.delete(:A)
 
     @report
   end
@@ -568,18 +569,18 @@ class ReporterHub
   delegate empty?: :@hash
 
   def dump(updated_formula_report: true)
-    if ENV["HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED"]
-      opoo "HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED can be unset, it is now the default!"
-    end
-
     # Key Legend: Added (A), Copied (C), Deleted (D), Modified (M), Renamed (R)
+
+    dump_formula_report :A, "New Formulae"
     if updated_formula_report
       dump_formula_report :M, "Updated Formulae"
     else
       updated = select_formula(:M).count
       ohai "Updated Formulae", "Updated #{updated} #{"formula".pluralize(updated)}." if updated.positive?
     end
+    dump_formula_report :R, "Renamed Formulae"
     dump_formula_report :D, "Deleted Formulae"
+    dump_formula_report :AC, "New Casks"
     if updated_formula_report
       dump_formula_report :MC, "Updated Casks"
     else
@@ -592,13 +593,33 @@ class ReporterHub
   private
 
   def dump_formula_report(key, title)
-    formulae = select_formula(key).sort.map do |name, _new_name|
+    # TODO: 3.4.0: odisabled the old functionality and make this default
+    only_installed = Homebrew::EnvConfig.update_report_only_installed?
+
+    formulae = select_formula(key).sort.map do |name, new_name|
+      # Format list items of renamed formulae
       case key
+      when :R
+        name = pretty_installed(name) if installed?(name)
+        new_name = pretty_installed(new_name) if installed?(new_name)
+        "#{name} -> #{new_name}" unless only_installed
+      when :A
+        name if !installed?(name) && !only_installed
+      when :AC
+        name.split("/").last if !cask_installed?(name) && !only_installed
       when :MC, :DC
         name = name.split("/").last
-        pretty_installed(name) if cask_installed?(name)
-      when :M, :D
-        pretty_installed(name) if installed?(name)
+        if cask_installed?(name)
+          pretty_installed(name)
+        elsif !only_installed
+          name
+        end
+      else
+        if installed?(name)
+          pretty_installed(name)
+        elsif !only_installed
+          name
+        end
       end
     end.compact
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -325,6 +325,10 @@ module Homebrew
         default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
+      HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED:     {
+        description: "If set, `brew update` only lists updates to installed software.",
+        boolean:     true,
+      },
       HOMEBREW_UPDATE_TO_TAG:                    {
         description: "If set, always use the latest stable tag (even if developer commands " \
                      "have been run).",

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -2626,6 +2626,8 @@ module Homebrew::EnvConfig
 
   def self.temp(); end
 
+  def self.update_report_only_installed?(); end
+
   def self.update_to_tag?(); end
 
   def self.verbose?(); end

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -53,6 +53,7 @@ describe "brew update-report" do
       perform_update("update_git_diff_output_without_formulae_changes")
 
       expect(hub.select_formula(:M)).to be_empty
+      expect(hub.select_formula(:A)).to be_empty
       expect(hub.select_formula(:D)).to be_empty
     end
 
@@ -60,6 +61,7 @@ describe "brew update-report" do
       perform_update("update_git_diff_output_with_formulae_changes")
 
       expect(hub.select_formula(:M)).to eq(%w[xar yajl])
+      expect(hub.select_formula(:A)).to eq(%w[antiword bash-completion ddrescue dict lua])
     end
 
     specify "with removed Formulae" do
@@ -72,6 +74,7 @@ describe "brew update-report" do
       perform_update("update_git_diff_output_with_changed_filetype")
 
       expect(hub.select_formula(:M)).to eq(%w[elixir])
+      expect(hub.select_formula(:A)).to eq(%w[libbson])
       expect(hub.select_formula(:D)).to eq(%w[libgsasl])
     end
 
@@ -79,7 +82,9 @@ describe "brew update-report" do
       allow(tap).to receive(:formula_renames).and_return("cv" => "progress")
       perform_update("update_git_diff_output_with_formula_rename")
 
+      expect(hub.select_formula(:A)).to be_empty
       expect(hub.select_formula(:D)).to be_empty
+      expect(hub.select_formula(:R)).to eq([["cv", "progress"]])
     end
 
     context "when updating a Tap other than the core Tap" do
@@ -96,25 +101,32 @@ describe "brew update-report" do
       specify "with restructured Tap" do
         perform_update("update_git_diff_output_with_restructured_tap")
 
+        expect(hub.select_formula(:A)).to be_empty
         expect(hub.select_formula(:D)).to be_empty
+        expect(hub.select_formula(:R)).to be_empty
       end
 
       specify "with renamed Formula and restructured Tap" do
         allow(tap).to receive(:formula_renames).and_return("xchat" => "xchat2")
         perform_update("update_git_diff_output_with_formula_rename_and_restructuring")
 
+        expect(hub.select_formula(:A)).to be_empty
         expect(hub.select_formula(:D)).to be_empty
+        expect(hub.select_formula(:R)).to eq([%w[foo/bar/xchat foo/bar/xchat2]])
       end
 
       specify "with simulated 'homebrew/php' restructuring" do
         perform_update("update_git_diff_simulate_homebrew_php_restructuring")
 
+        expect(hub.select_formula(:A)).to be_empty
         expect(hub.select_formula(:D)).to be_empty
+        expect(hub.select_formula(:R)).to be_empty
       end
 
       specify "with Formula changes" do
         perform_update("update_git_diff_output_with_tap_formulae_changes")
 
+        expect(hub.select_formula(:A)).to eq(%w[foo/bar/lua])
         expect(hub.select_formula(:M)).to eq(%w[foo/bar/git])
         expect(hub.select_formula(:D)).to be_empty
       end


### PR DESCRIPTION
Reverts Homebrew/brew#12910

Haven't decided whether to revert this yet or not but given the number of complaints so far: I'm getting tempted to do so before the 3.4.0 release.