### PR TITLE
Display old and new version numbers when updating Homebrew

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -124,7 +124,7 @@ module Homebrew
 
     if initial_revision != current_revision
       update_preinstall_header args: args
-      puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
+
       updated = true
 
       old_tag = Settings.read "latesttag"
@@ -133,7 +133,13 @@ module Homebrew
         "git", "-C", HOMEBREW_REPOSITORY, "tag", "--list", "--sort=-version:refname", "*.*"
       ).lines.first.chomp
 
-      new_repository_version = new_tag if new_tag != old_tag
+      if old_tag.blank? || (new_tag == old_tag)
+        puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
+      else
+        new_repository_version = new_tag
+        puts "Updated Homebrew from #{old_tag} (#{shorten_revision(initial_revision)}) " \
+             "to #{new_tag} (#{shorten_revision(current_revision)})."
+      end
     end
 
     Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This outputs the old and new version numbers along with the version hashes when they are different otherwise it outputs the old message. This was first proposed in issue #12760.

```
$ brew update    
Updated Homebrew from 3.3.9 (db648bcde) to 3.3.11 (249b0439e).
...
==> Homebrew was updated to version 3.3.11
The changelog can be found at:
  https://github.com/Homebrew/brew/releases/tag/3.3.11
```

Closes #12760