### PR TITLE
linux/linkage_checker: remove `gcc` from `undeclared_deps`

### DIFF
--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -80,5 +80,7 @@ class LinkageChecker
     @unwanted_system_dylibs = @system_dylibs.reject do |s|
       SYSTEM_LIBRARY_ALLOWLIST.include? File.basename(s)
     end
+
+    @undeclared_deps.delete("gcc")
   end
 end

--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -81,6 +81,13 @@ class LinkageChecker
       SYSTEM_LIBRARY_ALLOWLIST.include? File.basename(s)
     end
 
+    # We build all formulae with an RPATH that includes the gcc formula's runtime lib directory.
+    # See: https://github.com/Homebrew/brew/blob/e689cc07/Library/Homebrew/extend/os/linux/extend/ENV/super.rb#L53
+    # This results in formulae showing linkage with gcc whenever it is installed, even if no dependency is declared.
+    # See discussions at:
+    #   https://github.com/Homebrew/brew/pull/13659
+    #   https://github.com/Homebrew/brew/pull/13796
+    # TODO: Find a nicer way to handle this. (e.g. examining the ELF file to determine the required libstdc++.)
     @undeclared_deps.delete("gcc")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is causing warnings all over Homebrew/homebrew-core.

For example, there are dozens of warnings about this in the following CI
run: https://github.com/Homebrew/homebrew-core/runs/8116257943?check_suite_focus=true
