### PR TITLE
Skip `brew update-report` altogether when passing `--quiet` to `brew update`

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -105,7 +105,7 @@ module Homebrew
       Utils::Analytics.messages_displayed! if $stdout.tty?
     end
 
-    if Settings.read("donationmessage") != "true" && !args.quiet?
+    if Settings.read("donationmessage") != "true"
       ohai "Homebrew is run entirely by unpaid volunteers. Please consider donating:"
       puts "  #{Formatter.url("https://github.com/Homebrew/brew#donations")}\n"
 
@@ -194,9 +194,9 @@ module Homebrew
 
     if updated
       if hub.empty?
-        puts "No changes to formulae." unless args.quiet?
+        puts "No changes to formulae."
       else
-        hub.dump(updated_formula_report: !args.preinstall?) unless args.quiet?
+        hub.dump(updated_formula_report: !args.preinstall?)
         hub.reporters.each(&:migrate_tap_migration)
         hub.reporters.each { |r| r.migrate_formula_rename(force: args.force?, verbose: args.verbose?) }
         CacheStoreDatabase.use(:descriptions) do |db|
@@ -236,7 +236,7 @@ module Homebrew
       end
       puts if args.preinstall?
     elsif !args.preinstall? && !ENV["HOMEBREW_UPDATE_FAILED"] && !ENV["HOMEBREW_MIGRATE_LINUXBREW_FORMULAE"]
-      puts "Already up-to-date." unless args.quiet?
+      puts "Already up-to-date."
     end
 
     Commands.rebuild_commands_completion_list

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -5,6 +5,7 @@
 #:        --merge                      Use `git merge` to apply updates (rather than `git rebase`).
 #:        --preinstall                 Run on auto-updates (e.g. before `brew install`). Skips some slower steps.
 #:    -f, --force                      Always do a slower, full update check (even if unnecessary).
+#:    -q, --quiet                      Hide the update report. Display only errors.
 #:    -v, --verbose                    Print the directories checked and `git` operations performed.
 #:    -d, --debug                      Display a trace of all shell commands as they are executed.
 #:    -h, --help                       Show this message.
@@ -748,19 +749,22 @@ EOS
 
   # HOMEBREW_UPDATE_PREINSTALL wasn't modified in subshell.
   # shellcheck disable=SC2031
-  if [[ -n "${HOMEBREW_UPDATED}" ]] ||
-     [[ -n "${HOMEBREW_UPDATE_FAILED}" ]] ||
-     [[ -n "${HOMEBREW_MISSING_REMOTE_REF_DIRS}" ]] ||
-     [[ -n "${HOMEBREW_UPDATE_FORCE}" ]] ||
-     [[ -n "${HOMEBREW_MIGRATE_LINUXBREW_FORMULAE}" ]] ||
-     [[ -d "${HOMEBREW_LIBRARY}/LinkedKegs" ]] ||
-     [[ ! -f "${HOMEBREW_CACHE}/all_commands_list.txt" ]] ||
-     [[ -n "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_UPDATE_PREINSTALL}" ]]
+  if [[ -z "${HOMEBREW_QUIET}" ]]
   then
-    brew update-report "$@"
-    return $?
-  elif [[ -z "${HOMEBREW_UPDATE_PREINSTALL}" && -z "${HOMEBREW_QUIET}" ]]
-  then
-    echo "Already up-to-date."
+    if [[ -n "${HOMEBREW_UPDATED}" ]] ||
+       [[ -n "${HOMEBREW_UPDATE_FAILED}" ]] ||
+       [[ -n "${HOMEBREW_MISSING_REMOTE_REF_DIRS}" ]] ||
+       [[ -n "${HOMEBREW_UPDATE_FORCE}" ]] ||
+       [[ -n "${HOMEBREW_MIGRATE_LINUXBREW_FORMULAE}" ]] ||
+       [[ -d "${HOMEBREW_LIBRARY}/LinkedKegs" ]] ||
+       [[ ! -f "${HOMEBREW_CACHE}/all_commands_list.txt" ]] ||
+       [[ -n "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_UPDATE_PREINSTALL}" ]]
+    then
+      brew update-report "$@"
+      return $?
+    elif [[ -z "${HOMEBREW_UPDATE_PREINSTALL}" ]]
+    then
+      echo "Already up-to-date."
+    fi
   fi
 }

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -200,6 +200,7 @@ describe Homebrew::Completions do
           "--help"       => "Show this message.",
           "--merge"      => "Use `git merge` to apply updates (rather than `git rebase`).",
           "--preinstall" => "Run on auto-updates (e.g. before `brew install`). Skips some slower steps.",
+          "--quiet"      => "Hide the update report. Display only errors.",
           "--verbose"    => "Print the directories checked and `git` operations performed.",
         }
         expect(described_class.command_options("update")).to eq expected_options
@@ -281,6 +282,7 @@ describe Homebrew::Completions do
                 --help
                 --merge
                 --preinstall
+                --quiet
                 --verbose
                 "
                 return
@@ -345,6 +347,7 @@ describe Homebrew::Completions do
               '--help[Show this message]' \\
               '--merge[Use `git merge` to apply updates (rather than `git rebase`)]' \\
               '--preinstall[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \\
+              '--quiet[Hide the update report. Display only errors]' \\
               '--verbose[Print the directories checked and `git` operations performed]'
           }
         COMPLETION
@@ -404,6 +407,7 @@ describe Homebrew::Completions do
           __fish_brew_complete_arg 'update' -l help -d 'Show this message'
           __fish_brew_complete_arg 'update' -l merge -d 'Use `git merge` to apply updates (rather than `git rebase`)'
           __fish_brew_complete_arg 'update' -l preinstall -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
+          __fish_brew_complete_arg 'update' -l quiet -d 'Hide the update report. Display only errors'
           __fish_brew_complete_arg 'update' -l verbose -d 'Print the directories checked and `git` operations performed'
         COMPLETION
       end


### PR DESCRIPTION
Why?
====
When humans run `brew update`, the update report is helpful feedback; but when `brew update` is composed into other scripts, the update report is rarely useful.

Scripts could always capture or discard its output (we've been capturing it and displaying it only when `brew update` fails), but since generating the update report can be very expensive (#13224), this seems like a lot of wasted effort.

This solution differs from `--preinstall` in two important ways where `--preinstall`'s behavior is undesirable:
1. `--preinstall` limits but still produces the update report
2. `--preinstall` takes several shortcuts in `brew update`, softening its guarantees

Alternatives
=========

I felt it was OK to alter the behavior of the (existing) `-q`/`--quiet` flag because it was undocumented. If we're uncomfortable with that, how would you feel about introducing an `-s`/`--silent` flag or `--skip-update-report` or `--no-report`.

(`-q`/`--quiet` makes sense to me; but I think I'd prefer `--no-report` to `--silent` because it's more explicit about what it's doing ... `--preinstall` is suffering from ambiguity: it's hard to tell what behavior it governs (even reading the source!) and it's only documented as "Skips some slower steps.")

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
