### PR TITLE
Include `loaded_from_api` key in `Tab`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2704,6 +2704,10 @@ class Formula
       super
     end
 
+    # Whether this formula was loaded using the formulae.brew.sh API
+    # @private
+    attr_accessor :loaded_from_api
+
     # Whether this formula contains OS/arch-specific blocks
     # (e.g. `on_macos`, `on_arm`, `on_monterey :or_older`, `on_system :linux, macos: :big_sur_or_newer`).
     # @private

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1202,6 +1202,7 @@ class FormulaInstaller
     tab.unused_options = []
     tab.built_as_bottle = true
     tab.poured_from_bottle = true
+    tab.loaded_from_api = formula.class.loaded_from_api
     tab.installed_as_dependency = installed_as_dependency?
     tab.installed_on_request = installed_on_request?
     tab.time = Time.now.to_i

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -217,6 +217,7 @@ module Formulary
       end
     end
 
+    klass.loaded_from_api = true
     mod.const_set(class_s, klass)
 
     cache[:api] ||= {}

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -31,6 +31,7 @@ class Tab < OpenStruct
       "installed_as_dependency" => false,
       "installed_on_request"    => false,
       "poured_from_bottle"      => false,
+      "loaded_from_api"         => false,
       "time"                    => Time.now.to_i,
       "source_modified_time"    => formula.source_modified_time.to_i,
       "compiler"                => compiler,
@@ -189,6 +190,7 @@ class Tab < OpenStruct
       "installed_as_dependency" => false,
       "installed_on_request"    => false,
       "poured_from_bottle"      => false,
+      "loaded_from_api"         => false,
       "time"                    => nil,
       "source_modified_time"    => 0,
       "stdlib"                  => nil,
@@ -332,6 +334,7 @@ class Tab < OpenStruct
       "unused_options"          => unused_options.as_flags,
       "built_as_bottle"         => built_as_bottle,
       "poured_from_bottle"      => poured_from_bottle,
+      "loaded_from_api"         => loaded_from_api,
       "installed_as_dependency" => installed_as_dependency,
       "installed_on_request"    => installed_on_request,
       "changed_files"           => changed_files&.map(&:to_s),
@@ -384,6 +387,7 @@ class Tab < OpenStruct
       "Built from source"
     end
 
+    s << "using the formulae.brew.sh API" if loaded_from_api
     s << Time.at(time).strftime("on %Y-%m-%d at %H:%M:%S") if time
 
     unless used_options.empty?


### PR DESCRIPTION
This PR adds a `loaded_from_api` item to a formula's `Tab`. Whether the formula was loaded from the API or not is determined by checking the formula namespace to see if it starts with `FormulaNamespaceAPI` which would only be the case when loading from the API. This change will allow us to check whether formulae were installed from the API or not which could be helpful for debugging or other things like that.

I'd also like to note this for casks somehow too, but I'm not totally sure what the best way to do that is. Maybe put it in `config.json` somehow?
