### PR TITLE
Fix `nil` handling in `arch` cask DSL

### DIFF
--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -66,7 +66,7 @@ module OnSystem
       end
     end
 
-    base.define_method(:on_arch_conditional) do |arm:, intel:|
+    base.define_method(:on_arch_conditional) do |arm: nil, intel: nil|
       @on_system_blocks_exist = true
 
       return arm if OnSystem.arch_condition_met? :arm


### PR DESCRIPTION
This PR fixes a bug I found in the `arch` and `on_arch_conditional` DSLs. Passing `nil` or leaving an arg blank is allowed in the `arch` method, but was mistakenly not allowed in the `on_arch_conditional` method. This causes a problem in a small number of casks (e.g. `studio-3t`) that call `on_arch_conditional` with only one of the arches.
