### PR TITLE
cask: skip sha256 generation on directories

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -138,7 +138,7 @@ module Cask
 
       @new_download_sha ||= Installer.new(self, verify_download_integrity: false)
                                      .download(quiet: true)
-                                     .instance_eval { |x| Digest::SHA256.file(x).hexdigest }
+                                     .instance_eval { |x| Digest::SHA256.file(x).hexdigest unless x.directory? }
     end
 
     def outdated_download_sha?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is an idea for fixing - https://github.com/Homebrew/homebrew-cask-fonts/issues/5855

Because `svn` is used to download the fonts, the `Digest::SHA256` is failing on the contents because it is a directory not a file.
I have added a check to not return a value in these cases so that no shasum is stored.
The downside of running the check there is that I believe that we may still be fetching the download when the cask is `version :latest`.
We could potentially add a check for URLs using `:svn` instead, however there may be other edge cases?

I am not aware of a way to gather a shasum for a directory, if there is then that could be another approach.

CC: @apainintheneck
