### PR TITLE
Add `--no-force-auto-update` option to `brew tap`

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -311,6 +311,9 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def print_path?; end
+
+      sig { returns(T.nilable(T::Boolean)) }
+      def force_auto_update?; end
     end
   end
 end

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -34,7 +34,7 @@ module Homebrew
       switch "--shallow",
              description: "Fetch tap as a shallow clone rather than a full clone. Useful for continuous integration.",
              replacement: false
-      switch "--force-auto-update",
+      switch "--[no-]force-auto-update",
              description: "Auto-update tap even if it is not hosted on GitHub. By default, only taps "\
                           "hosted on GitHub are auto-updated (for performance reasons)."
       switch "--custom-remote",
@@ -63,7 +63,7 @@ module Homebrew
       tap = Tap.fetch(args.named.first)
       begin
         tap.install clone_target:      args.named.second,
-                    force_auto_update: force_auto_update?(args: args),
+                    force_auto_update: args.force_auto_update?,
                     custom_remote:     args.custom_remote?,
                     quiet:             args.quiet?
       rescue TapRemoteMismatchError, TapNoCustomRemoteError => e
@@ -72,10 +72,5 @@ module Homebrew
         nil
       end
     end
-  end
-
-  def force_auto_update?(args:)
-    # if no relevant flag is present, return nil, meaning "no change"
-    true if args.force_auto_update?
   end
 end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -276,7 +276,11 @@ class Tap
       end
 
       unless force_auto_update.nil?
-        config["forceautoupdate"] = force_auto_update
+        if force_auto_update
+          config["forceautoupdate"] = force_auto_update
+        elsif config["forceautoupdate"] == "true"
+          config.delete("forceautoupdate")
+        end
         return
       end
 
@@ -931,6 +935,13 @@ class TapConfig
     return unless Utils::Git.available?
 
     Homebrew::Settings.write key, value.to_s, repo: tap.path
+  end
+
+  def delete(key)
+    return unless tap.git?
+    return unless Utils::Git.available?
+
+    Homebrew::Settings.delete key, repo: tap.path
   end
 end
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -337,7 +337,7 @@ describe Tap do
       it "disables forced auto-updates when false" do
         expect(already_tapped_tap).to be_installed
         already_tapped_tap.install force_auto_update: false
-        expect(already_tapped_tap.config["forceautoupdate"]).to eq("false")
+        expect(already_tapped_tap.config["forceautoupdate"]).to be_nil
       end
     end
 
@@ -453,7 +453,7 @@ describe Tap do
     expect(homebrew_foo_tap.config["foo"]).to be_nil
     homebrew_foo_tap.config["foo"] = "bar"
     expect(homebrew_foo_tap.config["foo"]).to eq("bar")
-    homebrew_foo_tap.config["foo"] = nil
+    homebrew_foo_tap.config.delete("foo")
     expect(homebrew_foo_tap.config["foo"]).to be_nil
   end
 


### PR DESCRIPTION
Enable this option to delete `homebrew.forceautoupdate` git config option

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Unlike what the issue described, using `--force-auto-update` will add the `homebrew.forceautoupdate` git config option for a installed tap, so I only add a new option to delete this value.

Resolves #13246
