### PR TITLE
Allow `ignore_missing_libraries` when simulating Linux on macOS

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3215,6 +3215,8 @@ class Formula
 
     # Permit links to certain libraries that don't exist. Available on Linux only.
     def ignore_missing_libraries(*)
+      return if Homebrew::SimulateSystem.linux?
+
       raise FormulaSpecificationError, "#{__method__} is available on Linux only"
     end
 


### PR DESCRIPTION
Since `ignore_missing_libraries` raises and error when called on macOS, generating the variations hash for formulae that use this inside an `on_linux` block fails. This PR adds a condition so that if `Homebrew::SimulateSystem.os` is set to `:linux` (i.e. we're currently simulating Linux for the purposes of the variations hash), we just return instead of failing.
