### PR TITLE
Allow more developer commands with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -107,6 +107,10 @@ begin
   end
 
   if internal_cmd || Commands.external_ruby_v2_cmd_path(cmd)
+    if Commands::INSTALL_FROM_API_FORBIDDEN_COMMANDS.include?(cmd) && Homebrew::EnvConfig.install_from_api?
+      odie "This command cannot be run while HOMEBREW_INSTALL_FROM_API is set!"
+    end
+
     Homebrew.send Commands.method_name(cmd)
   elsif (path = Commands.external_ruby_cmd_path(cmd))
     require?(path)

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -748,34 +748,6 @@ then
   export HOMEBREW_DEVELOPER_COMMAND="1"
 fi
 
-# Set HOMEBREW_DEVELOPER_MODE if this command will turn (or keep) developer mode on. This is the case if:
-# - The command being run is not `brew developer off`
-# - Any of the following are true
-#   - HOMEBREW_DEVELOPER is set
-#   - HOMEBREW_DEV_CMD_RUN is set
-#   - A developer command is being run
-#   - The command being run is `brew developer on`
-if [[ "${HOMEBREW_COMMAND}" != "developer" || ! $* =~ "off" ]] &&
-   [[ -n "${HOMEBREW_DEVELOPER}" ||
-      -n "${HOMEBREW_DEV_CMD_RUN}" ||
-      -n "${HOMEBREW_DEVELOPER_COMMAND}" ||
-      "${HOMEBREW_COMMAND}" == "developer" && $* =~ "on" ]]
-then
-  export HOMEBREW_DEVELOPER_MODE="1"
-fi
-
-if [[ -n "${HOMEBREW_INSTALL_FROM_API}" && -n "${HOMEBREW_DEVELOPER_COMMAND}" && "${HOMEBREW_COMMAND}" != "irb" ]]
-then
-  odie "Developer commands cannot be run while HOMEBREW_INSTALL_FROM_API is set!"
-elif [[ -n "${HOMEBREW_INSTALL_FROM_API}" && -n "${HOMEBREW_DEVELOPER_MODE}" ]]
-then
-  message="Developers should not have HOMEBREW_INSTALL_FROM_API set!
-Please unset HOMEBREW_INSTALL_FROM_API or turn developer mode off by running:
-  brew developer off
-"
-  opoo "${message}"
-fi
-
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]
 then
   if [[ -z "${HOMEBREW_DEV_CMD_RUN}" ]]

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -140,6 +140,10 @@ module Homebrew
   def install
     args = install_args.parse
 
+    if args.build_from_source? && Homebrew::EnvConfig.install_from_api?
+      raise UsageError, "--build-from-source is not supported when using HOMEBREW_INSTALL_FROM_API."
+    end
+
     if args.env.present?
       # Can't use `replacement: false` because `install_args` are used by
       # `build.rb`. Instead, `hide_from_man_page` and don't do anything with

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -88,6 +88,10 @@ module Homebrew
   def reinstall
     args = reinstall_args.parse
 
+    if args.build_from_source? && Homebrew::EnvConfig.install_from_api?
+      raise UsageError, "--build-from-source is not supported when using HOMEBREW_INSTALL_FROM_API."
+    end
+
     formulae, casks = args.named.to_formulae_and_casks(method: :resolve)
                           .partition { |o| o.is_a?(Formula) }
 

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -31,6 +31,25 @@ module Commands
     "tc"          => "typecheck",
   }.freeze
 
+  INSTALL_FROM_API_FORBIDDEN_COMMANDS = %w[
+    audit
+    bottle
+    bump-cask-pr
+    bump-formula-pr
+    bump-revision
+    bump-unversioned-casks
+    cat
+    create
+    edit
+    extract
+    formula
+    livecheck
+    pr-pull
+    pr-upload
+    test
+    update-python-resources
+  ].freeze
+
   def valid_internal_cmd?(cmd)
     require?(HOMEBREW_CMD_PATH/cmd)
   end

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -114,7 +114,7 @@ module Homebrew
       end.compact
       @sort = " (sorted by installs in the last 90 days; top 10,000 only)"
 
-      all_formulae = Formula
+      all_formulae = Formula.all
     end
 
     [formulae, all_formulae, formula_installs]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR modifies the handling of developer commands with `HOMEBREW_INSTALL_FROM_API`. I've vetted every developer command and separated those that will still work with `HOMEBREW_INSTALL_FROM_API` set so that only those are forbidden. This means that developers can have it set and still run things like `brew irb`, `brew style`, `brew typecheck`, `brew pr-automerge`, etc.

The list mostly comes from [this comment](https://github.com/Homebrew/brew/pull/12936#discussion_r816027220) with the only changes being that `brew pr-automerge` and `brew unbottled` both seem to work with `HOMEBREW_INSTALL_FROM_API` even though they weren't on that list.

I also added a check in `brew install` and `brew reinstall` to make sure that you can't pass `--build-from-source` as this isn't currently supported (and likely won't be).
