### PR TITLE
os/mac/xcode: do not recommend `softwareupdate` CLI

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -325,8 +325,7 @@ module OS
         end
 
         <<~EOS
-          Update them from Software Update in #{software_update_location} or run:
-            softwareupdate --all --install --force --verbose
+          Update them from Software Update in #{software_update_location}.
 
           If that doesn't show you any updates, run:
             sudo rm -rf /Library/Developer/CommandLineTools


### PR DESCRIPTION
With macOS Ventura, Apple have changed this tool to force-upgrade macOS Monterey installs to macOS Ventura, without any ability to Ctrl+C cancel once it starts downloading. This behaviour cannot be opted out of, unless you manually check the list and install updates individually.

This is an extremely invasive thing to recommend for just updating the CLT, so we should recommend users to use System Preferences instead.