### PR TITLE
ENV/super: add Python's `libexec/"bin"` directory when applicable

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -125,7 +125,10 @@ module Superenv
 
   sig { returns(T::Array[Pathname]) }
   def homebrew_extra_paths
+    # Reverse sort by version so that we prefer the newest when there are multiple.
     deps.select { |d| d.name.match? Version.formula_optionally_versioned_regex(:python) }
+        .sort_by(&:version)
+        .reverse
         .map { |d| d.opt_libexec/"bin" }
   end
   alias generic_homebrew_extra_paths homebrew_extra_paths

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -125,8 +125,10 @@ module Superenv
 
   sig { returns(T::Array[Pathname]) }
   def homebrew_extra_paths
-    []
+    deps.select { |d| d.name.match? Version.formula_optionally_versioned_regex(:python) }
+        .map { |d| d.opt_libexec/"bin" }
   end
+  alias generic_homebrew_extra_paths homebrew_extra_paths
 
   sig { returns(T.nilable(PATH)) }
   def determine_path

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -27,7 +27,7 @@ module Superenv
   end
 
   def homebrew_extra_paths
-    paths = []
+    paths = generic_homebrew_extra_paths
     paths += %w[binutils make].map do |f|
       bin = Formulary.factory(f).opt_bin
       bin if bin.directory?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When Homebrew/homebrew-core#107517 is merged, builds will no longer be
able to find `python@3.9` as `python3`. This is also what is likely to
happen to `python@3.10` when we add a `python@3.11`.

This is likely to break many builds, so let's make sure they can keep
finding a `python3` for formulae that don't have a dependency on the
latest Python3.

This is arguably something we should've done earlier: it also means that
builds that go looking for an unversioned `python` end up finding our
Python3 (whenever present in the build environment) instead of, say,
`/usr/bin/python` which is typically Python2.
