### PR TITLE
utils/pypi: handle HTTP error codes

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -57,7 +57,7 @@ module PyPI
       else
         "https://pypi.org/pypi/#{@name}/json"
       end
-      out, _, status = curl_output metadata_url, "--location"
+      out, _, status = curl_output metadata_url, "--location", "--fail"
 
       return unless status.success?
 


### PR DESCRIPTION
Fixes recent test failures.

Previously the 404 response returned invalid JSON so we would return nil from the `JSON::ParserError` rescue. It has changed today to now be valid JSON, so we should properly check for HTTP codes indicating failure.