### PR TITLE
exceptions: fix did_you_mean error in some scenarios

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -95,6 +95,8 @@ class FormulaOrCaskUnavailableError < RuntimeError
 
   sig { returns(String) }
   def did_you_mean
+    require "formula"
+
     similar_formula_names = Formula.fuzzy_search(name)
     return "" if similar_formula_names.blank?
 


### PR DESCRIPTION
Discovered while testing a release workflow for Homebrew/portable-ruby.

```
 /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/exceptions.rb:98:in `did_you_mean': undefined method `fuzzy_search' for Formula:Class (NoMethodError)
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/exceptions.rb:142:in `to_s'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:168:in `message'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:168:in `rescue in <main>'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:145:in `<main>'
```