### PR TITLE
pr-pull: check for conflicts with long running builds

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -479,8 +479,9 @@ module GitHub
 
   def check_for_duplicate_pull_requests(name, tap_remote_repo, state:, file:, args:, version: nil)
     pull_requests = fetch_pull_requests(name, tap_remote_repo, state: state, version: version).select do |pr|
-      pr_files = API.open_rest(url_to("repos", tap_remote_repo, "pulls", pr["number"], "files"))
-      pr_files.any? { |f| f["filename"] == file }
+      get_pull_request_changed_files(
+        name, tap_remote_repo, pr["number"]
+      ).any? { |f| f["filename"] == file }
     end
     return if pull_requests.blank?
 
@@ -499,6 +500,10 @@ module GitHub
         #{error_message}
       EOS
     end
+  end
+
+  def get_pull_request_changed_files(name, tap_remote_repo, pr)
+    API.open_rest(url_to("repos", name, tap_remote_repo, "pulls", pr, "files"))
   end
 
   def forked_repo_info!(tap_remote_repo, org: nil)


### PR DESCRIPTION
This change will prevent us having to run some long running builds
multiple times and to rely on luck to get things merged without conflicts.

The check takes less than 30 seconds on my local setup.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
