### PR TITLE
Write latesttag to config when testing

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -122,6 +122,12 @@ module Homebrew
       # set test copy to start_commit
       safe_system "git", "reset", "--hard", start_commit
 
+      # write latesttag
+      latest_tag = Utils.safe_popen_read(
+        "git", "tag", "--list", "--sort=-version:refname", "--merged"
+      ).lines.first.chomp
+      safe_system "git", "config", "--local", "homebrew.latesttag", latest_tag
+
       # update ENV["PATH"]
       ENV["PATH"] = PATH.new(ENV.fetch("PATH")).prepend(curdir/"bin")
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

When running `brew update-test`, `latesttag` is written to the local test git config file prior to the running of `brew update`. Currently the `old_tag` variable in update-report.cmd is always blank.