### PR TITLE
dev-cmd/pr-pull: require unzip to be installed

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -335,6 +335,9 @@ module Homebrew
   def pr_pull
     args = pr_pull_args.parse
 
+    # Needed when extracting the CI artifact.
+    ensure_executable!("unzip", reason: "extracting CI artifacts")
+
     workflows = args.workflows.presence || ["tests.yml"]
     artifact = args.artifact || "bottles"
     tap = Tap.fetch(args.tap || CoreTap.instance.name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`unzip` isn't necessarily installed by default. It isn't in our docker container.