### PR TITLE
docs: clarify application of HOMEBREW_ARTIFACT_DOMAIN

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -25,9 +25,9 @@ module Homebrew
                      "formula with the URL `https://example.com/foo.tar.gz` to instead download from " \
                      "`http://localhost:8080/https://example.com/foo.tar.gz`. " \
                      "Bottle URLs however, have their domain replaced with this prefix. " \
-                     "Using the same value for example, would cause data hosted under " \
+                     "This results in e.g. " \
                      "`https://ghcr.io/v2/homebrew/core/gettext/manifests/0.21` " \
-                     "to be instead downloaded from " \
+                     "to instead be downloaded from " \
                      "`http://localhost:8080/v2/homebrew/core/gettext/manifests/0.21`",
       },
       HOMEBREW_AUTO_UPDATE_SECS:                 {

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -23,7 +23,12 @@ module Homebrew
         description: "Prefix all download URLs, including those for bottles, with this value. " \
                      "For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a " \
                      "formula with the URL `https://example.com/foo.tar.gz` to instead download from " \
-                     "`http://localhost:8080/example.com/foo.tar.gz`.",
+                     "`http://localhost:8080/https://example.com/foo.tar.gz`. " \
+                     "Bottle URLs however, have their domain replaced with this prefix. " \
+                     "Using the same value for example, would cause data hosted under " \
+                     "`https://ghcr.io/v2/homebrew/core/gettext/manifests/0.21` " \
+                     "to be instead downloaded from " \
+                     "`http://localhost:8080/v2/homebrew/core/gettext/manifests/0.21`",
       },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
         description: "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \


### PR DESCRIPTION
bottle URLs are treated differently than any other URL.
this change clarifies the resulting URLs in the manpage.

closes #13222

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
