### PR TITLE
Add `on_{system}` methods to formula cookbook

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -554,7 +554,7 @@ on_linux do
 end
 ```
 
-Components can also be declared for specific macOS versions or version ranges. For example, to declare a dependency only on High Sierra, nest the `depends_on` call inside an `on_high_sierra` block. Add an `:or_older` or `:or_newer` parameter to the `on_high_sierra` method to add the dependency to all macOS versions that meet the condition. For example, to add `gettext` as a build dependency on Mojave and all macOS versions that are newer than Mojave, use:
+Components can also be declared for specific macOS versions or version ranges. For example, to declare a dependency only on High Sierra, nest the `depends_on` call inside an `on_high_sierra` block. Add an `:or_older` or `:or_newer` parameter to the `on_high_sierra` method to add the dependency to all macOS versions that meet the condition. For example, to add `gettext` as a build dependency on Mojave and all later macOS versions, use:
 
 ```ruby
 on_mojave :or_newer do
@@ -574,7 +574,7 @@ To check multiple conditions, nest the corresponding blocks. For example, the fo
 
 ```ruby
 on_macos do
-  on_intel do
+  on_arm do
     depends_on "gettext" => :build
   end
 end
@@ -582,7 +582,7 @@ end
 
 #### Inside `def install` and `test do`
 
-Inside `def install` and `test` do, don't use these `on_*` methods. Instead, use `if` statements and the following conditionals:
+Inside `def install` and `test do`, don't use these `on_*` methods. Instead, use `if` statements and the following conditionals:
 
 * `OS.mac?` and `OS.linux?` return `true` or `false` based on the OS
 * `Hardware::CPU.intel?` and `Hardware::CPU.arm?` return `true` or `false` based on the arch

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -554,7 +554,7 @@ on_linux do
 end
 ```
 
-Components can also be declared only for specific macOS versions or version ranges. For example, to declare a dependency only on High Sierra, nest the `depends_on` call inside an `on_high_sierra` block. Add an `:or_older` or `:or_newer` parameter to the `on_high_sierra` method to add the dependency to all macOS versions that meet the condition. For example, to add `gettext` as a build dependency on Mojave and all macOS versions that are newer than Mojave, use:
+Components can also be declared for specific macOS versions or version ranges. For example, to declare a dependency only on High Sierra, nest the `depends_on` call inside an `on_high_sierra` block. Add an `:or_older` or `:or_newer` parameter to the `on_high_sierra` method to add the dependency to all macOS versions that meet the condition. For example, to add `gettext` as a build dependency on Mojave and all macOS versions that are newer than Mojave, use:
 
 ```ruby
 on_mojave :or_newer do
@@ -562,7 +562,7 @@ on_mojave :or_newer do
 end
 ```
 
-Sometimes, a dependency is needed on certain macOS versions and on Linux. In these cases, a special `on_system` method can be used:
+Sometimes, a dependency is needed on certain macOS versions *and* on Linux. In these cases, a special `on_system` method can be used:
 
 ```ruby
 on_system :linux, macos: :sierra_or_older do
@@ -570,7 +570,7 @@ on_system :linux, macos: :sierra_or_older do
 end
 ```
 
-To check multiple conditions, nest the corresponding blocks. For example, the following code adds a `gettext` build dependency only on an ARM and macOS:
+To check multiple conditions, nest the corresponding blocks. For example, the following code adds a `gettext` build dependency when on ARM *and* macOS:
 
 ```ruby
 on_macos do

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "July 2022" "Homebrew" "brew"
+.TH "BREW" "1" "August 2022" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)


### PR DESCRIPTION
Now that we require the use of `on_{system}` blocks in homebrew/core, we should document them. This PR adds a section to the formula cookbook with information on how to use the `on_{system}` blocks and also how to use `if` statements to check the same conditions inside `def install` and `test do`
