### PR TITLE
cask: audit for minimal OS version in sparkle feeds

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -546,6 +546,7 @@ module Cask
     end
 
     def check_livecheck_min_os
+      return unless online?
       return unless cask.livecheckable?
       return unless cask.livecheck.strategy == :sparkle
 

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -545,6 +545,37 @@ module Cask
       false
     end
 
+    def check_livecheck_min_os
+      return unless cask.livecheckable?
+      return unless cask.livecheck.strategy == :sparkle
+
+      out, _, status = curl_output(cask.livecheck.url)
+      return unless status.success?
+
+      require "rexml/document"
+
+      xml = begin
+        REXML::Document.new(out)
+      rescue
+        nil
+      end
+
+      return if xml.blank?
+
+      item = xml.get_elements("//rss//channel//item").first
+      return if item.blank?
+
+      min_os = item.elements["sparkle:minimumSystemVersion"].text
+      return if min_os.blank?
+
+      min_os_string = OS::Mac::Version.new(min_os).strip_patch
+      cask_min_os = cask.depends_on.macos.version
+
+      return if cask_min_os == min_os_string
+
+      add_error "Upstream defined #{min_os_string} as minimal OS version and the cask defined #{cask_min_os}"
+    end
+
     sig { void }
     def check_appcast_contains_version
       return unless appcast?

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -556,7 +556,7 @@ module Cask
 
       xml = begin
         REXML::Document.new(out)
-      rescue
+      rescue REXML::ParseException
         nil
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should prevent situations where we forget to update the macOS dependency if there is a new version required upstream