### PR TITLE
Include dsl key in cask artifact hash

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require "active_support/core_ext/object/deep_dup"
+
 module Cask
   module Artifact
     # Abstract superclass for all artifacts.
@@ -127,8 +129,9 @@ module Cask
 
       attr_reader :cask
 
-      def initialize(cask)
+      def initialize(cask, *dsl_args)
         @cask = cask
+        @dsl_args = dsl_args.deep_dup
       end
 
       def config
@@ -138,6 +141,10 @@ module Cask
       sig { returns(String) }
       def to_s
         "#{summarize} (#{self.class.english_name})"
+      end
+
+      def to_args
+        @dsl_args.reject(&:blank?)
       end
     end
   end

--- a/Library/Homebrew/cask/artifact/abstract_flight_block.rb
+++ b/Library/Homebrew/cask/artifact/abstract_flight_block.rb
@@ -32,6 +32,10 @@ module Cask
         abstract_phase(self.class.uninstall_dsl_key)
       end
 
+      def summarize
+        directives.keys.map(&:to_s).join(", ")
+      end
+
       private
 
       def class_for_dsl_key(dsl_key)
@@ -43,10 +47,6 @@ module Cask
         return if (block = directives[dsl_key]).nil?
 
         class_for_dsl_key(dsl_key).new(cask).instance_eval(&block)
-      end
-
-      def summarize
-        directives.keys.map(&:to_s).join(", ")
       end
     end
   end

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -40,7 +40,7 @@ module Cask
       def initialize(cask, directives)
         directives.assert_valid_keys!(*ORDERED_DIRECTIVES)
 
-        super(cask)
+        super(cask, **directives)
         directives[:signal] = Array(directives[:signal]).flatten.each_slice(2).to_a
         @directives = directives
 

--- a/Library/Homebrew/cask/artifact/installer.rb
+++ b/Library/Homebrew/cask/artifact/installer.rb
@@ -72,7 +72,7 @@ module Cask
       attr_reader :path, :args
 
       def initialize(cask, **args)
-        super(cask)
+        super(cask, **args)
 
         if args.key?(:manual)
           @path = Pathname(args[:manual])

--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -23,7 +23,7 @@ module Cask
       end
 
       def initialize(cask, path, **stanza_options)
-        super(cask)
+        super(cask, path, **stanza_options)
         @path = cask.staged_path.join(path)
         @stanza_options = stanza_options
       end

--- a/Library/Homebrew/cask/artifact/relocated.rb
+++ b/Library/Homebrew/cask/artifact/relocated.rb
@@ -42,12 +42,13 @@ module Cask
       attr_reader :source, :target
 
       sig {
-        params(cask: Cask, source: T.nilable(T.any(String, Pathname)), target: T.nilable(T.any(String, Pathname)))
+        params(cask: Cask, source: T.nilable(T.any(String, Pathname)), target_hash: String)
           .void
       }
-      def initialize(cask, source, target: nil)
-        super(cask)
+      def initialize(cask, source, **target_hash)
+        super(cask, source, **target_hash)
 
+        target = target_hash[:target]
         @source_string = source.to_s
         @target_string = target.to_s
         source = cask.staged_path.join(source)

--- a/Library/Homebrew/cask/artifact/stage_only.rb
+++ b/Library/Homebrew/cask/artifact/stage_only.rb
@@ -14,7 +14,7 @@ module Cask
       def self.from_args(cask, *args)
         raise CaskInvalidError.new(cask.token, "'stage_only' takes only a single argument: true") if args != [true]
 
-        new(cask)
+        new(cask, true)
       end
 
       sig { returns(T::Array[T::Boolean]) }

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -235,7 +235,7 @@ module Cask
         "installed"      => versions.last,
         "outdated"       => outdated?,
         "sha256"         => sha256,
-        "artifacts"      => artifacts.map(&method(:to_h_gsubs)),
+        "artifacts"      => artifacts_list,
         "caveats"        => (to_h_string_gsubs(caveats) unless caveats.empty?),
         "depends_on"     => depends_on,
         "conflicts_with" => conflicts_with,
@@ -280,6 +280,19 @@ module Cask
     end
 
     private
+
+    def artifacts_list
+      artifacts.map do |artifact|
+        if artifact.is_a? Artifact::AbstractFlightBlock
+          { type: artifact.summarize }
+        else
+          {
+            type: artifact.class.dsl_key,
+            args: to_h_gsubs(artifact.to_args),
+          }
+        end
+      end
+    end
 
     def to_h_string_gsubs(string)
       string.to_s

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -283,14 +283,13 @@ module Cask
 
     def artifacts_list
       artifacts.map do |artifact|
-        if artifact.is_a? Artifact::AbstractFlightBlock
-          { type: artifact.summarize }
+        key, value = if artifact.is_a? Artifact::AbstractFlightBlock
+          artifact.summarize
         else
-          {
-            type: artifact.class.dsl_key,
-            args: to_h_gsubs(artifact.to_args),
-          }
+          [artifact.class.dsl_key, to_h_gsubs(artifact.to_args)]
         end
+
+        { key => value }
       end
     end
 

--- a/Library/Homebrew/test/cask/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/list_spec.rb
@@ -106,13 +106,19 @@ describe Cask::Cmd::List, :cask do
             "outdated": false,
             "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
             "artifacts": [
-              [
-                "Caffeine.app"
-              ],
               {
-                "trash": "$HOME/support/fixtures/cask/caffeine/org.example.caffeine.plist",
-                "signal": {
-                }
+                "type": "app",
+                "args": [
+                  "Caffeine.app"
+                ]
+              },
+              {
+                "type": "zap",
+                "args": [
+                  {
+                    "trash": "$HOME/support/fixtures/cask/caffeine/org.example.caffeine.plist"
+                  }
+                ]
               }
             ],
             "caveats": null,
