### PR TITLE
official_taps: Add `cask-fonts`, `cask-drivers` taps

### DIFF
--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -3,6 +3,8 @@
 
 OFFICIAL_CASK_TAPS = %w[
   cask
+  cask-drivers
+  cask-fonts
   cask-versions
 ].freeze
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- These weren't in `OFFICIAL_CASK_TAPS` but they probably should be given they're active repos in the Homebrew org.
- Related conversation: https://github.com/Homebrew/brew/pull/13603#discussion_r936895145.