### PR TITLE
Move `HOMEBREW_SIMULATE_MACOS_ON_LINUX` handling to `SimulateSystem`

### DIFF
--- a/Library/Homebrew/default_prefix.rb
+++ b/Library/Homebrew/default_prefix.rb
@@ -1,10 +1,12 @@
 # typed: true
 # frozen_string_literal: true
 
+require "simulate_system"
+
 module Homebrew
   DEFAULT_PREFIX, DEFAULT_REPOSITORY = if OS.mac? && Hardware::CPU.arm?
     [HOMEBREW_MACOS_ARM_DEFAULT_PREFIX, HOMEBREW_MACOS_ARM_DEFAULT_REPOSITORY]
-  elsif OS.linux? && !EnvConfig.simulate_macos_on_linux?
+  elsif Homebrew::SimulateSystem.simulating_or_running_on_linux?
     [HOMEBREW_LINUX_DEFAULT_PREFIX, HOMEBREW_LINUX_DEFAULT_REPOSITORY]
   else
     [HOMEBREW_DEFAULT_PREFIX, HOMEBREW_DEFAULT_REPOSITORY]

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -31,7 +31,11 @@ module OnSystem
     return false if Homebrew::SimulateSystem.simulating_or_running_on_linux?
 
     base_os = MacOS::Version.from_symbol(os_name)
-    current_os = MacOS::Version.from_symbol(Homebrew::SimulateSystem.current_os)
+    current_os = if Homebrew::SimulateSystem.current_os == :macos
+      Version::NULL
+    else
+      MacOS::Version.from_symbol(Homebrew::SimulateSystem.current_os)
+    end
 
     return current_os >= base_os if or_condition == :or_newer
     return current_os <= base_os if or_condition == :or_older

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -32,6 +32,8 @@ module OnSystem
 
     base_os = MacOS::Version.from_symbol(os_name)
     current_os = if Homebrew::SimulateSystem.current_os == :macos
+      # Assume the oldest macOS version when simulating a generic macOS version
+      # Version::NULL is always treated as less than any other version.
       Version::NULL
     else
       MacOS::Version.from_symbol(Homebrew::SimulateSystem.current_os)

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -20,11 +20,6 @@ module OnSystem
 
   sig { params(os_name: Symbol, or_condition: T.nilable(Symbol)).returns(T::Boolean) }
   def os_condition_met?(os_name, or_condition = nil)
-    if Homebrew::EnvConfig.simulate_macos_on_linux?
-      return false if os_name == :linux
-      return true if [:macos, *MacOSVersions::SYMBOLS.keys].include?(os_name)
-    end
-
     return Homebrew::SimulateSystem.send("simulating_or_running_on_#{os_name}?") if BASE_OS_OPTIONS.include?(os_name)
 
     raise ArgumentError, "Invalid OS condition: #{os_name.inspect}" unless MacOSVersions::SYMBOLS.key?(os_name)

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -80,16 +80,4 @@ class Keg
     end
     elf_files
   end
-
-  def self.bottle_dependencies
-    @bottle_dependencies ||= begin
-      formulae = []
-      gcc = Formulary.factory(CompilerSelector.preferred_gcc)
-      if !Homebrew::EnvConfig.simulate_macos_on_linux? &&
-         DevelopmentTools.non_apple_gcc_version("gcc") < gcc.version.to_i
-        formulae << gcc
-      end
-      formulae
-    end
-  end
 end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -329,7 +329,7 @@ module Homebrew
 
       # The number of conflicts on Linux is absurd.
       # TODO: remove this and check these there too.
-      return if OS.linux? && !Homebrew::EnvConfig.simulate_macos_on_linux?
+      return if Homebrew::SimulateSystem.simulating_or_running_on_linux?
 
       recursive_runtime_formulae = formula.runtime_formula_dependencies(undeclared: false)
       version_hash = {}

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -368,7 +368,14 @@ class Keg
   end
 
   def self.bottle_dependencies
-    []
+    return [] unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
+
+    @bottle_dependencies ||= begin
+      formulae = []
+      gcc = Formulary.factory(CompilerSelector.preferred_gcc)
+      formulae << gcc if DevelopmentTools.non_apple_gcc_version("gcc") < gcc.version.to_i
+      formulae
+    end
   end
 end
 

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -105,7 +105,7 @@ module Homebrew
       # Ideally `ca-certificates` would not be excluded here, but sourcing a HTTP mirror was tricky.
       # Instead, we have logic elsewhere to pass `--insecure` to curl when downloading the certs.
       # TODO: try remove the OS/env conditional
-      if (OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?) && spec_name == :stable &&
+      if Homebrew::SimulateSystem.simulating_or_running_on_macos? && spec_name == :stable &&
          owner.name != "ca-certificates" && curl_dep && !urls.find { |u| u.start_with?("http://") }
         problem "should always include at least one HTTP mirror"
       end

--- a/Library/Homebrew/simulate_system.rb
+++ b/Library/Homebrew/simulate_system.rb
@@ -9,7 +9,14 @@ module Homebrew
     class << self
       extend T::Sig
 
-      attr_reader :os, :arch
+      attr_reader :arch
+
+      sig { returns(T.nilable(Symbol)) }
+      def os
+        return :macos if @os.blank? && !OS.mac? && Homebrew::EnvConfig.simulate_macos_on_linux?
+
+        @os
+      end
 
       sig { params(new_os: Symbol).void }
       def os=(new_os)
