### PR TITLE
rubocops/uses_from_macos: allow keg only berkeley-db

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -11,6 +11,7 @@ module RuboCop
         PROVIDED_BY_MACOS_FORMULAE = %w[
           apr
           bc
+          berkeley-db
           bison
           bzip2
           cups


### PR DESCRIPTION
The macOS SDK contains headers for Berkeley DB (1.8-era).

I believe people with our Berkeley DB installed are getting errors compiling OpenJDK as the newer header is shadowing the older one in the SDK.

To fix this, we should make it keg only.