### PR TITLE
rubocops: refactor all formula cops to use a single-pass force class

### DIFF
--- a/Library/Homebrew/rubocops/bottle.rb
+++ b/Library/Homebrew/rubocops/bottle.rb
@@ -12,9 +12,8 @@ module RuboCop
       class BottleFormat < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
-          return if bottle_node.nil?
+        def on_formula_bottle(bottle_node)
+          return unless bottle_node.block_type?
 
           sha256_nodes = find_method_calls_by_name(bottle_node.body, :sha256)
           cellar_node = find_node_method_by_name(bottle_node.body, :cellar)
@@ -59,9 +58,8 @@ module RuboCop
       class BottleTagIndentation < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
-          return if bottle_node.nil?
+        def on_formula_bottle(bottle_node)
+          return unless bottle_node.block_type?
 
           sha256_nodes = find_method_calls_by_name(bottle_node.body, :sha256)
 
@@ -95,9 +93,8 @@ module RuboCop
       class BottleDigestIndentation < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
-          return if bottle_node.nil?
+        def on_formula_bottle(bottle_node)
+          return unless bottle_node.block_type?
 
           sha256_nodes = find_method_calls_by_name(bottle_node.body, :sha256)
 
@@ -131,9 +128,8 @@ module RuboCop
       class BottleOrder < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
-          return if bottle_node.nil?
+        def on_formula_bottle(bottle_node)
+          return unless bottle_node.block_type?
           return if bottle_node.child_nodes.blank?
 
           non_sha256_nodes = []

--- a/Library/Homebrew/rubocops/caveats.rb
+++ b/Library/Homebrew/rubocops/caveats.rb
@@ -25,8 +25,8 @@ module RuboCop
       #
       # @api private
       class Caveats < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, _body_node)
-          caveats_strings.each do |n|
+        def on_formula_caveats(node)
+          find_strings(node).each do |n|
             next unless regex_match_group(n, /\bsetuid\b/i)
 
             problem "Don't recommend setuid in the caveats, suggest sudo instead."

--- a/Library/Homebrew/rubocops/checksum.rb
+++ b/Library/Homebrew/rubocops/checksum.rb
@@ -10,18 +10,18 @@ module RuboCop
       #
       # @api private
       class Checksum < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
-
-          problem "MD5 checksums are deprecated, please use SHA-256" if method_called_ever?(body_node, :md5)
-
-          problem "SHA1 checksums are deprecated, please use SHA-256" if method_called_ever?(body_node, :sha1)
-
-          sha256_calls = find_every_method_call_by_name(body_node, :sha256)
-          sha256_calls.each do |sha256_call|
-            sha256_node = get_checksum_node(sha256_call)
-            audit_sha256(sha256_node)
+        def on_formula_send(send_node)
+          case send_node.method_name
+          when :md5
+            problem "MD5 checksums are deprecated, please use SHA-256"
+          when :sha1
+            problem "SHA1 checksums are deprecated, please use SHA-256"
           end
+        end
+
+        def on_formula_sha256(sha256_call)
+          sha256_node = get_checksum_node(sha256_call)
+          audit_sha256(sha256_node)
         end
 
         def audit_sha256(checksum)
@@ -48,20 +48,15 @@ module RuboCop
       class ChecksumCase < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        def on_formula_sha256(sha256_call)
+          checksum = get_checksum_node(sha256_call)
+          return if checksum.nil?
+          return unless regex_match_group(checksum, /[A-F]+/)
 
-          sha256_calls = find_every_method_call_by_name(body_node, :sha256)
-          sha256_calls.each do |sha256_call|
-            checksum = get_checksum_node(sha256_call)
-            next if checksum.nil?
-            next unless regex_match_group(checksum, /[A-F]+/)
-
-            add_offense(@offensive_source_range, message: "sha256 should be lowercase") do |corrector|
-              correction = @offensive_node.source.downcase
-              corrector.insert_before(@offensive_node.source_range, correction)
-              corrector.remove(@offensive_node.source_range)
-            end
+          add_offense(@offensive_source_range, message: "sha256 should be lowercase") do |corrector|
+            correction = @offensive_node.source.downcase
+            corrector.insert_before(@offensive_node.source_range, correction)
+            corrector.remove(@offensive_node.source_range)
           end
         end
       end

--- a/Library/Homebrew/rubocops/conflicts.rb
+++ b/Library/Homebrew/rubocops/conflicts.rb
@@ -14,37 +14,33 @@ module RuboCop
         MSG = "Versioned formulae should not use `conflicts_with`. " \
               "Use `keg_only :versioned_formula` instead."
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          find_method_calls_by_name(body_node, :conflicts_with).each do |conflicts_with_call|
-            next unless parameters(conflicts_with_call).last.respond_to? :values
-
-            reason = parameters(conflicts_with_call).last.values.first
-            offending_node(reason)
-            name = Regexp.new(@formula_name, Regexp::IGNORECASE)
-            reason_text = string_content(reason).sub(name, "")
-            first_word = reason_text.split.first
-
-            if reason_text.match?(/\A[A-Z]/)
-              problem "'#{first_word}' from the `conflicts_with` reason "\
-                      "should be '#{first_word.downcase}'." do |corrector|
-                reason_text[0] = reason_text[0].downcase
-                corrector.replace(reason.source_range, "\"#{reason_text}\"")
-              end
-            end
-            next unless reason_text.end_with?(".")
-
-            problem "`conflicts_with` reason should not end with a period." do |corrector|
-              corrector.replace(reason.source_range, "\"#{reason_text.chop}\"")
-            end
-          end
-
-          return unless versioned_formula?
-
-          if !tap_style_exception?(:versioned_formulae_conflicts_allowlist) && method_called_ever?(body_node,
-                                                                                                   :conflicts_with)
+        def on_formula_conflicts_with(node)
+          if versioned_formula? && !tap_style_exception?(:versioned_formulae_conflicts_allowlist)
+            offending_node(node)
             problem MSG do |corrector|
               corrector.replace(@offensive_node.source_range, "keg_only :versioned_formula")
             end
+          end
+
+          return unless parameters(node).last.respond_to? :values
+
+          reason = parameters(node).last.values.first
+          offending_node(reason)
+          name = Regexp.new(@formula_name, Regexp::IGNORECASE)
+          reason_text = string_content(reason).sub(name, "")
+          first_word = reason_text.split.first
+
+          if reason_text.match?(/\A[A-Z]/)
+            problem "'#{first_word}' from the `conflicts_with` reason "\
+                    "should be '#{first_word.downcase}'." do |corrector|
+              reason_text[0] = reason_text[0].downcase
+              corrector.replace(reason.source_range, "\"#{reason_text}\"")
+            end
+          end
+          return unless reason_text.end_with?(".")
+
+          problem "`conflicts_with` reason should not end with a period." do |corrector|
+            corrector.replace(reason.source_range, "\"#{reason_text.chop}\"")
           end
         end
       end

--- a/Library/Homebrew/rubocops/dependency_order.rb
+++ b/Library/Homebrew/rubocops/dependency_order.rb
@@ -13,16 +13,21 @@ module RuboCop
       class DependencyOrder < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          check_dependency_nodes_order(body_node)
-          check_uses_from_macos_nodes_order(body_node)
-          [:head, :stable].each do |block_name|
-            block = find_block(body_node, block_name)
-            next unless block
+        def on_formula_class(class_node)
+          check_dependency_nodes_order(class_node.body)
+          check_uses_from_macos_nodes_order(class_node.body)
+        end
 
-            check_dependency_nodes_order(block.body)
-            check_uses_from_macos_nodes_order(block.body)
-          end
+        def on_formula_stable(node)
+          check_dependency_nodes_order(node.body)
+          check_uses_from_macos_nodes_order(node.body)
+        end
+
+        def on_formula_head(node)
+          return unless node.block_type?
+
+          check_dependency_nodes_order(node.body)
+          check_uses_from_macos_nodes_order(node.body)
         end
 
         def check_uses_from_macos_nodes_order(parent_node)

--- a/Library/Homebrew/rubocops/deprecate_disable.rb
+++ b/Library/Homebrew/rubocops/deprecate_disable.rb
@@ -10,20 +10,24 @@ module RuboCop
       class DeprecateDisableDate < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          [:deprecate!, :disable!].each do |method|
-            node = find_node_method_by_name(body_node, method)
+        def on_formula_deprecate!(node)
+          check_date(node)
+        end
 
-            next if node.nil?
+        def on_formula_disable!(node)
+          check_date(node)
+        end
 
-            date(node) do |date_node|
-              Date.iso8601(string_content(date_node))
-            rescue ArgumentError
-              fixed_date_string = Date.parse(string_content(date_node)).iso8601
-              offending_node(date_node)
-              problem "Use `#{fixed_date_string}` to comply with ISO 8601" do |corrector|
-                corrector.replace(date_node.source_range, "\"#{fixed_date_string}\"")
-              end
+        private
+
+        def check_date(node)
+          date(node) do |date_node|
+            Date.iso8601(string_content(date_node))
+          rescue ArgumentError
+            fixed_date_string = Date.parse(string_content(date_node)).iso8601
+            offending_node(date_node)
+            problem "Use `#{fixed_date_string}` to comply with ISO 8601" do |corrector|
+              corrector.replace(date_node.source_range, "\"#{fixed_date_string}\"")
             end
           end
         end
@@ -39,42 +43,45 @@ module RuboCop
 
         PUNCTUATION_MARKS = %w[. ! ?].freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          [:deprecate!, :disable!].each do |method|
-            node = find_node_method_by_name(body_node, method)
+        def on_formula_deprecate!(node)
+          return if check_reason(node)
 
-            next if node.nil?
+          offending_node(node)
+          problem 'Add a reason for deprecation: `deprecate! because: "..."`'
+        end
 
-            reason_found = T.let(false, T::Boolean)
-            reason(node) do |reason_node|
-              reason_found = true
-              next if reason_node.sym_type?
+        def on_formula_disable!(node)
+          return if check_reason(node)
 
