### PR TITLE
exceptions: handle backslash in args for BuildError

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -479,7 +479,7 @@ class BuildError < RuntimeError
     @cmd = cmd
     @args = args
     @env = env
-    pretty_args = Array(args).map { |arg| arg.to_s.gsub " ", "\\ " }.join(" ")
+    pretty_args = Array(args).map { |arg| arg.to_s.gsub(/[\\ ]/, "\\\\\\0") }.join(" ")
     super "Failed executing: #{cmd} #{pretty_args}".strip
   end
 


### PR DESCRIPTION
Fix an issue where if a failing command argument reported to BuildError contains a backslash, it was not being escaped.

The effect is cosmetic and not a security issue. It only affects how the command is printed to console. After this change, such commands should more correctly reflect how the command would look if entered into a command line.

Fixes https://github.com/Homebrew/brew/security/code-scanning/6.