### PR TITLE
Freeze formula definition once first instance is created

### DIFF
--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -33,9 +33,17 @@ class BuildEnvironment
   module DSL
     extend T::Sig
 
+    # Initialise @env for each class which may use this DSL (e.g. each formula subclass).
+    # `env` may never be called, and it needs to be initialised before the class is frozen.
+    def inherited(child)
+      super
+      child.instance_eval do
+        @env = BuildEnvironment.new
+      end
+    end
+
     sig { params(settings: Symbol).returns(BuildEnvironment) }
     def env(*settings)
-      @env ||= BuildEnvironment.new
       @env.merge(settings)
     end
   end

--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -1,8 +1,17 @@
 # typed: true
 # frozen_string_literal: true
 
+require "requirement"
+
 # An adapter for casks to provide dependency information in a formula-like interface.
 class CaskDependent
+  # Defines a dependency on another cask
+  class Requirement < ::Requirement
+    satisfy(build_env: false) do
+      Cask::CaskLoader.load(cask).installed?
+    end
+  end
+
   attr_reader :cask
 
   def initialize(cask)
@@ -33,11 +42,21 @@ class CaskDependent
       dsl_reqs = @cask.depends_on
 
       dsl_reqs.arch&.each do |arch|
-        requirements << ArchRequirement.new([:x86_64]) if arch[:bits] == 64
-        requirements << ArchRequirement.new([arch[:type]])
+        arch = if arch[:bits] == 64
+          if arch[:type] == :intel
+            :x86_64
+          else
+            :"#{arch[:type]}64"
+          end
+        elsif arch[:type] == :intel && arch[:bits] == 32
+          :i386
+        else
+          arch[:type]
+        end
+        requirements << ArchRequirement.new([arch])
       end
       dsl_reqs.cask.each do |cask_ref|
-        requirements << Requirement.new([{ cask: cask_ref }])
+        requirements << CaskDependent::Requirement.new([{ cask: cask_ref }])
       end
       requirements << dsl_reqs.macos if dsl_reqs.macos
 

--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "delegate"
-require "cask_dependent"
 
 # A collection of dependencies.
 #

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -26,16 +26,23 @@ class DependencyCollector
 
   sig { void }
   def initialize
+    # Ensure this is synced with `initialize_dup` and `freeze` (excluding simple objects like integers and booleans)
     @deps = Dependencies.new
     @requirements = Requirements.new
 
     init_global_dep_tree_if_needed!
   end
 
-  def initialize_copy(other)
+  def initialize_dup(other)
     super
     @deps = @deps.dup
     @requirements = @requirements.dup
+  end
+
+  def freeze
+    @deps.freeze
+    @requirements.freeze
+    super
   end
 
   def add(spec)

--- a/Library/Homebrew/extend/module.rb
+++ b/Library/Homebrew/extend/module.rb
@@ -5,11 +5,17 @@ class Module
   def attr_rw(*attrs)
     attrs.each do |attr|
       module_eval <<-EOS, __FILE__, __LINE__+1
