### PR TITLE
Require deprecate_disable module in formulary

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -264,6 +264,7 @@ module Formulary
   end
 
   def self.convert_to_deprecate_disable_reason_string_or_symbol(string)
+    require "deprecate_disable"
     return string unless DeprecateDisable::DEPRECATE_DISABLE_REASONS.keys.map(&:to_s).include?(string)
 
     string.to_sym


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This solves a recurrent issue where various brew commands (e.g. doctor, cleanup) would print the following stack trace:

    Error: uninitialized constant Formulary::DeprecateDisable
    Did you mean?  DeprecatedOption
    /opt/homebrew/Library/Homebrew/formulary.rb:269:in `convert_to_deprecate_disable_reason_string_or_symbol'
    /opt/homebrew/Library/Homebrew/formulary.rb:171:in `block in load_formula_from_api'
    /opt/homebrew/Library/Homebrew/formulary.rb:139:in `initialize'
    /opt/homebrew/Library/Homebrew/formulary.rb:139:in `new'
    /opt/homebrew/Library/Homebrew/formulary.rb:139:in `load_formula_from_api'
    /opt/homebrew/Library/Homebrew/formulary.rb:519:in `load_from_api'
    /opt/homebrew/Library/Homebrew/formulary.rb:510:in `klass'
    /opt/homebrew/Library/Homebrew/formulary.rb:296:in `get_formula'
    /opt/homebrew/Library/Homebrew/formulary.rb:542:in `factory'
    /opt/homebrew/Library/Homebrew/formulary.rb:565:in `from_rack'
    /opt/homebrew/Library/Homebrew/cleanup.rb:85:in `stale_formula?'
    /opt/homebrew/Library/Homebrew/cleanup.rb:58:in `stale?'
    /opt/homebrew/Library/Homebrew/cleanup.rb:356:in `block in cleanup_cache'
    /opt/homebrew/Library/Homebrew/cleanup.rb:339:in `each'
    /opt/homebrew/Library/Homebrew/cleanup.rb:339:in `cleanup_cache'
    /opt/homebrew/Library/Homebrew/cleanup.rb:222:in `clean!'
    /opt/homebrew/Library/Homebrew/cmd/cleanup.rb:58:in `cleanup'
    /opt/homebrew/Library/Homebrew/brew.rb:93:in `<main>'
