### PR TITLE
utils/github: take last artifact rather than first

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -353,7 +353,7 @@ module GitHub
       EOS
     end
 
-    artifact.first["archive_download_url"]
+    artifact.last["archive_download_url"]
   end
 
   def public_member_usernames(org, per_page: 100)


### PR DESCRIPTION
We had an issue where a CI run contained multiple artifacts of the same name: https://github.com/Homebrew/homebrew-core/actions/runs/2352886523

This is the first time I've ever seen it happen, so the issue is perhaps very rare or was the result of a temporary issue, but in such cases I believe taking the last artifact is more correct than taking the first, given the last one should have a higher ID number and thus have been created most recently.