### PR TITLE
Ignore empty `patch` blocks

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -205,6 +205,8 @@ class SoftwareSpec
 
   def patch(strip = :p1, src = nil, &block)
     p = Patch.create(strip, src, &block)
+    return if p.is_a?(ExternalPatch) && p.url.blank?
+
     dependency_collector.add(p.resource) if p.is_a? ExternalPatch
     patches << p
   end

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -171,5 +171,12 @@ describe SoftwareSpec do
       expect(spec.patches.count).to eq(1)
       expect(spec.patches.first.strip).to eq(:p1)
     end
+
+    it "doesn't add a patch with no url" do
+      spec.patch do
+        sha256 "7852a7a365f518b12a1afd763a6a80ece88ac7aeea3c9023aa6c1fe46ac5a1ae"
+      end
+      expect(spec.patches.empty?).to be true
+    end
   end
 end


### PR DESCRIPTION
In order to make formulae with `on_{system}` blocks easier to read, we'd like to keep patches and resources where they're supposed to go (i.e. below dependencies) even if they are only present on some system configurations. However, since only one of each `on_{system}` block is allowed, we need to next the `on_{system}` block within the `patch` or `resource` block as is done in this example:

```ruby
patch do
  on_high_sierra :or_newer do
    url "https://raw.githubusercontent.com/Homebrew/formula-patches/eed63e836e/alure/unistd.patch"
    sha256 "7852a7a365f518b12a1afd763a6a80ece88ac7aeea3c9023aa6c1fe46ac5a1ae"
  end
end
```

When the condition isn't met (in this example when `MacOS.version < :high_sierra`), this is the same as an empty `patch do; end` block which is not currently allowed. This PR changes the login of `SoftwareSpec#patch` to ignore any external patches that don't define a URL.

This was originally done in https://github.com/Homebrew/brew/pull/13539 but needed to be extracted.
