### PR TITLE
Separate test from runtime dependencies in `Formula#to_hash`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2070,6 +2070,10 @@ class Formula
       "dependencies"             => dependencies.reject(&:optional?)
                                                 .reject(&:recommended?)
                                                 .reject(&:build?)
+                                                .reject(&:test?)
+                                                .map(&:name)
+                                                .uniq,
+      "test_dependencies"        => dependencies.select(&:test?)
                                                 .map(&:name)
                                                 .uniq,
       "recommended_dependencies" => dependencies.select(&:recommended?)


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/13891

It turns out that we don't separate test dependencies from runtime dependencies in the fromula JSON API like we do for build and other types of dependencies. This means that there's no way to differentiate between test and runtime deps when loading a formula from the API. This PR adds a new `test_dependencies` element to the JSON API and moves the test dependencies there from the `dependencies` element.
