### PR TITLE
shims: make CC shim callable without a symlink

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -470,7 +470,13 @@ if __FILE__ == $PROGRAM_NAME
 
   args << { close_others: false }
   if mac?
-    exec "#{dirname}/xcrun", tool, *args
+    # If we are being called from the shims/mac/super/cc symlink, xcrun is in our directory.
+    # Otherwise, xcrun is in ../mac/super
+    xcrun_path = "#{dirname}/xcrun"
+    if !File.exists? xcrun_path
+      xcrun_path = "#{dirname}/../mac/super/xcrun"
+    end
+    exec xcrun_path, tool, *args
   else
     paths = ENV["PATH"].split(":")
     paths = remove_superbin_from_path(paths)


### PR DESCRIPTION
Currently, the CC shim is only callable via its symlink in shims/mac/super:
https://github.com/Homebrew/brew/blob/master/Library/Homebrew/shims/mac/super/cc

In particular, it expects xcrun to be in the same directory:
https://github.com/Homebrew/brew/blob/02b0a45705b33e22475b98df9ebb4cd40d170848/Library/Homebrew/shims/super/cc#L473

This poses a problem for build systems such as Bazel that resolve symlinks during toolchain configuration.
Bazel seems to have a good reason for resolving symlinks, which is a bug in clang related to symlink handling:
https://github.com/bazelbuild/bazel/blob/a987b98ea0d6da2656c4115568ef9cbe8a164550/tools/cpp/unix_cc_configure.bzl#L312

Therefore, it seems preferable to make CC more-flexible in how it is called.

I do this by checking both possible locations for xcrun.

This change should enable using Bazel C++ rules in Brew, which will allow us to remove the shim bypass from the Bazel
formula and enable new formulas that use Bazel:
https://github.com/Homebrew/homebrew-core/blob/master/Formula/bazel.rb#L48

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
