### PR TITLE
Set env vars in zshenv, not zprofile

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -92,7 +92,7 @@ module Cask
       caveat :zsh_path_helper do |path|
         <<~EOS
           To use #{@cask}, zsh users may need to add the following line to their
-          ~/.zprofile. (Among other effects, #{path} will be added to the
+          ~/.zshenv. (Among other effects, #{path} will be added to the
           PATH environment variable):
             eval `/usr/libexec/path_helper -s`
         EOS

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -5,7 +5,7 @@
 #:  The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
 #:  To help guarantee idempotence, this command produces no output when Homebrew's `bin` and `sbin` directories are first and second
 #:  respectively in your `PATH`. Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`,
-#:  `~/.bash_profile`, or `~/.zprofile`) with: `eval "$(brew shellenv)"`
+#:  `~/.bash_profile`, or `~/.zshenv`) with: `eval "$(brew shellenv)"`
 
 # HOMEBREW_CELLAR and HOMEBREW_PREFIX are set by extend/ENV/super.rb
 # HOMEBREW_REPOSITORY is set by bin/brew

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -617,7 +617,7 @@ Print export statements. When run in a shell, this installation of Homebrew will
 The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
 To help guarantee idempotence, this command produces no output when Homebrew's `bin` and `sbin` directories are first and second
 respectively in your `PATH`. Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`,
-`~/.bash_profile`, or `~/.zprofile`) with: `eval "$(brew shellenv)"`
+`~/.bash_profile`, or `~/.zshenv`) with: `eval "$(brew shellenv)"`
 
 ### `tap` [*`options`*] [*`user`*`/`*`repo`*] [*`URL`*]
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -46,7 +46,7 @@ then
 fi
 ```
 
-This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you, so this must be done before you call `oh-my-zsh.sh`. This may be done by appending the following line to your `~/.zprofile` after Homebrew's initialization, instead of modifying your `~/.zshrc` as above:
+This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you, so this must be done before you call `oh-my-zsh.sh`. This may be done by appending the following line to your `~/.zshenv` after Homebrew's initialization, instead of modifying your `~/.zshrc` as above:
 
 ```sh
 FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -871,7 +871,7 @@ Search for \fItext\fR in the given database\.
 Print export statements\. When run in a shell, this installation of Homebrew will be added to your \fBPATH\fR, \fBMANPATH\fR, and \fBINFOPATH\fR\.
 .
 .P
-The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. To help guarantee idempotence, this command produces no output when Homebrew\'s \fBbin\fR and \fBsbin\fR directories are first and second respectively in your \fBPATH\fR\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval "$(brew shellenv)"\fR
+The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. To help guarantee idempotence, this command produces no output when Homebrew\'s \fBbin\fR and \fBsbin\fR directories are first and second respectively in your \fBPATH\fR\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zshenv\fR) with: \fBeval "$(brew shellenv)"\fR
 .
 .SS "\fBtap\fR [\fIoptions\fR] [\fIuser\fR\fB/\fR\fIrepo\fR] [\fIURL\fR]"
 Tap a formula repository\.


### PR DESCRIPTION
According to [the Zsh docs][]:

> `.zshenv` is sourced on all invocations of the shell, unless the -f
> option is set. **It should contain commands to set the command search
> path, plus other important environment variables.**

> `.zlogin` is sourced in login shells. It should contain commands that
> should be executed only in login shells. `.zlogout` is sourced when
> login shells exit. `.zprofile` is similar to `.zlogin`, except that it
> is sourced before `.zshrc`. `.zprofile` is meant as an alternative to
> `.zlogin` for ksh fans; the two are not intended to be used together,
> although this could certainly be done if desired. **`.zlogin` is not the
> place for alias definitions, options, environment variable settings,
> etc.; as a general rule, it should not change the shell environment at
> all.** Rather, it should be used to set the terminal type and run a
> series of external commands (fortune, msgs, etc).

Since the `brew shellenv` command sets environment variables, including `PATH`, that likely means that it should be eval'ed in `.zshenv`.

[the Zsh docs]: https://zsh.sourceforge.io/Intro/intro_3.html

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
