### PR TITLE
Update uses of `Formula.all`/`Cask::Cask.all`

### DIFF
--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -30,6 +30,9 @@ module Homebrew
              description: "Resolve more than one level of dependencies."
       switch "--installed",
              description: "Only list formulae and casks that are currently installed."
+      switch "--all",
+             description: "List all formulae and casks whether installed or not.",
+             hidden:      true
       switch "--include-build",
              description: "Include all formulae that specify <formula> as `:build` type dependency."
       switch "--include-test",
@@ -44,6 +47,7 @@ module Homebrew
              description: "Include only casks."
 
       conflicts "--formula", "--cask"
+      conflicts "--installed", "--all"
 
       named_args :formula, min: 1
     end
@@ -83,6 +87,8 @@ module Homebrew
     recursive = args.recursive?
     show_formulae_and_casks = !args.formula? && !args.cask?
     includes, ignores = args_includes_ignores(args)
+
+    # TODO: 3.6.0: odeprecate not specifying args.all?, require args.installed?
 
     deps = []
     if use_runtime_dependents

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -36,6 +36,7 @@ class DescriptionCacheStore < CacheStore
   def populate_if_empty!
     return unless database.empty?
 
+    # TODO: 3.6.0: consider if we want to actually read all contents of all formulae or odeprecate.
     Formula.all.each { |f| update!(f.full_name, f.desc) }
   end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -39,6 +39,11 @@ module Homebrew
              description: "Run additional, slower style checks that navigate the Git repository."
       switch "--online",
              description: "Run additional, slower style checks that require a network connection."
+      switch "--installed",
+             description: "Only check formulae and casks that are currently installed."
+      switch "--all",
+             description: "Check all formulae and casks whether installed or not.",
+             hidden:      true
       switch "--new", "--new-formula", "--new-cask",
              description: "Run various additional style checks to determine if a new formula or cask is eligible "\
                           "for Homebrew. This should be used when creating new formula and implies "\
@@ -87,6 +92,7 @@ module Homebrew
       conflicts "--display-cop-names", "--only-cops"
       conflicts "--display-cop-names", "--except-cops"
       conflicts "--formula", "--cask"
+      conflicts "--installed", "--all"
 
       named_args [:formula, :cask]
     end
@@ -112,6 +118,8 @@ module Homebrew
     ENV.activate_extensions!
     ENV.setup_build_environment
 
+    # TODO: 3.6.0: odeprecate not specifying args.all?, require args.installed?
+
     audit_formulae, audit_casks = if args.tap
       Tap.fetch(args.tap).yield_self do |tap|
         [
@@ -119,6 +127,9 @@ module Homebrew
           tap.cask_files.map { |path| Cask::CaskLoader.load(path) },
         ]
       end
+    elsif args.installed?
+      no_named_args = true
+      [Formula.installed, Cask::Cask.casks]
     elsif args.no_named?
       no_named_args = true
       [Formula.all, Cask::Cask.all]

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -34,6 +34,9 @@ module Homebrew
       EOS
       switch "-n", "--dry-run",
              description: "Print what would be done rather than doing it."
+      switch "--all",
+             description: "Read all formulae if necessary to determine URL.",
+             hidden:      true
       switch "--write-only",
              description: "Make the expected file modifications without taking any Git actions."
       switch "--write", hidden: true
@@ -81,6 +84,7 @@ module Homebrew
       conflicts "--no-audit", "--strict"
       conflicts "--no-audit", "--online"
       conflicts "--url", "--tag"
+      conflicts "--installed", "--all"
 
       named_args :formula, max: 1
     end
@@ -367,6 +371,7 @@ module Homebrew
     base_url = url_split.first(components_to_match).join("/")
     base_url = /#{Regexp.escape(base_url)}/
     guesses = []
+    # TODO: 3.6.0: odeprecate not specifying args.all?
     Formula.all.each do |f|
       guesses << f if f.stable&.url&.match(base_url)
     end

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -20,10 +20,11 @@ module Homebrew
              description: "Use the specified bottle tag (e.g. `big_sur`) instead of the current OS."
       switch "--dependents",
              description: "Skip getting analytics data and sort by number of dependents instead."
