### PR TITLE
cask: add statement when upgrade won't be installed

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -150,12 +150,12 @@ module Cask
       @caskroom_path ||= Caskroom.path.join(token)
     end
 
-    def outdated?(greedy: false, greedy_latest: false, greedy_auto_updates: false)
+    def outdated?(greedy: false, greedy_latest: false, greedy_auto_updates: false, upgrade: false)
       !outdated_versions(greedy: greedy, greedy_latest: greedy_latest,
-                         greedy_auto_updates: greedy_auto_updates).empty?
+                         greedy_auto_updates: greedy_auto_updates, upgrade: upgrade).empty?
     end
 
-    def outdated_versions(greedy: false, greedy_latest: false, greedy_auto_updates: false)
+    def outdated_versions(greedy: false, greedy_latest: false, greedy_auto_updates: false, upgrade: false)
       # special case: tap version is not available
       return [] if version.nil?
 
@@ -168,6 +168,9 @@ module Cask
 
       if greedy || greedy_latest || (greedy_auto_updates && auto_updates)
         if latest_version.latest?
+          if !outdated_download_sha? && upgrade
+            ohai "Not upgrading #{token} because the downloaded artifact has not changed"
+          end
           return versions if outdated_download_sha?
 
           return []

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -96,13 +96,13 @@ module Cask
         outdated_casks = if casks.empty?
           Caskroom.casks(config: Config.from_args(args)).select do |cask|
             cask.outdated?(greedy: greedy, greedy_latest: greedy_latest,
-                           greedy_auto_updates: greedy_auto_updates)
+                           greedy_auto_updates: greedy_auto_updates, upgrade: true)
           end
         else
           casks.select do |cask|
             raise CaskNotInstalledError, cask if !cask.installed? && !force
 
-            cask.outdated?(greedy: true)
+            cask.outdated?(greedy: true, upgrade: true)
           end
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow up from https://github.com/Homebrew/brew/pull/13275 to add a statement when the upgrade does not proceed due to the artifact having not changed.
At the moment, if the downloaded artifact has not changed, the upgrade does not proceed, but there is no output provided to the user to explain what has happened.

CC: @apainintheneck