### PR TITLE
formula_auditor: fix versioned alias audit

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -68,31 +68,42 @@ module Homebrew
           unversioned_name = unversioned_formula.basename(".rb")
           problem "#{formula} is versioned but no #{unversioned_name} formula exists"
         end
-      elsif @build_stable &&
-            formula.stable? &&
+      elsif formula.stable? &&
             !@versioned_formula &&
             (versioned_formulae = formula.versioned_formulae - [formula]) &&
             versioned_formulae.present?
-        versioned_aliases = formula.aliases.grep(/.@\d/)
+        versioned_aliases, unversioned_aliases = formula.aliases.partition { |a| a =~ /.@\d/ }
         _, last_alias_version = versioned_formulae.map(&:name).last.split("@")
+
         alias_name_major = "#{formula.name}@#{formula.version.major}"
-        alias_name_major_minor = "#{alias_name_major}.#{formula.version.minor}"
+        alias_name_major_minor = "#{formula.name}@#{formula.version.major_minor}"
         alias_name = if last_alias_version.split(".").length == 1
           alias_name_major
         else
           alias_name_major_minor
         end
-        valid_alias_names = [alias_name_major, alias_name_major_minor]
+        valid_main_alias_names = [alias_name_major, alias_name_major_minor].uniq
 
-        unless @core_tap
-          versioned_aliases.map! { |a| "#{formula.tap}/#{a}" }
-          valid_alias_names.map! { |a| "#{formula.tap}/#{a}" }
+        # Also accept versioned aliases with names of other aliases, but do not require them.
+        valid_other_alias_names = unversioned_aliases.flat_map do |name|
+          %W[
+            #{name}@#{formula.version.major}
+            #{name}@#{formula.version.major_minor}
+          ].uniq
         end
 
-        valid_versioned_aliases = versioned_aliases & valid_alias_names
-        invalid_versioned_aliases = versioned_aliases - valid_alias_names
+        unless @core_tap
+          [versioned_aliases, valid_main_alias_names, valid_other_alias_names].each do |array|
+            array.map! { |a| "#{formula.tap}/#{a}" }
+          end
+        end
 
-        if valid_versioned_aliases.empty?
+        valid_versioned_aliases = versioned_aliases & valid_main_alias_names
+        invalid_versioned_aliases = versioned_aliases - valid_main_alias_names - valid_other_alias_names
+
+        latest_versioned_formula = versioned_formulae.map(&:name).first
+
+        if valid_versioned_aliases.empty? && alias_name != latest_versioned_formula
           if formula.tap
             problem <<~EOS
               Formula has other versions so create a versioned alias:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

* Fix audit not being run at all due to always-false condition (`@build_stable`).
* Don't fail audit if versioned alias would clash with a versioned formula (e.g. we for a few days had `go@1.17` as a formula while the main `go` formula was also still 1.17).
* Allow versioned aliases with the name of another alias (e.g. `kubectl` is an alias of `kubernetes-cli`, so allow - but not require - `kubectl@1.23` to exist).