### PR TITLE
test/rubocops/patches: silence CodeQL alerts

### DIFF
--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -60,11 +60,11 @@ describe RuboCop::Cop::FormulaAudit::Patches do
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
             MacPorts patches should specify a revision instead of trunk: #{patch_url}
           EOS
-        elsif patch_url.start_with?("http://trac.macports.org")
+        elsif patch_url.start_with?("http://trac.macports.org/")
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
             Patches from MacPorts Trac should be https://, not http: #{patch_url}
           EOS
-        elsif patch_url.start_with?("http://bugs.debian.org")
+        elsif patch_url.start_with?("http://bugs.debian.org/")
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
             Patches from Debian should be https://, not http: #{patch_url}
           EOS
@@ -203,11 +203,11 @@ describe RuboCop::Cop::FormulaAudit::Patches do
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
             MacPorts patches should specify a revision instead of trunk: #{patch_url}
           EOS
-        elsif patch_url.start_with?("http://trac.macports.org")
+        elsif patch_url.start_with?("http://trac.macports.org/")
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
             Patches from MacPorts Trac should be https://, not http: #{patch_url}
           EOS
-        elsif patch_url.start_with?("http://bugs.debian.org")
+        elsif patch_url.start_with?("http://bugs.debian.org/")
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
             Patches from Debian should be https://, not http: #{patch_url}
           EOS


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/security/code-scanning/2 (2).
Fixes https://github.com/Homebrew/brew/security/code-scanning/3 (3).
Fixes https://github.com/Homebrew/brew/security/code-scanning/4 (4).
Fixes https://github.com/Homebrew/brew/security/code-scanning/5 (5).

These are tests, and the inputs are controlled by a fixed array in the same file, so this is not a security issue or even a possible bug. Nevertheless, silencing those alerts is trivial here.