### PR TITLE
formula: add optional `source` and `target` args to `#rpath`

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -3,7 +3,7 @@
 
 class Formula
   undef shared_library
-  undef rpath
+  undef loader_path
   undef deuniversalize_machos
 
   sig { params(name: String, version: T.nilable(T.any(String, Integer))).returns(String) }
@@ -17,8 +17,8 @@ class Formula
   end
 
   sig { returns(String) }
-  def rpath
-    "'$ORIGIN/../lib'"
+  def loader_path
+    "$ORIGIN"
   end
 
   sig { params(targets: T.nilable(T.any(Pathname, String))).void }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1572,9 +1572,23 @@ class Formula
   end
 
   # Executable/Library RPATH according to platform conventions.
+  #
+  # Optionally specify a `source` or `target` depending on the location
+  # of the file containing the RPATH command and where its target is located.
+  #
+  # <pre>
+  # rpath #=> "@loader_path/../lib"
+  # rpath(target: frameworks) #=> "@loader_path/../Frameworks"
+  # rpath(source: libexec/"bin") #=> "@loader_path/../../lib"
+  # </pre>
+  sig { params(source: Pathname, target: Pathname).returns(String) }
+  def rpath(source: bin, target: lib)
+    "#{loader_path}/#{target.relative_path_from(source)}"
+  end
+
   sig { returns(String) }
-  def rpath
-    "@loader_path/../lib"
+  def loader_path
+    "@loader_path"
   end
 
   # Creates a new `Time` object for use in the formula as the build time.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There are about 10 formulae which need a bit more flexibility from
`#rpath`. Most of them use `Pathname#relative_path_from`, so we can
replace those instances with a call to `#rpath` instead once `#rpath`
knows how to handle this.
