### PR TITLE
dev-cmd/contributions: Retrieve a user's repo contributions over time

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -300,6 +300,15 @@ module Homebrew
       sig { returns(T.nilable(String)) }
       def screen_saverdir; end
 
+      sig { returns(T::Array[String])}
+      def repositories; end
+
+      sig { returns(T.nilable(String)) }
+      def from; end
+
+      sig { returns(T.nilable(String)) }
+      def to; end
+
       sig { returns(T.nilable(T::Array[String])) }
       def groups; end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -28,10 +28,10 @@ module Homebrew
       flag "--to=",
            description: "Date (ISO-8601 format) to stop searching contributions."
 
-      comma_array "--repos=",
+      comma_array "--repositories=",
                   description: "The Homebrew repositories to search for contributions in. " \
-                               "Comma separated. Pass `all` to search all repos. " \
-                               "Supported repos: #{SUPPORTED_REPOS.join(", ")}."
+                               "Comma separated. Pass `all` to search all repositories. " \
+                               "Supported repositories: #{SUPPORTED_REPOS.join(", ")}."
 
       named_args :email, number: 1
     end
@@ -44,18 +44,18 @@ module Homebrew
     commits = 0
     coauthorships = 0
 
-    all_repos = args[:repos].first == "all"
-    repos = all_repos ? SUPPORTED_REPOS : args[:repos]
+    all_repos = args[:repositories].first == "all"
+    repos = all_repos ? SUPPORTED_REPOS : args[:repositories]
     repos.each do |repo|
       if SUPPORTED_REPOS.exclude?(repo)
-        return ofail "Unsupported repo: #{repo}. Try one of #{SUPPORTED_REPOS.join(", ")}."
+        return ofail "Unsupported repository: #{repo}. Try one of #{SUPPORTED_REPOS.join(", ")}."
       end
 
       repo_path = find_repo_path_for_repo(repo)
       unless repo_path.exist?
         next if repo == "versions" # This tap is deprecated, tapping it will error.
 
-        opoo "Couldn't find repo #{repo} locally. Tapping it now..."
+        opoo "Repository #{repo} not yet tapped! Tapping it now..."
         Utils.safe_system("brew", "tap", repo_path) # TODO: Figure out why `exit code 1` happens here.
       end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -17,7 +17,7 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def contributions_args
     Homebrew::CLI::Parser.new do
-      usage_banner "`contributions` <email|name>"
+      usage_banner "`contributions` <email|name> [<--repositories>`=`]"
       description <<~EOS
         Contributions to Homebrew repos for a user.
 
@@ -34,7 +34,7 @@ module Homebrew
       flag "--to=",
            description: "Date (ISO-8601 format) to stop searching contributions."
 
-      named_args min: 1, max: 1
+      named_args number: 1
     end
   end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -8,11 +8,11 @@ module Homebrew
 
   module_function
 
-  SUPPORTED_REPOS = (
-      %w[brew core cask] +
-      OFFICIAL_CMD_TAPS.keys.map { |t| t.delete_prefix("homebrew/") } +
-      OFFICIAL_CASK_TAPS
-    ).freeze
+  SUPPORTED_REPOS = [
+    %w[brew core cask],
+    OFFICIAL_CMD_TAPS.keys.map { |t| t.delete_prefix("homebrew/") },
+    OFFICIAL_CASK_TAPS,
+  ].flatten.freeze
 
   sig { returns(CLI::Parser) }
   def contributions_args

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -53,7 +53,7 @@ module Homebrew
       end
 
       repo_path = find_repo_path_for_repo(repo)
-      if !repo_path.exist?
+      unless repo_path.exist?
         next if repo == "versions" # This tap is deprecated, tapping it will error.
 
         opoo "Couldn't find repo #{repo} locally. Tapping it now..."
@@ -104,6 +104,6 @@ module Homebrew
     cmd << "--before=#{args[:to]}" if args[:to]
     cmd << "--after=#{args[:from]}" if args[:from]
 
-    Utils.safe_popen_read(*cmd).lines.select { |l| l.include?(args.named.first) }.length
+    Utils.safe_popen_read(*cmd).lines.count { |l| l.include?(args.named.first) }
   end
 end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -34,7 +34,7 @@ module Homebrew
       flag "--to=",
            description: "Date (ISO-8601 format) to stop searching contributions."
 
