### PR TITLE
arrange error message of 'brew edit --cask'

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -55,9 +55,20 @@ module Homebrew
       args.named.to_paths.select do |path|
         next path if path.exist?
 
-        raise UsageError, "#{path} doesn't exist on disk. " \
-                          "Run #{Formatter.identifier("brew create --set-name #{path.basename} $URL")} " \
-                          "to create a new formula!"
+        message = if args.cask?
+          <<~EOS
+            #{path.basename(".rb")} doesn't exist on disk. \
+            Run #{Formatter.identifier("brew create --cask --set-name #{path.basename(".rb")} $URL")} \
+            to create a new cask!
+          EOS
+        else
+          <<~EOS
+            #{path} doesn't exist on disk. \
+            Run #{Formatter.identifier("brew create --set-name #{path.basename} $URL")} \
+            to create a new formula!
+          EOS
+        end
+        raise UsageError, message
       end.presence
     end
 

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -64,7 +64,7 @@ module Homebrew
         else
           <<~EOS
             #{path} doesn't exist on disk. \
-            Run #{Formatter.identifier("brew create --set-name #{path.basename} $URL")} \
+            Run #{Formatter.identifier("brew create --formula --set-name #{path.basename} $URL")} \
             to create a new formula!
           EOS
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
 arrange the error message of `brew edit --cask` like one of `brew edit --formula`
 

 
 - before PR
```bash
$ brew edit --cask atomm
Usage: brew edit [options] [formula|cask ...]

Open a formula or cask in the editor set by EDITOR or HOMEBREW_EDITOR,
or open the Homebrew repository for editing if no formula is provided.

      --formula, --formulae        Treat all named arguments as formulae.
      --cask, --casks              Treat all named arguments as casks.
      --print-path                 Print the file path to be edited, without
                                   opening an editor.
  -d, --debug                      Display any debugging information.
  -q, --quiet                      Make some output more quiet.
  -v, --verbose                    Make some output more verbose.
  -h, --help                       Show this message.

Error: Invalid usage: /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/atomm.rb doesn't exist on disk. Run brew create --set-name atomm.rb $URL to create a new formula!
```


 - after PR
 ```bash
$ brew edit --cask atomm
Usage: brew edit [options] [formula|cask ...]

--< omitted >--

Error: Invalid usage: atomm doesn't exist on disk. Run brew create --cask --set-name atomm $URL to create a new cask!
```