### PR TITLE
formula_auditor: fix false negatives in `audit_gcc_dependency`

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -892,8 +892,9 @@ module Homebrew
           # This variation either:
           #   1. does not exist
           #   2. has no variation-specific dependencies
-          # In either case, it matches Linux.
-          return false if variation_dependencies.blank?
+          # In either case, it matches Linux. We must check for `nil` because an empty
+          # array indicates that this variation does not depend on GCC.
+          return false if variation_dependencies.nil?
           # We found a non-Linux variation that depends on GCC.
           return false if variation_dependencies.include?("gcc")
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This audit is mistakenly passing for formulae where
`variations_dependencies` is an empty array. We can fix that by checking
for `nil` instead.

See Homebrew/homebrew-core#111280.
