### PR TITLE
Add `on_system` to and reorder component order cop

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -29,6 +29,10 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = [
   [{ name: :depends_on, type: :method_call }],
   [{ name: :uses_from_macos, type: :method_call }],
   [{ name: :on_macos, type: :block_call }],
+  *MacOSVersions::SYMBOLS.keys.map do |os_name|
+    [{ name: :"on_#{os_name}", type: :block_call }]
+  end,
+  [{ name: :on_system, type: :block_call }],
   [{ name: :on_linux, type: :block_call }],
   [{ name: :on_arm, type: :block_call }],
   [{ name: :on_intel, type: :block_call }],

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -15,7 +15,7 @@ module RuboCop
         extend AutoCorrector
 
         def on_system_methods
-          @on_system_methods ||= [:intel, :arm, :macos, :linux, *MacOSVersions::SYMBOLS.keys].map do |m|
+          @on_system_methods ||= [:intel, :arm, :macos, :linux, :system, *MacOSVersions::SYMBOLS.keys].map do |m|
             :"on_#{m}"
           end
         end

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -116,6 +116,15 @@ module RuboCop
         end
 
         def check_on_system_block_content(component_precedence_list, on_system_block)
+          if on_system_block.body.block_type? && !on_system_methods.include?(on_system_block.body.method_name)
+            offending_node(on_system_block)
+            problem "Nest `#{on_system_block.method_name}` blocks inside `#{on_system_block.body.method_name}` " \
+                    "blocks when there is only one inner block." do |corrector|
+              original_source = on_system_block.source.split("\n")
+              new_source = [original_source.second, original_source.first, *original_source.drop(2)]
+              corrector.replace(on_system_block.source_range, new_source.join("\n"))
+            end
+          end
           on_system_allowed_methods = %w[
             depends_on
             patch

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -679,6 +679,130 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    it "reports an offense when a single `patch` block is inside the `on_arm` block" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_arm do
+          ^^^^^^^^^ Nest `on_arm` blocks inside `patch` blocks when there is only one inner block.
+            patch do
+              url "https://brew.sh/patch1.tar.gz"
+              sha256 "2c39089f64d9d4c3e632f120894b36b68dcc8ae8c6f5130c0c2e6f5bb7aebf2f"
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+              patch do
+        on_arm do
+              url "https://brew.sh/patch1.tar.gz"
+              sha256 "2c39089f64d9d4c3e632f120894b36b68dcc8ae8c6f5130c0c2e6f5bb7aebf2f"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when a single `resource` block is inside the `on_linux` block" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_linux do
+          ^^^^^^^^^^^ Nest `on_linux` blocks inside `resource` blocks when there is only one inner block.
+            resource do
+              url "https://brew.sh/resource1.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+              resource do
+        on_linux do
+              url "https://brew.sh/resource1.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when a single `patch` block is inside the `on_monterey :or_newer` block" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_monterey :or_newer do
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Nest `on_monterey` blocks inside `patch` blocks when there is only one inner block.
+            patch do
+              url "https://brew.sh/patch1.tar.gz"
+              sha256 "2c39089f64d9d4c3e632f120894b36b68dcc8ae8c6f5130c0c2e6f5bb7aebf2f"
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+              patch do
+        on_monterey :or_newer do
+              url "https://brew.sh/patch1.tar.gz"
+              sha256 "2c39089f64d9d4c3e632f120894b36b68dcc8ae8c6f5130c0c2e6f5bb7aebf2f"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when a single `resource` block is inside the `on_system` block" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_system :linux, macos: :monterey_or_older do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nest `on_system` blocks inside `resource` blocks when there is only one inner block.
+            resource do
+              url "https://brew.sh/resource1.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+              resource do
+        on_system :linux, macos: :monterey_or_older do
+              url "https://brew.sh/resource1.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses when a single `on_arm` block is inside the `on_macos` block" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          on_macos do
+            on_arm do
+              resource do
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
     context "when in a resource block" do
       it "reports no offenses for a valid `on_macos` and `on_linux` block" do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR is a follow-up to https://github.com/Homebrew/brew/pull/13529 that adds `on_system` to the component order list and also modifies the order of the various `on_{system}` components.

For now, I went with the following order:

- `on_macos`
- `on_ventura`
- `on_monterey`
- ...
- `on_el_capitan`
- `on_system :linux, macos:`
- `on_linux`
- `on_arm`
- `on_intel`

My thinking is that we should keep all OS-related blocks together and move from macOS to Linux. This keeps all of the macOS-only blocks together and has the combo `on_system` blocks in the middle. Then, the two arch-related blocks are together and move from ARM to Intel.

---

This works great for dependencies, but looks a little weird in cases such as [`alure`](https://github.com/Homebrew/homebrew-core/blob/736dbebd122d756cfcbcf415cb85849b35935e49/Formula/alure.rb#L29-L40) which would read:

```ruby
class Alure < Formula
  ...

  # Fix missing unistd include
  # Reported by email to author on 2017-08-25
  on_high_sierra :or_newer do
    patch do
      url "https://raw.githubusercontent.com/Homebrew/formula-patches/eed63e836e/alure/unistd.patch"
      sha256 "7852a7a365f518b12a1afd763a6a80ece88ac7aeea3c9023aa6c1fe46ac5a1ae"
    end
  end

  on_linux do
    depends_on "openal-soft"
  end

  ...
end
```

In that case, some dependencies end up appearing after the patch since the `on_linux` must come after `on_high_sierra`. One suggestion from @carlocab was to flip the nesting of `on_high_sierra` and `patch`:

```ruby
  patch do
    on_high_sierra :or_newer do
      url "https://raw.githubusercontent.com/Homebrew/formula-patches/eed63e836e/alure/unistd.patch"
      sha256 "7852a7a365f518b12a1afd763a6a80ece88ac7aeea3c9023aa6c1fe46ac5a1ae"
    end
  end
```

But this doesn't currently work since the `patch` blocks would end up with empty contents when `on_high_sierra :or_newer` isn't evaluated which causes an error. One solution could be to allow `patch` blocks to be empty like this. This is only a problem for 8 formulae so it may not be worth fixing.

---

_This is marked as "do not merge" for now since it will need a rebase after https://github.com/Homebrew/brew/pull/13529 is merged and will need to wait until https://github.com/Homebrew/homebrew-core/pull/105149 is merged._