### PR TITLE
Load formulae from their aliases using the API

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -26,7 +26,7 @@ module Homebrew
           Homebrew::API.fetch "#{formula_api_path}/#{name}.json"
         end
 
-        sig { returns(Array) }
+        sig { returns(Hash) }
         def all_formulae
           @all_formulae ||= begin
             curl_args = %w[--compressed --silent https://formulae.brew.sh/api/formula.json]
@@ -37,10 +37,22 @@ module Homebrew
 
             json_formulae = JSON.parse(cached_formula_json_file.read)
 
+            @all_aliases = {}
             json_formulae.to_h do |json_formula|
+              json_formula["aliases"].each do |alias_name|
+                @all_aliases[alias_name] = json_formula["name"]
+              end
+
               [json_formula["name"], json_formula.except("name")]
             end
           end
+        end
+
+        sig { returns(Hash) }
+        def all_aliases
+          all_formulae if @all_aliases.blank?
+
+          @all_aliases
         end
       end
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1165,7 +1165,7 @@ class FormulaInstaller
 
     if pour_bottle?(output_warning: true)
       formula.fetch_bottle_tab
-    elsif Homebrew::EnvConfig.install_from_api?
+    elsif formula.core_formula? && Homebrew::EnvConfig.install_from_api?
       odie "Unable to build #{formula.name} from source with HOMEBREW_INSTALL_FROM_API."
     else
       formula.fetch_patches

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -529,6 +529,14 @@ module Formulary
     end
   end
 
+  # Load aliases from the API.
+  class AliasAPILoader < FormulaAPILoader
+    def initialize(alias_name)
+      super Homebrew::API::Formula.all_aliases[alias_name]
+      @alias_path = Formulary.core_alias_path(alias_name).to_s
+    end
+  end
+
   # Return a {Formula} instance for the given reference.
   # `ref` is a string containing:
   #
@@ -655,6 +663,7 @@ module Formulary
       if ref.start_with?("homebrew/core/") && Homebrew::EnvConfig.install_from_api?
         name = ref.split("/", 3).last
         return FormulaAPILoader.new(name) if Homebrew::API::Formula.all_formulae.key?(name)
+        return AliasAPILoader.new(name) if Homebrew::API::Formula.all_aliases.key?(name)
       end
 
       return TapLoader.new(ref, from: from)
@@ -662,14 +671,15 @@ module Formulary
 
     return FromPathLoader.new(ref) if File.extname(ref) == ".rb" && Pathname.new(ref).expand_path.exist?
 
-    if Homebrew::EnvConfig.install_from_api? && Homebrew::API::Formula.all_formulae.key?(ref)
-      return FormulaAPILoader.new(ref)
+    if Homebrew::EnvConfig.install_from_api?
+      return FormulaAPILoader.new(ref) if Homebrew::API::Formula.all_formulae.key?(ref)
+      return AliasAPILoader.new(ref) if Homebrew::API::Formula.all_aliases.key?(ref)
     end
 
     formula_with_that_name = core_path(ref)
     return FormulaLoader.new(ref, formula_with_that_name) if formula_with_that_name.file?
 
-    possible_alias = CoreTap.instance.alias_dir/ref
+    possible_alias = core_alias_path(ref)
     return AliasLoader.new(possible_alias) if possible_alias.file?
 
     possible_tap_formulae = tap_paths(ref)
@@ -703,6 +713,10 @@ module Formulary
 
   def self.core_path(name)
     CoreTap.instance.formula_dir/"#{name.to_s.downcase}.rb"
+  end
+
+  def self.core_alias_path(name)
+    CoreTap.instance.alias_dir/name.to_s.downcase
   end
 
   def self.tap_paths(name, taps = Dir[HOMEBREW_LIBRARY/"Taps/*/*/"])


### PR DESCRIPTION
Closes https://github.com/Homebrew/brew/issues/13856

This PR modifies `Formulary` to handle loading formulae from their alias names via the API. Like the non-api method, I've added a separate `AliasAPILoader` to handle the additional steps that are necessary when loading from an alias.

In order for this to work best, I've added an `all_aliases` method to `API::Formula`. Since retrieving this information requires going through the entire collection of API formulae (including all of their data) I've linked this to `all_formulae`. So calling one of these methods will load both typical formulae and aliases into their respective instance variables, allowing us to cache both at the same time and eliminate the need to go through a second time.

Finally, this also fixes the issue @MikeMcQuaid reported in Slack where non-core formulae weren't allowed to build from source when trying to use the API.
