### PR TITLE
shims: add new to fix `xml2-config --libs` output

### DIFF
--- a/Library/Homebrew/shims/mac/super/xml2-config
+++ b/Library/Homebrew/shims/mac/super/xml2-config
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+xml2config="$(which -a xml2-config | awk NR==2)"
+if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt 101300 ]] &&
+   [[ "${xml2config}" == "/usr/bin/xml2-config" ]] && 
+   [[ "$*" =~ (^| )--libs ]]
+then
+  exec "${xml2config}" "$@" | sed 's:-L/:-isysroot /:'
+else
+  exec "${xml2config}" "$@"
+fi


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

_Although this is coming far too late to be of much practical use, it's still useful information._

A few formulae [currently set](https://github.com/Homebrew/discussions/discussions/2533#discussioncomment-1703103) `ENV["SDKROOT"] = MacOS.sdk_path` to fix building with libxml2 on Sierra. But, the setting of SDKROOT causes the build to fail with "C compiler cannot create executables" / "SDK ... cannot be located" if `xcode-select -p` indicates the active SDK is Xcode's, resulting in formulae that suddenly won't build if Xcode is installed.

First, why was adding SDKROOT needed in the first place? The most common comment says it fixes `"ld: file not found: /usr/lib/system/libsystem_darwin.dylib" for lxml`, or some similar message relating to libxml2. That particular error occurs only on 10.12 because [a .tbd file](https://developer.apple.com/forums/thread/655588?answerId=665804022#665804022) in the 10.13 SDK references a library that is [not actually included with 10.12](https://github.com/Homebrew/homebrew-core/pull/20872#issuecomment-345651099). 

Ordinarily this wouldn't be a problem, except that the _xml2-config_ that ships with macOS and the libxml2 formula makes the [error of using _-L_ instead of _-isysroot_](https://developer.apple.com/forums/thread/87829?answerId=266575022#266575022) to refer to the Xcode SDK when it's active. If the CLT is active, the _-L_ reference is not generated.

    # on macOS 10.12
    $ sudo xcode-select -r
    $ xcode-select -p
    /Applications/Xcode.app/Contents/Developer
    $ /usr/bin/xml2-config --libs
    -L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/lib -lxml2 -lz -lpthread -licucore -lm

    $ sudo xcode-select --switch /Library/Developer/CommandLineTools
    $ xcode-select -p
    /Library/Developer/CommandLineTools
    $ /usr/bin/xml2-config --libs
    -lxml2 -lz -lpthread -licucore -lm

And since _xml2-config_ is a shell script, we can see that this is occurring only because `xcrun -show-sdk-path` returns a path only when Xcode's is active, and no value when the CLT is active.

    $ xcrun -show-sdk-path

    $ sudo xcode-select -r
    $ xcrun -show-sdk-path
    /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk

On later macOS versions, `xcrun -show-sdk-path` prints the path to the CLT's SDK when the CLT is active, causing `xml2-config --libs` to always include `-L<sdk path>` in its output, but since `/usr/lib/system/libsystem_darwin.dylib` is present, it doesn't cause an issue.

For example, `libslax` builds on Sierra with or without SDKROOT being set as long as the CLT is active. From `~/Library/Logs/Homebrew/libslax/01.configure`:

    # CLT without SDKROOT fix
      libxml libs:       -lxml2 -lz -lpthread -licucore -lm

    # CLT with SDKROOT fix
      libxml libs:       -L/Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk/usr/lib -lxml2 -lz -lpthread -licucore -lm

When Xcode is active, it fails with either "libsystem_darwin.dylib" or fails to find clang at all.

    # Xcode without SDKROOT fix
      libxml libs:       -L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/lib -lxml2 -lz -lpthread -licucore -lm

    # Xcode with SDKROOT fix
      checking whether the C compiler works... no

It remains unknown why setting SDKROOT causes issues when Xcode's SDK is active:

    # CLT active
    $ SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk/ clang --version
    Apple LLVM version 9.0.0 (clang-900.0.39.2)
    Target: x86_64-apple-darwin16.7.0
    Thread model: posix
    InstalledDir: /Library/Developer/CommandLineTools/usr/bin

    # Xcode active
    $ SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk/ clang --version
    xcodebuild: error: SDK "/Library/Developer/CommandLineTools/SDKs/MacOSX10.13.sdk/" cannot be located.
    clang: error: unable to find utility "clang", not a developer tool or in PATH

What this shim does is take the output of `xml2-config --libs` from the next _xml2-config_ in the path (whether built-in or from the formula) and change _-L_ to _-isysroot_. This allows the following formulae to build under macOS 10.12 when Xcode is active and their SDKROOT fix is removed… _checks notes_… xmlrpc-c, sqliteodbc, postgresql@9.4, flowgrind, uwsgi. The others have either been fixed by using a newer lxml or aren't fixable by the shim alone. 

Like I said, a rather late and probably ignorable fix, but I'll be linking some formula PRs back to here shortly to explain my changes.