### PR TITLE
cmd/deps: drop `--installed` requirement for `--formula`/`--cask`

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -61,10 +61,8 @@ module Homebrew
                           "for each provided <formula>, one formula per line. This is used for " \
                           "debugging the `--installed`/`--all` display mode."
       switch "--formula", "--formulae",
-             depends_on:  "--installed",
              description: "Treat all named arguments as formulae."
       switch "--cask", "--casks",
-             depends_on:  "--installed",
              description: "Treat all named arguments as casks."
 
       conflicts "--tree", "--graph"


### PR DESCRIPTION
It appears the requirement was originally imposed in #9414 because only the `--installed` logic checked for `--formula` or `--cask`. But with the addition of `named_args`, that check is done automatically. 

Fixes #13592.