### PR TITLE
Add messaging for `homebrew/ubuntu16.04:master` image deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,7 +174,16 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Build Docker image
-        run: docker build -t brew --build-arg=version=22.04 .
+        run: |
+          docker build -t brew --build-arg=version=22.04 \
+               --label org.opencontainers.image.created="$(date --rfc-3339=seconds --utc)" \
+               --label org.opencontainers.image.url="https://brew.sh" \
+               --label org.opencontainers.image.documentation="https://docs.brew.sh" \
+               --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}" \
+               --label org.opencontainers.image.revision="${GITHUB_SHA}" \
+               --label org.opencontainers.image.vendor="${GITHUB_REPOSITORY_OWNER}" \
+               --label org.opencontainers.image.licenses="BSD-2-Clause" \
+               .
 
       - name: Deploy the Docker image to GitHub Packages and Docker Hub
         if: github.ref == 'refs/heads/master'
@@ -187,6 +196,28 @@ jobs:
             docker login -u brewtestbot --password-stdin
           docker tag brew "homebrew/ubuntu22.04:master"
           docker push "homebrew/ubuntu22.04:master"
+
+      - name: Build deprecated 16.04 Docker image
+        run: |
+          echo "homebrew/ubuntu16.04:master is deprecated and will soon be retired. Use homebrew/ubuntu22.04:master or homebrew/ubuntu16.04 or homebrew/brew. For CI, homebrew/ubuntu22.04:master is recommended." > .docker-deprecate
+          docker build -t brew-deprecated --build-arg=version=16.04 \
+               --label org.opencontainers.image.created="$(date --rfc-3339=seconds --utc)" \
+               --label org.opencontainers.image.url="https://brew.sh" \
+               --label org.opencontainers.image.documentation="https://docs.brew.sh" \
+               --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}" \
+               --label org.opencontainers.image.revision="${GITHUB_SHA}" \
+               --label org.opencontainers.image.vendor="${GITHUB_REPOSITORY_OWNER}" \
+               --label org.opencontainers.image.licenses="BSD-2-Clause" \
+               --label org.opencontainers.image.support.end-of-support="2022-09-07T00:00:00Z" \
+               .
+
+      - name: Deploy the deprecated 16.04 Docker image to GitHub Packages and Docker Hub
+        if: github.ref == 'refs/heads/master'
+        run: |
+          docker tag brew-deprecated "ghcr.io/homebrew/ubuntu16.04:master"
+          docker push "ghcr.io/homebrew/ubuntu16.04:master"
+          docker tag brew-deprecated "homebrew/ubuntu16.04:master"
+          docker push "homebrew/ubuntu16.04:master"
 
   tests:
     name: ${{ matrix.name }}

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -359,6 +359,18 @@ fi
 ##### Now, do everything else (that may be a bit slower).
 #####
 
+# Docker image deprecation
+if [[ -f "${HOMEBREW_REPOSITORY}/.docker-deprecate" ]]
+then
+  DOCKER_DEPRECATION_MESSAGE="$(cat "${HOMEBREW_REPOSITORY}/.docker-deprecate")"
+  if [[ -n "${GITHUB_ACTIONS}" ]]
+  then
+    echo "::warning::${DOCKER_DEPRECATION_MESSAGE}" >&2
+  else
+    opoo "${DOCKER_DEPRECATION_MESSAGE}"
+  fi
+fi
+
 # USER isn't always set so provide a fall back for `brew` and subprocesses.
 export USER="${USER:-$(id -un)}"
 


### PR DESCRIPTION
Note that this is not a 3.6.0 blocker given it only applies on `master` pushes anyway.

I've not tested if printing to stderr breaks anything in `Homebrew/test-bot`. I hope not.

Closes https://github.com/Homebrew/brew/pull/13806 (added by @MikeMcQuaid)