### PR TITLE
Gnome: Update default regex and version filtering

### DIFF
--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -66,7 +66,7 @@ module Homebrew
           # GNOME archive files seem to use a standard filename format, so we
           # count on the delimiter between the package name and numeric
           # version being a hyphen and the file being a tarball.
-          values[:regex] = /#{regex_name}-(\d+(?:\.\d+)+)\.t/i
+          values[:regex] = /#{regex_name}-(\d+(?:\.\d+)*)\.t/i
 
           values
         end
@@ -99,7 +99,11 @@ module Homebrew
             # Filter out unstable versions using the old version scheme where
             # the major version is below 40.
             version_data[:matches].reject! do |_, version|
-              version.major < 40 && (version.minor >= 90 || version.minor.to_i.odd?)
+              next if version.major >= 40
+              next if version.minor.blank?
+
+              (version.minor.to_i.odd? || version.minor >= 90) ||
+                (version.patch.present? && version.patch >= 90)
             end
           end
 

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -12,7 +12,7 @@ describe Homebrew::Livecheck::Strategy::Gnome do
   let(:generated) {
     {
       url:   "https://download.gnome.org/sources/abc/cache.json",
-      regex: /abc-(\d+(?:\.\d+)+)\.t/i,
+      regex: /abc-(\d+(?:\.\d+)*)\.t/i,
     }
   }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `Gnome` strategy's default regex uses the `+` form of the standard regex for matching versions like 1.2.3. However, with the switch to the new version scheme, some packages had a release that omits a minor and patch (i.e., `40` instead of `40.0`). The default regex fails to match versions like this but the looser `*` form will match both. [When creating regexes, we generally start with the `+` form and only switch to the looser `*` form when it's necessary and contextually-appropriate.]

This also updates the default version filtering logic that's applied to versions using the old GNOME version scheme (below version 40). Outside of the refactoring changes, this also filters out versions where the patch number is 90+, as these are also unstable.

Comparing the output without/with these changes, the only difference is that unstable versions with a 90+ patch are now omitted. As before, if a formula doesn't use the GNOME version scheme, we can opt out of the default filtering by adding a `livecheck` block with a `regex` (we only have a few formulae meeting this criteria at the moment).

-----

For what it's worth, I'll be expanding the `Gnome` strategy test cases as part of a forthcoming PR and these changes are covered as part of that. [These issues were surfaced as part of writing the forthcoming tests but I'm creating separate PRs for fixes beforehand.]