### PR TITLE
Allow developers to use dev commands and `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -86,7 +86,8 @@ begin
   end
 
   if internal_cmd || Commands.external_ruby_v2_cmd_path(cmd)
-    if Commands::INSTALL_FROM_API_FORBIDDEN_COMMANDS.include?(cmd) && Homebrew::EnvConfig.install_from_api?
+    if Commands::INSTALL_FROM_API_FORBIDDEN_COMMANDS.include?(cmd) &&
+       Homebrew::EnvConfig.install_from_api? && !Homebrew::EnvConfig.developer?
       odie "This command cannot be run while HOMEBREW_INSTALL_FROM_API is set!"
     end
 


### PR DESCRIPTION
See https://github.com/Homebrew/brew/issues/13794

This PR updates `brew.rb` so that users who have set `HOMEBREW_DEVELOPER` and `HOMEBREW_INSTALL_FROM_API` are allowed to run any developer command. This restriction was originally put in place to combat users trying to run commands that required homebrew/core to be installed without it installed (or with a super old version). However, now that `brew update` will keep homebrew/core up to date for developers, I think it's safe to remove for these people.
