### PR TITLE
Update `components_order` cop to check other `on_{system}` methods

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "macos_versions"
+
 FORMULA_COMPONENT_PRECEDENCE_LIST = [
   [{ name: :include,   type: :method_call }],
   [{ name: :desc,      type: :method_call }],
@@ -28,6 +30,11 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = [
   [{ name: :uses_from_macos, type: :method_call }],
   [{ name: :on_macos, type: :block_call }],
   [{ name: :on_linux, type: :block_call }],
+  [{ name: :on_arm, type: :block_call }],
+  [{ name: :on_intel, type: :block_call }],
+  *MacOSVersions::SYMBOLS.keys.map do |os_name|
+    [{ name: :"on_#{os_name}", type: :block_call }]
+  end,
   [{ name: :conflicts_with, type: :method_call }],
   [{ name: :skip_clean, type: :method_call }],
   [{ name: :cxxstdlib_check, type: :method_call }],

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -337,7 +337,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     RUBY
   end
 
-  context "when formula has no OS-specific blocks" do
+  context "when formula has no system-specific blocks" do
     it "reports no offenses" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
@@ -352,7 +352,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     end
   end
 
-  context "when formula has OS-specific block(s)" do
+  context "when formula has system-specific block(s)" do
     it "reports no offenses when `on_macos` and `on_linux` are used correctly" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
@@ -363,7 +363,13 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           uses_from_macos "libxml2"
 
           on_macos do
-            depends_on "perl"
+            on_arm do
+              depends_on "perl"
+            end
+
+            on_intel do
+              depends_on "python"
+            end
 
             resource "resource1" do
               url "https://brew.sh/resource1.tar.gz"
@@ -433,6 +439,70 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    it "reports no offenses when `on_intel` is used correctly" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+
+          on_intel do
+            disable! because: :does_not_build
+            depends_on "readline"
+          end
+
+          def install
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses when `on_arm` is used correctly" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+
+          on_arm do
+            deprecate! because: "it's deprecated"
+            depends_on "readline"
+          end
+
+          def install
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses when `on_monterey` is used correctly" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+
+          on_monterey do
+            disable! because: :does_not_build
+            depends_on "readline"
+          end
+
+          def install
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses when `on_monterey :or_older` is used correctly" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+
+          on_monterey :or_older do
+            deprecate! because: "it's deprecated"
+            depends_on "readline"
+          end
+
+          def install
+          end
+        end
+      RUBY
+    end
+
     it "reports an offense when there are multiple `on_macos` blocks" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -465,6 +535,70 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    it "reports an offense when there are multiple `on_intel` blocks" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_intel do
+            depends_on "readline"
+          end
+
+          on_intel do
+          ^^^^^^^^^^^ there can only be one `on_intel` block in a formula.
+            depends_on "foo"
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when there are multiple `on_arm` blocks" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_arm do
+            depends_on "readline"
+          end
+
+          on_arm do
+          ^^^^^^^^^ there can only be one `on_arm` block in a formula.
+            depends_on "foo"
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when there are multiple `on_monterey` blocks" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_monterey do
+            depends_on "readline"
+          end
+
+          on_monterey do
+          ^^^^^^^^^^^^^^ there can only be one `on_monterey` block in a formula.
+            depends_on "foo"
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when there are multiple `on_monterey` blocks with parameters" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_monterey do
+            depends_on "readline"
+          end
+
+          on_monterey :or_older do
+          ^^^^^^^^^^^^^^^^^^^^^^^^ there can only be one `on_monterey` block in a formula.
+            depends_on "foo"
+          end
+        end
+      RUBY
+    end
+
     it "reports an offense when the `on_macos` block contains nodes other than `depends_on`, `patch` or `resource`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -491,6 +625,60 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    it "reports an offense when the `on_intel` block contains nodes other than `depends_on`, `patch` or `resource`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_intel do
+            depends_on "readline"
+            uses_from_macos "ncurses"
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ `on_intel` cannot include `uses_from_macos`. [...]
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when the `on_arm` block contains nodes other than `depends_on`, `patch` or `resource`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_arm do
+            depends_on "readline"
+            uses_from_macos "ncurses"
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ `on_arm` cannot include `uses_from_macos`. [...]
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when the `on_monterey` block contains nodes other than " \
+       "`depends_on`, `patch` or `resource`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_monterey do
+            depends_on "readline"
+            uses_from_macos "ncurses"
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ `on_monterey` cannot include `uses_from_macos`. [...]
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when the `on_monterey :or_older` block contains nodes other than " \
+       "`depends_on`, `patch` or `resource`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_monterey :or_older do
+            depends_on "readline"
+            uses_from_macos "ncurses"
+            ^^^^^^^^^^^^^^^^^^^^^^^^^ `on_monterey` cannot include `uses_from_macos`. [...]
+          end
+        end
+      RUBY
+    end
+
     context "when in a resource block" do
       it "reports no offenses for a valid `on_macos` and `on_linux` block" do
         expect_no_offenses(<<~RUBY)
@@ -512,19 +700,19 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         RUBY
       end
 
-      it "reports no offenses for a valid `on_macos` and `on_linux` block (with `version`)" do
+      it "reports no offenses for a valid `on_arm` and `on_intel` block (with `version`)" do
         expect_no_offenses(<<~RUBY)
           class Foo < Formula
             homepage "https://brew.sh"
 
             resource do
-              on_macos do
+              on_arm do
                 url "https://brew.sh/resource1.tar.gz"
                 version "1.2.3"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
 
-              on_linux do
+              on_intel do
                 url "https://brew.sh/resource2.tar.gz"
                 version "1.2.3"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -576,6 +764,69 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         RUBY
       end
 
+      it "reports an offense if there are two `on_intel` blocks" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+
+            resource do
+            ^^^^^^^^^^^ there can only be one `on_intel` block in a resource block.
+              on_intel do
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+
+              on_intel do
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "reports an offense if there are two `on_arm` blocks" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+
+            resource do
+            ^^^^^^^^^^^ there can only be one `on_arm` block in a resource block.
+              on_arm do
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+
+              on_arm do
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "reports an offense if there are two `on_monterey` blocks" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+
+            resource do
+            ^^^^^^^^^^^ there can only be one `on_monterey` block in a resource block.
+              on_monterey do
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+
+              on_monterey :or_older do
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        RUBY
+      end
+
       it "reports no offenses if there is an `on_macos` block but no `on_linux` block" do
         expect_no_offenses(<<~RUBY)
           class Foo < Formula
@@ -596,6 +847,34 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
             resource do
               on_linux do
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "reports no offenses if there is an `on_intel` block but no `on_arm` block" do
+        expect_no_offenses(<<~RUBY)
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            resource do
+              on_intel do
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "reports no offenses if there is an `on_arm` block but no `on_intel` block" do
+        expect_no_offenses(<<~RUBY)
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            resource do
+              on_arm do
                 url "https://brew.sh/resource1.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
@@ -697,19 +976,19 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         RUBY
       end
 
-      it "reports an offense if the content of an `on_linux` block is improperly formatted" do
+      it "reports an offense if the content of an `on_arm` block is improperly formatted" do
         expect_offense(<<~RUBY)
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-              on_macos do
+              on_intel do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
 
-              on_linux do
-              ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
+              on_arm do
+              ^^^^^^^^^ `on_arm` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
                 url "https://brew.sh/resource2.tar.gz"
               end
@@ -718,18 +997,18 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         RUBY
       end
 
-      it "reports no offenses if an `on_linux` block has if-else branches that are properly formatted" do
+      it "reports no offenses if an `on_arm` block has if-else branches that are properly formatted" do
         expect_no_offenses(<<~RUBY)
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-              on_macos do
+              on_intel do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
 
-              on_linux do
+              on_arm do
                 if foo == :bar
                   url "https://brew.sh/resource2.tar.gz"
                   sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -743,19 +1022,19 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         RUBY
       end
 
-      it "reports an offense if an `on_linux` block has if-else branches that aren't properly formatted" do
+      it "reports an offense if an `on_arm` block has if-else branches that aren't properly formatted" do
         expect_offense(<<~RUBY)
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-              on_macos do
+              on_intel do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
 
-              on_linux do
-              ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
+              on_arm do
+              ^^^^^^^^^ `on_arm` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 if foo == :bar
                   url "https://brew.sh/resource2.tar.gz"
                   sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "June 2022" "Homebrew" "brew"
+.TH "BREW" "1" "July 2022" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)


### PR DESCRIPTION
This changes the components order cop to properly check `on_intel`, `on_arm` and `on_{macos_version}` blocks in addition to `on_macos` and `on_linux`. This PR has been broken off of https://github.com/Homebrew/brew/pull/13493 because some changes are needed before we can start migrating homebrew/core to use the new `on_{system}` blocks.