-      named_args [:email, :name, :repositories], min: 2, max: 2
+      named_args min: 2, max: 2
     end
   end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -1,0 +1,101 @@
+# typed: true
+# frozen_string_literal: true
+
+require "cli/parser"
+
+module Homebrew
+  extend T::Sig
+
+  module_function
+
+  SUPPORTED_REPOS = %w[brew core cask bundle].freeze
+
+  sig { returns(CLI::Parser) }
+  def contributions_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `contributions`
+
+        Contributions to Homebrew repos for a user.
+      EOS
+
+      flag "--email=",
+           description: "A user's email address that they commit with."
+
+      flag "--from=",
+           description: "Date (ISO-8601 format) to start searching contributions."
+
+      flag "--to=",
+           description: "Date (ISO-8601 format) to stop searching contributions."
+
+      comma_array "--repos=",
+                  description: "The Homebrew repositories to search for contributions in. " \
+                               "Comma separated. Supported repos: #{SUPPORTED_REPOS.join(", ")}."
+
+      named_args :none
+    end
+  end
+
+  sig { returns(NilClass) }
+  def contributions
+    args = contributions_args.parse
+
+    return ofail "`--repos` and `--email` are required." if !args[:repos] || !args[:email]
+
+    commits = 0
+    coauthorships = 0
+
+    args[:repos].each do |repo|
+      repo_location = find_repo_path_for_repo(repo)
+      unless repo_location
+        return ofail "Couldn't find location for #{repo}. Do you have it tapped, or is there a typo? " \
+                     "We only support #{SUPPORTED_REPOS.join(", ")} repos so far."
+      end
+
+      commits += git_log_cmd("author", repo_location, args)
+      coauthorships += git_log_cmd("coauthorships", repo_location, args)
+    end
+
+    sentence = "Person #{args[:email]} directly authored #{commits} commits"
+    sentence += " and co-authored #{coauthorships} commits"
+    sentence += " to #{args[:repos].join(", ")}"
+    sentence += if args[:from] && args[:to]
+      " between #{args[:from]} and #{args[:to]}"
+    elsif args[:from]
+      " after #{args[:from]}"
+    elsif args[:to]
+      " before #{args[:to]}"
+    else
+      " in all time"
+    end
+    sentence += "."
+
+    puts sentence
+  end
+
+  sig { params(repo: String).returns(T.nilable(String)) }
+  def find_repo_path_for_repo(repo)
+    case repo
+    when "brew"
+      HOMEBREW_REPOSITORY
+    when "core"
+      "#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-core"
+    when "cask"
+      "#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask"
+    when "bundle"
+      "#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-bundle"
+    end
+  end
+
+  sig { params(kind: String, repo_location: String, args: Homebrew::CLI::Args).returns(Integer) }
+  def git_log_cmd(kind, repo_location, args)
+    cmd = "git -C #{repo_location} log --oneline"
+    cmd += " --author=#{args[:email]}" if kind == "author"
+    cmd += " --format='%(trailers:key=Co-authored-by:)'" if kind == "coauthorships"
+    cmd += " --before=#{args[:to]}" if args[:to]
+    cmd += " --after=#{args[:from]}" if args[:from]
+    cmd += " | grep #{args[:email]}" if kind == "coauthorships"
+
+    `#{cmd} | wc -l`.strip.to_i
+  end
+end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -17,9 +17,8 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def contributions_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `contributions [email]`
-
+      usage_banner "`contributions` [<email>]"
+      description <<~EOS
         Contributions to Homebrew repos for a user.
       EOS
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -17,9 +17,11 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def contributions_args
     Homebrew::CLI::Parser.new do
-      usage_banner "`contributions` <email> <repo1,repo2|all>"
+      usage_banner "`contributions` <email|name> <repo1,repo2|all>"
       description <<~EOS
         Contributions to Homebrew repos for a user.
+
+        The first argument is a name (e.g. "BrewTestBot") or an email address (e.g. "brewtestbot@brew.sh").
 
         The second argument is a comma-separated list of repos to search.
         Specify <all> to search all repositories.
@@ -32,7 +34,7 @@ module Homebrew
       flag "--to=",
            description: "Date (ISO-8601 format) to stop searching contributions."
 
