### PR TITLE
Remove unused parser option required_for

### DIFF
--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -164,21 +164,15 @@ describe Homebrew::CLI::Parser do
     subject(:parser) {
       described_class.new do
         flag      "--flag1="
+        flag      "--flag2=", depends_on: "--flag1="
         flag      "--flag3="
-        flag      "--flag2=", required_for: "--flag1="
-        flag      "--flag4=", depends_on: "--flag3="
 
         conflicts "--flag1=", "--flag3="
       end
     }
 
-    it "raises exception on required_for constraint violation" do
-      expect { parser.parse(["--flag1=flag1"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
-    end
-
     it "raises exception on depends_on constraint violation" do
       expect { parser.parse(["--flag2=flag2"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
-      expect { parser.parse(["--flag4=flag4"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
     end
 
     it "raises exception for conflict violation" do
@@ -216,20 +210,14 @@ describe Homebrew::CLI::Parser do
       described_class.new do
         switch      "-a", "--switch-a", env: "switch_a"
         switch      "-b", "--switch-b", env: "switch_b"
-        switch      "--switch-c", required_for: "--switch-a"
-        switch      "--switch-d", depends_on: "--switch-b"
+        switch      "--switch-c", depends_on: "--switch-a"
 
         conflicts "--switch-a", "--switch-b"
       end
     }
 
-    it "raises exception on required_for constraint violation" do
-      expect { parser.parse(["--switch-a"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
-    end
-
     it "raises exception on depends_on constraint violation" do
       expect { parser.parse(["--switch-c"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
-      expect { parser.parse(["--switch-d"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
     end
 
     it "raises exception for conflict violation" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I was looking at the parser and I was surprised to see that there is a `:required_for` option available for both `switch` and `flag`. Unlike `:depends_on` this option is not used anywhere so I figured it could be removed.