-      switch "--total",
+      switch "--all", "--total",
              description: "Print the number of unbottled and total formulae."
 
-      conflicts "--dependents", "--total"
+      conflicts "--dependents", "--all"
+      conflicts "--installed", "--all"
 
       named_args :formula
     end
@@ -41,10 +42,12 @@ module Homebrew
       Utils::Bottles.tag
     end
 
+    # TODO: 3.6.0: odeprecate args.total?
+
     if args.named.blank?
       ohai "Getting formulae..."
-    elsif args.total?
-      raise UsageError, "cannot specify `<formula>` and `--total`."
+    elsif args.all?
+      raise UsageError, "cannot specify `<formula>` and `--all`/`--total`."
     end
 
     formulae, all_formulae, formula_installs =
@@ -59,7 +62,7 @@ module Homebrew
       end.reverse
     end
 
-    if args.total?
+    if args.all?
       output_total(formulae)
       return
     end
@@ -78,9 +81,10 @@ module Homebrew
   def formulae_all_installs_from_args(args)
     if args.named.present?
       formulae = all_formulae = args.named.to_formulae
-    elsif args.total?
+    elsif args.all?
       formulae = all_formulae = Formula.all
     elsif args.dependents?
+      # TODO: 3.6.0: odeprecate not specifying args.all? for args.dependents?
       formulae = all_formulae = Formula.all
 
       @sort = " (sorted by number of dependents)"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1683,8 +1683,11 @@ class Formula
   end
 
   # an array of all {Formula}
+  # this should only be used when users specify `--all` to a command
   # @private
   def self.all
+    # TODO: 3.6.0: consider checking ARGV for --all
+
     files.map do |file|
       Formulary.factory(file)
     rescue FormulaUnavailableError, FormulaUnreadableError => e

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -304,6 +304,8 @@ class Tap
 
     begin
       safe_system "git", *args
