### PR TITLE
Enable .rubocop.yml in taps

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -126,10 +126,15 @@ module Homebrew
       end
 
       files&.map!(&:expand_path)
+      config, = files.flat_map do |f|
+        tap = f.to_s[%r{.+/homebrew-[^/]+}]
+        Pathname.glob("#{tap}/.rubocop.yml")
+      end
+
       if files.blank? || files == [HOMEBREW_REPOSITORY]
         files = [HOMEBREW_LIBRARY_PATH]
       elsif files.none? { |f| f.to_s.start_with? HOMEBREW_LIBRARY_PATH }
-        config = if files.any? { |f| (f/"spec").exist? }
+        config ||= if files.any? { |f| (f/"spec").exist? }
           HOMEBREW_LIBRARY/".rubocop_rspec.yml"
         else
           HOMEBREW_LIBRARY/".rubocop.yml"


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Allows for example:
~~~ yaml
# /path/to/my/homebrew-tap/.rubocop.yml
inherit_from: /usr/local/Homebrew/Library/.rubocop.yml

Style/WordArray:
  MinSize: 3
~~~