### PR TITLE
linux/keg_relocate: clean up GCC RPATH fix.

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -30,16 +30,10 @@ class Keg
       lib_path = "#{new_prefix}/lib"
       rpath << lib_path unless rpath.include? lib_path
 
-      # Add GCC's lib directory (as of GCC 12+) to RPATH when there is existing linkage.
-      # This fixes linkage for newly-poured bottles.
-      if !name.match?(Version.formula_optionally_versioned_regex(:gcc)) &&
-         rpath.any? { |rp| rp.match?(%r{lib/gcc/\d+$}) }
-        # TODO: Replace with
-        #   rpath.map! { |path| path = path.sub(%r{lib/gcc/\d+$}, "lib/gcc/current") }
-        # when
-        #   1. Homebrew/homebrew-core#106755 is merged
-        #   2. No formula has a runtime dependency on a versioned GCC (see `envoy.rb`)
-        rpath.prepend HOMEBREW_PREFIX/"opt/gcc/lib/gcc/current"
+      # Add GCC's lib directory (as of GCC 12+) to RPATH when there is existing versioned linkage.
+      # This prevents broken linkage when pouring bottles built with an old GCC formula.
+      unless name.match?(Version.formula_optionally_versioned_regex(:gcc))
+        rpath.map! { |rp| rp.sub(%r{lib/gcc/\d+$}, "lib/gcc/current") }
       end
 
       rpath.join(":")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There are no more formulae in Homebrew/core that have a runtime
dependency on GCC (see Homebrew/homebrew-core#110883), so there is no
more need to retain linkage with GCC through a versioned path.
