### PR TITLE
workflows/docker: add OCI metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,20 @@ jobs:
         run: git fetch origin master
 
       - name: Build Docker image
-        run: docker build -t brew --build-arg=version=${{matrix.version}} .
+        run: |
+          brew_version="$(git describe --tags --dirty --abbrev=7)"
+          echo "Building for Homebrew ${brew_version}"
+          docker build -t brew \
+               --build-arg=version=${{matrix.version}} \
+               --label org.opencontainers.image.created="$(date --rfc-3339=seconds --utc)" \
+               --label org.opencontainers.image.url="https://brew.sh" \
+               --label org.opencontainers.image.documentation="https://docs.brew.sh" \
+               --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}" \
+               --label org.opencontainers.image.version="${brew_version}" \
+               --label org.opencontainers.image.revision="${GITHUB_SHA}" \
+               --label org.opencontainers.image.vendor="${GITHUB_REPOSITORY_OWNER}" \
+               --label org.opencontainers.image.licenses="BSD-2-Clause" \
+               .
 
       - name: Run brew test-bot --only-setup
         run: docker run --rm brew brew test-bot --only-setup


### PR DESCRIPTION
When we published the ubuntu22.04 image, it wasn't attached to this repository and so it was hidden away in the masses of the org-wide packages.

I've linked the image to the repository manually, but it looks like GitHub looks for and points to documentation on OCI metadata when auto-linking: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

So that there's one less thing to do in the future, might as well add those?

I also forgot to create a Docker Hub repository (since unlike GCR, you need to go do that yourself on the website), but I'll do that and push locally so it should work for 3.4.10.