### PR TITLE
Improve `brew update` with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -33,7 +33,7 @@ module Homebrew
             if cached_formula_json_file.exist? && !cached_formula_json_file.empty?
               curl_args.prepend("--time-cond", cached_formula_json_file)
             end
-            curl_download(*curl_args, to: HOMEBREW_CACHE_API/"#{formula_api_path}.json", max_time: 5)
+            curl_download(*curl_args, to: cached_formula_json_file, max_time: 5)
 
             json_formulae = JSON.parse(cached_formula_json_file.read)
 

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -547,7 +547,7 @@ EOS
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
     if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
-       [[ -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
+       [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ]]
     then
       continue
@@ -705,6 +705,7 @@ EOS
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
     if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
+       [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ||
           "${DIR}" == "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" ]]
     then
@@ -748,11 +749,11 @@ EOS
   if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]]
   then
     mkdir -p "${HOMEBREW_CACHE}/api"
-    # TODO: use --header If-Modified-Since
     curl \
       "${CURL_DISABLE_CURLRC_ARGS[@]}" \
       --fail --compressed --silent --max-time 5 \
       --location --remote-time --output "${HOMEBREW_CACHE}/api/formula.json" \
+      --time-cond "${HOMEBREW_CACHE}/api/formula.json" \
       --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
       "https://formulae.brew.sh/api/formula.json"
     # TODO: we probably want to print an error if this fails.


### PR DESCRIPTION
This PR modifies some `brew update` related logic to work better with `HOMEBREW_INSTALL_FROM_API`. Currently, if you have `HOMEBREW_INSTALL_FROM_API` set, `brew update` will never update the core and cask taps. We want this to remain, but also want a way for developers to continue maintaining homebrew/core and homebrew/cask. So, this PR modifies `brew update` so that it _does_ update the core and cask taps when someone with `HOMEBREW_DEVELOPER` set runs `brew update`. As before. `brew update --auto-update` will not update the core and cask taps.

Additionally, I updated the call in `brew update` that updates the cached formula JSON file so that it uses `--time-cond` like we do in `Homebrew::API::Formula.all_formulae` to avoid unnecessary downloading when the file hasn't changed.

Finally, I made a small change to `Homebrew::API::Formula.all_formulae` to remove a duplicated file path.
