### PR TITLE
Cask: Ensure `#discontinued?` returns a boolean

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -281,7 +281,7 @@ module Cask
     end
 
     def discontinued?
-      @caveats&.discontinued?
+      @caveats&.discontinued? == true
     end
 
     # @api public


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `Cask::DSL#discontinued?` method is expected to return a boolean value (`true`/`false`) but it will return `nil` for any casks without a `caveats` block. `nil` is still falsy but this PR ensures that the method will properly return a boolean value in this scenario.