### PR TITLE
Binary patching of build prefixes 

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1228,6 +1228,14 @@ class FormulaInstaller
     keg = Keg.new(formula.prefix)
     skip_linkage = formula.bottle_specification.skip_relocation?
     keg.replace_placeholders_with_locations tab.changed_files, skip_linkage: skip_linkage
+
+    cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)
+    return if [:any, :any_skip_relocation].include?(cellar)
+
+    prefix = Pathname(cellar).parent.to_s
+    return if cellar == HOMEBREW_CELLAR.to_s && prefix == HOMEBREW_PREFIX.to_s
+
+    keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX)
   end
 
   sig { params(output: T.nilable(String)).void }

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -529,6 +529,8 @@ class Keg
     elf_files
   end
 
+  def codesign_patched_binary(_binary_file); end
+
   private
 
   def resolve_any_conflicts(dst, dry_run: false, verbose: false, overwrite: false)

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -473,6 +473,8 @@ class Bottle
 end
 
 class BottleSpecification
+  RELOCATABLE_CELLARS = [:any, :any_skip_relocation].freeze
+
   extend T::Sig
 
   attr_rw :rebuild
@@ -518,12 +520,15 @@ class BottleSpecification
   def compatible_locations?(tag: Utils::Bottles.tag)
     cellar = tag_to_cellar(tag)
 
-    return true if [:any, :any_skip_relocation].include?(cellar)
+    return true if RELOCATABLE_CELLARS.include?(cellar)
 
     prefix = Pathname(cellar).parent.to_s
 
-    compatible_cellar = cellar == HOMEBREW_CELLAR.to_s
-    compatible_prefix = prefix == HOMEBREW_PREFIX.to_s
+    cellar_relocatable = cellar.size >= HOMEBREW_CELLAR.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"]
+    prefix_relocatable = prefix.size >= HOMEBREW_PREFIX.to_s.size && ENV["HOMEBREW_RELOCATE_BUILD_PREFIX"]
+
+    compatible_cellar = cellar == HOMEBREW_CELLAR.to_s || cellar_relocatable
+    compatible_prefix = prefix == HOMEBREW_PREFIX.to_s || prefix_relocatable
 
     compatible_cellar && compatible_prefix
   end

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+# frozen_string_literal: true
+
+require "keg_relocate"
+
+describe Keg do
+  subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
+
+  let(:dir) { HOMEBREW_CELLAR/"foo/1.0.0" }
+  let(:newdir) { HOMEBREW_CELLAR/"foo" }
+  let(:binary_file) { dir/"file.bin" }
+
+  before do
+    dir.mkpath
+  end
+
+  def setup_binary_file
+    binary_file.atomic_write <<~EOS
+      \x00#{dir}\x00
+    EOS
+  end
+
+  describe "#relocate_build_prefix" do
+    specify "replace prefix in binary files" do
+      setup_binary_file
+
+      keg.relocate_build_prefix(keg, dir, newdir)
+
+      old_prefix_matches = Set.new
+      keg.each_unique_file_matching(dir) do |file|
+        old_prefix_matches << file
+      end
+
+      expect(old_prefix_matches.size).to eq 0
+
+      new_prefix_matches = Set.new
+      keg.each_unique_file_matching(newdir) do |file|
+        new_prefix_matches << file
+      end
+
+      expect(new_prefix_matches.size).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Now that we've merged https://github.com/Homebrew/brew/pull/12890, we can narrow the focus of this PR only to what is necessary to enable binary patching.  I've written a new unit test `keg_relocate/binary_relocation_spec.rb` to test `relocate_build_prefix`, which is by far the most complicated part of the PR.  This should help us avoid breaking this method in the future.   I'm not sure how practical it is implement useful unit tests for the other changes but they're not as complex.   