### PR TITLE
update-report: various updates

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -137,7 +137,7 @@ module Homebrew
       if old_tag.blank? || (new_tag == old_tag)
         puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
       else
-        puts "Updated Homebrew from #{old_tag} (#{shorten_revision(initial_revision)}) " \
+        ohai "Updated Homebrew from #{old_tag} (#{shorten_revision(initial_revision)}) " \
              "to #{new_tag} (#{shorten_revision(current_revision)})."
       end
     end
@@ -239,13 +239,13 @@ module Homebrew
     return if new_tag.blank? || new_tag == old_tag || args.quiet?
 
     puts
-    ohai "Homebrew was updated to version #{new_tag}"
+
     new_major_version, new_minor_version, new_patch_version = new_tag.split(".").map(&:to_i)
     old_major_version, old_minor_version = (old_tag.split(".")[0, 2]).map(&:to_i) if old_tag.present?
     if old_tag.blank? || new_major_version > old_major_version \
         || new_minor_version > old_minor_version
       puts <<~EOS
-        More detailed release notes are available on the Homebrew Blog:
+        The #{new_major_version}.#{new_minor_version}.0 release notes are available on the Homebrew Blog:
           #{Formatter.url("https://brew.sh/blog/#{new_major_version}.#{new_minor_version}.0")}
       EOS
     end
@@ -253,7 +253,7 @@ module Homebrew
     return if new_patch_version.zero?
 
     puts <<~EOS
-      The changelog can be found at:
+      The #{new_tag} changelog can be found at:
         #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_tag}")}
     EOS
   end

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -106,7 +106,7 @@ module Homebrew
 
     if Settings.read("donationmessage") != "true" && !args.quiet?
       ohai "Homebrew is run entirely by unpaid volunteers. Please consider donating:"
-      puts "  #{Formatter.url("https://github.com/Homebrew/brew#donations")}\n"
+      puts "  #{Formatter.url("https://github.com/Homebrew/brew#donations")}\n\n"
 
       # Consider the message possibly missed if not a TTY.
       Settings.write "donationmessage", true if $stdout.tty?

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -134,8 +134,11 @@ module Homebrew
 
       Settings.write "latesttag", new_tag if new_tag != old_tag
 
-      if old_tag.blank? || (new_tag == old_tag)
+      if new_tag == old_tag
         puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
+      elsif old_tag.blank?
+        ohai "Updated Homebrew from #{shorten_revision(initial_revision)} " \
+             "to #{new_tag} (#{shorten_revision(current_revision)})."
       else
         ohai "Updated Homebrew from #{old_tag} (#{shorten_revision(initial_revision)}) " \
              "to #{new_tag} (#{shorten_revision(current_revision)})."

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -115,7 +115,7 @@ module Homebrew
     install_core_tap_if_necessary
 
     updated = false
-    new_repository_version = nil
+    new_tag = nil
 
     initial_revision = ENV["HOMEBREW_UPDATE_BEFORE"].to_s
     current_revision = ENV["HOMEBREW_UPDATE_AFTER"].to_s
@@ -135,7 +135,6 @@ module Homebrew
       if old_tag.blank? || (new_tag == old_tag)
         puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
       else
-        new_repository_version = new_tag
         puts "Updated Homebrew from #{old_tag} (#{shorten_revision(initial_revision)}) " \
              "to #{new_tag} (#{shorten_revision(current_revision)})."
       end
@@ -235,20 +234,20 @@ module Homebrew
       EOS
     end
 
-    return if new_repository_version.blank?
+    return if new_tag.blank? || new_tag == old_tag
 
     puts
-    ohai "Homebrew was updated to version #{new_repository_version}"
-    Settings.write "latesttag", new_repository_version
-    if new_repository_version.split(".").last == "0"
+    ohai "Homebrew was updated to version #{new_tag}"
+    Settings.write "latesttag", new_tag if new_tag != old_tag
+    if new_tag.split(".").last == "0"
       puts <<~EOS
         More detailed release notes are available on the Homebrew Blog:
-          #{Formatter.url("https://brew.sh/blog/#{new_repository_version}")}
+          #{Formatter.url("https://brew.sh/blog/#{new_tag}")}
       EOS
     elsif !args.quiet?
       puts <<~EOS
         The changelog can be found at:
-          #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_repository_version}")}
+          #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_tag}")}
       EOS
     end
   end

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -240,17 +240,22 @@ module Homebrew
 
     puts
     ohai "Homebrew was updated to version #{new_tag}"
-    if new_tag.split(".").last == "0"
+    new_major_version, new_minor_version, new_patch_version = new_tag.split(".").map(&:to_i)
+    old_major_version, old_minor_version = (old_tag.split(".")[0, 2]).map(&:to_i) if old_tag.present?
+    if old_tag.blank? || new_major_version > old_major_version \
+        || new_minor_version > old_minor_version
       puts <<~EOS
         More detailed release notes are available on the Homebrew Blog:
-          #{Formatter.url("https://brew.sh/blog/#{new_tag}")}
-      EOS
-    else
-      puts <<~EOS
-        The changelog can be found at:
-          #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_tag}")}
+          #{Formatter.url("https://brew.sh/blog/#{new_major_version}.#{new_minor_version}.0")}
       EOS
     end
+
+    return if new_patch_version.zero?
+
+    puts <<~EOS
+      The changelog can be found at:
+        #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_tag}")}
+    EOS
   end
 
   def shorten_revision(revision)

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -135,7 +135,7 @@ module Homebrew
       Settings.write "latesttag", new_tag if new_tag != old_tag
 
       if new_tag == old_tag
-        puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
+        ohai "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
       elsif old_tag.blank?
         ohai "Updated Homebrew from #{shorten_revision(initial_revision)} " \
              "to #{new_tag} (#{shorten_revision(current_revision)})."

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -236,7 +236,7 @@ module Homebrew
       EOS
     end
 
-    return if new_tag.blank? || new_tag == old_tag
+    return if new_tag.blank? || new_tag == old_tag || args.quiet?
 
     puts
     ohai "Homebrew was updated to version #{new_tag}"
@@ -245,7 +245,7 @@ module Homebrew
         More detailed release notes are available on the Homebrew Blog:
           #{Formatter.url("https://brew.sh/blog/#{new_tag}")}
       EOS
-    elsif !args.quiet?
+    else
       puts <<~EOS
         The changelog can be found at:
           #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_tag}")}

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -132,6 +132,8 @@ module Homebrew
         "git", "-C", HOMEBREW_REPOSITORY, "tag", "--list", "--sort=-version:refname", "*.*"
       ).lines.first.chomp
 
+      Settings.write "latesttag", new_tag if new_tag != old_tag
+
       if old_tag.blank? || (new_tag == old_tag)
         puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
       else
@@ -238,7 +240,6 @@ module Homebrew
 
     puts
     ohai "Homebrew was updated to version #{new_tag}"
-    Settings.write "latesttag", new_tag if new_tag != old_tag
     if new_tag.split(".").last == "0"
       puts <<~EOS
         More detailed release notes are available on the Homebrew Blog:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Eight minor updates to update-report:
- Update x_repository_version variable names to x_tag to eliminate unnecessary variables and for consistency
- Resolve `latesttag` not being updated if message section is skipped. This is an update on pull request #13470 and reverts part of 92a4238
-  Expand output excluded by quiet
- Adds a feature to highlight release notes for versions changes other than x.x.0
- Print version number in messages
- Report new_tag even when old_tag blank
- Highlight new revision message
- Add new line after donate message
