### PR TITLE
Fix multi-arch cask `sha256` updates

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -138,13 +138,13 @@ module Homebrew
           replacement_pairs << fetch_cask(tmp_contents, config: lang_config)
         end
 
-        # TODO: Use SimulateSystem once all casks use on_system blocks
-        if tmp_contents.include?("Hardware::CPU.intel?")
-          other_intel = !Hardware::CPU.intel?
-          Homebrew::SimulateSystem.arch = other_intel ? :intel : :arm
-          other_contents = tmp_contents.gsub("Hardware::CPU.intel?", other_intel.to_s)
-          other_cask = Cask::CaskLoader.load(other_contents)
+        # TODO: remove the `Hardware::CPU.intel?` substitution once no casks use the conditional
+        other_intel = !Hardware::CPU.intel?
+        Homebrew::SimulateSystem.arch = other_intel ? :intel : :arm
+        other_contents = tmp_contents.gsub("Hardware::CPU.intel?", other_intel.to_s)
+        other_cask = Cask::CaskLoader.load(other_contents)
 
+        if other_cask.url.to_s != tmp_cask.url.to_s
           if other_cask.sha256 != :no_check && other_cask.language.blank?
             replacement_pairs << fetch_cask(other_contents)
           end
@@ -153,9 +153,9 @@ module Homebrew
             lang_config = other_cask.config.merge(Cask::Config.new(explicit: { languages: [language] }))
             replacement_pairs << fetch_cask(other_contents, config: lang_config)
           end
-
-          Homebrew::SimulateSystem.clear
         end
+
+        Homebrew::SimulateSystem.clear
       end
     end
 
@@ -163,8 +163,8 @@ module Homebrew
       hash_regex = (old_hash == :no_check) ? ":no_check" : "[\"']#{Regexp.escape(old_hash.to_s)}[\"']"
 
       replacement_pairs << [
-        /sha256\s+#{hash_regex}/m,
-        "sha256 #{(new_hash == :no_check) ? ":no_check" : "\"#{new_hash}\""}",
+        /#{hash_regex}/m,
+        ((new_hash == :no_check) ? ":no_check" : "\"#{new_hash}\"").to_s,
       ]
     end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/13713

This PR modifies `bump-cask-pr` to be able to handle all of the forms of `sha256` that we currently or are planning on supporting. This includes `sha256 :no_check`, `sha256 "..."`, `sha256` in `on_arm`/`on_intel`, and `sha256 arm: "...". intel: "..."`.

Before, we only tried to find the `sha256` of other arches when the text `if Hardware::CPU.intel?` was present. Now that we've removed that, we need to have a more reliable check. We now replace the `version`, switch to the opposite arch, reload the cask, and then compare the `url`. If the `urls` are different, this means the `sha256` will be different and we can handle that.

In the future, once all `if Hardware::CPU.intel?` calls are removed (plus some extra time for third party taps to adjust), this can be refactored again to remove that logic and simplify the rest.
