### PR TITLE
dev-cmd/bump-formula-pr: allow --version for version formatting changes

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -392,7 +392,7 @@ module Homebrew
     resource = Resource.new
     resource.url(url, specs)
     resource.owner = Resource.new(formula.name)
-    forced_version = new_version && new_version != resource.version
+    forced_version = new_version && new_version != resource.version.to_s
     resource.version = new_version if forced_version
     odie "Couldn't identify version, specify it using `--version=`." if resource.version.blank?
     [resource.fetch, forced_version]


### PR DESCRIPTION
`--version` is not allowed (with a confusing message IMO) if the version specified matches the one auto-detected from the URL.

This makes sense, but there is a case where we might want to change the formatting of the version, so let's make the check a strict string comparison.

Example use case: icu4c where it detects "68-1" from the URL, but we change that to read "68.1".