### PR TITLE
resource: support relative paths as `targets` of `#stage`

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -121,6 +121,7 @@ class Resource
   # is a {ResourceStageContext}.
   # A target or a block must be given, but not both.
   def unpack(target = nil)
+    current_working_directory = Pathname.pwd
     mktemp(download_name) do |staging|
       downloader.stage do
         @source_modified_time = downloader.source_modified_time
@@ -129,6 +130,7 @@ class Resource
           yield ResourceStageContext.new(self, staging)
         elsif target
           target = Pathname(target)
+          target = current_working_directory/target if target.relative?
           target.install Pathname.pwd.children
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`#stage` takes an optional `target` argument, which specifies the
location in which to unpack the `resource`.

Passing relative paths to `#stage`, as in
```ruby
resource("foo").stage "bar"
```
does not work, because this calls `Pathname("bar").install` inside the
temporary directory that the contents of the resource are unpacked to.
This means that passing a relative path to `#stage` has the unintended
effect of moving files around inside a temporary directory the formula
has no access to.

Let's fix that by keeping track of the original working directory before
`#stage` was called and prepending this to `target` whenever `target` is
a relative path.
