### PR TITLE
audit_glibc: Permit glibc 2.27, 2.31, or 2.35 and fix the error message

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -410,13 +410,10 @@ module Homebrew
     end
 
     def audit_glibc
-      return if formula.name != "glibc"
       return unless @core_tap
+      return if formula.name != "glibc" || formula.version.to_s == OS::CI_GLIBC_VERSION
 
-      version = formula.version.to_s
-      return if version == OS::CI_GLIBC_VERSION
-
-      problem "The glibc version must be #{version}, as this is the version used by our CI on Linux. " \
+      problem "The glibc version must be #{OS::CI_GLIBC_VERSION}, as this is the version used by our CI on Linux. " \
               "Glibc is for users who have a system Glibc with a lower version, " \
               "which allows them to use our Linux bottles, which were compiled against system Glibc on CI."
     end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -411,7 +411,7 @@ module Homebrew
 
     def audit_glibc
       return unless @core_tap
-      return if formula.name != "glibc" || formula.version.to_s == OS::CI_GLIBC_VERSION
+      return if formula.name != "glibc" || [OS::CI_GLIBC_VERSION, "2.35"].include?(formula.version.to_s)
 
       problem "The glibc version must be #{OS::CI_GLIBC_VERSION}, as this is the version used by our CI on Linux. " \
               "Glibc is for users who have a system Glibc with a lower version, " \

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -411,7 +411,8 @@ module Homebrew
 
     def audit_glibc
       return unless @core_tap
-      return if formula.name != "glibc" || [OS::CI_GLIBC_VERSION, "2.35"].include?(formula.version.to_s)
+      return if formula.name != "glibc"
+      return if [OS::CI_GLIBC_VERSION, "2.27", "2.31", "2.35"].include?(formula.version.to_s)
 
       problem "The glibc version must be #{OS::CI_GLIBC_VERSION}, as this is the version used by our CI on Linux. " \
               "Glibc is for users who have a system Glibc with a lower version, " \


### PR DESCRIPTION
- Permit glibc 2.27, 2.31, or 2.35
    - https://github.com/Homebrew/brew/issues/13619
- `The glibc version must be 2.35` should have read `The glibc version must be 2.23`.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

> The glibc version must be 2.23, as this is the version used by our CI on Linux. Glibc is for users who have a system Glibc with a lower version, which allows them to use our Linux bottles, which were compiled against system Glibc on CI.