### PR TITLE
rubocops: allow uses_from_macos "less"

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -82,6 +82,7 @@ module RuboCop
           git
           groff
           gzip
+          less
           openssl
           perl
           php


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This would be nice to have for the `circumflex` formula so that `depends_on "less" if MacOS.version <= :big_sur` could be replaced with `uses_from_macos "less", since: :monterey` (https://github.com/Homebrew/homebrew-core/pull/105577)

In addition, the `modules` formula could use this too to replace `on_linux { depends_on "less" }`