### PR TITLE
Allow gem installation on Rubies other than 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 **/vendor/bundle/ruby/*/cache
 **/vendor/bundle/ruby/*/extensions
 **/vendor/bundle/ruby/*/gems/*/*
+**/vendor/bundle/ruby/*/plugins
 **/vendor/bundle/ruby/*/specifications
 
 # Ignore YARD files

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -42,7 +42,6 @@ end
 gem "activesupport"
 gem "addressable"
 gem "concurrent-ruby"
-gem "did_you_mean" # remove when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
 gem "mechanize"
 gem "patchelf"
 gem "plist"
@@ -52,3 +51,8 @@ gem "rubocop-rspec"
 gem "rubocop-sorbet"
 gem "ruby-macho"
 gem "sorbet-runtime"
+
+# remove when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
+install_if -> { RUBY_VERSION < "2.7" } do
+  gem "did_you_mean"
+end

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -64,7 +64,7 @@ module Homebrew
     paths = ENV.fetch("PATH").split(":")
     paths.unshift(ruby_bindir) unless paths.include?(ruby_bindir)
     paths.unshift(Gem.bindir) unless paths.include?(Gem.bindir)
-    paths.unshift(HOMEBREW_SHIMS_PATH/"ruby") unless paths.include?(HOMEBREW_SHIMS_PATH/"ruby")
+    paths.unshift(HOMEBREW_LIBRARY_PATH/"shims/ruby") unless paths.include?(HOMEBREW_LIBRARY_PATH/"shims/ruby")
     ENV["PATH"] = paths.compact.join(":")
 
     # Set envs so the above binaries can be invoked.
@@ -80,8 +80,9 @@ module Homebrew
 
     if specs.empty?
       ohai_if_defined "Installing '#{name}' gem"
-      # document: [] , is equivalent to --no-document
-      specs = Gem.install name, version, document: []
+      # `document: []` is equivalent to --no-document
+      # `build_args: []` stops ARGV being used as a default
+      specs = Gem.install name, version, document: [], build_args: []
     end
 
     specs += specs.flat_map(&:runtime_dependencies)
@@ -115,10 +116,6 @@ module Homebrew
   end
 
   def install_bundler!
-    if Gem.ruby_version >= Gem::Version.new("2.7")
-      raise "Installing and using Bundler is currently only supported on Ruby 2.6."
-    end
-
     setup_gem_environment!
     install_gem_setup_path!(
       "bundler",


### PR DESCRIPTION
This PR:

* Removes the Ruby >= 2.7 restriction on `brew install-bundler-gems`.
* ~~Modifies `brew vendor-gems` to vendor for both 2.6 and 3.1. It will install 3.1 if you are running 2.6 and find 2.6 if you are running 3.1. It will then run `bundle install` and `bundle pristine` for both these versions.~~
  - ~~`brew vendor-gems` as a result from the changes can now be the first port of call when bootstrapping for a new Ruby. From an existing working Ruby, you can modify the command to pick up (for example) Ruby 3.2 and run `brew vendor-gems` on the old Ruby to install the necessary gems for `brew` to run on the new Ruby.~~
* ~~Adds the vendored gems for Ruby 3.1.~~