### PR TITLE
unpack_strategy/directory: preserve hard links

### DIFF
--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -23,9 +23,15 @@ module UnpackStrategy
 
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
     def extract_to_dir(unpack_dir, basename:, verbose:)
+      command, flags = if OS.linux?
+        ["cp", "-a"]
+      else
+        # BSD cp cannot preserve hard links
+        ["rsync", "-aH"]
+      end
       path.children.each do |child|
-        system_command! "cp",
-                        args:    ["-pR", (child.directory? && !child.symlink?) ? "#{child}/." : child,
+        system_command! command,
+                        args:    [flags, (child.directory? && !child.symlink?) ? "#{child}/." : child,
                                   unpack_dir/child.basename],
                         verbose: verbose
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

WIP/Experimenting based on unwanted bottle size increase due to hard link loss seen in Homebrew/homebrew-core#98803. Definitely needs tests and haven't tried on Linux.

Probably need to figure out best command to use (e.g. `rsync`, `cpio`, `pax`, `tar`, GNU `cp`) and flags needed.

Also need to consider demerits like memory usage, etc.

---

Just basic experimenting with `trino` (1.9GB vs 743.6MB):

Before:
```console
% brew install -s trino
...
🍺  /usr/local/Cellar/trino/376: 2,902 files, 1.9GB, built in 11 seconds
```

After:
```console
% brew install -s trino
...
==> Summary
🍺  /usr/local/Cellar/trino/376: 2,902 files, 743.6MB, built in 12 seconds
```