### PR TITLE
Curl: Check all responses for protected cookies

### DIFF
--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -14,7 +14,7 @@ describe "Utils::Curl" do
     details[:normal][:no_cookie] = {
       url:            "https://www.example.com/",
       final_url:      nil,
-      status:         "403",
+      status_code:    "403",
       headers:        {
         "age"            => "123456",
         "cache-control"  => "max-age=604800",
@@ -35,7 +35,7 @@ describe "Utils::Curl" do
     }
 
     details[:normal][:ok] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
-    details[:normal][:ok][:status] = "200"
+    details[:normal][:ok][:status_code] = "200"
 
     details[:normal][:single_cookie] = Marshal.load(Marshal.dump(details[:normal][:no_cookie]))
     details[:normal][:single_cookie][:headers]["set-cookie"] = "a_cookie=for_testing"
@@ -52,7 +52,7 @@ describe "Utils::Curl" do
     details[:cloudflare][:single_cookie] = {
       url:            "https://www.example.com/",
       final_url:      nil,
-      status:         "403",
+      status_code:    "403",
       headers:        {
         "date"            => "Wed, 1 Jan 2020 01:23:45 GMT",
         "content-type"    => "text/plain; charset=UTF-8",

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -198,21 +198,20 @@ module Utils
     end
 
     # Check if a URL is protected by CloudFlare (e.g. badlion.net and jaxx.io).
-    # @param details [Hash] Response information from
-    #  `#curl_http_content_headers_and_checksum`.
+    # @param response [Hash] A response hash from `#parse_curl_response`.
     # @return [true, false] Whether a response contains headers indicating that
     #   the URL is protected by Cloudflare.
-    sig { params(details: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
-    def url_protected_by_cloudflare?(details)
-      return false if details[:headers].blank?
-      return false unless [403, 503].include?(details[:status_code].to_i)
+    sig { params(response: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+    def url_protected_by_cloudflare?(response)
+      return false if response[:headers].blank?
+      return false unless [403, 503].include?(response[:status_code].to_i)
 
-      set_cookie_header = Array(details[:headers]["set-cookie"])
+      set_cookie_header = Array(response[:headers]["set-cookie"])
       has_cloudflare_cookie_header = set_cookie_header.compact.any? do |cookie|
         cookie.match?(/^(__cfduid|__cf_bm)=/i)
       end
 
-      server_header = Array(details[:headers]["server"])
+      server_header = Array(response[:headers]["server"])
       has_cloudflare_server = server_header.compact.any? do |server|
         server.match?(/^cloudflare/i)
       end
@@ -221,16 +220,15 @@ module Utils
     end
 
     # Check if a URL is protected by Incapsula (e.g. corsair.com).
-    # @param details [Hash] Response information from
-    #  `#curl_http_content_headers_and_checksum`.
+    # @param response [Hash] A response hash from `#parse_curl_response`.
     # @return [true, false] Whether a response contains headers indicating that
     #   the URL is protected by Incapsula.
-    sig { params(details: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
-    def url_protected_by_incapsula?(details)
-      return false if details[:headers].blank?
-      return false if details[:status_code].to_i != 403
+    sig { params(response: T::Hash[Symbol, T.untyped]).returns(T::Boolean) }
+    def url_protected_by_incapsula?(response)
+      return false if response[:headers].blank?
+      return false if response[:status_code].to_i != 403
 
-      set_cookie_header = Array(details[:headers]["set-cookie"])
+      set_cookie_header = Array(response[:headers]["set-cookie"])
       set_cookie_header.compact.any? { |cookie| cookie.match?(/^(visid_incap|incap_ses)_/i) }
     end
 
@@ -284,7 +282,9 @@ module Utils
       end
 
       unless http_status_ok?(details[:status_code])
-        return if url_protected_by_cloudflare?(details) || url_protected_by_incapsula?(details)
+        return if details[:responses].any? do |response|
+          url_protected_by_cloudflare?(response) || url_protected_by_incapsula?(response)
+        end
 
         return "The #{url_type} #{url} is not reachable (HTTP status code #{details[:status_code]})"
       end
@@ -403,6 +403,7 @@ module Utils
         content_length: content_length,
         file:           file_contents,
         file_hash:      file_hash,
+        responses:      responses,
       }
     ensure
       file.unlink


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The response from a URL protected by Cloudflare may only provide a relevant cookie on the first response but `#curl_http_content_headers_and_checksum` only returns the headers of the final response. In this scenario, `#curl_check_http_content` isn't able to properly detect the protected URL and this is surfaced as an error instead of skipping the URL (see https://github.com/Homebrew/homebrew-cask/pull/124277).

This PR resolves the issue by including the array of response hashes in the return value from `#curl_http_content_headers_and_checksum`, so we can check all the responses in `#curl_check_http_content`.

Besides that, this also renames the `:status` key in the return hash from `#curl_http_content_headers_and_checksum` to `:status_code`. This aligns the key name with the return hash from `#parse_curl_response` and technically allows us to pass either hash to the `#url_protected_by_*` methods (as they both contain `:status_code` and `:headers` in the expected format. This felt like a nicer way of approaching the switch from the `details` hash to a `response` hash.