### PR TITLE
Fix Rubocop trailing `/` bug

### DIFF
--- a/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
+++ b/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
@@ -11,6 +11,7 @@ module RuboCop
       # if it does not have a path component.
       class HomepageUrlTrailingSlash < Base
         include OnHomepageStanza
+        include HelperFunctions
         extend AutoCorrector
 
         MSG_NO_SLASH = "'%<url>s' must have a slash after the domain."
@@ -27,7 +28,8 @@ module RuboCop
 
           return unless url&.match?(%r{^.+://[^/]+$})
 
-          domain = URI(url_node.str_content).host
+          domain = URI(string_content(url_node, strip_dynamic: true)).host
+          return if domain.blank?
 
           # This also takes URLs like 'https://example.org?path'
           # and 'https://example.org#path' into account.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
