### PR TITLE
set `prefer_loading_from_api: true` for `brew fetch`

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -71,7 +71,15 @@ module Homebrew
         when Formula
           f = formula_or_cask
 
-          [f, *f.recursive_dependencies.map(&:to_formula)]
+          deps = if Homebrew::EnvConfig.install_from_api?
+            f.recursive_dependencies do |_, dependency|
+              Dependency.prune if EnvConfig.install_from_api? && (dependency.build? || dependency.test?)
+            end
+          else
+            f.recursive_dependencies
+          end
+
+          [f, *deps.map(&:to_formula)]
         else
           formula_or_cask
         end

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -66,7 +66,7 @@ module Homebrew
     args = fetch_args.parse
 
     bucket = if args.deps?
-      args.named.to_formulae_and_casks.flat_map do |formula_or_cask|
+      args.named.to_formulae_and_casks(prefer_loading_from_api: true).flat_map do |formula_or_cask|
         case formula_or_cask
         when Formula
           f = formula_or_cask
@@ -77,7 +77,7 @@ module Homebrew
         end
       end
     else
-      args.named.to_formulae_and_casks
+      args.named.to_formulae_and_casks(prefer_loading_from_api: true)
     end.uniq
 
     puts "Fetching: #{bucket * ", "}" if bucket.size > 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This is to fix #13088 by passing `prefer_loading_from_api: true` when calling `to_formulae_and_casks`. I am following what I found in `Library/Homebrew/cmd/install.rb` and this solves the issue in my testing; however I know there are larger discussions happening around overall support for `HOMEBREW_INSTALL_FROM_API` so I'm happy to incorporate any additional changes that are needed.