### PR TITLE
dev-cmd/test: set `RUST_BACKTRACE` when retrying

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -119,6 +119,7 @@ module Homebrew
     if args.retry? && @test_failed.add?(f)
       oh1 "Testing #{f.full_name} (again)"
       f.clear_cache
+      ENV["RUST_BACKTRACE"] = "full"
       true
     else
       Homebrew.failed = true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Occasionally, a new version of Rust will cause failures in dependents.
See, for example, Homebrew/homebrew-core#107818.

This change will allow us to get a fuller backtrace in CI, which will
also make it easier to submit bug reports upstream.

Without this change, recovering a full backtrace requires installing the
new version of Rust and rebuilding the failing formula from source. Both
these steps can be skipped if we set `RUST_BACKTRACE` when retrying a
failing test.

I'm not sure if this is the right place to put this. However, it's much
nicer to only do this when retrying the test, so I've put it here.
