### PR TITLE
Clean up GitHub headers

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -603,13 +603,13 @@ EOS
           # Only try to `git fetch` when the upstream tags have changed
           # (so the API does not return 304: unmodified).
           GITHUB_API_ETAG="$(sed -n 's/^ETag: "\([a-f0-9]\{32\}\)".*/\1/p' ".git/GITHUB_HEADERS" 2>/dev/null)"
-          GITHUB_API_ACCEPT="application/vnd.github.v3+json"
+          GITHUB_API_ACCEPT="application/vnd.github+json"
           GITHUB_API_ENDPOINT="tags"
         else
           # Only try to `git fetch` when the upstream branch is at a different SHA
           # (so the API does not return 304: unmodified).
           GITHUB_API_ETAG="$(git rev-parse "refs/remotes/origin/${UPSTREAM_BRANCH_DIR}")"
-          GITHUB_API_ACCEPT="application/vnd.github.v3.sha"
+          GITHUB_API_ACCEPT="application/vnd.github.sha"
           GITHUB_API_ENDPOINT="commits/${UPSTREAM_BRANCH_DIR}"
         fi
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1034,7 +1034,7 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
 
     output, _, status = curl_output(
       "--silent", "--head", "--location",
-      "-H", "Accept: application/vnd.github.v3.sha",
+      "-H", "Accept: application/vnd.github.sha",
       "https://api.github.com/repos/#{@user}/#{@repo}/commits/#{@ref}"
     )
 
@@ -1051,7 +1051,7 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
 
     output, _, status = curl_output(
       "--silent", "--head", "--location",
-      "-H", "Accept: application/vnd.github.v3.sha",
+      "-H", "Accept: application/vnd.github.sha",
       "https://api.github.com/repos/#{@user}/#{@repo}/commits/#{commit}"
     )
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -184,8 +184,7 @@ module GitHub
       # This is a no-op if the user is opting out of using the GitHub API.
       return block_given? ? yield({}) : {} if Homebrew::EnvConfig.no_github_api?
 
-      args = ["--header", "Accept: application/vnd.github.v3+json", "--write-out", "\n%\{http_code}"]
-      args += ["--header", "Accept: application/vnd.github.antiope-preview+json"]
+      args = ["--header", "Accept: application/vnd.github+json", "--write-out", "\n%\{http_code}"]
 
       token = credentials
       args += ["--header", "Authorization: token #{token}"] unless credentials_type == :none


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR cleans up GitHub headers:
- Replaces `Accept: application/vnd.github.v3` header with `Accept: application/vnd.github` [ref ](https://docs.github.com/en/rest/overview/media-types)
  > Note: In the past, we recommended including v3 in your Accept header. This is no longer required and will have no impact on your API requests.


- Removes `Accept: application/vnd.github.antiope-preview+json` header [ref](https://developer.github.com/changes/2020-10-01-graduate-antiope-preview/)
  > The antiope preview is now an official part of the API. These preview headers are no longer required. The Checks API endpoints no longer require the antiope preview header.
