### PR TITLE
brew.sh: create `current` symlink in `pkgconfig` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /Library/PinnedTaps
 /Library/Homebrew/.byebug_history
 /Library/Homebrew/sorbet/rbi/hidden-definitions/errors.txt
+/Library/Homebrew/os/mac/pkgconfig/current
 
 # Ignore Bundler files
 **/.bundle/bin

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -426,22 +426,13 @@ then
   HOMEBREW_SYSTEM="Macintosh"
   [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]] && HOMEBREW_PROCESSOR="Intel"
   HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
+  HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION}"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X ${HOMEBREW_MACOS_VERSION}"
 
   # Intentionally set this variable by exploding another.
   # shellcheck disable=SC2086,SC2183
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
-
-  # Don't include minor versions for Big Sur and later, or patch versions for Catalina and older.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -gt "110000" ]]
-  then
-    HOMEBREW_MACOS_VERSION_NUMBER="${HOMEBREW_MACOS_VERSION%%.*}"
-    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION_NUMBER}"
-  else
-    HOMEBREW_MACOS_VERSION_NUMBER="${HOMEBREW_MACOS_VERSION%.*}"
-    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION_NUMBER}"
-  fi
 
   # Refuse to run on pre-El Capitan
   if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "101100" ]]
@@ -492,8 +483,16 @@ then
     HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH="1"
   fi
 
+  # Strip the minor/patch version on Big Sur or newer, and the patch version on Catalina or older.
+  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -gt "110000" ]]
+  then
+    HOMEBREW_MACOS_CANONICAL_VERSION="${HOMEBREW_MACOS_VERSION%%.*}"
+  else
+    HOMEBREW_MACOS_CANONICAL_VERSION="${HOMEBREW_MACOS_VERSION%.*}"
+  fi
+
   # This allows us to avoid rebuilding/reinstalling `pkg-config` on OS upgrades.
-  /bin/ln -sfh "${HOMEBREW_MACOS_VERSION_NUMBER}" "${HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/current"
+  /bin/ln -sfh "${HOMEBREW_MACOS_CANONICAL_VERSION}" "${HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/current"
 else
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
   [[ -n "${HOMEBREW_LINUX}" ]] && HOMEBREW_OS_VERSION="$(lsb_release -s -d 2>/dev/null)"

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -484,7 +484,7 @@ then
   fi
 
   # Strip the minor/patch version on Big Sur or newer, and the patch version on Catalina or older.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -gt "110000" ]]
+  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "110000" ]]
   then
     HOMEBREW_MACOS_CANONICAL_VERSION="${HOMEBREW_MACOS_VERSION%%.*}"
   else

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -433,12 +433,14 @@ then
   # shellcheck disable=SC2086,SC2183
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
 
-  # Don't include minor versions for Big Sur and later.
+  # Don't include minor versions for Big Sur and later, or patch versions for Catalina and older.
   if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -gt "110000" ]]
   then
-    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION%.*}"
+    HOMEBREW_MACOS_VERSION_NUMBER="${HOMEBREW_MACOS_VERSION%%.*}"
+    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION_NUMBER}"
   else
-    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION}"
+    HOMEBREW_MACOS_VERSION_NUMBER="${HOMEBREW_MACOS_VERSION%.*}"
+    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION_NUMBER}"
   fi
 
   # Refuse to run on pre-El Capitan
@@ -489,6 +491,9 @@ then
     # shellcheck disable=SC2034
     HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH="1"
   fi
+
+  # This allows us to avoid rebuilding/reinstalling `pkg-config` on OS upgrades.
+  /bin/ln -sfh "${HOMEBREW_MACOS_VERSION_NUMBER}" "${HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/current"
 else
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
   [[ -n "${HOMEBREW_LINUX}" ]] && HOMEBREW_OS_VERSION="$(lsb_release -s -d 2>/dev/null)"

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -482,17 +482,6 @@ then
     # shellcheck disable=SC2034
     HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH="1"
   fi
