### PR TITLE
`parse_curl_response`: Handle duplicate headers

### DIFF
--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -4,6 +4,115 @@
 require "utils/curl"
 
 describe "Utils::Curl" do
+  let(:details) {
+    details = {
+      normal:     {},
+      cloudflare: {},
+      incapsula:  {},
+    }
+
+    details[:normal][:no_cookie] = {
+      url:            "https://www.example.com/",
+      final_url:      nil,
+      status:         "403",
+      headers:        {
+        "age"            => "123456",
+        "cache-control"  => "max-age=604800",
+        "content-type"   => "text/html; charset=UTF-8",
+        "date"           => "Wed, 1 Jan 2020 01:23:45 GMT",
+        "etag"           => "\"3147526947+ident\"",
+        "expires"        => "Wed, 31 Jan 2020 01:23:45 GMT",
+        "last-modified"  => "Wed, 1 Jan 2020 00:00:00 GMT",
+        "server"         => "ECS (dcb/7EA2)",
+        "vary"           => "Accept-Encoding",
+        "x-cache"        => "HIT",
+        "content-length" => "3",
+      },
+      etag:           "3147526947+ident",
+      content_length: "3",
+      file:           "...",
+      file_hash:      nil,
+    }
+
+    details[:normal][:ok] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:normal][:ok][:status] = "200"
+
+    details[:normal][:single_cookie] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:normal][:single_cookie][:headers]["set-cookie"] = "a_cookie=for_testing"
+
+    details[:normal][:multiple_cookies] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:normal][:multiple_cookies][:headers]["set-cookie"] = [
+      "first_cookie=for_testing",
+      "last_cookie=also_for_testing",
+    ]
+
+    details[:normal][:blank_headers] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:normal][:blank_headers][:headers] = {}
+
+    details[:cloudflare][:single_cookie] = {
+      url:            "https://www.example.com/",
+      final_url:      nil,
+      status:         "403",
+      headers:        {
+        "date"            => "Wed, 1 Jan 2020 01:23:45 GMT",
+        "content-type"    => "text/plain; charset=UTF-8",
+        "content-length"  => "16",
+        "x-frame-options" => "SAMEORIGIN",
+        "referrer-policy" => "same-origin",
+        "cache-control"   => "private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0",
+        "expires"         => "Thu, 01 Jan 1970 00:00:01 GMT",
+        "expect-ct"       => "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "set-cookie"      => "__cf_bm=0123456789abcdef; path=/; expires=Wed, 31-Jan-20 01:23:45 GMT;" \
+                             " domain=www.example.com; HttpOnly; Secure; SameSite=None",
+        "server"          => "cloudflare",
+        "cf-ray"          => "0123456789abcdef-IAD",
+        "alt-svc"         => "h3=\":443\"; ma=86400, h3-29=\":443\"; ma=86400",
+      },
+      etag:           nil,
+      content_length: "16",
+      file:           "error code: 1020",
+      file_hash:      nil,
+    }
+
+    details[:cloudflare][:multiple_cookies] = Marshal.load(Marshal.dump(details[:cloudflare][:single_cookie]))
+    details[:cloudflare][:multiple_cookies][:headers]["set-cookie"] = [
+      "first_cookie=for_testing",
+      "__cf_bm=abcdef0123456789; path=/; expires=Thu, 28-Apr-22 18:38:40 GMT; domain=www.example.com; HttpOnly;" \
+      " Secure; SameSite=None",
+      "last_cookie=also_for_testing",
+    ]
+
+    details[:cloudflare][:no_server] = Marshal.load(Marshal.dump(details[:cloudflare][:single_cookie]))
+    details[:cloudflare][:no_server][:headers].delete("server")
+
+    details[:cloudflare][:wrong_server] = Marshal.load(Marshal.dump(details[:cloudflare][:single_cookie]))
+    details[:cloudflare][:wrong_server][:headers]["server"] = "nginx 1.2.3"
+
+    # TODO: Make the Incapsula test data more realistic once we can find an
+    # example website to reference.
+    details[:incapsula][:single_cookie_visid_incap] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:incapsula][:single_cookie_visid_incap][:headers]["set-cookie"] = "visid_incap_something=something"
+
+    details[:incapsula][:single_cookie_incap_ses] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:incapsula][:single_cookie_incap_ses][:headers]["set-cookie"] = "incap_ses_something=something"
+
+    details[:incapsula][:multiple_cookies_visid_incap] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:incapsula][:multiple_cookies_visid_incap][:headers]["set-cookie"] = [
+      "first_cookie=for_testing",
+      "visid_incap_something=something",
+      "last_cookie=also_for_testing",
+    ]
+
+    details[:incapsula][:multiple_cookies_incap_ses] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
+    details[:incapsula][:multiple_cookies_incap_ses][:headers]["set-cookie"] = [
+      "first_cookie=for_testing",
+      "incap_ses_something=something",
+      "last_cookie=also_for_testing",
+    ]
+
+    details
+  }
+
   let(:location_urls) {
     %w[
       https://example.com/example/
@@ -291,6 +400,46 @@ describe "Utils::Curl" do
       expect(curl_args(*args, show_output: nil).join(" ")).to include("--fail")
       expect(curl_args(*args).join(" ")).to include("--fail")
       expect(curl_args(*args, show_output: true).join(" ")).not_to include("--fail")
+    end
+  end
+
+  describe "url_protected_by_cloudflare?" do
+    it "returns `true` when a URL is protected by Cloudflare" do
+      expect(url_protected_by_cloudflare?(details[:cloudflare][:single_cookie])).to be(true)
+      expect(url_protected_by_cloudflare?(details[:cloudflare][:multiple_cookies])).to be(true)
+    end
+
+    it "returns `false` when a URL is not protected by Cloudflare" do
+      expect(url_protected_by_cloudflare?(details[:cloudflare][:no_server])).to be(false)
+      expect(url_protected_by_cloudflare?(details[:cloudflare][:wrong_server])).to be(false)
+      expect(url_protected_by_cloudflare?(details[:normal][:no_cookie])).to be(false)
+      expect(url_protected_by_cloudflare?(details[:normal][:ok])).to be(false)
+      expect(url_protected_by_cloudflare?(details[:normal][:single_cookie])).to be(false)
+      expect(url_protected_by_cloudflare?(details[:normal][:multiple_cookies])).to be(false)
+    end
+
+    it "returns `false` when response headers are blank" do
+      expect(url_protected_by_cloudflare?(details[:normal][:blank_headers])).to be(false)
+    end
+  end
+
+  describe "url_protected_by_incapsula?" do
+    it "returns `true` when a URL is protected by Cloudflare" do
+      expect(url_protected_by_incapsula?(details[:incapsula][:single_cookie_visid_incap])).to be(true)
+      expect(url_protected_by_incapsula?(details[:incapsula][:single_cookie_incap_ses])).to be(true)
+      expect(url_protected_by_incapsula?(details[:incapsula][:multiple_cookies_visid_incap])).to be(true)
+      expect(url_protected_by_incapsula?(details[:incapsula][:multiple_cookies_incap_ses])).to be(true)
+    end
+
+    it "returns `false` when a URL is not protected by Incapsula" do
+      expect(url_protected_by_incapsula?(details[:normal][:no_cookie])).to be(false)
+      expect(url_protected_by_incapsula?(details[:normal][:ok])).to be(false)
+      expect(url_protected_by_incapsula?(details[:normal][:single_cookie])).to be(false)
+      expect(url_protected_by_incapsula?(details[:normal][:multiple_cookies])).to be(false)
+    end
+
+    it "returns `false` when response headers are blank" do
+      expect(url_protected_by_incapsula?(details[:normal][:blank_headers])).to be(false)
     end
   end
 

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -112,6 +112,24 @@ describe "Utils::Curl" do
       },
     }
 
