### PR TITLE
test/spec_helper: prevent stdin trashing

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -214,12 +214,14 @@ RSpec.configure do |config|
 
     @__stdout = $stdout.clone
     @__stderr = $stderr.clone
+    @__stdin = $stdin.clone
 
     begin
       if (example.metadata.keys & [:focus, :byebug]).empty? && !ENV.key?("HOMEBREW_VERBOSE_TESTS")
         $stdout.reopen(File::NULL)
         $stderr.reopen(File::NULL)
       end
+      $stdin.reopen(File::NULL)
 
       begin
         timeout = example.metadata.fetch(:timeout, 60)
@@ -236,8 +238,10 @@ RSpec.configure do |config|
 
       $stdout.reopen(@__stdout)
       $stderr.reopen(@__stderr)
+      $stdin.reopen(@__stdin)
       @__stdout.close
       @__stderr.close
+      @__stdin.close
 
       Formulary.clear_cache
       Tap.clear_cache


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a situation where the output of `brew tests` will modify the `stty` attributes of the terminal and also cause test output to appear garbled with mishandled newlines.

Not entirely sure why this happens - I can't reproduce it outside of `brew tests` - but we should be doing this safe handling anyway, and we already to it for stdout and stderr.