### PR TITLE
formula: ensure that kegs with `version_scheme == -1` are outdated

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1352,6 +1352,7 @@ class Formula
         next if version.head?
 
         tab = Tab.for_keg(keg)
+        next if tab.version_scheme == -1
         next if version_scheme > tab.version_scheme && pkg_version != version
         next if version_scheme == tab.version_scheme && pkg_version > version
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes Homebrew/discussions#3500. A `version_scheme` of `-1` alone is not sufficient to mark a keg as outdated.

Apologies for missing this earlier -- my earlier testing had rewriting the version scheme to `-1` as resulting in the formula becoming outdated. However, I was also moving the `HEAD` of my repository around to try to simulate a `gcc` update, and I must've done that wrong.
