### PR TITLE
Cask: fix signing audit using unexpected pkg method

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -572,10 +572,15 @@ module Cask
         tmpdir = Pathname(tmpdir)
         primary_container.extract_nestedly(to: tmpdir, basename: downloaded_path.basename, verbose: false)
         artifacts.each do |artifact|
-          result = system_command("codesign", args: [
-            "--verify",
-            tmpdir/artifact.source.basename,
-          ], print_stderr: false)
+          path = case artifact
+          when Artifact::Moved
+            tmpdir/artifact.source.basename
+          when Artifact::Pkg
+            artifact.path
+          end
+          next unless path.exist?
+
+          result = system_command("codesign", args: ["--verify", path], print_stderr: false)
           add_warning result.merged_output unless result.success?
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I really hope this is the last fix to the signing audit. All my tests were with app files so I didn't catch this.