### PR TITLE
official_taps: Refer to `Homebrew/homebrew-cask-versions` properly

### DIFF
--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -3,7 +3,7 @@
 
 OFFICIAL_CASK_TAPS = %w[
   cask
-  versions
+  cask-versions
 ].freeze
 
 OFFICIAL_CMD_TAPS = {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This is needed for https://github.com/Homebrew/brew/pull/13603 because `Homebrew/homebrew-versions` is deprecated (legitimately), but `OFFICIAL_CASK_TAPS` spits out `versions` as a repo, which could then be interpreted as `Homebrew/versions` rather than `Homebrew/cask-versions` which it actually is.