### PR TITLE
cask/cmd/list_spec.rb: fix leaky version variable

### DIFF
--- a/Library/Homebrew/test/cask/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/list_spec.rb
@@ -246,7 +246,7 @@ describe Cask::Cmd::List, :cask do
         ]
       EOS
     }
-    let(:original_macos_version) { MacOS.full_version.to_s }
+    let!(:original_macos_version) { MacOS.full_version.to_s }
 
     before do
       # Use a more limited symbols list to shorten the variations hash


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The lazy evaluation in `let()` was failing to reset `MacOS#full_version` to the original_macos_version. This meant that all tests that were run after this one automatically had `MacOS#version` monterey which caused some of the tests to fail if you were running a different macOS version.

This might not be noticeable on macOS monterey because that is the default version it will get set to accidentally. I came across this on my old iMac which is running catalina. To give an example of a failing test case `brew tests --seed=52182` was failing before but all tests pass now.

@Bo98 Thanks for helping me debug this.