### PR TITLE
linkage_checker: deprecate libnsl.so.1 linkage

### DIFF
--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -26,12 +26,27 @@ class LinkageChecker
   ].freeze
 
   def display_deprecated_warning(strict: false)
-    return unless @libcrypt_found
-
-    # Steps when removing this entirely:
+    # Steps when moving these to `odisabled`:
+    # - Remove the old library from SYSTEM_LIBRARY_ALLOWLIST above.
+    # - Remove the `disable` and `disable_for_developer` kwargs here.
+    # - Adjust the `broken_library_linkage?` override below to not check for the library.
+    # - Remove the relevant `fail_on_lib*?`.
+    # If there's no more deprecations left:
+    # - Remove the `broken_library_linkage?` override and the generic alias in HOMEBREW_LIBRARY/linkage_checker.rb.
+    #
+    # Steps when removing handling for a library entirely (assuming the steps to `odisabled` has already been done):
+    # - Remove the relevant setting of `@lib*_found` in `check_dylibs` below.
+    # - Remove the `odisabled` line
+    # If there's no library deprecated/disabled handling left:
     # - Remove the `display_` overrides here and the associated generic aliases in HOMEBREW_LIBRARY/linkage_checker.rb
-    # - Remove the setting of `@libcrypt_found` in `check_dylibs` below.
-    odisabled "linkage to libcrypt.so.1", "libcrypt.so.2 in the libxcrypt formula"
+
+    odisabled "linkage to libcrypt.so.1", "libcrypt.so.2 in the libxcrypt formula" if @libcrypt_found
+
+    return unless @libnsl_found
+
+    odeprecated "linkage to libnsl.so.1", "libnsl.so.3 in the libnsl formula",
+                disable:                fail_on_libnsl1?(strict: strict),
+                disable_for_developers: false
   end
 
   def display_normal_output
@@ -45,15 +60,20 @@ class LinkageChecker
   end
 
   def broken_library_linkage?(test: false, strict: false)
-    generic_broken_library_linkage?(test: test, strict: strict)
+    generic_broken_library_linkage?(test: test, strict: strict) || (fail_on_libnsl1?(strict: strict) && @libnsl_found)
   end
 
   private
+
+  def fail_on_libnsl1?(strict:)
+    strict || ENV["HOMEBREW_DISALLOW_LIBNSL1"].present?
+  end
 
   def check_dylibs(rebuild_cache:)
     generic_check_dylibs(rebuild_cache: rebuild_cache)
 
     @libcrypt_found = true if @system_dylibs.any? { |s| File.basename(s) == "libcrypt.so.1" }
+    @libnsl_found = true if @system_dylibs.any? { |s| File.basename(s) == "libnsl.so.1" }
 
     # glibc and gcc are implicit dependencies.
     # No other linkage to system libraries is expected or desired.


### PR DESCRIPTION
This is a trickier one as we're far too late deprecating this (I did not know it was going to be removed from our Glibc formula) so really should be disabling this by now...

Interested in thoughts on what the deprecation schedule should look like here.