### PR TITLE
os/mac/xcode: require Xcode 14.1 on Ventura

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -23,7 +23,7 @@ module OS
       def latest_version(macos: MacOS.version)
         latest_stable = "13.4"
         case macos
-        when "13" then "14.0"
+        when "13" then "14.1"
         when "12" then latest_stable
         when "11" then "13.2.1"
         when "10.15" then "12.4"
@@ -46,7 +46,7 @@ module OS
       sig { returns(String) }
       def minimum_version
         case MacOS.version
-        when "13" then "14.0"
+        when "13" then "14.1"
         when "12" then "13.1"
         when "11" then "12.2"
         when "10.15" then "11.0"
@@ -245,8 +245,8 @@ module OS
         when "12.0.0" then "12.4"
         when "12.0.5" then "12.5.1"
         when "13.0.0" then "13.2.1"
-        when "14.0.0" then "14.0"
-        else               "13.4"
+        when "13.1.6" then "13.4.1"
+        else               "14.0.1"
         end
       end
 
@@ -343,7 +343,7 @@ module OS
       sig { returns(String) }
       def latest_clang_version
         case MacOS.version
-        when "13"    then "1400.0.17.3.1"
+        when "13"    then "1400.0.29.201"
         when "12"    then "1316.0.21.2.5"
         when "11"    then "1300.0.29.30"
         when "10.15" then "1200.0.32.29"


### PR DESCRIPTION
As is pretty much standard now, 14.0 RC/final removed the Ventura SDK, but the 14.1 betas do have it. As such, we need to now require Xcode 14.1 on Ventura.

(Side note: I've not updated `latest_stable` on Monterey from 13.4 yet. This is intentional due to the regular reports of GCC breakages, which is fixed in 14.1, as well as our own issues such as #13863, which all means we really shouldn't promote it as the recommended version yet - but hopefully we can for Xcode 14.1 by the time it releases in a couple weeks)