### PR TITLE
`brew search --verbose` to tell about `brew desc`

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -82,6 +82,11 @@ module Homebrew
       search_names(query, string_or_regex, args)
     end
 
+    if args.verbose?
+      puts
+      puts "Check 'brew desc' to list packages with short description."
+    end
+
     print_regex_help(args)
   end
 

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -82,10 +82,7 @@ module Homebrew
       search_names(query, string_or_regex, args)
     end
 
-    if args.verbose?
-      puts
-      puts "Check 'brew desc' to list packages with short description."
-    end
+    puts "Use `brew desc` to list packages with a short description." if args.verbose?
 
     print_regex_help(args)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew search` doesn't include package descriptions in the output, so even when a package matches, it is hard to tell if it does what is needed. In the proposal to add package descriptions into `search -v` output https://github.com/Homebrew/brew/issues/11932 I've discovered that there is a separate `brew desc` search command that does exactly this. So per discussion https://github.com/Homebrew/brew/issues/11932#issuecomment-909189260 this is the PR that adds hint to use `brew desc` if `search` is supplied with `--verbose`.

(hit this problem again today and forgot about `desc` already)