### PR TITLE
fix debug-symbols

### DIFF
--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -49,7 +49,7 @@ class Mktemp
     prefix_name = @prefix.tr "@", "AT"
     @tmpdir = if retain_in_cache?
       tmp_dir = HOMEBREW_CACHE/"Sources/#{prefix_name}"
-      chmod_rm_rf(tmpdir) # clear out previous staging directory
+      chmod_rm_rf(tmp_dir) # clear out previous staging directory
       tmp_dir.mkpath
       tmp_dir
     else


### PR DESCRIPTION
Fixes `--debug-symbols`. An incorrectly named variable means existing directory is never removed
so new directory can't be copied in. This occurred during a refactoring of the `--debug-symbols` code (very unfortunately).

@MikeMcQuaid sorry I missed this bug.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? (I get the same errors as on master branch.)

-----
