### PR TITLE
cli/parser: Allow `comma_array` to take multiple names

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -195,12 +195,14 @@ module Homebrew
         @parser.banner
       end
 
-      def comma_array(name, description: nil, hidden: false)
-        name = name.chomp "="
-        description = option_description(description, name, hidden: hidden)
-        process_option(name, description, type: :comma_array, hidden: hidden)
-        @parser.on(name, OptionParser::REQUIRED_ARGUMENT, Array, *wrap_option_desc(description)) do |list|
-          @args[option_to_name(name)] = list
+      def comma_array(*names, description: nil, hidden: false)
+        names.map! { |name| name.chomp "=" }
+        description = option_description(description, *names, hidden: hidden)
+        process_option(*names, description, type: :comma_array, hidden: hidden)
+        @parser.on(*names, OptionParser::REQUIRED_ARGUMENT, Array, *wrap_option_desc(description)) do |list|
+          names.each do |name|
+            @args[option_to_name(name)] = list
+          end
         end
       end
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -17,7 +17,7 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def contributions_args
     Homebrew::CLI::Parser.new do
-      usage_banner "`contributions` <email|name> [<--repositories|--repos>`=`]"
+      usage_banner "`contributions` <email|name> [<--repositories>`=`]"
       description <<~EOS
         Contributions to Homebrew repos for a user.
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -17,14 +17,14 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def contributions_args
     Homebrew::CLI::Parser.new do
-      usage_banner "`contributions` <email|name> [<--repositories>`=`]"
+      usage_banner "`contributions` <email|name> [<--repositories|--repos>`=`]"
       description <<~EOS
         Contributions to Homebrew repos for a user.
 
         The first argument is a name (e.g. "BrewTestBot") or an email address (e.g. "brewtestbot@brew.sh").
       EOS
 
-      comma_array "--repositories",
+      comma_array "--repositories", "--repos",
                   description: "Specify a comma-separated (no spaces) list of repositories to search. " \
                                "Supported repositories: #{SUPPORTED_REPOS.map { |t| "`#{t}`" }.to_sentence}." \
                                "Omitting this flag, or specifying `--repositories=all`, will search all repositories."

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -115,6 +115,26 @@ describe Homebrew::CLI::Parser do
     end
   end
 
+  describe "test comma array options" do
+    subject(:parser) {
+      described_class.new do
+        comma_array "--repos", "--repositories=", description: "List of repositories"
+      end
+    }
+
+    it "parses a short comma_array option with its argument" do
+      args = parser.parse(["--repos=test1,test2"])
+      expect(args.repos).to eq %w[test1 test2]
+      expect(args.repositories).to eq %w[test1 test2]
+    end
+
+    it "parses a long comma_array option with its argument" do
+      args = parser.parse(["--repositories=test1,test2"])
+      expect(args.repositories).to eq %w[test1 test2]
+      expect(args.repos).to eq %w[test1 test2]
+    end
+  end
+
   describe "test long flag options" do
     subject(:parser) {
       described_class.new do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This [came up](https://github.com/Homebrew/brew/pull/13603#discussion_r933122540) when developing `brew contributions`, the `--repositories` flag (comma array) is long to type. It turned out that unlike normal flags, `comma_array`s didn't allow multiple arg names.
- Now in `brew contributions` (and potentially elsewhere, though I've not had a look) we can make the args easier to type by letting `--repositories` and `--repos` equate to the same thing.
