### PR TITLE
Enable Linux AArch64 support

### DIFF
--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -7,6 +7,7 @@ class LinkageChecker
   # Libraries provided by glibc and gcc.
   SYSTEM_LIBRARY_ALLOWLIST = %w[
     ld-linux-x86-64.so.2
+    ld-linux-aarch64.so.1
     libanl.so.1
     libatomic.so.1
     libc.so.6

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -11,7 +11,7 @@ module Hardware
     INTEL_64BIT_ARCHS = [:x86_64].freeze
     PPC_32BIT_ARCHS   = [:ppc, :ppc32, :ppc7400, :ppc7450, :ppc970].freeze
     PPC_64BIT_ARCHS   = [:ppc64, :ppc64le, :ppc970].freeze
-    ARM_64BIT_ARCHS   = [:arm64].freeze
+    ARM_64BIT_ARCHS   = [:arm64, :aarch64].freeze
     ALL_ARCHS = [
       *INTEL_32BIT_ARCHS,
       *INTEL_64BIT_ARCHS,


### PR DESCRIPTION
Add system loader filename and arch tag for proper builds and bottling.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
