### PR TITLE
language/python: add `--install-lib` to `setup_install_args`

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -70,7 +70,7 @@ module Language
       quiet_system python, "-c", script
     end
 
-    def self.setup_install_args(prefix)
+    def self.setup_install_args(prefix, python = "python3")
       shim = <<~PYTHON
         import setuptools, tokenize
         __file__ = 'setup.py'
@@ -84,6 +84,7 @@ module Language
         install
         --prefix=#{prefix}
         --install-scripts=#{prefix}/bin
+        --install-lib=#{prefix/site_packages(python)}
         --single-version-externally-managed
         --record=installed.txt
       ]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

About 25 formula in homebrew/core pass `--install-lib` to `python3` in
addition to `*setup_install_args` in order to ensure that all files are
installed into the formula's prefix rather than into a `site-packages`
directory in Python's keg.

Let's simplify these formulae by also adding the appropriate
`--install-lib` flag to `setup_install_args`.
