### PR TITLE
cask/audit: skip code signing check when the cask depends on intel

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -496,7 +496,13 @@ module Cask
           message = "Signature verification failed:\n#{result.merged_output}\nmacOS on ARM requires applications " \
                     "to be signed. Please contact the upstream developer to let them know they should "
 
-          message += if result.stderr.include?("not signed at all")
+          not_signed = result.stderr.include?("not signed at all")
+
+          depends_on_intel = cask.depends_on.arch&.any? { |arch| arch[:type] == :intel }
+
+          next if not_signed && depends_on_intel
+
+          message += if not_signed
             "sign their app."
           else
             "fix the signature of their app."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

 code signing is not required on intel to run executable.
