### PR TITLE
bump-formula-pr: expose update-python-resources CLI flags

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -78,6 +78,13 @@ module Homebrew
                           "or specified <version>."
       switch "-f", "--force",
              description: "Ignore duplicate open PRs. Remove all mirrors if `--mirror` was not specified."
+      flag   "--python-package-name=",
+             description: "Use the specified <package-name> when finding Python resources for <formula>. "\
+                          "If no package name is specified, it will be inferred from the formula's stable URL."
+      comma_array "--python-extra-packages=",
+                  description: "Include these additional Python packages when finding resources."
+      comma_array "--python-exclude-packages=",
+                  description: "Exclude these Python packages when finding resources."
 
       conflicts "--dry-run", "--write-only"
       conflicts "--dry-run", "--write"
@@ -329,8 +336,13 @@ module Homebrew
     end
 
     unless args.dry_run?
-      resources_checked = PyPI.update_python_resources! formula, version: new_formula_version,
-                                                        silent: args.quiet?, ignore_non_pypi_packages: true
+      resources_checked = PyPI.update_python_resources! formula,
+                                                        version:                  new_formula_version,
+                                                        package_name:             args.python_package_name,
+                                                        extra_packages:           args.python_extra_packages,
+                                                        exclude_packages:         args.python_exclude_packages,
+                                                        silent:                   args.quiet?,
+                                                        ignore_non_pypi_packages: true
     end
 
     run_audit(formula, alias_rename, old_contents, args: args)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Exposes CLI flags from `update-python-resources` so they can be used in `bump-formula-pr`:

- `brew update-python-resources --package-name` -> `brew bump-formula-pr --python-package-name`
- `--extra-packages` -> `--python-extra-packages`
- `--exclude-packages` -> `--python-exclude-packages`

Original PR changes (outdated)
<details>
- Add support for HOMEBREW_PIPGRIP_ADDITIONAL_DEPENDENCIES which will be
  propagated into PIPGRIP_ADDITIONAL_DEPENDENCIES when calling pipgrip

pipgrip 0.8.0 adds support for the `PIPGRIP_ADDITIONAL_DEPENDENCIES` environment variable which can be used to pass additional dependency information into pipgrip. When using the homebrew dev tools (`update-python-resources` and `bump-formula-pr`) this cannot be propagated into pipgrip due to the env var filtering (unless you also set the hidden+deprecated `HOMEBREW_NO_ENV_FILTERING` env var).

This PR adds an equivalent `HOMEBREW_PIPGRIP_ADDITIONAL_DEPENDENCIES` env var so that it can be passed into pipgrip through the filtering.

As to why this is needed, basically pipgrip has problems resolving dependencies for DVC due to misbehaving/broken pypi packages (that we don't have control over). This env var can be used to provide hints for specific versions pipgrip should try in order to successfully resolve the dependencies. See:

- https://github.com/iterative/homebrew-dvc/issues/50
- https://github.com/ddelange/pipgrip/issues/77
</details>