### PR TITLE
shims/gems/rubocop: handle when `brew` isn't in PATH.

### DIFF
--- a/Library/Homebrew/shims/gems/rubocop
+++ b/Library/Homebrew/shims/gems/rubocop
@@ -1,2 +1,3 @@
 #!/bin/bash
-exec brew rubocop "$@"
+HOMEBREW_PREFIX_BIN="$(cd "$(dirname "$0")"/../../../../ && pwd)/bin/"
+exec "${HOMEBREW_PREFIX_BIN}"brew rubocop "$@"


### PR DESCRIPTION
Instead, figure out where `$HOMEBREW_PREFIX/bin` should be and use that.