### PR TITLE
Allow livecheck method in on_system blocks

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -120,14 +120,15 @@ module RuboCop
             end
           end
           on_system_allowed_methods = %w[
-            depends_on
-            patch
-            resource
-            deprecate!
+            livecheck
+            keg_only
             disable!
+            deprecate!
+            depends_on
             conflicts_with
             fails_with
-            keg_only
+            resource
+            patch
             ignore_missing_libraries
           ]
           on_system_allowed_methods += on_system_methods.map(&:to_s)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It's sometimes necessary to have a `livecheck` block in an `on_macos` or `on_linux` block. For example, a formula may be disabled on macOS but not on Linux (e.g., `ntfs-3g`). In that scenario, we only want a `livecheck` block to apply to Linux, so livecheck will automatically skip the formula as disabled on macOS.

While this setup works on a technical level, `brew style` will give an `on_linux cannot include livecheck` offense. This PR addresses the issue by adding `livecheck` to `on_system_allowed_methods` in the `ComponentsOrder` Rubocop.

This also updates `on_system_allowed_methods` to use the order in `FORMULA_COMPONENT_PRECEDENCE_LIST`, which may make it a bit easier for formula maintainers to read at a glance. If there was a particular reason for the existing order, I can rework this PR to simply add `livecheck` to the list without reordering.