### PR TITLE
Restore ARM Linux support when installing gems

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -56,12 +56,18 @@ GEM
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     msgpack (1.6.0)
     mustache (1.1.1)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
+    nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
@@ -212,6 +218,8 @@ GEM
     zeitwerk (2.6.1)
 
 PLATFORMS
+  aarch64-linux
+  arm-linux
   arm64-darwin
   x86_64-darwin
   x86_64-linux
@@ -257,4 +265,4 @@ RUBY VERSION
    ruby 2.6.8p205
 
 BUNDLED WITH
-   2.3.23
+   2.3.24

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -10,7 +10,7 @@ require "English"
 module Homebrew
   # Keep in sync with the `Gemfile.lock`'s BUNDLED WITH.
   # After updating this, run `brew vendor-gems --update=--bundler`.
-  HOMEBREW_BUNDLER_VERSION = "2.3.23"
+  HOMEBREW_BUNDLER_VERSION = "2.3.24"
 
   module_function
 


### PR DESCRIPTION
This regressed when updating to Bundler 2 because we needed a list of supported platforms and trying to add the ARM Linux platforms would make the resolver hang (perhaps due to the consideration needed for Sorbet not supporting those platforms). This appears to be fixed in 2.3.24, or at least it is for me.

`brew typecheck` continues to be unsupported on those platforms but that's ok and has always been that way. At least `brew bottle` etc will now work again, which I know is being used.

The list of supported platforms here should now match the list of supported platforms we support for `brew install`.