### PR TITLE
cmd/update: stop Git's fsmonitor when needed

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -556,12 +556,6 @@ EOS
     [[ -d "${DIR}/.git" ]] || continue
     cd "${DIR}" || continue
 
-    # Git's fsmonitor daemon will not release our lock unless we stop it.
-    if git fsmonitor--daemon status &>/dev/null
-    then
-      git fsmonitor--daemon stop 2>/dev/null
-    fi
-
     if ! git config --local --get remote.origin.url &>/dev/null
     then
       opoo "No remote 'origin' in ${DIR}, skipping update!"
@@ -746,6 +740,9 @@ EOS
       merge_or_rebase "${DIR}" "${TAP_VAR}" "${UPSTREAM_BRANCH}"
       [[ -n "${HOMEBREW_VERBOSE}" ]] && echo
     fi
+
+    # Git's fsmonitor daemon will not release our lock unless we stop it.
+    git fsmonitor--daemon stop 2>/dev/null
   done
 
   if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -556,6 +556,9 @@ EOS
     [[ -d "${DIR}/.git" ]] || continue
     cd "${DIR}" || continue
 
+    # Git's fsmonitor prevents the release of our locks
+    git config --bool core.fsmonitor false
+
     if ! git config --local --get remote.origin.url &>/dev/null
     then
       opoo "No remote 'origin' in ${DIR}, skipping update!"
@@ -740,9 +743,6 @@ EOS
       merge_or_rebase "${DIR}" "${TAP_VAR}" "${UPSTREAM_BRANCH}"
       [[ -n "${HOMEBREW_VERBOSE}" ]] && echo
     fi
-
-    # Git's fsmonitor daemon will not release our lock unless we stop it.
-    git fsmonitor--daemon stop 2>/dev/null
   done
 
   if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -556,6 +556,12 @@ EOS
     [[ -d "${DIR}/.git" ]] || continue
     cd "${DIR}" || continue
 
+    # Git's fsmonitor daemon will not release our lock unless we stop it.
+    if git fsmonitor--daemon status &>/dev/null
+    then
+      git fsmonitor--daemon stop 2>/dev/null
+    fi
+
     if ! git config --local --get remote.origin.url &>/dev/null
     then
       opoo "No remote 'origin' in ${DIR}, skipping update!"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Git's fsmonitor daemon will prevent our update lock file from being
released if it is running before a `brew update`.

Let's fix that by stopping it whenever necessary so our update lock is
released upon completion.

Fixes #13521.
