### PR TITLE
Stop filtering formulae with unchanged versions from the update report

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -362,27 +362,7 @@ class Reporter
         new_tap = tap.tap_migrations[name]
         @report[status.to_sym] << full_name unless new_tap
       when "M"
-        name = tap.formula_file_to_name(src)
-
-        # Skip reporting updated formulae to speed up automatic updates.
-        if preinstall
-          @report[:M] << name
-          next
-        end
-
-        begin
-          formula = Formulary.factory(tap.path/src)
-          new_version = formula.pkg_version
-          old_version = FormulaVersions.new(formula).formula_at_revision(@initial_revision, &:pkg_version)
-          next if new_version == old_version
-        rescue FormulaUnavailableError
-          # Don't care if the formula isn't available right now.
-          nil
-        rescue Exception => e # rubocop:disable Lint/RescueException
-          onoe "#{e.message}\n#{e.backtrace.join "\n"}" if Homebrew::EnvConfig.developer?
-        end
-
-        @report[:M] << name
+        @report[:M] << tap.formula_file_to_name(src)
       when /^R\d{0,3}/
         src_full_name = tap.formula_file_to_name(src)
         dst_full_name = tap.formula_file_to_name(dst)


### PR DESCRIPTION
`brew update` fast-forwards each tap from one commit to another. `update-report` lists all the formulae that were modified in that commit range. The clause this commit removes was filtering out modified formulae _whose `pkg_version` had not changed._

The outcome of this filtering:

- If you rewind homebrew/core **2,000 commits** (or 2 weeks), **819** formulae were modified. This clause would have taken **29.0 seconds** to filter out **153** (18.7%) of them.

- If you rewind homebrew/core **20,000 commits** (or 5 months), 3532 formulae were modified. This clause would have taken **119.4 seconds** to filter out **1121** (31.7%) of them.

### Data
| Homebrew Branch | Command | Commits Rewound | Time Elapsed | Updated Formulae |
| --- | --- | --- | --- | --- |
| `master` | `git -C "$(brew --repo homebrew/core)" reset --hard aa1b3d5df78; time sh -c "brew update &> output-2k.txt"` | 2,000 | 35.6s | 666 |
| `master` | `git -C "$(brew --repo homebrew/core)" reset --hard 11e6919661c; time sh -c "brew update &> output-20k.txt"` | 20,000 | 129.8s | 2411 |
| _this one_ | `git -C "$(brew --repo homebrew/core)" reset --hard aa1b3d5df78; time sh -c "brew update &> output-2k.txt"` | 2,000 | 6.6s | 819 |
| _this one_ | `git -C "$(brew --repo homebrew/core)" reset --hard 11e6919661c; time sh -c "brew update &> output-20k.txt"` | 20,000 | 10.4s | 3532 |

### Root Cause
This operation was so expensive because it shelled out to `git cat-file` for each formula that had been touched in the commit window.

Fixes #13224

### Alternatives

- https://github.com/Homebrew/brew/pull/13244

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
