### PR TITLE
linux/diagnostic: check `LD_LIBRARY_PATH` when `glibc` is installed.

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -168,6 +168,25 @@ module Homebrew
           are prone to breaking when GCC is updated. You should `brew reinstall` these formulae:
         EOS
       end
+
+      def check_ld_library_path
+        glibc = begin
+          Formula["glibc"]
+        rescue FormulaUnavailableError
+          nil
+        end
+        return unless glibc&.any_version_installed?
+
+        ld_library_paths = ENV["HOMEBREW_LD_LIBRARY_PATH"]&.split(":")
+        return if ld_library_paths.blank? || ld_library_paths.exclude?("#{HOMEBREW_PREFIX}/lib")
+
+        <<~EOS
+          Your LD_LIBRARY_PATH contains #{HOMEBREW_PREFIX}/lib.
+          This will break many things when `glibc` is installed.
+          You must unset LD_LIBRARY_PATH or adjust to to exclude
+          #{HOMEBREW_PREFIX}/lib.
+        EOS
+      end
     end
   end
 end

--- a/bin/brew
+++ b/bin/brew
@@ -84,7 +84,18 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
-for VAR in BAT_THEME BROWSER DISPLAY EDITOR NO_COLOR TMUX DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR
+PASSTHROUGH_VARS=(
+  BAT_THEME
+  BROWSER
+  DBUS_SESSION_BUS_ADDRESS
+  DISPLAY
+  EDITOR
+  LD_LIBRARY_PATH
+  NO_COLOR
+  TMUX
+  XDG_RUNTIME_DIR
+)
+for VAR in "${PASSTHROUGH_VARS[@]}"
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue
@@ -94,7 +105,7 @@ do
   [[ -n "${!VAR_NEW}" ]] && continue
   export "${VAR_NEW}"="${!VAR}"
 done
-unset VAR VAR_NEW
+unset VAR VAR_NEW PASSTHROUGH_VARS
 
 export HOMEBREW_BREW_FILE
 export HOMEBREW_PREFIX


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Adding `$HOMEBREW_PREFIX/lib` to `LD_LIBRARY_PATH` breaks many things
when `glibc` is installed, so let's make sure `brew doctor` complains
about it.

Closes Homebrew/homebrew-core#109893.
