### PR TITLE
Added Service#keep_alive? method

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -112,6 +112,14 @@ module Homebrew
       end
     end
 
+    # Returns a `Boolean` describing if a service is set to be kept alive.
+    # @return [Boolean]
+    sig { returns(T::Boolean) }
+    def keep_alive?
+      instance_eval(&@service_block)
+      @keep_alive == true
+    end
+
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def launch_only_once(value = nil)
       case T.unsafe(value)

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -425,6 +425,34 @@ describe Homebrew::Service do
     end
   end
 
+  describe "#keep_alive?" do
+    it "returns true when keep_alive set to true" do
+      f.class.service do
+        run [opt_bin/"beanstalkd", "test"]
+        keep_alive true
+      end
+
+      expect(f.service.keep_alive?).to be(true)
+    end
+
+    it "returns false when keep_alive not set" do
+      f.class.service do
+        run [opt_bin/"beanstalkd", "test"]
+      end
+
+      expect(f.service.keep_alive?).to be(false)
+    end
+
+    it "returns false when keep_alive set to false" do
+      f.class.service do
+        run [opt_bin/"beanstalkd", "test"]
+        keep_alive false
+      end
+
+      expect(f.service.keep_alive?).to be(false)
+    end
+  end
+
   describe "#command" do
     it "returns @run data" do
       f.class.service do


### PR DESCRIPTION
- [ x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ x] Have you successfully run `brew style` with your changes locally?
- [ x] Have you successfully run `brew typecheck` with your changes locally?
- [ x] Have you successfully run `brew tests` with your changes locally?

-----

This PR is related to the kill command that I'm currently working on adding to brew services [(over here)](https://github.com/Homebrew/homebrew-services/pull/464). As a part of that I'd like to be able to see if a service has been marked as keep_alive. Currently, there is only a setter for that in the Service class so I added a getter.