### PR TITLE
rubocop: generate_completions DSL

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -441,7 +441,7 @@ module RuboCop
             elsif shell_parameter_stripped == "--shell="
               :arg
             else
-              "\"#{shell_parameter_stripped}\""
+              shell_parameter_stripped
             end
 
             replacement_args = %w[]

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -423,6 +423,7 @@ module RuboCop
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           install = find_method_def(body_node, :install)
+          return if install.blank?
 
           correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcmd, shell_parameter| # rubocop:disable Metrics/ParameterLists
             # generate_completions_from_executable only applicable if shell is passed
@@ -505,6 +506,7 @@ module RuboCop
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           install = find_method_def(body_node, :install)
+          return if install.blank?
 
           methods = find_every_method_call_by_name(install, :generate_completions_from_executable)
           return if methods.length <= 1

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -431,7 +431,10 @@ module RuboCop
             base_name = base_name.delete_prefix("_").delete_suffix(".fish")
             shell = shell.to_s.delete_suffix("_completion").to_sym
             executable = executable.source
-            shell_parameter_stripped = shell_parameter.delete_suffix("bash").delete_suffix("zsh").delete_suffix("fish")
+            shell_parameter_stripped = shell_parameter
+                                       .delete_suffix("bash")
+                                       .delete_suffix("zsh")
+                                       .delete_suffix("fish")
             shell_parameter_format = if shell_parameter_stripped.empty?
               nil
             elsif shell_parameter_stripped == "--"
@@ -447,7 +450,9 @@ module RuboCop
             replacement_args << subcmd.inspect
             replacement_args << "base_name: \"#{base_name}\"" unless base_name == @formula_name
             replacement_args << "shells: [:#{shell}]"
-            replacement_args << "shell_parameter_format: #{shell_parameter_format.inspect}" unless shell_parameter_format.nil?
+            unless shell_parameter_format.nil?
+              replacement_args << "shell_parameter_format: #{shell_parameter_format.inspect}"
+            end
 
             offending_node(node)
             replacement = "generate_completions_from_executable(#{replacement_args.join(", ")})"
@@ -463,7 +468,7 @@ module RuboCop
           end
         end
 
