### PR TITLE
Install the bottle dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -626,7 +626,7 @@ class FormulaInstaller
       if all_bottle_deps.exclude?(formula.name)
         bottle_deps = Keg.bottle_dependencies.flat_map do |bottle_dep|
           expanded_bottle_deps, = expand_dependencies_for_formula(bottle_dep, inherited_options)
-          expanded_bottle_deps
+          expanded_bottle_deps + [Dependency.new(bottle_dep.name)]
         end
         expanded_deps = Dependency.merge_repeats(bottle_deps + expanded_deps)
       end

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -370,12 +370,13 @@ class Keg
   def self.bottle_dependencies
     return [] unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
 
-    @bottle_dependencies ||= begin
-      formulae = []
-      gcc = Formulary.factory(CompilerSelector.preferred_gcc)
-      formulae << gcc if DevelopmentTools.gcc_version("gcc") < gcc.version.to_i
-      formulae
-    end
+    @bottle_dependencies ||= if OS::Linux::Glibc.system_version < OS::LINUX_GLIBC_CI_VERSION
+      ["glibc", CompilerSelector.preferred_gcc]
+    elsif DevelopmentTools.gcc_version("gcc") < OS::LINUX_GCC_CI_VERSION
+      [CompilerSelector.preferred_gcc]
+    else
+      []
+    end.map { |dep| Formulary.factory(dep) }
   end
 end
 


### PR DESCRIPTION
The dependencies of the bottle dependencies were installed, but the actual bottle dependencies themselves were not.

- `expand_dependencies`: Install the bottle dependencies
- `bottle_dependencies`: Install `glibc` if it's too old

Bug introduced with

- https://github.com/Homebrew/brew/pull/13494

Related inflight PR

- https://github.com/Homebrew/brew/pull/13577

### Before
```console
$ brew install hello
…
==> Installing dependencies for hello: gmp, isl, mpfr, libmpc, lz4, xz, zlib, zstd and binutils
…
```

### After
```console
$ brew install hello
…
==> Installing dependencies for hello: gmp, isl, mpfr, libmpc, lz4, xz, zlib, zstd, binutils and gcc@5
…
```

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- https://github.com/Homebrew/brew/issues/13619