### PR TITLE
macOS Ventura (and related) test fixes

### DIFF
--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -91,11 +91,12 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_for_config_scripts" do
-    mktmpdir do |path|
-      file = "#{path}/foo-config"
+    mktmpdir do |tmp|
+      file = "#{tmp}/foo-config"
       FileUtils.touch file
       FileUtils.chmod 0755, file
-      ENV["PATH"] = "#{path}#{File::PATH_SEPARATOR}#{ENV.fetch("PATH")}"
+      homebrew_path = "#{tmp}#{File::PATH_SEPARATOR}#{ENV.fetch("PATH")}"
+      stub_const("ORIGINAL_PATHS", PATH.new(homebrew_path).map { |path| Pathname.new(path).expand_path }.compact)
 
       expect(checks.check_for_config_scripts)
         .to match('"config" scripts exist')

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -225,6 +225,9 @@ RSpec.configure do |config|
       if (example.metadata.keys & [:focus, :byebug]).empty? && !ENV.key?("HOMEBREW_VERBOSE_TESTS")
         $stdout.reopen(File::NULL)
         $stderr.reopen(File::NULL)
+      else
+        # don't retry when focusing/debugging
+        config.default_retry_count = 0
       end
       $stdin.reopen(File::NULL)
 

--- a/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.arm64_ventura.bottle.tar.gz
+++ b/Library/Homebrew/test/support/fixtures/bottles/testball_bottle-0.1.arm64_ventura.bottle.tar.gz
@@ -1,0 +1,1 @@
+testball_bottle-0.1.yosemite.bottle.tar.gz


### PR DESCRIPTION
- fix `check_for_config_scripts` test, no idea why this wasn't working
- don't autoretry tests if `focus` or `byebug` are enabled
- add a ARM64 Ventura bottle symlink