### PR TITLE
Add `arm:` and `intel:` arguments to cask `sha256` stanza

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -230,8 +230,13 @@ module Cask
     end
 
     # @api public
-    def sha256(arg = nil)
-      set_unique_stanza(:sha256, arg.nil?) do
+    def sha256(arg = nil, arm: nil, intel: nil)
+      should_return = arg.blank? && arm.blank? && intel.blank?
+
+      set_unique_stanza(:sha256, should_return) do
+        @on_system_blocks_exist = true if arm.present? || intel.present?
+
+        arg ||= on_arch_conditional(arm: arm, intel: intel)
         case arg
         when :no_check
           arg

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -214,7 +214,7 @@ describe Cask::Cask, :cask do
 
   describe "#to_hash_with_variations" do
     let!(:original_macos_version) { MacOS.full_version.to_s }
-    let(:expected_variations) {
+    let(:expected_versions_variations) {
       <<~JSON
         {
           "arm64_big_sur": {
@@ -243,6 +243,28 @@ describe Cask::Cask, :cask do
         }
       JSON
     }
+    let(:expected_sha256_variations) {
+      <<~JSON
+        {
+          "monterey": {
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel.zip",
+            "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          },
+          "big_sur": {
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel.zip",
+            "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          },
+          "catalina": {
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel.zip",
+            "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          },
+          "mojave": {
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine-intel.zip",
+            "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+          }
+        }
+      JSON
+    }
 
     before do
       # Use a more limited symbols list to shorten the variations hash
@@ -263,12 +285,20 @@ describe Cask::Cask, :cask do
       MacOS.full_version = original_macos_version
     end
 
-    it "returns the correct variations hash" do
+    it "returns the correct variations hash for a cask with multiple versions" do
       c = Cask::CaskLoader.load("multiple-versions")
       h = c.to_hash_with_variations
 
       expect(h).to be_a(Hash)
-      expect(JSON.pretty_generate(h["variations"])).to eq expected_variations.strip
+      expect(JSON.pretty_generate(h["variations"])).to eq expected_versions_variations.strip
+    end
+
+    it "returns the correct variations hash for a cask different sha256s on each arch" do
+      c = Cask::CaskLoader.load("sha256-arch")
+      h = c.to_hash_with_variations
+
+      expect(h).to be_a(Hash)
+      expect(JSON.pretty_generate(h["variations"])).to eq expected_sha256_variations.strip
     end
   end
 end

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -126,6 +126,34 @@ describe Cask::DSL, :cask do
 
       expect(cask.sha256).to eq("imasha2")
     end
+
+    context "with a different arm and intel checksum" do
+      let(:cask) do
+        Cask::Cask.new("checksum-cask") do
+          sha256 arm: "imasha2arm", intel: "imasha2intel"
+        end
+      end
+
+      context "when running on arm" do
+        before do
+          allow(Hardware::CPU).to receive(:type).and_return(:arm)
+        end
+
+        it "stores only the arm checksum" do
+          expect(cask.sha256).to eq("imasha2arm")
+        end
+      end
+
+      context "when running on intel" do
+        before do
+          allow(Hardware::CPU).to receive(:type).and_return(:intel)
+        end
+
+        it "stores only the intel checksum" do
+          expect(cask.sha256).to eq("imasha2intel")
+        end
+      end
+    end
   end
 
   describe "language stanza" do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-arch.rb
@@ -1,0 +1,12 @@
+cask "sha256-arch" do
+  arch arm: "arm", intel: "intel"
+
+  version "1.2.3"
+  sha256 arm:   "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+         intel: "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine-#{arch}.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
As discussed in https://github.com/Homebrew/homebrew-cask-versions/pull/14494#discussion_r945865830, this PR adds `arm:` and `intel:` names arguments to the cask `sha256` stanza. This will allow us to simplify the common pattern where `sha256` stanzas are the only elements inside `on_intel` and `on_arm` blocks.

For example, instead of this:

```ruby
cask "foo" do
  arch arm: "arm", intel: "intel"

  version "1.2.3"

  on_intel do
    sha256 "21d28f0bfd4129a5e394990e981ad79d27c4613f3da9f171417c17af785ebcba"
  end
  on_arm do
    sha256 "1b6bdf86fee03525b1978b4312624bcc522796bbf5675f370797c5f21e189e5d"
  end
end
```

We can do:

```ruby
cask "foo" do
  arch arm: "arm", intel: "intel"

  version "1.2.3"
  sha256 arm:   "1b6bdf86fee03525b1978b4312624bcc522796bbf5675f370797c5f21e189e5d",
         intel: "21d28f0bfd4129a5e394990e981ad79d27c4613f3da9f171417c17af785ebcba"
end
```
