### PR TITLE
searchable: flatten array before matching

### DIFF
--- a/Library/Homebrew/searchable.rb
+++ b/Library/Homebrew/searchable.rb
@@ -23,7 +23,7 @@ module Searchable
   def search_regex(regex)
     select do |*args|
       args = yield(*args) if block_given?
-      args = Array(args).compact
+      args = Array(args).flatten.compact
       args.any? { |arg| arg.match?(regex) }
     end
   end


### PR DESCRIPTION
Fix #13203 which occurs when searching cask descriptions.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?