### PR TITLE
formula_auditor: refactor GCC dependency check into separate method

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -409,7 +409,9 @@ module Homebrew
     end
 
     def audit_gcc_dependency
+      return unless @git
       return unless @core_tap
+      return unless formula.tap.git? # git log is required
       return unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
       return unless linux_only_gcc_dep?(formula)
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -888,11 +888,10 @@ module Homebrew
       #   depends_on "gcc"
       # end
       # ```
-      variations_deps = []
-      variations.each_value do |data|
-        variations_deps += data["dependencies"]
-      end
-      variations_deps.uniq!
+      variations_deps = variations.values
+                                  .flat_map { |data| data["dependencies"] }
+                                  .compact
+                                  .uniq
 
       variations_deps.exclude?("gcc")
     end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -411,7 +411,7 @@ module Homebrew
     def audit_gcc_dependency
       return unless @git
       return unless @core_tap
-      return unless formula.tap.git? # git log is required
+      return if !@strict && !formula.tap.git? # git log is required for non-strict audit
       return unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
       return unless linux_only_gcc_dep?(formula)
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -879,7 +879,7 @@ module Homebrew
       return false if linux_deps.exclude?("gcc")
 
       variations = formula_hash["variations"]
-      # The formula has no variations, so all versions depend on GCC.
+      # The formula has no variations, so all OS-version-arch triples depend on GCC.
       return false if variations.blank?
 
       # FIXME: This returns a false positive for formulae that do, for example:
@@ -889,7 +889,7 @@ module Homebrew
       # end
       # ```
       variations_deps = []
-      formula_hash["variations"].each_value do |data|
+      variations.each_value do |data|
         variations_deps += data["dependencies"]
       end
       variations_deps.uniq!

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -873,12 +873,9 @@ module Homebrew
 
     def linux_only_gcc_dep?(formula)
       odie "`#linux_only_gcc_dep?` works only on Linux!" if Homebrew::SimulateSystem.simulating_or_running_on_macos?
+      return false if formula.deps.map(&:name).exclude?("gcc")
 
-      formula_hash = formula.to_hash_with_variations
-      linux_deps = formula_hash["dependencies"]
-      return false if linux_deps.exclude?("gcc")
-
-      variations = formula_hash["variations"]
+      variations = formula.to_hash_with_variations["variations"]
       # The formula has no variations, so all OS-version-arch triples depend on GCC.
       return false if variations.blank?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The GCC dependency check is adding a couple of minutes to our
`tap_syntax` jobs. Let's fix that by moving the check into a separate
method so we can exclude it from `tap_syntax`.
