### PR TITLE
utils: prefer BBEdit over TextWrangler

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -364,8 +364,8 @@ module Kernel
     editor = Homebrew::EnvConfig.editor
     return editor if editor
 
-    # Find Atom, Sublime Text, VS Code, Textmate, BBEdit / TextWrangler, or vim
-    editor = %w[atom subl code mate edit vim].find do |candidate|
+    # Find Atom, Sublime Text, VS Code, Textmate, BBEdit, or vim
+    editor = %w[atom subl code mate bbedit vim].find do |candidate|
       candidate if which(candidate, ORIGINAL_PATHS)
     end
     editor ||= "vim"


### PR DESCRIPTION
[TextWrangler](https://www.barebones.com/support/textwrangler/updates.html) has long since been relegated to the 32-bit dustbin, and its `edit` command has been replaced with [`bbedit`](https://www.barebones.com/products/bbedit/benefitscommand.html).