### PR TITLE
dev-cmd/update-test: test against merge-base rather than latest master

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -52,7 +52,8 @@ module Homebrew
       "master"
     end
 
-    start_commit, end_commit = nil
+    start_commit = nil
+    end_commit = "HEAD"
     cd HOMEBREW_REPOSITORY do
       start_commit = if (commit = args.commit)
         commit
@@ -79,14 +80,13 @@ module Homebrew
         # ^0 ensures this points to the commit rather than the tag object.
         "#{previous_tag}^0"
       else
-        Utils.popen_read("git", "rev-parse", "origin/master").chomp
+        Utils.popen_read("git", "merge-base", "origin/master", end_commit).chomp
       end
       odie "Could not find start commit!" if start_commit.empty?
 
       start_commit = Utils.popen_read("git", "rev-parse", start_commit).chomp
       odie "Could not find start commit!" if start_commit.empty?
 
-      end_commit ||= "HEAD"
       end_commit = Utils.popen_read("git", "rev-parse", end_commit).chomp
       odie "Could not find end commit!" if end_commit.empty?
 


### PR DESCRIPTION
When testing a commit not on `master` and `master` has since been updated since the branching, then `brew update` will perform a rebase of those commits onto the latest master since a fast-forward is not possible.

This behaviour is correct but the end commit cannot be predicted by `brew update-test`. The hash of the commits after a rebase will change, so the test will always fail when it's trying to look for the original commit hash under this scenario.

Since the commit hash is not known ahead of time in a rebase scenario, the fix here is to simply avoid testing scenarios where a rebase will be required. That means not testing an update from the HEAD of `origin/master` but instead from the `git merge-base` of the current HEAD and the HEAD of `origin/master`.

This does mean losing some coverage of the rebase part of `brew update`, but if testing that is desired then that should be done under a more controlled environment rather than random chance of doing it and failing everytime anyway. The rebase path should also only be applicable to anyone who has have local commits on `master` that don't exist remotely, rather than the majority of users.