### PR TITLE
cask: fix greedy outdated command

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -170,7 +170,7 @@ module Cask
         return versions if (greedy || greedy_latest) && outdated_download_sha?
 
         return []
-      elsif auto_updates && !(greedy || greedy_auto_updates)
+      elsif auto_updates && !greedy && !greedy_auto_updates
         return []
       end
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -166,13 +166,11 @@ module Cask
         version
       end
 
-      if greedy || greedy_latest || (greedy_auto_updates && auto_updates)
-        if latest_version.latest?
-          return versions if outdated_download_sha?
+      if latest_version.latest?
+        return versions if (greedy || greedy_latest) && outdated_download_sha?
 
-          return []
-        end
-      elsif auto_updates
+        return []
+      elsif auto_updates && !(greedy || greedy_auto_updates)
         return []
       end
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -134,7 +134,7 @@ describe Cask::Cask, :cask do
       shared_examples ":latest cask" do |greedy, outdated_sha, tap_version, expectations|
         expectations.each do |installed_version, expected_output|
           context "when versions #{installed_version} are installed and the " \
-                  "tap version is #{tap_version}, #{"not " unless greedy}greedy" \
+                  "tap version is #{tap_version}, #{"not " unless greedy}greedy " \
                   "and sha is #{"not " unless outdated_sha}outdated" do
             subject { cask.outdated_versions(greedy: greedy) }
 
@@ -160,7 +160,7 @@ describe Cask::Cask, :cask do
 
       describe "numbered version installed, :latest version in tap" do
         include_examples ":latest cask", false, false, "latest",
-                         ["1.2.3"] => ["1.2.3"]
+                         ["1.2.3"] => []
         include_examples ":latest cask", true, false, "latest",
                          ["1.2.3"] => []
         include_examples ":latest cask", true, true, "latest",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Following the merge of https://github.com/Homebrew/brew/pull/13275 calling `brew outdated --greedy-latest` or `brew upgrade --greedy-latest` was also upgrading other outdated casks (that aren't `version :latest`). This change now ignores casks that are `auto_updates true` but not `version :latest` when using the `--greedy-latest` flag.


BEFORE:
```
==> brew outdated --greedy-latest 
firefox (100.0.1) != 100.0.2
firefox-developer-edition (latest) != latest
font-bebas-neue (latest) != latest
font-josefin-sans (latest) != latest
font-karla (latest) != latest
font-merriweather-sans (latest) != latest
font-nanum-gothic (latest) != latest
```

AFTER:
```
==> brew outdated --greedy-latest
firefox-developer-edition (latest) != latest
font-bebas-neue (latest) != latest
font-josefin-sans (latest) != latest
font-karla (latest) != latest
font-merriweather-sans (latest) != latest
font-nanum-gothic (latest) != latest
```