### PR TITLE
livecheck: update --newer-only and --quiet behavior

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -245,7 +245,7 @@ module Homebrew
 
         skip_info ||= SkipConditions.skip_information(formula_or_cask, full_name: use_full_name, verbose: verbose)
         if skip_info.present?
-          next skip_info if json
+          next skip_info if json && !newer_only
 
           SkipConditions.print_skip_information(skip_info) if !newer_only && !quiet
           next
@@ -285,6 +285,7 @@ module Homebrew
         if latest.blank?
           no_versions_msg = "Unable to get versions"
           raise Livecheck::Error, no_versions_msg unless json
+          next if quiet
 
           next version_info if version_info.is_a?(Hash) && version_info[:status] && version_info[:messages]
 
@@ -341,7 +342,7 @@ module Homebrew
 
         if json
           progress&.increment
-          status_hash(formula_or_cask, "error", [e.to_s], full_name: use_full_name, verbose: verbose)
+          status_hash(formula_or_cask, "error", [e.to_s], full_name: use_full_name, verbose: verbose) unless quiet
         elsif !quiet
           name = formula_or_cask_name(formula_or_cask, full_name: use_full_name)
           name += " (cask)" if ambiguous_casks.include?(formula_or_cask)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -247,7 +247,7 @@ module Homebrew
         if skip_info.present?
           next skip_info if json
 
-          SkipConditions.print_skip_information(skip_info) unless quiet
+          SkipConditions.print_skip_information(skip_info) if !newer_only && !quiet
           next
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It was mentioned in #13395 that skip messages are printed when livecheck's `--newer-only` option is used and there's currently no way to avoid this. That issue suggested an `--ignore-skipped` option but we agreed that it's simpler to update livecheck's behavior to omit skip messages when the `--newer-only` option is used. [If a user also wants to omit error messages (i.e., only printing newer formulae/casks), they can use `--newer-only --quiet`.]

This PR implements the aforementioned change and also brings the JSON output in line by making the `--newer-only` and `--quiet` options apply to `--json` runs. This gives users a bit of control over the JSON output without having to manually filter it themselves.

Resolves #13395.