### PR TITLE
Sparkle: Provide channel information in Item

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -36,6 +36,8 @@ module Homebrew
         Item = Struct.new(
           # @api public
           :title,
+          # @api public
+          :channel,
           # @api private
           :pub_date,
           # @api public
@@ -102,6 +104,7 @@ module Homebrew
               os = enclosure["os"]
             end
 
+            channel = item.elements["channel"]&.text
             url ||= item.elements["link"]&.text
             short_version ||= item.elements["shortVersionString"]&.text&.strip
             version ||= item.elements["version"]&.text&.strip
@@ -135,6 +138,7 @@ module Homebrew
 
             data = {
               title:          title,
+              channel:        channel,
               pub_date:       pub_date,
               url:            url,
               bundle_version: bundle_version,

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -52,7 +52,15 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
       </item>
     EOS
 
-    appcast_xml = <<~EOS
+    items_to_omit = <<~EOS
+      #{first_item.sub(%r{<(enclosure[^>]+?)\s*?/>}, '<\1 os="not-osx" />')}
+      #{first_item.sub(/(<sparkle:minimumSystemVersion>)[^<]+?</m, '\1100<')}
+      #{first_item.sub(/(<sparkle:minimumSystemVersion>)[^<]+?</m, '\19000<')}
+      <item>
+      </item>
+    EOS
+
+    appcast = <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
       <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
         <channel>
@@ -66,16 +74,8 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
       </rss>
     EOS
 
-    extra_items = <<~EOS
-      #{first_item.sub(%r{<(enclosure[^>]+?)\s*?/>}, '<\1 os="not-osx" />')}
-      #{first_item.sub(/(<sparkle:minimumSystemVersion>)[^<]+?</m, '\1100<')}
-      #{first_item.sub(/(<sparkle:minimumSystemVersion>)[^<]+?</m, '\19000<')}
-      <item>
-      </item>
-    EOS
-
-    appcast_with_omitted_items = appcast_xml.sub("</item>", "</item>\n#{extra_items}")
-    beta_channel_item = appcast_xml.sub(
+    omitted_items = appcast.sub("</item>", "</item>\n#{items_to_omit}")
+    beta_channel_item = appcast.sub(
       first_item,
       first_item.sub(
         "</title",
@@ -83,23 +83,23 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
       ),
     )
     no_versions_item =
-      appcast_xml
+      appcast
         .sub(second_item, "")
         .gsub(/sparkle:(shortVersionString|version)="[^"]+?"\s*/, "")
         .sub(
           "<title>#{item_hash[0][:title]}</title>",
           "<title>Version</title>",
         )
-    no_items = appcast_xml.sub(%r{<item>.+</item>}m, "")
-    undefined_namespace_xml = appcast_xml.sub(/\s*xmlns:sparkle="[^"]+?"/, "")
+    no_items = appcast.sub(%r{<item>.+</item>}m, "")
+    undefined_namespace = appcast.sub(/\s*xmlns:sparkle="[^"]+?"/, "")
 
     {
-      appcast:                    appcast_xml,
-      appcast_with_omitted_items: appcast_with_omitted_items,
-      beta_channel_item:          beta_channel_item,
-      no_versions_item:           no_versions_item,
-      no_items:                   no_items,
-      undefined_namespace:        undefined_namespace_xml,
+      appcast:             appcast,
+      omitted_items:       omitted_items,
+      beta_channel_item:   beta_channel_item,
+      no_versions_item:    no_versions_item,
+      no_items:            no_items,
+      undefined_namespace: undefined_namespace,
     }
   }
 
@@ -107,7 +107,7 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
 
   let(:items) {
     items = {
-      appcast:          [
+      appcast: [
         Homebrew::Livecheck::Strategy::Sparkle::Item.new(
           title:          item_hash[0][:title],
           pub_date:       Time.parse(item_hash[0][:pub_date]),
@@ -121,19 +121,16 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
           bundle_version: Homebrew::BundleVersion.new(item_hash[1][:short_version], item_hash[1][:version]),
         ),
       ],
-      no_versions_item: [
-        Homebrew::Livecheck::Strategy::Sparkle::Item.new(
-          title:          "Version",
-          pub_date:       Time.parse(item_hash[0][:pub_date]),
-          url:            item_hash[0][:url],
-          bundle_version: nil,
-        ),
-      ],
     }
 
     beta_channel_item = items[:appcast][0].clone
     beta_channel_item.channel = "beta"
     items[:beta_channel_item] = [beta_channel_item, items[:appcast][1].clone]
+
+    no_versions_item = items[:appcast][0].clone
+    no_versions_item.title = "Version"
+    no_versions_item.bundle_version = nil
+    items[:no_versions_item] = [no_versions_item]
 
     items
   }
@@ -151,15 +148,15 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
   end
 
   describe "::items_from_content" do
-    let(:items_from_appcast_xml) { sparkle.items_from_content(xml[:appcast]) }
-    let(:first_item) { items_from_appcast_xml[0] }
+    let(:items_from_appcast) { sparkle.items_from_content(xml[:appcast]) }
+    let(:first_item) { items_from_appcast[0] }
 
     it "returns nil if content is blank" do
       expect(sparkle.items_from_content("")).to eq([])
     end
 
     it "returns an array of Items when given XML data" do
-      expect(items_from_appcast_xml).to eq(items[:appcast])
+      expect(items_from_appcast).to eq(items[:appcast])
       expect(first_item.title).to eq(item_hash[0][:title])
       expect(first_item.pub_date).to eq(Time.parse(item_hash[0][:pub_date]))
       expect(first_item.url).to eq(item_hash[0][:url])
@@ -176,7 +173,7 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
 
     it "returns an array of version strings when given content" do
       expect(sparkle.versions_from_content(xml[:appcast])).to eq(versions)
-      expect(sparkle.versions_from_content(xml[:appcast_with_omitted_items])).to eq(versions)
+      expect(sparkle.versions_from_content(xml[:omitted_items])).to eq(versions)
       expect(sparkle.versions_from_content(xml[:beta_channel_item])).to eq(versions)
       expect(sparkle.versions_from_content(xml[:no_versions_item])).to eq([])
       expect(sparkle.versions_from_content(xml[:undefined_namespace])).to eq(versions)
@@ -214,7 +211,7 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
         sparkle.versions_from_content(xml[:appcast], title_regex) do |item, regex|
           item.title[regex, 1]
         end,
-      ).to eq([items[:appcast][0].short_version])
+      ).to eq([item_hash[0][:short_version]])
 
       expect(
         sparkle.versions_from_content(xml[:appcast], title_regex) do |items, regex|
@@ -225,18 +222,18 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
 
           "#{match[1]},#{item.version}"
         end,
-      ).to eq(["#{items[:appcast][0].short_version},#{items[:appcast][0].version}"])
+      ).to eq(["#{item_hash[0][:short_version]},#{item_hash[0][:version]}"])
 
       # Returning an array of strings from the block
       expect(
         sparkle.versions_from_content(xml[:appcast], title_regex) do |item, regex|
           [item.title[regex, 1]]
         end,
-      ).to eq([items[:appcast][0].short_version])
+      ).to eq([item_hash[0][:short_version]])
 
       expect(
         sparkle.versions_from_content(xml[:appcast], &:short_version),
-      ).to eq([items[:appcast][0].short_version])
+      ).to eq([item_hash[0][:short_version]])
 
       expect(
         sparkle.versions_from_content(xml[:appcast], title_regex) do |items, regex|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to #13357, where I added the ability to optionally pass all `Sparkle` `items` into a `strategy` block. That was necessary to be able to filter (or sort) items in a `strategy` block. This PR adds `sparkle:channel` information to the `Item` struct, so we can access it in a `strategy` block and use it for filtering.

These changes are geared toward omitting `beta` channel items in the Sparkle feed for the `graphicconverter` cask (see Homebrew/homebrew-cask#124613). The `strategy` block will be very simple but these changes were necessary to make it technically possible:

```ruby
strategy :sparkle do |items|
  items.find { |item| item.channel.nil? }&.nice_version
end
```

Basically, Sparkle items without a channel (i.e., `item.channel == nil`) are implicitly on the default channel and this is what Sparkle itself uses for updates. Stable casks should be restricted to the default channel but there are also unstable casks (e.g., in homebrew/cask-versions), so we shouldn't do this filtering within the strategy like we do for `minimumSystemVersion`. So far `graphicconverter` is the only cask where this has been reported as a problem, so it makes sense to push this filtering to `strategy` blocks for now.

-----

Past that, this also tidies up the Sparkle tests a bit. After adding `channel` tests, I took another pass to rename variables, restructure, etc. (mostly to clean up my work from #13357).