### PR TITLE
Also skip filtering null modifications when `--quiet` is passed to `brew update`

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -182,7 +182,7 @@ module Homebrew
       end
       if reporter.updated?
         updated_taps << tap.name
-        hub.add(reporter, only_show_upgraded_modified_formulae: !args.preinstall?)
+        hub.add(reporter, only_show_upgraded_modified_formulae: !args.preinstall? && !args.quiet?)
       end
     end
 


### PR DESCRIPTION
(We're already skipping this when `--preinstall` is passed)

This change is orthogonal to (not instead of) optimizing this filtering logic (See #13244, #13243 discussion)

----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
