### PR TITLE
version: tokenize prior to freezing

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -635,6 +635,12 @@ class Version
   end
   alias to_str to_s
 
+  sig { returns(T.self_type) }
+  def freeze
+    tokens # Determine and store tokens before freezing
+    super
+  end
+
   protected
 
   sig { returns(String) }


### PR DESCRIPTION
Noticed this while using a Version constant over at Homebrew/portable-ruby.

We modify `@tokens` the first time `tokens` is called, so let's make sure that happens before the object is frozen.