### PR TITLE
Ignore duplicate warning messages

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -142,8 +142,10 @@ module Kernel
 
   # Print a message prefixed with "Warning" (do this rarely).
   def opoo(message)
+    return unless (warning_msg = Formatter.warning(message, label: "Warning"))
+
     Tty.with($stderr) do |stderr|
-      stderr.puts Formatter.warning(message, label: "Warning")
+      stderr.puts warning_msg
     end
   end
 

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -29,7 +29,12 @@ module Formatter
     label(label, string, :green)
   end
 
+  # Ignores duplicate warning messages
   def warning(string, label: nil)
+    @warning_cache ||= Set.new
+    return if @warning_cache.include?(string)
+
+    @warning_cache.add(string)
     label(label, string, :yellow)
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This just caches error messages so they only show up once in the output. I honestly couldn't think of an instance where duplicate warning messages would be helpful to the user. This is tangentially related to #13772 where some duplicate warning messages showed up.

There is probably a more elegant solution to this but I couldn't figure out how to add it to the `opoo` method directly so I decided to add the cache to `Formatter#warning` which works fine.