-              offending_node(reason_node)
-              reason_string = string_content(reason_node)
+          offending_node(node)
+          problem 'Add a reason for disabling: `disable! because: "..."`'
+        end
 
-              if reason_string.start_with?("it ")
-                problem "Do not start the reason with `it`" do |corrector|
-                  corrector.replace(@offensive_node.source_range, "\"#{reason_string[3..]}\"")
-                end
-              end
+        private
 
-              if PUNCTUATION_MARKS.include?(reason_string[-1])
-                problem "Do not end the reason with a punctuation mark" do |corrector|
-                  corrector.replace(@offensive_node.source_range, "\"#{reason_string.chop}\"")
-                end
+        def check_reason(node)
+          reason_found = T.let(false, T::Boolean)
+          reason(node) do |reason_node|
+            reason_found = true
+            next if reason_node.sym_type?
+
+            offending_node(reason_node)
+            reason_string = string_content(reason_node)
+
+            if reason_string.start_with?("it ")
+              problem "Do not start the reason with `it`" do |corrector|
+                corrector.replace(@offensive_node.source_range, "\"#{reason_string[3..]}\"")
               end
             end
 
-            next if reason_found
-
-            case method
-            when :deprecate!
-              problem 'Add a reason for deprecation: `deprecate! because: "..."`'
-            when :disable!
-              problem 'Add a reason for disabling: `disable! because: "..."`'
+            if PUNCTUATION_MARKS.include?(reason_string[-1])
+              problem "Do not end the reason with a punctuation mark" do |corrector|
+                corrector.replace(@offensive_node.source_range, "\"#{reason_string.chop}\"")
+              end
             end
           end
+
+          reason_found
         end
 
         def_node_search :reason, <<~EOS

--- a/Library/Homebrew/rubocops/extend/formula_force.rb
+++ b/Library/Homebrew/rubocops/extend/formula_force.rb
@@ -1,0 +1,110 @@
+# typed: true
+# frozen_string_literal: true
+
+require "ast_constants"
+
+module RuboCop
+  module Cop
+    # It's the formula police force! 🚔
+    # The dispatcher for all formula cops.
+    #
+    # @api private
+    class FormulaForce < Force
+      def investigate(processed_source)
+        file_path = processed_source.buffer.name
+        return unless file_path_allowed?(file_path)
+
+        root_node = processed_source.ast
+        return unless root_node
+
+        formula_found = T.let(false, T::Boolean)
+        if root_node.class_type? && formula_class?(root_node)
+          formula_found = true
+          run_file_hooks(file_path, processed_source)
+          process_formula(root_node)
+        elsif root_node.begin_type?
+          root_node.each_child_node(:class) do |class_node|
+            next false unless formula_class?(class_node)
+
+            unless formula_found
+              run_file_hooks(file_path, processed_source)
+              formula_found = true
+            end
+
+            process_formula(class_node)
+          end
+        end
+
+        return unless formula_found
+
+        run_hook :on_formula_source_end, processed_source
+      end
+
+      private
+
+      def file_path_allowed?(file_path)
+        return true if file_path.nil? # file_path is nil when source is directly passed to the cop, e.g. in specs
+
+        file_path !~ Regexp.union([%r{/Library/Homebrew/compat/}, %r{/Library/Homebrew/test/}])
+      end
+
+      def formula_class?(class_node)
+        class_names = %w[
+          Formula
+          GithubGistFormula
+          ScriptFileFormula
+          AmazonWebServicesFormula
+        ]
+
+        parent = class_node.parent_class
+        parent && class_names.include?(parent.const_name)
+      end
+
+      def run_file_hooks(file_path, processed_source)
+        run_hook :on_formula_file, file_path
+        run_hook :on_formula_source, processed_source
+      end
+
+      def process_formula(class_node)
+        run_hook :on_formula_class, class_node
+
+        components = FORMULA_COMPONENT_PRECEDENCE_LIST.flatten
+        method_call_components = components.select { |component| component[:type] == :method_call }
+                                           .map { |component| component[:name] }
+        block_call_components = components.select { |component| component[:type] == :block_call }
+                                          .map { |component| component[:name] }
+        method_def_components = components.select { |component| component[:type] == :method_definition }
+                                          .map { |component| component[:name] }
+
+        report_descendant = lambda do |node|
+          components_to_check = case node.type
+          when :send
+            method_call_components if valid_send_node?(node)
+          when :block
+            block_call_components if node.send_node.receiver.nil?
+          when :def
+            method_def_components
+          end
+
+          if components_to_check&.include?(node.method_name)
+            run_hook :"on_formula_#{node.method_name}", node
+          else
+            run_hook :"on_formula_#{node.type}", node
+          end
+        end
+        report_descendant.call(class_node.body)
+        class_node.body.each_descendant(&report_descendant)
+
+        run_hook :on_formula_class_end, class_node
+      end
+
+      def valid_send_node?(node)
+        return false unless node.receiver.nil?
+        return false if node.arguments.empty? && !node.method_name.to_s.end_with?("!")
+        return false if node.parent&.block_type? && node.parent.send_node == node
+
+        true
+      end
+    end
+  end
+end

--- a/Library/Homebrew/rubocops/files.rb
+++ b/Library/Homebrew/rubocops/files.rb
@@ -10,10 +10,10 @@ module RuboCop
       #
       # @api private
       class Files < FormulaCop
-        def audit_formula(node, _class_node, _parent_class_node, _body_node)
+        def on_formula_class(class_node)
           return unless file_path
 
-          offending_node(node)
+          offending_node(class_node)
           actual_mode = File.stat(file_path).mode
           # Check that the file is world-readable.
           if actual_mode & 0444 != 0444

--- a/Library/Homebrew/rubocops/formula_desc.rb
+++ b/Library/Homebrew/rubocops/formula_desc.rb
@@ -14,10 +14,19 @@ module RuboCop
         include DescHelper
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        def on_formula_class(_class_node)
+          @formula_desc = nil
+        end
+
+        def on_formula_desc(node)
+          # audit_desc also tracks description presence, so defer to class end
+          @formula_desc = node
+        end
+
+        def on_formula_class_end(class_node)
           @name = @formula_name
-          desc_call = find_node_method_by_name(body_node, :desc)
-          audit_desc(:formula, @name, desc_call)
+          offending_node(class_node)
+          audit_desc(:formula, @name, @formula_desc)
         end
       end
     end

--- a/Library/Homebrew/rubocops/homepage.rb
+++ b/Library/Homebrew/rubocops/homepage.rb
@@ -10,15 +10,14 @@ module RuboCop
       class Homepage < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          homepage_node = find_node_method_by_name(body_node, :homepage)
+        def on_formula_class(_class_node)
+          @homepage_found = false
+        end
 
-          if homepage_node.nil?
-            problem "Formula should have a homepage."
-            return
-          end
+        def on_formula_homepage(node)
+          @homepage_found = true
 
-          homepage_parameter_node = parameters(homepage_node).first
+          homepage_parameter_node = parameters(node).first
           offending_node(homepage_parameter_node)
           homepage = string_content(homepage_parameter_node)
 
@@ -98,6 +97,13 @@ module RuboCop
               corrector.replace(homepage_parameter_node.source_range, "\"#{homepage.sub("http", "https")}\"")
             end
           end
+        end
+
+        def on_formula_class_end(class_node)
+          return if @homepage_found
+
+          offending_node(class_node)
+          problem "Formula should have a homepage."
         end
       end
     end

--- a/Library/Homebrew/rubocops/keg_only.rb
+++ b/Library/Homebrew/rubocops/keg_only.rb
@@ -12,10 +12,7 @@ module RuboCop
       class KegOnly < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          keg_only_node = find_node_method_by_name(body_node, :keg_only)
-          return unless keg_only_node
-
+        def on_formula_keg_only(node)
           allowlist = %w[
             Apple
             macOS
@@ -28,7 +25,7 @@ module RuboCop
             Firefox
           ].freeze
 
-          reason = parameters(keg_only_node).first
+          reason = parameters(node).first
           offending_node(reason)
           name = Regexp.new(@formula_name, Regexp::IGNORECASE)
           reason = string_content(reason).sub(name, "")

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -10,22 +10,22 @@ module RuboCop
       #
       # @api private
       class Lines < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, _body_node)
+        def on_formula_depends_on(node)
           [:automake, :ant, :autoconf, :emacs, :expat, :libtool, :mysql, :perl,
            :postgresql, :python, :python3, :rbenv, :ruby].each do |dependency|
-            next unless depends_on?(dependency)
+            next unless depends_on_matches?(node, dependency)
 
             problem ":#{dependency} is deprecated. Usage should be \"#{dependency}\"."
           end
 
           { apr: "apr-util", fortran: "gcc", gpg: "gnupg", hg: "mercurial",
             mpi: "open-mpi", python2: "python" }.each do |requirement, dependency|
-            next unless depends_on?(requirement)
+            next unless depends_on_matches?(node, requirement)
 
             problem ":#{requirement} is deprecated. Usage should be \"#{dependency}\"."
           end
 
-          problem ":tex is deprecated." if depends_on?(:tex)
+          problem ":tex is deprecated." if depends_on_matches?(node, :tex)
         end
       end
 
@@ -33,13 +33,13 @@ module RuboCop
       #
       # @api private
       class ClassInheritance < FormulaCop
-        def audit_formula(_node, class_node, parent_class_node, _body_node)
-          begin_pos = start_column(parent_class_node)
-          end_pos = end_column(class_node)
+        def on_formula_class(class_node)
+          begin_pos = start_column(class_node.parent_class)
+          end_pos = end_column(class_node.identifier)
           return unless begin_pos-end_pos != 3
 
           problem "Use a space in class inheritance: " \
-                  "class #{@formula_name.capitalize} < #{class_name(parent_class_node)}"
+                  "class #{@formula_name.capitalize} < #{class_name(class_node.parent_class)}"
         end
       end
 
