### PR TITLE
utils/ruby_check_version_script: fix and test.

### DIFF
--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+# frozen_string_literal: true
+
+describe Utils do
+  describe "ruby_check_version_script", :needs_linux do
+    subject do
+      quiet_system "#{HOMEBREW_LIBRARY_PATH}/utils/ruby_check_version_script.rb", required_ruby_version
+    end
+
+    before do
+      ENV.delete("HOMEBREW_DEVELOPER")
+      ENV.delete("HOMEBREW_USE_RUBY_FROM_PATH")
+    end
+
+    describe "succeeds on Homebrew required Ruby version" do
+      let(:required_ruby_version) { HOMEBREW_REQUIRED_RUBY_VERSION }
+
+      it { is_expected.to be true }
+    end
+
+    describe "succeeds on newer mismatched major/minor required Ruby version and configurated environment" do
+      let(:required_ruby_version) { "2.0.0" }
+
+      before do
+        ENV["HOMEBREW_DEVELOPER"] = "1"
+        ENV["HOMEBREW_USE_RUBY_FROM_PATH"] = "1"
+      end
+
+      it { is_expected.to be true }
+    end
+
+    describe "fails on on mismatched major/minor required Ruby version" do
+      let(:required_ruby_version) { "1.2.3" }
+
+      it { is_expected.to be false }
+    end
+
+    describe "fails on invalid required Ruby version" do
+      let(:required_ruby_version) { "fish" }
+
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 describe Utils do
-  describe "ruby_check_version_script", :needs_linux do
+  describe "ruby_check_version_script" do
     subject do
       quiet_system "#{HOMEBREW_LIBRARY_PATH}/utils/ruby_check_version_script.rb", required_ruby_version
     end

--- a/Library/Homebrew/utils/ruby_check_version_script.rb
+++ b/Library/Homebrew/utils/ruby_check_version_script.rb
@@ -17,8 +17,8 @@ ruby_version_major, ruby_version_minor, = ruby_version.canonical_segments
 homebrew_required_ruby_version_major, homebrew_required_ruby_version_minor, =
   homebrew_required_ruby_version.canonical_segments
 
-if ENV["HOMEBREW_DEVELOPER"].present? &&
-   ENV["HOMEBREW_USE_RUBY_FROM_PATH"].present? &&
+if !ENV.fetch("HOMEBREW_DEVELOPER", "").empty? &&
+   !ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", "").empty? &&
    ruby_version >= homebrew_required_ruby_version
   return
 elsif ruby_version_major != homebrew_required_ruby_version_major ||

--- a/Library/Homebrew/utils/ruby_check_version_script.rb
+++ b/Library/Homebrew/utils/ruby_check_version_script.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt
+#!/usr/bin/env ruby
 # typed: true
 # frozen_string_literal: true
 


### PR DESCRIPTION
Don't use ActiveSupport methods and add a test to make sure this doesn't regress.

Fixes #13559