### PR TITLE
LINUX_PREFERRED_GCC_FORMULA: Bump to gcc@11

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -616,7 +616,7 @@ class FormulaInstaller
     expanded_deps, any_dep_bottle_used = expand_dependencies_for_formula(formula, inherited_options)
     any_bottle_used ||= any_dep_bottle_used
 
-    # We require some dependencies (glibc, GCC 5, etc.) if binaries were built.
+    # We require some dependencies (glibc, GCC, etc.) if binaries were built.
     # Native binaries shouldn't exist in cross-platform `all` bottles.
     if any_bottle_used && !formula.bottled?(:all) && !Keg.bottle_dependencies.empty?
       all_bottle_deps = Keg.bottle_dependencies.flat_map do |bottle_dep|

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -48,12 +48,11 @@ module OS
   LINUX_CI_OS_VERSION = "Ubuntu 16.04"
   LINUX_GLIBC_CI_VERSION = "2.23"
   LINUX_GCC_CI_VERSION = "5.0"
-  LINUX_PREFERRED_GCC_FORMULA = "gcc@5"
+  LINUX_PREFERRED_GCC_FORMULA = "gcc@11"
 
   # Ubuntu 22.04 (see Linux-CI.md)
   LINUX_GLIBC_NEXT_CI_VERSION = "2.35"
   # LINUX_GCC_CI_VERSION = "11.0"
-  # LINUX_PREFERRED_GCC_FORMULA = "gcc@11"
 
   if OS.mac?
     require "os/mac"

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -52,7 +52,7 @@ describe CompilerSelector do
 
     it "returns gcc-5 if gcc formula offers gcc-5 on linux", :needs_linux do
       software_spec.fails_with(:clang)
-      allow(Formulary).to receive(:factory).with("gcc@5").and_return(double(version: Version.new("5.0")))
+      allow(Formulary).to receive(:factory).with("gcc@11").and_return(double(version: Version.new("5.0")))
       expect(selector.compiler).to eq("gcc-5")
     end
 
@@ -60,14 +60,14 @@ describe CompilerSelector do
       software_spec.fails_with(:clang)
       software_spec.fails_with(gcc: "5")
       software_spec.fails_with(gcc: "7")
-      allow(Formulary).to receive(:factory).with("gcc@5").and_return(double(version: Version.new("5.0")))
+      allow(Formulary).to receive(:factory).with("gcc@11").and_return(double(version: Version.new("5.0")))
       expect(selector.compiler).to eq("gcc-6")
     end
 
     it "returns gcc-7 if gcc formula offers gcc-5 and fails with gcc <= 6 on linux", :needs_linux do
       software_spec.fails_with(:clang)
       software_spec.fails_with(:gcc) { version "6" }
-      allow(Formulary).to receive(:factory).with("gcc@5").and_return(double(version: Version.new("5.0")))
+      allow(Formulary).to receive(:factory).with("gcc@11").and_return(double(version: Version.new("5.0")))
       expect(selector.compiler).to eq("gcc-7")
     end
 

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -24,7 +24,7 @@ describe FormulaInstaller do
 
     stub_formula_loader formula
     stub_formula_loader formula("gcc") { url "gcc-1.0" }
-    stub_formula_loader formula("gcc@5") { url "gcc-5.0" }
+    stub_formula_loader formula("gcc@11") { url "gcc-11.0" }
 
     fi = FormulaInstaller.new(formula)
     fi.fetch

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -142,7 +142,7 @@ describe Formulary do
       before do
         allow(described_class).to receive(:loader_for).and_call_original
         stub_formula_loader formula("gcc") { url "gcc-1.0" }
-        stub_formula_loader formula("gcc@5") { url "gcc-5.0" }
+        stub_formula_loader formula("gcc@11") { url "gcc-11.0" }
       end
 
       let(:installed_formula) { described_class.factory(formula_path) }


### PR DESCRIPTION
Change `LINUX_PREFERRED_GCC_FORMULA` from `gcc@5` to `gcc@11`.

> Similarly to how we bumped the brewed Glibc version before building bottles with that Glibc version, perhaps we can also bump the preferred brewed GCC version before building bottles with that GCC version.

See https://github.com/Homebrew/brew/issues/13619#issuecomment-1226044992

I'd like to have a stable release of Homebrew 3.6.0 that migrates our users to `glibc` 2.35 and `gcc@11` before we move our bottling infrastructure to Ubuntu 22.04.

This PR needs to be merged and Homebrew 3.6.0 tagged simultaneously with merging PR https://github.com/Homebrew/homebrew-core/pull/108816 
- https://github.com/Homebrew/homebrew-core/pull/108816

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- <https://github.com/Homebrew/brew/issues/13619>
