### PR TITLE
formula: fix inreplace errors not being printed

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2324,7 +2324,8 @@ class Formula
   # @api public
   def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
     super(paths, before, after, audit_result)
-  rescue Utils::Inreplace::Error
+  rescue Utils::Inreplace::Error => e
+    onoe e.to_s
     raise BuildError.new(self, "inreplace", paths, {})
   end
 


### PR DESCRIPTION
Match the behaviour of regular BuildErrors by printing the error before throwing.