### PR TITLE
Git: Use system_command instead of Open3.capture3

### DIFF
--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -52,23 +52,22 @@ module Homebrew
         # @return [Hash]
         sig { params(url: String, regex: T.nilable(Regexp)).returns(T::Hash[Symbol, T.untyped]) }
         def self.tag_info(url, regex = nil)
-          # Open3#capture3 is used here because we need to capture stderr
-          # output and handle it in an appropriate manner. Alternatives like
-          # SystemCommand always print errors (as well as debug output) and
-          # don't meet the same goals.
-          stdout_str, stderr_str, _status = Open3.capture3(
-            { "GIT_TERMINAL_PROMPT" => "0" }, "git", "ls-remote", "--tags", url
+          stdout, stderr, _status = system_command(
+            "git",
+            args:         ["ls-remote", "--tags", url],
+            env:          { "GIT_TERMINAL_PROMPT" => "0" },
+            print_stdout: false,
+            print_stderr: false,
+            debug:        false,
+            verbose:      false,
           )
 
           tags_data = { tags: [] }
-          tags_data[:messages] = stderr_str.split("\n") if stderr_str.present?
-          return tags_data if stdout_str.blank?
+          tags_data[:messages] = stderr.split("\n") if stderr.present?
+          return tags_data if stdout.blank?
 
-          # Isolate tag strings by removing leading/trailing text
-          stdout_str.gsub!(%r{^.*\trefs/tags/}, "")
-          stdout_str.gsub!("^{}", "")
-
-          tags = stdout_str.split("\n").uniq.sort
+          # Isolate tag strings and filter by regex
+          tags = stdout.gsub(%r{^.*\trefs/tags/|\^{}$}, "").split("\n").uniq.sort
           tags.select! { |t| t =~ regex } if regex
           tags_data[:tags] = tags
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In a past discussion, it was preferred that we use `system_command` in livecheck's `Git` strategy instead of `Open3.capture3` but it wasn't feasible at the time because we couldn't prevent `#system_command` from printing certain output. I resolved the `SystemCommand` shortcoming long ago in Homebrew/brew#10066, so this finally migrates the `Git` strategy to `system_command`.

I did comparative runs without/with these changes across formulae/casks using the `Git` strategy and didn't observe any issues (i.e., everything works the same as before). I tested known error conditions (e.g., a missing repository, a repository with no tags) and the behavior remains the same.

-----

This should be the last bit of `Git` rework before the forthcoming PR to expand support of cached content in strategies (similar to what `PageMatch` has). [The actual caching logic will be added in a later PR but the `content` changes should be the last of the underlying foundation.]