### PR TITLE
Remove bad submatch and update docs

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -459,7 +459,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     return @resolved_info_cache[url] if @resolved_info_cache.include?(url)
 
     if (domain = Homebrew::EnvConfig.artifact_domain)
-      url = url.sub(%r{^(https?://#{GitHubPackages::URL_DOMAIN}/)?}o, "#{domain.chomp("/")}/")
+      url = url.sub(%r{^https?://#{GitHubPackages::URL_DOMAIN}/?}o, "#{domain.chomp("/")}/")
     end
 
     output, _, _status = curl_output(

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -22,8 +22,8 @@ module Homebrew
       HOMEBREW_ARTIFACT_DOMAIN:                  {
         description: "Replace GitHub Packages URL to enable use of a private image registry for formulae. " \
                      "For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a " \
-                     "formula with the URL `https://ghcr.io/v2/homebrew/core/foo/manifests/1.0` to instead download from " \
-                     "`http://localhost:8080/v2/homebrew/core/foo/manifests/1.0`.",
+                     "formula with the URL `https://ghcr.io/v2/homebrew/core/foo/manifests/1.0` " \
+                     "to instead download from `http://localhost:8080/v2/homebrew/core/foo/manifests/1.0`.",
       },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
         description: "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -20,10 +20,10 @@ module Homebrew
         default:     "native",
       },
       HOMEBREW_ARTIFACT_DOMAIN:                  {
-        description: "Prefix all download URLs, including those for bottles, with this value. " \
+        description: "Replace GitHub Packages URL to enable use of a private image registry for formulae. " \
                      "For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a " \
-                     "formula with the URL `https://example.com/foo.tar.gz` to instead download from " \
-                     "`http://localhost:8080/example.com/foo.tar.gz`.",
+                     "formula with the URL `https://ghcr.io/v2/homebrew/core/foo/manifests/1.0` to instead download from " \
+                     "`http://localhost:8080/v2/homebrew/core/foo/manifests/1.0`.",
       },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
         description: "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related to #13226 where the Cask download URL was being modified when using HOMEBREW_ARTIFACT_DOMAIN.  Small change to regex in the GitHubPackages::URL_DOMAIN where an extra set of parens created a match on https and not just on the content of the URL_DOMAIN const.  This resulted in prefixing of Cask download URLs in a fashion that was unlikely to be supported on most proxies and couldn't be supported on Package mirrors (e.g JFrog Artifactory).  This adjusts the regex to remove the extra submatch so that use of the HOMEBREW_ARTIFACT_DOMAIN envvar will only replace the content of the const and not match the "https" token.
