### PR TITLE
extend/os/linux/system_config: support gcc 12 & keg-only glibc

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -28,7 +28,7 @@ module SystemConfig
     def formula_linked_version(formula)
       return "N/A" unless CoreTap.instance.installed?
 
-      Formulary.factory(formula).linked_version || "N/A"
+      Formulary.factory(formula).any_installed_version || "N/A"
     rescue FormulaUnavailableError
       "N/A"
     end
@@ -47,7 +47,7 @@ module SystemConfig
       out.puts "Host glibc: #{host_glibc_version}"
       out.puts "/usr/bin/gcc: #{host_gcc_version}"
       out.puts "/usr/bin/ruby: #{host_ruby_version}" if RUBY_PATH != HOST_RUBY_PATH
-      ["glibc", CompilerSelector.preferred_gcc, "xorg"].each do |f|
+      ["glibc", CompilerSelector.preferred_gcc, OS::LINUX_PREFERRED_GCC_RUNTIME_FORMULA, "xorg"].each do |f|
         out.puts "#{f}: #{formula_linked_version(f)}"
       end
     end


### PR DESCRIPTION
Otherwise we'll just see:

```
glibc: N/A
gcc@11: N/A
```