+    response_hash[:duplicate_header] = {
+      status_code: "200",
+      status_text: "OK",
+      headers:     {
+        "cache-control"  => "max-age=604800",
+        "content-type"   => "text/html; charset=UTF-8",
+        "date"           => "Wed, 1 Jan 2020 01:23:45 GMT",
+        "expires"        => "Wed, 31 Jan 2020 01:23:45 GMT",
+        "last-modified"  => "Thu, 1 Jan 2019 01:23:45 GMT",
+        "content-length" => "123",
+        "set-cookie"     => [
+          "example1=first",
+          "example2=second; Expires Wed, 31 Jan 2020 01:23:45 GMT",
+          "example3=third",
+        ],
+      },
+    }
+
     response_hash
   }
 
@@ -143,6 +161,13 @@ describe "Utils::Curl" do
       #{response_text[:redirection]}
       #{response_text[:ok]}
     EOS
+
+    response_text[:duplicate_header] = response_text[:ok].sub(
+      /\r\n\Z/,
+      "Set-Cookie: #{response_hash[:duplicate_header][:headers]["set-cookie"][0]}\r\n" \
+      "Set-Cookie: #{response_hash[:duplicate_header][:headers]["set-cookie"][1]}\r\n" \
+      "Set-Cookie: #{response_hash[:duplicate_header][:headers]["set-cookie"][2]}\r\n\r\n",
+    )
 
     response_text
   }
