### PR TITLE
cask/installer.rb: stop including Staged module

### DIFF
--- a/Library/Homebrew/cask/dsl/preflight.rb
+++ b/Library/Homebrew/cask/dsl/preflight.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "cask/staged"
+
 module Cask
   class DSL
     # Class corresponding to the `preflight` stanza.

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -7,7 +7,6 @@ require "utils/topological_hash"
 
 require "cask/config"
 require "cask/download"
-require "cask/staged"
 require "cask/quarantine"
 
 require "cgi"
@@ -20,12 +19,6 @@ module Cask
     extend T::Sig
 
     extend Predicable
-    # TODO: it is unwise for Cask::Staged to be a module, when we are
-    #       dealing with both staged and unstaged casks here. This should
-    #       either be a class which is only sometimes instantiated, or there
-    #       should be explicit checks on whether staged state is valid in
-    #       every method.
-    include Staged
 
     def initialize(cask, command: SystemCommand, force: false,
                    skip_cask_deps: false, binaries: true, verbose: false,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The original pr #13516 was closed because of failing tests which were resolved in pr #13545.

The idea here is to tackle the todo on line 32 of `cask/installer.rb` related to the including of `cask/staged`. There are two methods found in `cask/staged` which are `#set_permissions` and `#set_ownership`. Neither of these methods are called throughout the entire brew codebase. These methods are made available through the `preflight`, `postflight` and `uninstall_postflight` cask stanzas where a quick search shows they do get used and staged is now required in each of those dsl files.