### PR TITLE
Git: Remove tags_only_debian logic

### DIFF
--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -101,13 +101,7 @@ module Homebrew
             return Strategy.handle_block_return(block_return_value)
           end
 
-          tags_only_debian = tags.all? { |tag| tag.start_with?("debian/") }
-
           tags.map do |tag|
-            # Skip tag if it has a 'debian/' prefix and upstream does not do
-            # only 'debian/' prefixed tags
-            next if tag =~ %r{^debian/} && !tags_only_debian
-
             if regex
               # Use the first capture group (the version)
               tag.scan(regex).first&.first


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `tags_only_debian` code in livecheck's `Git` strategy was originally introduced in Homebrew/homebrew-livecheck#131 when livecheck was in a less mature state and relied more on internal special-casing like this (i.e., while we worked to add appropriate `livecheck` blocks). This logic only has the potential to be beneficial when a formula/cask doesn't contain a `livecheck` block but I would argue that we shouldn't be making assumptions in the strategy around whether tags with a `debian/` prefix should be matched or omitted. The answer depends upon the context of a given formula/cask and should be handled with a `livecheck` block, as we do with other situations like this.

Besides that, the `tags_only_debian` logic expects that the tags have already been filtered to only include ones that match a provided regex before they're passed to `#versions_from_tags` (the `#tag_info` method currently does this). That is to say, if a repository uses tags with a `debian/` prefix but there's even one tag that doesn't include the prefix, `tags_only_debian` will be `false` and the method will skip tags that we should be matching.  For example, the `posh` repository uses `debian/` tags and the formula's `livecheck` block contains a `%r{^debian/v?(\d+(?:\.\d+)+)$}i` regex that clearly intends to match debian tags but they would be omitted in this scenario.

I'm working on refactoring the `Git` strategy to be able to work with cached `git ls-remote --tags` output and part of this involves removing the regex filtering from `#tag_info`, so it returns the unfiltered tags (i.e., caching filtered tags would cause problems for a different formula/cask checking the same repository with a different regex). The `#versions_from_tags` method already uses a provided regex for filtering (i.e., a tag that doesn't match will be omitted), so the forthcoming changes will also simplify the strategy in some areas.

With this in mind, I've run comparative checks over formulae/casks using the `Git` strategy and there are only four formulae that would be affected by removing the `tags_only_debian` logic. I created PRs to add `livecheck` blocks for these (now merged), so they're each handled in a contextually-appropriate manner instead of having the strategy make assumptions.