### PR TITLE
formula_installer: Fix `--only-dependencies` formula arch handling

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -579,7 +579,8 @@ class FormulaInstaller
         if req.prune_from_option?(build) ||
            req.satisfied?(env: @env, cc: @cc, build_bottle: @build_bottle, bottle_arch: @bottle_arch) ||
            ((req.build? || req.test?) && !keep_build_test) ||
-           formula_deps_map[dependent.name]&.build?
+           formula_deps_map[dependent.name]&.build? ||
+           (only_deps? && f == dependent)
           Requirement.prune
         else
           unsatisfied_reqs[dependent] << req


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #12965.
- For a formula with an architecture requirement and a user requesting `--only-dependencices` to be installed, this now proceeds to install the formula dependencies regardless of the requested formula architecture because the formula itself will never be installed.
- The way dependencies and requirements are computed, the `depends_on :arch` is still a dependency, so it's in the list of formula dependencies to check and potentially install. Hence, we have to remove from the list the dependent from `recursive_requirements` with the same name as the formula so that there are no confusing unsatisfied requirements for the named formula when we don't need it to be installed.
- I thought about why this might be, maybe it's because we can't guarantee that formula dependencies work on different architectures. But in that case they'd have their own architecture requirements, so we'd see the failure for them. So I don't know of any more reasons.

Before:

```shell
$ brew install --only-dependencies julia
julia: The x86_64 architecture is required for this software.
Error: julia: An unsatisfied requirement failed this build.
```

After:

```shell
❯ brew install --only-dependencies julia
==> Downloading [...]
==> Installing dependencies for julia: libnghttp2, mpfr and suite-sparse [...]
```
