### PR TITLE
missing_formula: message for postgres rename.

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -89,6 +89,12 @@ module Homebrew
           uconv is part of the icu4c formula:
             brew install icu4c
         EOS
+        when "postgresql", "postgres" then <<~EOS
+          postgresql breaks existing databases on upgrade without human intervention.
+
+          See a more specific version to install with:
+            brew formulae | grep postgresql@
+        EOS
         end
       end
       alias generic_disallowed_reason disallowed_reason


### PR DESCRIPTION
PostgreSQL is being renamed to always be a versioned formula so handle when people type `brew install postgresql`.

Companion PR: https://github.com/Homebrew/homebrew-core/pull/107726