### PR TITLE
linkage_checker: report linkage with system frameworks

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -198,7 +198,7 @@ class LinkageChecker
             # In macOS Big Sur and later, system libraries do not exist on-disk and instead exist in a cache.
             # If dlopen finds the dylib, then the linkage is not broken.
             @system_dylibs << dylib
-          else
+          elsif !system_framework?(dylib)
             @broken_dylibs << dylib
           end
         else
@@ -306,11 +306,13 @@ class LinkageChecker
   def harmless_broken_link?(dylib)
     # libgcc_s_* is referenced by programs that use the Java Service Wrapper,
     # and is harmless on x86(_64) machines
-    return true if [
+    [
       "/usr/lib/libgcc_s_ppc64.1.dylib",
       "/opt/local/lib/libgcc/libgcc_s.1.dylib",
     ].include?(dylib)
+  end
 
+  def system_framework?(dylib)
     dylib.start_with?("/System/Library/Frameworks/")
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, `brew linkage` reports linkage with system frameworks only if
they can be found on the file system. This results in this linkage not
being reported on Big Sur and newer, where system libraries are stored
in the dyld cache instead.

Let's fix that by avoiding silently ignoring system frameworks by moving
them out of `#harmless_broken_link?`. We retain the behaviour desired
from 7228e60da51392b20d55e0c087b2082b86fb3bbf by deferring checking if a
broken library is actually a system framework to just before we add it
to `@broken_dylibs`.

To see how this changes the behaviour of `brew linkage`, here's an
example with this change:

    ❯ brew linkage neovim
    System libraries:
      /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
      /usr/lib/libSystem.B.dylib
      /usr/lib/libiconv.2.dylib
      /usr/lib/libutil.dylib
    Homebrew libraries:
      /usr/local/opt/gettext/lib/libintl.8.dylib (gettext)
      /usr/local/opt/libtermkey/lib/libtermkey.1.dylib (libtermkey)
      /usr/local/opt/libuv/lib/libuv.1.dylib (libuv)
      /usr/local/opt/luajit/lib/libluajit-5.1.2.dylib (luajit)
      /usr/local/opt/luv/lib/libluv.1.dylib (luv)
      /usr/local/opt/msgpack/lib/libmsgpackc.2.dylib (msgpack)
      /usr/local/opt/tree-sitter/lib/libtree-sitter.0.dylib (tree-sitter)
      /usr/local/opt/unibilium/lib/libunibilium.4.dylib (unibilium)

and without this change:

    ❯ brew linkage neovim
    System libraries:
      /usr/lib/libSystem.B.dylib
      /usr/lib/libiconv.2.dylib
      /usr/lib/libutil.dylib
    Homebrew libraries:
      /usr/local/opt/gettext/lib/libintl.8.dylib (gettext)
      /usr/local/opt/libtermkey/lib/libtermkey.1.dylib (libtermkey)
      /usr/local/opt/libuv/lib/libuv.1.dylib (libuv)
      /usr/local/opt/luajit/lib/libluajit-5.1.2.dylib (luajit)
      /usr/local/opt/luv/lib/libluv.1.dylib (luv)
      /usr/local/opt/msgpack/lib/libmsgpackc.2.dylib (msgpack)
      /usr/local/opt/tree-sitter/lib/libtree-sitter.0.dylib (tree-sitter)
      /usr/local/opt/unibilium/lib/libunibilium.4.dylib (unibilium)
