### PR TITLE
fix: hide *-config warnings for directories or non-exectuable files

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -504,7 +504,9 @@ module Homebrew
           realpath = Pathname.new(p).realpath.to_s
           next if realpath.start_with?(real_cellar.to_s, HOMEBREW_CELLAR.to_s)
 
-          scripts += Dir.chdir(p) { Dir["*-config"] }.map { |c| File.join(p, c) }
+          scripts += Dir.chdir(p) { Dir["*-config"] }
+                        .map { |c| File.join(p, c) }
+                        .select { |f| File.file?(f) && File.executable?(f) }
         end
 
         return if scripts.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When I run `brew install pkg-config` on Ventura it creates a directory `/opt/homebrew/opt/pkg-config` which shows this `brew doctor` warning:

```
Warning: "config" scripts exist outside your system or Homebrew directories.
`./configure` scripts often look for *-config scripts to determine if
software packages are installed, and which additional flags to use when
compiling and linking.

Having additional scripts in your path can confuse software installed via
Homebrew if the config script overrides a system or Homebrew-provided
script of the same name. We found the following "config" scripts:
  /opt/homebrew/opt/pkg-config
```

As I mentioned though: that file isn't a script, it's a directory. I added a filter to not report directories or non-executable files in the `check_for_config_scripts` diagnostic.