@@ -33,16 +40,16 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def simulating_or_running_on_macos?
-        return OS.mac? if @os.blank?
+        return OS.mac? if os.blank?
 
-        [:macos, *MacOSVersions::SYMBOLS.keys].include?(@os)
+        [:macos, *MacOSVersions::SYMBOLS.keys].include?(os)
       end
 
       sig { returns(T::Boolean) }
       def simulating_or_running_on_linux?
-        return OS.linux? if @os.blank?
+        return OS.linux? if os.blank?
 
-        @os == :linux
+        os == :linux
       end
 
       sig { returns(Symbol) }
@@ -52,7 +59,7 @@ module Homebrew
 
       sig { returns(Symbol) }
       def current_os
-        return @os if @os.present?
+        return T.must(os) if os.present?
         return :linux if OS.linux?
 
         MacOS.version.to_sym

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -170,14 +170,16 @@ class SoftwareSpec
 
     @uses_from_macos_elements << deps
 
-    # Linux simulating macOS. Assume oldest macOS version.
-    return if Homebrew::EnvConfig.simulate_macos_on_linux? && !bounds.key?(:since)
-
-    # macOS new enough for dependency to not be required.
+    # Check whether macOS is new enough for dependency to not be required.
     if Homebrew::SimulateSystem.simulating_or_running_on_macos?
-      current_os = MacOS::Version.from_symbol(Homebrew::SimulateSystem.current_os)
-      since_os = MacOS::Version.from_symbol(bounds[:since]) if bounds.key?(:since)
-      return if current_os >= since_os
+      # Assume the oldest macOS version when simulating a generic macOS version
+      return if Homebrew::SimulateSystem.current_os == :macos && !bounds.key?(:since)
+
+      if Homebrew::SimulateSystem.current_os != :macos
+        current_os = MacOS::Version.from_symbol(Homebrew::SimulateSystem.current_os)
+        since_os = MacOS::Version.from_symbol(bounds[:since]) if bounds.key?(:since)
+        return if current_os >= since_os
+      end
     end
 
     depends_on deps

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -36,6 +36,12 @@ describe Homebrew::SimulateSystem do
       described_class.os = :monterey
       expect(described_class.simulating_or_running_on_macos?).to be true
     end
+
+    it "returns true on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
+      described_class.clear
+      ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
+      expect(described_class.simulating_or_running_on_macos?).to be true
+    end
   end
 
   describe "::simulating_or_running_on_linux?" do
@@ -64,6 +70,12 @@ describe Homebrew::SimulateSystem do
     it "returns false on Linux when simulating a specific macOS version", :needs_linux do
       described_class.clear
       described_class.os = :monterey
+      expect(described_class.simulating_or_running_on_linux?).to be false
+    end
+
+    it "returns false on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
+      described_class.clear
+      ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
       expect(described_class.simulating_or_running_on_linux?).to be false
     end
   end
@@ -113,6 +125,18 @@ describe Homebrew::SimulateSystem do
       described_class.clear
       described_class.os = :monterey
       expect(described_class.current_os).to eq :monterey
+    end
+
+    it "returns the current macOS version on macOS with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_macos do
+      described_class.clear
+      ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
+      expect(described_class.current_os).to eq MacOS.version.to_sym
+    end
+
+    it "returns `:macos` on Linux with HOMEBREW_SIMULATE_MACOS_ON_LINUX", :needs_linux do
+      described_class.clear
+      ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
+      expect(described_class.current_os).to eq :macos
     end
   end
 end

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -150,6 +150,20 @@ describe SoftwareSpec do
         expect(spec.deps.first.tags).to include(:build)
       end
 
+      it "ignores dependencies with HOMEBREW_SIMULATE_MACOS_ON_LINUX" do
+        ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
+        spec.uses_from_macos("foo")
+
+        expect(spec.deps).to be_empty
+      end
+
+      it "ignores dependencies with tags with HOMEBREW_SIMULATE_MACOS_ON_LINUX" do
+        ENV["HOMEBREW_SIMULATE_MACOS_ON_LINUX"] = "1"
+        spec.uses_from_macos("foo" => :build)
+
+        expect(spec.deps).to be_empty
+      end
+
       it "ignores OS version specifications" do
         spec.uses_from_macos("foo", since: :mojave)
         spec.uses_from_macos("bar" => :build, :since => :mojave)


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/13599

This PR moves the handling of `HOMEBREW_SIMULATE_MACOS_ON_LINUX` into `SimulateSystem`. Since the env var is accomplishing the same thing as simulating using the `SimulateSystem` methods, it makes sense to handle it in the same place instead of needing to have separate conditionals for the two possible ways of simulating. When `HOMEBREW_SIMULATE_MACOS_ON_LINUX` is set, we assume that we're simulating a generic macOS version, so `Homebrew::SimulateSystem.os` returns `:macos`. I've also set it up so that simulations set up using `SimulateSystem` methods take precedence over the environment variable, but `Homebrew::SimulateSystem.clear` will not clear the simulation since the env var is still set.

In this PR, if the env var is set while actually on macOS, it is essentially a no-op. `Homebrew::SimulateSystem.os` will be `nil` and `Homebrew::SimulateSystem.current_os` will return the symbol for whatever version of macOS is actually being used. Should setting this variable on macOS use the generic `:macos` instead? I don't think I see much value in this, but it's a possibility.
