### PR TITLE
cmd/update.sh: fix race condition reporting fetch failures

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -647,7 +647,7 @@ EOS
         echo "Fetching ${DIR}..."
       fi
 
-      local tmp_failure_file="${HOMEBREW_REPOSITORY}/.git/TMP_FETCH_FAILURES"
+      local tmp_failure_file="${DIR}/.git/TMP_FETCH_FAILURES"
       rm -f "${tmp_failure_file}"
 
       if [[ -n "${HOMEBREW_UPDATE_AUTO}" ]]


### PR DESCRIPTION
The fetching of repositories is done in a parallel fashion. We however pipe all failures into a single file which each parellel fetch routine will read, write and even delete. This leads to race conditions, so let's make this failure file per-repository instead.

Fixes errors like `cat: /opt/homebrew/.git/TMP_FETCH_FAILURES: No such file or directory` seen in #13504. This issue _does not_ cause any fetch to fail - it only causes the errors reported by `git` to not be displayed so you still have an underlying issue to address if you are hitting this.