### PR TITLE
cmd/update-report: always output new formulae.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -542,12 +542,9 @@ class ReporterHub
   def dump(updated_formula_report: true)
     report_all = Homebrew::EnvConfig.update_report_all_formulae?
 
-    if report_all
-      dump_new_formula_report
-      dump_new_cask_report
-      dump_renamed_formula_report
-    end
-
+    dump_new_formula_report
+    dump_new_cask_report
+    dump_renamed_formula_report if report_all
     dump_deleted_formula_report(report_all)
     dump_deleted_cask_report(report_all)
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -336,7 +336,7 @@ module Homebrew
       },
       HOMEBREW_UPDATE_REPORT_ALL_FORMULAE:       {
         description: "If set, `brew update` lists changes to all formulae and cask files rather than only showing " \
-                     "when they are installed or outdated.",
+                     "when they are new and not installed or outdated and installed.",
         boolean:     true,
       },
       HOMEBREW_UPDATE_TO_TAG:                    {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2177,7 +2177,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   *Default:* macOS: `/private/tmp`, Linux: `/tmp`.
 
 - `HOMEBREW_UPDATE_REPORT_ALL_FORMULAE`
-  <br>If set, `brew update` lists changes to all formulae and cask files rather than only showing when they are installed or outdated.
+  <br>If set, `brew update` lists changes to all formulae and cask files rather than only showing when they are new and not installed or outdated and installed.
 
 - `HOMEBREW_UPDATE_TO_TAG`
   <br>If set, always use the latest stable tag (even if developer commands have been run).

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3195,7 +3195,7 @@ Use this path as the temporary directory for building packages\. Changing this m
 \fBHOMEBREW_UPDATE_REPORT_ALL_FORMULAE\fR
 .
 .br
-If set, \fBbrew update\fR lists changes to all formulae and cask files rather than only showing when they are installed or outdated\.
+If set, \fBbrew update\fR lists changes to all formulae and cask files rather than only showing when they are new and not installed or outdated and installed\.
 .
 .TP
 \fBHOMEBREW_UPDATE_TO_TAG\fR


### PR DESCRIPTION
There's near zero performance overhead and this seems good for discovery.

Marking as `critical` to get into 3.5.1 today.

Fixes #13412