### PR TITLE
Include `on_{system}` blocks as stanzas in rubocop

### DIFF
--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -49,7 +49,7 @@ module RuboCop
           stanzas.sort do |s1, s2|
             i1 = stanza_order_index(s1)
             i2 = stanza_order_index(s2)
-            if i1 == i2
+            if i1 == i2 || i1.blank? || i2.blank?
               i1 = stanzas.index(s1)
               i2 = stanzas.index(s2)
             end

--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -55,6 +55,8 @@ module RuboCop
         end.freeze
 
       STANZA_ORDER = STANZA_GROUPS.flatten.freeze
+
+      ON_SYSTEM_METHODS = [:arm, :intel, *MacOSVersions::SYMBOLS.keys].map { |option| :"on_#{option}" }.freeze
     end
   end
 end

--- a/Library/Homebrew/rubocops/cask/extend/node.rb
+++ b/Library/Homebrew/rubocops/cask/extend/node.rb
@@ -19,8 +19,10 @@ module RuboCop
 
       def stanza?
         return true if arch_variable?
+        return false if !send_type? && !block_type?
+        return true if ON_SYSTEM_METHODS.include?(method_name)
 
-        (send_type? || block_type?) && STANZA_ORDER.include?(method_name)
+        STANZA_ORDER.include?(method_name)
       end
 
       def heredoc?

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/multiple-versions.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/multiple-versions.rb
@@ -9,7 +9,6 @@ cask "multiple-versions" do
     version "1.2.0"
     sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
   end
-
   on_catalina :or_older do
     version "1.0.0"
     sha256 "1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216"


### PR DESCRIPTION
This PR updates the cask stanza grouping rubocop to treat `on_{system}` blocks as being part of their own group. This doesn't add them to the list of stanzas since I want their position to be variable, but it does mean that when they're right after each other, they'll be treated as a standalone group. I think it's important not to restrict their exact position since something they may contain only stanzas that belong toward the top of the cask file (e.g. `version`) and sometimes they may contain stanzas that belong farther down (e.g. `url` or artifacts) or both. I think that the blocks should have the flexibility to go where it makes most sense for them to be depending on what the contents are.

This PR is needed for https://github.com/Homebrew/homebrew-cask/pull/130261
