### PR TITLE
add error log of download `formula.json`

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -761,8 +761,11 @@ EOS
       --time-cond "${HOMEBREW_CACHE}/api/formula.json" \
       --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
       "https://formulae.brew.sh/api/formula.json"
-    # TODO: we probably want to print an error if this fails.
-    # TODO: set HOMEBREW_UPDATED or HOMEBREW_UPDATE_FAILED
+    exit_code=$?
+    if [[ ${exit_code} -ne 0 ]]
+    then
+      echo "download formula.json failed!" >>"${update_failed_file}"
+    fi
   fi
 
   safe_cd "${HOMEBREW_REPOSITORY}"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -756,14 +756,7 @@ EOS
     mkdir -p "${HOMEBREW_CACHE}/api"
     if [[ -f "${HOMEBREW_CACHE}/api/formula.json" ]]
     then
-      INITIAL_JSON_SHASUM="$(
-        ruby <<EOSCRIPT
-require 'digest/sha2'
-digest = Digest::SHA256.new
-File.open('${HOMEBREW_CACHE}/api/formula.json') { |f| digest.update(f.read) }
-puts digest.hexdigest
-EOSCRIPT
-      )"
+      INITIAL_JSON_BYTESIZE="$(wc -c "${HOMEBREW_CACHE}"/api/formula.json)"
     fi
     curl \
       "${CURL_DISABLE_CURLRC_ARGS[@]}" \
@@ -775,15 +768,8 @@ EOSCRIPT
     curl_exit_code=$?
     if [[ ${curl_exit_code} -eq 0 ]]
     then
-      CURRENT_JSON_SHASUM="$(
-        ruby <<EOSCRIPT
-require 'digest/sha2'
-digest = Digest::SHA256.new
-File.open('${HOMEBREW_CACHE}/api/formula.json') { |f| digest.update(f.read) }
-puts digest.hexdigest
-EOSCRIPT
-      )"
-      if [[ "${INITIAL_JSON_SHASUM}" != "${CURRENT_JSON_SHASUM}" ]]
+      CURRENT_JSON_BYTESIZE="$(wc -c "${HOMEBREW_CACHE}"/api/formula.json)"
+      if [[ "${INITIAL_JSON_BYTESIZE}" != "${CURRENT_JSON_BYTESIZE}" ]]
       then
         HOMEBREW_UPDATED="1"
       fi

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -756,7 +756,14 @@ EOS
     mkdir -p "${HOMEBREW_CACHE}/api"
     if [[ -f "${HOMEBREW_CACHE}/api/formula.json" ]]
     then
-      INITIAL_JSON_SHASUM="$(shasum -a 256 "${HOMEBREW_CACHE}"/api/formula.json)"
+      INITIAL_JSON_SHASUM="$(
+        ruby <<EOSCRIPT
+require 'digest/sha2'
+digest = Digest::SHA256.new
+File.open('${HOMEBREW_CACHE}/api/formula.json') { |f| digest.update(f.read) }
+puts digest.hexdigest
+EOSCRIPT
+      )"
     fi
     curl \
       "${CURL_DISABLE_CURLRC_ARGS[@]}" \
@@ -768,7 +775,14 @@ EOS
     curl_exit_code=$?
     if [[ ${curl_exit_code} -eq 0 ]]
     then
-      CURRENT_JSON_SHASUM="$(shasum -a 256 "${HOMEBREW_CACHE}"/api/formula.json)"
+      CURRENT_JSON_SHASUM="$(
+        ruby <<EOSCRIPT
+require 'digest/sha2'
+digest = Digest::SHA256.new
+File.open('${HOMEBREW_CACHE}/api/formula.json') { |f| digest.update(f.read) }
+puts digest.hexdigest
+EOSCRIPT
+      )"
       if [[ "${INITIAL_JSON_SHASUM}" != "${CURRENT_JSON_SHASUM}" ]]
       then
         HOMEBREW_UPDATED="1"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -774,7 +774,7 @@ EOS
         HOMEBREW_UPDATED="1"
       fi
     else
-      echo "download formula.json failed!" >>"${update_failed_file}"
+      echo "Failed to download formula.json!" >>"${update_failed_file}"
     fi
   fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
repair for `We need to handle download errors of the formula.json and cask.json files` in https://github.com/Homebrew/brew/issues/13794