### PR TITLE
Fix require Xcode version on macOS Ventura, rollback to 14.0.1

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -23,7 +23,7 @@ module OS
       def latest_version(macos: MacOS.version)
         latest_stable = "13.4"
         case macos
-        when "13" then "14.1"
+        when "13" then "14.0.1"
         when "12" then latest_stable
         when "11" then "13.2.1"
         when "10.15" then "12.4"
@@ -46,7 +46,7 @@ module OS
       sig { returns(String) }
       def minimum_version
         case MacOS.version
-        when "13" then "14.1"
+        when "13" then "14.0.1"
         when "12" then "13.1"
         when "11" then "12.2"
         when "10.15" then "11.0"
@@ -246,7 +246,7 @@ module OS
         when "12.0.5" then "12.5.1"
         when "13.0.0" then "13.2.1"
         when "13.1.6" then "13.4.1"
-        else               "14.1"
+        else               "14.0.1"
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
The latest released Xcode version is 14.0.1, the 14.1 version is still in RC2. Require 14.1 on Ventura could cause some problem.