### PR TITLE
linux/diagnostic: add check for versioned GCC linkage

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -139,6 +139,34 @@ module Homebrew
           e.g. by using homebrew instead).
         EOS
       end
+
+      def check_gcc_dependent_linkage
+        gcc_dependents = Formula.installed.select do |formula|
+          next false unless formula.tap&.core_tap?
+
+          formula.recursive_dependencies.map(&:name).include? "gcc"
+        rescue TapFormulaUnavailableError
+          false
+        end
+        return if gcc_dependents.empty?
+
+        badly_linked = gcc_dependents.select do |dependent|
+          keg = Keg.new(dependent.prefix)
+          keg.binary_executable_or_library_files.any? do |binary|
+            paths = binary.rpath.split(":")
+            versioned_linkage = paths.any? { |path| path.match?(%r{lib/gcc/\d+$}) }
+            unversioned_linkage = paths.any? { |path| path.match?(%r{lib/gcc/current$}) }
+
+            versioned_linkage && !unversioned_linkage
+          end
+        end
+        return if badly_linked.empty?
+
+        inject_file_list badly_linked, <<~EOS
+          Formulae which link to GCC through a versioned path were found. These formulae
+          are prone to breaking when GCC is updated. You should `brew reinstall` these formulae:
+        EOS
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This complements my other two GCC-on-Linux PRs (#13631, #13633), however
they are both reliant on bottles eventually being (re-)poured.

Let's try to speed that up by returning an error message from `brew doctor`
whenever a user has formulae installed that would benefit from a `brew reinstall`.
