### PR TITLE
keg: create subdirectories of `lib/lua` instead of symlinks

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -446,7 +446,7 @@ class Keg
            /^gdk-pixbuf/,
            "ghc",
            /^gio/,
-           "lua",
+           /^lua/,
            /^mecab/,
            /^node/,
            /^ocaml/,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some formulae (e.g. `luv`) have a `lib/lua/5.1` subdirectory inside
their keg. Before this change, the `5.1` subdirectory is symlinked into
`HOMEBREW_PREFIX`.

This can result in `luarocks` installing things into a formula's keg,
which we don't want.

Let's fix that by making sure that `brew link` creates these
subdirectories instead of symlinking them. We already do this for
subdirectories of `share/lua`:

https://github.com/Homebrew/brew/blob/8dd96ae8bacb4f7eb3ef476af63470e3702aee35/Library/Homebrew/keg.rb#L430
