### PR TITLE
workflows: add nightly linux tests

### DIFF
--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -1,10 +1,10 @@
 name: Linux Nightly Builds
 
 # Hombrew supports glibc 2.13 or newer
-# Binutils is built with glibc 2.13 (debian:wheezy)
+# Binutils is built with glibc 2.13 (ubuntu:16.04)
 # Bottles are built with glibc 2.23 (ubuntu:16.04)
 
-# You can't install any package with a glibc version below 2.12
+# You can't install any package with a glibc version below or equal to 2.12
 # When you install a package and your glibc version is >= 2.13 and < 2.23, brewed binutils, gcc@5 and glibc 2.13 will be installed for you
 # When you install a package and your glibc version is >= 2.23, the bottle is poured and can be used right away
 

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -1,0 +1,56 @@
+name: Linux Nightly Builds
+
+# Hombrew supports glibc 2.13 or newer
+# Binutils is built with glibc 2.13 (debian:wheezy)
+# Bottles are built with glibc 2.23 (ubuntu:16.04)
+
+# You can't install any package with a glibc version below 2.12
+# When you install a package and your glibc version is >= 2.13 and < 2.23, brewed binutils, gcc@5 and glibc 2.13 will be installed for you
+# When you install a package and your glibc version is >= 2.23, the bottle is poured and can be used right away
+
+# debian:wheezy (7)      glibc 2.13
+# centos7                glibc 2.17
+# debian:jessie (8)      glibc 2.19
+# ubuntu:16.04           glibc 2.23
+# debian:stretch (9)     glibc 2.24
+# ubuntu:18.04           glibc 2.27
+# centos8                glibc 2.28
+# debian:buster (10)     glibc 2.28
+# ubuntu:20.04           glibc 2.31
+# debian:bullseye (11)   glibc 2.31
+# ubuntu:22.04           glibc 2.35
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/nightly-linux.yml
+      - Library/Homebrew/nightly-linux/**
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container: [
+          "ubuntu16.04",
+          "ubuntu18.04",
+          "ubuntu20.04",
+          "ubuntu22.04",
+          "centos7",
+          "centos8",
+          "debian7",
+          "debian8",
+          "debian9",
+          "debian10",
+          "debian11",]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Docker image
+        run: docker build -t ${{ matrix.container }} .
+        working-directory: Library/Homebrew/nightly-linux/${{ matrix.container }}
+      - name: Run tests
+        run: docker run --rm --user linuxbrew -w /home/linuxbrew -v $(pwd)/Library/Homebrew/nightly-linux/test.sh:/home/linuxbrew/test.sh ${{ matrix.container }} /bin/bash -i -c ./test.sh

--- a/.github/workflows/nightly-linux.yml
+++ b/.github/workflows/nightly-linux.yml
@@ -53,4 +53,4 @@ jobs:
         run: docker build -t ${{ matrix.container }} .
         working-directory: Library/Homebrew/nightly-linux/${{ matrix.container }}
       - name: Run tests
-        run: docker run --rm --user linuxbrew -w /home/linuxbrew -v $(pwd)/Library/Homebrew/nightly-linux/test.sh:/home/linuxbrew/test.sh ${{ matrix.container }} /bin/bash -i -c ./test.sh
+        run: docker run --rm --user linuxbrew -w /home/linuxbrew -v $(pwd)/Library/Homebrew/nightly-linux/test.sh:/home/linuxbrew/test.sh ${{ matrix.container }} /bin/bash -c "BASH_ENV=/home/linuxbrew/.linuxbrew-bashrc /home/linuxbrew/test.sh"

--- a/Library/Homebrew/nightly-linux/centos7/Dockerfile
+++ b/Library/Homebrew/nightly-linux/centos7/Dockerfile
@@ -52,3 +52,11 @@ RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bas
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
 # This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
 RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc
+
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.linuxbrew-bashrc
+# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
+RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/centos7/Dockerfile
+++ b/Library/Homebrew/nightly-linux/centos7/Dockerfile
@@ -1,0 +1,54 @@
+FROM centos:7
+
+# hadolint ignore=DL3008
+RUN yum -y update \
+   && yum groupinstall -y 'Development Tools' \
+   && yum install -y procps-ng curl file
+
+# For git:
+RUN yum install -y zlib-devel
+# For curl:
+RUN yum install -y openssl-devel
+
+RUN curl -sL http://ftp.gnu.org/gnu/tar/tar-1.32.tar.gz | tar xz \
+    && cd /tar-1.32 \
+    && FORCE_UNSAFE_CONFIGURE=1 ./configure --prefix=/usr/local \
+    && make install \
+    && cd / \
+    && rm -rf /tar-1.32
+
+RUN curl -sL https://curl.se/download/curl-7.82.0.tar.bz2 | tar xj \
+    && cd /curl-7.82.0 \
+    && make configure \
+    && ./configure --prefix=/usr/local --with-openssl \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf /curl-7.82.0
+
+RUN curl -sL http://mirrors.edge.kernel.org/pub/software/scm/git/git-2.28.0.tar.gz | tar xz \
+    && cd /git-2.28.0 \
+    && make configure \
+    && ./configure --prefix=/usr/local --with-curl=/usr/local \
+    && make install NO_TCLTK=1 \
+    && cd / \
+    && rm -rf /git-2.28.0
+
+ENV HOMEBREW_GIT_PATH=/usr/local/bin/git
+ENV HOMEBREW_CURL_PATH=/usr/local/bin/curl
+ENV HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
+# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
+RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/centos7/Dockerfile
+++ b/Library/Homebrew/nightly-linux/centos7/Dockerfile
@@ -50,13 +50,9 @@ RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.b
 RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.bashrc
 RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bashrc
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
-# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
-RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc
 
 # For non-interactive shells:
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.linuxbrew-bashrc
-# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
-RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/centos8/Dockerfile
+++ b/Library/Homebrew/nightly-linux/centos8/Dockerfile
@@ -18,3 +18,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/centos8/Dockerfile
+++ b/Library/Homebrew/nightly-linux/centos8/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:8
+
+# Fix: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+# hadolint ignore=DL3008
+RUN yum -y update \
+   && yum groupinstall -y 'Development Tools' \
+   && yum install -y procps-ng curl file
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/debian10/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian10/Dockerfile
@@ -14,3 +14,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/debian10/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian10/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:buster
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file git
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/debian11/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian11/Dockerfile
@@ -14,3 +14,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/debian11/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian11/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:bullseye
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file git
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/debian7/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian7/Dockerfile
@@ -55,3 +55,11 @@ RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bas
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
 # This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
 RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc
+
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.linuxbrew-bashrc
+# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
+RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/debian7/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian7/Dockerfile
@@ -53,13 +53,9 @@ RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.b
 RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.bashrc
 RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bashrc
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
-# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
-RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc
 
 # For non-interactive shells:
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.linuxbrew-bashrc
-# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
-RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/debian7/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian7/Dockerfile
@@ -1,0 +1,57 @@
+FROM debian/eol:wheezy
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file
+
+# For git:
+RUN apt-get install -y libz-dev
+# For curl:
+RUN apt-get install -y libssl-dev autoconf gettext
+
+RUN curl -sL http://ftp.gnu.org/gnu/tar/tar-1.32.tar.gz | tar xz \
+    && cd /tar-1.32 \
+    && FORCE_UNSAFE_CONFIGURE=1 ./configure --prefix=/usr/local \
+    && make install \
+    && cd / \
+    && rm -rf /tar-1.32
+
+RUN curl -sL --insecure https://curl.se/download/curl-7.82.0.tar.bz2 | tar xj \
+    && cd /curl-7.82.0 \
+    && make configure \
+    && ./configure --prefix=/usr/local --with-openssl --disable-static \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf /curl-7.82.0
+
+# Fix curl: symbol lookup error: curl: undefined symbol: curl_mime_free
+RUN ldconfig
+
+RUN curl -sL http://mirrors.edge.kernel.org/pub/software/scm/git/git-2.28.0.tar.gz | tar xz \
+    && cd /git-2.28.0 \
+    && make configure \
+    && ./configure --prefix=/usr/local --with-curl=/usr/local/ \
+    && make install NO_TCLTK=1 \
+    && cd / \
+    && rm -rf /git-2.28.0
+
+ENV HOMEBREW_GIT_PATH=/usr/local/bin/git
+ENV HOMEBREW_CURL_PATH=/usr/local/bin/curl
+ENV HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
+# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
+RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/debian8/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian8/Dockerfile
@@ -48,3 +48,11 @@ RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bas
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
 # This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
 RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc
+
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.linuxbrew-bashrc
+RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.linuxbrew-bashrc
+# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
+RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/debian8/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian8/Dockerfile
@@ -46,13 +46,9 @@ RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.b
 RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.bashrc
 RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bashrc
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
-# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
-RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc
 
 # For non-interactive shells:
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.linuxbrew-bashrc
 RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.linuxbrew-bashrc
-# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
-RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/debian8/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian8/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian/eol:jessie
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file
+
+# For git:
+RUN apt-get install -y libz-dev
+# For curl:
+RUN apt-get install -y libssl-dev autoconf gettext
+
+RUN curl -sL --insecure https://curl.se/download/curl-7.82.0.tar.bz2 | tar xj \
+    && cd /curl-7.82.0 \
+    && make configure \
+    && ./configure --prefix=/usr/local --with-openssl --disable-static \
+    && make \
+    && make install \
+    && cd / \
+    && rm -rf /curl-7.82.0
+
+# Fix curl: symbol lookup error: curl: undefined symbol: curl_mime_free
+RUN ldconfig
+
+RUN curl -sL http://mirrors.edge.kernel.org/pub/software/scm/git/git-2.28.0.tar.gz | tar xz \
+    && cd /git-2.28.0 \
+    && make configure \
+    && ./configure --prefix=/usr/local --with-curl=/usr/local/ \
+    && make install NO_TCLTK=1 \
+    && cd / \
+    && rm -rf /git-2.28.0
+
+ENV HOMEBREW_GIT_PATH=/usr/local/bin/git
+ENV HOMEBREW_CURL_PATH=/usr/local/bin/curl
+ENV HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_GIT_PATH=/usr/local/bin/git" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_CURL_PATH=/usr/local/bin/curl" >> /home/linuxbrew/.bashrc
+RUN echo "export HOMEBREW_FORCE_BREWED_CA_CERTIFICATES=1" >> /home/linuxbrew/.bashrc
+# This is necessary so that HOMEBREW_GIT_PATH and HOMEBREW_CURL_PATH are picked up by brew:
+RUN echo "export HOMEBREW_DEVELOPER=1" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/debian9/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian9/Dockerfile
@@ -14,3 +14,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/debian9/Dockerfile
+++ b/Library/Homebrew/nightly-linux/debian9/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stretch
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file git
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/test.sh
+++ b/Library/Homebrew/nightly-linux/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 brew install hello
 brew test hello

--- a/Library/Homebrew/nightly-linux/test.sh
+++ b/Library/Homebrew/nightly-linux/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+brew install hello
+brew test hello
+brew uninstall hello
+brew install -s hello
+brew test hello

--- a/Library/Homebrew/nightly-linux/ubuntu16.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu16.04/Dockerfile
@@ -14,3 +14,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/ubuntu16.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu16.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:16.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file git
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/ubuntu18.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu18.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file git
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/ubuntu18.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu18.04/Dockerfile
@@ -14,3 +14,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/ubuntu20.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu20.04/Dockerfile
@@ -14,3 +14,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc

--- a/Library/Homebrew/nightly-linux/ubuntu20.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu20.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file git
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/ubuntu22.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu22.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+   && apt-get install -y build-essential procps curl file git
+
+RUN useradd -m -s /bin/bash linuxbrew
+RUN echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+RUN su - linuxbrew -c 'mkdir ~/.linuxbrew'
+
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
+
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc

--- a/Library/Homebrew/nightly-linux/ubuntu22.04/Dockerfile
+++ b/Library/Homebrew/nightly-linux/ubuntu22.04/Dockerfile
@@ -14,3 +14,5 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 RUN chown -R linuxbrew /home/linuxbrew/.linuxbrew
 
 RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.bashrc
+# For non-interactive shells:
+RUN echo "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> /home/linuxbrew/.linuxbrew-bashrc


### PR DESCRIPTION
Test a simple simple brew installation and "brew install hello" step for various distributions.

This makes sure everything is working well.
We use our installer as we want to test everything end to end.

The idea is also to be able to tell users how to install curl/git/tar on older linux versions when needed.

In the future, these images might be uploaded to our docker registry, and I plan to use them
to test migrations (from gcc5 to gcc7, and potentially for building binutils on ubuntu 18.04).

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
