### PR TITLE
dev-cmd/extract: strip out old bottle disable reasons

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -64,7 +64,7 @@ module Homebrew
 
   module_function
 
-  BOTTLE_BLOCK_REGEX = /  bottle do.+?end\n\n/m.freeze
+  BOTTLE_BLOCK_REGEX = /  bottle (?:do.+?end|:[a-z]+)\n\n/m.freeze
 
   sig { returns(CLI::Parser) }
   def extract_args


### PR DESCRIPTION
These lines now error since 3.5.0 so let's just strip them out like we do for bottle blocks.

Fixes #13405.