### PR TITLE
linux/diagnostic: fix `rpath` returning `nil`.

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -144,6 +144,7 @@ module Homebrew
         gcc_dependents = Formula.installed.select do |formula|
           next false unless formula.tap&.core_tap?
 
+          # FIXME: This includes formulae that have no runtime dependency on GCC.
           formula.recursive_dependencies.map(&:name).include? "gcc"
         rescue TapFormulaUnavailableError
           false
@@ -153,7 +154,7 @@ module Homebrew
         badly_linked = gcc_dependents.select do |dependent|
           keg = Keg.new(dependent.prefix)
           keg.binary_executable_or_library_files.any? do |binary|
-            paths = binary.rpath.split(":")
+            paths = binary.rpaths
             versioned_linkage = paths.any? { |path| path.match?(%r{lib/gcc/\d+$}) }
             unversioned_linkage = paths.any? { |path| path.match?(%r{lib/gcc/current$}) }
 

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -97,7 +97,7 @@ module ELFShim
   # An array of runtime search path entries, such as:
   # ["/lib", "/usr/lib", "/usr/local/lib"]
   def rpaths
-    rpath&.split(":").to_a
+    Array(rpath&.split(":"))
   end
 
   def interpreter

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -97,7 +97,7 @@ module ELFShim
   # An array of runtime search path entries, such as:
   # ["/lib", "/usr/lib", "/usr/local/lib"]
   def rpaths
-    rpath.split(":")
+    rpath&.split(":").to_a
   end
 
   def interpreter


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #13762.

There's still a bug in the GCC linkage check, but I'll need a bit more
time to work on a fix. This at least makes sure `brew doctor` will not
return the error in the issue linked above.
