### PR TITLE
formula_installer: handle unexpected .brew presence/absence

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -285,12 +285,14 @@ module FormulaCellarChecks
   end
 
   def check_cpuid_instruction(formula)
-    return unless formula.prefix.directory?
-    # TODO: add methods to `utils/ast` to allow checking for method use
-    return unless (formula.prefix/".brew/#{formula.name}.rb").read.include? "ENV.runtime_cpu_detection"
     # Checking for `cpuid` only makes sense on Intel:
     # https://en.wikipedia.org/wiki/CPUID
     return unless Hardware::CPU.intel?
+
+    dot_brew_formula = formula.prefix/".brew/#{formula.name}.rb"
+    return unless dot_brew_formula.exist?
+    # TODO: add methods to `utils/ast` to allow checking for method use
+    return unless dot_brew_formula.read.include? "ENV.runtime_cpu_detection"
 
     # macOS `objdump` is a bit slow, so we prioritise llvm's `llvm-objdump` (~5.7x faster)
     # or binutils' `objdump` (~1.8x faster) if they are installed.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -460,7 +460,7 @@ class FormulaInstaller
       end
       s = formula_contents.gsub(/  bottle do.+?end\n\n?/m, "")
       brew_prefix = formula.prefix/".brew"
-      brew_prefix.mkdir
+      brew_prefix.mkpath
       Pathname(brew_prefix/"#{formula.name}.rb").atomic_write(s)
 
       keg = Keg.new(formula.prefix)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This fixes two complementary errors I've seen recently:

- `formula_installer.rb`: when running `brew reinstall`, `reinstall.rb` checks for the existing keg via its opt prefix and backs it up to `#{path}.reinstall` if it exists. But if for some reason that opt prefix symlink is missing, the installer will happily overwrite the existing keg in-place… until it attempts to create the ".brew" folder, which throws `Error: File exists @ dir_s_mkdir - /usr/local/Cellar/<formula>/<version>/.brew`. Swapping `mkpath` for `mkdir` avoids the error.
- `formula_cellar_checks.rb`: some bottles that have been around for a while (e.g. `yajl`) lack the ".brew" directory, which causes `check_cpuid_instruction` to complain with `Error: No such file or directory @ rb_sysopen - /usr/local/opt/<formula>/.brew/<formula>.rb` when installing. I updated it to a) check for an Intel CPU first, and b) check for the full path to the `.brew/<formula>.rb` file before attempting to read it.
