### PR TITLE
Only upgrade :latest casks when --greedy and the cask has been updated

### DIFF
--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -131,15 +131,17 @@ describe Cask::Cask, :cask do
     describe ":latest casks" do
       let(:cask) { described_class.new("basic-cask") }
 
-      shared_examples ":latest cask" do |greedy, tap_version, expectations|
+      shared_examples ":latest cask" do |greedy, outdated_sha, tap_version, expectations|
         expectations.each do |installed_version, expected_output|
           context "when versions #{installed_version} are installed and the " \
-                  "tap version is #{tap_version}, #{"not" unless greedy} greedy" do
+                  "tap version is #{tap_version}, #{"not " unless greedy}greedy" \
+                  "and sha is #{"not " unless outdated_sha}outdated" do
             subject { cask.outdated_versions(greedy: greedy) }
 
             it {
               allow(cask).to receive(:versions).and_return(installed_version)
               allow(cask).to receive(:version).and_return(Cask::DSL::Version.new(tap_version))
+              allow(cask).to receive(:outdated_download_sha?).and_return(outdated_sha)
               expect(cask).to receive(:outdated_versions).and_call_original
               expect(subject).to eq expected_output
             }
@@ -148,23 +150,29 @@ describe Cask::Cask, :cask do
       end
 
       describe ":latest version installed, :latest version in tap" do
-        include_examples ":latest cask", false, "latest",
+        include_examples ":latest cask", false, false, "latest",
                          ["latest"] => []
-        include_examples ":latest cask", true, "latest",
+        include_examples ":latest cask", true, false, "latest",
+                         ["latest"] => []
+        include_examples ":latest cask", true, true, "latest",
                          ["latest"] => ["latest"]
       end
 
       describe "numbered version installed, :latest version in tap" do
-        include_examples ":latest cask", false, "latest",
+        include_examples ":latest cask", false, false, "latest",
                          ["1.2.3"] => ["1.2.3"]
-        include_examples ":latest cask", true, "latest",
+        include_examples ":latest cask", true, false, "latest",
+                         ["1.2.3"] => []
+        include_examples ":latest cask", true, true, "latest",
                          ["1.2.3"] => ["1.2.3"]
       end
 
       describe "latest version installed, numbered version in tap" do
-        include_examples ":latest cask", false, "1.2.3",
+        include_examples ":latest cask", false, false, "1.2.3",
                          ["latest"] => ["latest"]
-        include_examples ":latest cask", true, "1.2.3",
+        include_examples ":latest cask", true, false, "1.2.3",
+                         ["latest"] => ["latest"]
+        include_examples ":latest cask", true, true, "1.2.3",
                          ["latest"] => ["latest"]
       end
     end

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -223,6 +223,22 @@ describe Cask::Installer, :cask do
         described_class.new(caffeine, quiet: true).install
       }.to output(nil).to_stdout
     end
+
+    it "does NOT generate LATEST_DOWNLOAD_SHA256 file for installed Cask without version :latest" do
+      caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
+
+      described_class.new(caffeine).install
+
+      expect(caffeine.download_sha_path).not_to be_a_file
+    end
+
+    it "generates and finds LATEST_DOWNLOAD_SHA256 file for installed Cask with version :latest" do
+      latest_cask = Cask::CaskLoader.load(cask_path("version-latest"))
+
+      described_class.new(latest_cask).install
+
+      expect(latest_cask.download_sha_path).to be_a_file
+    end
   end
 
   describe "uninstall" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR is related to issue #11513 where `version :latest` casks would always be reinstalled when the `--greedy` or `--greed-latest` flags were passed to `brew upgrade` regardless of whether or not the casks had been updated.

Basically the idea is to store a sha256 hash of the original download file every time a `version :latest` cask is installed. Then, before upgrading casks `cask#outdated?` is queried which internally compares the new and old sha of `version :latest` casks to see if they should be updated. As far as I can see, the first download used to check the sha should be cached so it shouldn't need to be downloaded again before installing it.

The sha is stored in a file called `LATEST_DOWNLOAD_SHA256` in the `.metadata/` cask subdirectory. If there is no previous sha stored, it just automatically assumes the cask should be updated.

Fixes #11513.