### PR TITLE
gcc_dep_if_needed: Install GCC if Glibc is too old

### DIFF
--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -12,7 +12,8 @@ class DependencyCollector
 
   sig { params(related_formula_names: T::Set[String]).returns(T.nilable(Dependency)) }
   def gcc_dep_if_needed(related_formula_names)
-    return unless DevelopmentTools.system_gcc_too_old?
+    # gcc is required for libgcc_s.so.1 if glibc or gcc are too old
+    return unless DevelopmentTools.build_system_too_old?
     return if building_global_dep_tree?
     return if related_formula_names.include?(GCC)
     return if global_dep_tree[GCC]&.intersect?(related_formula_names)


### PR DESCRIPTION
Brewed GCC is required for `libgcc_s.so.1` if either the host Glibc or GCC is too old.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- <https://github.com/Homebrew/brew/issues/13619>
