### PR TITLE
Support git partial clones with sparse checkouts (take 2)

### DIFF
--- a/Library/Homebrew/cask/artifact/relocated.rb
+++ b/Library/Homebrew/cask/artifact/relocated.rb
@@ -51,7 +51,9 @@ module Cask
         target = target_hash[:target]
         @source_string = source.to_s
         @target_string = target.to_s
-        source = cask.staged_path.join(source)
+        base_path = cask.staged_path
+        base_path = base_path.join(cask.url.only_path) if cask.url && cask.url.only_path.present?
+        source = base_path.join(source)
         @source = source
         target ||= source.basename
         @target = resolve_target(target)

--- a/Library/Homebrew/cask/artifact/relocated.rb
+++ b/Library/Homebrew/cask/artifact/relocated.rb
@@ -52,7 +52,7 @@ module Cask
         @source_string = source.to_s
         @target_string = target.to_s
         base_path = cask.staged_path
-        base_path = base_path.join(cask.url.only_path) if cask.url && cask.url.only_path.present?
+        base_path = base_path.join(cask.url.only_path) if cask.url&.only_path.present?
         source = base_path.join(source)
         @source = source
         target ||= source.basename

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -15,7 +15,7 @@ class URL < Delegator
                 :verified, :using,
                 :tag, :branch, :revisions, :revision,
                 :trust_cert, :cookies, :referer, :header, :user_agent,
-                :data, :only_paths
+                :data, :only_path
 
     extend Forwardable
     def_delegators :uri, :path, :scheme, :to_s
@@ -36,7 +36,7 @@ class URL < Delegator
         header:     T.nilable(String),
         user_agent: T.nilable(T.any(Symbol, String)),
         data:       T.nilable(T::Hash[String, String]),
-        only_paths: T.nilable(T::Array[String]),
+        only_path:  T.nilable(String),
       ).void
     }
     def initialize(
@@ -53,7 +53,7 @@ class URL < Delegator
       header: nil,
       user_agent: nil,
       data: nil,
-      only_paths: nil
+      only_path: nil
     )
 
       @uri = URI(uri)
@@ -71,7 +71,7 @@ class URL < Delegator
       specs[:header]     = @header     = header
       specs[:user_agent] = @user_agent = user_agent || :default
       specs[:data]       = @data       = data
-      specs[:only_paths] = @only_paths = only_paths
+      specs[:only_path]  = @only_path  = only_path
 
       @specs = specs.compact
     end
@@ -159,7 +159,7 @@ class URL < Delegator
       header:          T.nilable(String),
       user_agent:      T.nilable(T.any(Symbol, String)),
       data:            T.nilable(T::Hash[String, String]),
-      only_paths:      T.nilable(T::Array[String]),
+      only_path:       T.nilable(String),
       caller_location: Thread::Backtrace::Location,
       dsl:             T.nilable(Cask::DSL),
       block:           T.nilable(T.proc.params(arg0: T.all(String, BlockDSL::PageWithURL)).returns(T.untyped)),
@@ -179,7 +179,7 @@ class URL < Delegator
     header: nil,
     user_agent: nil,
     data: nil,
-    only_paths: nil,
+    only_path: nil,
     caller_location: T.must(caller_locations).fetch(0),
     dsl: nil,
     &block
@@ -207,7 +207,7 @@ class URL < Delegator
         header:     header,
         user_agent: user_agent,
         data:       data,
-        only_paths: only_paths,
+        only_path:  only_path,
       )
     end
     )

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -15,7 +15,7 @@ class URL < Delegator
                 :verified, :using,
                 :tag, :branch, :revisions, :revision,
                 :trust_cert, :cookies, :referer, :header, :user_agent,
-                :data
+                :data, :only_paths
 
     extend Forwardable
     def_delegators :uri, :path, :scheme, :to_s
@@ -36,6 +36,7 @@ class URL < Delegator
         header:     T.nilable(String),
         user_agent: T.nilable(T.any(Symbol, String)),
         data:       T.nilable(T::Hash[String, String]),
+        only_paths: T.nilable(T::Array[String]),
       ).void
     }
     def initialize(
@@ -51,7 +52,8 @@ class URL < Delegator
       referer: nil,
       header: nil,
       user_agent: nil,
-      data: nil
+      data: nil,
+      only_paths: nil
     )
 
       @uri = URI(uri)
@@ -69,6 +71,7 @@ class URL < Delegator
       specs[:header]     = @header     = header
       specs[:user_agent] = @user_agent = user_agent || :default
       specs[:data]       = @data       = data
+      specs[:only_paths] = @only_paths = only_paths
 
       @specs = specs.compact
     end
@@ -156,6 +159,7 @@ class URL < Delegator
       header:          T.nilable(String),
       user_agent:      T.nilable(T.any(Symbol, String)),
       data:            T.nilable(T::Hash[String, String]),
+      only_paths:      T.nilable(T::Array[String]),
       caller_location: Thread::Backtrace::Location,
       dsl:             T.nilable(Cask::DSL),
       block:           T.nilable(T.proc.params(arg0: T.all(String, BlockDSL::PageWithURL)).returns(T.untyped)),
@@ -175,6 +179,7 @@ class URL < Delegator
     header: nil,
     user_agent: nil,
     data: nil,
+    only_paths: nil,
     caller_location: T.must(caller_locations).fetch(0),
     dsl: nil,
     &block
@@ -202,6 +207,7 @@ class URL < Delegator
         header:     header,
         user_agent: user_agent,
         data:       data,
