### PR TITLE
use docs command instead of URL in `brew help`

### DIFF
--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -37,7 +37,7 @@ module Homebrew
         brew commands
         brew help [COMMAND]
         man brew
-        https://docs.brew.sh
+        brew docs
     EOS
     private_constant :HOMEBREW_HELP
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
use `brew docs` instead of the documentation URL in `brew help` because of https://github.com/Homebrew/brew/pull/13844/