### PR TITLE
rubocop: Deal with some TODOs for `Naming/MethodParameterName`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -371,6 +371,9 @@ Metrics/PerceivedComplexity:
 # allow those that are standard
 # TODO: try to remove some of these
 Naming/MethodParameterName:
+  inherit_mode:
+    merge:
+      - AllowedNames
   AllowedNames:
     - "a"
     - "b"
@@ -383,14 +386,12 @@ Naming/MethodParameterName:
     - "ff"
     - "fn"
     - "id"
-    - "io"
     - "o"
     - "p"
     - "pr"
     - "r"
     - "rb"
     - "s"
-    - "to"
     - "v"
 
 # GitHub diff UI wraps beyond 118 characters

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -372,7 +372,6 @@ Metrics/PerceivedComplexity:
 # TODO: try to remove some of these
 Naming/MethodParameterName:
   AllowedNames:
-    - "_"
     - "a"
     - "b"
     - "cc"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- As of RuboCop v0.67.0 (quite some time ago!), this rule allows `_` by default as it commonly denotes "this argument is unused". This is not set upstream in `AllowedNames`, the code [ignores underscores](https://github.com/rubocop/rubocop/commit/4bc7d8c1bc14109525ec370cd5b338a9470bed84#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) entirely.
- In the default RuboCop configs the method names `to` and `io` are [allowed by default](https://github.com/rubocop/rubocop/blob/41a8249b3595cc8656b823d50b2abe38206fd09a/config/default.yml#L2794). But we weren't inheriting those allowed names correctly from the upstream configuration. This fixes that so that we get future enhancements automatically for this particular cop allowlist.
