### PR TITLE
Don't print Cask installed error message when `--quiet` is used

### DIFF
--- a/Library/Homebrew/cask/cmd/install.rb
+++ b/Library/Homebrew/cask/cmd/install.rb
@@ -67,6 +67,7 @@ module Cask
           skip_cask_deps: skip_cask_deps,
           require_sha:    require_sha,
           quarantine:     quarantine,
+          quiet:          quiet,
           zap:            zap,
         }.compact
 

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -216,6 +216,13 @@ describe Cask::Installer, :cask do
       m_subdir = caffeine.metadata_subdir(subdir_name, timestamp: :now, create: true)
       expect(caffeine.metadata_subdir(subdir_name, timestamp: :latest)).to eq(m_subdir)
     end
+
+    it "don't print cask installed message with --quiet option" do
+      caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
+      expect {
+        described_class.new(caffeine, quiet: true).install
+      }.to output(nil).to_stdout
+    end
   end
 
   describe "uninstall" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix #13265