+        only_paths: only_paths,
       )
     end
     )

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -934,12 +934,12 @@ class GitDownloadStrategy < VCSDownloadStrategy
              args:  ["config", "advice.detachedHead", "false"],
              chdir: cached_location
 
-    if partial_clone_sparse_checkout?
-      command! "git",
-               args:  ["config", "origin.partialclonefilter", "blob:none"],
-               chdir: cached_location
-      configure_sparse_checkout
-    end
+    return unless partial_clone_sparse_checkout?
+
+    command! "git",
+             args:  ["config", "origin.partialclonefilter", "blob:none"],
+             chdir: cached_location
+    configure_sparse_checkout
   end
 
   sig { params(timeout: T.nilable(Time)).void }
@@ -1047,7 +1047,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
              args:  ["config", "core.sparseCheckout", "true"],
              chdir: cached_location
 
-    sparse_checkout_paths = @only_paths.join("\n") + "\n"
+    sparse_checkout_paths = "#{@only_paths.join("\n")}\n"
     (git_dir/"info"/"sparse-checkout").atomic_write(sparse_checkout_paths)
   end
 end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -882,7 +882,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   end
 
   def partial_clone_sparse_checkout?
-    return false if @only_paths.nil?
+    return false if @only_paths.blank?
 
     # There is some support for partial clones prior to 2.20, but we avoid using it
     # due to performance issues

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -813,7 +813,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   def initialize(url, name, version, **meta)
     # Needs to be before the call to `super`, as the VCSDownloadStrategy's
     # constructor calls `cache_tag` and sets the cache path.
-    @only_paths = meta[:only_paths]
+    @only_path = meta[:only_path]
 
     super
     @ref_type ||= :branch
@@ -889,7 +889,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   end
 
   def partial_clone_sparse_checkout?
-    return false if @only_paths.blank?
+    return false if @only_path.blank?
 
     Utils::Git.supports_partial_clone_sparse_checkout?
   end
@@ -1052,8 +1052,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
              args:  ["config", "core.sparseCheckout", "true"],
              chdir: cached_location
 
-    sparse_checkout_paths = "#{@only_paths.join("\n")}\n"
-    (git_dir/"info"/"sparse-checkout").atomic_write(sparse_checkout_paths)
+    (git_dir/"info"/"sparse-checkout").atomic_write("#{@only_path}\n")
   end
 end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -884,9 +884,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   def partial_clone_sparse_checkout?
     return false if @only_paths.blank?
 
-    # There is some support for partial clones prior to 2.20, but we avoid using it
-    # due to performance issues
-    Version.create(Utils::Git.version) >= Version.create("2.20.0")
+    Utils::Git.supports_partial_clone_sparse_checkout?
   end
 
   sig { returns(T::Array[String]) }

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -811,10 +811,13 @@ end
 # @api public
 class GitDownloadStrategy < VCSDownloadStrategy
   def initialize(url, name, version, **meta)
+    # Needs to be before the call to `super`, as the VCSDownloadStrategy's
+    # constructor calls `cache_tag` and sets the cache path.
+    @only_paths = meta[:only_paths]
+
     super
     @ref_type ||= :branch
     @ref ||= "master"
-    @only_paths = meta[:only_paths]
   end
 
   # @see AbstractDownloadStrategy#source_modified_time
@@ -837,7 +840,11 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
   sig { returns(String) }
   def cache_tag
-    "git"
+    if partial_clone_sparse_checkout?
+      "git-sparse"
+    else
+      "git"
+    end
   end
 
   sig { returns(Integer) }

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -141,5 +141,11 @@ module Utils
         raise ErrorDuringExecution.new(cmd, status: $CHILD_STATUS, output: [[:stdout, output]])
       end
     end
+
+    def supports_partial_clone_sparse_checkout?
+      # There is some support for partial clones prior to 2.20, but we avoid using it
+      # due to performance issues
+      Version.create(version) >= Version.create("2.20.0")
+    end
   end
 end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -1138,6 +1138,18 @@ In rare cases, a distribution may not be available over ordinary HTTP/S. Subvers
 | `revision:`        | a string identifying the subversion revision to download
 | `trust_cert:`      | set to `true` to automatically trust the certificate presented by the server (avoiding an interactive prompt)
 
+#### Git URLs
+
+Artifacts also may be distributed via git repositories. URLs that end in `.git` are automatically assumed to be git repositories, and the following key/value pairs may be appended to `url`:
+
+| key                | value       |
+| ------------------ | ----------- |
+| `using:`           | the symbol `:git` is the only legal value
+| `tag:`             | a string identifying the git tag to download
+| `revision:`        | a string identifying the git revision to download
+| `branch:`          | a string identifying the git branch to download
+| `only_path:`       | a path within the repository to limit the checkout to. If only a single directory of a large repository is required, using this option can signficantly speed up downloads. If provided, artifact paths are relative to this path.
+
 #### SourceForge/OSDN URLs
 
 SourceForge and OSDN (formerly `SourceForge.JP`) projects are common ways to distribute binaries, but they provide many different styles of URLs to get to the goods.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Continuing #13232 since it got closed for going stale. Sorry for vanishing and not finishing this off last time round!

The first five commits on this branch are the same as the commits in #13232, but rebased onto master to ensure they still work with changes made since I originally opened the #13232.

The following two commits (b11df3bef825417b4d67ed9b5639f206e20851bf and 2d68e27d7b1f15f52e88909280777a38ec287d75) rename `only_paths` to `only_path` (and make it a string rather than an array), which means we can automatically apply the `only_path` prefix to artifact sources ([as discussed](https://github.com/Homebrew/homebrew-cask-fonts/pull/5758/files#r910515049)).

The final commit documents installing cask artifacts via git repositories.