### PR TITLE
Replace deprecated `srb` command with `tapioca`

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -67,7 +67,7 @@ module Homebrew
         ohai "Updating Tapioca RBI files..."
         safe_system "bundle", "exec", "tapioca", "gem", *tapioca_args
         safe_system "bundle", "exec", "parlour"
-        safe_system "bundle", "exec", "srb", "rbi", "hidden-definitions"
+        safe_system "bundle", "exec", "tapioca", "dsl"
         safe_system "bundle", "exec", "tapioca", "todo"
 
         if args.suggest_typed?


### PR DESCRIPTION
`srb rbi hidden-definitions` is slated for deprecation: https://sorbet.org/docs/rbi#dsl-rbis

In its place, `tapioca dsl` provides the same functionality.
