### PR TITLE
Curl: Remove guard from certain parsing logic

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -345,20 +345,20 @@ module Utils
         user_agent:        user_agent
       )
 
+      parsed_output = parse_curl_output(output)
+      responses = parsed_output[:responses]
+
+      final_url = curl_response_last_location(responses)
+      headers = if responses.last.present?
+        status_code = responses.last[:status_code]
+        responses.last[:headers]
+      else
+        {}
+      end
+      etag = headers["etag"][ETAG_VALUE_REGEX, 1] if headers["etag"].present?
+      content_length = headers["content-length"]
+
       if status.success?
-        parsed_output = parse_curl_output(output)
-        responses = parsed_output[:responses]
-
-        final_url = curl_response_last_location(responses)
-        headers = if responses.last.present?
-          status_code = responses.last[:status_code]
-          responses.last[:headers]
-        else
-          {}
-        end
-        etag = headers["etag"][ETAG_VALUE_REGEX, 1] if headers["etag"].present?
-        content_length = headers["content-length"]
-
         file_contents = File.read(file.path)
         file_hash = Digest::SHA2.hexdigest(file_contents) if hash_needed
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

@bevanjkay brought it to my attention that some cask PRs started failing on CI with a `The binary url ... is not reachable` error after #11252 was merged. This error message comes from the `Utils::Curl#curl_check_http_content` method, which calls `#curl_http_content_headers_and_checksum`. Both of these methods were modified in that PR but the issue arises from the latter.

Long story short, I naively moved the response parsing logic in `#curl_http_content_headers_and_checksum` into the `if status.success?` block and this change causes this error to arise when the download for a URL doesn't finish before the 25 second timeout. Previously, this method would parse the output regardless of whether a final response arrived and this would technically work if there were other responses in the output (e.g., redirections).

This PR reinstates the previous behavior by moving the parsing logic back out of the `if status.success?` block, which resolves this issue. We may want to look into this further after this is merged but I wanted to get this fix out relatively quickly, to unblock related cask PRs.

I was able to replicate this issue locally (and confirm the fix) using the `visual-paradigm` cask (related open PR: Homebrew/homebrew-cask#122490) because the dmg file is ~750 MB and this will trigger the `curl` timeout. You can test this locally using `brew audit --cask --appcast --online visual-paradigm`.

I've labelled this as "critical", since it's a bug fix. I did a limited amount of testing and didn't see any new errors but if anyone wants to test this more before merging, please feel free. It's very late over here and I'm crawling into bed but I can check on this again in the morning (EDT).