@@ -47,39 +47,37 @@ module RuboCop
       #
       # @api private
       class Comments < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, _body_node)
-          audit_comments do |comment|
-            [
-              "# PLEASE REMOVE",
-              "# Documentation:",
-              "# if this fails, try separate make/make install steps",
-              "# The URL of the archive",
-              "## Naming --",
-              "# if your formula fails when building in parallel",
-              "# Remove unrecognized options if warned by configure",
-              '# system "cmake',
-            ].each do |template_comment|
-              next unless comment.include?(template_comment)
+        TEMPLATE_COMMENTS = [
+          "# PLEASE REMOVE",
+          "# Documentation:",
+          "# if this fails, try separate make/make install steps",
+          "# The URL of the archive",
+          "## Naming --",
+          "# if your formula fails when building in parallel",
+          "# Remove unrecognized options if warned by configure",
+          '# system "cmake',
+        ].freeze
 
+        def on_formula_source(processed_source)
+          processed_source.comments.each do |comment|
+            TEMPLATE_COMMENTS.each do |template_comment|
+              next unless comment.text.include?(template_comment)
+
+              offending_node(comment)
               problem "Please remove default template comments"
               break
             end
-          end
 
-          audit_comments do |comment|
-            # Commented-out depends_on
-            next unless comment =~ /#\s*depends_on\s+(.+)\s*$/
+            if comment.text =~ /#\s*depends_on\s+(.+)\s*$/
+              # Commented-out depends_on
+              offending_node(comment)
+              problem "Commented-out dependency #{Regexp.last_match(1)}"
+            elsif core_tap? && comment.text =~ /#\s*(cite(?=\s*\w+:)|doi(?=\s*['"])|tag(?=\s*['"]))/
+              # Citation and tag comments from third-party taps
 
-            problem "Commented-out dependency #{Regexp.last_match(1)}"
-          end
-
-          return if formula_tap != "homebrew-core"
-
-          # Citation and tag comments from third-party taps
-          audit_comments do |comment|
-            next if comment !~ /#\s*(cite(?=\s*\w+:)|doi(?=\s*['"])|tag(?=\s*['"]))/
-
-            problem "Formulae in homebrew/core should not use `#{Regexp.last_match(1)}` comments"
+              offending_node(comment)
+              problem "Formulae in homebrew/core should not use `#{Regexp.last_match(1)}` comments"
+            end
           end
         end
       end
@@ -88,24 +86,25 @@ module RuboCop
       #
       # @api private
       class AssertStatements < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          find_every_method_call_by_name(body_node, :assert).each do |method|
-            if method_called_ever?(method, :include?) && !method_called_ever?(method, :!)
-              problem "Use `assert_match` instead of `assert ...include?`"
-            end
+        def on_formula_send(send_node)
+          return if send_node.method_name != :assert
 
-            if method_called_ever?(method, :exist?) && !method_called_ever?(method, :!)
-              problem "Use `assert_predicate <path_to_file>, :exist?` instead of `#{method.source}`"
-            end
-
-            if method_called_ever?(method, :exist?) && method_called_ever?(method, :!)
-              problem "Use `refute_predicate <path_to_file>, :exist?` instead of `#{method.source}`"
-            end
-
-            if method_called_ever?(method, :executable?) && !method_called_ever?(method, :!)
-              problem "Use `assert_predicate <path_to_file>, :executable?` instead of `#{method.source}`"
-            end
+          if method_called_ever?(send_node, :include?) && !method_called_ever?(send_node, :!)
+            problem "Use `assert_match` instead of `assert ...include?`"
           end
+
+          if method_called_ever?(send_node, :exist?) && !method_called_ever?(send_node, :!)
+            problem "Use `assert_predicate <path_to_file>, :exist?` instead of `#{send_node.source}`"
+          end
+
+          if method_called_ever?(send_node, :exist?) && method_called_ever?(send_node, :!)
+            problem "Use `refute_predicate <path_to_file>, :exist?` instead of `#{send_node.source}`"
+          end
+
+          return unless method_called_ever?(send_node, :executable?)
+          return if method_called_ever?(send_node, :!)
+
+          problem "Use `assert_predicate <path_to_file>, :executable?` instead of `#{send_node.source}`"
         end
       end
 
@@ -113,71 +112,62 @@ module RuboCop
       #
       # @api private
       class OptionDeclarations < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          problem "Use new-style option definitions" if find_method_def(body_node, :options)
+        def on_formula_def(def_node)
+          return if def_node.method_name != :options
 
-          if formula_tap == "homebrew-core"
-            # Use of build.with? implies options, which are forbidden in homebrew/core
-            find_instance_method_call(body_node, :build, :without?) do
+          offending_node(def_node)
+          problem "Use new-style option definitions"
+        end
+
+        def on_formula_if(node)
+          build_with_node = depends_on_build_with(node)
+          return if build_with_node.nil?
+
+          offending_node(build_with_node)
+          problem "Use `:optional` or `:recommended` instead of `if #{build_with_node.source}`"
+        end
+
+        def on_formula_send(send_node)
+          if send_node.method_name == :without? && instance_method_call?(send_node, :build)
+            if core_tap?
               problem "Formulae in homebrew/core should not use `build.without?`."
+            else
+              if unless_modifier?(send_node.parent)
+                correct = send_node.source.gsub("out?", "?")
+                problem "Use if #{correct} instead of unless #{send_node.source}"
+              end
+
+              problem "Don't negate 'build.without?': use 'build.with?'" if expression_negated?(send_node)
+
+              arg = parameters(send_node).first
+              if (match = regex_match_group(arg, /^-?-?without-(.*)/))
+                problem "Don't duplicate 'without': " \
+                        "Use `build.without? \"#{match[1]}\"` to check for \"--without-#{match[1]}\""
+              end
             end
-            find_instance_method_call(body_node, :build, :with?) do
+          elsif send_node.method_name == :with? && instance_method_call?(send_node, :build)
+            if core_tap?
               problem "Formulae in homebrew/core should not use `build.with?`."
+            else
+              if unless_modifier?(send_node.parent)
+                correct = send_node.source.gsub("?", "out?")
+                problem "Use if #{correct} instead of unless #{send_node.source}"
+              end
+
+              problem "Don't negate 'build.with?': use 'build.without?'" if expression_negated?(send_node)
+
+              arg = parameters(send_node).first
+              if (match = regex_match_group(arg, /^-?-?with-(.*)/))
+                problem "Don't duplicate 'with': " \
+                        "Use `build.with? \"#{match[1]}\"` to check for \"--with-#{match[1]}\""
+              end
             end
-
-            return
-          end
-
-          depends_on_build_with(body_node) do |build_with_node|
-            offending_node(build_with_node)
-            problem "Use `:optional` or `:recommended` instead of `if #{build_with_node.source}`"
-          end
-
-          find_instance_method_call(body_node, :build, :without?) do |method|
-            next unless unless_modifier?(method.parent)
-
-            correct = method.source.gsub("out?", "?")
-            problem "Use if #{correct} instead of unless #{method.source}"
-          end
-
-          find_instance_method_call(body_node, :build, :with?) do |method|
-            next unless unless_modifier?(method.parent)
-
-            correct = method.source.gsub("?", "out?")
-            problem "Use if #{correct} instead of unless #{method.source}"
-          end
-
-          find_instance_method_call(body_node, :build, :with?) do |method|
-            next unless expression_negated?(method)
-
-            problem "Don't negate 'build.with?': use 'build.without?'"
-          end
-
-          find_instance_method_call(body_node, :build, :without?) do |method|
-            next unless expression_negated?(method)
-
-            problem "Don't negate 'build.without?': use 'build.with?'"
-          end
-
-          find_instance_method_call(body_node, :build, :without?) do |method|
-            arg = parameters(method).first
-            next unless (match = regex_match_group(arg, /^-?-?without-(.*)/))
-
-            problem "Don't duplicate 'without': " \
-                    "Use `build.without? \"#{match[1]}\"` to check for \"--without-#{match[1]}\""
-          end
-
-          find_instance_method_call(body_node, :build, :with?) do |method|
-            arg = parameters(method).first
-            next unless (match = regex_match_group(arg, /^-?-?with-(.*)/))
-
-            problem "Don't duplicate 'with': Use `build.with? \"#{match[1]}\"` to check for \"--with-#{match[1]}\""
-          end
-
-          find_instance_method_call(body_node, :build, :include?) do
+          elsif send_node.method_name == :include? && instance_method_call?(send_node, :build)
             problem "`build.include?` is deprecated"
           end
         end
+
+        private
 
         def unless_modifier?(node)
           return false unless node.if_type?
@@ -186,7 +176,7 @@ module RuboCop
         end
 
         # Finds `depends_on "foo" if build.with?("bar")` or `depends_on "foo" if build.without?("bar")`
-        def_node_search :depends_on_build_with, <<~EOS
+        def_node_matcher :depends_on_build_with, <<~EOS
           (if $(send (send nil? :build) {:with? :without?} str)
             (send nil? :depends_on str) nil?)
         EOS
@@ -198,15 +188,14 @@ module RuboCop
       class MpiCheck < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        def on_formula_depends_on(node)
           # Enforce use of OpenMPI for MPI dependency in core
-          return unless formula_tap == "homebrew-core"
+          return unless core_tap?
+          return unless depends_on_matches?(node, "mpich")
 
-          find_method_with_args(body_node, :depends_on, "mpich") do
-            problem "Formulae in homebrew/core should use 'depends_on \"open-mpi\"' " \
-                    "instead of '#{@offensive_node.source}'." do |corrector|
-              corrector.replace(@offensive_node.source_range, "depends_on \"open-mpi\"")
-            end
+          problem "Formulae in homebrew/core should use 'depends_on \"open-mpi\"' " \
+                  "instead of '#{@offensive_node.source}'." do |corrector|
+            corrector.replace(@offensive_node.source_range, "depends_on \"open-mpi\"")
           end
         end
       end
