### PR TITLE
tap_constants: allow to use underscore in cask names

### DIFF
--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -4,7 +4,7 @@
 # Match taps' formulae, e.g. `someuser/sometap/someformula`
 HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.@]+)$}.freeze
 # Match taps' casks, e.g. `someuser/sometap/somecask`
-HOMEBREW_TAP_CASK_REGEX = %r{^([\w-]+)/([\w-]+)/([a-z0-9\-]+)$}.freeze
+HOMEBREW_TAP_CASK_REGEX = %r{^([\w-]+)/([\w-]+)/([a-z0-9\-_]+)$}.freeze
 # Match taps' directory paths, e.g. `HOMEBREW_LIBRARY/Taps/someuser/sometap`
 HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/(?<user>[\w-]+)/(?<repo>[\w-]+)}.freeze
 # Match taps' formula paths, e.g. `HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula`


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR allows using `_` in cask names. 
`_` still is not allowed for homebrews tap casks, should we allow it or we'd like to be a bit more strict about it?

Fixes https://github.com/Homebrew/brew/issues/13168