### PR TITLE
cask: add statements when direct cask upgrades won't be installed

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -102,7 +102,15 @@ module Cask
           casks.select do |cask|
             raise CaskNotInstalledError, cask if !cask.installed? && !force
 
-            cask.outdated?(greedy: true)
+            if cask.outdated?(greedy: true)
+              true
+            elsif cask.version.latest?
+              opoo "Not upgrading #{cask.token}, the downloaded artifact has not changed"
+              false
+            else
+              opoo "Not upgrading #{cask.token}, the latest version is already installed"
+              false
+            end
           end
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a fresh take on #13312

Outputs have been added for when a specific cask is requested to be upgraded via its token and the upgrade will not proceed because - 
1. the shasum of the downloaded artifact matches the currently installed package, or
2. the currently installed version is already the latest version