### PR TITLE
diagnostic: improve cask quarantine messaging.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1049,11 +1049,11 @@ module Homebrew
         when :quarantine_available
           nil
         when :xattr_broken
-          "There's no working version of `xattr` on this system."
+          "No Cask quarantine support available: there's no working version of `xattr` on this system."
         when :no_swift
-          "Swift is not available on this system."
+          "No Cask quarantine support available: there's no available version of `swift` on this system."
         else
-          "Unknown support status"
+          "No Cask quarantine support available: unknown reason."
         end
       end
 


### PR DESCRIPTION
I'm now getting "Unknown support status" on 12.6 and it's not obvious at all what's outputting this and why.