-        def #{attr}(val=nil)           # def prefix(val=nil)
-          @#{attr} ||= nil             #   @prefix ||= nil
-          return @#{attr} if val.nil?  #   return @prefix if val.nil?
-          @#{attr} = val               #   @prefix = val
-        end                            # end
+        def #{attr}(val=nil)                         # def prefix(val=nil)
+          if val.nil?                                #   if val.nil?
+            if instance_variable_defined?(:@#{attr}) #      if instance_variable_defined?(:@prefix)
+              return @#{attr}                        #        return @prefix
+            else                                     #      else
+              return nil                             #        return nil
+            end                                      #      end
+          end                                        #    end
+                                                     #
+          @#{attr} = val                             #   @prefix = val
+        end                                          # end
       EOS
     end
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2695,6 +2695,7 @@ class Formula
   # The methods below define the formula DSL.
   class << self
     extend Predicable
+    extend T::Sig
     include BuildEnvironment::DSL
     include OnSystem::MacOSAndLinux
 
@@ -2903,8 +2904,9 @@ class Formula
     #
     # Formulae which should not be bottled should be tagged with:
     # <pre>bottle :disable, "reasons"</pre>
-    def bottle(*args, &block)
-      stable.bottle(*args, &block)
+    sig { params(block: T.proc.bind(BottleSpecification).void).void }
+    def bottle(&block)
+      stable.bottle(&block)
     end
 
     # @private

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -181,6 +181,9 @@ class Formula
 
   # @private
   def initialize(name, path, spec, alias_path: nil, force_bottle: false)
+    # Only allow instances of subclasses. The base class does not hold any spec information (URLs etc).
+    raise "Do not call `Formula.new' directly without a subclass." unless self.class < Formula
+
     @name = name
     @path = path
     @alias_path = alias_path

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -184,6 +184,11 @@ class Formula
     # Only allow instances of subclasses. The base class does not hold any spec information (URLs etc).
     raise "Do not call `Formula.new' directly without a subclass." unless self.class < Formula
 
+    # Stop any subsequent modification of a formula's definition.
+    # Changes do not propagate to existing instances of formulae.
+    # Now that we have an instance, it's too late to make any changes to the class-level definition.
+    self.class.freeze
+
     @name = name
     @path = path
     @alias_path = alias_path
@@ -2699,6 +2704,22 @@ class Formula
     include BuildEnvironment::DSL
     include OnSystem::MacOSAndLinux
 
+    # Initialise instance variables for each subclass. These need to be initialised before the class is frozen,
+    # and some DSL may never be called so it can't be done lazily.
+    def inherited(child)
+      super
+      child.instance_eval do
+        # Ensure this is synced with `freeze`
+        @stable = SoftwareSpec.new(flags: build_flags)
+        @head = HeadSoftwareSpec.new(flags: build_flags)
+        @livecheck = Livecheck.new(self)
+        @conflicts = []
+        @skip_clean_paths = Set.new
+        @link_overwrite_paths = Set.new
+        @allowed_missing_libraries = Set.new
+      end
+    end
+
     def method_added(method)
       super
 
@@ -2708,6 +2729,16 @@ class Formula
       when :test
         define_method(:test_defined?) { true }
       end
+    end
+
+    def freeze
+      specs.each(&:freeze)
+      @livecheck.freeze
+      @conflicts.freeze
+      @skip_clean_paths.freeze
+      @link_overwrite_paths.freeze
+      @allowed_missing_libraries.freeze
+      super
     end
 
     # Whether this formula contains OS/arch-specific blocks
@@ -2790,6 +2821,18 @@ class Formula
     # @private
     attr_reader :plist_manual
 
+    # @private
+    attr_reader :conflicts
+
+    # @private
+    attr_reader :skip_clean_paths
+
+    # @private
+    attr_reader :link_overwrite_paths
+
+    # @private
+    attr_reader :allowed_missing_libraries
+
     # If `pour_bottle?` returns `false` the user-visible reason to display for
     # why they cannot use the bottle.
     # @private
@@ -2820,7 +2863,7 @@ class Formula
     # A list of the {.stable} and {.head} {SoftwareSpec}s.
     # @private
     def specs
-      @specs ||= [stable, head].freeze
+      [stable, head].freeze
     end
 
     # @!attribute [w] url
@@ -2937,7 +2980,6 @@ class Formula
     #   depends_on "libffi"
     # end</pre>
     def stable(&block)
-      @stable ||= SoftwareSpec.new(flags: build_flags)
       return @stable unless block
 
       @stable.instance_eval(&block)
@@ -2956,7 +2998,6 @@ class Formula
     # or (if autodetect fails):
     # <pre>head "https://hg.is.awesome.but.git.has.won.example.com/", using: :hg</pre>
     def head(val = nil, specs = {}, &block)
-      @head ||= HeadSoftwareSpec.new(flags: build_flags)
       if block
         @head.instance_eval(&block)
       elsif val
@@ -3107,11 +3148,6 @@ class Formula
       @plist_manual = options[:manual]
     end
 
-    # @private
-    def conflicts
-      @conflicts ||= []
-    end
-
     # One or more formulae that conflict with this one and why.
     # <pre>conflicts_with "imagemagick", because: "both install `convert` binaries"</pre>
     def conflicts_with(*names)
@@ -3130,11 +3166,6 @@ class Formula
       paths.flatten!
       # Specifying :all is deprecated and will become an error
       skip_clean_paths.merge(paths)
-    end
-
-    # @private
-    def skip_clean_paths
-      @skip_clean_paths ||= Set.new
     end
 
     # Software that will not be symlinked into the `brew --prefix` and will
@@ -3240,7 +3271,6 @@ class Formula
     #   regex /foo-(\d+(?:\.\d+)+)\.tar/
     # end</pre>
     def livecheck(&block)
-      @livecheck ||= Livecheck.new(self)
       return @livecheck unless block
 
       @livecheckable = true
@@ -3396,11 +3426,6 @@ class Formula
       link_overwrite_paths.merge(paths)
     end
 
-    # @private
-    def link_overwrite_paths
-      @link_overwrite_paths ||= Set.new
-    end
-
     # Permit links to certain libraries that don't exist. Available on Linux only.
     def ignore_missing_libraries(*libs)
       unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
@@ -3413,11 +3438,6 @@ class Formula
       end
 
       allowed_missing_libraries.merge(libraries)
-    end
-
-    # @private
-    def allowed_missing_libraries
-      @allowed_missing_libraries ||= Set.new
     end
   end
 end

--- a/Library/Homebrew/options.rb
+++ b/Library/Homebrew/options.rb
@@ -82,7 +82,18 @@ class Options
   end
 
   def initialize(*args)
+    # Ensure this is synced with `initialize_dup` and `freeze` (excluding simple objects like integers and booleans)
     @options = Set.new(*args)
+  end
+
+  def initialize_dup(other)
+    super
+    @options = @options.dup
+  end
+
+  def freeze
+    @options.dup
+    super
   end
 
   def each(*args, &block)

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -20,6 +20,10 @@ class Requirement
   attr_reader :tags, :name, :cask, :download
 
   def initialize(tags = [])
+    # Only allow instances of subclasses. This base class enforces no constraints on its own.
+    # Individual subclasses use the `satisfy` DSL to define those constraints.
+    raise "Do not call `Requirement.new' directly without a subclass." unless self.class < Requirement
+
     @cask = self.class.cask
     @download = self.class.download
     tags.each do |tag|

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -141,9 +141,9 @@ class Requirement
   private
 
   def infer_name
-    klass = self.class.name || self.class.to_s
-    klass = klass.sub(/(Dependency|Requirement)$/, "")
-                 .sub(/^(\w+::)*/, "")
+    klass = self.class.name
+    klass = klass&.sub(/(Dependency|Requirement)$/, "")
+                 &.sub(/^(\w+::)*/, "")
     return klass.downcase if klass.present?
 
     return @cask if @cask.present?

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -29,6 +29,7 @@ class Resource
   attr_accessor :name
 
   def initialize(name = nil, &block)
+    # Ensure this is synced with `initialize_dup` and `freeze` (excluding simple objects like integers and booleans)
     @name = name
     @url = nil
     @version = nil
@@ -37,9 +38,33 @@ class Resource
     @checksum = nil
     @using = nil
     @patches = []
-    @livecheck = nil
+    @livecheck = Livecheck.new(self)
     @livecheckable = false
     instance_eval(&block) if block
+  end
+
+  def initialize_dup(other)
+    super
+    @name = @name.dup
+    @version = @version.dup
+    @mirrors = @mirrors.dup
+    @specs = @specs.dup
+    @checksum = @checksum.dup
+    @using = @using.dup
+    @patches = @patches.dup
+    @livecheck = @livecheck.dup
+  end
+
+  def freeze
+    @name.freeze
+    @version.freeze
+    @mirrors.freeze
+    @specs.freeze
+    @checksum.freeze
+    @using.freeze
+    @patches.freeze
+    @livecheck.freeze
+    super
   end
 
   def owner=(owner)
@@ -185,7 +210,6 @@ class Resource
   #   regex /foo-(\d+(?:\.\d+)+)\.tar/
   # end</pre>
   def livecheck(&block)
-    @livecheck ||= Livecheck.new(self) if block
     return @livecheck unless block
 
     @livecheckable = true

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -36,6 +36,7 @@ class SoftwareSpec
   def_delegators :@resource, :sha256
 
   def initialize(flags: [])
+    # Ensure this is synced with `initialize_dup` and `freeze` (excluding simple objects like integers and booleans)
     @resource = Resource.new
     @resources = {}
     @dependency_collector = DependencyCollector.new
@@ -50,9 +51,36 @@ class SoftwareSpec
     @uses_from_macos_elements = []
   end
 
-  def initialize_copy(other)
+  def initialize_dup(other)
     super
+    @resource = @resource.dup
+    @resources = @resources.dup
     @dependency_collector = @dependency_collector.dup
+    @bottle_specification = @bottle_specification.dup
+    @patches = @patches.dup
+    @options = @options.dup
+    @flags = @flags.dup
+    @deprecated_flags = @deprecated_flags.dup
+    @deprecated_options = @deprecated_options.dup
+    @build = @build.dup
+    @compiler_failures = @compiler_failures.dup
+    @uses_from_macos_elements = @uses_from_macos_elements.dup
+  end
+
+  def freeze
+    @resource.freeze
+    @resources.freeze
+    @dependency_collector.freeze
+    @bottle_specification.freeze
+    @patches.freeze
+    @options.freeze
+    @flags.freeze
+    @deprecated_flags.freeze
+    @deprecated_options.freeze
+    @build.freeze
+    @compiler_failures.freeze
+    @uses_from_macos_elements.freeze
+    super
   end
 
   def owner=(owner)

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -30,11 +30,16 @@ describe BuildEnvironment do
   end
 
   describe BuildEnvironment::DSL do
-    subject(:build_environment_dsl) { double.extend(described_class) }
+    let(:build_environment_dsl) do
+      klass = described_class
+      Class.new do
+        extend(klass)
+      end
+    end
 
     context "with a single argument" do
-      before do
-        build_environment_dsl.instance_eval do
+      subject do
+        Class.new(build_environment_dsl) do
           env :std
         end
       end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -832,15 +832,15 @@ describe Formula do
     specify "service complicated" do
       f = formula do
         url "https://brew.sh/test-1.0.tbz"
-      end
 
-      f.class.service do
-        run [opt_bin/"beanstalkd"]
-        run_type :immediate
-        error_log_path var/"log/beanstalkd.error.log"
-        log_path var/"log/beanstalkd.log"
-        working_dir var
-        keep_alive true
+        service do
+          run [opt_bin/"beanstalkd"]
+          run_type :immediate
+          error_log_path var/"log/beanstalkd.error.log"
+          log_path var/"log/beanstalkd.log"
+          working_dir var
+          keep_alive true
+        end
       end
       expect(f.service).not_to be_nil
     end

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -98,11 +98,15 @@ describe Homebrew::Livecheck do
 
   describe "::livecheck_url_to_string" do
     let(:f_livecheck_url) do
+      homepage_url_s = homepage_url
+      stable_url_s = stable_url
+      head_url_s = head_url
+
       formula("test_livecheck_url") do
         desc "Test Livecheck URL formula"
-        homepage "https://brew.sh"
-        url "https://brew.sh/test-0.0.1.tgz"
-        head "https://github.com/Homebrew/brew.git"
+        homepage homepage_url_s
+        url stable_url_s
+        head head_url_s
       end
     end
 
@@ -120,25 +124,15 @@ describe Homebrew::Livecheck do
     end
 
     it "returns a URL string when given a livecheck_url string" do
-      f_livecheck_url.livecheck.url(livecheck_url)
       expect(livecheck.livecheck_url_to_string(livecheck_url, f_livecheck_url)).to eq(livecheck_url)
     end
 
     it "returns a URL symbol when given a valid livecheck_url symbol" do
-      f_livecheck_url.livecheck.url(:head)
-      expect(livecheck.livecheck_url_to_string(head_url, f_livecheck_url)).to eq(head_url)
-
-      f_livecheck_url.livecheck.url(:homepage)
-      expect(livecheck.livecheck_url_to_string(homepage_url, f_livecheck_url)).to eq(homepage_url)
-
-      c_livecheck_url.livecheck.url(:homepage)
-      expect(livecheck.livecheck_url_to_string(homepage_url, c_livecheck_url)).to eq(homepage_url)
-
-      f_livecheck_url.livecheck.url(:stable)
-      expect(livecheck.livecheck_url_to_string(stable_url, f_livecheck_url)).to eq(stable_url)
-
-      c_livecheck_url.livecheck.url(:url)
-      expect(livecheck.livecheck_url_to_string(cask_url, c_livecheck_url)).to eq(cask_url)
+      expect(livecheck.livecheck_url_to_string(:head, f_livecheck_url)).to eq(head_url)
+      expect(livecheck.livecheck_url_to_string(:homepage, f_livecheck_url)).to eq(homepage_url)
+      expect(livecheck.livecheck_url_to_string(:homepage, c_livecheck_url)).to eq(homepage_url)
+      expect(livecheck.livecheck_url_to_string(:stable, f_livecheck_url)).to eq(stable_url)
+      expect(livecheck.livecheck_url_to_string(:url, c_livecheck_url)).to eq(cask_url)
     end
 
     it "returns nil when not given a string or valid symbol" do

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -12,7 +12,7 @@ describe Requirement do
   let(:klass) { Class.new(described_class) }
 
   describe "#tags" do
-    subject { described_class.new(tags) }
+    subject { klass.new(tags) }
 
     context "with a single tag" do
       let(:tags) { ["bar"] }
@@ -149,7 +149,7 @@ describe Requirement do
 
   describe "#build?" do
     context "when the :build tag is specified" do
-      subject { described_class.new([:build]) }
+      subject { klass.new([:build]) }
 
       it { is_expected.to be_a_build_requirement }
     end
@@ -186,24 +186,24 @@ describe Requirement do
   end
 
   describe "#eql? and #==" do
-    subject(:requirement) { described_class.new }
+    subject(:requirement) { klass.new }
 
     it "returns true if the names and tags are equal" do
-      other = described_class.new
+      other = klass.new
 
       expect(requirement).to eql(other)
       expect(requirement).to eq(other)
     end
 
     it "returns false if names differ" do
-      other = described_class.new
+      other = klass.new
       allow(other).to receive(:name).and_return("foo")
       expect(requirement).not_to eql(other)
       expect(requirement).not_to eq(other)
     end
 
     it "returns false if tags differ" do
-      other = described_class.new([:optional])
+      other = klass.new([:optional])
 
       expect(requirement).not_to eql(other)
       expect(requirement).not_to eq(other)
@@ -211,21 +211,21 @@ describe Requirement do
   end
 
   describe "#hash" do
-    subject(:requirement) { described_class.new }
+    subject(:requirement) { klass.new }
 
     it "is equal if names and tags are equal" do
-      other = described_class.new
+      other = klass.new
       expect(requirement.hash).to eq(other.hash)
     end
 
     it "differs if names differ" do
-      other = described_class.new
+      other = klass.new
       allow(other).to receive(:name).and_return("foo")
       expect(requirement.hash).not_to eq(other.hash)
     end
 
     it "differs if tags differ" do
-      other = described_class.new([:optional])
+      other = klass.new([:optional])
       expect(requirement.hash).not_to eq(other.hash)
     end
   end

--- a/Library/Homebrew/test/requirements_spec.rb
+++ b/Library/Homebrew/test/requirements_spec.rb
@@ -12,7 +12,8 @@ describe Requirements do
     end
 
     it "merges duplicate requirements" do
-      requirements << Requirement.new << Requirement.new
+      klass = Class.new(Requirement)
+      requirements << klass.new << klass.new
       expect(requirements.count).to eq(1)
     end
   end

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -66,10 +66,6 @@ describe Resource do
   end
 
   describe "#livecheck" do
-    it "returns nil if livecheck block is not set in resource" do
-      expect(resource.livecheck).to be_nil
-    end
-
     specify "when livecheck block is set" do
       expect(livecheck_resource.livecheck.url).to eq("https://brew.sh/test/releases")
       expect(livecheck_resource.livecheck.regex).to eq(/foo[._-]v?(\d+(?:\.\d+)+)\.t/i)

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -5,26 +5,28 @@ require "formula"
 require "service"
 
 describe Homebrew::Service do
-  let(:klass) do
-    Class.new(Formula) do
+  let(:name) { "formula_name" }
+
+  def stub_formula(&block)
+    formula(name) do
       url "https://brew.sh/test-1.0.tbz"
+
+      instance_eval(&block) if block
     end
   end
-  let(:name) { "formula_name" }
-  let(:path) { Formulary.core_path(name) }
-  let(:spec) { :stable }
-  let(:f) { klass.new(name, path, spec) }
 
   describe "#std_service_path_env" do
     it "returns valid std_service_path_env" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :immediate
-        environment_variables PATH: std_service_path_env
-        error_log_path var/"log/beanstalkd.error.log"
-        log_path var/"log/beanstalkd.log"
-        working_dir var
-        keep_alive true
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :immediate
+          environment_variables PATH: std_service_path_env
+          error_log_path var/"log/beanstalkd.error.log"
+          log_path var/"log/beanstalkd.log"
+          working_dir var
+          keep_alive true
+        end
       end
 
       path = f.service.std_service_path_env
@@ -34,9 +36,11 @@ describe Homebrew::Service do
 
   describe "#process_type" do
     it "throws for unexpected type" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        process_type :cow
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          process_type :cow
+        end
       end
 
       expect {
@@ -47,9 +51,11 @@ describe Homebrew::Service do
 
   describe "#keep_alive" do
     it "throws for unexpected keys" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        keep_alive test: "key"
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          keep_alive test: "key"
+        end
       end
 
       expect {
@@ -60,9 +66,11 @@ describe Homebrew::Service do
 
   describe "#run_type" do
     it "throws for unexpected type" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :cow
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :cow
+        end
       end
 
       expect {
@@ -73,9 +81,11 @@ describe Homebrew::Service do
 
   describe "#sockets" do
     it "throws for missing type" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        sockets "127.0.0.1:80"
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          sockets "127.0.0.1:80"
+        end
       end
 
       expect {
@@ -84,9 +94,11 @@ describe Homebrew::Service do
     end
 
     it "throws for missing host" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        sockets "tcp://:80"
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          sockets "tcp://:80"
+        end
       end
 
       expect {
@@ -95,9 +107,11 @@ describe Homebrew::Service do
     end
 
     it "throws for missing port" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        sockets "tcp://127.0.0.1"
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          sockets "tcp://127.0.0.1"
+        end
       end
 
       expect {
@@ -108,14 +122,16 @@ describe Homebrew::Service do
 
   describe "#manual_command" do
     it "returns valid manual_command" do
-      f.class.service do
-        run "#{HOMEBREW_PREFIX}/bin/beanstalkd"
-        run_type :immediate
-        environment_variables PATH: std_service_path_env, ETC_DIR: etc/"beanstalkd"
-        error_log_path var/"log/beanstalkd.error.log"
-        log_path var/"log/beanstalkd.log"
-        working_dir var
-        keep_alive true
+      f = stub_formula do
+        service do
+          run "#{HOMEBREW_PREFIX}/bin/beanstalkd"
+          run_type :immediate
+          environment_variables PATH: std_service_path_env, ETC_DIR: etc/"beanstalkd"
+          error_log_path var/"log/beanstalkd.error.log"
+          log_path var/"log/beanstalkd.log"
+          working_dir var
+          keep_alive true
+        end
       end
 
       path = f.service.manual_command
@@ -123,14 +139,16 @@ describe Homebrew::Service do
     end
 
     it "returns valid manual_command without variables" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :immediate
-        environment_variables PATH: std_service_path_env
-        error_log_path var/"log/beanstalkd.error.log"
-        log_path var/"log/beanstalkd.log"
-        working_dir var
-        keep_alive true
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :immediate
+          environment_variables PATH: std_service_path_env
+          error_log_path var/"log/beanstalkd.error.log"
+          log_path var/"log/beanstalkd.log"
+          working_dir var
+          keep_alive true
+        end
       end
 
       path = f.service.manual_command
@@ -140,21 +158,23 @@ describe Homebrew::Service do
 
   describe "#to_plist" do
     it "returns valid plist" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        run_type :immediate
-        environment_variables PATH: std_service_path_env, FOO: "BAR", ETC_DIR: etc/"beanstalkd"
-        error_log_path var/"log/beanstalkd.error.log"
-        log_path var/"log/beanstalkd.log"
-        input_path var/"in/beanstalkd"
-        root_dir var
-        working_dir var
-        keep_alive true
-        launch_only_once true
-        process_type :interactive
-        restart_delay 30
-        interval 5
-        macos_legacy_timers true
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          run_type :immediate
+          environment_variables PATH: std_service_path_env, FOO: "BAR", ETC_DIR: etc/"beanstalkd"
+          error_log_path var/"log/beanstalkd.error.log"
+          log_path var/"log/beanstalkd.log"
+          input_path var/"in/beanstalkd"
+          root_dir var
+          working_dir var
+          keep_alive true
+          launch_only_once true
+          process_type :interactive
+          restart_delay 30
+          interval 5
+          macos_legacy_timers true
+        end
       end
 
       plist = f.service.to_plist
@@ -216,9 +236,11 @@ describe Homebrew::Service do
     end
 
     it "returns valid plist with socket" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        sockets "tcp://127.0.0.1:80"
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          sockets "tcp://127.0.0.1:80"
+        end
       end
 
       plist = f.service.to_plist
@@ -265,9 +287,11 @@ describe Homebrew::Service do
     end
 
     it "returns valid partial plist" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :immediate
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :immediate
+        end
       end
 
       plist = f.service.to_plist
@@ -299,10 +323,12 @@ describe Homebrew::Service do
     end
 
     it "returns valid interval plist" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :interval
-        interval 5
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :interval
+          interval 5
+        end
       end
 
       plist = f.service.to_plist
@@ -336,10 +362,12 @@ describe Homebrew::Service do
     end
 
     it "returns valid cron plist" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :cron
-        cron "@daily"
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :cron
+          cron "@daily"
+        end
       end
 
       plist = f.service.to_plist
@@ -378,9 +406,11 @@ describe Homebrew::Service do
     end
 
     it "returns valid keepalive-exit plist" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        keep_alive successful_exit: false
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          keep_alive successful_exit: false
+        end
       end
 
       plist = f.service.to_plist
@@ -417,9 +447,11 @@ describe Homebrew::Service do
     end
 
     it "returns valid keepalive-crashed plist" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        keep_alive crashed: true
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          keep_alive crashed: true
+        end
       end
 
       plist = f.service.to_plist
@@ -456,9 +488,11 @@ describe Homebrew::Service do
     end
 
     it "returns valid keepalive-path plist" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        keep_alive path: opt_pkgshare/"test-path"
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          keep_alive path: opt_pkgshare/"test-path"
+        end
       end
 
       plist = f.service.to_plist
@@ -497,19 +531,21 @@ describe Homebrew::Service do
 
   describe "#to_systemd_unit" do
     it "returns valid unit" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        run_type :immediate
-        environment_variables PATH: std_service_path_env, FOO: "BAR"
-        error_log_path var/"log/beanstalkd.error.log"
-        log_path var/"log/beanstalkd.log"
-        input_path var/"in/beanstalkd"
-        root_dir var
-        working_dir var
-        keep_alive true
-        process_type :interactive
-        restart_delay 30
-        macos_legacy_timers true
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          run_type :immediate
+          environment_variables PATH: std_service_path_env, FOO: "BAR"
+          error_log_path var/"log/beanstalkd.error.log"
+          log_path var/"log/beanstalkd.log"
+          input_path var/"in/beanstalkd"
+          root_dir var
+          working_dir var
+          keep_alive true
+          process_type :interactive
+          restart_delay 30
+          macos_legacy_timers true
+        end
       end
 
       unit = f.service.to_systemd_unit
@@ -538,10 +574,12 @@ describe Homebrew::Service do
     end
 
     it "returns valid partial oneshot unit" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :immediate
-        launch_only_once true
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :immediate
+          launch_only_once true
+        end
       end
 
       unit = f.service.to_systemd_unit
@@ -562,10 +600,12 @@ describe Homebrew::Service do
 
   describe "#to_systemd_timer" do
     it "returns valid timer" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        run_type :interval
-        interval 5
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          run_type :interval
+          interval 5
+        end
       end
 
       unit = f.service.to_systemd_timer
@@ -584,9 +624,11 @@ describe Homebrew::Service do
     end
 
     it "returns valid partial timer" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :immediate
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :immediate
+        end
       end
 
       unit = f.service.to_systemd_timer
@@ -604,10 +646,12 @@ describe Homebrew::Service do
     end
 
     it "throws on incomplete cron" do
-      f.class.service do
-        run opt_bin/"beanstalkd"
-        run_type :cron
-        cron "1 2 3 4"
+      f = stub_formula do
+        service do
+          run opt_bin/"beanstalkd"
+          run_type :cron
+          cron "1 2 3 4"
+        end
       end
 
       expect {
@@ -627,10 +671,12 @@ describe Homebrew::Service do
       }
 
       styles.each do |cron, calendar|
-        f.class.service do
-          run opt_bin/"beanstalkd"
-          run_type :cron
-          cron cron.to_s
+        f = stub_formula do
+          service do
+            run opt_bin/"beanstalkd"
+            run_type :cron
+            cron cron.to_s
+          end
         end
 
         unit = f.service.to_systemd_timer
@@ -653,18 +699,22 @@ describe Homebrew::Service do
 
   describe "#timed?" do
     it "returns false for immediate" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        run_type :immediate
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          run_type :immediate
+        end
       end
 
       expect(f.service.timed?).to be(false)
     end
 
     it "returns true for interval" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        run_type :interval
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          run_type :interval
+        end
       end
 
       expect(f.service.timed?).to be(true)
@@ -673,35 +723,43 @@ describe Homebrew::Service do
 
   describe "#keep_alive?" do
     it "returns true when keep_alive set to hash" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        keep_alive crashed: true
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          keep_alive crashed: true
+        end
       end
 
       expect(f.service.keep_alive?).to be(true)
     end
 
     it "returns true when keep_alive set to true" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        keep_alive true
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          keep_alive true
+        end
       end
 
       expect(f.service.keep_alive?).to be(true)
     end
 
     it "returns false when keep_alive not set" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+        end
       end
 
       expect(f.service.keep_alive?).to be(false)
     end
 
     it "returns false when keep_alive set to false" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        keep_alive false
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          keep_alive false
+        end
       end
 
       expect(f.service.keep_alive?).to be(false)
@@ -710,9 +768,11 @@ describe Homebrew::Service do
 
   describe "#command" do
     it "returns @run data" do
-      f.class.service do
-        run [opt_bin/"beanstalkd", "test"]
-        run_type :immediate
+      f = stub_formula do
+        service do
+          run [opt_bin/"beanstalkd", "test"]
+          run_type :immediate
+        end
       end
 
       command = f.service.command

--- a/Library/Homebrew/test/support/fixtures/failball.rb
+++ b/Library/Homebrew/test/support/fixtures/failball.rb
@@ -4,11 +4,20 @@
 class Failball < Formula
   def initialize(name = "failball", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, force_bottle: false)
-    self.class.instance_eval do
-      stable.url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-      stable.sha256 TESTBALL_SHA256
-    end
     super
+  end
+
+  DSL_PROC = proc do
+    url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
+    sha256 TESTBALL_SHA256
+  end.freeze
+  private_constant :DSL_PROC
+
+  DSL_PROC.call
+
+  def self.inherited(other)
+    super
+    other.instance_eval(&DSL_PROC)
   end
 
   def install

--- a/Library/Homebrew/test/support/fixtures/testball.rb
+++ b/Library/Homebrew/test/support/fixtures/testball.rb
@@ -4,11 +4,20 @@
 class Testball < Formula
   def initialize(name = "testball", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, force_bottle: false)
-    self.class.instance_eval do
-      stable.url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-      stable.sha256 TESTBALL_SHA256
-    end
     super
+  end
+
+  DSL_PROC = proc do
+    url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
+    sha256 TESTBALL_SHA256
+  end.freeze
+  private_constant :DSL_PROC
+
+  DSL_PROC.call
+
+  def self.inherited(other)
+    super
+    other.instance_eval(&DSL_PROC)
   end
 
   def install

--- a/Library/Homebrew/test/support/fixtures/testball_bottle.rb
+++ b/Library/Homebrew/test/support/fixtures/testball_bottle.rb
@@ -4,16 +4,27 @@
 class TestballBottle < Formula
   def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, force_bottle: false)
-    self.class.instance_eval do
-      stable.url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-      stable.sha256 TESTBALL_SHA256
-      stable.bottle do
-        root_url "file://#{TEST_FIXTURE_DIR}/bottles"
-        sha256 cellar: :any_skip_relocation, Utils::Bottles.tag.to_sym => "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
-      end
-      cxxstdlib_check :skip
-    end
     super
+  end
+
+  DSL_PROC = proc do
+    url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
+    sha256 TESTBALL_SHA256
+
+    bottle do
+      root_url "file://#{TEST_FIXTURE_DIR}/bottles"
+      sha256 cellar: :any_skip_relocation, Utils::Bottles.tag.to_sym => "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
+    end
+
+    cxxstdlib_check :skip
+  end.freeze
+  private_constant :DSL_PROC
+
+  DSL_PROC.call
+
+  def self.inherited(other)
+    super
+    other.instance_eval(&DSL_PROC)
   end
 
   def install

--- a/Library/Homebrew/test/support/fixtures/testball_bottle_cellar.rb
+++ b/Library/Homebrew/test/support/fixtures/testball_bottle_cellar.rb
@@ -4,17 +4,27 @@
 class TestballBottleCellar < Formula
   def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable,
                  alias_path: nil, force_bottle: false)
-    self.class.instance_eval do
-      stable.url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-      stable.sha256 TESTBALL_SHA256
-      hexdigest = "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
-      stable.bottle do
-        root_url "file://#{TEST_FIXTURE_DIR}/bottles"
-        sha256 cellar: :any_skip_relocation, Utils::Bottles.tag.to_sym => hexdigest
-      end
-      cxxstdlib_check :skip
-    end
     super
+  end
+
+  DSL_PROC = proc do
+    url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
+    sha256 TESTBALL_SHA256
+
+    bottle do
+      root_url "file://#{TEST_FIXTURE_DIR}/bottles"
+      sha256 cellar: :any_skip_relocation, Utils::Bottles.tag.to_sym => "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
+    end
+
+    cxxstdlib_check :skip
+  end.freeze
+  private_constant :DSL_PROC
+
+  DSL_PROC.call
+
+  def self.inherited(other)
+    super
+    other.instance_eval(&DSL_PROC)
   end
 
   def install


### PR DESCRIPTION
This PR implements safety mechanisms to avoid hitting the unsupported behaviour of modifying a formula's definition (e.g. adding a dependency) after the first instance has been created. Note that you will still have the ability to do so if such changes are applied to only that particular instance of the formula (typically involving private API). Only changes to the global definition on the class-level is prevented, as those would have an undefined effect on existing instances.

Each commit can be separated into a separate PR, but the order matters as each commit depends on the previous one.

Details on each one, in reverse order:

* 22ccede2d8342f5fe9232f3e173bcfdae12c61bc - Freeze formula definition once first instance is created
  - What this does is call `self.class.freeze` at the begininning of `initialize`.
  - Since we want to prevent modification of `SoftwareSpec` etc too, I've made it propagate the freeze request down.
  - We already `dup` the `SoftwareSpec`s when create the instance, which means the spec stored at instance level will be unfrozen. I've added code to also propagate the `dup` down too so everything on instance level is unfrozen and cannot propagate back up to the global definition.
  - A part of this involved moving lazily-initialized variables to a `self.inherited` method, which act's effectively like a class-level constructor.
* 7e825af24dd771cecced3f44ff413849f19cf47a - test: avoid improper, late usage of formula DSL
  - Fixes multiple tests that abused late formula modifications like `Formula["foo"].class.depends_on "bar"`, which this PR was aiming to prevent being possible
  - This contains some overlap with #13577, but the PRs merged in any order.
* 39a83ee256cab12c52e37519d00884d5ad74cf41 - formula: require instances to use a subclass
  - Because I'm using `self.inherited`, some variables are no longer initialised on the Formula base class. Calling `Formula.new` on this base class never really worked anyway since it doesn't make sense so I made it an explicit error when this action is performed.
* df949859c24ea6e1898a2579b8a00fd4917bc687 - requirement: require instances to use a subclass
  - Apply the same logic to Requirement so I can share the logic of `BuildEnvironment::DSL` better.
  - This technically worked without errors before - but it didn't make any sense since the requirement would have no `satisfy` conidition so it was a no-op requirement.
* fe87f36ae645311acfe99764492a3ee9058df61b - cask_dependent: fix incorrect requirement logic
  - The change requiring Requirement instances to use a subclass revealed a bug: the logic in `CaskDependent` was incorrect in a few ways (e.g. it displayed "x86_64" for a formula requiring arm64).
* 0a780b94489fa9feadd7f7f9a60ce4403b0e8c97 - requirement: improve name detection of anonymous subclasses
  - There's logic to use the required cask name if the requirement itself doesn't have a name. But this never ever got used because it would prioritise a `class.to_s` which is typically not human-readable.
  - This name is in `brew deps --include-requirements`