### PR TITLE
Keep `info/#{f.name}/dir` files in cleaner

### DIFF
--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -31,7 +31,9 @@ class Cleaner
     # Get rid of any info 'dir' files, so they don't conflict at the link stage
     Dir.glob(@f.info/"**/dir").each do |f|
       info_dir_file = Pathname(f)
-      observe_file_removal info_dir_file if info_dir_file.file? && info_dir_file != Pathname("#{@f.info}/#{@f.name}/dir") && !@f.skip_clean?(info_dir_file)
+      next if info_dir_file == Pathname("#{@f.info}/#{@f.name}/dir")
+
+      observe_file_removal info_dir_file if info_dir_file.file? && !@f.skip_clean?(info_dir_file)
     end
 
     rewrite_shebangs

--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -31,7 +31,7 @@ class Cleaner
     # Get rid of any info 'dir' files, so they don't conflict at the link stage
     Dir.glob(@f.info/"**/dir").each do |f|
       info_dir_file = Pathname(f)
-      observe_file_removal info_dir_file if info_dir_file.file? && !@f.skip_clean?(info_dir_file)
+      observe_file_removal info_dir_file if info_dir_file.file? && info_dir_file != Pathname("#{@f.info}/#{@f.name}/dir") && !@f.skip_clean?(info_dir_file)
     end
 
     rewrite_shebangs

--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -32,8 +32,10 @@ class Cleaner
     Dir.glob(@f.info/"**/dir").each do |f|
       info_dir_file = Pathname(f)
       next if info_dir_file == Pathname("#{@f.info}/#{@f.name}/dir")
+      next if @f.skip_clean?(info_dir_file)
+      next unless info_dir_file.file?
 
-      observe_file_removal info_dir_file if info_dir_file.file? && !@f.skip_clean?(info_dir_file)
+      observe_file_removal info_dir_file
     end
 
     rewrite_shebangs

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -144,7 +144,7 @@ describe Cleaner do
 
       f.info.mkpath
       (f.info/"i686-elf").mkpath
-      (f.info/"#{f.name}").mkpath
+      (f.info/ + f.name.to_s).mkpath
 
       touch file
       touch arch_file

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -96,7 +96,7 @@ describe Cleaner do
     it "removes '.la' files" do
       file = f.lib/"foo.la"
 
-      f.lib.mkpath
+      file.dirname.mkpath
       touch file
 
       cleaner.clean
@@ -107,7 +107,7 @@ describe Cleaner do
     it "removes 'perllocal' files" do
       file = f.lib/"perl5/darwin-thread-multi-2level/perllocal.pod"
 
-      (f.lib/"perl5/darwin-thread-multi-2level").mkpath
+      file.dirname.mkpath
       touch file
 
       cleaner.clean
@@ -118,7 +118,7 @@ describe Cleaner do
     it "removes '.packlist' files" do
       file = f.lib/"perl5/darwin-thread-multi-2level/auto/test/.packlist"
 
-      (f.lib/"perl5/darwin-thread-multi-2level/auto/test").mkpath
+      file.dirname.mkpath
       touch file
 
       cleaner.clean
@@ -129,7 +129,7 @@ describe Cleaner do
     it "removes 'charset.alias' files" do
       file = f.lib/"charset.alias"
 
-      f.lib.mkpath
+      file.dirname.mkpath
       touch file
 
       cleaner.clean

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -140,11 +140,11 @@ describe Cleaner do
     it "removes 'info/**/dir' files except for 'info/<name>/dir'" do
       file = f.info/"dir"
       arch_file = f.info/"i686-elf/dir"
-      name_file = f.info/"#{f.name}/dir"
+      name_file = f.info/f.name/"dir"
 
-      f.info.mkpath
-      (f.info/"i686-elf").mkpath
-      (f.info/ + f.name.to_s).mkpath
+      file.dirname.mkpath
+      arch_file.dirname.mkpath
+      name_file.dirname.mkpath
 
       touch file
       touch arch_file

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -136,6 +136,26 @@ describe Cleaner do
 
       expect(file).not_to exist
     end
+
+    it "removes 'info/**/dir' files except for 'info/<name>/dir'" do
+      file = f.info/"dir"
+      arch_file = f.info/"i686-elf/dir"
+      name_file = f.info/"#{f.name}/dir"
+
+      f.info.mkpath
+      (f.info/"i686-elf").mkpath
+      (f.info/"#{f.name}").mkpath
+
+      touch file
+      touch arch_file
+      touch name_file
+
+      cleaner.clean
+
+      expect(file).not_to exist
+      expect(arch_file).not_to exist
+      expect(name_file).to exist
+    end
   end
 
   describe "::skip_clean" do


### PR DESCRIPTION
Still cleans `info/dir` and `info/<arch>/dir` files.

Fixes https://github.com/Homebrew/homebrew-core/issues/100190