### PR TITLE
Support git partial clones with sparse checkouts

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -130,7 +130,7 @@ module Cask
     end
 
     def checksumable?
-      url.using.blank? || url.using == :post
+      (url.using.blank? && url.only_paths.blank?) || url.using == :post
     end
 
     def download_sha_path

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -15,7 +15,7 @@ class URL < Delegator
                 :verified, :using,
                 :tag, :branch, :revisions, :revision,
                 :trust_cert, :cookies, :referer, :header, :user_agent,
-                :data
+                :data, :only_paths
 
     extend Forwardable
     def_delegators :uri, :path, :scheme, :to_s
@@ -36,6 +36,7 @@ class URL < Delegator
         header:     T.nilable(String),
         user_agent: T.nilable(T.any(Symbol, String)),
         data:       T.nilable(T::Hash[String, String]),
+        only_paths: T.nilable(T::Array[String]),
       ).void
     }
     def initialize(
@@ -51,7 +52,8 @@ class URL < Delegator
       referer: nil,
       header: nil,
       user_agent: nil,
-      data: nil
+      data: nil,
+      only_paths: nil
     )
 
       @uri = URI(uri)
@@ -69,6 +71,7 @@ class URL < Delegator
       specs[:header]     = @header     = header
       specs[:user_agent] = @user_agent = user_agent || :default
       specs[:data]       = @data       = data
+      specs[:only_paths] = @only_paths = only_paths
 
       @specs = specs.compact
     end
@@ -156,6 +159,7 @@ class URL < Delegator
       header:          T.nilable(String),
       user_agent:      T.nilable(T.any(Symbol, String)),
       data:            T.nilable(T::Hash[String, String]),
+      only_paths:      T.nilable(T::Array[String]),
       caller_location: Thread::Backtrace::Location,
       dsl:             T.nilable(Cask::DSL),
       block:           T.nilable(T.proc.params(arg0: T.all(String, BlockDSL::PageWithURL)).returns(T.untyped)),
@@ -175,6 +179,7 @@ class URL < Delegator
     header: nil,
     user_agent: nil,
     data: nil,
+    only_paths: nil,
     caller_location: T.must(caller_locations).fetch(0),
     dsl: nil,
     &block
@@ -202,6 +207,7 @@ class URL < Delegator
         header:     header,
         user_agent: user_agent,
         data:       data,
+        only_paths: only_paths,
       )
     end
     )

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -875,7 +875,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   end
 
   def partial_clone_sparse_checkout?
-    return false if @only_paths.nil?
+    return false if @only_paths.blank?
 
     # There is some support for partial clones prior to 2.20, but we avoid using it
     # due to performance issues

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -927,12 +927,12 @@ class GitDownloadStrategy < VCSDownloadStrategy
              args:  ["config", "advice.detachedHead", "false"],
              chdir: cached_location
 
-    if partial_clone_sparse_checkout?
-      command! "git",
-               args:  ["config", "origin.partialclonefilter", "blob:none"],
-               chdir: cached_location
-      configure_sparse_checkout
-    end
+    return unless partial_clone_sparse_checkout?
+
+    command! "git",
+             args:  ["config", "origin.partialclonefilter", "blob:none"],
+             chdir: cached_location
+    configure_sparse_checkout
   end
 
   sig { params(timeout: T.nilable(Time)).void }
@@ -1040,7 +1040,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
              args:  ["config", "core.sparseCheckout", "true"],
              chdir: cached_location
 
-    sparse_checkout_paths = @only_paths.join("\n") + "\n"
+    sparse_checkout_paths = "#{@only_paths.join("\n")}\n"
     (git_dir/"info"/"sparse-checkout").atomic_write(sparse_checkout_paths)
   end
 end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -804,10 +804,13 @@ end
 # @api public
 class GitDownloadStrategy < VCSDownloadStrategy
   def initialize(url, name, version, **meta)
+    # Needs to be before the call to `super`, as the VCSDownloadStrategy's
+    # constructor calls `cache_tag` and sets the cache path.
+    @only_paths = meta[:only_paths]
+
     super
     @ref_type ||= :branch
     @ref ||= "master"
-    @only_paths = meta[:only_paths]
   end
 
   # @see AbstractDownloadStrategy#source_modified_time
@@ -830,7 +833,11 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
   sig { returns(String) }
   def cache_tag
-    "git"
+    if partial_clone_sparse_checkout?
+      "git-sparse"
+    else
+      "git"
+    end
   end
 
   sig { returns(Integer) }

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -807,6 +807,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
     super
     @ref_type ||= :branch
     @ref ||= "master"
+    @only_paths = meta[:only_paths]
   end
 
   # @see AbstractDownloadStrategy#source_modified_time
@@ -873,6 +874,14 @@ class GitDownloadStrategy < VCSDownloadStrategy
     (cached_location/".gitmodules").exist?
   end
 
