### PR TITLE
extend/ENV/std: ignore `fails_with` during `brew test`.

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -59,9 +59,9 @@ module Stdenv
 
     begin
       send(compiler)
-    rescue CompilerSelectionError => e
+    rescue CompilerSelectionError
       # We don't care if our compiler fails to build the formula during `brew test`.
-      raise e unless testing_formula
+      raise unless testing_formula
 
       send(DevelopmentTools.default_compiler)
     end

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -57,7 +57,14 @@ module Stdenv
     # Os is the default Apple uses for all its stuff so let's trust them
     define_cflags "-Os #{SAFE_CFLAGS_FLAGS}"
 
-    send(compiler)
+    begin
+      send(compiler)
+    rescue CompilerSelectionError => e
+      # We don't care if our compiler fails to build the formula during `brew test`.
+      raise e unless testing_formula
+
+      send(DevelopmentTools.default_compiler)
+    end
 
     return unless cc&.match?(GNU_GCC_REGEXP)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The compiler used to a build a formula is typically not needed during
the test.

This will allow us to get rid of some `:test` dependencies, which were
added to prevent `brew` from throwing a `CompilerSelectionError` because
the formula declares `fails_with` the default compiler.

This also helps us get more accurate results from `brew linkage` in
cases of unintended linkage with the compiler used to build.

Fixes #11795.
