### PR TITLE
Revert "Enable .rubocop.yml in taps"

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -126,15 +126,10 @@ module Homebrew
       end
 
       files&.map!(&:expand_path)
-      config, = files.flat_map do |f|
-        tap = f.to_s[%r{.+/homebrew-[^/]+}]
-        Pathname.glob("#{tap}/.rubocop.yml")
-      end
-
       if files.blank? || files == [HOMEBREW_REPOSITORY]
         files = [HOMEBREW_LIBRARY_PATH]
       elsif files.none? { |f| f.to_s.start_with? HOMEBREW_LIBRARY_PATH }
-        config ||= if files.any? { |f| (f/"spec").exist? }
+        config = if files.any? { |f| (f/"spec").exist? }
           HOMEBREW_LIBRARY/".rubocop_rspec.yml"
         else
           HOMEBREW_LIBRARY/".rubocop.yml"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Revert Homebrew/brew#13044.  In that PR, @MikeMcQuaid commented:  

> Passing on this. Will review additional parameters to `brew test-bot` if desired.

then closed the PR by merging its proposed changes.  Given the above, I suspect this was an accident, hence this PR to revert said changes.  

(Note:  Regarding unchecked boxes in the PR header above:  apologies; I unfortunately don't have a working machine capable of running Homebrew that I can complete those steps on at the moment.  I made this PR via GitHub's web interface.)  

