### PR TITLE
dev-cmd/pr-pull: avoid expensive search API calls

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -15,19 +15,19 @@ describe GitHub do
     end
   end
 
-  describe "::query_string" do
+  describe "::search_query_string" do
     it "builds a query with the given hash parameters formatted as key:value" do
-      query = described_class.query_string(user: "Homebrew", repo: "brew")
+      query = described_class.search_query_string(user: "Homebrew", repo: "brew")
       expect(query).to eq("q=user%3AHomebrew+repo%3Abrew&per_page=100")
     end
 
     it "adds a variable number of top-level string parameters to the query when provided" do
-      query = described_class.query_string("value1", "value2", user: "Homebrew")
+      query = described_class.search_query_string("value1", "value2", user: "Homebrew")
       expect(query).to eq("q=value1+value2+user%3AHomebrew&per_page=100")
     end
 
     it "turns array values into multiple key:value parameters" do
-      query = described_class.query_string(user: ["Homebrew", "caskroom"])
+      query = described_class.search_query_string(user: ["Homebrew", "caskroom"])
       expect(query).to eq("q=user%3AHomebrew+user%3Acaskroom&per_page=100")
     end
   end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -30,6 +30,12 @@ module GitHub
     API.open_rest(url_to("repos", repo, "check-runs"), data: data)
   end
 
+  def issues(repo:, **filters)
+    uri = url_to("repos", repo, "issues")
+    uri.query = URI.encode_www_form(filters)
+    API.open_rest(uri)
+  end
+
   def search_issues(query, **qualifiers)
     search("issues", query, **qualifiers)
   end
@@ -153,7 +159,7 @@ module GitHub
     API.open_rest(uri) { |json| json["private"] }
   end
 
-  def query_string(*main_params, **qualifiers)
+  def search_query_string(*main_params, **qualifiers)
     params = main_params
 
     params += qualifiers.flat_map do |key, value|
@@ -169,7 +175,7 @@ module GitHub
 
   def search(entity, *queries, **qualifiers)
     uri = url_to "search", entity
-    uri.query = query_string(*queries, **qualifiers)
+    uri.query = search_query_string(*queries, **qualifiers)
     API.open_rest(uri) { |json| json.fetch("items", []) }
   end
 


### PR DESCRIPTION
The search API has a rate limit of 30 per minute. This is far too small for something invoked on every merge in both Homebrew/core and Homebrew/cask.

Instead let's not use the search API at all and use the Issues REST API.

As a bonus: add a check to avoid an unnecessary `GitHub.get_pull_request_changed_files` REST API call when there is no long PRs to check.