### PR TITLE
null.rb: alias outdated_release? to allow formulae usage

### DIFF
--- a/Library/Homebrew/version/null.rb
+++ b/Library/Homebrew/version/null.rb
@@ -51,6 +51,7 @@ class Version
     alias requires_sse41? requires_nehalem_cpu?
     alias requires_sse42? requires_nehalem_cpu?
     alias requires_popcnt? requires_nehalem_cpu?
+    alias outdated_release? requires_nehalem_cpu?
 
     sig { override.returns(Token) }
     def major


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Alias the `MacOS.version.outdated_release?` method so it can be used in formulae, i.e. https://github.com/Homebrew/homebrew-core/pull/99023#discussion_r849000378.