### PR TITLE
dev-cmd/tests: make sorbet optional.

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -29,7 +29,6 @@ require "rspec/its"
 require "rspec/github"
 require "rspec/wait"
 require "rspec/retry"
-require "rspec/sorbet"
 require "rubocop/rspec/support"
 require "find"
 require "byebug"
@@ -60,9 +59,12 @@ TEST_DIRECTORIES = [
   HOMEBREW_TEMP,
 ].freeze
 
-# Make `instance_double` and `class_double`
-# work when type-checking is active.
-RSpec::Sorbet.allow_doubles!
+# Make `instance_double` and `class_double` work when type-checking is active.
+# Be resistant to the Sorbet gem not being installed but be sure we always do this in CI.
+if require?("rspec/sorbet") || \
+   ENV.fetch("CI", false) || ENV.fetch("HOMEBREW_SORBET_RUNTIME", false)
+  RSpec::Sorbet.allow_doubles!
+end
 
 RSpec.configure do |config|
   config.order = :random
@@ -81,7 +83,7 @@ RSpec.configure do |config|
   config.default_sleep_interval = 1
 
   # Don't make retries as noisy unless in CI.
-  if ENV["CI"]
+  if ENV.fetch("CI", false)
     config.verbose_retry = true
     config.display_try_failure_messages = true
   end

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -139,9 +139,15 @@ module Homebrew
 
     require "settings"
 
-    # Combine the passed groups with the ones stored in settings
-    groups |= (Homebrew::Settings.read(:gemgroups)&.split(";") || [])
-    groups.sort!
+    groups = if groups.nil?
+      # Don't use any existing groups if this is explicitly set to nil
+      Homebrew::Settings.delete(:gemgroups)
+      []
+    else
+      # Combine the passed groups with the ones stored in settings
+      groups |= (Homebrew::Settings.read(:gemgroups)&.split(";") || [])
+      groups.sort
+    end
 
     ENV["BUNDLE_GEMFILE"] = File.join(ENV.fetch("HOMEBREW_LIBRARY"), "Homebrew", "Gemfile")
     ENV["BUNDLE_WITH"] = groups.join(" ")


### PR DESCRIPTION
Installing Sorbet gems is error-prone and it blocks maintainers from testing when it fails.

Ensure that we still always run it if HOMEBREW_SORBET_RUNTIME or CI are enabled.