### PR TITLE
diagnostic: skip linuxbrew-core tap check when installing from API

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -121,6 +121,7 @@ module Homebrew
       end
 
       def check_linuxbrew_core
+        return if Homebrew::EnvConfig.install_from_api?
         return unless CoreTap.instance.linuxbrew_core?
 
         <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should fix https://github.com/Homebrew/brew/issues/13039. Right now on Linux, we run `check_linuxbrew_core` unconditionally. The core tap is absent when installing from API so this leads to a fatal error. Instead, adjust `check_linuxbrew_core` to skip/ignore missing core tap when installing from API.