### PR TITLE
bump-formula-pr: even more precise tag replacement

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -243,8 +243,8 @@ module Homebrew
     elsif new_tag.present?
       [
         [
-          /#{formula_spec.specs[:tag]}(?=")/,
-          new_tag,
+          /tag:(\s+")#{formula_spec.specs[:tag]}(?=")/,
+          "tag:\\1#{new_tag}\\2",
         ],
         [
           formula_spec.specs[:revision],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
If in a formula `tag` matches `version`, then bump-formula-pr with `--version` argument fails:

```
% brew bump-formula-pr --version 2022-07-22  --debug exploitdb              
...
==> replace /2022-07-12(?=")/ with "2022-07-22"
==> replace "d84f857e94f91c71fcb93041483f661d29023c1e" with "46346f8944f5d01e09a8ed3d78e34cf759697b47"
==> replace "version \"2022-07-12\"" with "version \"2022-07-22\""
Error: inreplace failed
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/exploitdb.rb:
  expected replacement of "version \"2022-07-12\"" with "version \"2022-07-22\""
/opt/homebrew/Library/Homebrew/utils/inreplace.rb:89:in `inreplace_pairs'
/opt/homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:311:in `bump_formula_pr'
/opt/homebrew/Library/Homebrew/brew.rb:93:in `<main>'
```

Version got replaced by the first replacement pair (for the tag), and it failed to be replaced on the third one (for version).
 
Closes https://github.com/Homebrew/brew/issues/13596