### PR TITLE
rubocop: Remove an allowlist entry for `blacklist` usage

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -95,9 +95,6 @@ Naming/InclusiveLanguage:
         - "ssdb_slave" # Used in formula `ssdb`
         - "var_slave" # Used in formula `ssdb`
         - "patches/13_fix_scope_for_show_slave_status_data.patch" # Used in formula `mytop`
-    blacklist:
-      AllowedRegex:
-        - "--listBlacklist" # Used in formula `xmlsectool`
 
 Naming/MethodName:
   IgnoredPatterns:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The usage in the `xmlsectool` formula went away in https://github.com/Homebrew/homebrew-core/commit/76618ad7fca31ed7c5a7c1f8a4c688662bbacc64.
- If I revert the changes in that commit and run `brew style --only="Naming/InclusiveLanguage" xmlsectool`, RuboCop reports an offense and suggests an alternative term.