+  def partial_clone_sparse_checkout?
+    return false if @only_paths.nil?
+
+    # There is some support for partial clones prior to 2.20, but we avoid using it
+    # due to performance issues
+    Version.create(Utils::Git.version) >= Version.create("2.20.0")
+  end
+
   sig { returns(T::Array[String]) }
   def clone_args
     args = %w[clone]
@@ -881,6 +890,8 @@ class GitDownloadStrategy < VCSDownloadStrategy
     when :branch, :tag
       args << "--branch" << @ref
     end
+
+    args << "--no-checkout" << "--filter=blob:none" if partial_clone_sparse_checkout?
 
     args << "-c" << "advice.detachedHead=false" # silences detached head warning
     args << @url << cached_location
@@ -915,6 +926,13 @@ class GitDownloadStrategy < VCSDownloadStrategy
     command! "git",
              args:  ["config", "advice.detachedHead", "false"],
              chdir: cached_location
+
+    if partial_clone_sparse_checkout?
+      command! "git",
+               args:  ["config", "origin.partialclonefilter", "blob:none"],
+               chdir: cached_location
+      configure_sparse_checkout
+    end
   end
 
   sig { params(timeout: T.nilable(Time)).void }
@@ -943,6 +961,9 @@ class GitDownloadStrategy < VCSDownloadStrategy
              args:    ["config", "homebrew.cacheversion", cache_version],
              chdir:   cached_location,
              timeout: timeout&.remaining
+
+    configure_sparse_checkout if partial_clone_sparse_checkout?
+
     checkout(timeout: timeout)
     update_submodules(timeout: timeout) if submodules?
   end
@@ -1012,6 +1033,15 @@ class GitDownloadStrategy < VCSDownloadStrategy
       relative_git_dir = Pathname.new(git_dir).relative_path_from(work_dir)
       dot_git.atomic_write("gitdir: #{relative_git_dir}\n")
     end
+  end
+
+  def configure_sparse_checkout
+    command! "git",
+             args:  ["config", "core.sparseCheckout", "true"],
+             chdir: cached_location
+
+    sparse_checkout_paths = @only_paths.join("\n") + "\n"
+    (git_dir/"info"/"sparse-checkout").atomic_write(sparse_checkout_paths)
   end
 end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -877,9 +877,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   def partial_clone_sparse_checkout?
     return false if @only_paths.blank?
 
-    # There is some support for partial clones prior to 2.20, but we avoid using it
-    # due to performance issues
-    Version.create(Utils::Git.version) >= Version.create("2.20.0")
+    Utils::Git.supports_partial_clone_sparse_checkout?
   end
 
   sig { returns(T::Array[String]) }

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -141,5 +141,11 @@ module Utils
         raise ErrorDuringExecution.new(cmd, status: $CHILD_STATUS, output: [[:stdout, output]])
       end
     end
+
+    def supports_partial_clone_sparse_checkout?
+      # There is some support for partial clones prior to 2.20, but we avoid using it
+      # due to performance issues
+      Version.create(version) >= Version.create("2.20.0")
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a new option to enable downloads that use git partial clones with sparse checkouts, which can dramatically speed up clones of large repositories as well as reducing the checkout size on disk. The background and motivation is described in more detail in #13188.

