### PR TITLE
linux/super: add unversioned GCC lib directory to RPATH

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -51,6 +51,7 @@ module Superenv
   def determine_rpath_paths(formula)
     PATH.new(
       *formula&.lib,
+      "#{HOMEBREW_PREFIX}/opt/gcc/lib/gcc/current",
       PATH.new(run_time_deps.map { |dep| dep.opt_lib.to_s }).existing,
       "#{HOMEBREW_PREFIX}/lib",
     )

--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -72,6 +72,9 @@ class LinkageChecker
     @unwanted_system_dylibs = @system_dylibs.reject do |s|
       SYSTEM_LIBRARY_ALLOWLIST.include? File.basename(s)
     end
-    @undeclared_deps -= [CompilerSelector.preferred_gcc, "glibc"]
+    # FIXME: Remove this when these dependencies are injected correctly (e.g. through `DependencyCollector`)
+    # See discussion at
+    #   https://github.com/Homebrew/brew/pull/13577
+    @undeclared_deps -= [CompilerSelector.preferred_gcc, "glibc", "gcc"]
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This adds GCC's runtime lib directory to the RPATH of every build on
Linux (unconditionally!).

This is useful for three things:

1. It fixes versioned GCC linkage for formulae that users build from
   source instead of pouring from a bottle. We currently only handle
   bottle installs. See #13633.

2. It helps minimise the GCC dependency explosion. When a formula has a
   Linux-only GCC dependency, then all its dependents that link with
   some GCC runtime library (typically `libstdc++`) must, before this
   change, also adopt a GCC dependency. This is a consequence of our
   injecting GCC's runtime library directory into RPATH only when a
   formula is built with GCC (this is done through the specs file). We
   can avoid the need to do this by always injecting this path instead.

3. This enables us to automatically install Homebrew GCC whenever the
   user's GCC is too old and the formula may need it. Without this
   change, auto-installing GCC is not that useful because formulae that
   need it may not know to look for our GCC, unless the formula already
   happened to be built with our GCC. With this change, these formulae
   will always be able to find our GCC when it is installed. This is
   particularly useful for when we start building with a version of GCC
   that is much closer to the latest than we currently do.

This approach comes with at least two drawbacks:

1. We will see spurious linkage warnings in CI about an undeclared
   dependency with linkage as soon as Homebrew GCC is installed, because
   formulae will link with our GCC instead of the host's. Users will
   also see a similar complaint if they do `brew linkage`.

2. This leans _very_ heavily on GCC delivering backward compatibility of
   their runtime libraries. If they do not, we could see different
   behaviour across different CI runs for the same formula depending on
   whether Homebrew GCC is installed.

It's worth noting that item 3 in the "useful" list above may rely on
features not yet implement in `brew`.
