### PR TITLE
utils/curl: fix headers check for protected urls

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -200,19 +200,18 @@ module Utils
     # Check if a URL is protected by CloudFlare (e.g. badlion.net and jaxx.io).
     def url_protected_by_cloudflare?(details)
       return false if details[:headers].blank?
+      return unless [403, 503].include?(details[:status].to_i)
 
-      [403, 503].include?(details[:status].to_i) &&
-        details[:headers].match?(/^Set-Cookie: (__cfduid|__cf_bm)=/i) &&
-        details[:headers].match?(/^Server: cloudflare/i)
+      details[:headers].fetch("set-cookie", nil)&.match?(/^(__cfduid|__cf_bm)=/i) &&
+        details[:headers].fetch("server", nil)&.match?(/^cloudflare/i)
     end
 
     # Check if a URL is protected by Incapsula (e.g. corsair.com).
     def url_protected_by_incapsula?(details)
       return false if details[:headers].blank?
+      return false if details[:status].to_i != 403
 
-      details[:status].to_i == 403 &&
-        details[:headers].match?(/^Set-Cookie: visid_incap_/i) &&
-        details[:headers].match?(/^Set-Cookie: incap_ses_/i)
+      details[:headers].fetch("set-cookie", nil)&.match?(/^(visid_incap|incap_ses)_/i)
     end
 
     def curl_check_http_content(url, url_type, specs: {}, user_agents: [:default],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR fixes headers check in `url_protected_by_cloudflare? and `url_protected_by_incapsula?` methods.

```
$ brew audit linode-cli --online --git --skip-style --verbose
Error: undefined method `match?' for #<Hash:0x00007fd81a9de668>
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/utils/curl.rb:205:in `url_protected_by_cloudflare?'
/usr/local/Homebrew/Library/Homebrew/utils/curl.rb:268:in `curl_check_http_content'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:469:in `audit_homepage'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:845:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:840:in `each'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:840:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:196:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:180:in `to_h'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:180:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

Spotted in https://github.com/Homebrew/homebrew-core/pull/100147