### PR TITLE
Improve updating behaviour

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -226,13 +226,13 @@ EOS
   fi
 }
 
-# Let user know we're still updating Homebrew if brew update --preinstall
+# Let user know we're still updating Homebrew if brew update --auto-update
 # exceeds 3 seconds.
-update-preinstall-timer() {
+auto-update-timer() {
   sleep 3
   # Outputting a command but don't want to run it, hence single quotes.
   # shellcheck disable=SC2016
-  echo 'Running `brew update --preinstall`...' >&2
+  echo 'Running `brew update --auto-update`...' >&2
   if [[ -z "${HOMEBREW_NO_ENV_HINTS}" && -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
   then
     # shellcheck disable=SC2016
@@ -244,11 +244,11 @@ update-preinstall-timer() {
 
 # These variables are set from various Homebrew scripts.
 # shellcheck disable=SC2154
-update-preinstall() {
+auto-update() {
   [[ -z "${HOMEBREW_HELP}" ]] || return
   [[ -z "${HOMEBREW_NO_AUTO_UPDATE}" ]] || return
   [[ -z "${HOMEBREW_AUTO_UPDATING}" ]] || return
-  [[ -z "${HOMEBREW_UPDATE_PREINSTALL}" ]] || return
+  [[ -z "${HOMEBREW_UPDATE_AUTO}" ]] || return
   [[ -z "${HOMEBREW_AUTO_UPDATE_CHECKED}" ]] || return
 
   # If we've checked for updates, we don't need to check again.
@@ -280,11 +280,11 @@ update-preinstall() {
 
     if [[ -z "${HOMEBREW_VERBOSE}" ]]
     then
-      update-preinstall-timer &
+      auto-update-timer &
       timer_pid=$!
     fi
 
-    brew update --preinstall
+    brew update --auto-update
 
     if [[ -n "${timer_pid}" ]]
     then
@@ -842,7 +842,7 @@ then
   source "${HOMEBREW_BASH_COMMAND}"
 
   {
-    update-preinstall "$@"
+    auto-update "$@"
     "homebrew-${HOMEBREW_COMMAND}" "$@"
     exit $?
   }
@@ -856,7 +856,7 @@ else
   # HOMEBREW_RUBY_PATH set by utils/ruby.sh
   # shellcheck disable=SC2154
   {
-    update-preinstall "$@"
+    auto-update "$@"
     exec "${HOMEBREW_RUBY_PATH}" "${HOMEBREW_RUBY_WARNINGS}" "${RUBY_DISABLE_OPTIONS}" \
       "${HOMEBREW_LIBRARY}/Homebrew/brew.rb" "$@"
   }

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -3,7 +3,7 @@
 #:  Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations.
 #:
 #:        --merge                      Use `git merge` to apply updates (rather than `git rebase`).
-#:        --preinstall                 Run on auto-updates (e.g. before `brew install`). Skips some slower steps.
+#:        --auto-update                Run on auto-updates (e.g. before `brew install`). Skips some slower steps.
 #:    -f, --force                      Always do a slower, full update check (even if unnecessary).
 #:    -q, --quiet                      Make some output more quiet
 #:    -v, --verbose                    Print the directories checked and `git` operations performed.
@@ -337,7 +337,7 @@ homebrew-update() {
       --merge) HOMEBREW_MERGE=1 ;;
       --force) HOMEBREW_UPDATE_FORCE=1 ;;
       --simulate-from-current-branch) HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH=1 ;;
-      --preinstall) export HOMEBREW_UPDATE_PREINSTALL=1 ;;
+      --auto-update) export HOMEBREW_UPDATE_AUTO=1 ;;
       --*) ;;
       -*)
         [[ "${option}" == *v* ]] && HOMEBREW_VERBOSE=1
@@ -547,7 +547,7 @@ EOS
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
     if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
-       [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
+       [[ -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ]]
     then
       continue
@@ -591,7 +591,7 @@ EOS
     (
       UPSTREAM_REPOSITORY_URL="$(git config remote.origin.url)"
 
-      # HOMEBREW_UPDATE_FORCE and HOMEBREW_UPDATE_PREINSTALL aren't modified here so ignore subshell warning.
+      # HOMEBREW_UPDATE_FORCE and HOMEBREW_UPDATE_AUTO aren't modified here so ignore subshell warning.
       # shellcheck disable=SC2030
       if [[ "${UPSTREAM_REPOSITORY_URL}" == "https://github.com/"* ]]
       then
@@ -630,7 +630,7 @@ EOS
         # Touch FETCH_HEAD to confirm we've checked for an update.
         [[ -f "${DIR}/.git/FETCH_HEAD" ]] && touch "${DIR}/.git/FETCH_HEAD"
         [[ -z "${HOMEBREW_UPDATE_FORCE}" ]] && [[ "${UPSTREAM_SHA_HTTP_CODE}" == "304" ]] && exit
-      elif [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]]
+      elif [[ -n "${HOMEBREW_UPDATE_AUTO}" ]]
       then
         FORCE_AUTO_UPDATE="$(git config homebrew.forceautoupdate 2>/dev/null || echo "false")"
         if [[ "${FORCE_AUTO_UPDATE}" != "true" ]]
@@ -650,7 +650,7 @@ EOS
       local tmp_failure_file="${HOMEBREW_REPOSITORY}/.git/TMP_FETCH_FAILURES"
       rm -f "${tmp_failure_file}"
 
-      if [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]]
+      if [[ -n "${HOMEBREW_UPDATE_AUTO}" ]]
       then
         git fetch --tags --force "${QUIET_ARGS[@]}" origin \
           "refs/heads/${UPSTREAM_BRANCH_DIR}:refs/remotes/origin/${UPSTREAM_BRANCH_DIR}" 2>/dev/null
@@ -701,10 +701,10 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    # HOMEBREW_UPDATE_PREINSTALL wasn't modified in subshell.
+    # HOMEBREW_UPDATE_AUTO wasn't modified in subshell.
     # shellcheck disable=SC2031
     if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
-       [[ -n "${HOMEBREW_UPDATE_PREINSTALL}" ]] &&
+       [[ -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ||
           "${DIR}" == "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" ]]
     then
@@ -747,7 +747,7 @@ EOS
 
   safe_cd "${HOMEBREW_REPOSITORY}"
 
-  # HOMEBREW_UPDATE_PREINSTALL wasn't modified in subshell.
+  # HOMEBREW_UPDATE_AUTO wasn't modified in subshell.
   # shellcheck disable=SC2031
   if [[ -n "${HOMEBREW_UPDATED}" ]] ||
      [[ -n "${HOMEBREW_UPDATE_FAILED}" ]] ||
@@ -756,11 +756,11 @@ EOS
      [[ -n "${HOMEBREW_MIGRATE_LINUXBREW_FORMULAE}" ]] ||
      [[ -d "${HOMEBREW_LIBRARY}/LinkedKegs" ]] ||
      [[ ! -f "${HOMEBREW_CACHE}/all_commands_list.txt" ]] ||
-     [[ -n "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_UPDATE_PREINSTALL}" ]]
+     [[ -n "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_UPDATE_AUTO}" ]]
   then
     brew update-report "$@"
     return $?
-  elif [[ -z "${HOMEBREW_UPDATE_PREINSTALL}" && -z "${HOMEBREW_QUIET}" ]]
+  elif [[ -z "${HOMEBREW_UPDATE_AUTO}" && -z "${HOMEBREW_QUIET}" ]]
   then
     echo "Already up-to-date."
   fi

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -11,40 +11,40 @@ module Homebrew
     module_function
 
     ENVS = {
-      HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID:   {
+      HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID:         {
         description: "Additional Google Analytics tracking ID to emit user behaviour analytics to. " \
                      "For more information, see: <https://docs.brew.sh/Analytics>",
       },
-      HOMEBREW_ARCH:                             {
+      HOMEBREW_ARCH:                                   {
         description: "Linux only: Pass this value to a type name representing the compiler's `-march` option.",
         default:     "native",
       },
-      HOMEBREW_ARTIFACT_DOMAIN:                  {
+      HOMEBREW_ARTIFACT_DOMAIN:                        {
         description: "Prefix all download URLs, including those for bottles, with this value. " \
                      "For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a " \
                      "formula with the URL `https://example.com/foo.tar.gz` to instead download from " \
                      "`http://localhost:8080/example.com/foo.tar.gz`.",
       },
-      HOMEBREW_AUTO_UPDATE_SECS:                 {
+      HOMEBREW_AUTO_UPDATE_SECS:                       {
         description: "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
                      "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
                      "disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.",
         default:     300,
       },
-      HOMEBREW_BAT:                              {
+      HOMEBREW_BAT:                                    {
         description: "If set, use `bat` for the `brew cat` command.",
         boolean:     true,
       },
-      HOMEBREW_BAT_CONFIG_PATH:                  {
+      HOMEBREW_BAT_CONFIG_PATH:                        {
         description:  "Use this as the `bat` configuration file.",
         default_text: "`$HOME/.config/bat/config`.",
       },
-      HOMEBREW_BOOTSNAP:                         {
+      HOMEBREW_BOOTSNAP:                               {
         description: "If set, use Bootsnap to speed up repeated `brew` calls. "\
                      "A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).",
         boolean:     true,
       },
-      HOMEBREW_BOTTLE_DOMAIN:                    {
+      HOMEBREW_BOTTLE_DOMAIN:                          {
         description:  "Use this URL as the download mirror for bottles. " \
                       "If bottles at that URL are temporarily unavailable, " \
                       "the default bottle domain will be used as a fallback mirror. " \
@@ -55,78 +55,78 @@ module Homebrew
         default_text: "`https://ghcr.io/v2/homebrew/core`.",
         default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,
       },
-      HOMEBREW_BREW_GIT_REMOTE:                  {
+      HOMEBREW_BREW_GIT_REMOTE:                        {
         description: "Use this URL as the Homebrew/brew `git`(1) remote.",
         default:     HOMEBREW_BREW_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_BROWSER:                          {
+      HOMEBREW_BROWSER:                                {
         description:  "Use this as the browser when opening project homepages.",
         default_text: "`$BROWSER` or the OS's default browser.",
       },
-      HOMEBREW_CACHE:                            {
+      HOMEBREW_CACHE:                                  {
         description:  "Use this directory as the download cache.",
         default_text: "macOS: `$HOME/Library/Caches/Homebrew`, " \
                       "Linux: `$XDG_CACHE_HOME/Homebrew` or `$HOME/.cache/Homebrew`.",
         default:      HOMEBREW_DEFAULT_CACHE,
       },
-      HOMEBREW_CASK_OPTS:                        {
+      HOMEBREW_CASK_OPTS:                              {
         description: "Append these options to all `cask` commands. All `--*dir` options, " \
                      "`--language`, `--require-sha`, `--no-quarantine` and `--no-binaries` are supported. " \
                      "For example, you might add something like the following to your " \
                      "`~/.profile`, `~/.bash_profile`, or `~/.zshenv`:\n\n" \
                      '    `export HOMEBREW_CASK_OPTS="--appdir=~/Applications --fontdir=/Library/Fonts"`',
       },
-      HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS:       {
+      HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS:             {
         description: "If set, `brew install`, `brew upgrade` and `brew reinstall` will cleanup all formulae " \
                      "when this number of days has passed.",
         default:     30,
       },
-      HOMEBREW_CLEANUP_MAX_AGE_DAYS:             {
+      HOMEBREW_CLEANUP_MAX_AGE_DAYS:                   {
         description: "Cleanup all cached files older than this many days.",
         default:     120,
       },
-      HOMEBREW_COLOR:                            {
+      HOMEBREW_COLOR:                                  {
         description: "If set, force colour output on non-TTY outputs.",
         boolean:     true,
       },
-      HOMEBREW_CORE_GIT_REMOTE:                  {
+      HOMEBREW_CORE_GIT_REMOTE:                        {
         description:  "Use this URL as the Homebrew/homebrew-core `git`(1) remote.",
         default_text: "`https://github.com/Homebrew/homebrew-core`.",
         default:      HOMEBREW_CORE_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_CURLRC:                           {
+      HOMEBREW_CURLRC:                                 {
         description: "If set, do not pass `--disable` when invoking `curl`(1), which disables the " \
                      "use of `curlrc`.",
         boolean:     true,
       },
-      HOMEBREW_CURL_RETRIES:                     {
+      HOMEBREW_CURL_RETRIES:                           {
         description: "Pass the given retry count to `--retry` when invoking `curl`(1).",
         default:     3,
       },
-      HOMEBREW_CURL_VERBOSE:                     {
+      HOMEBREW_CURL_VERBOSE:                           {
         description: "If set, pass `--verbose` when invoking `curl`(1).",
         boolean:     true,
       },
-      HOMEBREW_DEVELOPER:                        {
+      HOMEBREW_DEVELOPER:                              {
         description: "If set, tweak behaviour to be more relevant for Homebrew developers (active or " \
                      "budding) by e.g. turning warnings into errors.",
         boolean:     true,
       },
-      HOMEBREW_DISABLE_LOAD_FORMULA:             {
+      HOMEBREW_DISABLE_LOAD_FORMULA:                   {
         description: "If set, refuse to load formulae. This is useful when formulae are not trusted (such " \
                      "as in pull requests).",
         boolean:     true,
       },
-      HOMEBREW_DISPLAY:                          {
+      HOMEBREW_DISPLAY:                                {
         description:  "Use this X11 display when opening a page in a browser, for example with " \
                       "`brew home`. Primarily useful on Linux.",
         default_text: "`$DISPLAY`.",
       },
-      HOMEBREW_DISPLAY_INSTALL_TIMES:            {
+      HOMEBREW_DISPLAY_INSTALL_TIMES:                  {
         description: "If set, print install times for each formula at the end of the run.",
         boolean:     true,
       },
-      HOMEBREW_EDITOR:                           {
+      HOMEBREW_EDITOR:                                 {
         description:  "Use this editor when editing a single formula, or several formulae in the " \
                       "same directory." \
                       "\n\n    *Note:* `brew edit` will open all of Homebrew as discontinuous files " \
@@ -134,35 +134,35 @@ module Homebrew
                       "editors will do strange things in this case.",
         default_text: "`$EDITOR` or `$VISUAL`.",
       },
-      HOMEBREW_FAIL_LOG_LINES:                   {
+      HOMEBREW_FAIL_LOG_LINES:                         {
         description: "Output this many lines of output on formula `system` failures.",
         default:     15,
       },
-      HOMEBREW_FORBIDDEN_LICENSES:               {
+      HOMEBREW_FORBIDDEN_LICENSES:                     {
         description: "A space-separated list of licenses. Homebrew will refuse to install a " \
                      "formula if it or any of its dependencies has a license on this list.",
       },
-      HOMEBREW_FORCE_BREWED_CA_CERTIFICATES:     {
+      HOMEBREW_FORCE_BREWED_CA_CERTIFICATES:           {
         description: "If set, always use a Homebrew-installed `ca-certificates` rather than the system version. " \
                      "Automatically set if the system version is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_BREWED_CURL:                {
+      HOMEBREW_FORCE_BREWED_CURL:                      {
         description: "If set, always use a Homebrew-installed `curl`(1) rather than the system version. " \
                      "Automatically set if the system version of `curl` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_BREWED_GIT:                 {
+      HOMEBREW_FORCE_BREWED_GIT:                       {
         description: "If set, always use a Homebrew-installed `git`(1) rather than the system version. " \
                      "Automatically set if the system version of `git` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_VENDOR_RUBY:                {
+      HOMEBREW_FORCE_VENDOR_RUBY:                      {
         description: "If set, always use Homebrew's vendored, relocatable Ruby version even if the system version " \
                      "of Ruby is new enough.",
         boolean:     true,
       },
-      HOMEBREW_GITHUB_API_TOKEN:                 {
+      HOMEBREW_GITHUB_API_TOKEN:                       {
         description: "Use this personal access token for the GitHub API, for features such as " \
                      "`brew search`. You can create one at <https://github.com/settings/tokens>. If set, " \
                      "GitHub will allow you a greater number of API requests. For more information, see: " \
@@ -170,51 +170,51 @@ module Homebrew
                      "\n\n    *Note:* Homebrew doesn't require permissions for any of the scopes, but some " \
                      "developer commands may require additional permissions.",
       },
-      HOMEBREW_GITHUB_PACKAGES_TOKEN:            {
+      HOMEBREW_GITHUB_PACKAGES_TOKEN:                  {
         description: "Use this GitHub personal access token when accessing the GitHub Packages Registry "\
                      "(where bottles may be stored).",
       },
-      HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN: {
+      HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN:       {
         description: "Use this base64 encoded username and password for authenticating with a Docker registry " \
                      "proxying GitHub Packages. If HOMEBREW_DOCKER_REGISTRY_TOKEN is set, it will be used instead.",
       },
-      HOMEBREW_DOCKER_REGISTRY_TOKEN:            {
+      HOMEBREW_DOCKER_REGISTRY_TOKEN:                  {
         description: "Use this bearer token for authenticating with a Docker registry proxying GitHub Packages. " \
                      "Preferred over HOMEBREW_DOCKER_REGISTRY_TOKEN_BASIC.",
       },
-      HOMEBREW_GITHUB_PACKAGES_USER:             {
+      HOMEBREW_GITHUB_PACKAGES_USER:                   {
         description: "Use this username when accessing the GitHub Packages Registry (where bottles may be stored).",
       },
-      HOMEBREW_GIT_EMAIL:                        {
+      HOMEBREW_GIT_EMAIL:                              {
         description: "Set the Git author and committer email to this value.",
       },
-      HOMEBREW_GIT_NAME:                         {
+      HOMEBREW_GIT_NAME:                               {
         description: "Set the Git author and committer name to this value.",
       },
-      HOMEBREW_INSTALL_BADGE:                    {
+      HOMEBREW_INSTALL_BADGE:                          {
         description:  "Print this text before the installation summary of each successful build.",
         default_text: 'The "Beer Mug" emoji.',
         default:      "🍺",
       },
-      HOMEBREW_INSTALL_FROM_API:                 {
+      HOMEBREW_INSTALL_FROM_API:                       {
         description: "If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's " \
                      "API instead of needing (large, slow) local checkouts of these repositories." \
                      "\n\n    *Note:* Setting HOMEBREW_INSTALL_FROM_API is not compatible with Homebrew's " \
                      "developer mode so will error (as Homebrew development needs a full clone).",
         boolean:     true,
       },
-      HOMEBREW_LIVECHECK_WATCHLIST:              {
+      HOMEBREW_LIVECHECK_WATCHLIST:                    {
         description: "Consult this file for the list of formulae to check by default when no formula argument " \
                      "is passed to `brew livecheck`.",
         default:     "$HOME/.brew_livecheck_watchlist",
       },
-      HOMEBREW_LOGS:                             {
+      HOMEBREW_LOGS:                                   {
         description:  "Use this directory to store log files.",
         default_text: "macOS: `$HOME/Library/Logs/Homebrew`, " \
                       "Linux: `$XDG_CACHE_HOME/Homebrew/Logs` or `$HOME/.cache/Homebrew/Logs`.",
         default:      HOMEBREW_DEFAULT_LOGS,
       },
-      HOMEBREW_MAKE_JOBS:                        {
+      HOMEBREW_MAKE_JOBS:                              {
         description:  "Use this value as the number of parallel jobs to run when building with `make`(1).",
         default_text: "The number of available CPU cores.",
         default:      lambda {
@@ -223,100 +223,100 @@ module Homebrew
           Hardware::CPU.cores
         },
       },
-      HOMEBREW_NO_ANALYTICS:                     {
+      HOMEBREW_NO_ANALYTICS:                           {
         description: "If set, do not send analytics. For more information, see: <https://docs.brew.sh/Analytics>",
         boolean:     true,
       },
-      HOMEBREW_NO_AUTO_UPDATE:                   {
+      HOMEBREW_NO_AUTO_UPDATE:                         {
         description: "If set, do not automatically update before running some commands, e.g. " \
                      "`brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
                      "run this less often by setting HOMEBREW_AUTO_UPDATE_SECS to a value higher than the default.",
         boolean:     true,
       },
-      HOMEBREW_NO_BOOTSNAP:                      {
+      HOMEBREW_NO_BOOTSNAP:                            {
         description: "If set, do not use Bootsnap to speed up repeated `brew` calls.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK:    {
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK:          {
         description: "If set, do not check for broken linkage of dependents or outdated dependents after " \
                      "installing, upgrading or reinstalling formulae. This will result in fewer dependents " \
                      " (and their dependencies) being upgraded or reinstalled but may result in more breakage " \
                      "from running `brew install <formula>` or `brew upgrade <formula>`.",
         boolean:     true,
       },
-      HOMEBREW_NO_CLEANUP_FORMULAE:              {
+      HOMEBREW_NO_CLEANUP_FORMULAE:                    {
         description: "A comma-separated list of formulae. Homebrew will refuse to clean up a " \
                      "formula if it appears on this list.",
       },
-      HOMEBREW_NO_COLOR:                         {
+      HOMEBREW_NO_COLOR:                               {
         description:  "If set, do not print text with colour added.",
         default_text: "`$NO_COLOR`.",
         boolean:      true,
       },
-      HOMEBREW_NO_COMPAT:                        {
+      HOMEBREW_NO_COMPAT:                              {
         description: "If set, disable all use of legacy compatibility code.",
         boolean:     true,
       },
-      HOMEBREW_NO_EMOJI:                         {
+      HOMEBREW_NO_EMOJI:                               {
         description: "If set, do not print `HOMEBREW_INSTALL_BADGE` on a successful build." \
                      "\n\n    *Note:* Will only try to print emoji on OS X Lion or newer.",
         boolean:     true,
       },
-      HOMEBREW_NO_ENV_HINTS:                     {
+      HOMEBREW_NO_ENV_HINTS:                           {
         description: "If set, do not print any hints about changing Homebrew's behaviour with environment variables.",
         boolean:     true,
       },
-      HOMEBREW_NO_GITHUB_API:                    {
+      HOMEBREW_NO_GITHUB_API:                          {
         description: "If set, do not use the GitHub API, e.g. for searches or fetching relevant issues " \
                      "after a failed install.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSECURE_REDIRECT:             {
+      HOMEBREW_NO_INSECURE_REDIRECT:                   {
         description: "If set, forbid redirects from secure HTTPS to insecure HTTP." \
                      "\n\n    *Note:* While ensuring your downloads are fully secure, this is likely to cause " \
                      "from-source SourceForge, some GNU & GNOME-hosted formulae to fail to download.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALL_CLEANUP:               {
+      HOMEBREW_NO_INSTALL_CLEANUP:                     {
         description: "If set, `brew install`, `brew upgrade` and `brew reinstall` will never automatically " \
                      "cleanup installed/upgraded/reinstalled formulae or all formulae every " \
                      "`HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` days. Alternatively, HOMEBREW_NO_CLEANUP_FORMULAE " \
                      "allows specifying specific formulae to not clean up.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALL_UPGRADE:               {
+      HOMEBREW_NO_INSTALL_UPGRADE:                     {
         description: "If set, `brew install <formula>` will not upgrade `<formula>` if it is installed but " \
                      "outdated.",
         boolean:     true,
       },
-      HOMEBREW_PRY:                              {
+      HOMEBREW_PRY:                                    {
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
-      HOMEBREW_SIMULATE_MACOS_ON_LINUX:          {
+      HOMEBREW_SIMULATE_MACOS_ON_LINUX:                {
         description: "If set, running Homebrew on Linux will simulate certain macOS code paths. This is useful " \
                      "when auditing macOS formulae while on Linux.",
         boolean:     true,
       },
-      HOMEBREW_SSH_CONFIG_PATH:                  {
+      HOMEBREW_SSH_CONFIG_PATH:                        {
         description:  "If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching " \
                       "`git` repos over `ssh`.",
         default_text: "`$HOME/.ssh/config`",
       },
-      HOMEBREW_SKIP_OR_LATER_BOTTLES:            {
+      HOMEBREW_SKIP_OR_LATER_BOTTLES:                  {
         description: "If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions " \
                      "of macOS. This is useful in development on new macOS versions.",
         boolean:     true,
       },
-      HOMEBREW_SORBET_RUNTIME:                   {
+      HOMEBREW_SORBET_RUNTIME:                         {
         description: "If set, enable runtime typechecking using Sorbet.",
         boolean:     true,
       },
-      HOMEBREW_SVN:                              {
+      HOMEBREW_SVN:                                    {
         description:  "Use this as the `svn`(1) binary.",
         default_text: "A Homebrew-built Subversion (if installed), or the system-provided binary.",
       },
-      HOMEBREW_TEMP:                             {
+      HOMEBREW_TEMP:                                   {
         description:  "Use this path as the temporary directory for building packages. Changing " \
                       "this may be needed if your system temporary directory and Homebrew prefix are on " \
                       "different volumes, as macOS has trouble moving symlinks across volumes when the target " \
@@ -325,45 +325,50 @@ module Homebrew
         default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
-      HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED:     {
-        description: "If set, `brew update` only lists updates to installed software.",
+      HOMEBREW_UPDATE_REPORT_ALL_FORMULAE:             {
+        description: "If set, `brew update` lists updates to all software.",
         boolean:     true,
       },
-      HOMEBREW_UPDATE_TO_TAG:                    {
+      HOMEBREW_UPDATE_REPORT_VERSION_CHANGED_FORMULAE: {
+        description: "If set, `brew update` only lists updates to formulae with differing versions. " \
+                     "Note this is slower than the default behaviour.",
+        boolean:     true,
+      },
+      HOMEBREW_UPDATE_TO_TAG:                          {
         description: "If set, always use the latest stable tag (even if developer commands " \
                      "have been run).",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE:                          {
+      HOMEBREW_VERBOSE:                                {
         description: "If set, always assume `--verbose` when running commands.",
         boolean:     true,
       },
-      HOMEBREW_DEBUG:                            {
+      HOMEBREW_DEBUG:                                  {
         description: "If set, always assume `--debug` when running commands.",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE_USING_DOTS:               {
+      HOMEBREW_VERBOSE_USING_DOTS:                     {
         description: "If set, verbose output will print a `.` no more than once a minute. This can be " \
                      "useful to avoid long-running Homebrew commands being killed due to no output.",
         boolean:     true,
       },
-      all_proxy:                                 {
+      all_proxy:                                       {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      ftp_proxy:                                 {
+      ftp_proxy:                                       {
         description: "Use this FTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      http_proxy:                                {
+      http_proxy:                                      {
         description: "Use this HTTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      https_proxy:                               {
+      https_proxy:                                     {
         description: "Use this HTTPS proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      no_proxy:                                  {
+      no_proxy:                                        {
         description: "A comma-separated list of hostnames and domain names excluded " \
                      "from proxying by `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      SUDO_ASKPASS:                              {
+      SUDO_ASKPASS:                                    {
         description: "If set, pass the `-A` option when calling `sudo`(8).",
       },
     }.freeze

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -195,13 +195,13 @@ describe Homebrew::Completions do
 
       it "returns an array of options for a shell command" do
         expected_options = {
-          "--debug"      => "Display a trace of all shell commands as they are executed.",
-          "--force"      => "Always do a slower, full update check (even if unnecessary).",
-          "--help"       => "Show this message.",
-          "--merge"      => "Use `git merge` to apply updates (rather than `git rebase`).",
-          "--preinstall" => "Run on auto-updates (e.g. before `brew install`). Skips some slower steps.",
-          "--quiet"      => "Make some output more quiet",
-          "--verbose"    => "Print the directories checked and `git` operations performed.",
+          "--auto-update" => "Run on auto-updates (e.g. before `brew install`). Skips some slower steps.",
+          "--debug"       => "Display a trace of all shell commands as they are executed.",
+          "--force"       => "Always do a slower, full update check (even if unnecessary).",
+          "--help"        => "Show this message.",
+          "--merge"       => "Use `git merge` to apply updates (rather than `git rebase`).",
+          "--quiet"       => "Make some output more quiet",
+          "--verbose"     => "Print the directories checked and `git` operations performed.",
         }
         expect(described_class.command_options("update")).to eq expected_options
       end
@@ -277,11 +277,11 @@ describe Homebrew::Completions do
             case "${cur}" in
               -*)
                 __brewcomp "
+                --auto-update
                 --debug
                 --force
                 --help
                 --merge
-                --preinstall
                 --quiet
                 --verbose
                 "
@@ -342,11 +342,11 @@ describe Homebrew::Completions do
           # brew update
           _brew_update() {
             _arguments \\
+              '--auto-update[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \\
               '--debug[Display a trace of all shell commands as they are executed]' \\
               '--force[Always do a slower, full update check (even if unnecessary)]' \\
               '--help[Show this message]' \\
               '--merge[Use `git merge` to apply updates (rather than `git rebase`)]' \\
-              '--preinstall[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \\
               '--quiet[Make some output more quiet]' \\
               '--verbose[Print the directories checked and `git` operations performed]'
           }
@@ -402,11 +402,11 @@ describe Homebrew::Completions do
         completion = described_class.generate_fish_subcommand_completion("update")
         expect(completion).to eq <<~COMPLETION
           __fish_brew_complete_cmd 'update' 'Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations'
+          __fish_brew_complete_arg 'update' -l auto-update -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
           __fish_brew_complete_arg 'update' -l debug -d 'Display a trace of all shell commands as they are executed'
           __fish_brew_complete_arg 'update' -l force -d 'Always do a slower, full update check (even if unnecessary)'
           __fish_brew_complete_arg 'update' -l help -d 'Show this message'
           __fish_brew_complete_arg 'update' -l merge -d 'Use `git merge` to apply updates (rather than `git rebase`)'
-          __fish_brew_complete_arg 'update' -l preinstall -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
           __fish_brew_complete_arg 'update' -l quiet -d 'Make some output more quiet'
           __fish_brew_complete_arg 'update' -l verbose -d 'Print the directories checked and `git` operations performed'
         COMPLETION

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -2199,11 +2199,11 @@ _brew_up() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --auto-update
       --debug
       --force
       --help
       --merge
-      --preinstall
       --quiet
       --verbose
       "
@@ -2218,11 +2218,11 @@ _brew_update() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --auto-update
       --debug
       --force
       --help
       --merge
-      --preinstall
       --quiet
       --verbose
       "
@@ -2294,10 +2294,10 @@ _brew_update_report() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --auto-update
       --debug
       --force
       --help
-      --preinstall
       --quiet
       --verbose
       "

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1468,21 +1468,21 @@ __fish_brew_complete_arg 'untap' -a '(__fish_brew_suggest_taps_installed)'
 
 
 __fish_brew_complete_cmd 'up' 'Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations'
+__fish_brew_complete_arg 'up' -l auto-update -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
 __fish_brew_complete_arg 'up' -l debug -d 'Display a trace of all shell commands as they are executed'
 __fish_brew_complete_arg 'up' -l force -d 'Always do a slower, full update check (even if unnecessary)'
 __fish_brew_complete_arg 'up' -l help -d 'Show this message'
 __fish_brew_complete_arg 'up' -l merge -d 'Use `git merge` to apply updates (rather than `git rebase`)'
-__fish_brew_complete_arg 'up' -l preinstall -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
 __fish_brew_complete_arg 'up' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'up' -l verbose -d 'Print the directories checked and `git` operations performed'
 
 
 __fish_brew_complete_cmd 'update' 'Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations'
+__fish_brew_complete_arg 'update' -l auto-update -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
 __fish_brew_complete_arg 'update' -l debug -d 'Display a trace of all shell commands as they are executed'
 __fish_brew_complete_arg 'update' -l force -d 'Always do a slower, full update check (even if unnecessary)'
 __fish_brew_complete_arg 'update' -l help -d 'Show this message'
 __fish_brew_complete_arg 'update' -l merge -d 'Use `git merge` to apply updates (rather than `git rebase`)'
-__fish_brew_complete_arg 'update' -l preinstall -d 'Run on auto-updates (e.g. before `brew install`). Skips some slower steps'
 __fish_brew_complete_arg 'update' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'update' -l verbose -d 'Print the directories checked and `git` operations performed'
 
@@ -1518,10 +1518,10 @@ __fish_brew_complete_arg 'update-python-resources' -a '(__fish_brew_suggest_form
 
 
 __fish_brew_complete_cmd 'update-report' 'The Ruby implementation of `brew update`'
+__fish_brew_complete_arg 'update-report' -l auto-update -d 'Run in \'auto-update\' mode (faster, less output)'
 __fish_brew_complete_arg 'update-report' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'update-report' -l force -d 'Treat installed and updated formulae as if they are from the same taps and migrate them anyway'
 __fish_brew_complete_arg 'update-report' -l help -d 'Show this message'
-__fish_brew_complete_arg 'update-report' -l preinstall -d 'Run in \'auto-update\' mode (faster, less output)'
 __fish_brew_complete_arg 'update-report' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'update-report' -l verbose -d 'Make some output more verbose'
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1798,11 +1798,11 @@ _brew_untap() {
 # brew up
 _brew_up() {
   _arguments \
+    '--auto-update[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \
     '--debug[Display a trace of all shell commands as they are executed]' \
     '--force[Always do a slower, full update check (even if unnecessary)]' \
     '--help[Show this message]' \
     '--merge[Use `git merge` to apply updates (rather than `git rebase`)]' \
-    '--preinstall[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Print the directories checked and `git` operations performed]'
 }
@@ -1810,11 +1810,11 @@ _brew_up() {
 # brew update
 _brew_update() {
   _arguments \
+    '--auto-update[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \
     '--debug[Display a trace of all shell commands as they are executed]' \
     '--force[Always do a slower, full update check (even if unnecessary)]' \
     '--help[Show this message]' \
     '--merge[Use `git merge` to apply updates (rather than `git rebase`)]' \
-    '--preinstall[Run on auto-updates (e.g. before `brew install`). Skips some slower steps]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Print the directories checked and `git` operations performed]'
 }
@@ -1859,10 +1859,10 @@ _brew_update_python_resources() {
 # brew update-report
 _brew_update_report() {
   _arguments \
+    '--auto-update[Run in '\''auto-update'\'' mode (faster, less output)]' \
     '--debug[Display any debugging information]' \
     '--force[Treat installed and updated formulae as if they are from the same taps and migrate them anyway]' \
     '--help[Show this message]' \
-    '--preinstall[Run in '\''auto-update'\'' mode (faster, less output)]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]'
 }

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -682,7 +682,7 @@ Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1)
 
 * `--merge`:
   Use `git merge` to apply updates (rather than `git rebase`).
-* `--preinstall`:
+* `--auto-update`:
   Run on auto-updates (e.g. before `brew install`). Skips some slower steps.
 * `-f`, `--force`:
   Always do a slower, full update check (even if unnecessary).
@@ -2171,8 +2171,11 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
   *Default:* macOS: `/private/tmp`, Linux: `/tmp`.
 
-- `HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED`
-  <br>If set, `brew update` only lists updates to installed software.
+- `HOMEBREW_UPDATE_REPORT_ALL_FORMULAE`
+  <br>If set, `brew update` lists updates to all software.
+
+- `HOMEBREW_UPDATE_REPORT_VERSION_CHANGED_FORMULAE`
+  <br>If set, `brew update` only lists updates to formulae with differing versions. Note this is slower than the default behaviour.
 
 - `HOMEBREW_UPDATE_TO_TAG`
   <br>If set, always use the latest stable tag (even if developer commands have been run).

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -936,7 +936,7 @@ Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\f
 Use \fBgit merge\fR to apply updates (rather than \fBgit rebase\fR)\.
 .
 .TP
-\fB\-\-preinstall\fR
+\fB\-\-auto\-update\fR
 Run on auto\-updates (e\.g\. before \fBbrew install\fR)\. Skips some slower steps\.
 .
 .TP
@@ -3183,10 +3183,16 @@ Use this path as the temporary directory for building packages\. Changing this m
 \fIDefault:\fR macOS: \fB/private/tmp\fR, Linux: \fB/tmp\fR\.
 .
 .TP
-\fBHOMEBREW_UPDATE_REPORT_ONLY_INSTALLED\fR
+\fBHOMEBREW_UPDATE_REPORT_ALL_FORMULAE\fR
 .
 .br
-If set, \fBbrew update\fR only lists updates to installed software\.
+If set, \fBbrew update\fR lists updates to all software\.
+.
+.TP
+\fBHOMEBREW_UPDATE_REPORT_VERSION_CHANGED_FORMULAE\fR
+.
+.br
+If set, \fBbrew update\fR only lists updates to formulae with differing versions\. Note this is slower than the default behaviour\.
 .
 .TP
 \fBHOMEBREW_UPDATE_TO_TAG\fR


### PR DESCRIPTION
- Rename use of "preinstall" to "auto update". The original "preinstall" naming came from the fact that we used to only auto-update before `brew install` but now that it's many commands: this is more confusing than useful.
- Add `HOMEBREW_NO_UPDATE_REPORT_ONLY_INSTALLED` and remove `HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED`; the latter is now the default and the prior provides an opt-out for better output, performance and avoiding reading potentially untrusted formulae.
- Add `HOMEBREW_UPDATE_FORMULA_VERSION_CHECKS` and don't check formula versions by default for better performance by default.

CC @boblail for thoughts.