### PR TITLE
Gemfile: denote minimum Ruby

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+ruby ">= 2.6.0"
+
 # disallowed gems (should not be used)
 # * nokogiri - use rexml instead for XML parsing
 
@@ -32,7 +34,7 @@ group :sorbet, optional: true do
 end
 
 # vendored gems
-gem "activesupport", "< 7" # 7 requires Ruby 2.7
+gem "activesupport"
 gem "addressable"
 gem "concurrent-ruby"
 gem "did_you_mean" # remove when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -205,7 +205,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (< 7)
+  activesupport
   addressable
   bootsnap
   byebug
@@ -239,6 +239,9 @@ DEPENDENCIES
   sorbet-static-and-runtime
   tapioca
   warning
+
+RUBY VERSION
+   ruby 2.6.8p205
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
This might stop Dependabot from bumping dependencies that don't work with Ruby 2.6, a list which will only grow - it's a lot more than just ActiveSupport now.