### PR TITLE
Update Installation.md

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -65,9 +65,7 @@ Create a Homebrew installation wherever you extract the tarball. Whichever `brew
 
 ### Installation without continue prompt
 
-If you want a run of the Homebrew installer that doesn't prompt for confirmation to continue (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command. 
-
-Note that the installer will still ask for a sudo password if your username is not set up for passwordless sudo, or other options like `SUDO_ASKPASS` have not been setup.
+If you want a run of the Homebrew installer that doesn't prompt for confirmation to continue (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command and ensure your user is set up for passwordless `sudo` or other options like `SUDO_ASKPASS`.
 
 ## Uninstallation
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -63,7 +63,7 @@ chmod -R go-w "$(brew --prefix)/share/zsh"
 
 Create a Homebrew installation wherever you extract the tarball. Whichever `brew` command is called is where the packages will be installed. You can use this as you see fit, e.g. to have a system set of libs in the default prefix and tweaked formulae for development in `~/homebrew`.
 
-### Installation without continue prompt
+### Unattended installation
 
 If you want a run of the Homebrew installer that doesn't prompt for confirmation to continue (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command and ensure your user is set up for passwordless `sudo` or other options like `SUDO_ASKPASS`.
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -63,9 +63,11 @@ chmod -R go-w "$(brew --prefix)/share/zsh"
 
 Create a Homebrew installation wherever you extract the tarball. Whichever `brew` command is called is where the packages will be installed. You can use this as you see fit, e.g. to have a system set of libs in the default prefix and tweaked formulae for development in `~/homebrew`.
 
-### Unattended installation
+### Installation without continue prompt
 
-If you want a non-interactive run of the Homebrew installer that doesn't prompt for passwords (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command.
+If you want a run of the Homebrew installer that doesn't prompt for confirmation to continue (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command. 
+
+Note that the installer will still ask for a sudo password if your username is not set up for passwordless sudo, or other options like `SUDO_ASKPASS` have not been setup.
 
 ## Uninstallation
 


### PR DESCRIPTION
Amend misleading language surrounding NONINTERACTIVE=1

As a user who tried to install brew without any user interaction whatsoever, I bumped into the documentation stating it won't ask for a password. The documentation was misleading, one cannot install brew without any password prompts when passing `NONINTERACTIVE=1`.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
This is just a docs change, not a package/code contribution.
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
No, I don't believe that is applicable to site content changes.
- [ ] Have you successfully run `brew style` with your changes locally?
N/A
- [ ] Have you successfully run `brew typecheck` with your changes locally?
N/A
- [ ] Have you successfully run `brew tests` with your changes locally?
N/A

-----