<details>
<summary>Example (in a relatively small repo so there's not a huge difference)</summary>

**Without** partial clone and sparse checkout: 7.6s.

```ruby
cask "sparse-test" do
  version :latest
  sha256 :no_check

  url "https://github.com/hmarr-testing/sparse-test",
      using:      :git,
      branch:     "main"

  name "Sparse test"

  artifact "food/cheese", target: '/tmp/cheese'
end
```


```
brew $ rm -rf /Users/hmarr/Library/Caches/Homebrew/Cask/sparse-test--git/
brew $ time bin/brew upgrade --cask hmarr/tap/sparse-test
==> Upgrading 1 outdated package:
hmarr/tap/sparse-test latest -> latest
==> Upgrading sparse-test
==> Cloning https://github.com/hmarr-testing/sparse-test
Cloning into '/Users/hmarr/Library/Caches/Homebrew/Cask/sparse-test--git'...
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
Warning: No checksum defined for cask 'sparse-test', skipping verification.
==> Backing Generic Artifact 'cheese' up to '/Users/hmarr/src/github.com/homebrew/brew/Caskroom/sparse-test/latest/food/cheese'
==> Removing Generic Artifact '/tmp/cheese'
==> Moving Generic Artifact 'cheese' to '/tmp/cheese'
==> Purging files for version latest of Cask sparse-test
🍺  sparse-test was successfully upgraded!
bin/brew upgrade --cask hmarr/tap/sparse-test  2.29s user 2.07s system 56% cpu 7.674 total
```

**With** partial clone and sparse checkout: 4.8s.

```ruby
cask "sparse-test" do
  version :latest
  sha256 :no_check

  url "https://github.com/hmarr-testing/sparse-test",
      only_paths: ["food/cheese"],
      using:      :git,
      branch:     "main"

  name "Sparse test"

  artifact "food/cheese", target: '/tmp/cheese'
end
```


```
brew $ rm -rf /Users/hmarr/Library/Caches/Homebrew/Cask/sparse-test--git/                                                                                                                                         git-partial-clone-sparse-checkout
brew $ time bin/brew upgrade --cask hmarr/tap/sparse-test                                                                                                                                                         git-partial-clone-sparse-checkout
==> Upgrading 1 outdated package:
hmarr/tap/sparse-test latest -> latest
==> Upgrading sparse-test
==> Cloning https://github.com/hmarr-testing/sparse-test
Cloning into '/Users/hmarr/Library/Caches/Homebrew/Cask/sparse-test--git'...
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
Warning: No checksum defined for cask 'sparse-test', skipping verification.
==> Backing Generic Artifact 'cheese' up to '/Users/hmarr/src/github.com/homebrew/brew/Caskroom/sparse-test/latest/food/cheese'
==> Removing Generic Artifact '/tmp/cheese'
==> Moving Generic Artifact 'cheese' to '/tmp/cheese'
==> Purging files for version latest of Cask sparse-test
🍺  sparse-test was successfully upgraded!
bin/brew upgrade --cask hmarr/tap/sparse-test  1.79s user 1.27s system 62% cpu 4.866 total
```
</details>

## How it works

It relies on two git features working in tandem:

- [Partial clone](https://git-scm.com/docs/partial-clone) with a filter of `blob:none` and the `--no-checkout` option to avoid fetching any blobs during the initial clone.
- [Sparse checkout](https://git-scm.com/docs/git-sparse-checkout) to limit the working tree to only the paths specified. When `git checkout` is run, only the blobs required for the sparse checkout are fetched (thanks to the partial clone), then only those specified paths appear in the repository working tree.

The sparse checkout is created by enabling the `core.sparseCheckout` option, and writing the paths to `.git/info/sparse-checkout`. There is a `git-sparse-checkout` command that makes this easier, but I've avoided using it as it's relatively new and marked as experimental, and doesn't exist in older versions of git.

## Git version compatibility

It's a little hard to find builds for old git versions, but I built sevearl load of versions git from source to see what worked.

Sparse checkouts work with git 2.19, but although there's some support for partial clones, they don't work well. It seems to fetch more blobs than are necessary, and it fetches them one at a time, which is very slow.

From git 2.20, both sparse checkouts and partial clones seem to work well. This is the version of git that comes with macOS 10.15, which is the minimum _recommended_ macOS verison Homebrew supports right now. For earlier versions of git, the option is ignored, meaning the full repository is checked out. This feel in line with the "best effort" support guarantees for older versions of macOS that are promised.

## Handling repository updates

I did some testing to make sure that things don't to awry after the initial clone.

- A regular repository update works fine, including when additional paths are added to the array
- If the formula starts using the `only_paths` option for the first time, the repository should be configured correctly to use partial clones and sparse checkouts
- I haven't handled the reverse case where a formula author _stops_ using `only_paths`. It's not totally trivial as sparse checkouts set the [skip-worktree bit](https://git-scm.com/docs/git-update-index#_skip_worktree_bit), which needs to be removed to transition from a sparse checkout to a full checkout. I can see three options:
  1. When updating a repository, if `only_paths` is `nil`, check to see if the `core.sparseCheckout` option is enabled. If it is, set the paths in `.git/info/sparse-checkout` to `*`. This technically leaves the repository as a sparse checkout but includes all paths.
  2. The same as (1), but afterwards clean up by turning off the `core.sparseCheckout` option and deleting the `.git/info/sparse-checkout` file after `git checkout` has been run.
  3. Add a suffix like `-sparse` to the `cache_tag` if `only_paths` isn't `nil`, meaning we'd get a different cached repository if the option disabled.

## Open questions / things I'd love feedback on

- How to handle issue described above about handling the transition from a sparse checkout to a full checkout.
- The option (`only_paths`) is an array of strings, where each string is a path that will be checked out. I suspect that most of the time people will only provide one path, so we could go with a string rather than an array.
- Is the name `only_paths` clear enough? Other options I considered were `sparse_checkout_paths`, `only_checkout_paths`, `paths_to_fetch`.
- I haven't written any new tests for this behaviour. It looks like there isn't much of a precedent for writing download strategy tests as the existing tests are a bit sparse. I'm happy to take your steer on what to do here.


Thanks for all your hard work keeping homebrew awesome! ❤️ 