### PR TITLE
service: provide formula accessor.

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -28,6 +28,11 @@ module Homebrew
       @service_block = block
     end
 
+    sig { returns(Formula) }
+    def f
+      @formula
+    end
+
     sig { params(command: T.nilable(T.any(T::Array[String], String, Pathname))).returns(T.nilable(Array)) }
     def run(command = nil)
       case T.unsafe(command)


### PR DESCRIPTION
Use `f` because it's generally recognised as a formula and this shouldn't be widely needed/used.

Needed for https://github.com/Homebrew/homebrew-core/pull/107726