### PR TITLE
cleanup: use `cleanup_path` more consistently

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -428,7 +428,6 @@ module Homebrew
         next if !use_system_ruby && portable_ruby_latest_version == path.basename.to_s
 
         portable_rubies_to_remove << path
-        puts "Would remove: #{path} (#{path.abv})" if dry_run?
       end
 
       return if portable_rubies_to_remove.empty?
@@ -440,20 +439,16 @@ module Homebrew
         puts Utils.popen_read("git", "-C", HOMEBREW_REPOSITORY, "clean", "-ffqx", bundler_path).chomp
       end
 
-      return if dry_run?
-
-      FileUtils.rm_rf portable_rubies_to_remove
+      portable_rubies_to_remove.each do |portable_ruby|
+        cleanup_path(portable_ruby) { portable_ruby.rmtree }
+      end
     end
 
     def cleanup_bootsnap
       bootsnap = cache/"bootsnap"
       return unless bootsnap.exist?
 
-      if dry_run?
-        puts "Would remove: #{bootsnap} (#{bootsnap.abv})"
-      else
-        FileUtils.rm_rf bootsnap
-      end
+      cleanup_path(bootsnap) { bootsnap.rmtree }
     end
 
     def cleanup_cache_db(rack = nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`cleanup_path` already handles the dry-run logic, and also includes
those paths in the summary of space freed by `brew cleanup`.

Before this change:

    ❯ brew cleanup --dry-run
    Would remove: /Users/carlocab/Library/Caches/Homebrew/bootsnap (2,401 files, 41.9MB)

After this change:

    ❯ brew cleanup --dry-run
    Would remove: /Users/carlocab/Library/Caches/Homebrew/bootsnap (2,401 files, 41.9MB)
    ==> This operation would free approximately 41.9MB of disk space.
