### PR TITLE
Update `brew ls` to work when the cellar doesn't exist

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -70,14 +70,6 @@ module Homebrew
   def list
     args = list_args.parse
 
-    # Unbrewed uses the PREFIX, which will exist
-    # Things below use the CELLAR, which doesn't until the first formula is installed.
-    unless HOMEBREW_CELLAR.exist?
-      raise NoSuchKegError, args.named.first if args.named.present? && !args.cask?
-
-      return
-    end
-
     if args.full_name?
       unless args.cask?
         formula_names = args.no_named? ? Formula.installed : args.named.to_resolved_formulae
@@ -112,12 +104,10 @@ module Homebrew
       if !args.cask? && HOMEBREW_CELLAR.exist? && HOMEBREW_CELLAR.children.any?
         ohai "Formulae" if $stdout.tty? && !args.formula?
         safe_system "ls", *ls_args, HOMEBREW_CELLAR
+        puts if $stdout.tty? && !args.formula?
       end
       if !args.formula? && Cask::Caskroom.any_casks_installed?
-        if $stdout.tty? && !args.cask?
-          puts
-          ohai "Casks"
-        end
+        ohai "Casks" if $stdout.tty? && !args.cask?
         safe_system "ls", *ls_args, Cask::Caskroom.path
       end
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is just a small change to make sure `brew ls` works when the cellar doesn't exist. This can happen after an install or if the user only has casks installed not formulae.

To test this change I renamed the cellar folder and then made sure all of the normal `brew ls` commands worked as expected.

```shell
~ ❯❯❯ brew ls
==> Casks
slack		virtualbox
~ ❯❯❯ brew ls --formula
~ ❯❯❯ brew ls --cask
slack		virtualbox
~ ❯❯❯ brew ls --full-name
slack                                    virtualbox
~ ❯❯❯ brew ls --versions
slack 4.27.154
virtualbox 6.1.36,152435
~ ❯❯❯ brew ls --versions --multiple
~ ❯❯❯ brew ls --pinned
~ ❯❯❯ brew ls sdlkfsdkfj
Error: No available formula with the name "sdlkfsdkfj".
~ ❯❯❯ brew ls fish                                                           ✘ 1
Error: No such keg: /usr/local/Cellar/fish
~ ❯❯❯ brew ls virtualbox                                                     ✘ 1
==> Pkg
VirtualBox.pkg (Pkg)
==> Postflight Block
postflight (Postflight Block)
``` 

The only notable change is to move the insertion of a blank line in between the `Formula` and `Cask` lists up a few lines to prevent an unnecessary newline from showing up when `brew ls` is called and there is no cellar folder.

Fixes #13614.