### PR TITLE
#curl_download: Use first response headers

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -170,7 +170,7 @@ module Utils
         parsed_output = parse_curl_output(range_stdout)
 
         headers = if parsed_output[:responses].present?
-          parsed_output[:responses].last[:headers]
+          parsed_output[:responses].first[:headers]
         else
           {}
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Before Homebrew/brew#11252 was merged, `#curl_download` used the headers of the first HTTP response from `#curl_output` when checking for the presence/value of `accept-ranges` and `content-length` headers. This PR reverts a change to this behavior, as I accidentally incorporated a bugfix (to check the last HTTP response instead) in the aforementioned PR. This fix was straightforward and corrects the behavior of this method but I intended to introduce it in a follow-up PR.

As such, this PR simply serves to explain why the change was necessary, albeit after the fact. Sorry again about accidentally introducing this change prematurely without a separate PR.

To be clear, this PR should simply be closed (not merged) if we agree on the already-incorporated fix. Merging this PR would undo the bugfix, so I've labeled this "do not merge" and cancelled the CI run.

---

Checking the headers from the first response in `#curl_download` was incorrect behavior and it should have been checking the _last_ response headers instead. When there's more than one response, earlier responses would be redirections that may omit the `accept-ranges` header and/or use a different `content-length` value than the final response.

`#curl_download` is primarily used in `CurlDownloadStrategy` but the reason why this issue hadn't surfaced is because that strategy resolves the URL (using `#resolve_url_basename_time_file_size`) before passing it to `#curl_download`, so there are no redirections in the `#curl_download` request. If the strategy didn't resolve the URL first, then resuming an incomplete download wouldn't work (i.e., it would always start the download from the beginning).

You can confirm this behavior as follows:
* Apply the patch below in `Homebrew/brew`
* Run `brew install` (or `brew install --build-from-source`) on a formula/cask that uses a URL that redirects (e.g., `brew install --cask textmate`)
* Quickly enter `Ctrl+c` to cancel the download before it finishes
* Run the previous `brew install` command again to see if the download starts from the beginning or resumes the incomplete download (to be sure, you can also modify `#curl_download` to print the `args` before running `#curl`, to check whether `--continue-at` is part of the args).

```patch
diff --git a/Library/Homebrew/utils/curl.rb b/Library/Homebrew/utils/curl.rb
index 20792f25a50d81fe9555409b282e22a03b920498..af986a7192bb63a2a2a2dbb0f5dc1b551b3d84a0 100644
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -170,7 +170,7 @@ module Utils
         parsed_output = parse_curl_output(range_stdout)
 
         headers = if parsed_output[:responses].present?
-          parsed_output[:responses].last[:headers]
+          parsed_output[:responses].first[:headers]
         else
           {}
         end
diff --git a/Library/Homebrew/download_strategy.rb b/Library/Homebrew/download_strategy.rb
index 30bb8d9a716ed801c07dc79c0b097d32e214de56..5ed6a847e40678731984f21d75fae56163196172 100644
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -411,7 +411,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         puts "Already downloaded: #{cached_location}"
       else
         begin
-          _fetch(url: url, resolved_url: resolved_url, timeout: end_time&.remaining!)
+          _fetch(url: url, resolved_url: url, timeout: end_time&.remaining!)
         rescue ErrorDuringExecution
           raise CurlDownloadStrategyError, url
         end

```

This patch avoids using the resolved URL in `CurlDownloadStrategy`, so `#curl_download` will encounter redirection responses. This makes it easy to demonstrate that using the first response headers breaks partial downloading. After testing this, keep the `CurlDownloadStrategy` change but remove the `#curl_download` change (so it uses `#last`) and observe that partial downloads work as expected (i.e., the same as if using `resolved_url`).

As mentioned, this issue doesn't affect `CurlDownloadStrategy` at the moment but `#curl_download` is also used in `Formulary` and `CaskLoader` when loading a formula/cask from a URL. Since these are small text files, it's unlikely this issue will surface in those contexts but it's technically possible. Regardless, this was a technical bug that needed to be addressed, as it could affect any future use of `#curl_download` that uses a partial download.

Looking forward, we may want to modify the `#curl_download` calls in `Formulary` and `CaskLoader` to use `try_partial: false`, like the calls in `Utils::Spdx`. Partial downloads aren't useful in those contexts and it would avoid an unnecessary `HEAD` request before downloading the file.