### PR TITLE
Formulary Improvements with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -167,11 +167,13 @@ module Formulary
       end
 
       if (deprecation_date = json_formula["deprecation_date"]).present?
-        deprecate! date: deprecation_date, because: json_formula["deprecation_reason"]
+        reason = Formulary.convert_to_deprecate_disable_reason_string_or_symbol json_formula["deprecation_reason"]
+        deprecate! date: deprecation_date, because: reason
       end
 
       if (disable_date = json_formula["disable_date"]).present?
-        disable! date: disable_date, because: json_formula["disable_reason"]
+        reason = Formulary.convert_to_deprecate_disable_reason_string_or_symbol json_formula["disable_reason"]
+        disable! date: disable_date, because: reason
       end
 
       json_formula["build_dependencies"].each do |dep|
@@ -259,6 +261,12 @@ module Formulary
     return string[1..].to_sym if string.start_with?(":")
 
     string
+  end
+
+  def self.convert_to_deprecate_disable_reason_string_or_symbol(string)
+    return string unless DeprecateDisable::DEPRECATE_DISABLE_REASONS.keys.map(&:to_s).include?(string)
+
+    string.to_sym
   end
 
   # A {FormulaLoader} returns instances of formulae.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -203,7 +203,7 @@ module Formulary
 
       @caveats_string = json_formula["caveats"]
       def caveats
-        @caveats_string
+        self.class.instance_variable_get(:@caveats_string)
       end
     end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -241,7 +241,7 @@ describe Formulary do
             "recommended_dependencies" => ["recommended_dep"],
             "optional_dependencies"    => ["optional_dep"],
             "uses_from_macos"          => ["uses_from_macos_dep"],
-            "caveats"                  => "",
+            "caveats"                  => "example caveat string",
           }.merge(extra_items),
         }
       end
@@ -276,6 +276,7 @@ describe Formulary do
           expect(formula.deps.count).to eq 5
         end
         expect(formula.uses_from_macos_elements).to eq ["uses_from_macos_dep"]
+        expect(formula.caveats).to eq "example caveat string"
         expect {
           formula.install
         }.to raise_error("Cannot build from source from abstract formula.")

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -345,6 +345,16 @@ describe Formulary do
     end
   end
 
+  describe "::convert_to_string_or_symbol" do
+    it "returns the original string if it doesn't start with a colon" do
+      expect(described_class.convert_to_string_or_symbol("foo")).to eq "foo"
+    end
+
+    it "returns a symbol if the original string starts with a colon" do
+      expect(described_class.convert_to_string_or_symbol(":foo")).to eq :foo
+    end
+  end
+
   describe "::convert_to_deprecate_disable_reason_string_or_symbol" do
     it "returns the original string if it isn't a preset reason" do
       expect(described_class.convert_to_deprecate_disable_reason_string_or_symbol("foo")).to eq "foo"

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -256,7 +256,7 @@ describe Formulary do
       let(:disable_json) do
         {
           "disable_date"   => "2022-06-15",
-          "disable_reason" => "repo_archived",
+          "disable_reason" => "requires something else",
         }
       end
 
@@ -342,6 +342,17 @@ describe Formulary do
       name = "foo-bar"
       expect(described_class.core_path(name))
         .to eq(Pathname.new("#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/Formula/#{name}.rb"))
+    end
+  end
+
+  describe "::convert_to_deprecate_disable_reason_string_or_symbol" do
+    it "returns the original string if it isn't a preset reason" do
+      expect(described_class.convert_to_deprecate_disable_reason_string_or_symbol("foo")).to eq "foo"
+    end
+
+    it "returns a symbol if the original string is a preset reason" do
+      expect(described_class.convert_to_deprecate_disable_reason_string_or_symbol("does_not_build"))
+        .to eq :does_not_build
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR fixes a few issues that I've found with #12936 and adds some more tests.

First, I realized that the preset reason symbols for `deprecate!` and `disable!` aren't encoded into the JSON API in the same way that the preset symbols for `keg_only` and `cellar` are, so I added a method to handle those properly.

Also, the `caveats` method doesn't work as-is, so this PR attempts to fix it.
