### PR TITLE
livecheck: fix path to livecheck watchlist

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -11,10 +11,7 @@ module Homebrew
 
   module_function
 
-  WATCHLIST_PATH = (
-    Homebrew::EnvConfig.livecheck_watchlist ||
-    "#{Dir.home}/.brew_livecheck_watchlist"
-  ).freeze
+  WATCHLIST_PATH = File.expand_path(Homebrew::EnvConfig.livecheck_watchlist).freeze
 
   sig { returns(CLI::Parser) }
   def livecheck_args

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -221,9 +221,10 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_LIVECHECK_WATCHLIST:              {
-        description: "Consult this file for the list of formulae to check by default when no formula argument " \
-                     "is passed to `brew livecheck`.",
-        default:     "$HOME/.brew_livecheck_watchlist",
+        description:  "Consult this file for the list of formulae to check by default when no formula argument " \
+                      "is passed to `brew livecheck`.",
+        default_text: "$HOME/.brew_livecheck_watchlist",
+        default:      "~/.brew_livecheck_watchlist",
       },
       HOMEBREW_LOGS:                             {
         description:  "Use this directory to store log files.",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently the default path for `brew_livecheck_watchlist` doesn't work at all and the environment variable `HOMEBREW_LIVECHECK_WATCHLIST` doesn't get expanded so it only works with absolute paths. This PR sets a correct default path and expands the path before using it.

Is there some way to expand environment variables in a path too since that's currently not possible with `File#expand_path`? That would be nice to have as well.

Fixes #13453.