### PR TITLE
Rename apply_ad_hoc_signature

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -214,6 +214,8 @@ class Keg
     end
   end
 
+  def codesign_patched_binary(_binary_file); end
+
   def lib
     path/"lib"
   end

--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -8,7 +8,7 @@ class Keg
     @require_relocation = true
     odebug "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}"
     file.change_dylib_id(id, strict: false)
-    apply_ad_hoc_signature(file)
+    codesign_patched_binary(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing dylib ID of #{file}
@@ -24,7 +24,7 @@ class Keg
     @require_relocation = true
     odebug "Changing install name in #{file}\n  from #{old}\n    to #{new}"
     file.change_install_name(old, new, strict: false)
-    apply_ad_hoc_signature(file)
+    codesign_patched_binary(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing install name in #{file}
@@ -40,7 +40,7 @@ class Keg
     @require_relocation = true
     odebug "Changing rpath in #{file}\n  from #{old}\n    to #{new}"
     file.change_rpath(old, new, strict: false)
-    apply_ad_hoc_signature(file)
+    codesign_patched_binary(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing rpath in #{file}
@@ -53,7 +53,7 @@ class Keg
   def delete_rpath(rpath, file)
     odebug "Deleting rpath #{rpath} in #{file}"
     file.delete_rpath(rpath, strict: false)
-    apply_ad_hoc_signature(file)
+    codesign_patched_binary(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed deleting rpath #{rpath} in #{file}
@@ -61,7 +61,7 @@ class Keg
     raise
   end
 
-  def apply_ad_hoc_signature(file)
+  def codesign_patched_binary(file)
     return if MacOS.version < :big_sur
     return unless Hardware::CPU.arm?
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As we discussed in https://github.com/Homebrew/brew/pull/12940, it was suggested to rename `apply_ad_hoc_signature` to `codesign_patched_binary` to better reflect what the method does.  Additionally, I have added a generic method to `keg_relocate.rb` that does nothing, which allows us to call `codesign_patched_binary` in OS-generic code so that it has the expected behavior in Linux (do nothing) and macOS (patch the binary if on ARM).