### PR TITLE
Use GCC 12 for runtime libraries

### DIFF
--- a/Library/Homebrew/extend/os/linux/compilers.rb
+++ b/Library/Homebrew/extend/os/linux/compilers.rb
@@ -4,6 +4,6 @@
 class CompilerSelector
   sig { returns(String) }
   def self.preferred_gcc
-    OS::LINUX_PREFERRED_GCC_FORMULA
+    OS::LINUX_PREFERRED_GCC_COMPILER_FORMULA
   end
 end

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -34,7 +34,7 @@ class DependencyCollector
   private
 
   GLIBC = "glibc"
-  GCC = CompilerSelector.preferred_gcc.freeze
+  GCC = OS::LINUX_PREFERRED_GCC_RUNTIME_FORMULA
 
   sig { void }
   def init_global_dep_tree_if_needed!

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -33,6 +33,7 @@ class Formula
       dependency_collector = spec.dependency_collector
       related_formula_names = Set.new([
         name,
+        *aliases,
         *versioned_formulae_names,
       ])
       [

--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -20,7 +20,8 @@ module Homebrew
     ].freeze
     private_constant :DYNAMIC_LINKERS
 
-    GCC_VERSION_SUFFIX = OS::LINUX_GCC_CI_VERSION.delete_suffix(".0").freeze
+    PREFERRED_GCC_RUNTIME_VERSION = OS::LINUX_PREFERRED_GCC_RUNTIME_FORMULA.split("@").last.freeze
+    private_constant :PREFERRED_GCC_RUNTIME_VERSION
 
     # We link GCC runtime libraries that are not specificaly used for Fortran,
     # which are linked by the GCC formula.  We only use the versioned shared libraries
@@ -77,10 +78,10 @@ module Homebrew
     private_class_method :symlink_ld_so
 
     def symlink_gcc_libs
-      gcc_opt_prefix = HOMEBREW_PREFIX/"opt/#{OS::LINUX_PREFERRED_GCC_FORMULA}"
+      gcc_opt_prefix = HOMEBREW_PREFIX/"opt/#{OS::LINUX_PREFERRED_GCC_RUNTIME_FORMULA}"
 
       GCC_RUNTIME_LIBS.each do |library|
-        gcc_library = gcc_opt_prefix/"lib/gcc/#{GCC_VERSION_SUFFIX}/#{library}"
+        gcc_library = gcc_opt_prefix/"lib/gcc/#{PREFERRED_GCC_RUNTIME_VERSION}/#{library}"
         gcc_library_symlink = HOMEBREW_PREFIX/"lib/#{library}"
         # Skip if the link target doesn't exist.
         next unless gcc_library.readable?

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -50,7 +50,8 @@ module OS
   LINUX_GLIBC_CI_VERSION = "2.35"
   LINUX_GLIBC_NEXT_CI_VERSION = "2.35"
   LINUX_GCC_CI_VERSION = "11.0"
-  LINUX_PREFERRED_GCC_FORMULA = "gcc@11"
+  LINUX_PREFERRED_GCC_COMPILER_FORMULA = "gcc@11" # https://packages.ubuntu.com/jammy/gcc
+  LINUX_PREFERRED_GCC_RUNTIME_FORMULA = "gcc@12" # https://packages.ubuntu.com/jammy/libstdc++6
 
   if OS.mac?
     require "os/mac"


### PR DESCRIPTION
See Homebrew/homebrew-core#110917 for rationale. Ubuntu 22.04 ships with the GCC 11 compiler, but actually has GCC 12 runtime libraries, causing various formulae to fail under GCC 11 libraries when built using Ubuntu 22.04.

Really we should also change how we detect whether a system is "too old" to compare the runtime library rather than the compiler. With this change, we still don't install anything if the host is running GCC 11 runtime libraries, which isn't correct. The changes necessary to address that are larger however so I'd like to defer that change to 3.6.3 (that particular issue is pre-existing anyway).