### PR TITLE
Add stable checksum to the JSON API

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2107,6 +2107,7 @@ class Formula
         "url"      => stable.url,
         "tag"      => stable.specs[:tag],
         "revision" => stable.specs[:revision],
+        "checksum" => stable.checksum&.to_s,
       }
 
       hsh["bottle"]["stable"] = bottle_hash if bottle_defined?

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -159,6 +159,7 @@ module Formulary
         stable do
           url urls_stable["url"]
           version json_formula["versions"]["stable"]
+          sha256 urls_stable["checksum"] if urls_stable["checksum"].present?
         end
       end
 


### PR DESCRIPTION
Closes https://github.com/Homebrew/brew/issues/14029

This PR adds the stable checksum (if it exists) to the JSON API. This also updates the formula API loader to load this value if it exists. This will allow commands like `brew unpack` to be run even with `HOMEBREW_INSTALL_FROM_API` set. I think this can be valuable for maintainers to effectively maintain while having `HOMEBREW_INSTALL_FROM_API` set.
