### PR TITLE
Require an argument to `--bottle-tag` in `fetch` and `--cache`

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -24,7 +24,7 @@ module Homebrew
              description: "Show the cache file used when building from source."
       switch "--force-bottle",
              description: "Show the cache file used when pouring a bottle."
-      flag "--bottle-tag",
+      flag "--bottle-tag=",
            description: "Show the cache file used when pouring a bottle for the given tag."
       switch "--HEAD",
              description: "Show the cache file used when building from HEAD."

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -20,7 +20,7 @@ module Homebrew
         Download a bottle (if available) or source packages for <formula>e
         and binaries for <cask>s. For files, also print SHA-256 checksums.
       EOS
-      flag "--bottle-tag",
+      flag "--bottle-tag=",
            description: "Download a bottle for given tag."
       switch "--HEAD",
              description: "Fetch HEAD version instead of stable version."


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/13484

This PR requires that an argument is passed to `--bottle-tag` in `brew fetch` and `brew --cache`. Now, running these commands on their own will fail immediately:

```console
$ brew fetch wget --bottle-tag
Error: missing argument: --bottle-tag

$ brew --cache wget --bottle-tag
Error: missing argument: --bottle-tag
```
