### PR TITLE
`bump-cask-pr`: fix `sha256` replacement with `arch`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -138,8 +138,10 @@ module Homebrew
           replacement_pairs << fetch_cask(tmp_contents, config: lang_config)
         end
 
+        # TODO: Use SimulateSystem once all casks use on_system blocks
         if tmp_contents.include?("Hardware::CPU.intel?")
           other_intel = !Hardware::CPU.intel?
+          Homebrew::SimulateSystem.arch = other_intel ? :intel : :arm
           other_contents = tmp_contents.gsub("Hardware::CPU.intel?", other_intel.to_s)
           other_cask = Cask::CaskLoader.load(other_contents)
 
@@ -151,6 +153,8 @@ module Homebrew
             lang_config = other_cask.config.merge(Cask::Config.new(explicit: { languages: [language] }))
             replacement_pairs << fetch_cask(other_contents, config: lang_config)
           end
+
+          Homebrew::SimulateSystem.clear
         end
       end
     end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/13687

The current logic for replacing the `sha256` stanza for other arches is to do a text replace of `Hardware::CPU.intel?` to `true` or `false` in the cask. However, this doesn't work for casks that use the `arch` DSL since they don't call this method. Instead, we want to use `SimulateSystem` to simulate being on the other arch. However, we can't fully switch to this yet because we're only about halfway through the migration at the moment and casks currently use _both_ `arch` and `if Hardware::CPU.intel?`. So, for now, we should stick to the existing method but _also_ set `SimulateSystem.arch` in order to get the best of both worlds. Once we are done with the migration, we can remove the non-`SimulateSystem` method.
