### PR TITLE
utils/curl: force utf-8 encoding for text content

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -359,6 +359,7 @@ module Utils
 
       if status.success?
         file_contents = File.read(file.path)
+        file_contents.encode!(Encoding::UTF_8, invalid: :replace) if headers["content-type"]&.start_with?("text/")
         file_hash = Digest::SHA2.hexdigest(file_contents) if hash_needed
       end
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -296,8 +296,8 @@ module Utils
       return unless check_content
 
       no_protocol_file_contents = %r{https?:\\?/\\?/}
-      http_content = details[:file]&.gsub(no_protocol_file_contents, "/")
-      https_content = secure_details[:file]&.gsub(no_protocol_file_contents, "/")
+      http_content = details[:file]&.scrub&.gsub(no_protocol_file_contents, "/")
+      https_content = secure_details[:file]&.scrub&.gsub(no_protocol_file_contents, "/")
 
       # Check for the same content after removing all protocols
       if (http_content && https_content) && (http_content == https_content) && http_with_https_available
@@ -358,8 +358,19 @@ module Utils
       content_length = headers["content-length"]
 
       if status.success?
-        file_contents = File.read(file.path)
-        file_contents.encode!(Encoding::UTF_8, invalid: :replace) if headers["content-type"]&.start_with?("text/")
+        open_args = {}
+        # Try to get encoding from Content-Type header
+        # TODO: add guessing encoding by <meta http-equiv="Content-Type" ...> tag
+        if (content_type = headers["content-type"]) &&
+           (match = content_type.match(/;\s*charset\s*=\s*([^\s]+)/)) &&
+           (charset = match[1])
+          begin
+            open_args[:encoding] = Encoding.find(charset)
+          rescue ArgumentError
+            # Unknown charset in Content-Type header
+          end
+        end
+        file_contents = File.read(file.path, open_args)
         file_hash = Digest::SHA2.hexdigest(file_contents) if hash_needed
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This PR fixes an audit error for non-utf-8 URL content.

An example (spotted in https://github.com/Homebrew/homebrew-core/pull/100559):
```
$ brew audit opencsg --online --skip-style --verbose
Error: invalid byte sequence in UTF-8
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/utils/curl.rb:299:in `gsub'
/usr/local/Homebrew/Library/Homebrew/utils/curl.rb:299:in `curl_check_http_content'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:469:in `audit_homepage'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:845:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:840:in `each'
/usr/local/Homebrew/Library/Homebrew/formula_auditor.rb:840:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:196:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:180:in `to_h'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:180:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

Here https://opencsg.org/ has `<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">` 