### PR TITLE
named_args: handle additional cask exception

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -155,7 +155,7 @@ module Homebrew
             end
 
             return cask
-          rescue Cask::CaskUnreadableError => e
+          rescue Cask::CaskUnreadableError, Cask::CaskInvalidError => e
             # If we're trying to get a keg-like Cask, do our best to handle it
             # not being readable and return something that can be used.
             if want_keg_like_cask


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I stumbled across a case where I could not uninstall a cask because the caskfile was invalid (I had installed the test variant of `font-ibm-plex-mono` that uses the git spare checkout logic).
The exception being returning was [CaskInvalidError](https://github.com/Homebrew/brew/blob/6f06236bca93f354120f1d367d66cb7bbf4ddf82/Library/Homebrew/cask/exceptions.rb#L195-L202)

Because there was no `Rescue` for the exception, I was being presented an error.

```
==> brew uninstall font-ibm-plex-mono
Error: Cask 'font-ibm-plex-mono' definition is invalid: 'url' stanza failed with: unknown keyword: only_paths
```

After this change the same logic for unreadable casks is applied in these cases.