### PR TITLE
bump: resume checking for TLS 1.3 support

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -59,12 +59,14 @@ module Homebrew
 
     limit = args.limit.to_i if args.limit.present?
 
-    begin
-      unless Pathname.new(ENV["HOMEBREW_BREWED_CURL_PATH"]).exist?
-        ensure_formula_installed!("curl", reason: "Repology queries")
+    unless Utils::Curl.curl_supports_tls13?
+      begin
+        unless Pathname.new(ENV["HOMEBREW_BREWED_CURL_PATH"]).exist?
+          ensure_formula_installed!("curl", reason: "Repology queries")
+        end
+      rescue FormulaUnavailableError
+        opoo "A newer `curl` is required for Repology queries."
       end
-    rescue FormulaUnavailableError
-      opoo "A newer `curl` is required for Repology queries."
     end
 
     if formulae_and_casks.present?

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -19,7 +19,7 @@ module Repology
     last_package_in_response += "/" if last_package_in_response.present?
     url = "https://repology.org/api/v1/projects/#{last_package_in_response}?inrepo=#{repository}&outdated=1"
 
-    output, errors, = curl_output(url.to_s, "--silent", use_homebrew_curl: false)
+    output, errors, = curl_output(url.to_s, "--silent", use_homebrew_curl: !curl_supports_tls13?)
     JSON.parse(output)
   rescue
     if Homebrew::EnvConfig.developer?
@@ -35,7 +35,7 @@ module Repology
     url = "https://repology.org/tools/project-by?repo=#{repository}&" \
           "name_type=srcname&target_page=api_v1_project&name=#{name}"
 
-    output, errors, = curl_output("--location", "--silent", url.to_s, use_homebrew_curl: true)
+    output, errors, = curl_output("--location", "--silent", url.to_s, use_homebrew_curl: !curl_supports_tls13?)
 
     data = JSON.parse(output)
     { name => data }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
macOS 12.3's shipping curl now supports TLS 1.3, so we can skip installing the curl formula in that case.