### PR TITLE
version: make `formula_optionally_versioned_regex` public

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -13,6 +13,9 @@ class Version
 
   include Comparable
 
+  # Provides a {Regexp} object that can be used scan for names of a versioned formula.
+  # @see https://www.rubydoc.info/stdlib/core/Regexp Regexp
+  # @return [Regexp]
   # @api public
   sig { params(name: T.any(String, Symbol), full: T::Boolean).returns(Regexp) }
   def self.formula_optionally_versioned_regex(name, full: true)

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -13,6 +13,7 @@ class Version
 
   include Comparable
 
+  # @api public
   sig { params(name: T.any(String, Symbol), full: T::Boolean).returns(Regexp) }
   def self.formula_optionally_versioned_regex(name, full: true)
     /#{"^" if full}#{Regexp.escape(name)}(@\d[\d.]*)?#{"$" if full}/


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There are over 20 formulae that make use of a similar regex that could
be replaced with a call to `formula_optionally_versioned_regex`, so I'd
like to be able to use this there.