-
-  # Strip the minor/patch version on Big Sur or newer, and the patch version on Catalina or older.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "110000" ]]
-  then
-    HOMEBREW_MACOS_CANONICAL_VERSION="${HOMEBREW_MACOS_VERSION%%.*}"
-  else
-    HOMEBREW_MACOS_CANONICAL_VERSION="${HOMEBREW_MACOS_VERSION%.*}"
-  fi
-
-  # This allows us to avoid rebuilding/reinstalling `pkg-config` on OS upgrades.
-  /bin/ln -sfh "${HOMEBREW_MACOS_CANONICAL_VERSION}" "${HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/current"
 else
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
   [[ -n "${HOMEBREW_LINUX}" ]] && HOMEBREW_OS_VERSION="$(lsb_release -s -d 2>/dev/null)"

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -39,21 +39,12 @@ module Homebrew
   end
 
   def update_report
-    # Avoid mandatory reinstalls of `pkg-config` upon OS upgrade.
-    symlink_current_pkgconfig_directory
+    MacOS.symlink_current_pkgconfig_directory
     return output_update_report if $stdout.tty?
 
     redirect_stdout($stderr) do
       output_update_report
     end
-  end
-
-  def symlink_current_pkgconfig_directory
-    return if OS.linux?
-
-    pkgconfig_dir = HOMEBREW_LIBRARY/"Homebrew/os/mac/pkgconfig"
-    FileUtils.rm_f pkgconfig_dir/"current"
-    pkgconfig_dir.install_symlink MacOS.version => "current"
   end
 
   def output_update_report

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -39,11 +39,21 @@ module Homebrew
   end
 
   def update_report
+    # Avoid mandatory reinstalls of `pkg-config` upon OS upgrade.
+    symlink_current_pkgconfig_directory
     return output_update_report if $stdout.tty?
 
     redirect_stdout($stderr) do
       output_update_report
     end
+  end
+
+  def symlink_current_pkgconfig_directory
+    return if OS.linux?
+
+    pkgconfig_dir = HOMEBREW_LIBRARY/"Homebrew/os/mac/pkgconfig"
+    FileUtils.rm_f pkgconfig_dir/"current"
+    pkgconfig_dir.install_symlink MacOS.version => "current"
   end
 
   def output_update_report

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -488,6 +488,20 @@ module Homebrew
           #{installation_instructions}
         EOS
       end
+
+      def check_pkgconfig_current_symlink
+        current_symlink = HOMEBREW_LIBRARY/"Homebrew/os/mac/pkgconfig/current"
+        return if current_symlink.symlink? && Version.new(current_symlink.readlink) == MacOS.version
+        return unless Formula["pkg-config"].any_version_installed?
+
+        <<~EOS
+          The `current` symlink in Homebrew's `pkgconfig` directory is broken. Fix it with:
+            rm -rf #{current_symlink} && \\
+              ln -sfn #{MacOS.version} #{current_symlink}
+        EOS
+      rescue FormulaUnavailableError
+        nil
+      end
     end
   end
 end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -15,6 +15,7 @@ module Homebrew
     module_function
 
     def perform_preinstall_checks(all_fatal: false, cc: nil)
+      MacOS.symlink_current_pkgconfig_directory
       check_prefix
       check_cpu
       attempt_directory_creation

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -63,6 +63,8 @@ module OS
       nil
     end
 
+    def symlink_current_pkgconfig_directory; end
+
     module Xcode
       module_function
 

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -210,5 +210,13 @@ module OS
     def mdfind_query(*ids)
       ids.map! { |id| "kMDItemCFBundleIdentifier == #{id}" }.join(" || ")
     end
+
+    # Avoid mandatory reinstalls of `pkg-config` upon OS upgrade.
+    sig { void }
+    def symlink_current_pkgconfig_directory
+      pkgconfig_dir = HOMEBREW_LIBRARY/"Homebrew/os/mac/pkgconfig"
+      FileUtils.rm_f pkgconfig_dir/"current"
+      pkgconfig_dir.install_symlink MacOS.version => "current"
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`pkg-config` currently hardcodes the OS version it was built on in its
pc path in order to find the `.pc` files shipped with Homebrew. This
requires reinstallation of `pkg-config` with OS upgrades, which is
something we currently do not handle.

We can avoid this by automatically creating a `current` symlink that
points to the right directory whenever `brew.sh` runs. This will require
a rebuild of `pkg-config` that points it to the `current` directory.

In order to simplify identifying the right directory to symlink to, I've
dropped the patch version from `HOMEBREW_OS_VERSION` on Catalina and
earlier. I don't think this should break anything, but I can try a
different approach if this will cause problems.
