### PR TITLE
livecheck: allow custom url in extract_plist strategy

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -20,7 +20,7 @@ module Cask
 
     attr_reader :token, :sourcefile_path, :source, :config, :default_config
 
-    attr_accessor :download
+    attr_accessor :download, :allow_reassignment
 
     def self.all
       Tap.flat_map(&:cask_files).map do |f|
@@ -38,11 +38,12 @@ module Cask
       @tap
     end
 
-    def initialize(token, sourcefile_path: nil, source: nil, tap: nil, config: nil, &block)
+    def initialize(token, sourcefile_path: nil, source: nil, tap: nil, config: nil, allow_reassignment: false, &block)
       @token = token
       @sourcefile_path = sourcefile_path
       @source = source
       @tap = tap
+      @allow_reassignment = allow_reassignment
       @block = block
 
       @default_config = config || Config.new

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -112,7 +112,7 @@ module Cask
     def set_unique_stanza(stanza, should_return)
       return instance_variable_get("@#{stanza}") if should_return
 
-      if instance_variable_defined?("@#{stanza}")
+      if !@cask.allow_reassignment && instance_variable_defined?("@#{stanza}")
         raise CaskInvalidError.new(cask, "'#{stanza}' stanza may only appear once.")
       end
 
@@ -137,7 +137,7 @@ module Cask
 
         return unless default
 
-        unless @language_blocks.default.nil?
+        if !@cask.allow_reassignment && @language_blocks.default.present?
           raise CaskInvalidError.new(cask, "Only one default language may be defined.")
         end
 
@@ -294,7 +294,9 @@ module Cask
       @livecheck ||= Livecheck.new(self)
       return @livecheck unless block
 
-      raise CaskInvalidError.new(cask, "'livecheck' stanza may only appear once.") if @livecheckable
+      if !@cask.allow_reassignment && @livecheckable
+        raise CaskInvalidError.new(cask, "'livecheck' stanza may only appear once.")
+      end
 
       @livecheckable = true
       @livecheck.instance_eval(&block)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -563,6 +563,7 @@ module Homebrew
 
     # Identifies the latest version of the formula and returns a Hash containing
     # the version information. Returns nil if a latest version couldn't be found.
+    # rubocop:disable Metrics/CyclomaticComplexity
     sig {
       params(
         formula_or_cask:            T.any(Formula, Cask::Cask),
@@ -657,7 +658,7 @@ module Homebrew
         end
 
         if livecheck_strategy.present?
-          if livecheck_url.blank?
+          if livecheck_url.blank? && strategy.method(:find_versions).parameters.include?([:keyreq, :url])
             odebug "#{strategy_name} strategy requires a URL"
             next
           elsif livecheck_strategy != :page_match && strategies.exclude?(strategy)
@@ -768,6 +769,7 @@ module Homebrew
 
       nil
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
   end
   # rubocop:enable Metrics/ModuleLength
 end

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -103,14 +103,14 @@ module Homebrew
 
           match_data = { matches: {}, regex: regex, url: url }
 
-          if url && url != cask.url.to_s
-            cask_object_for_livecheck = Cask::Cask.new("livecheck-cask", config: cask.config) do
-              url url.to_s
-            end
-
-            unversioned_cask_checker = UnversionedCaskChecker.new(cask, livecheck_url: cask_object_for_livecheck)
+          unversioned_cask_checker = if url.present? && url != cask.url.to_s
+            # Create a copy of the `cask` that uses the `livecheck` block URL
+            cask_copy = Cask::CaskLoader.load(cask.full_name)
+            cask_copy.allow_reassignment = true
+            cask_copy.url { url }
+            UnversionedCaskChecker.new(cask_copy)
           else
-            unversioned_cask_checker = UnversionedCaskChecker.new(cask)
+            UnversionedCaskChecker.new(cask)
           end
 
           items = unversioned_cask_checker.all_versions.transform_values { |v| Item.new(bundle_version: v) }

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -82,6 +82,8 @@ module Homebrew
         # versions from `plist` files.
         #
         # @param cask [Cask::Cask] the cask to check for version information
+        # @param url [String, nil] an alternative URL to check for version
+        #   information
         # @param regex [Regexp, nil] a regex for use in a strategy block
         # @return [Hash]
         sig {
@@ -99,7 +101,7 @@ module Homebrew
           end
           raise ArgumentError, "The #{T.must(name).demodulize} strategy only supports casks." unless T.unsafe(cask)
 
-          match_data = { matches: {}, regex: regex }
+          match_data = { matches: {}, regex: regex, url: url }
 
           if url && url != cask.url.to_s
             cask_object_for_livecheck = Cask::Cask.new("livecheck-cask", config: cask.config) do

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -15,21 +15,15 @@ module Homebrew
 
     sig {  returns(Cask::Cask) }
     attr_reader :cask
-    attr_reader :livecheck_url
 
-    sig { params(cask: Cask::Cask, livecheck_url: T.nilable(Cask::Cask)).void }
-    def initialize(cask, livecheck_url: nil)
+    sig { params(cask: Cask::Cask).void }
+    def initialize(cask)
       @cask = cask
-      @livecheck_url = livecheck_url
     end
 
     sig { returns(Cask::Installer) }
     def installer
-      @installer ||= if livecheck_url
-        Cask::Installer.new(livecheck_url, verify_download_integrity: false)
-      else
-        Cask::Installer.new(cask, verify_download_integrity: false)
-      end
+      @installer ||= Cask::Installer.new(cask, verify_download_integrity: false)
     end
 
     sig { returns(T::Array[Cask::Artifact::App]) }

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -15,15 +15,21 @@ module Homebrew
 
     sig {  returns(Cask::Cask) }
     attr_reader :cask
+    attr_reader :livecheck_url
 
-    sig { params(cask: Cask::Cask).void }
-    def initialize(cask)
+    sig { params(cask: Cask::Cask, livecheck_url: T.nilable(Cask::Cask)).void }
+    def initialize(cask, livecheck_url: nil)
       @cask = cask
+      @livecheck_url = livecheck_url
     end
 
     sig { returns(Cask::Installer) }
     def installer
-      @installer ||= Cask::Installer.new(cask, verify_download_integrity: false)
+      @installer ||= if livecheck_url
+        Cask::Installer.new(livecheck_url, verify_download_integrity: false)
+      else
+        Cask::Installer.new(cask, verify_download_integrity: false)
+      end
     end
 
     sig { returns(T::Array[Cask::Artifact::App]) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This allows a custom url to be passed to livecheck when using the `:extract_plist` strategy. 

This is useful in edge cases that meet a couple of criteria:
- There is no version information available utilising the other livecheck methods
- There is an unversioned download link that points to the latest version
- There is a versioned download link available that we can use for download

At the moment in these cases we are limited to using the unversioned url OR using the versioned url and skipping the livecheck.

An example of a cask that is currently not functioning as intended is the [`speedify` cask](https://github.com/Homebrew/homebrew-cask/blob/43eadfc/Casks/speedify.rb).
