### PR TITLE
resource: automatic determine mirrors for `glibc-bootstrap` and PyPI resources

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -793,6 +793,9 @@ module Cask
       else
         host_uri.host
       end
+
+      return false if homepage.blank?
+
       home = homepage.downcase
       if (split_host = host.split(".")).length >= 3
         host = split_host[-2..].join(".")

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -318,6 +318,10 @@ module Homebrew
                      "outdated.",
         boolean:     true,
       },
+      HOMEBREW_PIP_INDEX_URL:                    {
+        description:  "If set, `brew install <formula>` will use this URL to download PyPI package resources.",
+        default_text: "`https://pypi.org/simple`.",
+      },
       HOMEBREW_PRY:                              {
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -294,6 +294,14 @@ class Resource
       end
     end
 
+    # PyPI packages: PEP 503 – Simple Repository API <https://peps.python.org/pep-0503>
+    if Homebrew::EnvConfig.pip_index_url.present?
+      pip_index_base_url = Homebrew::EnvConfig.pip_index_url.chomp("/").chomp("/simple")
+      %w[https://files.pythonhosted.org https://pypi.org].each do |base_url|
+        extra_urls << url.sub(base_url, pip_index_base_url) if url.start_with?("#{base_url}/packages")
+      end
+    end
+
     [*extra_urls, url, *mirrors].uniq
   end
 

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -2655,6 +2655,8 @@ module Homebrew::EnvConfig
 
   def self.no_proxy(); end
 
+  def self.pip_index_url(); end
+
   def self.pry?(); end
 
   def self.simulate_macos_on_linux?(); end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Alternative to #13868.

Resolves Homebrew/glibc-bootstrap#6
Closes #13868