### PR TITLE
`#parse_curl_output`: increase default `max_iterations`

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -400,7 +400,7 @@ module Utils
     # @return [Hash] A hash containing an array of response hashes and the body
     #   content, if found.
     sig { params(output: String, max_iterations: Integer).returns(T::Hash[Symbol, T.untyped]) }
-    def parse_curl_output(output, max_iterations: 5)
+    def parse_curl_output(output, max_iterations: 25)
       responses = []
 
       iterations = 0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `max_iterations` value in `#parse_curl_output` is only intended to prevent its `while` loop from potentially turning into an endless loop. This should only come into play in exceptional circumstances but the current default value (5) is low enough that we're seeing it under normal circumstances.

`#parse_curl_output` isn't intended to restrict the number of redirections (this should be done using the `--max-redirs` option in `curl) but it's effectively doing this in rare cases due to the low `max_iterations` default. This is a problem because `curl` can successfully return a response only to have `#parse_curl_output` error in relation to `max_iterations`.

Originally the code in `#parse_curl_output` was used in the context of livecheck, where it's not a huge issue if a check fails. However, now the `#parse_curl_output` method is used in important parts of brew like `#curl_download`. We've received a report of a download failing with the "Too many redirects (max = 5)` error, effectively preventing the user from installing a formula [from a third-party tap].

Until we can come up with a more adaptive way of bounding this `while` loop, I think we should simply raise the default to something that's less likely to be encountered under normal circumstances (e.g., 25).

I've labeled this as "critical" as it's a bug fix for an issue preventing a user from installing a formula.