### PR TITLE
keg_relocate (linux): prepend `gcc/lib/current` to `RPATH` when needed

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -35,10 +35,15 @@ class Keg
 
       # Add GCC's lib directory (as of GCC 12+) to RPATH when there is existing linkage.
       # This fixes linkage for newly-poured bottles.
-      # TODO: Replace with
-      #   rpath.map! { |path| path = path.sub(%r{lib/gcc/\d+$}, "lib/gcc/current") }
-      # when Homebrew/homebrew-core#106755 is merged.
-      rpath.prepend HOMEBREW_PREFIX/"opt/gcc/lib/gcc/current" if rpath.any? { |rp| rp.match?(%r{lib/gcc/\d+$}) }
+      if !name.match?(Version.formula_optionally_versioned_regex(:gcc)) &&
+         rpath.any? { |rp| rp.match?(%r{lib/gcc/\d+$}) }
+        # TODO: Replace with
+        #   rpath.map! { |path| path = path.sub(%r{lib/gcc/\d+$}, "lib/gcc/current") }
+        # when
+        #   1. Homebrew/homebrew-core#106755 is merged
+        #   2. No formula has a runtime dependency on a versioned GCC (see `envoy.rb`)
+        rpath.prepend HOMEBREW_PREFIX/"opt/gcc/lib/gcc/current"
+      end
 
       rpath.join(":")
     end

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -32,6 +32,7 @@ class Keg
 
       lib_path = "#{new_prefix}/lib"
       rpath << lib_path unless rpath.include? lib_path
+      rpath.prepend HOMEBREW_PREFIX/"opt/gcc/lib/current" if rpath.any? { |rp| rp.match?(%r{lib/gcc/\d+$}) }
 
       rpath.join(":")
     end

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -32,7 +32,13 @@ class Keg
 
       lib_path = "#{new_prefix}/lib"
       rpath << lib_path unless rpath.include? lib_path
-      rpath.prepend HOMEBREW_PREFIX/"opt/gcc/lib/current" if rpath.any? { |rp| rp.match?(%r{lib/gcc/\d+$}) }
+
+      # Add GCC's lib directory (as of GCC 12+) to RPATH when there is existing linkage.
+      # This fixes linkage for newly-poured bottles.
+      # TODO: Replace with
+      #   rpath.map! { |path| path = path.sub(%r{lib/gcc/\d+$}, "lib/gcc/current") }
+      # when Homebrew/homebrew-core#106755 is merged.
+      rpath.prepend HOMEBREW_PREFIX/"opt/gcc/lib/gcc/current" if rpath.any? { |rp| rp.match?(%r{lib/gcc/\d+$}) }
 
       rpath.join(":")
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should help keep bottles that require GCC working when
Homebrew/homebrew-core#106755 is merged.

This only works on freshly-poured bottles. Previously installed bottles
will still break on systems with a host GCC older than GCC 11.

-----

I've marked this as draft since this isn't ready to merge yet. For one thing, this line probably needs explanation in a comment. But I've opened this to suggest a potential way to minimise the pain of breaking all these Linux bottles for the GCC 12 migration.

As noted above, this fix only applies for bottles poured after `brew` includes this change. If desired, we could add a check to `brew doctor` that recommends a `brew install foo` if `foo` would benefit from having their `RPATH` fixed up by this change.