-      named_args [:email, :repositories], min: 2, max: 2
+      named_args [:email, :name, :repositories], min: 2, max: 2
     end
   end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -29,7 +29,7 @@ module Homebrew
                   description: "The Homebrew repositories to search for contributions in. " \
                                "Comma separated. Supported repos: #{SUPPORTED_REPOS.join(", ")}."
 
-      named_args :email
+      named_args :email, number: 1
     end
   end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -11,7 +11,7 @@ module Homebrew
   SUPPORTED_REPOS = [
     %w[brew core cask],
     OFFICIAL_CMD_TAPS.keys.map { |t| t.delete_prefix("homebrew/") },
-    OFFICIAL_CASK_TAPS,
+    OFFICIAL_CASK_TAPS.reject { |t| t == "cask" },
   ].flatten.freeze
 
   sig { returns(CLI::Parser) }
@@ -55,7 +55,6 @@ module Homebrew
 
       repo_path = find_repo_path_for_repo(repo)
       unless repo_path.exist?
-        next if repo == "versions" # This tap is deprecated, tapping it will error.
 
         opoo "Repository #{repo} not yet tapped! Tapping it now..."
         Tap.fetch("homebrew", repo).install

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -54,9 +54,9 @@ module Homebrew
       coauthorships += git_log_coauthor_cmd(T.must(repo_path), args)
     end
 
-    sentence = "Person #{args.named.first} directly authored #{commits} commits" \
-               " and co-authored #{coauthorships} commits" \
-               " to #{args[:repos].join(", ")}"
+    sentence = "Person #{args.named.first} directly authored #{commits} commits " \
+               "and co-authored #{coauthorships} commits " \
+               "to #{args[:repos].join(", ")}"
     sentence += if args[:from] && args[:to]
       " between #{args[:from]} and #{args[:to]}"
     elsif args[:from]

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -66,7 +66,7 @@ module Homebrew
 
     sentence = "Person #{args.named.first} directly authored #{commits} commits " \
                "and co-authored #{coauthorships} commits " \
-               "across #{all_repos ? "all Homebrew repos" : repos.join(", ")}"
+               "across #{all_repos ? "all Homebrew repos" : repos.to_sentence}"
     sentence += if args[:from] && args[:to]
       " between #{args[:from]} and #{args[:to]}"
     elsif args[:from]

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -51,7 +51,7 @@ module Homebrew
       end
 
       repo_path = find_repo_path_for_repo(repo)
-      return ofail "Couldn't find repo #{repo} locally. Do you have it tapped?" unless Dir.exist?(repo_path)
+      return ofail "Couldn't find repo #{repo} locally. Run `brew tap homebrew/#{repo}`." unless repo_path.exist?
 
       commits += git_log_cmd("author", repo_path, args)
       coauthorships += git_log_cmd("coauthorships", repo_path, args)
@@ -76,16 +76,9 @@ module Homebrew
 
   sig { params(repo: String).returns(T.nilable(String)) }
   def find_repo_path_for_repo(repo)
-    case repo
-    when "brew"
-      HOMEBREW_REPOSITORY
-    when "core"
-      "#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-core"
-    when "cask"
-      "#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-cask"
-    when "bundle"
-      "#{HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-bundle"
-    end
+    return HOMEBREW_REPOSITORY if repo == "brew"
+
+    Tap.fetch("homebrew", repo).path
   end
 
   sig { params(kind: String, repo_path: String, args: Homebrew::CLI::Args).returns(Integer) }

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -56,7 +56,7 @@ module Homebrew
         next if repo == "versions" # This tap is deprecated, tapping it will error.
 
         opoo "Repository #{repo} not yet tapped! Tapping it now..."
-        Utils.safe_system("brew", "tap", repo_path) # TODO: Figure out why `exit code 1` happens here.
+        Tap.fetch("homebrew", repo).install
       end
 
       commits += git_log_author_cmd(T.must(repo_path), args)

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -26,7 +26,7 @@ module Homebrew
 
       comma_array "--repositories",
                   description: "Specify a comma-separated (no spaces) list of repositories to search. " \
-                               "Supported repositories: #{SUPPORTED_REPOS.join(", ")}. " \
+                               "Supported repositories: #{SUPPORTED_REPOS.map { |t| "`#{t}`" }.to_sentence}." \
                                "Omitting this flag, or specifying `--repositories=all`, will search all repositories."
       flag "--from=",
            description: "Date (ISO-8601 format) to start searching contributions."

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -80,21 +80,20 @@ module Homebrew
 
   sig { params(repo_path: Pathname, args: Homebrew::CLI::Args).returns(Integer) }
   def git_log_author_cmd(repo_path, args)
