### PR TITLE
os/mac: allow fake El Capitan setup for Portable Ruby builds

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -466,11 +466,17 @@ then
     HOMEBREW_FORCE_BREWED_CA_CERTIFICATES="1"
   fi
 
-  # The system Git on macOS versions before Sierra is too old for some Homebrew functionality we rely on.
-  HOMEBREW_MINIMUM_GIT_VERSION="2.14.3"
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "101200" ]]
+  if [[ -n "${HOMEBREW_FAKE_EL_CAPITAN}" ]]
   then
-    HOMEBREW_FORCE_BREWED_GIT="1"
+    # We only need this to work enough to update brew and build the set portable formulae, so relax the requirement.
+    HOMEBREW_MINIMUM_GIT_VERSION="2.7.4"
+  else
+    # The system Git on macOS versions before Sierra is too old for some Homebrew functionality we rely on.
+    HOMEBREW_MINIMUM_GIT_VERSION="2.14.3"
+    if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "101200" ]]
+    then
+      HOMEBREW_FORCE_BREWED_GIT="1"
+    fi
   fi
 
   # Set a variable when the macOS system Ruby is new enough to avoid spawning

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -136,6 +136,10 @@ module Homebrew
         # Homebrew/brew is currently using.
         return if ENV["GITHUB_ACTIONS"]
 
+        # With fake El Capitan for Portable Ruby, we are intentionally not using Xcode 8.
+        # This is because we are not using the CLT and Xcode 8 has the 10.12 SDK.
+        return if ENV["HOMEBREW_FAKE_EL_CAPITAN"]
+
         message = <<~EOS
           Your Xcode (#{MacOS::Xcode.version}) is outdated.
           Please update to Xcode #{MacOS::Xcode.latest_version} (or delete it).

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -32,7 +32,11 @@ module OS
     # using the standard Ruby Comparable methods.
     sig { returns(Version) }
     def full_version
-      @full_version ||= Version.new((ENV["HOMEBREW_MACOS_VERSION"]).chomp)
+      @full_version ||= if ENV["HOMEBREW_FAKE_EL_CAPITAN"] # for Portable Ruby building
+        Version.new("10.11.6")
+      else
+        Version.new((ENV["HOMEBREW_MACOS_VERSION"]).chomp)
+      end
     end
 
     sig { params(version: Version).void }

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -71,6 +71,11 @@ module OS
       def needs_clt_installed?
         return false if latest_sdk_version?
 
+        # With fake El Capitan for Portable Ruby, we want the full 10.11 SDK so that we can link
+        # against the correct set of libraries in the SDK sysroot rather than the system's copies.
+        # We therefore do not use the CLT under this setup, which installs to /usr/include.
+        return false if ENV["HOMEBREW_FAKE_EL_CAPITAN"]
+
         without_clt?
       end
 


### PR DESCRIPTION
Building for El Capitan on a system that's not El Capitan is always going to be a hack. Aim here is to keep that to a minimum.