### PR TITLE
pr-pull: fix typo

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -369,7 +369,7 @@ module Homebrew
   end
 
   def pr_check_conflicts(name, tap_remote_repo, pr)
-    hash_template = Proc.new { |h, k| h[k] = [] }
+    hash_template = proc { |h, k| h[k] = [] }
     long_build_pr_files = GitHub.search_issues(
       "org:#{name}", repo: tap_remote_repo, state: "open", label: "\"no long build conflict\""
     ).each_with_object(Hash.new(hash_template)) do |long_build_pr, hash|

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -369,7 +369,7 @@ module Homebrew
   end
 
   def pr_check_conflicts(name, tap_remote_repo, pr)
-    hash_template = proc.new { |h, k| h[k] = [] }
+    hash_template = Proc.new { |h, k| h[k] = [] }
     long_build_pr_files = GitHub.search_issues(
       "org:#{name}", repo: tap_remote_repo, state: "open", label: "\"no long build conflict\""
     ).each_with_object(Hash.new(hash_template)) do |long_build_pr, hash|


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

    Error: tried to create Proc object without a block
    Do not report this issue until you've run `brew update` and tried again.
    /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:372:in `proc'
    /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:372:in `pr_check_conflicts'
    /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:439:in `block in pr_pull'
    /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:429:in `each'
    /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:429:in `pr_pull'
    /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:93:in `<main>'
    Error: Process completed with exit code 1.

https://github.com/Homebrew/homebrew-core/runs/7634004090?check_suite_focus=true#step:10:15
