### PR TITLE
Update Linux requirements

### DIFF
--- a/Library/Homebrew/os/linux/kernel.rb
+++ b/Library/Homebrew/os/linux/kernel.rb
@@ -13,7 +13,7 @@ module OS
 
       sig { returns(Version) }
       def minimum_version
-        Version.new "2.6.32"
+        Version.new "3.2"
       end
 
       def below_minimum_version?

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -47,8 +47,7 @@ If you're using an older distribution of Linux, installing your first package wi
 
 ## Requirements
 
-- **GCC** 4.7.0 or newer
-- **Linux** 2.6.32 or newer
+- **Linux** 3.2 or newer
 - **Glibc** 2.13 or newer
 - **64-bit x86_64** CPU
 
@@ -65,7 +64,6 @@ To install build tools, paste at a terminal prompt:
   ```sh
   sudo yum groupinstall 'Development Tools'
   sudo yum install procps-ng curl file git
-  sudo yum install libxcrypt-compat # needed by Fedora 30 and up
   ```
 
 ### ARM


### PR DESCRIPTION
* Glibc 2.26+ (we use 2.35) require Linux kernel 3.2 or later - see https://sourceware.org/pipermail/libc-announce/2017/000017.html.
* Remove GCC requirement given I don't think it matters for bottles (we install GCC ourselves if too old) and is probably wrong for the build-from-source case.
  - Everything besides `glibc` is relocatable, with that now supporting it's own bootstrapped GCC.
  - For non-x86_64 platforms which don't use the bootstrap, the minimum GCC is 6.2.
  - Given this, we could remove compiler support for < GCC 6 from `brew`, though we perhaps want to wait until the end of the `gcc@5` deprecation period, which is no earlier than 9th December.
* Remove libxcrypt-compat requirement given we don't use libcrypt.so.1 anymore.