### PR TITLE
update for PopOS bash profile file Update Homebrew-on-Linux.md

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -28,7 +28,7 @@ The installation script installs Homebrew to `/home/linuxbrew/.linuxbrew` using 
 
 The prefix `/home/linuxbrew/.linuxbrew` was chosen so that users without admin access can ask an admin to create a `linuxbrew` role account and still benefit from precompiled binaries. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory set to `/home/linuxbrew`.
 
-Follow the *Next steps* instructions to add Homebrew to your `PATH` and to your bash shell profile script, either `~/.profile` on Debian/Ubuntu or `~/.bash_profile` on CentOS/Fedora/Red Hat.
+Follow the *Next steps* instructions to add Homebrew to your `PATH` and to your bash shell profile script, either `~/.profile` on Debian/Ubuntu, `~/.bash_profile` on CentOS/Fedora/Red Hat, or `~/.bashrc` on Pop OS.
 
 ```sh
 test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)"


### PR DESCRIPTION
- [ x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x ] Have you successfully run `brew style` with your changes locally?
- [ x] Have you successfully run `brew typecheck` with your changes locally?
- [ x] Have you successfully run `brew tests` with your changes locally?

-----

Updating proper install file for PopOS install of Homebrew. PopOS uses `~/.bashrc` and not `~/.profile` or `./bash_profile`