### PR TITLE
cask/artifact/relocated: widen type

### DIFF
--- a/Library/Homebrew/cask/artifact/relocated.rb
+++ b/Library/Homebrew/cask/artifact/relocated.rb
@@ -42,7 +42,7 @@ module Cask
       attr_reader :source, :target
 
       sig {
-        params(cask: Cask, source: T.nilable(T.any(String, Pathname)), target_hash: String)
+        params(cask: Cask, source: T.nilable(T.any(String, Pathname)), target_hash: T.any(String, Pathname))
           .void
       }
       def initialize(cask, source, **target_hash)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes the bug:

```console
% brew readall --eval-all homebrew/cask
Error: Invalid cask: /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/touchosc-editor.rb
Cask 'touchosc-editor' definition is invalid: invalid 'artifact' stanza: Parameter 'target': Expected type String, got type Pathname with value #<Pathname:/Users/jonchang/...upport/TouchOSCEditor/layouts>
Caller: /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10175/lib/types/private/methods/call_validation.rb:117
Definition: /opt/homebrew/Library/Homebrew/cask/artifact/relocated.rb:48
Error: Invalid cask: /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/ilya-birman-typography-layout.rb
Cask 'ilya-birman-typography-layout' definition is invalid: invalid 'artifact' stanza: Parameter 'target': Expected type String, got type Pathname with value #<Pathname:/Users/jonchang/...rman Typography Layout.bundle>
Caller: /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10175/lib/types/private/methods/call_validation.rb:117
Definition: /opt/homebrew/Library/Homebrew/cask/artifact/relocated.rb:48
```