### PR TITLE
bump-formula-pr: handle url with specs hash

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -275,7 +275,7 @@ module Homebrew
 
     if new_mirrors.present?
       replacement_pairs << [
-        /^( +)(url "#{Regexp.escape(new_url)}"\n)/m,
+        /^( +)(url "#{Regexp.escape(new_url)}"[^\n]*?\n)/m,
         "\\1\\2\\1mirror \"#{new_mirrors.join("\"\n\\1mirror \"")}\"\n",
       ]
     end
@@ -293,7 +293,7 @@ module Homebrew
         ]
       elsif new_url.present?
         [
-          /^( +)(url "#{Regexp.escape(new_url)}"\n)/m,
+          /^( +)(url "#{Regexp.escape(new_url)}"[^\n]*?\n)/m,
           "\\1\\2\\1version \"#{new_version}\"\n",
         ]
       elsif new_revision.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As mentioned in #13471, the existing `bump-formula-pr` regexes expect a `url` string to only be followed by a newline. However, `url` also accepts a `specs` hash, which can appear after the `url` string. For example:

```ruby
url "https://www.example.com/1.2.3.tar.gz", using: :homebrew_curl
```

This commit modifies the regexes to capture anything after the `url` string and before the newline. This works for the aforementioned example, where the trailing hash is on the same line, but it won't work if the hash appears on a subsequent line. For example:

```ruby
url "https://www.example.com/1.2.3.tar.gz",
  using: :homebrew_curl
```

I spent some time trying to create a regex that would also work for the latter case but didn't meet with success (my brain is a bit too tired tonight). Since we don't have any instances of the multiline format in homebrew/core yet, there's something to be said for merging this PR in the short-term to fix `brew bump-formula-pr` and we can adjust this in a follow-up PR if we come up with a more comprehensive solution.

Fixes #13471.