### PR TITLE
cli/parser: Re-enable Sorbet Type Checking

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -107,9 +107,7 @@ module Homebrew
         ]
       end
 
-      # FIXME: Block should be `T.nilable(T.proc.bind(Parser).void)`.
-      # See https://github.com/sorbet/sorbet/issues/498.
-      sig { params(block: T.proc.bind(Parser).void).void.checked(:never) }
+      sig { params(block: T.nilable(T.proc.bind(Parser).void)).void }
       def initialize(&block)
         @parser = OptionParser.new
 
@@ -123,7 +121,9 @@ module Homebrew
 
         @args = Homebrew::CLI::Args.new
 
-        @command_name = caller_locations(2, 1).first.label.chomp("_args").tr("_", "-")
+        # Filter out Sorbet runtime type checking method calls.
+        @command_name = caller_locations.select { |location| location.path.exclude?("/gems/sorbet-runtime-") }
+                                        .second.label.chomp("_args").tr("_", "-")
 
         @constraints = []
         @conflicts = []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I just stumbled on this randomly and it looks like sorbet/sorbet#498 got resolved so the type checking should work as intended now. This specific case only seems to show up once in the codebase.

It looks like this small change actually helped uncover a small bug. Essentially, since this check was being skipped, the `caller_locations` method call on line 124 of the `cli/parser.rb` file was able to grab the right command name during testing. This is used in turn to create the usage banner.
```Ruby
@command_name = caller_locations(2, 1).first.label.chomp("_args").tr("_", "-")
```
Now it borks the tests in `test/cmd/help_spec.rb` because Sorbet is running extra checks and those caller locations have been added to the stack. It still works correctly when you use the app normally though. This is only something that shows up in testing.

`brew help cat` output:
- Normal Use: `Usage: brew cat..."`
- Testing: `Usage: brew #{sorbet function name}..."`

The way I see it we could leave it the way it is or change the `test/cmd/help_spec.rb` regexes to be more permissive (which is what I did here).