### PR TITLE
Show total disk space freed on cleanup.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -363,15 +363,13 @@ module Homebrew
       return unless path.exist?
       return unless @cleaned_up_paths.add?(path)
 
-      disk_usage = path.disk_usage
+      @disk_cleanup_size += path.disk_usage
 
       if dry_run?
         puts "Would remove: #{path} (#{path.abv})"
-        @disk_cleanup_size += disk_usage
       else
         puts "Removing: #{path}... (#{path.abv})"
         yield
-        @disk_cleanup_size += disk_usage - path.disk_usage
       end
     end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Shows total disk space freed on cleanup. Currently, `Cleanup.disk_cleanup_size` is only incremented during dry runs, and total disk space freed is only shown if `Cleanup.disk_cleanup_size` is not zero. This PR moves the `@disk_cleanup_size` update out of the `dry_run` check, and removes the bizarre provision to negate the update, since `disk_usage` is invariable equal to `path.disk_usage`, and thus `@disk_cleanup_size += disk_usage - path.disk_usage` never does anything.

I could not find any explanation / could not imagine a reason why this was done in the first place; please enlighten me if there  actually was a reason for this. In any case, the redundant/useless code should be removed.

I was motivated to make this change after running `brew cleanup`, seeing a bunch of files removed, and wondering how much space that actually freed.