### PR TITLE
generate_completions: fix `shell_parameter_format: :none`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1752,7 +1752,7 @@ class Formula
 
       popen_read_args = %w[]
       popen_read_args << commands
-      popen_read_args << shell_parameter unless shell_parameter.blank?
+      popen_read_args << shell_parameter if shell_parameter.present?
       popen_read_args.flatten!
 
       script_path.dirname.mkpath

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1752,7 +1752,7 @@ class Formula
 
       popen_read_args = %w[]
       popen_read_args << commands
-      popen_read_args << shell_parameter unless shell_parameter.nil?
+      popen_read_args << shell_parameter unless shell_parameter.blank?
       popen_read_args.flatten!
 
       script_path.dirname.mkpath

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1745,14 +1745,14 @@ class Formula
       elsif shell_parameter_format == :arg
         "--shell=#{shell}"
       elsif shell_parameter_format == :none
-        ""
+        nil
       else
         "#{shell_parameter_format}#{shell}"
       end
 
       popen_read_args = %w[]
       popen_read_args << commands
-      popen_read_args << shell_parameter
+      popen_read_args << shell_parameter unless shell_parameter.nil?
       popen_read_args.flatten!
 
       script_path.dirname.mkpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Followup to #13536 

Fixes the error seen in https://github.com/Homebrew/homebrew-core/pull/109486.
Some binaries apparently don't react well to an extra empty `''` appended to their invocation, so let's not pass that in the case of `shell_parameter_format: :none`.

(@Rylan12)