### PR TITLE
Revert "keg_relocate.rb: create generic codesign_patched_binary"

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -214,8 +214,6 @@ class Keg
     end
   end
 
-  def codesign_patched_binary(_binary_file); end
-
   def lib
     path/"lib"
   end


### PR DESCRIPTION
`codesign_patched_binary` does not live in `extend/os/mac/keg_relocate` so a generic method cannot be put in `keg_relocate`.