-        # matches ({bash,zsh,fish}_completion/"_?foo{.fish}?").write Utils.safe_popen_read(foo, subcmd, shell_parameter)
+        # match ({bash,zsh,fish}_completion/"_?foo{.fish}?").write Utils.safe_popen_read(foo, subcmd, shell_parameter)
         def_node_search :correctable_shell_completion_node, <<~EOS
           $(send
           (begin

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -424,7 +424,7 @@ module RuboCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           install = find_method_def(body_node, :install)
 
-          correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcmd, shell_parameter|
+          correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcmd, shell_parameter| # rubocop:disable Metrics/ParameterLists
             # generate_completions_from_executable only applicable if shell is passed
             next unless shell_parameter.match?(/(bash|zsh|fish)/)
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -521,9 +521,12 @@ module RuboCop
           return if offenses.blank?
 
           T.must(offenses[0...-1]).each_with_index do |node, i|
-            # executable and subcmd have to be the same to be combined
-            if node.arguments.first != offenses[i + 1].arguments.first ||
-               node.arguments.second != offenses[i + 1].arguments.second
+            # commands have to be the same to be combined
+            # send_type? matches `bin/"foo"`, str_type? matches remaining command parts,
+            # the rest are kwargs we need to filter out
+            method_commands = node.arguments.filter { |arg| arg.send_type? || arg.str_type? }
+            next_method_commands = offenses[i + 1].arguments.filter { |arg| arg.send_type? || arg.str_type? }
+            unless method_commands == next_method_commands
               shells.delete_at(i)
               next
             end

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -452,8 +452,7 @@ module RuboCop
             replacement_args << "shell_parameter_format: #{shell_parameter_format}" unless shell_parameter_format.nil?
 
             offending_node(node)
-            replacement = "generate_completions_from_executable"
-            replacement += "(#{replacement_args.join(", ")})" unless replacement_args.blank?
+            replacement = "generate_completions_from_executable(#{replacement_args.join(", ")})"
 
             problem "Use `#{replacement}` instead of `#{@offensive_node.source}`." do |corrector|
               corrector.replace(@offensive_node.source_range, replacement)

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -442,7 +442,9 @@ module RuboCop
             replacement_args = %w[]
             replacement_args << "base_name: \"#{base_name}\"" unless base_name == @formula_name
             replacement_args << "shells: [:#{shell}]"
-            replacement_args << "binary: #{binary}" unless binary.to_s == "bin/\"#{@formula_name}\""
+            if binary.to_s != "bin/\"#{@formula_name}\"" && binary.to_s != "bin/\"#{base_name}\""
+              replacement_args << "binary: #{binary}"
+            end
             replacement_args << "cmd: \"#{cmd}\"" unless cmd == "completion"
             replacement_args << "shell_prefix: #{shell_prefix}" unless shell_prefix.nil?
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -435,9 +435,9 @@ module RuboCop
             shell_parameter_format = if shell_parameter_stripped.empty?
               nil
             elsif shell_parameter_stripped == "--"
-              :flag
+              ":flag"
             elsif shell_parameter_stripped == "--shell="
-              :arg
+              ":arg"
             else
               "\"#{shell_parameter_stripped}\""
             end

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -519,10 +519,10 @@ module RuboCop
 
           T.must(offenses[0...-1]).each do |node|
             offending_node(node)
-            problem "Use a single `generate_completions_from_executable` call
-                         combining all specified shells" do |corrector|
-              # adjust range by +1 to also include & remove trailing \n
-              corrector.replace(@offensive_node.source_range.adjust(end_pos: 1), "")
+            problem "Use a single `generate_completions_from_executable` " \
+                    "call combining all specified shells." do |corrector|
+              # adjust range by -4 and +1 to also include & remove leading spaces and trailing \n
+              corrector.replace(@offensive_node.source_range.adjust(begin_pos: -4, end_pos: 1), "")
             end
           end
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -449,7 +449,11 @@ module RuboCop
             replacement_args << "shell_prefix: #{shell_prefix}" unless shell_prefix.nil?
 
             offending_node(node)
-            replacement = "generate_completions(#{replacement_args.join(", ")})"
+            replacement = if replacement_args.blank?
+              "generate_completions"
+            else
+              "generate_completions(#{replacement_args.join(", ")})"
+            end
             problem "Use `#{replacement}` instead of `#{@offensive_node.source}`." do |corrector|
               corrector.replace(@offensive_node.source_range, replacement)
             end

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -527,10 +527,8 @@ module RuboCop
           offending_node(offenses.last)
           replacement = if (%w[:bash :zsh :fish] - shells).empty?
             @offensive_node.source.sub(/shells: \[(:bash|:zsh|:fish)\]/, "")
-                           .gsub(",,", ",")
-                           .sub(", )", ")")
-                           .sub("(, ", "(")
-                           .sub("()", "")
+                           .sub(", )", ")") # clean up dangling trailing comma
+                           .sub("(, ", "(") # clean up dangling leading comma
           else
             @offensive_node.source.sub(/shells: \[(:bash|:zsh|:fish)\]/,
                                        "shells: [#{shells.join(", ")}]")

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -532,6 +532,7 @@ module RuboCop
             @offensive_node.source.sub(/shells: \[(:bash|:zsh|:fish)\]/, "")
                            .sub(", )", ")") # clean up dangling trailing comma
                            .sub("(, ", "(") # clean up dangling leading comma
+                           .sub(", , ", ", ") # clean up dangling enclosed comma
           else
             @offensive_node.source.sub(/shells: \[(:bash|:zsh|:fish)\]/,
                                        "shells: [#{shells.join(", ")}]")

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -518,7 +518,7 @@ module RuboCop
 
           return if offenses.blank?
 
-          offenses[0...-1].each do |node|
+          T.must(offenses[0...-1]).each do |node|
             offending_node(node)
             problem "Use a single `generate_completions_from_executable` call
                          combining all specified shells" do |corrector|

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -424,7 +424,7 @@ module RuboCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           install = find_method_def(body_node, :install)
 
-          correctable_shell_completion_node(install) do |node, shell, base_name, executable, cmd, shell_parameter|
+          correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcmd, shell_parameter|
             # generate_completions_from_executable only applicable if shell is passed
             next unless shell_parameter.match?(/(bash|zsh|fish)/)
 
@@ -443,12 +443,10 @@ module RuboCop
             end
 
             replacement_args = %w[]
+            replacement_args << executable
+            replacement_args << subcmd.inspect
             replacement_args << "base_name: \"#{base_name}\"" unless base_name == @formula_name
             replacement_args << "shells: [:#{shell}]"
-            if executable.to_s != "bin/\"#{@formula_name}\"" && executable.to_s != "bin/\"#{base_name}\""
-              replacement_args << "executable: #{executable}"
-            end
-            replacement_args << "cmd: \"#{cmd}\"" unless cmd == "completion"
             replacement_args << "shell_parameter_format: #{shell_parameter_format.inspect}" unless shell_parameter_format.nil?
 
             offending_node(node)
@@ -465,7 +463,7 @@ module RuboCop
           end
         end
 
-        # matches ({bash,zsh,fish}_completion/"_?foo{.fish}?").write Utils.safe_popen_read(foo, cmd, shell_parameter)
+        # matches ({bash,zsh,fish}_completion/"_?foo{.fish}?").write Utils.safe_popen_read(foo, subcmd, shell_parameter)
         def_node_search :correctable_shell_completion_node, <<~EOS
           $(send
           (begin

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -519,7 +519,8 @@ module RuboCop
             offending_node(node)
             problem "Use a single `generate_completions_from_executable` call
                          combining all specified shells" do |corrector|
-              corrector.replace(@offensive_node.source_range, "")
+              # adjust range by +1 to also include & remove trailing \n
+              corrector.replace(@offensive_node.source_range.adjust(end_pos: 1), "")
             end
           end
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -430,7 +430,6 @@ module RuboCop
 
             base_name = base_name.delete_prefix("_").delete_suffix(".fish")
             shell = shell.to_s.delete_suffix("_completion").to_sym
-            executable = executable.source
             shell_parameter_stripped = shell_parameter
                                        .delete_suffix("bash")
                                        .delete_suffix("zsh")
@@ -446,8 +445,8 @@ module RuboCop
             end
 
             replacement_args = %w[]
-            replacement_args << executable
-            replacement_args << subcmd.inspect
+            replacement_args << executable.source
+            replacement_args << subcmd.source
             replacement_args << "base_name: \"#{base_name}\"" unless base_name == @formula_name
             replacement_args << "shells: [:#{shell}]"
             unless shell_parameter_format.nil?
@@ -480,7 +479,7 @@ module RuboCop
             $(send
               (send nil? :bin) :/
               (str _))
-            (str $_)
+            $(str _)
             (str $_)))
         EOS
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -462,6 +462,9 @@ module RuboCop
           end
 
           shell_completion_node(install) do |node|
+            next if node.source.include?("<<~") # skip heredoc completion scripts
+            next if node.source.match?(/{.*=>.*}/) # skip commands needing custom ENV variables
+
             offending_node(node)
             problem "Use `generate_completions_from_executable` DSL instead of `#{@offensive_node.source}`."
           end

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -435,6 +435,8 @@ module RuboCop
               nil
             elsif shell_parameter_stripped == "--"
               :flag
+            elsif shell_parameter_stripped == "--shell="
+              :arg
             else
               "\"#{shell_parameter_stripped}\""
             end

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -435,9 +435,9 @@ module RuboCop
             shell_parameter_format = if shell_parameter_stripped.empty?
               nil
             elsif shell_parameter_stripped == "--"
-              ":flag"
+              :flag
             elsif shell_parameter_stripped == "--shell="
-              ":arg"
+              :arg
             else
               "\"#{shell_parameter_stripped}\""
             end
@@ -449,7 +449,7 @@ module RuboCop
               replacement_args << "executable: #{executable}"
             end
             replacement_args << "cmd: \"#{cmd}\"" unless cmd == "completion"
-            replacement_args << "shell_parameter_format: #{shell_parameter_format}" unless shell_parameter_format.nil?
+            replacement_args << "shell_parameter_format: #{shell_parameter_format.inspect}" unless shell_parameter_format.nil?
 
             offending_node(node)
             replacement = "generate_completions_from_executable(#{replacement_args.join(", ")})"

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -431,7 +431,7 @@ module RuboCop
             base_name = base_name.delete_prefix("_").delete_suffix(".fish")
             shell = shell.to_s.delete_suffix("_completion").to_sym
             executable = executable.source
-            shell_parameter_stripped = shell_parameter.sub("bash", "").sub("zsh", "").sub("fish", "")
+            shell_parameter_stripped = shell_parameter.delete_suffix("bash").delete_suffix("zsh").delete_suffix("fish")
             shell_parameter_format = if shell_parameter_stripped.empty?
               nil
             elsif shell_parameter_stripped == "--"

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -525,7 +525,7 @@ module RuboCop
           end
 
           offending_node(offenses.last)
-          replacement = if (shells - %w[:bash :zsh :fish]).empty?
+          replacement = if (%w[:bash :zsh :fish] - shells).empty?
             @offensive_node.source.sub(/shells: \[(:bash|:zsh|:fish)\]/, "")
                            .gsub(",,", ",")
                            .sub(", )", ")")

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -5098,6 +5098,12 @@ class RuboCop::Cop::FormulaAudit::DeprecateDisableReason
   def reason(param0); end
 end
 
+class RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL
+  def correctable_shell_completion_node(param0); end
+
+  def shell_completion_node(param0); end
+end
+
 class RuboCop::Cop::FormulaAudit::GitUrls
   def url_has_revision?(param0=T.unsafe(nil)); end
 end

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -1,0 +1,78 @@
+# typed: false
+# frozen_string_literal: true
+
+require "rubocops/lines"
+
+describe RuboCop::Cop::FormulaAudit do
+  describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
+    subject(:cop) { described_class.new }
+
+    it "reports an offense when writing to a shell completions file directly" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          name "foo"
+
+          def install
+            (bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])` instead of `(bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
+          end
+        end
+      RUBY
+    end
+
+    it "reports an offense when writing to a completions file indirectly" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            output = Utils.safe_popen_read(bin/"foo", "completions", "bash")
+            (bash_completion/"foo").write output
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable` DSL instead of `(bash_completion/"foo").write output`.
+          end
+        end
+      RUBY
+    end
+  end
+
+  describe RuboCop::Cop::FormulaAudit::SingleGenerateCompletionsDSLCall do
+    subject(:cop) { described_class.new }
+
+    it "reports an offense when using multiple #generate_completions_from_executable calls for different shells" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:zsh])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions")` instead of `generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions")
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -63,7 +63,7 @@ describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
   subject(:cop) { described_class.new }
 
   it "reports an offense when writing to a shell completions file directly" do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
       class Foo < Formula
         name "foo"
 

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -3,130 +3,56 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit do
-  describe RuboCop::Cop::FormulaAudit::Lines do
-    subject(:cop) { described_class.new }
+describe RuboCop::Cop::FormulaAudit::Lines do
+  subject(:cop) { described_class.new }
 
-    context "when auditing deprecated special dependencies" do
-      it "reports an offense when using depends_on :automake" do
-        expect_offense(<<~RUBY)
-          class Foo < Formula
-            url 'https://brew.sh/foo-1.0.tgz'
-            depends_on :automake
-            ^^^^^^^^^^^^^^^^^^^^ :automake is deprecated. Usage should be \"automake\".
-          end
-        RUBY
-      end
-
-      it "reports an offense when using depends_on :autoconf" do
-        expect_offense(<<~RUBY)
-          class Foo < Formula
-            url 'https://brew.sh/foo-1.0.tgz'
-            depends_on :autoconf
-            ^^^^^^^^^^^^^^^^^^^^ :autoconf is deprecated. Usage should be \"autoconf\".
-          end
-        RUBY
-      end
-
-      it "reports an offense when using depends_on :libtool" do
-        expect_offense(<<~RUBY)
-          class Foo < Formula
-            url 'https://brew.sh/foo-1.0.tgz'
-            depends_on :libtool
-            ^^^^^^^^^^^^^^^^^^^ :libtool is deprecated. Usage should be \"libtool\".
-          end
-        RUBY
-      end
-
-      it "reports an offense when using depends_on :apr" do
-        expect_offense(<<~RUBY)
-          class Foo < Formula
-            url 'https://brew.sh/foo-1.0.tgz'
-            depends_on :apr
-            ^^^^^^^^^^^^^^^ :apr is deprecated. Usage should be \"apr-util\".
-          end
-        RUBY
-      end
-
-      it "reports an offense when using depends_on :tex" do
-        expect_offense(<<~RUBY)
-          class Foo < Formula
-            url 'https://brew.sh/foo-1.0.tgz'
-            depends_on :tex
-            ^^^^^^^^^^^^^^^ :tex is deprecated.
-          end
-        RUBY
-      end
-    end
-  end
-
-  describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
-    subject(:cop) { described_class.new }
-
-    it "reports an offense when writing to a shell completions file directly" do
-      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
-        class Foo < Formula
-          name "foo"
-
-          def install
-            (bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])` instead of `(bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")`.
-          end
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        class Foo < Formula
-          name "foo"
-
-          def install
-            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
-          end
-        end
-      RUBY
-    end
-
-    it "reports an offense when writing to a completions file indirectly" do
+  context "when auditing deprecated special dependencies" do
+    it "reports an offense when using depends_on :automake" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          name "foo"
-
-          def install
-            output = Utils.safe_popen_read(bin/"foo", "completions", "bash")
-            (bash_completion/"foo").write output
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable` DSL instead of `(bash_completion/"foo").write output`.
-          end
+          url 'https://brew.sh/foo-1.0.tgz'
+          depends_on :automake
+          ^^^^^^^^^^^^^^^^^^^^ :automake is deprecated. Usage should be \"automake\".
         end
       RUBY
     end
-  end
 
-  describe RuboCop::Cop::FormulaAudit::SingleGenerateCompletionsDSLCall do
-    subject(:cop) { described_class.new }
-
-    it "reports an offense when using multiple #generate_completions_from_executable calls for different shells" do
+    it "reports an offense when using depends_on :autoconf" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          name "foo"
-
-          def install
-            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
-            generate_completions_from_executable(bin/"foo", "completions", shells: [:zsh])
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
-            generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions")` instead of `generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])`.
-          end
+          url 'https://brew.sh/foo-1.0.tgz'
+          depends_on :autoconf
+          ^^^^^^^^^^^^^^^^^^^^ :autoconf is deprecated. Usage should be \"autoconf\".
         end
       RUBY
+    end
 
-      expect_correction(<<~RUBY)
+    it "reports an offense when using depends_on :libtool" do
+      expect_offense(<<~RUBY)
         class Foo < Formula
-          name "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+          depends_on :libtool
+          ^^^^^^^^^^^^^^^^^^^ :libtool is deprecated. Usage should be \"libtool\".
+        end
+      RUBY
+    end
 
-          def install
-            generate_completions_from_executable(bin/"foo", "completions")
-          end
+    it "reports an offense when using depends_on :apr" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          depends_on :apr
+          ^^^^^^^^^^^^^^^ :apr is deprecated. Usage should be \"apr-util\".
+        end
+      RUBY
+    end
+
+    it "reports an offense when using depends_on :tex" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          depends_on :tex
+          ^^^^^^^^^^^^^^^ :tex is deprecated.
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -3,130 +3,132 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::Lines do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::FormulaAudit do
+  describe RuboCop::Cop::FormulaAudit::Lines do
+    subject(:cop) { described_class.new }
 
-  context "when auditing deprecated special dependencies" do
-    it "reports an offense when using depends_on :automake" do
-      expect_offense(<<~RUBY)
+    context "when auditing deprecated special dependencies" do
+      it "reports an offense when using depends_on :automake" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url 'https://brew.sh/foo-1.0.tgz'
+            depends_on :automake
+            ^^^^^^^^^^^^^^^^^^^^ :automake is deprecated. Usage should be \"automake\".
+          end
+        RUBY
+      end
+
+      it "reports an offense when using depends_on :autoconf" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url 'https://brew.sh/foo-1.0.tgz'
+            depends_on :autoconf
+            ^^^^^^^^^^^^^^^^^^^^ :autoconf is deprecated. Usage should be \"autoconf\".
+          end
+        RUBY
+      end
+
+      it "reports an offense when using depends_on :libtool" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url 'https://brew.sh/foo-1.0.tgz'
+            depends_on :libtool
+            ^^^^^^^^^^^^^^^^^^^ :libtool is deprecated. Usage should be \"libtool\".
+          end
+        RUBY
+      end
+
+      it "reports an offense when using depends_on :apr" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url 'https://brew.sh/foo-1.0.tgz'
+            depends_on :apr
+            ^^^^^^^^^^^^^^^ :apr is deprecated. Usage should be \"apr-util\".
+          end
+        RUBY
+      end
+
+      it "reports an offense when using depends_on :tex" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            url 'https://brew.sh/foo-1.0.tgz'
+            depends_on :tex
+            ^^^^^^^^^^^^^^^ :tex is deprecated.
+          end
+        RUBY
+      end
+    end
+  end
+
+  describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
+    subject(:cop) { described_class.new }
+
+    it "reports an offense when writing to a shell completions file directly" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://brew.sh/foo-1.0.tgz'
-          depends_on :automake
-          ^^^^^^^^^^^^^^^^^^^^ :automake is deprecated. Usage should be \"automake\".
+          name "foo"
+
+          def install
+            (bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])` instead of `(bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")`.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
+
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
+          end
         end
       RUBY
     end
 
-    it "reports an offense when using depends_on :autoconf" do
+    it "reports an offense when writing to a completions file indirectly" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://brew.sh/foo-1.0.tgz'
-          depends_on :autoconf
-          ^^^^^^^^^^^^^^^^^^^^ :autoconf is deprecated. Usage should be \"autoconf\".
-        end
-      RUBY
-    end
+          name "foo"
 
-    it "reports an offense when using depends_on :libtool" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          url 'https://brew.sh/foo-1.0.tgz'
-          depends_on :libtool
-          ^^^^^^^^^^^^^^^^^^^ :libtool is deprecated. Usage should be \"libtool\".
-        end
-      RUBY
-    end
-
-    it "reports an offense when using depends_on :apr" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          url 'https://brew.sh/foo-1.0.tgz'
-          depends_on :apr
-          ^^^^^^^^^^^^^^^ :apr is deprecated. Usage should be \"apr-util\".
-        end
-      RUBY
-    end
-
-    it "reports an offense when using depends_on :tex" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          url 'https://brew.sh/foo-1.0.tgz'
-          depends_on :tex
-          ^^^^^^^^^^^^^^^ :tex is deprecated.
+          def install
+            output = Utils.safe_popen_read(bin/"foo", "completions", "bash")
+            (bash_completion/"foo").write output
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable` DSL instead of `(bash_completion/"foo").write output`.
+          end
         end
       RUBY
     end
   end
-end
 
-describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
-  subject(:cop) { described_class.new }
+  describe RuboCop::Cop::FormulaAudit::SingleGenerateCompletionsDSLCall do
+    subject(:cop) { described_class.new }
 
-  it "reports an offense when writing to a shell completions file directly" do
-    expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
-      class Foo < Formula
-        name "foo"
+    it "reports an offense when using multiple #generate_completions_from_executable calls for different shells" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          name "foo"
 
-        def install
-          (bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])` instead of `(bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")`.
+          def install
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:zsh])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
+            generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions")` instead of `generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])`.
+          end
         end
