### PR TITLE
ENV/super: always set HOMEBREW_DEVELOPER_DIR regardless of macOS version

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -87,19 +87,19 @@ module Superenv
   # @private
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
     sdk = formula ? MacOS.sdk_for_formula(formula) : MacOS.sdk
-    if MacOS.sdk_root_needed? || sdk&.source == :xcode
-      Homebrew::Diagnostic.checks(:fatal_setup_build_environment_checks)
-      self["HOMEBREW_SDKROOT"] = sdk.path
+    is_xcode_sdk = sdk&.source == :xcode
 
-      self["HOMEBREW_DEVELOPER_DIR"] = if sdk.source == :xcode
-        MacOS::Xcode.prefix
-      else
-        MacOS::CLT::PKG_PATH
-      end
-    else
-      self["HOMEBREW_SDKROOT"] = nil
-      self["HOMEBREW_DEVELOPER_DIR"] = nil
+    self["HOMEBREW_SDKROOT"] = if is_xcode_sdk || MacOS.sdk_root_needed?
+      Homebrew::Diagnostic.checks(:fatal_setup_build_environment_checks)
+      sdk.path
     end
+
+    self["HOMEBREW_DEVELOPER_DIR"] = if is_xcode_sdk
+      MacOS::Xcode.prefix
+    else
+      MacOS::CLT::PKG_PATH
+    end
+
     generic_setup_build_environment(
       formula: formula, cc: cc, build_bottle: build_bottle,
       bottle_arch: bottle_arch, testing_formula: testing_formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will hopefully be a catch-all to fix all SDK-related issues prior to Mojave. (Needs testing.)

See #13098 for prior discussion.

I wonder if the `ac_*` hacks further down will be needed after this fix, but I've not touched them to be on the safe side.