### PR TITLE
Remove `arch` from cask stanza ordering temporarily

### DIFF
--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -6,7 +6,7 @@ module RuboCop
     # Constants available globally for use in all cask cops.
     module Constants
       STANZA_GROUPS = [
-        [:version, :sha256, :arch],
+        [:version, :sha256],
         [:language],
         [:url, :appcast, :name, :desc, :homepage],
         [:livecheck],

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/arch-arm-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/arch-arm-only.rb
@@ -1,7 +1,8 @@
 cask "arch-arm-only" do
+  arch arm: "-arm"
+
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
-  arch arm: "-arm"
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine#{arch}.zip"
   homepage "https://brew.sh/"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-arch.rb
@@ -1,8 +1,9 @@
 cask "invalid-two-arch" do
-  version "1.2.3"
-  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
   arch arm: "arm", intel: "intel"
   arch arm: "amd64", intel: "x86_64"
+
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   homepage "https://brew.sh/"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/multiple-versions.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/multiple-versions.rb
@@ -1,9 +1,9 @@
 cask "multiple-versions" do
+  arch arm: "arm", intel: "intel"
+  platform = on_arch_conditional arm: "darwin-arm64", intel: "darwin"
+
   version "1.2.3"
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
-  arch arm: "arm", intel: "intel"
-
-  platform = on_arch_conditional arm: "darwin-arm64", intel: "darwin"
 
   on_big_sur do
     version "1.2.0"


### PR DESCRIPTION
This PR temporarily removes the rule that the `arch` stanza must immediately follow the `sha256` stanza. We haven't decided yet where the best place for this to go is, so let's not require anything specific for now to give us more flexibility. I'm working on a rubocop PR that will re-add this (among other related changes), so this is just temporary while we start to add `arch` stanzas and figure out the preferred styling.
