### PR TITLE
Only checksum file downloads, not VCS downloads

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -130,7 +130,7 @@ module Cask
     end
 
     def checksumable?
-      url.using.blank? || url.using == :post
+      DownloadStrategyDetector.detect(url.to_s, url.using) <= AbstractFileDownloadStrategy
     end
 
     def download_sha_path


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/Homebrew/brew/pull/13358 fixes https://github.com/Homebrew/brew/pull/13354 for SVN casks, but I think the problem still exists for other VCS downloads such as Git. The special case of partial clones with sparse checkouts is handled in https://github.com/Homebrew/brew/pull/13232 via https://github.com/Homebrew/brew/commit/ccdd45dbb7322e60cdb72435e4c8c7562a0e7a8b, but for regular Git downloads I'm able to reproduce the problem.

#### Example cask

```ruby
cask "hmarr-gitignore" do
  version :latest
  sha256 :no_check

  url "https://github.com/hmarr/dotfiles.git",
      verified: "github.com/hmarr/dotfiles",
      branch: "main"
  name "hmarr-gitignore"
  homepage "https://github.com/hmarr/dotfiles"

  artifact "gitignore_global", target: "/tmp/gitignore"
end
```

#### Output

```console
$ brew install hmarr/test/hmarr-gitignore
==> Cloning https://github.com/hmarr/dotfiles.git
Cloning into '/Users/hmarr/Library/Caches/Homebrew/Cask/hmarr-gitignore--git'...
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
Warning: No checksum defined for cask 'hmarr-gitignore', skipping verification.
==> Installing Cask hmarr-gitignore
==> Moving Generic Artifact 'gitignore_global' to '/tmp/gitignore'
==> Backing Generic Artifact 'gitignore' up to '/opt/homebrew/Caskroom/hmarr-gitignore/latest/gitignore_global'
==> Removing Generic Artifact '/tmp/gitignore'
==> Purging files for version latest of Cask hmarr-gitignore
Error: Is a directory @ io_fread - /Users/hmarr/Library/Caches/Homebrew/Cask/hmarr-gitignore--git
```

This change uses the logic in the `DownloadStrategyDetector` to determine whether to calculate a checksum or not. It looks like all of the concrete `DownloadStrategy` implementation inherit either from `AbstractFileDownloadStrategy` or `VCSDownloadStrategy`, so I _think_ checking for `AbstractFileDownloadStrategy` in the list of ancestors should be a robust approach. If there's a better way of doing this, I'd be happy to change tack, though!

```console
$ rg '^class' Library/Homebrew/download_strategy.rb
24:class AbstractDownloadStrategy
182:class VCSDownloadStrategy < AbstractDownloadStrategy
272:class AbstractFileDownloadStrategy < AbstractDownloadStrategy
371:class CurlDownloadStrategy < AbstractFileDownloadStrategy
575:class HomebrewCurlDownloadStrategy < CurlDownloadStrategy
588:class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
610:class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy
648:class CurlPostDownloadStrategy < CurlDownloadStrategy
668:class NoUnzipCurlDownloadStrategy < CurlDownloadStrategy
680:class LocalBottleDownloadStrategy < AbstractFileDownloadStrategy
690:class SubversionDownloadStrategy < VCSDownloadStrategy
805:class GitDownloadStrategy < VCSDownloadStrategy
1021:class GitHubGitDownloadStrategy < GitDownloadStrategy
1106:class CVSDownloadStrategy < VCSDownloadStrategy
1188:class MercurialDownloadStrategy < VCSDownloadStrategy
1252:class BazaarDownloadStrategy < VCSDownloadStrategy
1317:class FossilDownloadStrategy < VCSDownloadStrategy
1370:class DownloadStrategyDetector
```

#### Output with this change

```console
$ bin/brew install hmarr/test/hmarr-gitignore
==> Cloning https://github.com/hmarr/dotfiles.git
Cloning into '/Users/hmarr/Library/Caches/Homebrew/Cask/hmarr-gitignore--git'...
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
Warning: No checksum defined for cask 'hmarr-gitignore', skipping verification.
==> Installing Cask hmarr-gitignore
==> Moving Generic Artifact 'gitignore_global' to '/tmp/gitignore'
🍺  hmarr-gitignore was successfully installed!
```

Shout out to @apainintheneck for the initial work on fixing this error 🙌 