### PR TITLE
superenv: avoid adding blank `--isysroot` flag

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -232,7 +232,7 @@ class Cmd
       if mac?
         sdk ||= enum.next
         # We set the sysroot for macOS SDKs
-        args << "-isysroot#{sdk}" unless sdk.downcase.include? "osx"
+        args << "-isysroot#{sdk}" if !sdk.downcase.include?("osx") && !sdk.empty?
       else
         args << arg
         args << enum.next unless sdk


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Recently encountered an issue on macOS Sierra where the "lxml" resource wouldn't build because `--isysroot ""` was being called by clang:
```
  clang -bundle -undefined dynamic_lookup build/temp.macosx-10.12-x86_64-cpython-39/src/lxml/etree.o -lxslt -lexslt -lxml2 -lz -lm -o build/lib.macosx-10.12-x86_64-cpython-39/lxml/etree.cpython-39-darwin.so -isysroot ""
  ld: library not found for -lxslt
``` 
The fix is to ensure `--isysroot` has a valid value before adding (or set SDKROOT in the formula, but that has its [own complications](https://github.com/Homebrew/homebrew-core/pull/99088)).

Side note that `brew style` is currently only checking the bash section of this file, so it has a few nits lurking in its ruby section.