### PR TITLE
Remove unused function from bump-cask-pr

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -188,19 +188,6 @@ module Homebrew
     GitHub.create_bump_pr(pr_info, args: args)
   end
 
-  def fetch_cask(contents, config: nil)
-    cask = Cask::CaskLoader.load(contents)
-    cask.config = config if config.present?
-    old_hash = cask.sha256.to_s
-
-    cask_download = Cask::Download.new(cask, quarantine: true)
-    download = cask_download.fetch(verify_download_integrity: false)
-    Utils::Tar.validate_file(download)
-    new_hash = download.sha256
-
-    [old_hash, new_hash]
-  end
-
   def check_open_pull_requests(cask, args:)
     tap_remote_repo = cask.tap.remote_repo || cask.tap.full_name
     GitHub.check_for_duplicate_pull_requests(cask.token, tap_remote_repo,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The function `fetch_cask` was originally added in https://github.com/Homebrew/brew/commit/f65f0f9245dde5e14c9dfdaf617f5aa4cf010c2e and the final reference to it was removed in https://github.com/Homebrew/brew/pull/13802/commits/092095a249814bb6ceea598786df678e150fc649.