### PR TITLE
download_strategy: ignore query strings when parsing resolved URLs

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -327,7 +327,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     @resolved_url_and_basename = [url, parse_basename(url)]
   end
 
-  def parse_basename(url)
+  def parse_basename(url, search_query: true)
     uri_path = if url.match?(URI::DEFAULT_PARSER.make_regexp)
       uri = URI(url)
 
@@ -339,7 +339,11 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
         end
       end
 
-      uri.query ? "#{uri.path}?#{uri.query}" : uri.path
+      if uri.query && search_query
+        "#{uri.path}?#{uri.query}"
+      else
+        uri.path
+      end
     else
       url
     end
@@ -509,8 +513,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
            .map(&:to_i)
            .last
 
-    basename = filenames.last || parse_basename(redirect_url)
     is_redirection = url != redirect_url
+    basename = filenames.last || parse_basename(redirect_url, search_query: !is_redirection)
 
     @resolved_info_cache[url] = [redirect_url, basename, time, file_size, is_redirection]
   end


### PR DESCRIPTION
An alternative to Homebrew/brew#13108 for fixing Homebrew/homebrew-cask#121725, but I think it makes sense to make both changes.

We currently parse query strings `https://example.com/download.php?file=foo-1.0.tar.gz` to extract the file extension.

This is not always correct. Sometimes you have scenarios like `https://example.com/file=foo-1.0.tar.gz?host=elsewhere.com` where it'll think `elsewhere.com` is the basename.

It's impossible to tell really how a URL should be parsed, so what I've done is alter the behaviour of URL parsing in the scenario where we've already followed redirects and checked headers. This means we have checked for and did not find a `Content-Disposition` so we are safe to follow what browsers do: take the basename, ingoring the query string.

Keep the original behaviour for the "dumber" scan-the-unresolved-URL case (i.e. the URL direct from the formula and cask), which is less likely to have crazy query strings at the end of the URL.