### PR TITLE
test/cask/quarantine: improve audit test output

### DIFF
--- a/Library/Homebrew/test/cask/quarantine_spec.rb
+++ b/Library/Homebrew/test/cask/quarantine_spec.rb
@@ -37,7 +37,11 @@ describe Cask::Quarantine, :cask do
     end
 
     it "quarantines Cask audits" do
-      Cask::Cmd::Audit.run("local-transmission", "--download")
+      expect {
+        Cask::Cmd::Audit.run("local-transmission", "--download")
+      }.to not_raise_error
+       .and output(/audit for local-transmission: passed/).to_stdout
+       .and not_to_output.to_stderr
 
       local_transmission = Cask::CaskLoader.load(cask_path("local-transmission"))
       cached_location = Cask::Download.new(local_transmission).fetch
@@ -148,7 +152,11 @@ describe Cask::Quarantine, :cask do
     end
 
     it "does not quarantine Cask audits" do
-      Cask::Cmd::Audit.run("local-transmission", "--download", "--no-quarantine")
+      expect {
+        Cask::Cmd::Audit.run("local-transmission", "--download", "--no-quarantine")
+      }.to not_raise_error
+       .and output(/audit for local-transmission: passed/).to_stdout
+       .and not_to_output.to_stderr
 
       local_transmission = Cask::CaskLoader.load(cask_path("local-transmission"))
       cached_location = Cask::Download.new(local_transmission).fetch

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -292,6 +292,7 @@ RSpec.configure do |config|
 end
 
 RSpec::Matchers.define_negated_matcher :not_to_output, :output
+RSpec::Matchers.define_negated_matcher :not_raise_error, :raise_error
 RSpec::Matchers.alias_matcher :have_failed, :be_failed
 RSpec::Matchers.alias_matcher :a_string_containing, :include
 


### PR DESCRIPTION
When this fails, it was pretty much impossible to figure out why as it just says "audit failed".

Compare stdout and stderr to try get those dumped too.