### PR TITLE
Always prefer loading from API when `HOMEBREW_INSTALL_FROM_API` is set

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -217,12 +217,15 @@ module Cask
         next unless loader_class.can_load?(ref)
 
         if loader_class == FromTapLoader && Homebrew::EnvConfig.install_from_api? &&
-           ref.start_with?("homebrew/cask/") && !Tap.fetch("homebrew/cask").installed? &&
-           Homebrew::API::CaskSource.available?(ref)
+           ref.start_with?("homebrew/cask/") && Homebrew::API::CaskSource.available?(ref)
           return FromContentLoader.new(Homebrew::API::CaskSource.fetch(ref))
         end
 
         return loader_class.new(ref)
+      end
+
+      if Homebrew::EnvConfig.install_from_api? && Homebrew::API::CaskSource.available?(ref)
+        return FromContentLoader.new(Homebrew::API::CaskSource.fetch(ref))
       end
 
       return FromTapPathLoader.new(default_path(ref)) if FromTapPathLoader.can_load?(default_path(ref))
@@ -237,10 +240,6 @@ module Cask
           Cask #{ref} exists in multiple taps:
           #{loaders.map { |loader| "  #{loader.tap}/#{loader.token}" }.join("\n")}
         EOS
-      end
-
-      if Homebrew::EnvConfig.install_from_api? && Homebrew::API::CaskSource.available?(ref)
-        return FromContentLoader.new(Homebrew::API::CaskSource.fetch(ref))
       end
 
       possible_installed_cask = Cask.new(ref)

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -149,7 +149,7 @@ module Homebrew
     updated_taps = []
     Tap.each do |tap|
       next unless tap.git?
-      next if (tap.core_tap? || tap == "homebrew/cask") && Homebrew::EnvConfig.install_from_api? && args.auto_update?
+      next if (tap.core_tap? || tap == "homebrew/cask") && Homebrew::EnvConfig.install_from_api?
 
       if ENV["HOMEBREW_MIGRATE_LINUXBREW_FORMULAE"].present? && tap.core_tap? &&
          Settings.read("linuxbrewmigrated") != "true"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -701,10 +701,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    # HOMEBREW_UPDATE_AUTO wasn't modified in subshell.
-    # shellcheck disable=SC2031
     if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
-       [[ -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ||
           "${DIR}" == "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" ]]
     then


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR modifies `Formulary` and `Cask::CaskLoader` so that when `HOMEBREW_INSTALL_FROM_API` is set, formulae and casks are always loaded from the API first (if they're available on the API), regardless of whether homebrew/core and homebrew/cask are tapped. Now, if you have an outdated homebrew/core tap that doesn't have the latest version for a formula, the newer version from the API will always be loaded instead of the outdated version from the tap.

I also modified `brew update` to not even try to update homebrew/core and homebrew/cask when `HOMEBREW_INSTALL_FROM_API` is set. Before, these taps were only skipped on auto-updates. I think this makes the most sense since `HOMEBREW_INSTALL_FROM_API` basically says "ignore the core and cask taps" everywhere else. However, if we think we're not ready for this yet, an alternative would be to add an `HOMEBREW_PREFER_API` variable or something like that which if not set would revert to the current functionality where taps take precedence.
