### PR TITLE
`OnSystem`: provide `::MacOSAndLinux` and `::MacOSOnly`

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -92,7 +92,7 @@ module Cask
     ]).freeze
 
     extend Predicable
-    include OnSystem
+    include OnSystem::MacOSOnly
 
     attr_reader :cask, :token
 

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -56,7 +56,7 @@ module OnSystem
   end
 
   sig { params(base: Class).void }
-  def self.included(base)
+  def setup_arch_methods(base)
     ARCH_OPTIONS.each do |arch|
       base.define_method("on_#{arch}") do |&block|
         @on_system_blocks_exist = true
@@ -70,7 +70,10 @@ module OnSystem
         result
       end
     end
+  end
 
+  sig { params(base: Class).void }
+  def setup_base_os_methods(base)
     BASE_OS_OPTIONS.each do |base_os|
       base.define_method("on_#{base_os}") do |&block|
         @on_system_blocks_exist = true
@@ -84,7 +87,10 @@ module OnSystem
         result
       end
     end
+  end
 
+  sig { params(base: Class).void }
+  def setup_macos_methods(base)
     MacOSVersions::SYMBOLS.each_key do |os_name|
       base.define_method("on_#{os_name}") do |or_condition = nil, &block|
         @on_system_blocks_exist = true
@@ -98,6 +104,32 @@ module OnSystem
 
         result
       end
+    end
+  end
+
+  sig { params(_base: Class).void }
+  def self.included(_base)
+    raise "Do not include `OnSystem` directly. Instead, include `OnSystem::MacOSAndLinux` or `OnSystem::MacOSOnly`"
+  end
+
+  module MacOSAndLinux
+    extend T::Sig
+
+    sig { params(base: Class).void }
+    def self.included(base)
+      OnSystem.setup_arch_methods(base)
+      OnSystem.setup_base_os_methods(base)
+      OnSystem.setup_macos_methods(base)
+    end
+  end
+
+  module MacOSOnly
+    extend T::Sig
+
+    sig { params(base: Class).void }
+    def self.included(base)
+      OnSystem.setup_arch_methods(base)
+      OnSystem.setup_macos_methods(base)
     end
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -64,7 +64,7 @@ class Formula
   include Utils::Shebang
   include Utils::Shell
   include Context
-  include OnSystem
+  include OnSystem::MacOSAndLinux
   extend Forwardable
   extend Cachable
   extend Predicable
@@ -2470,7 +2470,7 @@ class Formula
   # The methods below define the formula DSL.
   class << self
     include BuildEnvironment::DSL
-    include OnSystem
+    include OnSystem::MacOSAndLinux
 
     def method_added(method)
       super

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -17,7 +17,7 @@ class Resource
 
   include Context
   include FileUtils
-  include OnSystem
+  include OnSystem::MacOSAndLinux
 
   attr_reader :mirrors, :specs, :using, :source_modified_time, :patches, :owner
   attr_writer :version

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -18,7 +18,7 @@ class SoftwareSpec
   extend T::Sig
 
   extend Forwardable
-  include OnSystem
+  include OnSystem::MacOSAndLinux
 
   PREDEFINED_OPTIONS = {
     universal: Option.new("universal", "Build a universal binary"),
@@ -583,7 +583,7 @@ class BottleSpecification
 end
 
 class PourBottleCheck
-  include OnSystem
+  include OnSystem::MacOSAndLinux
 
   def initialize(formula)
     @formula = formula


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Homebrew/brew/pull/13451 which used several `include OnSystem` calls in various places around Homebrew. However, these call included all `on_{system}` methods, even when the `on_macos` and `on_linux` methods weren't needed (i.e. for casks). This PR creates two sub-modules of `OnSystem` called `WithOnLinuxMethod` and `WithoutOnLinuxMethod`. These are the modules that can be imported, and depending on which one is imported, the `on_{macos,linux}` methods will or won't be defined.

Currently, an error is thrown if you try to `include OnSystem`, forcing you to choose one of the following:

```ruby
# Include the `on_macos` and `on_linux` methods
include OnSystem::WithOnLinuxMethod

# Don't include the `on_macos` and `on_linux` methods
include OnSystem::WithoutOnLinuxMethod
```

However, another option is to not error if no sub-module is specified and just import everything:

```ruby
# Include the `on_macos` and `on_linux` methods
include OnSystem

# Don't include the `on_macos` and `on_linux` methods
include OnSystem::WithoutOnLinuxMethod
```

Also, I'm open to other naming styles for these sub-modules. Technically, they control whether the `on_macos` method is added in addition to the `on_linux` method (which is implied by the name) so if that's confusing, we can rename.

Thoughts on the above?
