### PR TITLE
Mohammad

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -183,7 +183,7 @@ class Resource
   #   regex /foo-(\d+(?:\.\d+)+)\.tar/
   # end</pre>
   def livecheck(&block)
-    @livecheck ||= Livecheck.new(self)
+    @livecheck ||= Livecheck.new(self) if block
     return @livecheck unless block
 
     @livecheckable = true

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -58,17 +58,15 @@ describe Resource do
       expect(resource.livecheck).to be_nil
     end
 
-    let(:r) do
-      Resource.new do
+    specify "when livecheck block is set" do
+      r = described_class.new do
         url "https://brew.sh/test-0.0.1.tgz"
         livecheck do
           url "https://brew.sh/foo-1.0.tar.gz"
           regex(/foo/)
         end
       end
-    end
 
-    it "when livecheck block is set" do
       expect(r.livecheck.url).to eq("https://brew.sh/foo-1.0.tar.gz")
       expect(r.livecheck.regex).to eq(/foo/)
     end
@@ -80,7 +78,7 @@ describe Resource do
     end
 
     specify "livecheck block defined in resources" do
-      r = Resource.new do
+      r = described_class.new do
         url "https://brew.sh/test-1.0.tbz"
         livecheck do
           url "https://brew.sh/foo-1.0.tar.gz"
@@ -90,7 +88,6 @@ describe Resource do
 
       expect(r.livecheckable?).to be true
     end
-
   end
 
   describe "#version" do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "resource"
+require "livecheck"
 
 describe Resource do
   subject(:resource) { described_class.new("test") }
@@ -50,6 +51,52 @@ describe Resource do
       expect(resource.using).to eq(:git)
       expect(specs).to eq(using: :git, branch: "master")
     end
+  end
+
+  describe Resource do
+    let(:r) do
+      livecheck do
+        url "https://brew.sh/foo-1.0.tar.gz"
+        regex(/foo/)
+      end
+    end
+
+    let(:livecheckable_r) { described_class.new(r) }
+
+    describe "#livecheck" do
+      it "returns nil if not set" do
+        expect(livecheckable_r.livecheck).to be_nil
+      end
+
+      it "returns the string if set" do
+        livecheckable_r.livecheck("other-resource")
+        expect(livecheckable_r.livecheck).to eq("other-resource")
+      end
+
+      it "raises a TypeError if the argument isn't a String" do
+        expect {
+          livecheckable_r.livecheck(123)
+        }.to raise_error(TypeError, "Resource#livecheck expects a String")
+      end
+    end
+
+    describe "#regex" do
+      it "returns nil if not set" do
+        expect(livecheckable_r.regex).to be_nil
+      end
+
+      it "returns the Regexp if set" do
+        livecheckable_r.regex(/foo/)
+        expect(livecheckable_r.regex).to eq(/foo/)
+      end
+
+      it "raises a TypeError if the argument isn't a Regexp" do
+        expect {
+          livecheckable_r.regex("foo")
+        }.to raise_error(TypeError, "Resource#livecheck#regex expects a Regexp")
+      end
+    end
+
   end
 
   describe "#version" do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -53,48 +53,42 @@ describe Resource do
     end
   end
 
-  describe Resource do
+  describe "#livecheck" do
+    it "returns nil if livecheck block is not set in resource" do
+      expect(resource.livecheck).to be_nil
+    end
+
     let(:r) do
-      livecheck do
-        url "https://brew.sh/foo-1.0.tar.gz"
-        regex(/foo/)
+      Resource.new do
+        url "https://brew.sh/test-0.0.1.tgz"
+        livecheck do
+          url "https://brew.sh/foo-1.0.tar.gz"
+          regex(/foo/)
+        end
       end
     end
 
-    let(:livecheckable_r) { described_class.new(r) }
+    it "when livecheck block is set" do
+      expect(r.livecheck.url).to eq("https://brew.sh/foo-1.0.tar.gz")
+      expect(r.livecheck.regex).to eq(/foo/)
+    end
+  end
 
-    describe "#livecheck" do
-      it "returns nil if not set" do
-        expect(livecheckable_r.livecheck).to be_nil
-      end
-
-      it "returns the string if set" do
-        livecheckable_r.livecheck("other-resource")
-        expect(livecheckable_r.livecheck).to eq("other-resource")
-      end
-
-      it "raises a TypeError if the argument isn't a String" do
-        expect {
-          livecheckable_r.livecheck(123)
-        }.to raise_error(TypeError, "Resource#livecheck expects a String")
-      end
+  describe "#livecheckable?" do
+    it "returns false if livecheck block is not set in resource" do
+      expect(resource.livecheckable?).to be false
     end
 
-    describe "#regex" do
-      it "returns nil if not set" do
-        expect(livecheckable_r.regex).to be_nil
+    specify "livecheck block defined in resources" do
+      r = Resource.new do
+        url "https://brew.sh/test-1.0.tbz"
+        livecheck do
+          url "https://brew.sh/foo-1.0.tar.gz"
+          regex(/foo/)
+        end
       end
 
-      it "returns the Regexp if set" do
-        livecheckable_r.regex(/foo/)
-        expect(livecheckable_r.regex).to eq(/foo/)
-      end
-
-      it "raises a TypeError if the argument isn't a Regexp" do
-        expect {
-          livecheckable_r.regex("foo")
-        }.to raise_error(TypeError, "Resource#livecheck#regex expects a Regexp")
-      end
+      expect(r.livecheckable?).to be true
     end
 
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR extends the `livecheck` DSL to work for resources as mentioned [here](https://github.com/Homebrew/gsoc/issues/49#issuecomment-1040520006).

---

As suggested by @nandahkrishna, I have verified `livecheck` DSL inside resource block by updating few resource blocks locally. 

_For instance_: inside `Library/Taps/homebrew/homebrew-core/Formula/airshare.rb`, add the `livecheck` block inside the resource `aiohttp` like mentioned below:

```ruby
...
  resource "aiohttp" do
    url "https://files.pythonhosted.org/packages/5a/86/5f63de7a202550269a617a5d57859a2961f3396ecd1739a70b92224766bc/aiohttp-3.8.1.tar.gz"
    sha256 "fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"
    livecheck do
      url "https://brew.sh/foo-1.0.tar.gz"
      regex(/foo/)
    end
  end
...
```

and from interactive ruby-shell (`brew irb`), run and check the following outputs:

```ruby
:airshare.f.resources[0].livecheck.class
:airshare.f.resources[0].livecheck.url
:airshare.f.resources[0].livecheck.regex
```

and it works as expected.

```
=> Livecheck
=> "https://brew.sh/foo-1.0.tar.gz"
=> /foo/
```

---

Kindly, do let me know if I miss something or any further improvement that we can do here. 