### PR TITLE
update-report: migrate GCC recursive dependents

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -294,18 +294,10 @@ module Homebrew
 
   def migrate_gcc_dependents_if_needed
     return if OS.mac?
-
-    # TODO: Remove this block when GCC 12 ships.
-    begin
-      return if Formula["gcc"].version < 12
-    rescue FormulaUnavailableError
-      return if Homebrew::EnvConfig.install_from_api?
-    end
-
-    return if Settings.read("gcc.dependents.migrated") == "true"
+    return if Settings.read("gcc.dep.rpaths.migrated") == "true"
 
     Formula.installed.each do |formula|
-      next unless formula.tap.core_tap?
+      next unless formula.tap&.core_tap?
       next unless formula.recursive_dependencies.map(&:name).include? "gcc"
 
       keg = formula.installed_kegs.last
@@ -317,7 +309,7 @@ module Homebrew
       nil
     end
 
-    Settings.write "gcc.dependents.migrated", true
+    Settings.write "gcc.dep.rpaths.migrated", true
   end
 end
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -294,7 +294,7 @@ module Homebrew
 
   def migrate_gcc_dependents_if_needed
     return if OS.mac?
-    return if Settings.read("gcc.dep.rpaths.migrated") == "true"
+    return if Settings.read("gcc-rpaths.fixed") == "true"
 
     Formula.installed.each do |formula|
       next unless formula.tap&.core_tap?
@@ -309,7 +309,7 @@ module Homebrew
       nil
     end
 
-    Settings.write "gcc.dep.rpaths.migrated", true
+    Settings.write "gcc-rpaths.fixed", true
   end
 end
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -148,6 +148,8 @@ module Homebrew
     Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
     return if Homebrew::EnvConfig.disable_load_formula?
 
+    migrate_gcc_dependents_if_needed
+
     hub = ReporterHub.new
 
     updated_taps = []
@@ -288,6 +290,34 @@ module Homebrew
       Failed to link all completions, docs and manpages:
         #{e}
     EOS
+  end
+
+  def migrate_gcc_dependents_if_needed
+    return if OS.mac?
+
+    # TODO: Remove this block when GCC 12 ships.
+    begin
+      return if Formula["gcc"].version < 12
+    rescue FormulaUnavailableError
+      return if Homebrew::EnvConfig.install_from_api?
+    end
+
+    return if Settings.read("gcc.dependents.migrated") == "true"
+
+    Formula.installed.each do |formula|
+      next unless formula.tap.core_tap?
+      next unless formula.recursive_dependencies.map(&:name).include? "gcc"
+
+      keg = formula.installed_kegs.last
+      tab = Tab.for_keg(keg)
+      # Force reinstallation upon `brew upgrade` to fix the bottle RPATH.
+      tab.source["versions"]["version_scheme"] = -1
+      tab.write
+    rescue TapFormulaUnavailableError
+      nil
+    end
+
+    Settings.write "gcc.dependents.migrated", true
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When GCC 12 ships (Homebrew/homebrew-core#106755) ships, most (all?)
Linux bottles that depend on GCC will break.

Let's fix that by using the same trick for handling divergent formula
revisions when migrating formulae from linuxbrew-core (#11982). We set
the recorded `version_scheme` to -1, which spoofs the formula being
outdated. When `brew upgrade` installs GCC 12, the broken formulae will
have their bottles reinstalled too.

This works because the reinstallation will also rewrite the existing
RPATHs to point to the new version of GCC instead (#13631). This should
handle most of the breakage.
