### PR TITLE
integration_test: fix Bundler deprecation.

### DIFF
--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -116,7 +116,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
       ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
     end
 
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       stdout, stderr, status = Open3.capture3(env, *@ruby_args, *args)
       $stdout.print stdout
       $stderr.print stderr
@@ -125,7 +125,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
   end
 
   def brew_sh(*args)
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       stdout, stderr, status = Open3.capture3("#{ENV.fetch("HOMEBREW_PREFIX")}/bin/brew", *args)
       $stdout.print stdout
       $stderr.print stderr


### PR DESCRIPTION
Otherwise in some configurations (e.g. https://github.com/Homebrew/brew/pull/13975) some tests will fail.