### PR TITLE
FAQ: Remove reference to `--enable-bar` that does not exist

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -78,7 +78,6 @@ Homebrew provides pre-built binary packages for many formulae. These are referre
 
 If available, bottled binaries will be used by default except under the following conditions:
 
-* Options were passed to the install command, i.e. `brew install <formula>` will use a bottled version of the formula, but `brew install --enable-bar <formula>` will trigger a source build.
 * The `--build-from-source` option is invoked.
 * No bottle is available for the machine's currently running OS version. (Bottles for macOS are generated only for supported macOS versions.)
 * Homebrew is installed to a prefix other than the default (although some bottles support this).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -81,6 +81,7 @@ If available, bottled binaries will be used by default except under the followin
 * The `--build-from-source` option is invoked.
 * No bottle is available for the machine's currently running OS version. (Bottles for macOS are generated only for supported macOS versions.)
 * Homebrew is installed to a prefix other than the default (although some bottles support this).
+* Formula options were passed to the install command. For example, `brew install <formula>` will try to find a bottled binary, but `brew install --with-foo <formula>` will trigger a source build.
 
 We aim to bottle everything.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
