### PR TITLE
workflows/docker: base homebrew/brew on 22.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ jobs:
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         version: ["16.04", "18.04", "20.04", "22.04"]
     steps:
@@ -55,7 +56,7 @@ jobs:
           docker push "homebrew/ubuntu${{matrix.version}}:latest"
 
       - name: Deploy the homebrew/brew Docker image to GitHub Packages and Docker Hub
-        if: startsWith(github.ref, 'refs/tags/') && matrix.version == '20.04'
+        if: startsWith(github.ref, 'refs/tags/') && matrix.version == '22.04'
         run: |
           docker tag brew "ghcr.io/homebrew/brew:${brew_version}"
           docker push "ghcr.io/homebrew/brew:${brew_version}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG version=20.04
+ARG version=22.04
 # shellcheck disable=SC2154
 FROM ubuntu:"${version}"
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
As per discussion on Slack, I think we can make the switch now rather than wait some arbitrary length of time.

I've also disabled fail-fast so that if a image upload fails in the future, we don't stop the other uploads halfway unnecessarily.