### PR TITLE
formula_auditor: add support for github_notability_allowlist

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -687,7 +687,7 @@ module Cask
 
       odebug "Auditing GitHub repo"
 
-      error = SharedAudits.github(user, repo)
+      error = SharedAudits.github(user, repo, cask: cask)
       add_error error if error
     end
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -531,7 +531,7 @@ module Homebrew
 
       return if user.blank?
 
-      warning = SharedAudits.github(user, repo)
+      warning = SharedAudits.github(user, repo, formula: formula)
       return if warning.nil?
 
       new_formula_problem warning


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
I noticed that there is no allowlist set up for exceptions to the "github repo must be notable" audit for new formulae, so adding one in this PR.

Also updated the wording of the audit error to be a little clearer.

I didn't see any tests covering this audit already so wasn't sure where to update them — advice welcome!