### PR TITLE
Mark macOS Ventura as supported

### DIFF
--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -17,13 +17,13 @@ module OS
       # and also update references in docs/Installation.md,
       # https://github.com/Homebrew/install/blob/HEAD/install.sh and
       # MacOSVersions::SYMBOLS
-      NEWEST_UNSUPPORTED = "13"
+      NEWEST_UNSUPPORTED = "14"
       private_constant :NEWEST_UNSUPPORTED
 
       # TODO: bump version when new macOS is released and also update
       # references in docs/Installation.md and
       # https://github.com/Homebrew/install/blob/HEAD/install.sh
-      OLDEST_SUPPORTED = "10.15"
+      OLDEST_SUPPORTED = "11"
       private_constant :OLDEST_SUPPORTED
 
       OLDEST_ALLOWED = "10.11"

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -84,7 +84,7 @@ Uninstallation is documented in the [FAQ](FAQ.md).
 
 <a name="1"><sup>1</sup></a> For 32-bit or PPC support see [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
-<a name="2"><sup>2</sup></a> 11 or higher is recommended, while 10.12–10.15 are supported on a best-effort basis. For 10.4–10.6 see [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
+<a name="2"><sup>2</sup></a> 11 or higher is recommended, while 10.11–10.15 are supported on a best-effort basis. For 10.4–10.6 see [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
 <a name="3"><sup>3</sup></a> Most formulae require a compiler. A handful require a full Xcode installation. You can install Xcode, the CLT, or both; Homebrew supports all three configurations. Downloading Xcode may require an Apple Developer account on older versions of Mac OS X. Sign up for free at [Apple's website](https://developer.apple.com/register/index.action).
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -7,7 +7,7 @@ This script installs Homebrew to its preferred prefix (`/usr/local` for macOS In
 ## macOS Requirements
 
 * A 64-bit Intel CPU or Apple Silicon CPU <sup>[1](#1)</sup>
-* macOS Catalina (10.15) (or higher) <sup>[2](#2)</sup>
+* macOS Big Sur (11) (or higher) <sup>[2](#2)</sup>
 * Command Line Tools (CLT) for Xcode (from `xcode-select --install` or
   [https://developer.apple.com/download/all/](https://developer.apple.com/download/all/)) or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
@@ -84,7 +84,7 @@ Uninstallation is documented in the [FAQ](FAQ.md).
 
 <a name="1"><sup>1</sup></a> For 32-bit or PPC support see [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
-<a name="2"><sup>2</sup></a> 10.15 or higher is recommended, while 10.11–10.14 are supported on a best-effort basis. For 10.4–10.6 see [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
+<a name="2"><sup>2</sup></a> 11 or higher is recommended, while 10.12–10.15 are supported on a best-effort basis. For 10.4–10.6 see [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
 <a name="3"><sup>3</sup></a> Most formulae require a compiler. A handful require a full Xcode installation. You can install Xcode, the CLT, or both; Homebrew supports all three configurations. Downloading Xcode may require an Apple Developer account on older versions of Mac OS X. Sign up for free at [Apple's website](https://developer.apple.com/register/index.action).
 


### PR DESCRIPTION
- macOS 13 RC has been shipped, and will soon be on our CI. 
- Release date is set to 24th October, so we can start abottling!