### PR TITLE
update "brew doctor" to check the HOMEBREW_PREFIX directory

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -239,8 +239,8 @@ module Homebrew
           "sentinel-*.dylib", # SentinelOne
         ]
 
-        __check_stray_files "/usr/local/lib", "*.dylib", allow_list, <<~EOS
-          Unbrewed dylibs were found in /usr/local/lib.
+        __check_stray_files "#{HOMEBREW_PREFIX}/lib", "*.dylib", allow_list, <<~EOS
+          Unbrewed dylibs were found in #{HOMEBREW_PREFIX}/lib.
           If you didn't put them there on purpose they could cause problems when
           building Homebrew formulae, and may need to be deleted.
 
@@ -264,8 +264,8 @@ module Homebrew
           "libtrustedcomponents.a", # Symantec Endpoint Protection
         ]
 
-        __check_stray_files "/usr/local/lib", "*.a", allow_list, <<~EOS
-          Unbrewed static libraries were found in /usr/local/lib.
+        __check_stray_files "#{HOMEBREW_PREFIX}/lib", "*.a", allow_list, <<~EOS
+          Unbrewed static libraries were found in #{HOMEBREW_PREFIX}/lib.
           If you didn't put them there on purpose they could cause problems when
           building Homebrew formulae, and may need to be deleted.
 
@@ -284,8 +284,8 @@ module Homebrew
           "libublio.pc", # NTFS-3G
         ]
 
-        __check_stray_files "/usr/local/lib/pkgconfig", "*.pc", allow_list, <<~EOS
-          Unbrewed '.pc' files were found in /usr/local/lib/pkgconfig.
+        __check_stray_files "#{HOMEBREW_PREFIX}/lib/pkgconfig", "*.pc", allow_list, <<~EOS
+          Unbrewed '.pc' files were found in #{HOMEBREW_PREFIX}/lib/pkgconfig.
           If you didn't put them there on purpose they could cause problems when
           building Homebrew formulae, and may need to be deleted.
 
@@ -305,8 +305,8 @@ module Homebrew
           "libublio.la", # NTFS-3G
         ]
 
-        __check_stray_files "/usr/local/lib", "*.la", allow_list, <<~EOS
-          Unbrewed '.la' files were found in /usr/local/lib.
+        __check_stray_files "#{HOMEBREW_PREFIX}/lib", "*.la", allow_list, <<~EOS
+          Unbrewed '.la' files were found in #{HOMEBREW_PREFIX}/lib.
           If you didn't put them there on purpose they could cause problems when
           building Homebrew formulae, and may need to be deleted.
 
@@ -324,8 +324,8 @@ module Homebrew
           "ntfs-3g/**/*.h", # NTFS-3G
         ]
 
-        __check_stray_files "/usr/local/include", "**/*.h", allow_list, <<~EOS
-          Unbrewed header files were found in /usr/local/include.
+        __check_stray_files "#{HOMEBREW_PREFIX}/include", "**/*.h", allow_list, <<~EOS
+          Unbrewed header files were found in #{HOMEBREW_PREFIX}/include.
           If you didn't put them there on purpose they could cause problems when
           building Homebrew formulae, and may need to be deleted.
 

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -26,6 +26,91 @@ describe Homebrew::Diagnostic::Checks do
     end
   end
 
+  specify "#check_for_stray_dylibs" do
+    mktmpdir do |path|
+      FileUtils.mkdir("#{path}/lib")
+      FileUtils.touch "#{path}/lib/test.dylib"
+      stub_const "HOMEBREW_PREFIX", Pathname(path)
+      expected_output = <<~EOS
+        Unbrewed dylibs were found in #{path}/lib.
+        If you didn't put them there on purpose they could cause problems when
+        building Homebrew formulae, and may need to be deleted.
+
+        Unexpected dylibs:
+          #{path}/lib/test.dylib
+      EOS
+      expect(checks.check_for_stray_dylibs).to eq(expected_output)
+    end
+  end
+
+  specify "#check_for_stray_static_libs" do
+    mktmpdir do |path|
+      FileUtils.mkdir("#{path}/lib")
+      FileUtils.touch "#{path}/lib/test.a"
+      stub_const "HOMEBREW_PREFIX", Pathname(path)
+      expected_output = <<~EOS
+        Unbrewed static libraries were found in #{path}/lib.
+        If you didn't put them there on purpose they could cause problems when
+        building Homebrew formulae, and may need to be deleted.
+
+        Unexpected static libraries:
+          #{path}/lib/test.a
+      EOS
+      expect(checks.check_for_stray_static_libs).to eq(expected_output)
+    end
+  end
+
+  specify "#check_for_stray_pcs" do
+    mktmpdir do |path|
+      FileUtils.mkdir_p("#{path}/lib/pkgconfig")
+      FileUtils.touch "#{path}/lib/pkgconfig/test.pc"
+      stub_const "HOMEBREW_PREFIX", Pathname(path)
+      expected_output = <<~EOS
+        Unbrewed '.pc' files were found in #{path}/lib/pkgconfig.
+        If you didn't put them there on purpose they could cause problems when
+        building Homebrew formulae, and may need to be deleted.
+
+        Unexpected '.pc' files:
+          #{path}/lib/pkgconfig/test.pc
+      EOS
+      expect(checks.check_for_stray_pcs).to eq(expected_output)
+    end
+  end
+
+  specify "#check_for_stray_las" do
+    mktmpdir do |path|
+      FileUtils.mkdir("#{path}/lib")
+      FileUtils.touch "#{path}/lib/test.la"
+      stub_const "HOMEBREW_PREFIX", Pathname(path)
+      expected_output = <<~EOS
+        Unbrewed '.la' files were found in #{path}/lib.
+        If you didn't put them there on purpose they could cause problems when
+        building Homebrew formulae, and may need to be deleted.
+
+        Unexpected '.la' files:
+          #{path}/lib/test.la
+      EOS
+      expect(checks.check_for_stray_las).to eq(expected_output)
+    end
+  end
+
+  specify "#check_for_stray_headers" do
+    mktmpdir do |path|
+      FileUtils.mkdir("#{path}/include")
+      FileUtils.touch "#{path}/include/test.h"
+      stub_const "HOMEBREW_PREFIX", Pathname(path)
+      expected_output = <<~EOS
+        Unbrewed header files were found in #{path}/include.
+        If you didn't put them there on purpose they could cause problems when
+        building Homebrew formulae, and may need to be deleted.
+
+        Unexpected header files:
+          #{path}/include/test.h
+      EOS
+      expect(checks.check_for_stray_headers).to eq(expected_output)
+    end
+  end
+
   specify "#check_access_directories" do
     skip "User is root so everything is writable." if Process.euid.zero?
     begin


### PR DESCRIPTION
Currently on M1 mac I'm getting errors when running brew doctor complaining about files being in /usr/local/lib.
I would expect it to ignore the /usr/local/* as it is installed under /opt/homebrew.
This change updates the directory to search for non-homebrew files to be `HOMEBREW_PREFIX` rather than `"/usr/local"`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This should fix issue #13079