### PR TITLE
search: drop Homebrew cask tap names from list

### DIFF
--- a/Library/Homebrew/extend/os/mac/search.rb
+++ b/Library/Homebrew/extend/os/mac/search.rb
@@ -29,7 +29,9 @@ module Homebrew
           end
         end
 
-        cask_tokens = Tap.flat_map(&:cask_tokens)
+        cask_tokens = Tap.flat_map(&:cask_tokens).map do |c|
+          c.sub(%r{^homebrew/cask.*/}, "")
+        end
 
         results = cask_tokens.extend(Searchable)
                              .search(string_or_regex)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Results in searching a list of tokens from official Homebrew cask taps and fully-qualified tokens from other taps, matching the list when searching formulae. Fixes #13193.