### PR TITLE
update-report: reset `version_scheme` only for runtime dependents

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -298,7 +298,14 @@ module Homebrew
 
     Formula.installed.each do |formula|
       next unless formula.tap&.core_tap?
-      next unless formula.recursive_dependencies.map(&:name).include? "gcc"
+
+      recursive_runtime_dependencies = Dependency.expand(
+        formula,
+        cache_key: "update-report",
+      ) do |_, dependency|
+        Dependency.prune if dependency.build? || dependency.test?
+      end
+      next unless recursive_runtime_dependencies.map(&:name).include? "gcc"
 
       keg = formula.installed_kegs.last
       tab = Tab.for_keg(keg)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`recursive_dependencies` includes build and test dependencies as well,
which means that we're doing this for too many formulae.
