### PR TITLE
Fix `Keg.bottle_dependencies` including unneeded build dependencies

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -100,15 +100,8 @@ module Homebrew
       return merge(args: args)
     end
 
-    ensure_relocation_formulae_installed! unless args.skip_relocation?
     args.named.to_resolved_formulae(uniq: false).each do |f|
       bottle_formula f, args: args
-    end
-  end
-
-  def ensure_relocation_formulae_installed!
-    Keg.relocation_formulae.each do |f|
-      ensure_formula_installed!(f, latest: true)
     end
   end
 

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -87,8 +87,7 @@ class Keg
       gcc = Formulary.factory(CompilerSelector.preferred_gcc)
       if !Homebrew::EnvConfig.simulate_macos_on_linux? &&
          DevelopmentTools.non_apple_gcc_version("gcc") < gcc.version.to_i
-        formulae += gcc.recursive_dependencies.map(&:name)
-        formulae << gcc.name
+        formulae << gcc
       end
       formulae
     end

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -83,7 +83,7 @@ class Keg
 
   def self.bottle_dependencies
     @bottle_dependencies ||= begin
-      formulae = relocation_formulae
+      formulae = []
       gcc = Formulary.factory(CompilerSelector.preferred_gcc)
       if !Homebrew::EnvConfig.simulate_macos_on_linux? &&
          DevelopmentTools.non_apple_gcc_version("gcc") < gcc.version.to_i

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -609,8 +609,6 @@ class FormulaInstaller
     if pour_bottle && !formula.bottled?(:all) && !Keg.bottle_dependencies.empty?
       bottle_deps = if Keg.bottle_dependencies.exclude?(formula.name)
         Keg.bottle_dependencies
-      elsif Keg.relocation_formulae.exclude?(formula.name)
-        Keg.relocation_formulae
       else
         []
       end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -577,9 +577,8 @@ class FormulaInstaller
     unsatisfied_reqs
   end
 
-  def expand_dependencies
-    inherited_options = Hash.new { |hash, key| hash[key] = Options.new }
-    pour_bottle = pour_bottle?
+  def expand_dependencies_for_formula(formula, inherited_options)
+    any_bottle_used = false
 
     # Cache for this expansion only. FormulaInstaller has a lot of inputs which can alter expansion.
     cache_key = "FormulaInstaller-#{formula.full_name}-#{Time.now.to_f}"
@@ -600,24 +599,34 @@ class FormulaInstaller
       elsif dep.satisfied?(inherited_options[dep.name])
         Dependency.skip
       else
-        pour_bottle ||= install_bottle_for?(dep.to_formula, build)
+        any_bottle_used ||= install_bottle_for?(dep.to_formula, build)
       end
     end
 
+    [expanded_deps, any_bottle_used]
+  end
+
+  def expand_dependencies
+    inherited_options = Hash.new { |hash, key| hash[key] = Options.new }
+    any_bottle_used = pour_bottle?
+
+    expanded_deps, any_dep_bottle_used = expand_dependencies_for_formula(formula, inherited_options)
+    any_bottle_used ||= any_dep_bottle_used
+
     # We require some dependencies (glibc, GCC 5, etc.) if binaries were built.
     # Native binaries shouldn't exist in cross-platform `all` bottles.
-    if pour_bottle && !formula.bottled?(:all) && !Keg.bottle_dependencies.empty?
-      bottle_deps = if Keg.bottle_dependencies.exclude?(formula.name)
-        Keg.bottle_dependencies
-      else
-        []
+    if any_bottle_used && !formula.bottled?(:all) && !Keg.bottle_dependencies.empty?
+      all_bottle_deps = Keg.bottle_dependencies.flat_map do |bottle_dep|
+        bottle_dep.recursive_dependencies.map(&:name) + [bottle_dep.name]
       end
-      bottle_deps = bottle_deps.map { |formula| Dependency.new(formula) }
-                               .reject do |dep|
-        inherited_options[dep.name] |= inherited_options_for(dep)
-        dep.satisfied? inherited_options[dep.name]
+
+      if all_bottle_deps.exclude?(formula.name)
+        bottle_deps = Keg.bottle_dependencies.flat_map do |bottle_dep|
+          expanded_bottle_deps, = expand_dependencies_for_formula(bottle_dep, inherited_options)
+          expanded_bottle_deps
+        end
+        expanded_deps = Dependency.merge_repeats(bottle_deps + expanded_deps)
       end
-      expanded_deps = Dependency.merge_repeats(bottle_deps + expanded_deps)
     end
 
     expanded_deps.map { |dep| [dep, inherited_options[dep.name]] }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -367,12 +367,8 @@ class Keg
     []
   end
 
-  def self.relocation_formulae
-    []
-  end
-
   def self.bottle_dependencies
-    relocation_formulae
+    []
   end
 end
 


### PR DESCRIPTION
Fixes https://github.com/orgs/Homebrew/discussions/3399.

This previously installed the entire `gcc@5` dependency tree without any checks for `:build` tags etc. We got away with this before, but now `depends_on "glibc@2.13" => :build` has bbeem introduced into that tree so the incorrect behaviour is now showing.

Instead, let's make it use the existing `FormulaInstaller` dependency logic.

To simplify the code, I have also removed `Keg.relocation_formulae` since that has been returning an empty array on all platforms for a while now.