### PR TITLE
Add flags to superenv when building with glibc@2.13

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -37,6 +37,17 @@ module Superenv
     paths
   end
 
+  def homebrew_extra_isystem_paths
+    paths = []
+    # Add paths for GCC headers when building against glibc@2.13 because we have to use -nostdinc.
+    if deps.any? { |d| d.name == "glibc@2.13" }
+      gcc_include_dir = Utils.safe_popen_read(cc, "--print-file-name=include").chomp
+      gcc_include_fixed_dir = Utils.safe_popen_read(cc, "--print-file-name=include-fixed").chomp
+      paths << gcc_include_dir << gcc_include_fixed_dir
+    end
+    paths
+  end
+
   def determine_rpath_paths(formula)
     PATH.new(
       *formula&.lib,

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -292,6 +292,8 @@ class Cmd
     args.concat(optflags) unless runtime_cpu_detection?
     args.concat(archflags)
     args << "-std=#{@arg0}" if /c[89]9/.match?(@arg0)
+    # Add -nostdinc when building against glibc@2.13 to avoid mixing system and brewed glibc headers.
+    args << "-nostdinc" if @deps.include?("glibc@2.13")
     args
   end
 
@@ -326,6 +328,9 @@ class Cmd
     end
     args += rpath_flags("#{wl}-rpath=", rpath_paths)
     args += ["#{wl}--dynamic-linker=#{dynamic_linker_path}"] if dynamic_linker_path
+    # Use -rpath-link to make sure linker uses glibc@2.13 rather than the system glibc for indirect
+    # dependencies because -L will only handle direct dependencies.
+    args << "#{wl}-rpath-link=#{@opt}/glibc@2.13/lib" if @deps.include?("glibc@2.13")
     args
   end
 


### PR DESCRIPTION
This PR should fix most of the issues we were hitting in https://github.com/Homebrew/homebrew-portable-ruby/pull/156.  The root of the problem is that we can't mix headers from the system `glibc` with `glibc@2.13` and the only way to guarantee this is to use `-nostdinc` and add the paths to the GCC headers with `-isystem` flags.