### PR TITLE
livecheck: update default match_data

### DIFF
--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -4,8 +4,8 @@
 module Homebrew
   module Livecheck
     module Strategy
-      # The {ElectronBuilder} strategy fetches content at a URL and parses
-      # it as an electron-builder appcast in YAML format.
+      # The {ElectronBuilder} strategy fetches content at a URL and parses it
+      # as an electron-builder appcast in YAML format.
       #
       # This strategy is not applied automatically and it's necessary to use
       # `strategy :electron_builder` in a `livecheck` block to apply it.
@@ -35,6 +35,7 @@ module Homebrew
         # Parses YAML text and identifies versions in it.
         #
         # @param content [String] the YAML text to parse and check
+        # @param regex [Regexp, nil] a regex for use in a strategy block
         # @return [Array]
         sig {
           params(

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -75,7 +75,7 @@ module Homebrew
             raise ArgumentError, "#{T.must(name).demodulize} only supports a regex when using a `strategy` block"
           end
 
-          match_data = { matches: {}, url: url }
+          match_data = { matches: {}, regex: regex, url: url }
 
           match_data.merge!(Strategy.page_content(url))
           content = match_data.delete(:content)

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -96,7 +96,7 @@ module Homebrew
           end
           raise ArgumentError, "The #{T.must(name).demodulize} strategy only supports casks." unless T.unsafe(cask)
 
-          match_data = { matches: {} }
+          match_data = { matches: {}, regex: regex }
 
           unversioned_cask_checker = UnversionedCaskChecker.new(cask)
           items = unversioned_cask_checker.all_versions.transform_values { |v| Item.new(bundle_version: v) }

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -58,6 +58,7 @@ module Homebrew
         # {UnversionedCaskChecker} version information.
         #
         # @param items [Hash] a hash of `Item`s containing version information
+        # @param regex [Regexp, nil] a regex for use in a strategy block
         # @return [Array]
         sig {
           params(
@@ -81,6 +82,7 @@ module Homebrew
         # versions from `plist` files.
         #
         # @param cask [Cask::Cask] the cask to check for version information
+        # @param regex [Regexp, nil] a regex for use in a strategy block
         # @return [Hash]
         sig {
           params(

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -199,7 +199,7 @@ module Homebrew
             raise ArgumentError, "#{T.must(name).demodulize} only supports a regex when using a `strategy` block"
           end
 
-          match_data = { matches: {}, url: url }
+          match_data = { matches: {}, regex: regex, url: url }
 
           match_data.merge!(Strategy.page_content(url))
           content = match_data.delete(:content)

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -6,8 +6,8 @@ require "bundle_version"
 module Homebrew
   module Livecheck
     module Strategy
-      # The {Sparkle} strategy fetches content at a URL and parses
-      # it as a Sparkle appcast in XML format.
+      # The {Sparkle} strategy fetches content at a URL and parses it as a
+      # Sparkle appcast in XML format.
       #
       # This strategy is not applied automatically and it's necessary to use
       # `strategy :sparkle` in a `livecheck` block to apply it.
@@ -60,7 +60,7 @@ module Homebrew
           delegate nice_version: :bundle_version
         end
 
-        # Identify version information from a Sparkle appcast.
+        # Identifies version information from a Sparkle appcast.
         #
         # @param content [String] the text of the Sparkle appcast
         # @return [Item, nil]
@@ -152,9 +152,12 @@ module Homebrew
           end.compact
         end
 
-        # Identify versions from content
+        # Uses `#items_from_content` to identify versions from the Sparkle
+        # appcast content or, if a block is provided, passes the content to
+        # the block to handle matching.
         #
-        # @param content [String] the content to pull version information from
+        # @param content [String] the content to check
+        # @param regex [Regexp, nil] a regex for use in a strategy block
         # @return [Array]
         sig {
           params(
@@ -186,6 +189,10 @@ module Homebrew
         end
 
         # Checks the content at the URL for new versions.
+        #
+        # @param url [String] the URL of the content to check
+        # @param regex [Regexp, nil] a regex for use in a strategy block
+        # @return [Hash]
         sig {
           params(
             url:     String,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

livecheck's `ElectronBuilder`, `ExtractPlist`, and `Sparkle` strategies did not support a regex when they were originally created but I added support for a regex when a `strategy` block is also provided (#12449). At the time, I forgot to add the `regex` value to the `match_data` hash, so this PR updates these strategies accordingly.

Besides that, this adds missing documentation comments (e.g., `# @param regex [Regexp, nil] a regex for use in a strategy block`) and makes other small comment tweaks.