-      end
-    RUBY
+      RUBY
 
-    expect_correction(<<~RUBY)
-      class Foo < Formula
-        name "foo"
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          name "foo"
 
-        def install
-          generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
+          def install
+            generate_completions_from_executable(bin/"foo", "completions")
+          end
         end
-      end
-    RUBY
-  end
-
-  it "reports an offense when writing to a completions file indirectly" do
-    expect_offense(<<~RUBY)
-      class Foo < Formula
-        name "foo"
-
-        def install
-          output = Utils.safe_popen_read(bin/"foo", "completions", "bash")
-          (bash_completion/"foo").write output
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable` DSL instead of `(bash_completion/"foo").write output`.
-        end
-      end
-    RUBY
-  end
-end
-
-describe RuboCop::Cop::FormulaAudit::SingleGenerateCompletionsDSLCall do
-  subject(:cop) { described_class.new }
-
-  it "reports an offense when using multiple #generate_completions_from_executable calls for different shells" do
-    expect_offense(<<~RUBY)
-      class Foo < Formula
-        name "foo"
-
-        def install
-          generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
-          generate_completions_from_executable(bin/"foo", "completions", shells: [:zsh])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
-          generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions")` instead of `generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])`.
-        end
-      end
-    RUBY
-
-    expect_correction(<<~RUBY)
-      class Foo < Formula
-        name "foo"
-
-        def install
-          generate_completions_from_executable(bin/"foo", "completions")
-        end
-      end
-    RUBY
+      RUBY
+    end
   end
 end

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -58,3 +58,75 @@ describe RuboCop::Cop::FormulaAudit::Lines do
     end
   end
 end
