### PR TITLE
dev-cmd/unbottled: ignore versioned macos when checking linux

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -169,7 +169,7 @@ module Homebrew
 
       requirements = f.recursive_requirements
       if @bottle_tag.linux?
-        if requirements.any?(MacOSRequirement)
+        if requirements.any? { |r| r.is_a?(MacOSRequirement) && !r.version }
           puts "#{Tty.bold}#{Tty.red}#{name}#{Tty.reset}: requires macOS" if any_named_args
           next
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`qt@5` was showing up as requiring macOS even though it is already bottled on Linux:
```console
❯ brew unbottled --tag=linux qt@5
==> Populating dependency tree...
==> :x86_64_linux bottle status
qt@5: requires macOS
```

With change:
```console
❯ brew unbottled --tag=linux qt@5
==> Populating dependency tree...
==> :x86_64_linux bottle status
qt@5: already bottled
```

Some other checks that should be unchanged:
```console
# depends_on :macos
❯ brew unbottled --tag=linux objc-codegenutils
==> Populating dependency tree...
==> :x86_64_linux bottle status
objc-codegenutils: requires macOS

# depends_on :xcode
❯ brew unbottled --tag=linux root
==> Populating dependency tree...
==> :x86_64_linux bottle status
root: already bottled

# depends_on :macos AND depends_on macos: :mojave
❯ brew unbottled --tag=linux dark-mode
==> Populating dependency tree...
==> :x86_64_linux bottle status
dark-mode: requires macOS

# depends_on xcode: ["11.1", :build]
❯ brew unbottled --tag=linux macosvpn
==> Populating dependency tree...
==> :x86_64_linux bottle status
macosvpn: ready to bottle
```