### PR TITLE
bump-formula-pr: more precise tag/version replacement

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -243,7 +243,7 @@ module Homebrew
     elsif new_tag.present?
       [
         [
-          formula_spec.specs[:tag],
+          /#{formula_spec.specs[:tag]}(?=")/,
           new_tag,
         ],
         [
@@ -283,8 +283,8 @@ module Homebrew
     if forced_version && new_version != "0"
       replacement_pairs << if old_contents.include?("version \"#{old_formula_version}\"")
         [
-          old_formula_version.to_s,
-          new_version,
+          "version \"#{old_formula_version}\"",
+          "version \"#{new_version}\"",
         ]
       elsif new_mirrors.present?
         [


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Encountered an [issue](https://github.com/Homebrew/homebrew-core/pull/105086#issuecomment-1174043240) where using `bump-formula-pr` on [openrct2 0.4.0](https://github.com/Homebrew/homebrew-core/blob/2ff6bee848109af7558dd55f8fc96007e2373cc8/Formula/openrct2.rb) also modified the URL for its "title-sequences" resource, which happened to contain the text of the formula's tag. This modifies the search regex to check for a double quote after the tag, which solves for this particular case. 