### PR TITLE
os/mac/pkgconfig/12: update for macOS 12.3

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/12/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/12/libcurl.pc
@@ -34,7 +34,7 @@ supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerber
 Name: libcurl
 URL: https://curl.se/
 Description: Library to transfer files with ftp, http, etc.
-Version: 7.77.0
+Version: 7.79.1
 Libs: -L${libdir} -lcurl
 Libs.private: -lldap -lz
 Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/12/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/12/libffi.pc
@@ -7,6 +7,6 @@ includedir=${prefix}/include/ffi
 
 Name: libffi
 Description: Library supporting Foreign Function Interfaces
-Version: 3.3-rc0
+Version: 3.4-rc1
 Libs: -L${toolexeclibdir} -lffi
 Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/12/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/12/sqlite3.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 
 Name: SQLite
 Description: SQL database engine
-Version: 3.36.0
+Version: 3.37.0
 Libs: -L${libdir} -lsqlite3
 Libs.private:
 Cflags:

--- a/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
+++ b/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
@@ -68,7 +68,7 @@ describe "pkg-config" do
   it "returns the correct version for libffi" do
     version = File.foreach("#{sdk}/usr/include/ffi/ffi.h")
                   .lazy
-                  .grep(/^\s*libffi (\S+) - Copyright /) { Regexp.last_match(1) }
+                  .grep(/^\s*libffi (\S+)\s+- Copyright /) { Regexp.last_match(1) }
                   .first
 
     skip "Cannot detect system libffi version." if version == "PyOBJC"


### PR DESCRIPTION
We're now actively building using the 12.3 SDK and will be using a runner with the 12.3 OS installed (the ephemeral one) from tomorrow afternoon.

Unfortunately we don't handle minor SDK versions, and this is one of the first times this has ever changed for something as potentially backwards ABI incompatible as curl. But we don't really test/support older minor versions anyway. And Apple don't either by not keeping an SDK for them.