### PR TITLE
Simulate all OS/arch combinations in `brew readall`

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -151,6 +151,9 @@ module Homebrew
       def syntax?; end
 
       sig { returns(T::Boolean) }
+      def no_simulate?; end
+
+      sig { returns(T::Boolean) }
       def ignore_non_pypi_packages?; end
 
       sig { returns(T::Boolean) }

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -26,6 +26,8 @@ module Homebrew
       switch "--eval-all",
              description: "Evaluate all available formulae and casks, whether installed or not. " \
                           "Implied if HOMEBREW_EVAL_ALL is set."
+      switch "--no-simulate",
+             description: "Don't simulate other system configurations when checking formulae and casks."
 
       named_args :tap
     end
@@ -41,7 +43,7 @@ module Homebrew
       Homebrew.failed = true unless Readall.valid_ruby_syntax?(ruby_files)
     end
 
-    options = { aliases: args.aliases? }
+    options = { aliases: args.aliases?, no_simulate: args.no_simulate? }
     taps = if args.no_named?
       if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
         odeprecated "brew readall", "brew readall --eval-all or HOMEBREW_EVAL_ALL"

--- a/Library/Homebrew/extend/os/linux/readall.rb
+++ b/Library/Homebrew/extend/os/linux/readall.rb
@@ -3,7 +3,7 @@
 
 module Readall
   class << self
-    def valid_casks?(_casks)
+    def valid_casks?(_casks, bottle_tag: nil)
       true
     end
   end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1710,6 +1710,7 @@ _brew_readall() {
       --debug
       --eval-all
       --help
+      --no-simulate
       --quiet
       --syntax
       --verbose

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1180,6 +1180,7 @@ __fish_brew_complete_arg 'readall' -l aliases -d 'Verify any alias symlinks in e
 __fish_brew_complete_arg 'readall' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'readall' -l eval-all -d 'Evaluate all available formulae and casks, whether installed or not. Implied if HOMEBREW_EVAL_ALL is set'
 __fish_brew_complete_arg 'readall' -l help -d 'Show this message'
+__fish_brew_complete_arg 'readall' -l no-simulate -d 'Don\'t simulate other system configurations when checking formulae and casks'
 __fish_brew_complete_arg 'readall' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'readall' -l syntax -d 'Syntax-check all of Homebrew\'s Ruby files (if no `tap` is passed)'
 __fish_brew_complete_arg 'readall' -l verbose -d 'Make some output more verbose'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1439,6 +1439,7 @@ _brew_readall() {
     '--debug[Display any debugging information]' \
     '--eval-all[Evaluate all available formulae and casks, whether installed or not. Implied if HOMEBREW_EVAL_ALL is set]' \
     '--help[Show this message]' \
+    '--no-simulate[Don'\''t simulate other system configurations when checking formulae and casks]' \
     '--quiet[Make some output more quiet]' \
     '--syntax[Syntax-check all of Homebrew'\''s Ruby files (if no `tap` is passed)]' \
     '--verbose[Make some output more verbose]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -528,6 +528,8 @@ all items or checking if any current formulae/casks have Ruby issues.
   Syntax-check all of Homebrew's Ruby files (if no `*`tap`*` is passed).
 * `--eval-all`:
   Evaluate all available formulae and casks, whether installed or not. Implied if HOMEBREW_EVAL_ALL is set.
+* `--no-simulate`:
+  Don't simulate other system configurations when checking formulae and casks.
 
 ### `reinstall` [*`options`*] *`formula`*|*`cask`* [...]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -731,6 +731,10 @@ Syntax\-check all of Homebrew\'s Ruby files (if no \fB<tap>\fR is passed)\.
 \fB\-\-eval\-all\fR
 Evaluate all available formulae and casks, whether installed or not\. Implied if HOMEBREW_EVAL_ALL is set\.
 .
+.TP
+\fB\-\-no\-simulate\fR
+Don\'t simulate other system configurations when checking formulae and casks\.
+.
 .SS "\fBreinstall\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR [\.\.\.]"
 Uninstall and then reinstall a \fIformula\fR or \fIcask\fR using the same options it was originally installed with, plus any appended options specific to a \fIformula\fR\.
 .


### PR DESCRIPTION
This PR updates `brew readall` to simulate other OS configurations. This will hopefully help us reduce errors in formulae and casks that don't appear in the OS versions we test with in CI.

I've also added a `--no-simulate` flag to `brew readall` to opt-out of this if desired, but if we think it's better just to force this everywhere then I can remove it.

Of course, this does make `brew readall` a lot slower (which might be a reason to include the `--no-simulate` flag):

```console
$ hyperfine 'brew readall --eval-all --no-simulate' 'brew readall --eval-all'
Benchmark 1: brew readall --eval-all --no-simulate
  Time (mean ± σ):      7.690 s ±  0.074 s    [User: 6.970 s, System: 0.690 s]
  Range (min … max):    7.560 s …  7.824 s    10 runs

Benchmark 2: brew readall --eval-all
  Time (mean ± σ):     46.813 s ±  0.382 s    [User: 43.519 s, System: 2.881 s]
  Range (min … max):   46.240 s … 47.521 s    10 runs

Summary
  'brew readall --eval-all --no-simulate' ran
    6.09 ± 0.08 times faster than 'brew readall --eval-all'
```