### PR TITLE
test/os/mac/dependency_collector_spec: fix svn test on older macOS

### DIFF
--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -35,10 +35,6 @@ describe DependencyCollector do
   specify "Resource dependency from a Subversion URL" do
     resource = Resource.new
     resource.url("svn://brew.sh/foo/bar")
-    if MacOS.version < :catalina
-      expect(collector.add(resource)).to be_nil
-    else
-      expect(collector.add(resource)).not_to be_nil
-    end
+    expect(collector.add(resource)).to eq(Dependency.new("subversion", [:build, :test]))
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

There should be no condition after d0de6ac24960140f16d969cc0abce164393e9009.
