### PR TITLE
Remove download sha file from .metadata dir when uninstalling casks

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -403,7 +403,10 @@ module Cask
     def uninstall
       oh1 "Uninstalling Cask #{Formatter.identifier(@cask)}"
       uninstall_artifacts(clear: true)
-      remove_config_file if !reinstall? && !upgrade?
+      if !reinstall? && !upgrade?
+        remove_download_sha
+        remove_config_file
+      end
       purge_versioned_files
       purge_caskroom_path if force?
     end
@@ -411,6 +414,10 @@ module Cask
     def remove_config_file
       FileUtils.rm_f @cask.config_path
       @cask.config_path.parent.rmdir_if_possible
+    end
+
+    def remove_download_sha
+      FileUtils.rm_f @cask.download_sha_path if @cask.download_sha_path.exist?
     end
 
     def start_upgrade


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This removes the `.metadata/DOWNLOAD_SHA256` file in each cask folder when uninstalling casks. This file was preventing a full uninstall and the presence of the almost empty cask folder would cause the uninstalled cask to continue to show up in `brew list`.