### PR TITLE
sandbox: allow file-write-setugid

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -35,6 +35,7 @@ class Sandbox
 
   def allow_write(path, options = {})
     add_rule allow: true, operation: "file-write*", filter: path_filter(path, options[:type])
+    add_rule allow: true, operation: "file-write-setugid", filter: path_filter(path, options[:type])
   end
 
   def deny_write(path, options = {})


### PR DESCRIPTION
A sandbox change in macOS 12.3 means that `file-write-setugid` is no longer covered by the wildcard `file-write*` permission.