### PR TITLE
dev-cmd/rubocop: use bundle check.

### DIFF
--- a/Library/Homebrew/dev-cmd/rubocop.sh
+++ b/Library/Homebrew/dev-cmd/rubocop.sh
@@ -13,13 +13,16 @@ homebrew-rubocop() {
 
   GEM_VERSION="$("${HOMEBREW_RUBY_PATH}" "${RUBY_DISABLE_OPTIONS}" -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]')"
   GEM_HOME="${HOMEBREW_LIBRARY}/Homebrew/vendor/bundle/ruby/${GEM_VERSION}"
+  BUNDLE_GEMFILE="${HOMEBREW_LIBRARY}/Homebrew/Gemfile"
 
-  if ! [[ -f "${GEM_HOME}/bin/rubocop" ]]
+  export GEM_HOME
+  export BUNDLE_GEMFILE
+
+  if ! bundle check &>/dev/null
   then
     "${HOMEBREW_BREW_FILE}" install-bundler-gems
   fi
 
-  export GEM_HOME
   export PATH="${GEM_HOME}/bin:${PATH}"
 
   RUBOCOP="${HOMEBREW_LIBRARY}/Homebrew/utils/rubocop.rb"


### PR DESCRIPTION
It's not reliable enough to just check for the binary.