### PR TITLE
workflows/triage: use PAT with read:org to indentify private members

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -35,7 +35,7 @@ jobs:
             github.event.action != 'closed' && github.event.pull_request.state != 'closed'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          github-token: ${{ secrets.HOMEBREW_BREW_TRIAGE_PULL_REQUESTS_TOKEN }}
           script: |
             async function approvePullRequest(pullRequestNumber) {
               const reviews = await approvalsByAuthenticatedUser(pullRequestNumber)


### PR DESCRIPTION
This PR switches the token used in the triage workflow to a newly generated one with `public_repo` and `read:org` scopes (the old one had only `public_repo`). This will allow the workflow to recognize those who have set their membership to private as Homebrew members.

See https://github.com/Homebrew/brew/pull/13454#issuecomment-1162524571