+      # TODO: 3.6.0: consider if we want to actually read all contents of tap or odeprecate.
+
       if !Readall.valid_tap?(self, aliases: true) && !Homebrew::EnvConfig.developer?
         raise "Cannot tap #{name}: invalid syntax in tap!"
       end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -357,6 +357,7 @@ _brew_audit() {
       --formula
       --git
       --help
+      --installed
       --new
       --no-appcast
       --online
@@ -2044,12 +2045,12 @@ _brew_unbottled() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --all
       --debug
       --dependents
       --help
       --quiet
       --tag
-      --total
       --verbose
       "
       return

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -337,6 +337,7 @@ __fish_brew_complete_arg 'audit' -l fix -d 'Fix style violations automatically u
 __fish_brew_complete_arg 'audit' -l formula -d 'Treat all named arguments as formulae'
 __fish_brew_complete_arg 'audit' -l git -d 'Run additional, slower style checks that navigate the Git repository'
 __fish_brew_complete_arg 'audit' -l help -d 'Show this message'
+__fish_brew_complete_arg 'audit' -l installed -d 'Only check formulae and casks that are currently installed'
 __fish_brew_complete_arg 'audit' -l new -d 'Run various additional style checks to determine if a new formula or cask is eligible for Homebrew. This should be used when creating new formula and implies `--strict` and `--online`'
 __fish_brew_complete_arg 'audit' -l no-appcast -d 'Audit the appcast'
 __fish_brew_complete_arg 'audit' -l online -d 'Run additional, slower style checks that require a network connection'
@@ -1376,12 +1377,12 @@ __fish_brew_complete_arg 'typecheck' -l verbose -d 'Make some output more verbos
 
 
 __fish_brew_complete_cmd 'unbottled' 'Show the unbottled dependents of formulae'
+__fish_brew_complete_arg 'unbottled' -l all -d 'Print the number of unbottled and total formulae'
 __fish_brew_complete_arg 'unbottled' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'unbottled' -l dependents -d 'Skip getting analytics data and sort by number of dependents instead'
 __fish_brew_complete_arg 'unbottled' -l help -d 'Show this message'
 __fish_brew_complete_arg 'unbottled' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'unbottled' -l tag -d 'Use the specified bottle tag (e.g. `big_sur`) instead of the current OS'
-__fish_brew_complete_arg 'unbottled' -l total -d 'Print the number of unbottled and total formulae'
 __fish_brew_complete_arg 'unbottled' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'unbottled' -a '(__fish_brew_suggest_formulae_all)'
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -416,6 +416,7 @@ _brew_audit() {
     '--fix[Fix style violations automatically using RuboCop'\''s auto-correct feature]' \
     '--git[Run additional, slower style checks that navigate the Git repository]' \
     '--help[Show this message]' \
+    '(--all)--installed[Only check formulae and casks that are currently installed]' \
     '--new[Run various additional style checks to determine if a new formula or cask is eligible for Homebrew. This should be used when creating new formula and implies `--strict` and `--online`]' \
     '--no-appcast[Audit the appcast]' \
     '--online[Run additional, slower style checks that require a network connection]' \
@@ -1682,12 +1683,12 @@ _brew_typecheck() {
 # brew unbottled
 _brew_unbottled() {
   _arguments \
+    '(--dependents --installed)--all[Print the number of unbottled and total formulae]' \
     '--debug[Display any debugging information]' \
-    '(--total)--dependents[Skip getting analytics data and sort by number of dependents instead]' \
+    '(--all)--dependents[Skip getting analytics data and sort by number of dependents instead]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
     '--tag[Use the specified bottle tag (e.g. `big_sur`) instead of the current OS]' \
-    '(--dependents)--total[Print the number of unbottled and total formulae]' \
     '--verbose[Make some output more verbose]' \
     - formula \
     '*::formula:__brew_formulae'
@@ -1919,7 +1920,7 @@ _brew_uses() {
     '--include-build[Include all formulae that specify formula as `:build` type dependency]' \
     '--include-optional[Include all formulae that specify formula as `:optional` type dependency]' \
     '--include-test[Include all formulae that specify formula as `:test` type dependency]' \
-    '--installed[Only list formulae and casks that are currently installed]' \
+    '(--all)--installed[Only list formulae and casks that are currently installed]' \
     '--quiet[Make some output more quiet]' \
     '--recursive[Resolve more than one level of dependencies]' \
     '--skip-recommended[Skip all formulae that specify formula as `:recommended` type dependency]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -848,6 +848,8 @@ non-zero status if any errors are found.
   Run additional, slower style checks that navigate the Git repository.
 * `--online`:
   Run additional, slower style checks that require a network connection.
+* `--installed`:
+  Only check formulae and casks that are currently installed.
 * `--new`:
   Run various additional style checks to determine if a new formula or cask is eligible for Homebrew. This should be used when creating new formula and implies `--strict` and `--online`.
 * `--[no-]appcast`:
@@ -1477,7 +1479,7 @@ Show the unbottled dependents of formulae.
   Use the specified bottle tag (e.g. `big_sur`) instead of the current OS.
 * `--dependents`:
   Skip getting analytics data and sort by number of dependents instead.
-* `--total`:
+* `--all`:
   Print the number of unbottled and total formulae.
 
 ### `unpack` [*`options`*] *`formula`* [...]

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "January 2022" "Homebrew" "brew"
+.TH "BREW" "1" "March 2022" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)
@@ -1165,6 +1165,10 @@ Run additional, slower style checks that navigate the Git repository\.
 Run additional, slower style checks that require a network connection\.
 .
 .TP
+\fB\-\-installed\fR
+Only check formulae and casks that are currently installed\.
+.
+.TP
 \fB\-\-new\fR
 Run various additional style checks to determine if a new formula or cask is eligible for Homebrew\. This should be used when creating new formula and implies \fB\-\-strict\fR and \fB\-\-online\fR\.
 .
@@ -2097,7 +2101,7 @@ Use the specified bottle tag (e\.g\. \fBbig_sur\fR) instead of the current OS\.
 Skip getting analytics data and sort by number of dependents instead\.
 .
 .TP
-\fB\-\-total\fR
+\fB\-\-all\fR
 Print the number of unbottled and total formulae\.
 .
 .SS "\fBunpack\fR [\fIoptions\fR] \fIformula\fR [\.\.\.]"


### PR DESCRIPTION
Add some `--all` flags we'll eventually migrate to to ensure that we'll eventually require their usage to read all formulae. Where we need to do stuff later, add some comments.