### PR TITLE
Fix `on_{macos_version}` blocks on Linux

### DIFF
--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -41,6 +41,8 @@ module OnSystem
       raise ArgumentError, "Invalid OS `or_*` condition: #{or_condition.inspect}"
     end
 
+    return false if Homebrew::SimulateSystem.linux? || (Homebrew::SimulateSystem.none? && OS.linux?)
+
     base_os = MacOS::Version.from_symbol(os_name)
     current_os = MacOS::Version.from_symbol(Homebrew::SimulateSystem.os || MacOS.version.to_sym)
 


### PR DESCRIPTION
This PR fixes a bug that I found when investigating Linux dependencies for some formulae. It turns out that evaluating an `on_{macos_version}` block while on Linux will throw an error because `MacOS.version` is `nil`. Instead, we need to just `return false` early if we're currently on Linux (simulating or not) and we've reached a macOS version check.
