### PR TITLE
`Strategy`: Add `--max-redirs` to `DEFAULT_CURL_ARGS`

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -393,13 +393,17 @@ module Utils
     # `:status_code`, `:status_text`, and `:headers`.
     # @param output [String] The output text from `curl` containing HTTP
     #   responses, body content, or both.
+    # @param max_iterations [Integer] The maximum number of iterations for the
+    #   `while` loop that parses HTTP response text. This should correspond to
+    #   the maximum number of requests in the output. If `curl`'s `--max-redirs`
+    #   option is used, `max_iterations` should be `max-redirs + 1`, to
+    #   account for any final response after the redirections.
     # @return [Hash] A hash containing an array of response hashes and the body
     #   content, if found.
-    sig { params(output: String).returns(T::Hash[Symbol, T.untyped]) }
-    def parse_curl_output(output)
+    sig { params(output: String, max_iterations: Integer).returns(T::Hash[Symbol, T.untyped]) }
+    def parse_curl_output(output, max_iterations: 5)
       responses = []
 
-      max_iterations = 5
       iterations = 0
       output = output.lstrip
       while output.match?(%r{\AHTTP/[\d.]+ \d+}) && output.include?(HTTP_RESPONSE_BODY_SEPARATOR)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The default redirection maximum for `curl` is 50 but we should use something more reasonable in livecheck. It's rare but a misconfigured server with an endless redirection loop will hit the 50 redirection limit. Unfortunately, we've encountered this in the wild (e.g., the server for `getmail` and `memtester` endlessly redirects at the moment), so it's not an idle concern. This PR basically adds `--max-redirs 5` to `Livecheck::Strategy::DEFAULT_CURL_ARGS` to enforce a more reasonable redirection maximum.

To be clear, the `max_iterations` logic in `#parse_curl_output` (which was previously found in `Strategy#page_content`) doesn't restrict the number of redirections that `curl` follows. At the point the `curl` output is being parsed, the requests have already been made and `max_iterations` simply restricts the number of responses `#parse_curl_output` is willing to parse before erroring.

That said, if we use `--max-redirs` we need to be able to control `max_iterations`, so we can set it to a contextually-appropriate value (instead of the hardcoded `5`). For example, if we pass `--max-redirs 5` to `curl` and there are exactly five redirections before the final response, the output would contain a total of six responses and `#parse_curl_output` wouldn't properly handle this (it would give a `Too many redirects` error). `max_iterations` should be the maximum number of redirections + 1 (to account for any final response after the redirections), so we need to be able to override this value when necessary.

This PR also adds a `max_iterations` parameter to `#parse_curl_output` with a default value of `5` (maintaining the current default).