### PR TITLE
formula_auditor: skip rename audit for `glib-utils`

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -263,7 +263,10 @@ module Homebrew
             next
           end
 
-          if dep_f.oldname && dep.name.split("/").last == dep_f.oldname
+          # FIXME: Remove `glib-utils` exemption when the following PRs are merged:
+          #   https://github.com/Homebrew/homebrew-core/pull/108307
+          #   https://github.com/Homebrew/homebrew-core/pull/108497
+          if dep_f.oldname && dep.name.split("/").last == dep_f.oldname && dep_f.oldname != "glib-utils"
             problem "Dependency '#{dep.name}' was renamed; use new name '#{dep_f.name}'."
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I am removing `glib-utils` in (1) Homebrew/homebrew-core#108307, and all
`glib-utils` dependencies in (2) Homebrew/homebrew-core#108497.

This audit prevents me from proceeding with (1) without rebuilding all
the formulae modified in (2). I don't think that is needed, so I'd like
to exempt `glib-utils` from the rename audit instead.

To give you a clearer idea of how I plan to do this, this is the order
of events:
1. Merge this change.
2. Merge Homebrew/homebrew-core#108307.
3. Merge Homebrew/homebrew-core#108497.
4. Revert this change.

This should allow us to get rid of `glib-utils` and its accompanying
hacks without having to rebuild dozens of formulae needlessly.