-    cmd = "git -C #{repo_path} log --oneline --author=#{args.named.first}"
-    cmd += " --before=#{args[:to]}" if args[:to]
-    cmd += " --after=#{args[:from]}" if args[:from]
+    cmd = ["git", "-C", repo_path, "log", "--oneline", "--author=#{args.named.first}"]
+    cmd << "--before=#{args[:to]}" if args[:to]
+    cmd << "--after=#{args[:from]}" if args[:from]
 
-    Utils.safe_popen_read(cmd).lines.count
+    Utils.safe_popen_read(*cmd).lines.count
   end
 
   sig { params(repo_path: Pathname, args: Homebrew::CLI::Args).returns(Integer) }
   def git_log_coauthor_cmd(repo_path, args)
-    cmd = "git -C #{repo_path} log --oneline"
-    cmd += " --format='%(trailers:key=Co-authored-by:)'"
-    cmd += " --before=#{args[:to]}" if args[:to]
-    cmd += " --after=#{args[:from]}" if args[:from]
-    cmd += " | grep #{args.named.first}"
+    cmd = ["git", "-C", repo_path, "log", "--oneline"]
+    cmd << "--format='%(trailers:key=Co-authored-by:)'"
+    cmd << "--before=#{args[:to]}" if args[:to]
+    cmd << "--after=#{args[:from]}" if args[:from]
 
-    Utils.safe_popen_read(cmd).lines.count
+    Utils.safe_popen_read(*cmd).lines.select { |l| l.include?(args.named.first) }.length
   end
 end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -38,7 +38,7 @@ module Homebrew
     end
   end
 
-  sig { returns(NilClass) }
+  sig { void }
   def contributions
     args = contributions_args.parse
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -29,14 +29,10 @@ module Homebrew
       flag "--to=",
            description: "Date (ISO-8601 format) to stop searching contributions."
 
-      flag "--all",
-           description: "Show contributions across all official Homebrew formula, cask and command repos."
-
       comma_array "--repos=",
                   description: "The Homebrew repositories to search for contributions in. " \
-                               "Comma separated. Supported repos: #{SUPPORTED_REPOS.join(", ")}."
-
-      conflicts "--all", "--repos"
+                               "Comma separated. Pass `all` to search all repos. " \
+                               "Supported repos: #{SUPPORTED_REPOS.join(", ")}."
 
       named_args :email, number: 1
     end
@@ -49,9 +45,10 @@ module Homebrew
     commits = 0
     coauthorships = 0
 
-    repos = args[:repos] || SUPPORTED_REPOS
+    all_repos = args[:repos].first == "all"
+    repos = all_repos ? SUPPORTED_REPOS : args[:repos]
     repos.each do |repo|
-      if !args[:all] && SUPPORTED_REPOS.exclude?(repo)
+      if SUPPORTED_REPOS.exclude?(repo)
         return ofail "Unsupported repo: #{repo}. Try one of #{SUPPORTED_REPOS.join(", ")}."
       end
 
@@ -69,7 +66,7 @@ module Homebrew
 
     sentence = "Person #{args.named.first} directly authored #{commits} commits " \
                "and co-authored #{coauthorships} commits " \
-               "to #{args[:all] ? "all Homebrew repos" : repos.join(", ")}"
+               "across #{all_repos ? "all Homebrew repos" : repos.join(", ")}"
     sentence += if args[:from] && args[:to]
       " between #{args[:from]} and #{args[:to]}"
     elsif args[:from]

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -84,7 +84,7 @@ module Homebrew
     cmd += " --before=#{args[:to]}" if args[:to]
     cmd += " --after=#{args[:from]}" if args[:from]
 
-    `#{cmd} | wc -l`.strip.to_i
+    Utils.safe_popen_read(cmd).lines.count
   end
 
   sig { params(repo_path: Pathname, args: Homebrew::CLI::Args).returns(Integer) }
@@ -95,6 +95,6 @@ module Homebrew
     cmd += " --after=#{args[:from]}" if args[:from]
     cmd += " | grep #{args.named.first}"
 
