### PR TITLE
repair `brew outdated --greedy` to show only casks

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -93,6 +93,8 @@ module Homebrew
   def print_outdated(formulae_or_casks, args:)
     formulae_or_casks.each do |formula_or_cask|
       if formula_or_cask.is_a?(Formula)
+        next if args.greedy? || args.greedy_latest? || args.greedy_auto_updates?
+
         f = formula_or_cask
 
         if verbose?

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -37,13 +37,13 @@ module Homebrew
                           "formula is outdated. Otherwise, the repository's HEAD will only be checked for "\
                           "updates when a new stable or development version has been released."
       switch "--greedy",
-             description: "Print include outdated casks with `auto_updates true` or `version :latest`."
+             description: "Also include outdated casks with `auto_updates true` or `version :latest`."
 
       switch "--greedy-latest",
-             description: "Print include outdated casks including those with `version :latest`."
+             description: "Also include outdated casks including those with `version :latest`."
 
       switch "--greedy-auto-updates",
-             description: "Print include outdated casks including those with `auto_updates true`."
+             description: "Also include outdated casks including those with `auto_updates true`."
 
       conflicts "--quiet", "--verbose", "--json"
       conflicts "--formula", "--cask"

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -37,13 +37,13 @@ module Homebrew
                           "formula is outdated. Otherwise, the repository's HEAD will only be checked for "\
                           "updates when a new stable or development version has been released."
       switch "--greedy",
-             description: "Print outdated casks with `auto_updates true` or `version :latest`."
+             description: "Print include outdated casks with `auto_updates true` or `version :latest`."
 
       switch "--greedy-latest",
-             description: "Print outdated casks including those with `version :latest`."
+             description: "Print include outdated casks including those with `version :latest`."
 
       switch "--greedy-auto-updates",
-             description: "Print outdated casks including those with `auto_updates true`."
+             description: "Print include outdated casks including those with `auto_updates true`."
 
       conflicts "--quiet", "--verbose", "--json"
       conflicts "--formula", "--cask"
@@ -93,8 +93,6 @@ module Homebrew
   def print_outdated(formulae_or_casks, args:)
     formulae_or_casks.each do |formula_or_cask|
       if formula_or_cask.is_a?(Formula)
-        next if args.greedy? || args.greedy_latest? || args.greedy_auto_updates?
-
         f = formula_or_cask
 
         if verbose?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
According to the description, `brew outdated --greedy` shows outdated casks. However, the command does casks and formulae actually.
I repair the command to show only casks.