### PR TITLE
caskroom: add, use any_casks_installed?.

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -12,7 +12,14 @@ module Cask
 
     sig { returns(Pathname) }
     def self.path
-      @path ||= HOMEBREW_PREFIX.join("Caskroom")
+      @path ||= HOMEBREW_PREFIX/"Caskroom"
+    end
+
+    sig { returns(T::Boolean) }
+    def self.any_casks_installed?
+      return false unless path.exist?
+
+      path.children.select(&:directory?).any?
     end
 
     sig { void }
@@ -36,7 +43,7 @@ module Cask
     def self.casks(config: nil)
       return [] unless path.exist?
 
-      Pathname.glob(path.join("*")).sort.select(&:directory?).map do |path|
+      path.children.select(&:directory?).sort.map do |path|
         token = path.basename.to_s
 
         if (tap_path = CaskLoader.tap_paths(token).first)

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -48,7 +48,7 @@ module Homebrew
         check_missing_deps
       ]
       methods = (checks.all - slow_checks) + slow_checks
-      methods -= checks.cask_checks if Cask::Caskroom.casks.blank?
+      methods -= checks.cask_checks unless Cask::Caskroom.any_casks_installed?
     else
       methods = args.named
     end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -113,7 +113,7 @@ module Homebrew
         ohai "Formulae" if $stdout.tty? && !args.formula?
         safe_system "ls", *ls_args, HOMEBREW_CELLAR
       end
-      if !args.formula? && Cask::Caskroom.casks.any?
+      if !args.formula? && Cask::Caskroom.any_casks_installed?
         if $stdout.tty? && !args.cask?
           puts
           ohai "Casks"


### PR DESCRIPTION
Add a new method for the two places we're checking if we have any casks installed. This is much more performance and user friendly than attempting to load every cask.

Fixes #13027