### PR TITLE
Keep formulas unlinked when reinstalling/upgrading [WIP]

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -44,7 +44,7 @@ class FormulaInstaller
 
   def initialize(
     formula,
-    link_keg: false,
+    link_keg: nil,
     installed_as_dependency: false,
     installed_on_request: true,
     show_header: false,
@@ -74,7 +74,7 @@ class FormulaInstaller
     @overwrite = overwrite
     @keep_tmp = keep_tmp
     @debug_symbols = debug_symbols
-    @link_keg = !formula.keg_only? || link_keg
+    @link_keg = link_keg.nil? ? !formula.keg_only? : link_keg
     @show_header = show_header
     @ignore_deps = ignore_deps
     @only_deps = only_deps


### PR DESCRIPTION
@carlocab recently indicated that it would be desirable to have upgrades of unlinked formulas *stay unlinked* after the upgrade. I believe this makes sense for reinstalls too. This PR is an attempt to implement that behaviour.

I'd be happy to write a test if someone could confirm this (very straightforward) approach is sensible.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----