### PR TITLE
Instruct user to tap untapped official tap when running its commands

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -103,13 +103,14 @@ begin
     possible_tap = OFFICIAL_CMD_TAPS.find { |_, cmds| cmds.include?(cmd) }
     possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
-    if !possible_tap || possible_tap.installed? || Tap.untapped_official_taps.include?(possible_tap.name)
-      blocked_tap = possible_tap && Tap.untapped_official_taps.include?(possible_tap.name)
+    if !possible_tap ||
+       possible_tap.installed? ||
+       (blocked_tap = Tap.untapped_official_taps.include?(possible_tap.name))
       if blocked_tap
-        [
-          "`brew #{cmd}` is unavailable because #{possible_tap.name} was manually untapped.",
-          "Run `brew tap #{possible_tap.name}` to reenable `brew #{cmd}`.",
-        ].each { |ln| onoe ln }
+        onoe <<~EOS
+          `brew #{cmd}` is unavailable because #{possible_tap.name} was manually untapped.
+          Run `brew tap #{possible_tap.name}` to reenable `brew #{cmd}`.
+        EOS
       end
       # Check for cask explicitly because it's very common in old guides
       odie "`brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead." if cmd == "cask"

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -104,6 +104,13 @@ begin
     possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
     if !possible_tap || possible_tap.installed? || Tap.untapped_official_taps.include?(possible_tap.name)
+      blocked_tap = possible_tap && Tap.untapped_official_taps.include?(possible_tap.name)
+      if blocked_tap
+        [
+          "`brew #{cmd}` is unavailable because #{possible_tap.name} was manually untapped and cannot be retapped.",
+          "Run `brew tap #{possible_tap.name}` to reenable `brew #{cmd}`.",
+        ].each { |ln| onoe ln }
+      end
       # Check for cask explicitly because it's very common in old guides
       odie "`brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead." if cmd == "cask"
       odie "Unknown command: #{cmd}"

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -107,7 +107,7 @@ begin
       blocked_tap = possible_tap && Tap.untapped_official_taps.include?(possible_tap.name)
       if blocked_tap
         [
-          "`brew #{cmd}` is unavailable because #{possible_tap.name} was manually untapped and cannot be retapped.",
+          "`brew #{cmd}` is unavailable because #{possible_tap.name} was manually untapped.",
           "Run `brew tap #{possible_tap.name}` to reenable `brew #{cmd}`.",
         ].each { |ln| onoe ln }
       end


### PR DESCRIPTION

This came up in https://github.com/Homebrew/homebrew-bundle/issues/1108 wherein a user had unwittingly untapped some official taps that get automatically tapped on first use and couldn't figure out why they couldn't use the associated command.

⚠️ I'm not really sure how best to test this. I think I could add something [here](https://github.com/Homebrew/brew/blob/ee93d7e08dbdc52d932572007bee0f5fb1d75cbe/Library/Homebrew/test/cmd/bundle_spec.rb#L4) that runs an empty check, then untaps the homebrew/bundle tap, then checks for an error when it runs the empty check again.


- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?
