### PR TITLE
test/download_strategies/curl_github_packages: fix bad const override

### DIFF
--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -10,9 +10,11 @@ describe CurlGitHubPackagesDownloadStrategy do
   let(:url) { "https://#{GitHubPackages::URL_DOMAIN}/v2/homebrew/core/spec_test/manifests/1.2.3" }
   let(:version) { "1.2.3" }
   let(:specs) { {} }
+  let(:authorization) { nil }
 
   describe "#fetch" do
     before do
+      stub_const("HOMEBREW_GITHUB_PACKAGES_AUTH", authorization) if authorization.present?
       strategy.temporary_path.dirname.mkpath
       FileUtils.touch strategy.temporary_path
     end
@@ -30,10 +32,6 @@ describe CurlGitHubPackagesDownloadStrategy do
 
     context "with Github Packages authentication defined" do
       let(:authorization) { "Bearer dead-beef-cafe" }
-
-      before do
-        HOMEBREW_GITHUB_PACKAGES_AUTH = authorization.freeze
-      end
 
       it "calls curl with the provided header value" do
         expect(strategy).to receive(:system_command).with(


### PR DESCRIPTION
Constants should never be overridden in tests without using `stub_const`. Otherwise, the constant will leak into other tests and potentially break them.

The constant also needs to be replaced before the first invokation of strategy's constructor, since it is there that the constant is used.