@@ -216,24 +205,12 @@ module RuboCop
       #
       # @api private
       class PyoxidizerCheck < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        def on_depends_on(node)
           # Disallow use of PyOxidizer as a dependency in core
-          return unless formula_tap == "homebrew-core"
+          return unless core_tap?
+          return unless depends_on_matches?(node, "pyoxidizer")
 
-          find_method_with_args(body_node, :depends_on, "pyoxidizer") do
-            problem "Formulae in homebrew/core should not use '#{@offensive_node.source}'."
-          end
-
-          [
-            :build,
-            [:build],
-            [:build, :test],
-            [:test, :build],
-          ].each do |type|
-            find_method_with_args(body_node, :depends_on, "pyoxidizer" => type) do
-              problem "Formulae in homebrew/core should not use '#{@offensive_node.source}'."
-            end
-          end
+          problem "Formulae in homebrew/core should not use '#{@offensive_node.source}'."
         end
       end
 
@@ -243,25 +220,28 @@ module RuboCop
       class SafePopenCommands < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          test = find_block(body_node, :test)
+        UNSAFE_METHODS = [:popen_read, :popen_write].freeze
 
-          [:popen_read, :popen_write].each do |unsafe_command|
-            test_methods = []
+        def on_formula_class(_class_node)
+          @test_methods = []
+        end
 
-            unless test.nil?
-              find_instance_method_call(test, "Utils", unsafe_command) do |method|
-                test_methods << method.source_range
-              end
+        def on_formula_test(test_node)
+          UNSAFE_METHODS.each do |unsafe_command|
+            find_instance_method_call(test_node, "Utils", unsafe_command) do |method_call|
+              @test_methods << method_call.source_range
             end
+          end
+        end
 
-            find_instance_method_call(body_node, "Utils", unsafe_command) do |method|
-              unless test_methods.include?(method.source_range)
-                problem "Use `Utils.safe_#{unsafe_command}` instead of `Utils.#{unsafe_command}`" do |corrector|
-                  corrector.replace(@offensive_node.loc.selector, "safe_#{@offensive_node.method_name}")
-                end
-              end
-            end
+        def on_formula_send(send_node)
+          method_name = send_node.method_name
+          return unless UNSAFE_METHODS.include?(method_name)
+          return unless instance_method_call?(send_node, "Utils")
+          return if @test_methods.include?(send_node.source_range)
+
+          problem "Use `Utils.safe_#{method_name}` instead of `Utils.#{method_name}`" do |corrector|
+            corrector.replace(@offensive_node.loc.selector, "safe_#{@offensive_node.method_name}")
           end
         end
       end
@@ -272,26 +252,25 @@ module RuboCop
       class ShellVariables < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          popen_commands = [
-            :popen,
-            :popen_read,
-            :safe_popen_read,
-            :popen_write,
-            :safe_popen_write,
-          ]
+        POPEN_COMMANDS = [
+          :popen,
+          :popen_read,
+          :safe_popen_read,
+          :popen_write,
+          :safe_popen_write,
+        ].freeze
 
