### PR TITLE
move check ENV.runtime_cpu_detection to `utils/ast`

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -292,8 +292,7 @@ module FormulaCellarChecks
     dot_brew_formula = formula.prefix/".brew/#{formula.name}.rb"
     return unless dot_brew_formula.exist?
 
-    require "utils/ast"
-    return unless Utils::AST::FormulaAST.new(dot_brew_formula.read).include_runtime_cpu_detection?
+    return unless dot_brew_formula.read.include? "ENV.runtime_cpu_detection"
 
     # macOS `objdump` is a bit slow, so we prioritise llvm's `llvm-objdump` (~5.7x faster)
     # or binutils' `objdump` (~1.8x faster) if they are installed.

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -291,8 +291,9 @@ module FormulaCellarChecks
 
     dot_brew_formula = formula.prefix/".brew/#{formula.name}.rb"
     return unless dot_brew_formula.exist?
-    # TODO: add methods to `utils/ast` to allow checking for method use
-    return unless dot_brew_formula.read.include? "ENV.runtime_cpu_detection"
+
+    require "utils/ast"
+    return unless Utils::AST::FormulaAST.new(dot_brew_formula.read).include_runtime_cpu_detection?
 
     # macOS `objdump` is a bit slow, so we prioritise llvm's `llvm-objdump` (~5.7x faster)
     # or binutils' `objdump` (~1.8x faster) if they are installed.

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -190,19 +190,6 @@ module Utils
         tree_rewriter.insert_after(preceding_expr, "\n#{stanza_text(name, value, indent: 2)}")
       end
 
-      sig { returns(T::Boolean) }
-      def include_runtime_cpu_detection?
-        install_node = children.find do |child|
-          (child.is_a? RuboCop::AST::DefNode) && child.method_name == :install
-        end
-
-        return false if install_node.blank?
-
-        install_node.each_node.any? do |node|
-          node.send_type? && node.receiver&.const_name == "ENV" && node.method_name == :runtime_cpu_detection
-        end
-      end
-
       private
 
       sig { returns(String) }

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -190,6 +190,19 @@ module Utils
         tree_rewriter.insert_after(preceding_expr, "\n#{stanza_text(name, value, indent: 2)}")
       end
 
+      sig { returns(T::Boolean) }
+      def include_runtime_cpu_detection?
+        install_node = children.find do |child|
+          (child.is_a? RuboCop::AST::DefNode) && child.method_name == :install
+        end
+
+        return false if install_node.blank?
+
+        install_node.each_node.any? do |node|
+          node&.receiver&.const_name == "ENV" && node&.method_name == :runtime_cpu_detection
+        end
+      end
+
       private
 
       sig { returns(String) }

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -199,7 +199,7 @@ module Utils
         return false if install_node.blank?
 
         install_node.each_node.any? do |node|
-          node.send_type? && node.receiver.const_name == "ENV" && node.method_name == :runtime_cpu_detection
+          node.send_type? && node.receiver&.const_name == "ENV" && node.method_name == :runtime_cpu_detection
         end
       end
 

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -199,7 +199,7 @@ module Utils
         return false if install_node.blank?
 
         install_node.each_node.any? do |node|
-          node&.receiver&.const_name == "ENV" && node&.method_name == :runtime_cpu_detection
+          node.send_type? && node.receiver.const_name == "ENV" && node.method_name == :runtime_cpu_detection
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
move the check whether the formula includes `ENV.runtime_cpu_detection` to `utils/ast`.