### PR TITLE
Revert "formula_auditor: skip rename audit for `glib-utils`"

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -263,10 +263,7 @@ module Homebrew
             next
           end
 
-          # FIXME: Remove `glib-utils` exemption when the following PRs are merged:
-          #   https://github.com/Homebrew/homebrew-core/pull/108307
-          #   https://github.com/Homebrew/homebrew-core/pull/108497
-          if dep_f.oldname && dep.name.split("/").last == dep_f.oldname && dep_f.oldname != "glib-utils"
+          if dep_f.oldname && dep.name.split("/").last == dep_f.oldname
             problem "Dependency '#{dep.name}' was renamed; use new name '#{dep_f.name}'."
           end
 


### PR DESCRIPTION
The necessary PRs in Homebrew/homebrew-core have been merged. See:
- Homebrew/homebrew-core#108307
- Homebrew/homebrew-core#108497

This reverts commit 6ca02b22bb27a45525fa62c6fba9902039152fcc.
