### PR TITLE
Cleanup and fix CI jobs

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   tapioca:
     if: github.repository == 'Homebrew/brew'
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           vale docs/
 
   tap-syntax:
-    name: tap syntax (Linux)
+    name: tap syntax
     needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-22.04
@@ -145,7 +145,7 @@ jobs:
                                          homebrew/cask-versions
 
   vendored-gems:
-    name: vendored gems (Linux)
+    name: vendored gems
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Homebrew
@@ -222,16 +222,23 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     needs: syntax
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
         include:
           - name: tests (no-compatibility mode)
             test-flags: --no-compat --online --coverage
+            runs-on: ubuntu-22.04
           - name: tests (generic OS)
             test-flags: --generic --online --coverage
-          - name: tests (Linux)
+            runs-on: ubuntu-22.04
+          - name: tests (Ubuntu 22.04)
             test-flags: --online --coverage
+            runs-on: ubuntu-22.04
+          # Enable later once this can be fixed.
+          # - name: tests (Ubuntu 18.04)
+          #   test-flags: --online --coverage
+          #   runs-on: ubuntu-18.04
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -274,10 +281,19 @@ jobs:
           files: Library/Homebrew/test/coverage/coverage.xml
 
   test-default-formula-linux:
-    name: test default formula (Linux)
-    runs-on: ubuntu-22.04
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
     env:
       HOMEBREW_BOOTSNAP: 1
+    strategy:
+      matrix:
+        include:
+          - name: test default formula (Ubuntu 22.04)
+            test-flags: --online --coverage
+            runs-on: ubuntu-22.04
+          - name: test default formula (Ubuntu 18.04)
+            test-flags: --online --coverage
+            runs-on: ubuntu-18.04
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -291,7 +307,7 @@ jobs:
     name: test everything (macOS)
     needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       HOMEBREW_BOOTSNAP: 1
     steps:

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -21,7 +21,7 @@ jobs:
           contains(github.event.pull_request.title, '/Library/Homebrew')
         )
       )
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -69,7 +69,7 @@ module Homebrew
     end
 
     if args.linux?
-      runners << "ubuntu-latest"
+      runners << "ubuntu-22.04"
     elsif args.linux_self_hosted?
       runners << "linux-self-hosted-1"
     end

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -74,7 +74,7 @@ module Homebrew
         test-bot:
           strategy:
             matrix:
-              os: [ubuntu-latest, macos-latest]
+              os: [ubuntu-22.04, macos-12]
           runs-on: ${{ matrix.os }}
           steps:
             - name: Set up Homebrew
@@ -119,7 +119,7 @@ module Homebrew
       jobs:
         pr-pull:
           if: contains(github.event.pull_request.labels.*.name, '#{label}')
-          runs-on: ubuntu-latest
+          runs-on: ubuntu-22.04
           steps:
             - name: Set up Homebrew
               uses: Homebrew/actions/setup-homebrew@master

--- a/README.md
+++ b/README.md
@@ -85,6 +85,6 @@ Flaky test detection and tracking is provided by [BuildPulse](https://buildpulse
 [![DNSimple](https://cdn.dnsimple.com/assets/resolving-with-us/logo-light.png)](https://dnsimple.com/resolving/homebrew#gh-light-mode-only)
 [![DNSimple](https://cdn.dnsimple.com/assets/resolving-with-us/logo-dark.png)](https://dnsimple.com/resolving/homebrew#gh-dark-mode-only)
 
-Homebrew is generously supported by [GitHub](https://github.com/github), [Custom Ink](https://github.com/customink), [Randy Reddig](https://github.com/ydnar), [Christian (Xian) M. Lilley](https://github.com/xml), [Codecademy](https://github.com/Codecademy), [David Fernandez](https://github.com/lidstromberg), [Appwrite](https://github.com/appwrite), [Mercedes-Benz Group](https://github.com/mercedes-benz), [embark-studios](https://github.com/embark-studios) and many other users and organisations via [GitHub Sponsors](https://github.com/sponsors/Homebrew).
+Homebrew is generously supported by [GitHub](https://github.com/github), [Custom Ink](https://github.com/customink), [Randy Reddig](https://github.com/ydnar), [Codecademy](https://github.com/Codecademy), [Appwrite](https://github.com/appwrite), [Mercedes-Benz Group](https://github.com/mercedes-benz), [embark-studios](https://github.com/embark-studios) and many other users and organisations via [GitHub Sponsors](https://github.com/sponsors/Homebrew).
 
 [![GitHub](https://github.com/github.png?size=64)](https://github.com/github)


### PR DESCRIPTION
- use macOS 12 or Ubuntu 22.04 wherever appropriate
- don't append `(Linux)` to job names
- use specific Ubuntu 22.04 and Ubuntu 18.04 jobs

We may want to consider more Ubuntu 18.04 jobs in future, too.