### PR TITLE
ResourceAuditor: Fix #audit_head_branch error

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -146,9 +146,8 @@ module Homebrew
       return if specs[:tag].present?
 
       branch = Utils.popen_read("git", "ls-remote", "--symref", url, "HEAD")
-                    .match(%r{ref: refs/heads/(.*?)\s+HEAD})[1]
-
-      return if branch == specs[:branch]
+                    .match(%r{ref: refs/heads/(.*?)\s+HEAD})&.to_a&.second
+      return if branch.blank? || branch == specs[:branch]
 
       problem "Use `branch: \"#{branch}\"` to specify the default branch"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The existing logic in `#audit_head_branch` for identifying the `HEAD` branch in a Git repository will give an ```undefined method `[]' for nil:NilClass``` error when a repository doesn't provide this reference. Expected output from `git ls-remote --symref <repository> HEAD` is as follows:

```
ref: refs/heads/master  HEAD
1a8f9ac700873d1a08de31a17a2fd654245d5085  HEAD
```

However, I encountered this error for a repository (`http://elinks.cz/elinks.git`, `head` in the `elinks` formula) with the following output (i.e., where no symref is provided for HEAD):

```
f86be659718c0cd0a67f88b42f07044c23d0d028  HEAD
```

This PR resolves the error by modifying the related logic to account for a `nil` value.

-----

It's technically possible to go further than this and add some logic to check all the heads [when a ref isn't provided] and find any that correspond to the `HEAD` commit hash. This would work for the `elinks` repository, as the output for `git ls-remote --heads` for this repository is as follows:

```
b9003548c11a4d4efb0913b742fbd383f57c094f	refs/heads/REL_0_10
7865bcd7f1936a0a9fa8530ca3643b2b05dc46ec	refs/heads/dom
2e174e5e05095494dc7b282275277653bcd9d409	refs/heads/elinks-0.11
029f16beb7f01459a621f5a7823d852fdc173d6b	refs/heads/elinks-0.12
f86be659718c0cd0a67f88b42f07044c23d0d028	refs/heads/master
d5f472f34b91b6014190658f62b9c65974326ace	refs/heads/pasky-images
c93cd94625af8e2449dd63a255a3c1dd5ecf2ea6	refs/heads/witekfl
```

In this case, only `master` has the same hash as `HEAD`, so `brew audit --strict --online elinks` could also give the ```HEAD: Use `branch: "master"` to specify the default branch``` error with some additional code. I have a local implementation of this approach but I decided against using it here initially because there may be more than one head with a matching hash. With this potential ambiguity, I figured it was better to only rely on an explicit upstream reference.

However, if we wanted to pursue this, we could use an allowlist to restrict this functionality to the most common branch names (e.g., `main`, `master`) and that may be better than nothing.