### PR TITLE
Run git gc on docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,7 @@ jobs:
           echo "Building for Homebrew ${brew_version}"
           docker build -t brew \
                --build-arg=version=${{matrix.version}} \
+               --build-arg=homebrew_git_gc=true \
                --label org.opencontainers.image.created="$(date --rfc-3339=seconds --utc)" \
                --label org.opencontainers.image.url="https://brew.sh" \
                --label org.opencontainers.image.documentation="https://docs.brew.sh" \
@@ -44,6 +45,10 @@ jobs:
                --label org.opencontainers.image.vendor="${GITHUB_REPOSITORY_OWNER}" \
                --label org.opencontainers.image.licenses="BSD-2-Clause" \
                .
+
+      - name: Get image size
+        run: |
+          docker container ls -s
 
       - name: Run brew test-bot --only-setup
         run: docker run --rm brew brew test-bot --only-setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 WORKDIR /home/linuxbrew
 
+ARG homebrew_git_gc="false"
+
+# shellcheck disable=SC2154
 RUN mkdir -p \
      .linuxbrew/bin \
      .linuxbrew/etc \
@@ -56,6 +59,8 @@ RUN mkdir -p \
   && HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
   && brew install-bundler-gems \
   && brew cleanup \
+  && { [[ "${homebrew_git_gc}" = "true" ]] && git -C .linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core gc --aggressive; true; } \
   && { git -C .linuxbrew/Homebrew config --unset gc.auto; true; } \
   && { git -C .linuxbrew/Homebrew config --unset homebrew.devcmdrun; true; } \
-  && rm -rf .cache
+  && rm -rf .cache \
+  && du -hs .linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/.git/


### PR DESCRIPTION
The current `ghcr.io/homebrew/ubuntu16.04:master` image's size is dominated by this layer, accounting for nearly 700mb of the total image size: https://github.com/Homebrew/brew/blob/c20b3ab91381aca5fdfda54374fc0390cc09dd51/Dockerfile#L43-L61

Of that 700mb, ~530mb comes from the homebrew-core `.git` directory:

<img width="595" alt="Screenshot 2022-05-15 at 23 38 28" src="https://user-images.githubusercontent.com/1027207/168496880-e9032be7-551a-4e04-9ed4-f82630e947f8.png">

By running `git gc --aggressive` on the image, we can reduce the size of the `.git` directory down to about ~280. This process takes a while, but because this image is used so heavily in the homebrew-core repo and almost always results in a fresh pull, it seems like saving over 250mb per pull would be a good idea.
 
```
linuxbrew@abfa6a1649c2:~/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core$ git -C ~/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core gc --aggressive
Enumerating objects: 1191812, done.
Counting objects: 100% (1191812/1191812), done.
Delta compression using up to 4 threads
Compressing objects: 100% (1188677/1188677), done.
Writing objects: 100% (1191812/1191812), done.
Total 1191812 (delta 839015), reused 340497 (delta 0), pack-reused 0
Expanding reachable commits in commit graph: 290762, done.
Writing out commit graph in 4 passes: 100% (1163048/1163048), done.

linuxbrew@abfa6a1649c2:~/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core$ du -hs .git
287M	.git
```