-    `#{cmd} | wc -l`.strip.to_i
+    Utils.safe_popen_read(cmd).lines.count
   end
 end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -65,7 +65,7 @@ module Homebrew
       coauthorships += git_log_coauthor_cmd(T.must(repo_path), args)
     end
 
-    sentence = "Person #{args.named.first} directly authored #{commits} commits " \
+    sentence = "#{args.named.first} directly authored #{commits} commits " \
                "and co-authored #{coauthorships} commits " \
                "across #{all_repos ? "all Homebrew repos" : repos.to_sentence}"
     sentence += if args.from && args.to

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -17,24 +17,24 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def contributions_args
     Homebrew::CLI::Parser.new do
-      usage_banner "`contributions` <email|name> <repo1,repo2|all>"
+      usage_banner "`contributions` <email|name>"
       description <<~EOS
         Contributions to Homebrew repos for a user.
 
         The first argument is a name (e.g. "BrewTestBot") or an email address (e.g. "brewtestbot@brew.sh").
-
-        The second argument is a comma-separated list of repos to search.
-        Specify <all> to search all repositories.
-        Supported repositories: #{SUPPORTED_REPOS.join(", ")}.
       EOS
 
+      comma_array "--repositories",
+                  description: "Specify a comma-separated (no spaces) list of repositories to search. " \
+                               "Supported repositories: #{SUPPORTED_REPOS.join(", ")}. " \
+                               "Omitting this flag, or specifying `--repositories=all`, will search all repositories."
       flag "--from=",
            description: "Date (ISO-8601 format) to start searching contributions."
 
       flag "--to=",
            description: "Date (ISO-8601 format) to stop searching contributions."
 
-      named_args min: 2, max: 2
+      named_args min: 1, max: 1
     end
   end
 
@@ -45,8 +45,8 @@ module Homebrew
     commits = 0
     coauthorships = 0
 
-    all_repos = args.named.last == "all"
-    repos = all_repos ? SUPPORTED_REPOS : args.named.last.split(",")
+    all_repos = args.repositories.nil? || args.repositories.include?("all")
+    repos = all_repos ? SUPPORTED_REPOS : args.repositories
 
     repos.each do |repo|
       if SUPPORTED_REPOS.exclude?(repo)

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -54,9 +54,9 @@ module Homebrew
       coauthorships += git_log_coauthor_cmd(T.must(repo_path), args)
     end
 
-    sentence = "Person #{args.named.first} directly authored #{commits} commits"
-    sentence += " and co-authored #{coauthorships} commits"
-    sentence += " to #{args[:repos].join(", ")}"
+    sentence = "Person #{args.named.first} directly authored #{commits} commits" \
+               " and co-authored #{coauthorships} commits" \
+               " to #{args[:repos].join(", ")}"
     sentence += if args[:from] && args[:to]
       " between #{args[:from]} and #{args[:to]}"
     elsif args[:from]

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -1,0 +1,8 @@
+# typed: false
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "brew contributions" do
+  it_behaves_like "parseable arguments"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Before each AGM it's currently a manual process for a PLC member to search commit logs and GitHub to figure out who contributed to Homebrew, so who should remain a member.
- I noticed that [looking at commits for a user](https://github.com/Homebrew/homebrew-core/commits?author=issyl0&since=2022-01-01&until=2023-01-01) would not count `Co-Authored-By`, which happens a lot now there's an autosquash action on PRs in `Homebrew/homebrew-core`, say if someone fixed a formula's build or tests or whatever and then the PR got auto-merged.
- Here's `brew contributions` that uses `git log` to be able to go back through all time or a specific time period (`--from`, `--to`). It's up to individual PLC discretion for "activity", but it does at least go some way to automating the data retrieval.
- Example (I can use my username as `--email` because my username is in all of the email addresses that I use for committing to Homebrew):

```
$ brew contributions --email=issyl0 --repos=brew,core
Person issyl0 directly authored 732 commits and co-authored 31 commits to brew, core in all time.
```

----

Future enhancement ideas:

- Ability to specify multiple email addresses for a user?
- Add a `--username=` flag to specify a GitHub username (instead of/as well as an email). As we know, open source isn't all about code, but reviews count as well as they're extremely valuable with the number of PRs we get. We could get data on how many reviews a user has submitted on PRs. And maybe we could use `--username` to retrieve the user's email addresses from GitHub too, so that the user of this script doesn't need to know them.
- Some other things I've not thought of yet. Ideas welcome!
