### PR TITLE
Use sorbet-static-and-runtime gem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,4 @@ updates:
       interval: daily
     allow:
       - dependency-type: all
-    ignore:
-      - dependency-name: sorbet-runtime
     versioning-strategy: lockfile-only

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -44,25 +44,13 @@ jobs:
 
           branch="$(git branch --show-current)"
           echo "::set-output name=branch::${branch}"
-
-          gem_name="$(echo "${branch}" | sed -E 's|.*/||;s|(.*)-.*$|\1|')"
-          echo "::set-output name=gem_name::${gem_name}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Vendor Gems
         env:
-          GEM_NAME: ${{ steps.checkout.outputs.gem_name }}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-        run: |
-          set -u
-
-          if [[ "${GEM_NAME}" == 'sorbet' ]]
-          then
-            brew vendor-gems --update sorbet,sorbet-runtime
-          else
-            brew vendor-gems
-          fi
+        run: brew vendor-gems
 
       - name: Update RBI files
         env:

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -27,8 +27,7 @@ gem "warning", require: false
 group :sorbet, optional: true do
   gem "parlour", require: false
   gem "rspec-sorbet", require: false
-  gem "sorbet", require: false
-  gem "sorbet-runtime", require: false
+  gem "sorbet-static-and-runtime", require: false
   gem "tapioca", require: false
 end
 

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -162,6 +162,9 @@ GEM
     sorbet-runtime (0.5.10010)
     sorbet-runtime-stub (0.2.0)
     sorbet-static (0.5.10010-universal-darwin-14)
+    sorbet-static-and-runtime (0.5.10010)
+      sorbet (= 0.5.10010)
+      sorbet-runtime (= 0.5.10010)
     spoom (1.1.11)
       sorbet (>= 0.5.9204)
       sorbet-runtime (>= 0.5.9204)
@@ -229,9 +232,8 @@ DEPENDENCIES
   ruby-macho
   simplecov
   simplecov-cobertura
-  sorbet
-  sorbet-runtime
   sorbet-runtime-stub
+  sorbet-static-and-runtime
   tapioca
   warning
 

--- a/Library/Homebrew/vendor/bundle/bundler/setup.rb
+++ b/Library/Homebrew/vendor/bundle/bundler/setup.rb
@@ -97,6 +97,7 @@ $:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/simplecov-cobertura-2
 $:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/sorbet-static-0.5.10010-universal-darwin-14/lib"
 $:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/sorbet-0.5.10010/lib"
 $:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/sorbet-runtime-stub-0.2.0/lib"
+$:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/sorbet-static-and-runtime-0.5.10010/lib"
 $:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/thor-1.2.1/lib"
 $:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/spoom-1.1.11/lib"
 $:.unshift "#{path}/../#{ruby_engine}/#{ruby_version}/gems/yard-0.9.27/lib"


### PR DESCRIPTION
This links `sorbet-static` with `sorbet-runtime`, creating an equality constraint that should allow Dependabot to update both at the same time without the special handling we do.

The gem itself is otherwise empty and contains nothing.
