### PR TITLE
resource: determine version before freezing

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -239,13 +239,13 @@ class Resource
     @download_strategy = DownloadStrategyDetector.detect(url, using)
     @specs.merge!(specs)
     @downloader = nil
+    @version = detect_version(@version)
   end
 
   def version(val = nil)
-    @version ||= begin
-      version = detect_version(val)
-      version.null? ? nil : version
-    end
+    return @version if val.nil?
+
+    @version = detect_version(val)
   end
 
   def mirror(val)
@@ -266,15 +266,15 @@ class Resource
   private
 
   def detect_version(val)
-    return Version::NULL if val.nil? && url.nil?
-
-    case val
-    when nil     then Version.detect(url, **specs)
+    version = case val
+    when nil     then url.nil? ? Version::NULL : Version.detect(url, **specs)
     when String  then Version.create(val)
     when Version then val
     else
       raise TypeError, "version '#{val.inspect}' should be a string"
     end
+
+    version.null? ? nil : version
   end
 
   # A resource containing a Go package.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -354,7 +354,7 @@ class Bottle
     @cellar = tag_spec.cellar
     @rebuild = spec.rebuild
 
-    @resource.version = formula.pkg_version
+    @resource.version = formula.pkg_version.to_s
     @resource.checksum = tag_spec.checksum
 
     @fetch_tab_retried = false


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/pull/109417

Previously the `version` variable was lazily set. Now it'll be set when either `url` or `version` is set.