### PR TITLE
resource: try to download from fast mirrors before resource URLs

### DIFF
--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -119,6 +119,27 @@ describe Resource do
     end
   end
 
+  describe "#fast_mirrors" do
+    it "is empty by defaults" do
+      expect(resource.fast_mirrors).to be_empty
+    end
+
+    it "returns an array of mirrors added with #fast_mirror" do
+      resource.fast_mirror("foo")
+      resource.fast_mirror("bar")
+      expect(resource.fast_mirrors).to eq(%w[foo bar])
+    end
+
+    it "downloads from the first fast mirror if any fast mirrors are given" do
+      strategy = Class.new(CurlDownloadStrategy)
+      resource.url("foo", using: strategy)
+      resource.fast_mirror("bar")
+      resource.fast_mirror("baz")
+      expect(resource.url).to eq("foo")
+      expect(resource.downloader.mirrors).to eq(%w[baz foo])
+    end
+  end
+
   describe "#mirrors" do
     it "is empty by defaults" do
       expect(resource.mirrors).to be_empty


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Resolves Homebrew/glibc-bootstrap#6

Support `fast_mirror` semantic in `resource` blocks. For example:

```ruby
resource "bootstrap-gcc" do
  url "https://github.com/Homebrew/glibc-bootstrap/releases/download/1.0.0/bootstrap-gcc-9.5.0.tar.gz"
  fast_mirror "${HOMEBREW_BOTTLE_DOMAIN}/homebrew/glibc-bootstrap/1.0.0/bootstrap-gcc-9.5.0.tar.gz"
  fast_mirror "${HOMEBREW_ARTIFACT_DOMAIN}/Homebrew/glibc-bootstrap/releases/download/1.0.0/bootstrap-gcc-9.5.0.tar.gz"
  fast_mirror "https://<hardcoded url>"
  mirror "https:/<hardcoded url>"
  sha256 "d549cf096864de5da77b4f068fab3741636206f3b7ace593b46a226d726f4538"
end
```

The word "fast“ means we should try it before `url`. For fast mirrors, we will:

1. Substitute the `${HOMEBREW_BOTTLE_DOMAIN}` and `${HOMEBREW_ARTIFACT_DOMAIN}` in the URL to the corresponding environment variables (curly brackets are optional). If the environment variable is not set or set to the default value, the fast mirror will be ignored.
2. The downloader will try to download from the fast mirror if any is present. The original `url` will treat as a fallback mirror. The priority of the URLs:
    1. `fast_mirrors` if any
    2. `url`
    4. `mirrors` if any
3. Only `CurlDownloadStrategy` will use `fast_mirrors`.