@@ -140,9 +146,12 @@ describe Cask::Cmd::List, :cask do
             "outdated": false,
             "sha256": "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68",
             "artifacts": [
-              [
-                "Transmission.app"
-              ]
+              {
+                "type": "app",
+                "args": [
+                  "Transmission.app"
+                ]
+              }
             ],
             "caveats": null,
             "depends_on": {
@@ -172,9 +181,12 @@ describe Cask::Cmd::List, :cask do
             "outdated": false,
             "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
             "artifacts": [
-              [
-                "Caffeine.app"
-              ]
+              {
+                "type": "app",
+                "args": [
+                  "Caffeine.app"
+                ]
+              }
             ],
             "caveats": null,
             "depends_on": {
@@ -201,9 +213,12 @@ describe Cask::Cmd::List, :cask do
             "outdated": false,
             "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b",
             "artifacts": [
-              [
-                "ThirdParty.app"
-              ]
+              {
+                "type": "app",
+                "args": [
+                  "ThirdParty.app"
+                ]
+              }
             ],
             "caveats": null,
             "depends_on": {

--- a/Library/Homebrew/test/cask/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/list_spec.rb
@@ -107,14 +107,12 @@ describe Cask::Cmd::List, :cask do
             "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
             "artifacts": [
               {
-                "type": "app",
-                "args": [
+                "app": [
                   "Caffeine.app"
                 ]
               },
               {
-                "type": "zap",
-                "args": [
+                "zap": [
                   {
                     "trash": "$HOME/support/fixtures/cask/caffeine/org.example.caffeine.plist"
                   }
@@ -147,8 +145,7 @@ describe Cask::Cmd::List, :cask do
             "sha256": "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68",
             "artifacts": [
               {
-                "type": "app",
-                "args": [
+                "app": [
                   "Transmission.app"
                 ]
               }
@@ -182,8 +179,7 @@ describe Cask::Cmd::List, :cask do
             "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
             "artifacts": [
               {
-                "type": "app",
-                "args": [
+                "app": [
                   "Caffeine.app"
                 ]
               }
@@ -214,8 +210,7 @@ describe Cask::Cmd::List, :cask do
             "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b",
             "artifacts": [
               {
-                "type": "app",
-                "args": [
+                "app": [
                   "ThirdParty.app"
                 ]
               }


### PR DESCRIPTION
In order to use the JSON API to load casks without having their files locally, we need to properly list the artifacts for each cask. Currently, the JSON data includes a poorly maintained list of artifacts, but the entries aren't labeled and aren't always complete (e.g. for `installer` artifacts). This PR updates the `artifacts` JSON object so that every artifact item includes a `type` key that corresponds to the DSL key that was used to declare that artifact, and an `args` key that corresponds to a list of arguments that were passed to the artifact method. This will allow us to reconstruct the cask using only the JSON data.

Like with `post_install` in formulae, the various `preflight` and `postflight` blocks will not really be included in this hash since we have to way of encoding the arbitrary ruby code in the API. Instead, the `args` key is simply omitted and the cask loader will need to skip these stanzas when loading. This is something we can address in the future once we decide how to handle `post_install` and these blocks.

_Note: this is a breaking change to the API since I'm currently replacing the existing `artifacts` object with the new and improved version. I think this is okay because the current version isn't really that useful without knowing the DSL keys (in my opinion), but if we think it's better to keep the old version around for compatibility sake, this can be added with a different name._

---

As an example, here is the `artifacts` list before and after for [`vlc`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/vlc.rb):

<details><summary>Before</summary>
<pre>      "artifacts": [
        "preflight (Preflight Block)",
        [
          "VLC.app"
        ],
        [
          "$(brew --prefix)/Caskroom/vlc/3.0.17.3/vlc.wrapper.sh",
          {
            "target": "vlc"
          }
        ],
        {
          "trash": [
            "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*",
            "~/Library/Application Support/org.videolan.vlc",
            "~/Library/Application Support/VLC",
            "~/Library/Caches/org.videolan.vlc",
            "~/Library/Preferences/org.videolan.vlc",
            "~/Library/Preferences/org.videolan.vlc.plist",
            "~/Library/Saved Application State/org.videolan.vlc.savedState"
          ],
          "signal": {
          }
        }
      ],
</pre></details>

<details><summary>After</summary>
<pre>      "artifacts": [
        {
          "preflight": null
        },
        {
          "app": [
            "VLC.app"
          ]
        },
        {
          "binary": [
            "$(brew --prefix)/Caskroom/vlc/3.0.17.3/vlc.wrapper.sh",
            {
              "target": "vlc"
            }
          ]
        },
        {
          "zap": [
            {
              "trash": [
                "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/org.videolan.vlc.sfl*",
                "~/Library/Application Support/org.videolan.vlc",
                "~/Library/Application Support/VLC",
                "~/Library/Caches/org.videolan.vlc",
                "~/Library/Preferences/org.videolan.vlc",
                "~/Library/Preferences/org.videolan.vlc.plist",
                "~/Library/Saved Application State/org.videolan.vlc.savedState"
              ]
            }
          ]
        }
      ],
</pre></details>
