### PR TITLE
Cleanup `Cask::Caskroom::casks`

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -236,10 +236,7 @@ module Cask
       when 2..Float::INFINITY
         loaders = possible_tap_casks.map(&FromTapPathLoader.method(:new))
 
-        raise CaskError, <<~EOS
-          Cask #{ref} exists in multiple taps:
-          #{loaders.map { |loader| "  #{loader.tap}/#{loader.token}" }.join("\n")}
-        EOS
+        raise TapCaskAmbiguityError.new(ref, loaders)
       end
 
       possible_installed_cask = Cask.new(ref)

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -47,14 +47,10 @@ module Cask
         token = path.basename.to_s
 
         begin
-          if (tap_path = CaskLoader.tap_paths(token).first)
-            CaskLoader::FromTapPathLoader.new(tap_path).load(config: config)
-          elsif (caskroom_path = Pathname.glob(path.join(".metadata/*/*/*/*.rb")).first) &&
-                (!Homebrew::EnvConfig.install_from_api? || !Homebrew::API::CaskSource.available?(token))
-            CaskLoader::FromPathLoader.new(caskroom_path).load(config: config)
-          else
-            CaskLoader.load(token, config: config)
-          end
+          CaskLoader.load(token, config: config)
+        rescue TapCaskAmbiguityError
+          tap_path = CaskLoader.tap_paths(token).first
+          CaskLoader::FromTapPathLoader.new(tap_path).load(config: config)
         rescue CaskUnavailableError
           # Don't blow up because of a single unavailable cask.
           nil

--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -124,6 +124,20 @@ module Cask
     end
   end
 
+  # Error when a cask with the same name is found in multiple taps.
+  #
+  # @api private
+  class TapCaskAmbiguityError < CaskError
+    extend T::Sig
+
+    def initialize(ref, loaders)
+      super <<~EOS
+        Cask #{ref} exists in multiple taps:
+        #{loaders.map { |loader| "  #{loader.tap}/#{loader.token}" }.join("\n")}
+      EOS
+    end
+  end
+
   # Error when a cask already exists.
   #
   # @api private


### PR DESCRIPTION
~This PR uses the new `/api/cask-source.json` endpoint to make loading casks using the API must faster. This is super noticeable in `brew outdated` when you have casks installed. Now, there's only one file to download that only needs to update whenever there's a new version available.~

~This PR depends on https://github.com/Homebrew/formulae.brew.sh/pull/654~

Cleanup `Cask::Caskroom::casks` so that it defaults to using a plain `Cask::CaskLoader::load` call. This will more reliably load the most up-to-date version of the cask without needing an extra `if Homebrew::EnvConfig.install_from_api?` call. `::load` uses nearly the same order to check for available casks to load:
1. Check API (if `HOMEBREW_INSTALL_FROM_API` is set)
2. Check `homebrew/cask`
3. Check other taps
4. Load from the caskfile in the metadata

This PR adds a new exception called `TapCaskAmbiguityException` that is raised when a cask exists in multiple taps (when neither is `homebrew/cask`). Now, `Cask::Caskroom::casks` will catch this exception and just choose the first available casks