### PR TITLE
Add `i`, `in` aliases for `install`

### DIFF
--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -17,6 +17,8 @@ module Commands
     "-S"          => "search",
     "up"          => "update",
     "ln"          => "link",
+    "i"           => "install",
+    "in"          => "install",
     "instal"      => "install", # gem does the same
     "uninstal"    => "uninstall",
     "rm"          => "uninstall",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

(Like [`npm `[`i`]`nstall`](https://docs.npmjs.com/cli/v8/commands/npm-install#synopsis))
