### PR TITLE
os/mac/diagnostic: allow Ruby 2.6.10 on < Ventura

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -205,19 +205,13 @@ module Homebrew
       end
 
       def check_ruby_version
-        # TODO: update portable-ruby to 2.6.10 when Ventura reaches RC
-        required_version = if MacOS.version >= :ventura &&
-                              ENV["HOMEBREW_RUBY_PATH"].to_s.exclude?("/vendor/portable-ruby/")
-          "2.6.10"
-        else
-          HOMEBREW_REQUIRED_RUBY_VERSION
-        end
-        return if RUBY_VERSION == required_version
+        return if RUBY_VERSION == HOMEBREW_REQUIRED_RUBY_VERSION
+        return if RUBY_VERSION == "2.6.10" # TODO: require 2.6.10
         return if Homebrew::EnvConfig.developer? && OS::Mac.version.prerelease?
 
         <<~EOS
           Ruby version #{RUBY_VERSION} is unsupported on macOS #{MacOS.version}. Homebrew
-          is developed and tested on Ruby #{required_version}, and may not work correctly
+          is developed and tested on Ruby #{HOMEBREW_REQUIRED_RUBY_VERSION}, and may not work correctly
           on other Rubies. Patches are accepted as long as they don't cause breakage
           on supported Rubies.
         EOS


### PR DESCRIPTION
2.6.10 got backported to 11.7.1 and 12.6.1.

We'll bump the minimum when enough people have updated - it's been less than 24 hours.