### PR TITLE
Document HOMEBREW_CURL_PATH and HOMEBREW_GIT_PATH

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -373,7 +373,7 @@ setup_curl() {
      "${HOMEBREW_BREWED_CURL_PATH}" --version &>/dev/null
   then
     HOMEBREW_CURL="${HOMEBREW_BREWED_CURL_PATH}"
-  elif [[ -n "${HOMEBREW_DEVELOPER}" && -x "${HOMEBREW_CURL_PATH}" ]]
+  elif [[ -n "${HOMEBREW_CURL_PATH}" ]]
   then
     HOMEBREW_CURL="${HOMEBREW_CURL_PATH}"
   else
@@ -388,7 +388,7 @@ setup_git() {
      "${HOMEBREW_PREFIX}/opt/git/bin/git" --version &>/dev/null
   then
     HOMEBREW_GIT="${HOMEBREW_PREFIX}/opt/git/bin/git"
-  elif [[ -n "${HOMEBREW_DEVELOPER}" && -x "${HOMEBREW_GIT_PATH}" ]]
+  elif [[ -n "${HOMEBREW_GIT_PATH}" ]]
   then
     HOMEBREW_GIT="${HOMEBREW_GIT_PATH}"
   else
@@ -512,12 +512,12 @@ else
   # shellcheck disable=SC2248
   if [[ "$(numeric "${curl_name_and_version##* }")" -lt "$(numeric "${HOMEBREW_MINIMUM_CURL_VERSION}")" ]]
   then
-    message="Please update your system curl.
+    message="Please update your system curl or set HOMEBREW_CURL_PATH to a newer version.
 Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}
 Your curl version: ${curl_name_and_version##* }
 Your curl executable: $(type -p ${HOMEBREW_CURL})"
 
-    if [[ -z ${HOMEBREW_CURL_PATH} || -z ${HOMEBREW_DEVELOPER} ]]
+    if [[ -z ${HOMEBREW_CURL_PATH} ]]
     then
       HOMEBREW_SYSTEM_CURL_TOO_OLD=1
       HOMEBREW_FORCE_BREWED_CURL=1
@@ -541,11 +541,11 @@ Your curl executable: $(type -p ${HOMEBREW_CURL})"
   # shellcheck disable=SC2248
   if [[ "$(numeric "${major}.${minor}.${micro}.${build}")" -lt "$(numeric "${HOMEBREW_MINIMUM_GIT_VERSION}")" ]]
   then
-    message="Please update your system Git.
+    message="Please update your system Git or set HOMEBREW_GIT_PATH to a newer version.
 Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}
 Your Git version: ${major}.${minor}.${micro}.${build}
 Your Git executable: $(unset git && type -p ${HOMEBREW_GIT})"
-    if [[ -z ${HOMEBREW_GIT_PATH} || -z ${HOMEBREW_DEVELOPER} ]]
+    if [[ -z ${HOMEBREW_GIT_PATH} ]]
     then
       HOMEBREW_FORCE_BREWED_GIT="1"
       if [[ -z ${HOMEBREW_GIT_WARNING} ]]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -108,6 +108,10 @@ module Homebrew
                      "use of `curlrc`.",
         boolean:     true,
       },
+      HOMEBREW_CURL_PATH:                        {
+        description: "Linux only: Set this value to a new enough `curl` executable for Homebrew to use.",
+        default:     "curl",
+      },
       HOMEBREW_CURL_RETRIES:                     {
         description: "Pass the given retry count to `--retry` when invoking `curl`(1).",
         default:     3,
@@ -199,6 +203,10 @@ module Homebrew
       },
       HOMEBREW_GIT_NAME:                         {
         description: "Set the Git author and committer name to this value.",
+      },
+      HOMEBREW_GIT_PATH:                         {
+        description: "Linux only: Set this value to a new enough `git` executable for Homebrew to use.",
+        default:     "git",
       },
       HOMEBREW_INSTALL_BADGE:                    {
         description:  "Print this text before the installation summary of each successful build.",


### PR DESCRIPTION
- document both these variables in `man brew`
- allow them to be used on Linux without `HOMEBREW_DEVELOPER`

Inspired by https://github.com/Homebrew/brew/issues/13071. FYI @newearthmartin

We actually check the version of these now so this seems fairly safe to allow users to use their own versions.