### PR TITLE
cleanup: handle Python `site-packages` directories

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -531,6 +531,7 @@ module Homebrew
 
       unused_pyc_files += pyc_files.reject { |k,| seen_non_pyc_file[k] }
                                    .values
+                                   .flatten
       return if unused_pyc_files.blank?
 
       unused_pyc_files.each do |pyc|

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -235,6 +235,7 @@ module Homebrew
         cleanup_cache
         cleanup_logs
         cleanup_lockfiles
+        cleanup_python_site_packages
         prune_prefix_symlinks_and_directories
 
         unless dry_run?
@@ -487,6 +488,54 @@ module Homebrew
             # don't care if we can't delete a .DS_Store
             nil
           end
+    end
+
+    def cleanup_python_site_packages
+      pyc_files = Hash.new { |h, k| h[k] = [] }
+      seen_non_pyc_file = Hash.new { |h, k| h[k] = false }
+      unused_pyc_files = []
+
+      HOMEBREW_PREFIX.glob("lib/python*/site-packages").each do |site_packages|
+        site_packages.each_child do |child|
+          next unless child.directory?
+          # TODO: Work out a sensible way to clean up pip's, setuptools', and wheel's
+          #       {dist,site}-info directories. Alternatively, consider always removing
+          #       all `-info` directories, because we may not be making use of them.
+          next if child.basename.to_s.end_with?("-info")
+
+          # Clean up old *.pyc files in the top-level __pycache__.
+          if child.basename.to_s == "__pycache__"
+            child.find do |path|
+              next unless path.extname == ".pyc"
+              next unless path.prune?(days)
+
+              unused_pyc_files << path
+            end
+
+            next
+          end
+
+          # Look for directories that contain only *.pyc files.
+          child.find do |path|
+            next if path.directory?
+
+            if path.extname == ".pyc"
+              pyc_files[child] << path
+            else
+              seen_non_pyc_file[child] = true
+              break
+            end
+          end
+        end
+      end
+
+      unused_pyc_files += pyc_files.reject { |k,| seen_non_pyc_file[k] }
+                                   .values
+      return if unused_pyc_files.blank?
+
+      unused_pyc_files.each do |pyc|
+        cleanup_path(pyc) { pyc.unlink }
+      end
     end
 
     def prune_prefix_symlinks_and_directories


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Inside a given `site-packages` directory, `*.pyc` files live in
`__pycache__` directories. These are created by the Python interpreter
when a module is imported in order to speed up future access to the
imported module.

These can be left behind when formulae are uninstalled, which results in
erroneous success in importing the modules they were originally compiled
for.

Let's fix that by cleaning these up. In the top-level `__pycache__`
directory, we use the `Pathname#prune?` extension in order to determine
whether a `*.pyc` file is old enough to clean up. In other directories,
we clean them up when they are all that remains in a given module's
tree.

Removing these `*.pyc` files will make `python3` regenerate them when
required, so deleting them is relatively safe. The worst consequence is
slightly slower module import times.

Closes #13701.
