### PR TITLE
Fix Oh-My-Zsh suggested completions configuration

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -46,7 +46,7 @@ then
 fi
 ```
 
-This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you, so this must be done before you call `oh-my-zsh.sh`. This may be done by appending the following line to your `~/.zprofile` after Homebrew's initialization, instead of modifying your `~/.zshrc` as above:
+This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you when sourced. In this case, instead of the above, add the following line to your `~/.zshrc`, before you call `oh-my-zsh.sh`:
 
 ```sh
 FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -46,7 +46,7 @@ then
 fi
 ```
 
-This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you when sourced. In this case, instead of the above, add the following line to your `~/.zshrc`, before you call `oh-my-zsh.sh`:
+This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you when you source `oh-my-zsh.sh`. In this case, instead of the above, add the following line to your `~/.zshrc`, before you source `oh-my-zsh.sh`:
 
 ```sh
 FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"


### PR DESCRIPTION
The currently suggested configuration for **Oh My Zsh** users breaks **completions** on **non-login** shells as `~/.zprofile` is only executed for login shells. This is further evidenced in Homebrew/brew.sh#900

Fixes https://github.com/Homebrew/brew.sh/issues/900

This PR rewords the suggested configuration to address this issue and keep the alternate simple configuration option for **Oh My Zsh** users.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
