### PR TITLE
Ignore renamed formulae when checking for unversioned formulae

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -52,14 +52,16 @@ module Homebrew
 
     def audit_file
       if formula.core_formula? && @versioned_formula
+        unversioned_name = formula.name.gsub(/@.*$/, "")
+
+        # ignore when an unversioned formula doesn't exist after an explicit rename
+        return if formula.tap.formula_renames.key?(unversioned_name)
+
+        # build this ourselves as we want e.g. homebrew/core to be present
+        full_name = "#{formula.tap}/#{unversioned_name}"
+
         unversioned_formula = begin
-          # build this ourselves as we want e.g. homebrew/core to be present
-          full_name = if formula.tap
-            "#{formula.tap}/#{formula.name}"
-          else
-            formula.name
-          end
-          Formulary.factory(full_name.gsub(/@.*$/, "")).path
+          Formulary.factory(full_name).path
         rescue FormulaUnavailableError, TapFormulaAmbiguityError,
                TapFormulaWithOldnameAmbiguityError
           Pathname.new formula.path.to_s.gsub(/@.*\.rb$/, ".rb")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This fixes #13772.

There is an audit for versioned formulae that makes sure an unversioned formula of the same name exists already. This ignores that check when we explicitly removed the unversioned formula by checking if it was renamed first.

Also, there is no need to check for `formula.tap` because `formula.core_formula?` guarantees the presence of `formula.tap`.