### PR TITLE
Fix curl_output for curl download strategy

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -580,6 +580,13 @@ class HomebrewCurlDownloadStrategy < CurlDownloadStrategy
 
     curl_download resolved_url, to: to, try_partial: @try_partial, timeout: timeout, use_homebrew_curl: true
   end
+
+  def curl_output(*args, **options)
+    raise HomebrewCurlDownloadStrategyError, url unless Formula["curl"].any_version_installed?
+
+    options[:use_homebrew_curl] = true
+    super(*args, **options)
+  end
 end
 
 # Strategy for downloading a file from an GitHub Packages URL.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
## Background
In order to install `getmail` brewed curl must be used, because older curl versions (like curl 7.79.1 on my macOS Monterey) can't follow the redirect properly.
I am aware that this might not be that relevant, because I've just deprecated `getmail` in https://github.com/Homebrew/homebrew-core/pull/113253, but this might be helpful to make brew more robust and predictable.

## Bug
I therefore use download strategy `:homebrew_curl` in the Formula, but in `resolve_url_basename_time_file_size` the non-brewed curl is still used.
While the actual downloading in `_curl_download` is overloaded in the `HomebrewCurlDownloadStrategy` class, `curl_output` isn't, so the non-brewed on from `CurlDownloadStrategy` is used.

## Fix
Overload `curl_output` in `HomebrewCurlDownloadStrategy` too.

## Steps to reproduce / review
- Checkout https://github.com/Homebrew/homebrew-core/pull/113253 for the fixed Formula using brewed curl.
- Run `HOMEBREW_NO_AUTO_UPDATE=1 brew install --build-from-source -d getmail`
- It won't work, because of too many redirects
- Checkout this PR
- Run `HOMEBREW_NO_AUTO_UPDATE=1 brew install --build-from-source -d getmail` again
- It'll work, because brewed curl is used for both curl calls