### PR TITLE
Make the "head only" check a separate formula audit

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -560,9 +560,11 @@ module Homebrew
       [user, repo]
     end
 
-    def audit_specs
+    def audit_head_only
       problem "Head-only (no stable download)" if head_only?(formula)
+    end
 
+    def audit_specs
       %w[Stable HEAD].each do |name|
         spec_name = name.downcase.to_sym
         next unless (spec = formula.send(spec_name))

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -783,6 +783,45 @@ module Homebrew
       end
     end
 
+    describe '#audit_head_only' do
+      it "does warn about a HEAD-only formula" do
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            head "https://brew.sh/foo.git", :branch => "master"
+          end
+        RUBY
+
+        fa.audit_head_only
+        expect(fa.problems).to_not be_empty
+      end
+
+      it "does not warn about a non HEAD-only formula" do
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+            head "https://brew.sh/foo.git"
+          end
+        RUBY
+
+        fa.audit_head_only
+        expect(fa.problems).to_not be_empty
+      end
+
+      it "does not warn about a HEAD-less formula" do
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+          end
+        RUBY
+
+        fa.audit_head_only
+        expect(fa.problems).to_not be_empty
+      end
+    end
+
     describe "#audit_deps" do
       describe "a dependency on a macOS-provided keg-only formula" do
         describe "which is allowlisted" do


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Not all taps have hard and fast rules on no head-only formulas.  By separating this audit type, it can be skipped explicitly without loosing the remainder of the `audit_spec` auditor.