### PR TITLE
utils/github: rewrite get_workflow_run using GraphQL

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -39,6 +39,8 @@ Metrics/ModuleLength:
   Exclude:
     # TODO: extract more of the bottling logic
     - "dev-cmd/bottle.rb"
+    # TODO: try break this down
+    - "utils/github.rb"
     - "test/**/*"
 
 Naming/PredicateName:

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -71,7 +71,7 @@ describe GitHub do
         described_class.get_artifact_url(
           described_class.get_workflow_run("Homebrew", "homebrew-core", 1),
         )
-      }.to raise_error(/No matching workflow run found/)
+      }.to raise_error(/No matching check suite found/)
     end
 
     it "fails to find artifacts that don't exist" do

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -253,8 +253,8 @@ module GitHub
       end
     end
 
-    def open_graphql(query, scopes: [].freeze)
-      data = { query: query }
+    def open_graphql(query, variables: nil, scopes: [].freeze)
+      data = { query: query, variables: variables }
       result = open_rest("#{API_URL}/graphql", scopes: scopes, data: data, request_method: "POST")
 
       if result["errors"].present?


### PR DESCRIPTION
The previous method of searching based on PR branch was very fragile - it was already known to be broken when a PR was submitted with the `master` branch as a source, and it has today broken entirely for some reason (likely an issue on GitHub's side).

I've rewritten it to now be much more reliable. Or at least it seems to work a lot better from the very low sample size of PRs I've tested.

Although ideally this would go through the usual 24 hour review period (and maybe refactoring to avoid the `Metrics/ModuleLength` exception), I'm expediting this since our merge process over at homebrew-core is currently completely broken.