### PR TITLE
utils/github: Add a `branch_exists?` method

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -80,6 +80,13 @@ module GitHub
     ["admin", "write"].include?(permission(repo, user)["permission"])
   end
 
+  def branch_exists?(user, repo, branch)
+    API.open_rest("#{API_URL}/repos/#{user}/#{repo}/branches/#{branch}")
+    true
+  rescue API::HTTPNotFoundError
+    false
+  end
+
   def pull_requests(repo, **options)
     url = "#{API_URL}/repos/#{repo}/pulls?#{URI.encode_www_form(options)}"
     API.open_rest(url)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- I wrote this as part of https://github.com/issyl0/homebrew-maintenance-utils/blob/main/cmd/find-invalid-head-branches.rb, as I needed to check if a branch exists on a repo, and thought I'd properly add it in case it's useful to others.
