### PR TITLE
Remove mentions of nonexistent command `brew diy`

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -84,7 +84,7 @@ module Homebrew
       formula = begin
         keg.to_formula
       rescue FormulaUnavailableError
-        # Not all kegs may belong to formulae e.g. with `brew diy`
+        # Not all kegs may belong to formulae
         nil
       end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -900,7 +900,7 @@ module Homebrew
 
         <<~EOS
           Some installed kegs have no formulae!
-          This means they were either deleted or installed with `brew diy`.
+          This means they were either deleted or installed manually.
           You should find replacements for the following formulae:
             #{deleted_formulae.join("\n  ")}
         EOS


### PR DESCRIPTION
The output of `brew doctor` can mention the command `brew diy`, which was removed in [this PR](https://github.com/Homebrew/brew/pull/11719). It's better to remove this output to avoid confusing users. I replaced the text "...deleted or installed with \`brew diy\`" with "...deleted or installed manually", since manual installation of a program is usually what will lead to this message, but if you think something else would be better, let me know.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
    - no, as far as I'm aware this change doesn't need a test
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
