### PR TITLE
add arm64 info to Cask-Cookbook.md

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -502,7 +502,7 @@ The available symbols for hardware are:
 | ---------- | -------------- |
 | `:x86_64`  | 64-bit Intel   |
 | `:intel`   | 64-bit Intel   |
-| `:arm64`   | Apple M1   |
+| `:arm64`   | Apple Silicon  |
 
 The following are all valid expressions:
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -502,6 +502,7 @@ The available symbols for hardware are:
 | ---------- | -------------- |
 | `:x86_64`  | 64-bit Intel   |
 | `:intel`   | 64-bit Intel   |
+| `:arm64`   | Apple M1   |
 
 The following are all valid expressions:
 
@@ -509,9 +510,8 @@ The following are all valid expressions:
 depends_on arch: :intel
 depends_on arch: :x86_64            # same meaning as above
 depends_on arch: [:x86_64]          # same meaning as above
+depends_on arch: :arm64
 ```
-
-Since as of now all the macOS versions we support only run on 64-bit Intel, `depends_on arch:` is never necessary.
 
 #### All depends_on Keys
 
@@ -750,7 +750,7 @@ strategy :header_match do |headers|
   v = headers["content-disposition"][/MyApp-(\d+(?:\.\d+)*)\.zip/i, 1]
   id = headers["location"][%r{/(\d+)/download$}i, 1]
   next if v.blank? || id.blank?
-  
+
   "#{v},#{id}"
 end
 ```
@@ -761,7 +761,7 @@ Similarly, the `:page_match` strategy can also be used for more complex versions
 strategy :page_match do |page|
   match = page.match(%r{href=.*?/(\d+)/MyApp-(\d+(?:\.\d+)*)\.zip}i)
   next if match.blank?
-  
+
   "#{match[2]},#{match[1]}"
 end
 ```


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Closes https://github.com/Homebrew/brew/issues/12998
add `arm64` to `depend_on` information in `docs/Cask-Cookbook.md`