### PR TITLE
Allow casks with outdated caskfiles to be reinstalled

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -155,7 +155,11 @@ module Cask
 
       # use the same cask file that was used for installation, if possible
       installed_caskfile = @cask.installed_caskfile
-      installed_cask = installed_caskfile.exist? ? CaskLoader.load(installed_caskfile) : @cask
+      installed_cask = begin
+        installed_caskfile.exist? ? CaskLoader.load(installed_caskfile) : @cask
+      rescue CaskInvalidError # could be thrown by call to CaskLoader#load with outdated caskfile
+        @cask # default
+      end
 
       # Always force uninstallation, ignore method parameter
       cask_installer = Installer.new(installed_cask, verbose: verbose?, force: true, upgrade: upgrade?)

--- a/Library/Homebrew/test/cask/cask_loader/from__path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from__path_loader_spec.rb
@@ -34,5 +34,14 @@ describe Cask::CaskLoader::FromPathLoader do
         }.to raise_error(Cask::CaskUnreadableError, /undefined local variable or method/)
       end
     end
+
+    context "when the file contains an outdated cask" do
+      it "raises an error" do
+        expect {
+          described_class.new(cask_path("invalid/invalid-depends-on-macos-bad-release")).load(config: nil)
+        }.to raise_error(Cask::CaskInvalidError,
+                         /invalid 'depends_on macos' value: unknown or unsupported macOS version:/)
+      end
+    end
   end
 end

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -251,4 +251,20 @@ describe Cask::Installer, :cask do
       expect(Cask::Caskroom.path.join("local-caffeine")).not_to be_a_directory
     end
   end
+
+  describe "uninstall_existing_cask" do
+    it "uninstalls when cask file is outdated" do
+      caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      described_class.new(caffeine).install
+
+      expect(Cask::CaskLoader.load(cask_path("local-caffeine"))).to be_installed
+
+      expect(caffeine).to receive(:installed?).once.and_return(true)
+      outdate_caskfile = cask_path("invalid/invalid-depends-on-macos-bad-release")
+      expect(caffeine).to receive(:installed_caskfile).once.and_return(outdate_caskfile)
+      described_class.new(caffeine).uninstall_existing_cask
+
+      expect(Cask::CaskLoader.load(cask_path("local-caffeine"))).not_to be_installed
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The problem occurred when calling `brew reinstall` on a cask with an out of date caskfile as described in issue #10833.

To solve the problem `Cask::Installer#uninstall_existing_cask` has been changed to catch a possible `CaskInvalidError` when trying to load outdated caskfiles using `Cask::CaskLoader#load`.

Fixes #10833.