### PR TITLE
repair cask's fuzzy_search in `search_casks`

### DIFF
--- a/Library/Homebrew/extend/os/mac/search.rb
+++ b/Library/Homebrew/extend/os/mac/search.rb
@@ -36,10 +36,9 @@ module Homebrew
         results = cask_tokens.extend(Searchable)
                              .search(string_or_regex)
 
-        if results.empty?
-          cask_names = Cask::Cask.all.map(&:full_name)
-          results = DidYouMean::SpellChecker.new(dictionary: cask_names).correct(string_or_regex)
-        end
+        cask_names = Cask::Cask.all.map(&:full_name)
+        results |= DidYouMean::SpellChecker.new(dictionary: cask_names)
+                                           .correct(string_or_regex)
 
         results.sort.map do |name|
           cask = Cask::CaskLoader.load(name)
@@ -48,7 +47,7 @@ module Homebrew
           else
             cask.token
           end
-        end
+        end.uniq
       end
     end
 

--- a/Library/Homebrew/extend/os/mac/search.rb
+++ b/Library/Homebrew/extend/os/mac/search.rb
@@ -36,8 +36,10 @@ module Homebrew
         results = cask_tokens.extend(Searchable)
                              .search(string_or_regex)
 
-        results |= DidYouMean::SpellChecker.new(dictionary: cask_tokens)
-                                           .correct(string_or_regex)
+        if results.empty?
+          cask_names = Cask::Cask.all.map(&:full_name)
+          results = DidYouMean::SpellChecker.new(dictionary: cask_names).correct(string_or_regex)
+        end
 
         results.sort.map do |name|
           cask = Cask::CaskLoader.load(name)

--- a/Library/Homebrew/extend/os/mac/search.rb
+++ b/Library/Homebrew/extend/os/mac/search.rb
@@ -37,7 +37,7 @@ module Homebrew
                              .search(string_or_regex)
 
         cask_names = Cask::Cask.all.map(&:full_name)
-        results |= DidYouMean::SpellChecker.new(dictionary: cask_names)
+        results += DidYouMean::SpellChecker.new(dictionary: cask_names)
                                            .correct(string_or_regex)
 
         results.sort.map do |name|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

related to https://github.com/Homebrew/brew/issues/13028
repair Homebrew::Search::Extension.search_casks to use Cask.full_name instead of Tap.cask_tokens for fuzzy_search

1. before
```bash
brew search  docker-compose
==> Formulae
docker-compose                                                                       docker-compose-completion                                                            docker-completion

If you meant "docker-compose" specifically:
It was migrated from homebrew/cask to homebrew/core.
```

2. after
```bash
brew search  docker-compose
==> Formulae
docker-compose                                                                       docker-compose-completion                                                            docker-completion

==> Casks
docker-toolbox

If you meant "docker-compose" specifically:
It was migrated from homebrew/cask to homebrew/core.
```