+
+describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
+  subject(:cop) { described_class.new }
+
+  it "reports an offense when writing to a shell completions file directly" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        name "foo"
+
+        def install
+          (bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])` instead of `(bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        name "foo"
+
+        def install
+          generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
+        end
+      end
+    RUBY
+  end
+
+  it "reports an offense when writing to a completions file indirectly" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        name "foo"
+
+        def install
+          output = Utils.safe_popen_read(bin/"foo", "completions", "bash")
+          (bash_completion/"foo").write output
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable` DSL instead of `(bash_completion/"foo").write output`.
+        end
+      end
+    RUBY
+  end
+end
+
+describe RuboCop::Cop::FormulaAudit::SingleGenerateCompletionsDSLCall do
+  subject(:cop) { described_class.new }
+
+  it "reports an offense when using multiple #generate_completions_from_executable calls for different shells" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        name "foo"
+
+        def install
+          generate_completions_from_executable(bin/"foo", "completions", shells: [:bash])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
+          generate_completions_from_executable(bin/"foo", "completions", shells: [:zsh])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a single `generate_completions_from_executable` call combining all specified shells.
+          generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `generate_completions_from_executable(bin/"foo", "completions")` instead of `generate_completions_from_executable(bin/"foo", "completions", shells: [:fish])`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        name "foo"
+
+        def install
+          generate_completions_from_executable(bin/"foo", "completions")
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
related to #13536 

needs https://github.com/Homebrew/homebrew-core/pull/105707

cc @Rylan12 

I have achieved to implement a preliminary RuboCop, but I will appreciate any feedback, since I'm sure there's room for improvement.

The Cop is able to correct
```
(bash_completion/"foo").write Utils.safe_popen_read(bin/"foo", "completions", "bash")
```
but I have been unable to come up with a solution to get and replace with all shells whilst only walking the AST once.

The Cop also warns for the 
```
output = Utils.safe_popen_read(bin/"foo", "completion", "bash")
(bash_completion/"foo").write output
```
pattern, but has no corrector, as discussed in #13536.

Please feel free to push any commits improving my implementation 😄 

