### PR TITLE
linkage_checker: ignore broken linkage with LLVM libc++.

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -311,9 +311,12 @@ class LinkageChecker
   def harmless_broken_link?(dylib)
     # libgcc_s_* is referenced by programs that use the Java Service Wrapper,
     # and is harmless on x86(_64) machines
+    # dyld will fall back to Apple libc++ if LLVM's is not available.
     [
       "/usr/lib/libgcc_s_ppc64.1.dylib",
       "/opt/local/lib/libgcc/libgcc_s.1.dylib",
+      # TODO: Report linkage with `/usr/lib/libc++.1.dylib` when this link is broken.
+      "#{HOMEBREW_PREFIX}/opt/llvm/lib/libc++.1.dylib",
     ].include?(dylib)
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When `dyld` is not able to find a library at its install name, it
attempts to find it inside its default search path.

This means that for libraries we ship that are also provided by the
system (e.g. `libc++`), `brew linkage` can fail even if the formula
still works (i.e. `brew test` succeeds).

Given this, it makes sense to attempt to `dlopen` the library first
before deciding the linkage is broken. This will be useful when we ship
Homebrew/homebrew-core#106925, which will move the install location of
`libc++`, causing `brew linkage` to fail for any formula that links with
that `libc++`.

Those formulae that link with LLVM's `libc++` will fall back to Apple's
`libc++`, which is why we see multiple `brew test`s succeed even when
`brew linkage` failed in the LLVM PR linked above.

This change helps avoid unnecessary source rebuilds for formulae that
link with LLVM's `libc++` after LLVM 15 ships.
