### PR TITLE
Create GCC and glibc symlinks after install is complete

### DIFF
--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -40,6 +40,12 @@ module Homebrew
       symlink_gcc_libs
     end
 
+    def global_post_install
+      generic_global_post_install
+      symlink_ld_so
+      symlink_gcc_libs
+    end
+
     def check_cpu
       return if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       return if Hardware::CPU.arm?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -775,6 +775,8 @@ class FormulaInstaller
 
     fix_dynamic_linkage(keg) if !@poured_bottle || !formula.bottle_specification.skip_relocation?
 
+    Homebrew::Install.global_post_install
+
     if build_bottle?
       ohai "Not running 'post_install' as we're building a bottle"
       puts "You can run it manually using:"

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -30,6 +30,10 @@ module Homebrew
       Diagnostic.checks(:build_from_source_checks, fatal: all_fatal)
     end
 
+    def global_post_install; end
+    alias generic_global_post_install global_post_install
+    module_function :generic_global_post_install
+
     def check_prefix
       if (Hardware::CPU.intel? || Hardware::CPU.in_rosetta2?) &&
          HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX


### PR DESCRIPTION
We should be creating these symlinks after these formulae are installed, and before we cache the linkage, instead of just before anything is installed. It is still worthwhile checking beforehand, just in case something has broken between `brew` invocations.

Fixes #13836.
