### PR TITLE
Use simpler method to detect binaries

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -186,7 +186,7 @@ class Keg
 
   def egrep_args
     grep_bin = "egrep"
-    grep_args = recursive_fgrep_args
+    grep_args = "--files-with-matches"
     [grep_bin, grep_args]
   end
 end

--- a/Library/Homebrew/test/keg_relocate/grep_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/grep_spec.rb
@@ -43,16 +43,15 @@ describe Keg do
     end
   end
 
-  describe "#each_unique_binary_file" do
-    specify "find null bytes in binaries" do
+  describe "#binary_file?" do
+    specify "test if file has null bytes" do
       setup_binary_file
 
-      binary_matches = Set.new
-      keg.each_unique_binary_file do |file|
-        binary_matches << file
-      end
+      expect(keg.binary_file?(binary_file)).to be true
 
-      expect(binary_matches.size).to eq 1
+      setup_text_file
+
+      expect(keg.binary_file?(text_file)).to be false
     end
   end
 end


### PR DESCRIPTION
We discussed here: https://github.com/Homebrew/brew/pull/12940/files#r818284011 that it is much simpler to use `grep` to check if an individual file contains null bytes than to iterate over all files in the keg.  We are only interested in checking files which we already know contain prefixes, which we can pass in as an argument.  This method could also be useful in the future if we need to determine if files are binaries in other situations.

I also reverted `each_unique_file_matching` back to its original state.  If we think it's better to still have a generic `each_unique_file` method that is called by `each_unique_file_matching`, that's totally fine with me.  At the moment only `each_unique_file_matching` would need to call `each_unique_file`, but it's possible some future methods could also use `each_unique_file` as well.