### PR TITLE
cask/audit: skip additional livecheck audit when cask is discontinued

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -308,7 +308,7 @@ module Cask
     LIVECHECK_REFERENCE_URL = "https://docs.brew.sh/Cask-Cookbook#stanza-livecheck"
 
     def check_hosting_with_livecheck(livecheck_result:)
-      return if block_url_offline? || cask.appcast || cask.livecheckable?
+      return if block_url_offline? || cask.appcast || cask.livecheckable? || cask.discontinued?
       return if livecheck_result == :auto_detected
 
       add_livecheck = "please add a livecheck. See #{Formatter.url(LIVECHECK_REFERENCE_URL)}"

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -308,14 +308,14 @@ module Cask
     LIVECHECK_REFERENCE_URL = "https://docs.brew.sh/Cask-Cookbook#stanza-livecheck"
 
     def check_hosting_with_livecheck(livecheck_result:)
-      return if block_url_offline? || cask.appcast || cask.livecheckable? || cask.discontinued?
+      return if cask.discontinued? || cask.version.latest?
+      return if block_url_offline? || cask.appcast || cask.livecheckable?
       return if livecheck_result == :auto_detected
 
       add_livecheck = "please add a livecheck. See #{Formatter.url(LIVECHECK_REFERENCE_URL)}"
 
       case cask.url.to_s
       when %r{sourceforge.net/(\S+)}
-        return if cask.version.latest?
         return unless online?
 
         add_error "Download is hosted on SourceForge, #{add_livecheck}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If a cask with a Sourceforge URL has a `discontinued` caveat, the audits are failing when the livecheck block is omitted. `discontinued` casks should not have livecheck blocks. This PR checks for `cask.discontinued?` and returns early in the audit if true.

Fixes current CI failure for https://github.com/Homebrew/homebrew-cask/pull/125791