-          popen_commands.each do |command|
-            find_instance_method_call(body_node, "Utils", command) do |method|
-              next unless (match = regex_match_group(parameters(method).first, /^([^"' ]+)=([^"' ]+)(?: (.*))?$/))
+        def on_formula_send(send_node)
+          command = send_node.method_name
+          return unless POPEN_COMMANDS.include?(command)
+          return unless instance_method_call?(send_node, "Utils")
+          return unless (match = regex_match_group(parameters(send_node).first, /^([^"' ]+)=([^"' ]+)(?: (.*))?$/))
 
-              good_args = "Utils.#{command}({ \"#{match[1]}\" => \"#{match[2]}\" }, \"#{match[3]}\")"
+          good_args = "Utils.#{command}({ \"#{match[1]}\" => \"#{match[2]}\" }, \"#{match[3]}\")"
 
-              problem "Use `#{good_args}` instead of `#{method.source}`" do |corrector|
-                corrector.replace(@offensive_node.source_range,
-                                  "{ \"#{match[1]}\" => \"#{match[2]}\" }, \"#{match[3]}\"")
-              end
-            end
+          problem "Use `#{good_args}` instead of `#{send_node.source}`" do |corrector|
+            corrector.replace(@offensive_node.source_range,
+                              "{ \"#{match[1]}\" => \"#{match[2]}\" }, \"#{match[3]}\"")
           end
         end
       end
@@ -302,13 +281,11 @@ module RuboCop
       class LicenseArrays < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          license_node = find_node_method_by_name(body_node, :license)
-          return unless license_node
-
+        def on_formula_license(license_node)
           license = parameters(license_node).first
           return unless license.array_type?
 
+          offending_node(license_node)
           problem "Use `license any_of: #{license.source}` instead of `license #{license.source}`" do |corrector|
             corrector.replace(license_node.source_range, "license any_of: #{parameters(license_node).first.source}")
           end
@@ -319,14 +296,13 @@ module RuboCop
       #
       # @api private
       class Licenses < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          license_node = find_node_method_by_name(body_node, :license)
-          return unless license_node
-          return if license_node.source.include?("\n")
+        def on_formula_license(node)
+          return if node.source.include?("\n")
 
-          parameters(license_node).first.each_descendant(:hash).each do |license_hash|
+          parameters(node).first.each_descendant(:hash).each do |license_hash|
             next if license_exception? license_hash
 
+            offending_node(node)
             problem "Split nested license declarations onto multiple lines"
           end
         end
@@ -342,25 +318,30 @@ module RuboCop
       class PythonVersions < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          python_formula_node = find_every_method_call_by_name(body_node, :depends_on).find do |dep|
-            string_content(parameters(dep).first).start_with? "python@"
-          end
+        def on_formula_class(_class_node)
+          @python_versions = []
+        end
 
-          return if python_formula_node.blank?
+        def on_formula_depends_on(depends_on_node)
+          dep_name = string_content(parameters(depends_on_node).first)
+          return unless dep_name.start_with?("python@")
 
-          python_version = string_content(parameters(python_formula_node).first).split("@").last
+          @python_versions << dep_name.split("@").last
+        end
 
-          find_strings(body_node).each do |str|
+        def on_formula_class_end(class_node)
+          return if @python_versions.empty?
+
+          find_strings(class_node.body).each do |str|
             content = string_content(str)
 
             next unless (match = content.match(/^python(@)?(\d\.\d+)$/))
-            next if python_version == match[2]
+            next if @python_versions.include?(match[2])
 
             fix = if match[1]
-              "python@#{python_version}"
+              "python@#{@python_versions.first}"
             else
-              "python#{python_version}"
+              "python#{@python_versions.first}"
             end
 
             offending_node(str)
@@ -378,17 +359,86 @@ module RuboCop
       class OSConditionals < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        OS_METHODS = [[:on_macos, :mac?], [:on_linux, :linux?]].freeze
+
+        def on_formula_install(node)
+          enforce_if_os_usage(node)
+        end
+
+        def on_formula_post_install(node)
+          enforce_if_os_usage(node)
+        end
+
+        def on_formula_service(node)
+          enforce_if_os_usage(node)
+        end
+
+        def on_formula_test(node)
+          enforce_if_os_usage(node)
+        end
+
+        def on_formula_send(send_node)
+          # Don't restrict OS.mac? or OS.linux? usage in taps; they don't care
+          # as much as we do about e.g. formulae.brew.sh generation, often use
+          # platform-specific URLs and we don't want to add DSLs to support
+          # that case.
+          return unless core_tap?
+          return unless (on_method_name, = OS_METHODS.find { |_, if_method| if_method == send_node.method_name })
+          return unless instance_method_call?(send_node, "OS")
+
           no_on_os_method_names = [:install, :post_install].freeze
           no_on_os_block_names = [:service, :test].freeze
-          [[:on_macos, :mac?], [:on_linux, :linux?]].each do |on_method_name, if_method_name|
-            if_method_and_class = "if OS.#{if_method_name}"
-            no_on_os_method_names.each do |formula_method_name|
-              method_node = find_method_def(body_node, formula_method_name)
-              next unless method_node
-              next unless method_called_ever?(method_node, on_method_name)
 
-              problem "Don't use '#{on_method_name}' in 'def #{formula_method_name}', " \
+          valid = T.let(false, T::Boolean)
+          send_node.each_ancestor do |ancestor|
+            valid_method_names = case ancestor.type
+            when :def
+              no_on_os_method_names
+            when :block
+              no_on_os_block_names
+            else
+              next
+            end
+            next unless valid_method_names.include?(ancestor.method_name)
+
+            valid = true
+            break
+          end
+          return if valid
+
+          offending_node(send_node)
+          problem "Don't use 'if OS.#{send_node.method_name}', use '#{on_method_name} do' instead." do |corrector|
+            if_node = send_node.parent
+            next if if_node.type != :if
+
+            # TODO: could fix corrector to handle this but punting for now.
+            next if if_node.unless?
+
+            corrector.replace(if_node.source_range, "#{on_method_name} do\n#{if_node.body.source}\nend")
+          end
+        end
+
+        private
+
+        def enforce_if_os_usage(node)
+          OS_METHODS.each do |on_method_name, if_method_name|
+            if_method_and_class = "if OS.#{if_method_name}"
+
+            if node.block_type?
+              next unless block_method_called_in_block?(node, on_method_name)
+
+              problem "Don't use '#{on_method_name}' in '#{node.method_name} do', " \
+                      "use '#{if_method_and_class}' instead." do |corrector|
+                # TODO: could fix corrector to handle this but punting for now.
+                next if offending_node.single_line?
+
+                source_range = offending_node.send_node.source_range.join(offending_node.body.source_range.begin)
+                corrector.replace(source_range, "#{if_method_and_class}\n")
+              end
+            else
+              next unless method_called_ever?(node, on_method_name)
+
+              problem "Don't use '#{on_method_name}' in 'def #{node.method_name}', " \
                       "use '#{if_method_and_class}' instead." do |corrector|
                 block_node = offending_node.parent
                 next if block_node.type != :block
@@ -400,57 +450,6 @@ module RuboCop
                 corrector.replace(source_range, if_method_and_class)
               end
             end
-
-            no_on_os_block_names.each do |formula_block_name|
-              block_node = find_block(body_node, formula_block_name)
-              next unless block_node
-              next unless block_method_called_in_block?(block_node, on_method_name)
-
-              problem "Don't use '#{on_method_name}' in '#{formula_block_name} do', " \
-                      "use '#{if_method_and_class}' instead." do |corrector|
-                # TODO: could fix corrector to handle this but punting for now.
-                next if offending_node.single_line?
-
-                source_range = offending_node.send_node.source_range.join(offending_node.body.source_range.begin)
-                corrector.replace(source_range, "#{if_method_and_class}\n")
-              end
-            end
-
-            # Don't restrict OS.mac? or OS.linux? usage in taps; they don't care
-            # as much as we do about e.g. formulae.brew.sh generation, often use
-            # platform-specific URLs and we don't want to add DSLs to support
-            # that case.
-            next if formula_tap != "homebrew-core"
-
-            find_instance_method_call(body_node, "OS", if_method_name) do |method|
-              valid = T.let(false, T::Boolean)
-              method.each_ancestor do |ancestor|
-                valid_method_names = case ancestor.type
-                when :def
-                  no_on_os_method_names
-                when :block
-                  no_on_os_block_names
-                else
-                  next
-                end
-                next unless valid_method_names.include?(ancestor.method_name)
-
-                valid = true
-                break
-              end
-              next if valid
-
-              offending_node(method)
-              problem "Don't use '#{if_method_and_class}', use '#{on_method_name} do' instead." do |corrector|
-                if_node = method.parent
-                next if if_node.type != :if
-
-                # TODO: could fix corrector to handle this but punting for now.
-                next if if_node.unless?
-
-                corrector.replace(if_node.source_range, "#{on_method_name} do\n#{if_node.body.source}\nend")
-              end
-            end
           end
         end
       end
@@ -459,94 +458,203 @@ module RuboCop
       #
       # @api private
       class Miscellaneous < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        def on_formula_send(send_node)
           # FileUtils is included in Formula
           # encfs modifies a file with this name, so check for some leading characters
-          find_instance_method_call(body_node, "FileUtils", nil) do |method_node|
-            problem "Don't need 'FileUtils.' before #{method_node.method_name}"
+          if instance_method_call?(send_node, "FileUtils")
+            problem "Don't need 'FileUtils.' before #{send_node.method_name}"
           end
 
-          # Check for long inreplace block vars
-          find_all_blocks(body_node, :inreplace) do |node|
-            block_arg = node.arguments.children.first
-            next unless block_arg.source.size > 1
-
-            problem "\"inreplace <filenames> do |s|\" is preferred over \"|#{block_arg.source}|\"."
-          end
-
-          [:rebuild, :version_scheme].each do |method_name|
-            find_method_with_args(body_node, method_name, 0) do
-              problem "'#{method_name} 0' should be removed"
-            end
-          end
-
-          find_instance_call(body_node, "ARGV") do |_method_node|
+          if instance_method_call?(send_node, "ARGV")
+            offending_node(send_node.receiver)
             problem "Use build instead of ARGV to check options"
           end
 
-          find_instance_method_call(body_node, :man, :+) do |method|
-            next unless (match = regex_match_group(parameters(method).first, /^man[1-8]$/))
+          if send_node.method_name == :+ && instance_method_call?(send_node, :man) &&
+             (match = regex_match_group(parameters(send_node).first, /^man[1-8]$/))
 
-            problem "\"#{method.source}\" should be \"#{match[0]}\""
+            problem "\"#{send_node.source}\" should be \"#{match[0]}\""
           end
 
           # Avoid hard-coding compilers
-          find_every_method_call_by_name(body_node, :system).each do |method|
-            param = parameters(method).first
-            if (match = regex_match_group(param, %r{^(/usr/bin/)?(gcc|llvm-gcc|clang)(\s|$)}))
+          if send_node.method_name == :system ||
+             (send_node.method_name == :[]= && instance_method_call?(send_node, "ENV"))
+            params = parameters(send_node)
+            param_to_check = if send_node.method_name == :system
+              params.first
+            else
+              params[1]
+            end
+
+            if (match = regex_match_group(param_to_check, %r{^(/usr/bin/)?(gcc|llvm-gcc|clang)(\s|$)}))
               problem "Use \"\#{ENV.cc}\" instead of hard-coding \"#{match[2]}\""
-            elsif (match = regex_match_group(param, %r{^(/usr/bin/)?((g|llvm-g|clang)\+\+)(\s|$)}))
+            elsif (match = regex_match_group(param_to_check, %r{^(/usr/bin/)?((g|llvm-g|clang)\+\+)(\s|$)}))
               problem "Use \"\#{ENV.cxx}\" instead of hard-coding \"#{match[2]}\""
             end
           end
 
-          find_instance_method_call(body_node, "ENV", :[]=) do |method|
-            param = parameters(method)[1]
-            if (match = regex_match_group(param, %r{^(/usr/bin/)?(gcc|llvm-gcc|clang)(\s|$)}))
-              problem "Use \"\#{ENV.cc}\" instead of hard-coding \"#{match[2]}\""
-            elsif (match = regex_match_group(param, %r{^(/usr/bin/)?((g|llvm-g|clang)\+\+)(\s|$)}))
-              problem "Use \"\#{ENV.cxx}\" instead of hard-coding \"#{match[2]}\""
-            end
-          end
-
-          # Prefer formula path shortcuts in strings
-          formula_path_strings(body_node, :share) do |p|
-            next unless (match = regex_match_group(p, %r{^(/(man))/?}))
-
-            problem "\"\#{share}#{match[1]}\" should be \"\#{#{match[2]}}\""
-          end
-
-          formula_path_strings(body_node, :prefix) do |p|
-            if (match = regex_match_group(p, %r{^(/share/(info|man))$}))
-              problem "\"\#\{prefix}#{match[1]}\" should be \"\#{#{match[2]}}\""
-            end
-            if (match = regex_match_group(p, %r{^((/share/man/)(man[1-8]))}))
-              problem "\"\#\{prefix}#{match[1]}\" should be \"\#{#{match[3]}}\""
-            end
-            if (match = regex_match_group(p, %r{^(/(bin|include|libexec|lib|sbin|share|Frameworks))}i))
-              problem "\"\#\{prefix}#{match[1]}\" should be \"\#{#{match[2].downcase}}\""
-            end
-          end
-
-          find_every_method_call_by_name(body_node, :depends_on).each do |method|
-            key, value = destructure_hash(parameters(method).first)
-            next if key.nil? || value.nil?
-            next unless (match = regex_match_group(value, /^(lua|perl|python|ruby)(\d*)/))
-
-            problem "#{match[1]} modules should be vendored rather than use deprecated `#{method.source}`"
-          end
-
-          find_every_method_call_by_name(body_node, :system).each do |method|
-            next unless (match = regex_match_group(parameters(method).first, /^(env|export)(\s+)?/))
-
+          if send_node.method_name == :system &&
+             (match = regex_match_group(parameters(send_node).first, /^(env|export)(\s+)?/))
             problem "Use ENV instead of invoking '#{match[1]}' to modify the environment"
           end
 
-          find_every_method_call_by_name(body_node, :depends_on).each do |method|
-            param = parameters(method).first
-            dep, option_child_nodes = hash_dep(param)
-            next if dep.nil? || option_child_nodes.empty?
+          if send_node.method_name == :== && instance_method_call?(send_node, :version) &&
+             parameters_passed?(send_node, "HEAD")
+            problem "Use 'build.head?' instead of inspecting 'version'"
+          end
 
+          if send_node.method_name == :include? && instance_method_call?(send_node, "ARGV") &&
+             parameters_passed?(send_node, "--HEAD")
+            problem "Use \"if build.head?\" instead"
+          end
+
+          if send_node.method_name == :system && parameters_passed?(send_node, /^(otool|install_name_tool|lipo)/)
+            problem "Use ruby-macho instead of calling #{@offensive_node.source}"
+          end
+
+          # Skip Kibana: npm cache edge (see formula for more details)
+          if send_node.method_name == :system && !@formula_name.match?(/^kibana(@\d[\d.]*)?$/)
+            first_param, second_param = parameters(send_node)
+            if first_param&.str_type? && first_param.value == "npm" &&
+               second_param&.str_type? && second_param.value == "install"
+              offending_node(send_node)
+              problem "Use Language::Node for npm install args" unless languageNodeModule?(send_node)
+            end
+          end
+
+          if send_node.method_name == :universal? && instance_method_call?(send_node, :build) &&
+             @formula_name != "wine"
+            problem "macOS has been 64-bit only since 10.6 so build.universal? is deprecated."
+          end
+
+          if send_node.method_name == :universal_binary && instance_method_call?(send_node, "ENV") &&
+             @formula_name != "wine"
+            problem "macOS has been 64-bit only since 10.6 so ENV.universal_binary is deprecated."
+          end
+
+          if send_node.method_name == :runtime_cpu_detection && instance_method_call?(send_node, "ENV") &&
+             !tap_style_exception?(:runtime_cpu_detection_allowlist)
+            problem "Formulae should be verified as having support for runtime hardware detection before " \
+                    "using ENV.runtime_cpu_detection."
+          end
+
+          if send_node.method_name == :[] && instance_method_call?(send_node, "ENV") && !modifier?(send_node.parent)
+            param = parameters(send_node).first
+            problem 'Don\'t use ENV["CI"] for Homebrew CI checks.' if param&.str_type? && param.value == "CI"
+          end
+
+          if send_node.method_name == :[] && instance_method_call?(send_node, "Dir") &&
+             parameters(send_node).size == 1
+            path = parameters(send_node).first
+            if path.str_type? && (match = regex_match_group(path, /^[^*{},]+$/))
+              problem "Dir([\"#{string_content(path)}\"]) is unnecessary; just use \"#{match[0]}\""
+            end
+          end
+
+          fileutils_methods = Regexp.new(
+            FileUtils.singleton_methods(false)
+                     .map { |m| "(?-mix:^#{Regexp.escape(m)}$)" }
+                     .join("|"),
+          )
+          if send_node.method_name == :system &&
+             (match = regex_match_group(parameters(send_node).first, fileutils_methods))
+            problem "Use the `#{match}` Ruby method instead of `#{send_node.source}`"
+          end
+        end
+
+        # Check for long inreplace block vars
+        def on_formula_block(block_node)
+          return if block_node.method_name != :inreplace
+
+          block_arg = block_node.arguments.children.first
+          return unless block_arg.source.size > 1
+
+          offending_node(block_node)
+          problem "\"inreplace <filenames> do |s|\" is preferred over \"|#{block_arg.source}|\"."
+        end
+
+        def on_formula_revision(node)
+          param = parameters(node).first
+          return unless param&.numeric_type?
+          return if param.value != 0
+
+          offending_node(node)
+          problem "'revision 0' should be removed"
+        end
+
+        def on_formula_version_scheme(node)
+          param = parameters(node).first
+          return unless param&.numeric_type?
+          return if param.value != 0
+
+          offending_node(node)
+          problem "'version_scheme 0' should be removed"
+        end
+
+        def on_formula_bottle(node)
+          return unless node.block_type?
+
+          node.body.each_child_node(:send) do |send_node|
+            next if send_node.method_name != :rebuild
+
+            param = parameters(send_node).first
+            next unless param&.numeric_type?
+            next if param.value != 0
+
+            offending_node(send_node)
+            problem "'rebuild 0' should be removed"
+          end
+        end
+
+        def on_formula_dstr(node)
+          # Prefer formula path shortcuts in strings
+          path = formula_path_strings(node, :share)
+          if path && (match = regex_match_group(path, %r{^(/(man))/?}))
+            problem "\"\#{share}#{match[1]}\" should be \"\#{#{match[2]}}\""
+          end
+
+          path = formula_path_strings(node, :prefix)
+          return unless path
+
+          if (match = regex_match_group(path, %r{^(/share/(info|man))$}))
+            problem "\"\#\{prefix}#{match[1]}\" should be \"\#{#{match[2]}}\""
+          elsif (match = regex_match_group(path, %r{^((/share/man/)(man[1-8]))}))
+            problem "\"\#\{prefix}#{match[1]}\" should be \"\#{#{match[3]}}\""
+          elsif (match = regex_match_group(path, %r{^(/(bin|include|libexec|lib|sbin|share|Frameworks))}i))
+            problem "\"\#\{prefix}#{match[1]}\" should be \"\#{#{match[2].downcase}}\""
+          end
+        end
+
+        def on_formula_if(node)
+          method, param, dep_node = conditional_dependencies(node)
+          return if dep_node.nil?
+
+          dep = string_content(dep_node)
+          if node.if?
+            if (method == :include? && regex_match_group(param, /^with-#{dep}$/)) ||
+               (method == :with? && regex_match_group(param, /^#{dep}$/))
+              offending_node(dep_node.parent)
+              problem "Replace #{node.source} with #{dep_node.parent.source} => :optional"
+            end
+          elsif node.unless?
+            if (method == :include? && regex_match_group(param, /^without-#{dep}$/)) ||
+               (method == :without? && regex_match_group(param, /^#{dep}$/))
+              offending_node(dep_node.parent)
+              problem "Replace #{node.source} with #{dep_node.parent.source} => :recommended"
+            end
+          end
+        end
+
+        def on_formula_depends_on(node)
+          param = parameters(node).first
+
+          key, value = destructure_hash(param)
+          if !key.nil? && !value.nil? && (match = regex_match_group(value, /^(lua|perl|python|ruby)(\d*)/))
+            problem "#{match[1]} modules should be vendored rather than use deprecated `#{node.source}`"
+          end
+
+          dep, option_child_nodes = hash_dep(param)
+          if !dep.nil? && !option_child_nodes.empty?
             option_child_nodes.each do |option|
               find_strings(option).each do |dependency|
                 next unless (match = regex_match_group(dependency, /(with(out)?-\w+|c\+\+11)/))
@@ -556,134 +664,59 @@ module RuboCop
             end
           end
 
-          find_instance_method_call(body_node, :version, :==) do |method|
-            next unless parameters_passed?(method, "HEAD")
+          problem "`depends_on` can take requirement classes instead of instances" if method_called?(node, :new)
+        end
 
-            problem "Use 'build.head?' instead of inspecting 'version'"
-          end
-
-          find_instance_method_call(body_node, "ARGV", :include?) do |method|
-            next unless parameters_passed?(method, "--HEAD")
-
-            problem "Use \"if build.head?\" instead"
-          end
-
-          find_const(body_node, "MACOS_VERSION") do
+        def on_formula_const(node)
+          case node.const_name
+          when "MACOS_VERSION"
+            offending_node(node)
             problem "Use MacOS.version instead of MACOS_VERSION"
-          end
-
-          find_const(body_node, "MACOS_FULL_VERSION") do
+          when "MACOS_FULL_VERSION"
+            offending_node(node)
             problem "Use MacOS.full_version instead of MACOS_FULL_VERSION"
           end
-
-          conditional_dependencies(body_node) do |node, method, param, dep_node|
-            dep = string_content(dep_node)
-            if node.if?
-              if (method == :include? && regex_match_group(param, /^with-#{dep}$/)) ||
-                 (method == :with? && regex_match_group(param, /^#{dep}$/))
-                offending_node(dep_node.parent)
-                problem "Replace #{node.source} with #{dep_node.parent.source} => :optional"
-              end
-            elsif node.unless?
-              if (method == :include? && regex_match_group(param, /^without-#{dep}$/)) ||
-                 (method == :without? && regex_match_group(param, /^#{dep}$/))
-                offending_node(dep_node.parent)
-                problem "Replace #{node.source} with #{dep_node.parent.source} => :recommended"
-              end
-            end
-          end
-
-          find_method_with_args(body_node, :fails_with, :llvm) do
-            problem "'fails_with :llvm' is now a no-op so should be removed"
-          end
-
-          find_method_with_args(body_node, :needs, :openmp) do
-            problem "'needs :openmp' should be replaced with 'depends_on \"gcc\"'"
-          end
-
-          find_method_with_args(body_node, :system, /^(otool|install_name_tool|lipo)/) do
-            problem "Use ruby-macho instead of calling #{@offensive_node.source}"
-          end
-
-          find_every_method_call_by_name(body_node, :system).each do |method_node|
-            # Skip Kibana: npm cache edge (see formula for more details)
-            next if @formula_name.match?(/^kibana(@\d[\d.]*)?$/)
-
-            first_param, second_param = parameters(method_node)
-            next if !node_equals?(first_param, "npm") ||
-                    !node_equals?(second_param, "install")
-
-            offending_node(method_node)
-            problem "Use Language::Node for npm install args" unless languageNodeModule?(method_node)
-          end
-
-          problem "Use new-style test definitions (test do)" if find_method_def(body_node, :test)
-
-          find_method_with_args(body_node, :skip_clean, :all) do
-            problem "`skip_clean :all` is deprecated; brew no longer strips symbols. " \
-                    "Pass explicit paths to prevent Homebrew from removing empty folders."
-          end
-
-          if find_method_def(processed_source.ast)
-            problem "Define method #{method_name(@offensive_node)} in the class body, not at the top-level"
-          end
-
-          find_instance_method_call(body_node, :build, :universal?) do
-            next if @formula_name == "wine"
-
-            problem "macOS has been 64-bit only since 10.6 so build.universal? is deprecated."
-          end
-
-          find_instance_method_call(body_node, "ENV", :universal_binary) do
-            next if @formula_name == "wine"
-
-            problem "macOS has been 64-bit only since 10.6 so ENV.universal_binary is deprecated."
-          end
-
-          find_instance_method_call(body_node, "ENV", :runtime_cpu_detection) do
-            next if tap_style_exception? :runtime_cpu_detection_allowlist
-
-            problem "Formulae should be verified as having support for runtime hardware detection before " \
-                    "using ENV.runtime_cpu_detection."
-          end
-
-          find_every_method_call_by_name(body_node, :depends_on).each do |method|
-            next unless method_called?(method, :new)
-
-            problem "`depends_on` can take requirement classes instead of instances"
-          end
-
-          find_instance_method_call(body_node, "ENV", :[]) do |method|
-            next unless modifier?(method.parent)
-
-            param = parameters(method).first
-            next unless node_equals?(param, "CI")
-
-            problem 'Don\'t use ENV["CI"] for Homebrew CI checks.'
-          end
-
-          find_instance_method_call(body_node, "Dir", :[]) do |method|
-            next unless parameters(method).size == 1
-
-            path = parameters(method).first
-            next unless path.str_type?
-            next unless (match = regex_match_group(path, /^[^*{},]+$/))
-
-            problem "Dir([\"#{string_content(path)}\"]) is unnecessary; just use \"#{match[0]}\""
-          end
-
-          fileutils_methods = Regexp.new(
-            FileUtils.singleton_methods(false)
-                     .map { |m| "(?-mix:^#{Regexp.escape(m)}$)" }
-                     .join("|"),
-          )
-          find_every_method_call_by_name(body_node, :system).each do |method|
-            param = parameters(method).first
-            next unless (match = regex_match_group(param, fileutils_methods))
-
-            problem "Use the `#{match}` Ruby method instead of `#{method.source}`"
-          end
         end
+
+        def on_formula_fails_with(node)
+          send_node = if node.block_type?
+            node.send_node
+          else
+            node
+          end
+
+          return unless parameters_passed?(send_node, :llvm)
+
+          problem "'fails_with :llvm' is now a no-op so should be removed"
+        end
+
+        def on_formula_needs(node)
+          return unless parameters_passed?(node, :openmp)
+
+          problem "'needs :openmp' should be replaced with 'depends_on \"gcc\"'"
+        end
+
+        def on_formula_def(node)
+          return if node.method_name != :test
+
+          offending_node(node)
+          problem "Use new-style test definitions (test do)"
+        end
+
+        def on_formula_skip_clean(node)
+          return unless parameters_passed?(node, :all)
+
+          problem "`skip_clean :all` is deprecated; brew no longer strips symbols. " \
+                  "Pass explicit paths to prevent Homebrew from removing empty folders."
+        end
+
+        def on_formula_source(processed_source)
+          return unless find_method_def(processed_source.ast)
+
+          problem "Define method #{method_name(@offensive_node)} in the class body, not at the top-level"
+        end
+
+        private
 
         def modifier?(node)
           return false unless node.if_type?
@@ -691,11 +724,11 @@ module RuboCop
           node.modifier_form?
         end
 
-        def_node_search :conditional_dependencies, <<~EOS
-          {$(if (send (send nil? :build) ${:include? :with? :without?} $(str _))
+        def_node_matcher :conditional_dependencies, <<~EOS
+          {(if (send (send nil? :build) ${:include? :with? :without?} $(str _))
               (send nil? :depends_on $({str sym} _)) nil?)
 
-           $(if (send (send nil? :build) ${:include? :with? :without?} $(str _)) nil?
+           (if (send (send nil? :build) ${:include? :with? :without?} $(str _)) nil?
               (send nil? :depends_on $({str sym} _)))}
         EOS
 
@@ -707,7 +740,7 @@ module RuboCop
           (hash (pair $(str _) $(sym _)))
         EOS
 
-        def_node_search :formula_path_strings, <<~EOS
+        def_node_matcher :formula_path_strings, <<~EOS
           {(dstr (begin (send nil? %1)) $(str _ ))
            (dstr _ (begin (send nil? %1)) $(str _ ))}
         EOS
@@ -724,35 +757,35 @@ module RuboCop
       #
       # @api private
       class MakeCheck < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if formula_tap != "homebrew-core"
+        def on_formula_send(send_node)
+          return unless core_tap?
+          return if send_node.method_name != :system
+          return if @formula_name.start_with?("lib")
+          return if tap_style_exception?(:make_check_allowlist)
 
-          # Avoid build-time checks in homebrew/core
-          find_every_method_call_by_name(body_node, :system).each do |method|
-            next if @formula_name.start_with?("lib")
-            next if tap_style_exception? :make_check_allowlist
+          params = parameters(send_node)
+          return unless params.first&.str_type?
+          return if params.first.value != "make"
 
-            params = parameters(method)
-            next unless node_equals?(params[0], "make")
+          params[1..].each do |arg|
+            next unless regex_match_group(arg, /^(checks?|tests?)$/)
 
-            params[1..].each do |arg|
-              next unless regex_match_group(arg, /^(checks?|tests?)$/)
-
-              offending_node(method)
-              problem "Formulae in homebrew/core (except e.g. cryptography, libraries) " \
-                      "should not run build-time checks"
-            end
+            offending_node(send_node)
+            problem "Formulae in homebrew/core (except e.g. cryptography, libraries) " \
+                    "should not run build-time checks"
           end
         end
       end
 
       # This cop ensures that new formulae depending on removed Requirements are not used
       class Requirements < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, _body_node)
-          problem "Formulae should depend on a versioned `openjdk` instead of :java" if depends_on? :java
-          problem "Formulae should depend on specific X libraries instead of :x11" if depends_on? :x11
-          problem "Formulae should not depend on :osxfuse" if depends_on? :osxfuse
-          problem "Formulae should not depend on :tuntap" if depends_on? :tuntap
+        def on_depends_on(node)
+          if depends_on_matches?(node, :java)
+            problem "Formulae should depend on a versioned `openjdk` instead of :java"
+          end
+          problem "Formulae should depend on specific X libraries instead of :x11" if depends_on_matches?(node, :x11)
+          problem "Formulae should not depend on :osxfuse" if depends_on_matches?(node, :osxfuse)
+          problem "Formulae should not depend on :tuntap" if depends_on_matches?(node, :tuntap)
         end
       end
     end

--- a/Library/Homebrew/rubocops/livecheck.rb
+++ b/Library/Homebrew/rubocops/livecheck.rb
@@ -13,10 +13,7 @@ module RuboCop
       class LivecheckSkip < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
-
+        def on_formula_livecheck(livecheck_node)
           skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.blank?
 
@@ -43,10 +40,7 @@ module RuboCop
       #
       # @api private
       class LivecheckUrlProvided < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
-
+        def on_formula_livecheck(livecheck_node)
           skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.present?
 
@@ -69,51 +63,75 @@ module RuboCop
       class LivecheckUrlSymbol < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
+        def on_formula_class(_class_node)
+          @livecheck_url_node = nil
+          @formula_urls = {}
+        end
 
-          skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
+        def on_formula_livecheck(livecheck_node)
+          return if @livecheck_url_node
+
+          skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.present?
 
-          livecheck_url_node = find_every_method_call_by_name(livecheck_node, :url).first
-          livecheck_url = find_strings(livecheck_url_node).first
+          @livecheck_url_node = find_every_method_call_by_name(livecheck_node, :url).first
+        end
+
+        def on_formula_head(node)
+          head_url = if node.block_type?
+            url_node = find_every_method_call_by_name(node, :url).first
+            return if url_node.nil?
+
+            find_strings(url_node).first
+          else
+            find_strings(node).first
+          end
+          return if head_url.nil?
+
+          @formula_urls[:head] = string_content(head_url)
+        end
+
+        def on_formula_url(node)
+          stable_url = find_strings(node).first
+          return if stable_url.nil?
+
+          block_url = node.each_ancestor(:block, :class).first&.block_type?
+          return if block_url
+
+          @formula_urls[:stable] = string_content(stable_url)
+        end
+
+        def on_formula_stable(node)
+          url_node = find_every_method_call_by_name(node, :url).first
+          return if url_node.nil?
+
+          stable_url = find_strings(url_node).first
+          return if stable_url.nil?
+
+          @formula_urls[:stable] = string_content(stable_url)
+        end
+
+        def on_formula_homepage(node)
+          homepage_url = find_strings(node).first
+          return if homepage_url.nil?
+
+          @formula_urls[:homepage] = string_content(homepage_url)
+        end
+
+        def on_formula_class_end(_class_node)
+          return if @livecheck_url_node.nil?
+
+          livecheck_url = find_strings(@livecheck_url_node).first
           return if livecheck_url.blank?
 
           livecheck_url = string_content(livecheck_url)
 
-          head = find_every_method_call_by_name(body_node, :head).first
-          head_url = find_strings(head).first
-
-          if head.present? && head_url.blank?
-            head = find_every_method_call_by_name(head, :url).first
-            head_url = find_strings(head).first
-          end
-
-          head_url = string_content(head_url) if head_url.present?
-
-          stable = find_every_method_call_by_name(body_node, :url).first
-          stable_url = find_strings(stable).first
-
-          if stable_url.blank?
-            stable = find_every_method_call_by_name(body_node, :stable).first
-            stable = find_every_method_call_by_name(stable, :url).first
-            stable_url = find_strings(stable).first
-          end
-
-          stable_url = string_content(stable_url) if stable_url.present?
-
-          homepage = find_every_method_call_by_name(body_node, :homepage).first
-          homepage_url = string_content(find_strings(homepage).first) if homepage.present?
-
-          formula_urls = { head: head_url, stable: stable_url, homepage: homepage_url }.compact
-
-          formula_urls.each do |symbol, url|
+          @formula_urls.each do |symbol, url|
             next if url != livecheck_url && url != "#{livecheck_url}/" && "#{url}/" != livecheck_url
 
-            offending_node(livecheck_url_node)
+            offending_node(@livecheck_url_node)
             problem "Use `url :#{symbol}`" do |corrector|
-              corrector.replace(livecheck_url_node.source_range, "url :#{symbol}")
+              corrector.replace(@livecheck_url_node.source_range, "url :#{symbol}")
             end
             break
           end
@@ -126,11 +144,8 @@ module RuboCop
       class LivecheckRegexParentheses < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
-
-          skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
+        def on_formula_livecheck(livecheck_node)
+          skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.present?
 
           livecheck_regex_node = find_every_method_call_by_name(livecheck_node, :regex).first
@@ -155,11 +170,8 @@ module RuboCop
 
         TAR_PATTERN = /\\?\.t(ar|(g|l|x)z$|[bz2]{2,4}$)(\\?\.((g|l|x)z)|[bz2]{2,4}|Z)?$/i.freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
-
-          skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
+        def on_formula_livecheck(livecheck_node)
+          skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.present?
 
           livecheck_regex_node = find_every_method_call_by_name(livecheck_node, :regex).first
@@ -184,11 +196,8 @@ module RuboCop
       #
       # @api private
       class LivecheckRegexIfPageMatch < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
-
-          skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
+        def on_formula_livecheck(livecheck_node)
+          skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.present?
 
           livecheck_strategy_node = find_every_method_call_by_name(livecheck_node, :strategy).first
@@ -214,13 +223,8 @@ module RuboCop
 
         MSG = "Regexes should be case-insensitive unless sensitivity is explicitly required for proper matching."
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if tap_style_exception? :regex_case_sensitive_allowlist
-
-          livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
-
-          skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
+        def on_formula_livecheck(livecheck_node)
+          skip = find_every_method_call_by_name(livecheck_node, :skip).first
           return if skip.present?
 
           livecheck_regex_node = find_every_method_call_by_name(livecheck_node, :regex).first
@@ -229,6 +233,8 @@ module RuboCop
           regex_node = livecheck_regex_node.descendants.first
           options_node = regex_node.regopt
           return if options_node.source.include?("i")
+
+          return if tap_style_exception? :regex_case_sensitive_allowlist
 
           offending_node(regex_node)
           problem MSG do |corrector|

--- a/Library/Homebrew/rubocops/options.rb
+++ b/Library/Homebrew/rubocops/options.rb
@@ -14,34 +14,56 @@ module RuboCop
         DEP_OPTION = "Formulae in homebrew/core should not use `deprecated_option`."
         OPTION = "Formulae in homebrew/core should not use `option`."
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          option_call_nodes = find_every_method_call_by_name(body_node, :option)
-          option_call_nodes.each do |option_call|
-            option = parameters(option_call).first
-            problem DEPRECATION_MSG if regex_match_group(option, /32-bit/)
+        def on_formula_class(_class_node)
+          @deprecated_check_options = []
+        end
 
-            offending_node(option_call)
-            option = string_content(option)
-            problem UNI_DEPRECATION_MSG if option == "universal"
+        def on_formula_option(node)
+          offending_node(node)
+          problem OPTION if core_tap?
 
-            if option !~ /with(out)?-/ &&
-               option != "cxx11" &&
-               option != "universal"
-              problem "Options should begin with with/without."\
-                      " Migrate '--#{option}' with `deprecated_option`."
-            end
+          option = parameters(node).first
+          problem DEPRECATION_MSG if regex_match_group(option, /32-bit/)
 
-            next unless option =~ /^with(out)?-(?:checks?|tests)$/
-            next if depends_on?("check", :optional, :recommended)
+          option = string_content(option)
+          problem UNI_DEPRECATION_MSG if option == "universal"
 
-            problem "Use '--with#{Regexp.last_match(1)}-test' instead of '--#{option}'."\
+          if option !~ /with(out)?-/ &&
+             option != "cxx11" &&
+             option != "universal"
+            problem "Options should begin with with/without."\
                     " Migrate '--#{option}' with `deprecated_option`."
           end
 
-          return if formula_tap != "homebrew-core"
+          return unless option =~ /^with(out)?-(?:checks?|tests)$/
 
-          problem DEP_OPTION if method_called_ever?(body_node, :deprecated_option)
-          problem OPTION if method_called_ever?(body_node, :option)
+          @deprecated_check_options << [node, Regexp.last_match(1)]
+        end
+
+        def on_formula_deprecated_option(node)
+          return unless core_tap?
+
+          offending_node(node)
+          problem DEP_OPTION
+        end
+
+        def on_formula_depends_on(node)
+          if !depends_on_matches?(node, "check", :optional) && !depends_on_matches?(node, "check", :recommended)
+            return
+          end
+
+          @depends_on_check = true
+        end
+
+        def on_formula_class_end(_class_node)
+          return if @depends_on_check
+
+          @deprecated_check_options.each do |node, with_suffix|
+            option = string_content(parameters(node).first)
+            offending_node(node)
+            problem "Use '--with#{with_suffix}-test' instead of '--#{option}'."\
+                    " Migrate '--#{option}' with `deprecated_option`."
+          end
         end
       end
     end

--- a/Library/Homebrew/rubocops/version.rb
+++ b/Library/Homebrew/rubocops/version.rb
@@ -10,11 +10,12 @@ module RuboCop
       #
       # @api private
       class Version < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          version_node = find_node_method_by_name(body_node, :version)
-          return unless version_node
+        def on_formula_version(node)
+          param = parameters(node).first
+          return if param.lvar_type?
 
-          version = string_content(parameters(version_node).first)
+          offending_node(node)
+          version = string_content(param)
 
           problem "version is set to an empty string" if version.empty?
 

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -5182,11 +5182,11 @@ class RuboCop::Cop::FormulaAudit::Licenses
 end
 
 class RuboCop::Cop::FormulaAudit::Miscellaneous
-  def conditional_dependencies(param0); end
+  def conditional_dependencies(param0=T.unsafe(nil)); end
 
   def destructure_hash(param0=T.unsafe(nil)); end
 
-  def formula_path_strings(param0, param1); end
+  def formula_path_strings(param0=T.unsafe(nil), param1); end
 
   def hash_dep(param0=T.unsafe(nil)); end
 
@@ -5194,7 +5194,7 @@ class RuboCop::Cop::FormulaAudit::Miscellaneous
 end
 
 class RuboCop::Cop::FormulaAudit::OptionDeclarations
-  def depends_on_build_with(param0); end
+  def depends_on_build_with(param0=T.unsafe(nil)); end
 end
 
 class RuboCop::Cop::FormulaAudit::Patches
@@ -5216,7 +5216,7 @@ class RuboCop::Cop::FormulaAudit::Test
 end
 
 class RuboCop::Cop::FormulaAudit::Text
-  def prefix_path(param0); end
+  def prefix_path(param0=T.unsafe(nil)); end
 end
 
 class RuboCop::Cop::FormulaAuditStrict::GitUrls
@@ -5224,19 +5224,19 @@ class RuboCop::Cop::FormulaAuditStrict::GitUrls
 end
 
 class RuboCop::Cop::FormulaAuditStrict::Text
-  def interpolated_share_path_starts_with(param0, param1); end
+  def interpolated_share_path_starts_with?(param0=T.unsafe(nil), param1); end
 
-  def share_path_starts_with(param0, param1); end
+  def share_path_starts_with?(param0=T.unsafe(nil), param1); end
 end
 
 class RuboCop::Cop::FormulaCop
-  def dependency_name_hash_match?(param0, param1); end
+  def dependency_name_hash_match?(param0=T.unsafe(nil), param1); end
 
-  def dependency_type_hash_match?(param0, param1); end
+  def dependency_type_hash_match?(param0=T.unsafe(nil), param1); end
 
-  def required_dependency?(param0); end
+  def required_dependency?(param0=T.unsafe(nil)); end
 
-  def required_dependency_name?(param0, param1); end
+  def required_dependency_name?(param0=T.unsafe(nil), param1); end
 end
 
 class RuboCop::Cop::Style::MutableConstant

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -40,10 +40,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
           bottle do
-          ^^^^^^^^^ `bottle :modifier` and `bottle do` should not be simultaneously present
             # bottles go here
           end
           bottle :unneeded
+          ^^^^^^^^^^^^^^^^ `bottle :modifier` and `bottle do` should not be simultaneously present
         end
       RUBY
     end


### PR DESCRIPTION
The performance of `brew style` in Homebrew/core has regressed quite noticeably as the number of cops and the size of the tap both grow. In CI, it takes about 4 minutes which, while could be worse, is noticeable, particularly when given the full actual test routine of some formulae is quicker than that.

The way formula cops worked before is that the base class would hook to `on_class`, check if its a Formula subclass, and invoke `audit_formula`. Subclasses of the base FormulaCop would implement this method, be given the full AST of the formula class and be expected to individually traverse through this AST. This meant that each individual formula cop basically did its own walking of formula file ASTs. On top of this, some helper functions like `find_every_method_call_by_name` were used which in themesleves traverse the entire AST looking for every instance of a particular method call, so each individual formula cop could traverse the AST multiple times. AST traversal isn't particularly slow in isolation, but it adds up when you multiply the 6000 formula files, 54 cops and the multiple calls to `find_every_method_call_by_name` etc in each cop.

Instead, I've used Rubocop's "force" feature which allows you to specify a class, which is separately invoked from the standard AST cop traversal, to read over a file's source and invoke hooks in cops that opt-in. I created a FormulaForce class (see `formula_force.rb`) which, when it detects a valid formula file, traverses through the formula AST and invokes `on_formula_` hooks on all cops that use it. The FormulaCop base class automatically opts-in all subclasses. A basic traversal of the [`hello` formula](https://github.com/Homebrew/homebrew-core/blob/983fc2bb30de562762ba9306af6fc751e9012401/Formula/hello.rb) would look something like:

* `on_formula_source`
* `on_formula_file`
* `on_formula_class`
* `on_formula_desc`
* `on_formula_url`
* `on_formula_sha256`
* `on_formula_license`
* `on_formula_bottle`
  - `on_formula_sha256`
* `on_formula_conflicts_with`
* `on_formula_install`
  - Generic method calls like `on_formula_send`, `on_formula_if`
* `on_formula_test`
  - `on_formula_send` etc.
* `on_formula_class_end`
* `on_formula_source_end`

This traversal happens _once_ for all formula cops combined, with each hook call itself traversing for cops that implement that hook.

The [Formula AST component precendence list](https://github.com/Homebrew/brew/blob/a4545e52315ceedf2deb97ac17d7234708d16e5b/Library/Homebrew/ast_constants.rb) is used to determine which method/block calls have their own hooks. Nodes in the AST that are not on this list are instead sent through generic hooks like `on_formula_send`.

The result is that all formula cops now collectively run single-pass over the formula file. There are some exceptions, most notably the ComponentOrder cop due to its complexity.

Since this required a major refactor of all cops, one other change I did at the same time was remove the `node_equals?` helper function. It was highly inefficient as it parsed Ruby code every time it was run. Instead, calls directly to this were replaced by value and type checks of the AST node. The `parameter_passed?` helper function no longer uses `node_equals?`, and the replacement implementation no longer supports non-basic-literal types, but this was never actually needed in practice.

Using the "extreme case" of a `brew style homebrew/core` run with parallelisation disabled and a clean RuboCops cache, it took six and a half minutes on my machine before this change. Now it takes just under five minutes. This is probably the best we'll get, and will in practice be much faster than that because parallelisation is usually enabled and caches shouldn't be empty on anything beyond the first run. For CI, I also hope to make better use of caching by storing the RuboCop cache in `actions/cache`.

As can happen as a result of a refactor, there are a couple known behavioural changes. I've avoided touching any existing tests, apart from one (minor output change), but there are still some new offences in Homebrew/core. These were not intentional, but on review I felt they were actually behavioural improvements rather than regressions:

* The enforcement for git URLs to have a fixed revision now applies to resources.
* `url :head` style checking for livechecks now properly supports head URLs located inside `head do` blocks.
* A redundant `revision 0` is now checked.