### PR TITLE
Use `variations` hash when installing from the API

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -136,9 +136,10 @@ module Formulary
     class_s = Formulary.class_s(name)
     json_formula = Homebrew::API::Formula.all_formulae[name]
 
-    bottle_tag = Utils::Bottles.tag.to_s
-    if json_formula.key?("variations") && json_formula["variations"].key?(bottle_tag)
-      json_formula = json_formula.merge(json_formula["variations"][bottle_tag])
+    if (bottle_tag = Utils::Bottles.tag.to_s.presence) && 
+       (variations = json_formula["variations"].presence) &&   
+       (variation = variations[bottle_tag].presence)
+      json_formula = json_formula.merge(variation)
     end
 
     uses_from_macos_names = json_formula["uses_from_macos"].map do |dep|

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -136,8 +136,8 @@ module Formulary
     class_s = Formulary.class_s(name)
     json_formula = Homebrew::API::Formula.all_formulae[name]
 
-    if (bottle_tag = Utils::Bottles.tag.to_s.presence) && 
-       (variations = json_formula["variations"].presence) &&   
+    if (bottle_tag = Utils::Bottles.tag.to_s.presence) &&
+       (variations = json_formula["variations"].presence) &&
        (variation = variations[bottle_tag].presence)
       json_formula = json_formula.merge(variation)
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -141,6 +141,12 @@ module Formulary
       json_formula = json_formula.merge(json_formula["variations"][bottle_tag])
     end
 
+    uses_from_macos_names = json_formula["uses_from_macos"].map do |dep|
+      next dep unless dep.is_a? Hash
+
+      dep.keys.first
+    end
+
     klass = Class.new(::Formula) do
       desc json_formula["desc"]
       homepage json_formula["homepage"]
@@ -181,20 +187,18 @@ module Formulary
         disable! date: disable_date, because: reason
       end
 
-      json_formula["build_dependencies"].each do |dep|
-        depends_on dep => :build
-      end
-
       json_formula["dependencies"].each do |dep|
+        next if uses_from_macos_names.include? dep
+
         depends_on dep
       end
 
-      json_formula["recommended_dependencies"].each do |dep|
-        depends_on dep => :recommended
-      end
+      [:build, :recommended, :optional].each do |type|
+        json_formula["#{type}_dependencies"].each do |dep|
+          next if uses_from_macos_names.include? dep
 
-      json_formula["optional_dependencies"].each do |dep|
-        depends_on dep => :optional
+          depends_on dep => type
+        end
       end
 
       json_formula["uses_from_macos"].each do |dep|

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -136,6 +136,11 @@ module Formulary
     class_s = Formulary.class_s(name)
     json_formula = Homebrew::API::Formula.all_formulae[name]
 
+    bottle_tag = Utils::Bottles.tag.to_s
+    if json_formula.key?("variations") && json_formula["variations"].key?(bottle_tag)
+      json_formula = json_formula.merge(json_formula["variations"][bottle_tag])
+    end
+
     klass = Class.new(::Formula) do
       desc json_formula["desc"]
       homepage json_formula["homepage"]

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -335,7 +335,8 @@ describe Formulary do
       end
 
       it "returns a Formula without duplicated deps and uses_from_macos with variations on Linux", :needs_linux do
-        allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(linux_variations_json)
+        allow(Homebrew::API::Formula)
+          .to receive(:all_formulae).and_return formula_json_contents(linux_variations_json)
         allow(Utils::Bottles).to receive(:tag).and_return(:arm64_monterey)
 
         formula = described_class.factory(formula_name)

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -326,7 +326,6 @@ describe Formulary do
 
       it "returns a Formula with variations when given a name", :needs_macos do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(variations_json)
-        allow(Utils::Bottles).to receive(:tag).and_return(:arm64_monterey)
 
         formula = described_class.factory(formula_name)
         expect(formula).to be_kind_of(Formula)
@@ -337,12 +336,11 @@ describe Formulary do
       it "returns a Formula without duplicated deps and uses_from_macos with variations on Linux", :needs_linux do
         allow(Homebrew::API::Formula)
           .to receive(:all_formulae).and_return formula_json_contents(linux_variations_json)
-        allow(Utils::Bottles).to receive(:tag).and_return(:arm64_monterey)
 
         formula = described_class.factory(formula_name)
         expect(formula).to be_kind_of(Formula)
         expect(formula.deps.count).to eq 5
-        expect(formula.deps.map(&:name).include?("variations_dep")).to be true
+        expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be true
       end
     end
   end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -270,6 +270,16 @@ describe Formulary do
         }
       end
 
+      let(:linux_variations_json) do
+        {
+          "variations" => {
+            "x86_64_linux" => {
+              "dependencies" => ["dep", "uses_from_macos_dep"],
+            },
+          },
+        }
+      end
+
       before do
         allow(described_class).to receive(:loader_for).and_return(described_class::FormulaAPILoader.new(formula_name))
       end
@@ -316,6 +326,16 @@ describe Formulary do
 
       it "returns a Formula with variations when given a name", :needs_macos do
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(variations_json)
+        allow(Utils::Bottles).to receive(:tag).and_return(:arm64_monterey)
+
+        formula = described_class.factory(formula_name)
+        expect(formula).to be_kind_of(Formula)
+        expect(formula.deps.count).to eq 5
+        expect(formula.deps.map(&:name).include?("variations_dep")).to be true
+      end
+
+      it "returns a Formula without duplicated deps and uses_from_macos with variations on Linux", :needs_linux do
+        allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(linux_variations_json)
         allow(Utils::Bottles).to receive(:tag).and_return(:arm64_monterey)
 
         formula = described_class.factory(formula_name)

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -260,6 +260,16 @@ describe Formulary do
         }
       end
 
+      let(:variations_json) do
+        {
+          "variations" => {
+            Utils::Bottles.tag.to_s => {
+              "dependencies" => ["dep", "variations_dep"],
+            },
+          },
+        }
+      end
+
       before do
         allow(described_class).to receive(:loader_for).and_return(described_class::FormulaAPILoader.new(formula_name))
       end
@@ -302,6 +312,16 @@ describe Formulary do
         expect {
           formula.install
         }.to raise_error("Cannot build from source from abstract formula.")
+      end
+
+      it "returns a Formula with variations when given a name", :needs_macos do
+        allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents(variations_json)
+        allow(Utils::Bottles).to receive(:tag).and_return(:arm64_monterey)
+
+        formula = described_class.factory(formula_name)
+        expect(formula).to be_kind_of(Formula)
+        expect(formula.deps.count).to eq 5
+        expect(formula.deps.map(&:name).include?("variations_dep")).to be true
       end
     end
   end


### PR DESCRIPTION
This PR modifies `Formulary` to include the data in the variations hash when loading a formula from the API. This means that we now load formulae with the correct dependencies, etc on all platforms, not just the one that generated the JSON output.

Also, in this PR, I fixed an issue where dependencies could be duplicated. If a formula called `uses_from_macos "ruby"`, `ruby` would be listed in both the `uses_from_macos` and `dependencies` section of the formula's JSON info (on Linux). This means that it's added as a dependency twice. Now, we all names in `dependencies` and `*_dependencies` before adding and, if they dep is listed under `uses_from_macos`, we let the `uses_from_macos` method determine whether to add it as a dep or not.