@@ -312,6 +337,7 @@ describe "Utils::Curl" do
     it "returns a correct hash when given HTTP response text" do
       expect(parse_curl_response(response_text[:ok])).to eq(response_hash[:ok])
       expect(parse_curl_response(response_text[:redirection])).to eq(response_hash[:redirection])
+      expect(parse_curl_response(response_text[:duplicate_header])).to eq(response_hash[:duplicate_header])
     end
 
     it "returns an empty hash when given an empty string" do

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -484,10 +484,25 @@ module Utils
       response_text = response_text.sub(%r{^HTTP/.* (\d+).*$\s*}, "")
 
       # Create a hash from the header lines
-      response[:headers] =
-        response_text.split("\r\n")
-                     .to_h { |header| header.split(/:\s*/, 2) }
-                     .transform_keys(&:downcase)
+      response[:headers] = {}
+      response_text.split("\r\n").each do |line|
+        header_name, header_value = line.split(/:\s*/, 2)
+        next if header_name.blank?
+
+        header_name = header_name.strip.downcase
+        header_value&.strip!
+
+        case response[:headers][header_name]
+        when nil
+          response[:headers][header_name] = header_value
+        when String
+          response[:headers][header_name] = [response[:headers][header_name], header_value]
+        when Array
+          response[:headers][header_name].push(header_value)
+        end
+
+        response[:headers][header_name]
+      end
 
       response
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Before `#parse_curl_output` was introduced and related methods were updated to use it, `#url_protected_by_cloudflare?` and `#url_protected_by_incapsula?` were checking a string of all the headers from a response and using a regex to check related header values.

However, when `#curl_http_content_headers_and_checksum` was updated to use `#parse_curl_output` internally, the `:headers` value became a hash generated by `#parse_curl_response`. The `#url_protected_by_*` methods were updated in #13198 to work with the hash value but this wasn't able to fully replicate the previous behavior because `#parse_curl_response` was only keeping the last instance of a given header (maintaining pre-existing behavior). This is an issue for these methods because they check `Set-Cookie` headers and there can be multiple instances of this header in a response.

`#parse_curl_response` only keeps the last instance of a given header (following pre-existing parsing behavior), so the `#url_protected_by_*` methods went from checking all headers to only checking the last instance of a header. This is an issue for these methods because they check `Set-Cookie` headers and there can be multiple instances of this header in a response.

This PR updates `#parse_curl_response` to collect the values of headers that appear more than once into an array (otherwise continuing to use a string value if there's only one instance of a given header in a response). Going forward, we'll have to be careful to check a header's type when we know a given header can appear more than once. With headers that should only appear once, we can continue to assume the value will be a string when present.

With that change in place, this updates the `#url_protected_by_*` methods to handle an array of strings in addition to the existing string support. This change ensures that these methods properly check all `Set-Cookie` headers, effectively reinstating the previous behavior.

Lastly, this updates one of the early return values in `#url_protected_by_cloudflare?` to be `false` instead of an implicit `nil`. After adding a type signature to this method, it became clear that it wasn't always returning a boolean value and this fixes it.

-----

Past that, I've added docs comments, type signatures, and tests for the `#url_protected_by_*` methods. The Incapsula tests are currently contrived (i.e., not necessarily representative of a real response) because I couldn't find a website that would trigger the Incapsula/Imperva protection response. I used to encounter this in the wild somewhat regularly when running an automated browser (e.g., using `chromedriver` and `geckodriver`) through a commercial VPN but I haven't seen it for a while.

I tried parts of corsair.com (referencing the existing comment before the method) but didn't have any luck (again, using an automated browser behind a VPN to try to look more suspicious). If anyone knows of a website that uses Incapsula/Imperva and can trigger the protection under certain circumstances, let me know and I'll update the tests. Otherwise, I left a `TODO` comment and we can revisit this if/when we encounter a working example in the future.