### PR TITLE
bottles: use different tag for newer Linux CI.

### DIFF
--- a/Library/Homebrew/extend/os/bottles.rb
+++ b/Library/Homebrew/extend/os/bottles.rb
@@ -1,4 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "extend/os/mac/utils/bottles" if OS.mac?
+if OS.mac?
+  require "extend/os/mac/utils/bottles"
+elsif OS.linux?
+  require "extend/os/linux/utils/bottles"
+end

--- a/Library/Homebrew/extend/os/linux/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/linux/utils/bottles.rb
@@ -1,0 +1,35 @@
+# typed: true
+# frozen_string_literal: true
+
+module Utils
+  module Bottles
+    class << self
+      alias generic_tag tag
+      undef tag
+
+      def tag(symbol = nil)
+        return super(symbol) if symbol.present?
+
+        OS::LINUX_CI_OS_VERSION.downcase.delete(" .")
+      end
+    end
+
+    class Collector
+      private
+
+      alias generic_find_matching_tag find_matching_tag
+
+      def find_matching_tag(tag, no_older_versions: false)
+        # Used primarily by developers newer Linux bottles.
+        if no_older_versions ||
+           (Homebrew::EnvConfig.developer? &&
+            Homebrew::EnvConfig.skip_or_later_bottles?)
+          generic_find_matching_tag(tag)
+        else
+          generic_find_matching_tag(tag) ||
+            generic_find_matching_tag(generic_tag)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This should allow a new tag format while falling back gracefully to the old one.