### PR TITLE
linkage_checker: don't reinstall formula on some linkage failures

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -50,7 +50,7 @@ module Homebrew
 
         if args.test?
           result.display_test_output(strict: args.strict?)
-          Homebrew.failed = true if result.broken_library_linkage?(strict: args.strict?)
+          Homebrew.failed = true if result.broken_library_linkage?(test: true, strict: args.strict?)
         elsif args.reverse?
           result.display_reverse_output
         else

--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -52,8 +52,9 @@ class LinkageChecker
     display_deprecated_warning(strict: strict)
   end
 
-  def broken_library_linkage?(strict: false)
-    generic_broken_library_linkage?(strict: strict) || (fail_on_libcrypt1?(strict: strict) && @libcrypt_found)
+  def broken_library_linkage?(test: false, strict: false)
+    generic_broken_library_linkage?(test: test, strict: strict) ||
+      (fail_on_libcrypt1?(strict: strict) && @libcrypt_found)
   end
 
   private

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -80,11 +80,16 @@ class LinkageChecker
   alias generic_display_test_output display_test_output
   private :generic_display_test_output
 
-  sig { params(strict: T::Boolean).returns(T::Boolean) }
-  def broken_library_linkage?(strict: false)
-    issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps]
-    issues += [@undeclared_deps, @files_missing_rpaths] if strict
-    [issues, unexpected_broken_dylibs, unexpected_present_dylibs].flatten.any?(&:present?)
+  sig { params(test: T::Boolean, strict: T::Boolean).returns(T::Boolean) }
+  def broken_library_linkage?(test: false, strict: false)
+    raise ArgumentError, "Strict linkage checking requires test mode to be enabled." if strict && !test
+
+    issues = [@broken_deps, unexpected_broken_dylibs]
+    if test
+      issues += [@unwanted_system_dylibs, @version_conflict_deps, unexpected_present_dylibs]
+      issues += [@undeclared_deps, @files_missing_rpaths] if strict
+    end
+    issues.any?(&:present?)
   end
   alias generic_broken_library_linkage? broken_library_linkage?
   private :generic_broken_library_linkage?


### PR DESCRIPTION
`brew linkage --test` checks more than just "unusably broken".

Things like unwanted system dependencies and unexpectedly present libraries are issues worth flagging, but they are typically formula code issues and not fixable by simply reinstalling. So triggering a reinstall for those issues is a waste of time.

This PR adds a test parameter to `LinkageChecker#broken_library_linkage?`, so that we can scope some checks to only `brew linkage --test` rather than every place which calls that method (like `upgrade.rb`).