### PR TITLE
docs: discontinue WSL 1 support; recommend WSL 2

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -9,7 +9,7 @@ redirect_from:
 
 # Homebrew on Linux
 
-The Homebrew package manager may be used on Linux and [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about). Homebrew was formerly referred to as Linuxbrew when running on Linux or WSL. It can be installed in your home directory, in which case it does not use *sudo*. Homebrew does not use any libraries provided by your host system, except *glibc* and *gcc* if they are new enough. Homebrew can install its own current versions of *glibc* and *gcc* for older distributions of Linux.
+The Homebrew package manager may be used on Linux and [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about) 2. Homebrew was formerly referred to as Linuxbrew when running on Linux or WSL. It can be installed in your home directory, in which case it does not use *sudo*. Homebrew does not use any libraries provided by your host system, except *glibc* and *gcc* if they are new enough. Homebrew can install its own current versions of *glibc* and *gcc* for older distributions of Linux.
 
 [Features](#features), [installation instructions](#install) and [requirements](#requirements) are described below. Terminology (e.g. the difference between a Cellar, Tap, Cask and so forth) is [explained in the documentation](Formula-Cookbook.md#homebrew-terminology).
 
@@ -77,6 +77,10 @@ You may need to install your own Ruby using your system package manager, a PPA, 
 ### 32-bit x86
 
 Homebrew does not currently support 32-bit x86 platforms. It would be possible for Homebrew to work on 32-bit x86 platforms with some effort. An interested and dedicated person could maintain a fork of Homebrew to develop support for 32-bit x86.
+
+### Windows Subsystem for Linux (WSL) 1
+
+Due to [known issues](https://github.com/microsoft/WSL/issues/8219) with WSL 1, you may experience issues running various executables installed by Homebrew. We recommend you switch to WSL 2 instead.
 
 ## Homebrew on Linux Community
 


### PR DESCRIPTION
For years, certain packages have had issues executing under WSL 1. It has gotten worse under newer `binutils` versions after https://github.com/bminor/binutils-gdb/commit/74e315dbfe5200c473b226e937935fb8ce391489. It has progressed so far that even `/usr/bin/gzip` on Ubuntu 22.04 is broken, as seen in https://github.com/orgs/Homebrew/discussions/3790 (Ubuntu has recently fixed the issue, but it took a few months and isn't in fresh 22.04 installs yet).

For this reason, I propose formally dropping WSL 1 support. This does not involve any code changes and is purely a documentation change, so this doesn't actually change anything from our part nor does this force anything on existing users who have got it working. I've updated the documentation to say that Homebrew runs on WSL 2 specifically, with a brief subsection about the issues with running WSL 1.

CI wise, WSL 1 was only ever tested in Homebrew/install. GitHub Actions doesn't support WSL 2 yet unfortunately, but WSL 2 is effectively Linux in a VM so there's unlikely to be any behavioural differences that wouldn't be covered by regular Ubuntu testing.