### PR TITLE
Check dependency order in on_system methods

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -14,12 +14,6 @@ module RuboCop
       class ComponentsOrder < FormulaCop
         extend AutoCorrector
 
-        def on_system_methods
-          @on_system_methods ||= [:intel, :arm, :macos, :linux, :system, *MacOSVersions::SYMBOLS.keys].map do |m|
-            :"on_#{m}"
-          end
-        end
-
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           @present_components, @offensive_nodes = check_order(FORMULA_COMPONENT_PRECEDENCE_LIST, body_node)
 

--- a/Library/Homebrew/rubocops/dependency_order.rb
+++ b/Library/Homebrew/rubocops/dependency_order.rb
@@ -16,7 +16,7 @@ module RuboCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           check_dependency_nodes_order(body_node)
           check_uses_from_macos_nodes_order(body_node)
-          [:head, :stable].each do |block_name|
+          ([:head, :stable] + on_system_methods).each do |block_name|
             block = find_block(body_node, block_name)
             next unless block
 

--- a/Library/Homebrew/rubocops/extend/formula.rb
+++ b/Library/Homebrew/rubocops/extend/formula.rb
@@ -198,6 +198,12 @@ module RuboCop
 
         @file_path !~ Regexp.union(paths_to_exclude)
       end
+
+      def on_system_methods
+        @on_system_methods ||= [:intel, :arm, :macos, :linux, :system, *MacOSVersions::SYMBOLS.keys].map do |m|
+          :"on_#{m}"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
    https://github.com/Homebrew/homebrew-core/pull/107194
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew audit` should check `depends_on` order in `on_linux` and co.

`homebrew/core/hurl` has:

```rb
  on_linux do
    depends_on "openssl@1.1"
    depends_on "pkg-config" => :build
  end
```

but it should be:

```rb
  on_linux do
    depends_on "pkg-config" => :build
    depends_on "openssl@1.1"
  end
```