### PR TITLE
env_config: clean up default text for `HOMEBREW_LIVECHECK_WATCHLIST`

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -223,7 +223,7 @@ module Homebrew
       HOMEBREW_LIVECHECK_WATCHLIST:              {
         description:  "Consult this file for the list of formulae to check by default when no formula argument " \
                       "is passed to `brew livecheck`.",
-        default_text: "$HOME/.brew_livecheck_watchlist",
+        default_text: "`$HOME/.brew_livecheck_watchlist`",
         default:      "~/.brew_livecheck_watchlist",
       },
       HOMEBREW_LOGS:                             {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2102,7 +2102,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_LIVECHECK_WATCHLIST`
   <br>Consult this file for the list of formulae to check by default when no formula argument is passed to `brew livecheck`.
 
-  *Default:* `$HOME/.brew_livecheck_watchlist`.
+  *Default:* `$HOME/.brew_livecheck_watchlist`
 
 - `HOMEBREW_LOGS`
   <br>Use this directory to store log files.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3051,7 +3051,7 @@ If set, install formulae and casks in homebrew/core and homebrew/cask taps using
 Consult this file for the list of formulae to check by default when no formula argument is passed to \fBbrew livecheck\fR\.
 .
 .IP
-\fIDefault:\fR \fB$HOME/\.brew_livecheck_watchlist\fR\.
+\fIDefault:\fR \fB$HOME/\.brew_livecheck_watchlist\fR
 .
 .TP
 \fBHOMEBREW_LOGS\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #13453. The default values for our other environment
variables are typically wrapped in backticks, so let's do the same here
for consistency.

Closes #13455.
