### PR TITLE
linkage_checker: restrict `RPATH` test to `--strict`

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -70,14 +70,16 @@ class LinkageChecker
     display_items "Broken dependencies", @broken_deps, puts_output: puts_output
     display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
     display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
-    display_items "Undeclared dependencies with linkage", @undeclared_deps, puts_output: puts_output if strict
+    return unless strict
+
+    display_items "Undeclared dependencies with linkage", @undeclared_deps, puts_output: puts_output
     display_items "Files with missing rpath", @files_missing_rpaths, puts_output: puts_output
   end
 
   sig { params(strict: T::Boolean).returns(T::Boolean) }
   def broken_library_linkage?(strict: false)
-    issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps, @files_missing_rpaths]
-    issues << @undeclared_deps if strict
+    issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps]
+    issues += [@undeclared_deps, @files_missing_rpaths] if strict
     [issues, unexpected_broken_dylibs, unexpected_present_dylibs].flatten.any?(&:present?)
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This test is causing some rebuilds due to failed linkage upon upgrade.
That's a problem because rebuilds won't fix the problem that the `RPATH`
check identifies.
