### PR TITLE
Support non-master init.defaultbranch

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -731,7 +731,7 @@ module Homebrew
       newest_committed_revision = nil
       newest_committed_url = nil
 
-      fv.rev_list("origin/master") do |rev|
+      fv.rev_list("origin/HEAD") do |rev|
         begin
           fv.formula_at_revision(rev) do |f|
             stable = f.stable

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -45,7 +45,7 @@ describe "brew install" do
     repo_path.join("bin").mkpath
 
     repo_path.cd do
-      system "git", "init"
+      system "git", "-c", "init.defaultBranch=master", "init"
       system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
       FileUtils.touch "bin/something.bin"
       FileUtils.touch "README"

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -927,7 +927,7 @@ module Homebrew
 
         tap_path.cd do
           system "git", "fetch"
-          system "git", "reset", "--hard", "origin/master"
+          system "git", "reset", "--hard", "origin/HEAD"
         end
       end
 

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -80,7 +80,7 @@ describe "brew bottle" do
 
     it "adds the bottle block to a formula that has none" do
       core_tap.path.cd do
-        system "git", "init"
+        system "git", "-c", "init.defaultBranch=master", "init"
         setup_test_formula "testball"
         system "git", "add", "--all"
         system "git", "commit", "-m", "testball 0.1"
@@ -140,7 +140,7 @@ describe "brew bottle" do
 
     it "replaces the bottle block in a formula that already has a bottle block" do
       core_tap.path.cd do
-        system "git", "init"
+        system "git", "-c", "init.defaultBranch=master", "init"
         setup_test_formula "testball", bottle_block: <<~EOS
 
           bottle do
@@ -207,7 +207,7 @@ describe "brew bottle" do
 
     it "updates the bottle block in a formula that already has a bottle block when using --keep-old" do
       core_tap.path.cd do
-        system "git", "init"
+        system "git", "-c", "init.defaultBranch=master", "init"
         setup_test_formula "testball", bottle_block: <<~EOS
 
           bottle do

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -23,7 +23,7 @@ describe GitDownloadStrategy do
   end
 
   def setup_git_repo
-    system "git", "init"
+    system "git", "-c", "init.defaultBranch=master", "init"
     system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
     FileUtils.touch "README"
     git_commit_all

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1480,7 +1480,7 @@ describe Formula do
         testball_repo.cd do
           FileUtils.touch "LICENSE"
 
-          system("git", "init")
+          system("git", "-c", "init.defaultBranch=master", "init")
           system("git", "add", "--all")
           system("git", "commit", "-m", "Initial commit")
         end


### PR DESCRIPTION
The default `init.defaultbranch` has changed from `master` to `main` in Xcode 14.

This PR fixes the following:

* Formula auditor had a hardcoded `origin/master` in the version/revision downgade audits. I've changed this to `origin/HEAD`. The corresponding test has also been updated to do this.
* Various Git download strategy tests (like `--HEAD` tests) failed because we (intentionally as far as I know?) default to `master` if no branch is specified, but our test git repo could have been created with any branch on `git init`. I've adjusted the tests to explicitly create a repo with `master`.
* `dev-cmd/bottle` tests failed because the regex comparisons had a hardcoded `master`. I took the easier option and just made our test repos use `master` too rather than figure out some branch regex. The actual operation of `dev-cmd/bottle` was working correctly.