### PR TITLE
superenv: prioritize dependencies' `opt_lib` in Linux rpath

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -40,8 +40,8 @@ module Superenv
   def determine_rpath_paths(formula)
     PATH.new(
       *formula&.lib,
-      "#{HOMEBREW_PREFIX}/lib",
       PATH.new(run_time_deps.map { |dep| dep.opt_lib.to_s }).existing,
+      "#{HOMEBREW_PREFIX}/lib",
     )
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

From discussion in Homebrew/homebrew-core#99630 to avoid issues when trying to prioritize keg_only linkage for "drop-in" libraries (e.g. `libpq`, `luajit-openresty`, `jpeg-turbo`, ...)

Didn't see anyone open PR for it yet. Can discuss further if there are any odd scenarios to consider.

Will still require new bottles to update problematic RPATHs.