### PR TITLE
Don't fallback to building from source with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1163,6 +1163,8 @@ class FormulaInstaller
 
     if pour_bottle?(output_warning: true)
       formula.fetch_bottle_tab
+    elsif Homebrew::EnvConfig.install_from_api?
+      odie "Unable to build #{formula.name} from source with HOMEBREW_INSTALL_FROM_API."
     else
       formula.fetch_patches
       formula.resources.each(&:fetch)


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/13824

We already block `--build-from-source` when installing with `HOMEBREW_INSTALL_FROM_API`, but a source install can still be triggered in certain cases (as seen in https://github.com/Homebrew/brew/issues/13824). As soon as we know that this is going to happen, let's fail with an appropriate error message.

Now:

```console
linuxbrew@7c5642691995:~/homebrew$ brew install gcc
Warning: Building glibc from source as the bottle needs:
- HOMEBREW_CELLAR: /home/linuxbrew/.linuxbrew/Cellar (yours is /home/linuxbrew/homebrew/Cellar)
- HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew (yours is /home/linuxbrew/homebrew)
Error: Unable to build glibc from source with HOMEBREW_INSTALL_FROM_API.
```