### PR TITLE
formula: ensure `rpath` is passed a valid `target`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1615,6 +1615,10 @@ class Formula
   # </pre>
   sig { params(source: Pathname, target: Pathname).returns(String) }
   def rpath(source: bin, target: lib)
+    unless target.to_s.start_with?(HOMEBREW_PREFIX)
+      odie "`target` should only be used for paths inside HOMEBREW_PREFIX!"
+    end
+
     "#{loader_path}/#{target.relative_path_from(source)}"
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1616,7 +1616,7 @@ class Formula
   sig { params(source: Pathname, target: Pathname).returns(String) }
   def rpath(source: bin, target: lib)
     unless target.to_s.start_with?(HOMEBREW_PREFIX)
-      raise "`target` should only be used for paths inside HOMEBREW_PREFIX!"
+      raise "rpath `target` should only be used for paths inside HOMEBREW_PREFIX!"
     end
 
     "#{loader_path}/#{target.relative_path_from(source)}"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1616,7 +1616,7 @@ class Formula
   sig { params(source: Pathname, target: Pathname).returns(String) }
   def rpath(source: bin, target: lib)
     unless target.to_s.start_with?(HOMEBREW_PREFIX)
-      odie "`target` should only be used for paths inside HOMEBREW_PREFIX!"
+      raise "`target` should only be used for paths inside HOMEBREW_PREFIX!"
     end
 
     "#{loader_path}/#{target.relative_path_from(source)}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Setting `target` to a path outside `HOMEBREW_PREFIX` is not portable,
and will be invalid for some Homebrew installations.

If we want to add an `rpath` outside of `HOMEBREW_PREFIX`, we should
just use the absolute path instead.

See discussion at Homebrew/homebrew-core#110520.
