### PR TITLE
Warn user about /opt/homebrew not being properly set in path

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -879,7 +879,8 @@ module Homebrew
         <<~EOS
           Your Homebrew's prefix is not #{Homebrew::DEFAULT_PREFIX}.
           Some of Homebrew's bottles (binary packages) can only be used with the default
-          prefix (#{Homebrew::DEFAULT_PREFIX}).
+          prefix (#{Homebrew::DEFAULT_PREFIX}). If your Homebrew is located at #{Homebrew::DEFAULT_PREFIX},
+          make sure #{Homebrew::DEFAULT_PREFIX}/bin is in your PATH.
           #{please_create_pull_requests}
         EOS
       end


### PR DESCRIPTION
Because Homebrew was set on my PATH as `/System/Volumes/Data/opt/homebrew` and this actually `/opt/homebrew`, it was mostly working, installation and installed software execution were fine, but it wasn't able to compile some dependencies unless I manually created some dirs before, as I was always having this error:

```
Last 15 lines from /Users/antonioribeiro/Library/Logs/Homebrew/guile/02.make:
 .././build-aux/install-sh -c -d '/System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/share/aclocal'
 .././build-aux/install-sh -c -d '/System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/lib/pkgconfig'
mkdir: /System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/lib: Operation not permitted
mkdir: /System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/bin: Operation not permitted
mkdir: /System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/share: Operation not permitted
mkdir: /System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/lib: Operation not permitted
mkdir: /System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/share: Operation not permitted
mkdir: /System/Volumes/Data/opt/homebrew/Cellar/guile/3.0.8_2/bin: Operation not permitted
make[3]: *** [install-pkgconfigDATA] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: *** [install-aclocalDATA] Error 1
make[3]: *** [install-binSCRIPTS] Error 1
make[2]: *** [install-am] Error 2
make[1]: *** [install-recursive] Error 1
make: *** [install] Error 2

Do not report this issue to Homebrew/brew or Homebrew/core!
```

Possibly because, `/System` is writable by the root only, even if permissions on `/opt/homebrew` would allow mkdir from the user running `brew install`. 

After running `brew doctor` I found this strange message saying `Your Homebrew's prefix is not /opt/homebrew`, as it was, and digging a little more issues here, found that `prefix` is being (somehow) computed by the PATH, probably because the PATH locating and running it from `/System/Volumes/Data/opt/homebrew/bin/brew` instead of `/opt/homebrew/bin/brew`.

I believe this extra warning message could also save other people some research time.