### PR TITLE
formula_auditor: require `--git` only if not `--strict` in `audit_gcc_dependency`

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -406,9 +406,8 @@ module Homebrew
     end
 
     def audit_gcc_dependency
-      return unless @git
       return unless @core_tap
-      return if !@strict && !formula.tap.git? # git log is required for non-strict audit
+      return if !@strict && !@git && !formula.tap.git? # git log is required for non-strict audit
       return unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
       return unless linux_only_gcc_dep?(formula)
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -407,7 +407,7 @@ module Homebrew
 
     def audit_gcc_dependency
       return unless @core_tap
-      return if !@strict && !@git && !formula.tap.git? # git log is required for non-strict audit
+      return if !@strict && !(@git && formula.tap.git?) # git log is required for non-strict audit
       return unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
       return unless linux_only_gcc_dep?(formula)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The Git log is required only when `--strict` is not passed. This check
should still run with one of `--strict` or `--git`, but currently
passing `--strict` also requires `--git` in order to run this check.

This will still not be done during `tap_syntax` jobs after this change.
