### PR TITLE
Livecheck: Use Homebrew curl based on root domain

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 # * nokogiri - use rexml instead for XML parsing
 
 # installed gems (should all be require: false)
+gem "addressable", require: false
 gem "bootsnap", require: false
 gem "byebug", require: false
 gem "json_schemer", require: false

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -201,6 +201,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (< 7)
+  addressable
   bootsnap
   byebug
   concurrent-ruby


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

At the moment, `#use_homebrew_curl?` can only be true for a `homepage` or `stable`/cask `url` with `using: :homebrew_curl`. If the checked URL differs from these URLs, livecheck won't use brewed curl. This limitation prevents livecheck from using brewed curl for a `livecheck` block URL that's a string literal (not a symbol for a `#checkable_url` like `:stable`, `:head`, `:url`). `libzip` was the original formula referenced in the related brew issue and it meets this criterion, so it doesn't appear to be handled by the existing `#use_homebrew_curl?` implementation.

Additionally, the existing behavior can cause livecheck to unnecessarily use brewed curl for a completely different website (e.g., `cubelib`, `otf2`). For example, if the `stable` URL has `using: :homebrew_curl` and the `livecheck` block has `url :homepage`, livecheck will use brewed curl when checking the `homepage`. If these are completely different domains/servers, it's unlikely that we would need to use brewed curl when checking the `homepage`, so this particular behavior may not be beneficial.

This commit reimplements `use_homebrew_curl?` to apply brewed curl when the checked URL's root domain is the same as the root domain of an aforementioned formula/cask URL with `using: :homebrew_curl`. For example, this looser approach would allow a `livecheck` block checking `https://www.example.com/downloads/` to use brewed curl if the `stable` URL was `https://downloads.example.com/example.zip` with `using: :homebrew_curl`. These could be different servers but, based on related formulae, this looseness is necessary for the moment.

This approach aims to resolve both issues, allowing brewed curl to be applied to a slightly broader range of URLs (i.e., not limited to just the `#checkable_urls`) while also helping to avoid unnecessarily applying brewed curl when it's less likely to be useful (completely different domains). Neither approach is perfect but this one may be more useful in the interim time.

Besides that, this reworks, expands, and reorganizes the related tests a bit. There's still some room for improvement here and I may take another pass at it but I wanted to get this PR up in the interim time, as there's an open PR in homebrew/core that fails CI due to a related `livecheck` situation and it should be resolved by this.

-----

One thing to note is that this implementation uses `addressable` to identify the root domain of a URL. Doing this accurately requires a TLD-aware approach, as some top-level domains use more than one part (e.g., `co.uk`), so we can't simply assume that the last two parts (e.g., `example.com`) are the root domain.

This gem is already in our dependency tree and this simply adds it to our `Gemfile`. There's a feature that I plan to implement eventually where this would also be useful, so I hope using this gem in `brew` is amenable. If not, do let me know of any alternatives, as the implementation relies on being able to identify the root domain (and matching the full host doesn't meet the same needs).

-----

Depending on how this looser approach works in practice, we may want to consider returning to a stricter approach once we have something like `using: :homebrew_curl` in `livecheck` blocks (this is forthcoming). Being explicit in a `livecheck` block is the most reliable approach (i.e., only use brewed curl when needed), so we could favor that and pare down the automated approach to only what's needed to support implicit checks (i.e., with no `livecheck` block). Of course, it's also possible to drop the automated approach entirely and simply require a `livecheck` block in this scenario but we can decide on how to handle this when the time comes.