### PR TITLE
cask/installer.rb: Stopped including Staged

### DIFF
--- a/Library/Homebrew/cask/dsl/preflight.rb
+++ b/Library/Homebrew/cask/dsl/preflight.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "cask/staged"
+
 module Cask
   class DSL
     # Class corresponding to the `preflight` stanza.

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -7,7 +7,6 @@ require "utils/topological_hash"
 
 require "cask/config"
 require "cask/download"
-require "cask/staged"
 require "cask/quarantine"
 
 require "cgi"
@@ -20,12 +19,6 @@ module Cask
     extend T::Sig
 
     extend Predicable
-    # TODO: it is unwise for Cask::Staged to be a module, when we are
-    #       dealing with both staged and unstaged casks here. This should
-    #       either be a class which is only sometimes instantiated, or there
-    #       should be explicit checks on whether staged state is valid in
-    #       every method.
-    include Staged
 
     def initialize(cask, command: SystemCommand, force: false,
                    skip_cask_deps: false, binaries: true, verbose: false,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The idea here was to tackle the todo on line 32 of `cask/installer.rb` related to the including `cask/staged`. There are two methods found in `cask/staged` which are `set_permissions` and `set_ownership`. Neither of these methods are called throughout the entire `brew` codebase. These methods are made available through the `preflight`, `post flight` and `uninstall_postflight` cask stanzas where a quick search shows they do get used.

So I thought why don't I just remove this include if it seems unnecessary. Turns out that caused a few tests to fail in seemingly unrelated parts of the test suite.

```
rspec ./test/cmd/unlink_spec.rb:9 # brew unlink unlinks a Formula
rspec ./test/requirement_spec.rb:112 # Requirement#satisfied? #satisfy with block returning true and without :build_env sets up build environment
rspec ./test/requirement_spec.rb:142 # Requirement#satisfied? #satisfy with block returning path and without :build_env infers path from #satisfy result
rspec ./test/os/mac/pkgconfig_spec.rb:79 # pkg-config returns the correct version for libxml-2.0
rspec ./test/os/mac/pkgconfig_spec.rb:97 # pkg-config returns the correct version for ncurses
rspec ./test/os/mac/pkgconfig_spec.rb:119 # pkg-config returns the correct version for zlib
rspec ./test/os/mac/pkgconfig_spec.rb:48 # pkg-config returns the correct version for libcurl
rspec ./test/os/mac/pkgconfig_spec.rb:88 # pkg-config returns the correct version for libxslt
rspec ./test/os/mac/pkgconfig_spec.rb:57 # pkg-config returns the correct version for libexslt
rspec ./test/os/mac/pkgconfig_spec.rb:68 # pkg-config returns the correct version for libffi
rspec ./test/os/mac/pkgconfig_spec.rb:110 # pkg-config returns the correct version for sqlite3
rspec ./test/os/mac/pkgconfig_spec.rb:36 # pkg-config returns the correct version for expat
rspec ./test/cmd/pin_spec.rb:9 # brew pin pins a Formula's version
```

#### The tests seem to fail for two reasons
1. They fail after a call to `Homebrew::Diagnostic.checks(:fatal_setup_build_environment_checks)`.
2. They fail after failing to get the correct sdk path on line 34 of `pkgconfig_spec.rb` in the `MacOS.sdk_path_if_needed` method.

The interesting thing here is that none of these test `cask/staged.rb` or `cask/installer.rb` at all and they all pass when run individually using the `brew tests --only=` command.

My guess is that either I overlooked something and this include is actually necessary or removing it has helped us discover a few more flaky tests. Hopefully one of you can help shed some light on this.