### PR TITLE
Add tag_to_cellar method

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -504,14 +504,19 @@ class BottleSpecification
     end
   end
 
-  sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
-  def compatible_locations?(tag: Utils::Bottles.tag)
+  sig { params(tag: Utils::Bottles::Tag).returns(T.any(Symbol, String)) }
+  def tag_to_cellar(tag = Utils::Bottles.tag)
     spec = collector.specification_for(tag)
-    cellar = if spec.present?
+    if spec.present?
       spec.cellar
     else
       tag.default_cellar
     end
+  end
+
+  sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
+  def compatible_locations?(tag: Utils::Bottles.tag)
+    cellar = tag_to_cellar(tag)
 
     return true if [:any, :any_skip_relocation].include?(cellar)
 

--- a/Library/Homebrew/test/software_spec/bottle_spec.rb
+++ b/Library/Homebrew/test/software_spec/bottle_spec.rb
@@ -41,6 +41,18 @@ describe BottleSpecification do
     end
   end
 
+  describe "#compatible_locations?" do
+    it "checks if the bottle cellar is relocatable" do
+      expect(bottle_spec.compatible_locations?).to be false
+    end
+  end
+
+  describe "#tag_to_cellar" do
+    it "returns the cellar for a tag" do
+      expect(bottle_spec.tag_to_cellar).to eq Utils::Bottles.tag.default_cellar
+    end
+  end
+
   %w[root_url rebuild].each do |method|
     specify "##{method}" do
       object = Object.new


### PR DESCRIPTION
This is a relatively minor change that extract the code we currently use to get the cellar from the tag from `compatible_locations?` into its own method so we can call it directly, and refactors `compatible_locations?` to use that method, to avoid redundant code.  Basic unit tests have also been added for both methods.  More complex testing may be difficult without more refactoring because `HOMEBREW_CELLAR` and `HOMEBREW_PREFIX` are constants that I didn't see an obvious way to override.