### PR TITLE
use --time-cond when caching the formula api json

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -30,10 +30,8 @@ module Homebrew
         def all_formulae
           @all_formulae ||= begin
             curl_args = %w[--compressed --silent https://formulae.brew.sh/api/formula.json]
-            if cached_formula_json_file.exist?
-              last_modified = cached_formula_json_file.mtime.utc
-              last_modified = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
-              curl_args = ["--time-cond", last_modified, *curl_args] unless cached_formula_json_file.empty?
+            if cached_formula_json_file.exist? && !cached_formula_json_file.empty?
+              curl_args.prepend("--time-cond", cached_formula_json_file)
             end
             curl_download(*curl_args, to: HOMEBREW_CACHE_API/"#{formula_api_path}.json", max_time: 5)
 

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -33,7 +33,7 @@ module Homebrew
             if cached_formula_json_file.exist?
               last_modified = cached_formula_json_file.mtime.utc
               last_modified = last_modified.strftime("%a, %d %b %Y %H:%M:%S GMT")
-              curl_args = ["--header", "If-Modified-Since: #{last_modified}", *curl_args]
+              curl_args = ["--time-cond", last_modified, *curl_args] unless cached_formula_json_file.empty?
             end
             curl_download(*curl_args, to: HOMEBREW_CACHE_API/"#{formula_api_path}.json", max_time: 5)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is to fix #13583 by using `--time-cond "<date>"` instead of `--header "If-Modified-Since: <date>"` when refreshing the cached Formula API. This prevents older versions of `curl` (such as the Apple-supplied `curl` in macOS Big Sur) from writing a zero-byte .json file. My change will also skip the mtime comparison and overwrite the cache file if the cache file is empty, in order to automatically fix this issue on affected systems.