### PR TITLE
Add shimscript arg to cask DSL

### DIFF
--- a/Library/Homebrew/cask/artifact/binary.rb
+++ b/Library/Homebrew/cask/artifact/binary.rb
@@ -3,13 +3,46 @@
 
 require "cask/artifact/symlinked"
 
+require "extend/hash_validator"
+using HashValidator
+
 module Cask
   module Artifact
     # Artifact corresponding to the `binary` stanza.
     #
     # @api private
     class Binary < Symlinked
+      def self.from_args(cask, *args)
+        source, args = args
+
+        if args
+          raise CaskInvalidError unless args.respond_to?(:keys)
+
+          args.assert_valid_keys!(:target, :shimscript)
+        end
+
+        args ||= {}
+
+        new(cask, source, **args)
+      end
+
+      def initialize(cask, source, target: nil, shimscript: nil)
+        super(cask, source, target: target)
+        return if shimscript.nil?
+
+        @shimscript_source = @source
+        @source_string = shimscript.to_s
+        @source = cask.staged_path.join(shimscript)
+      end
+
       def link(command: nil, **options)
+        if @shimscript_source
+          File.write source, <<~EOS
+            #!/bin/bash
+            exec '#{@shimscript_source}' "$@"
+          EOS
+        end
+
         super(command: command, **options)
         return if source.executable?
 

--- a/Library/Homebrew/cask/artifact/binary.rb
+++ b/Library/Homebrew/cask/artifact/binary.rb
@@ -30,7 +30,7 @@ module Cask
         super(cask, source, target: target)
         return if shimscript.nil?
 
-        @shimscript_source = @source
+        @shimscript_source = self.source
         @source_string = shimscript.to_s
         @source = cask.staged_path.join(shimscript)
       end
@@ -45,7 +45,7 @@ module Cask
             source.realpath.to_s.start_with?("#{cask.caskroom_path}/")
           end
 
-          ohai "Creating Shim Script of '#{@shimscript_source.basename}' at '#{source}'"
+          ohai "Creating shim script for '#{@shimscript_source.basename}' at '#{source}'"
           create_shimscript
         end
 
@@ -58,9 +58,9 @@ module Cask
       def unlink(**options)
         super(**options)
 
-        return unless @shimscript_source
+        return if @shimscript_source.blank?
 
-        ohai "Removing Shim Script '#{source}'"
+        ohai "Removing shim script '#{source}'"
         source.delete
       end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Sometimes, symlinking doesn't work on a cask binary, so a shim script must be used instead.

```rb
shimscript = "#{staged_path}/tiled.wrapper.sh"
binary shimscript, target: "tiled"

preflight do
  File.write shimscript, <<~EOS
    #!/bin/bash
    exec '#{appdir}/Tiled.app/Contents/MacOS/Tiled' "$@"
  EOS
end
```

can be reduced to

```rb
binary "#{appdir}/Tiled.app/Contents/MacOS/Tiled",
       shimscript: "tiled.wrapper.sh",
       target:     "tiled"
```

Also see: https://github.com/Homebrew/homebrew-cask/issues/18809