### PR TITLE
Remove sitedir from LOAD_PATH

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -724,7 +724,7 @@ then
 fi
 
 # Disable Ruby options we don't need.
-RUBY_DISABLE_OPTIONS="--disable=rubyopt"
+RUBY_DISABLE_OPTIONS="--disable=gems,rubyopt"
 
 if [[ -z "${HOMEBREW_RUBY_WARNINGS}" ]]
 then

--- a/Library/Homebrew/standalone/load_path.rb
+++ b/Library/Homebrew/standalone/load_path.rb
@@ -1,8 +1,12 @@
 # typed: true
 # frozen_string_literal: true
 
-require "pathname"
+# We trust base Ruby to provide what we need.
+# Don't look into the user-installed sitedir, which may contain older versions of RubyGems.
+require "rbconfig"
+$LOAD_PATH.reject! { |path| path.start_with?(RbConfig::CONFIG["sitedir"]) }
 
+require "pathname"
 HOMEBREW_LIBRARY_PATH = Pathname(__dir__).parent.realpath.freeze
 
 require_relative "../utils/gems"

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -44,6 +44,9 @@ module Homebrew
   end
 
   def setup_gem_environment!(setup_path: true)
+    require "rubygems"
+    raise "RubyGems too old!" if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.2.0")
+
     # Match where our bundler gems are.
     gem_home = "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
     Gem.paths = {


### PR DESCRIPTION
As #14036 shows, we cannot trust the contents of this directory won't break things. We do not need anything that base Ruby does not provide, so there's no need to allow the possibility to use, for example, updated versions of RubyGems.

Fixes #14036.