### PR TITLE
cmd/search: better handle non-TTY output.

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -146,9 +146,21 @@ module Homebrew
     print_formulae &&= all_formulae.any?
     print_casks &&= all_casks.any?
 
-    ohai "Formulae", Formatter.columns(all_formulae) if print_formulae
+    if print_formulae
+      if $stdout.tty?
+        ohai "Formulae", Formatter.columns(all_formulae)
+      else
+        puts all_formulae
+      end
+    end
     puts if print_formulae && print_casks
-    ohai "Casks", Formatter.columns(all_casks) if print_casks
+    if print_casks
+      if $stdout.tty?
+        ohai "Casks", Formatter.columns(all_casks)
+      else
+        puts all_casks
+      end
+    end
 
     count = all_formulae.count + all_casks.count
 


### PR DESCRIPTION
When `stdout` is not a TTY then using `ohai` is a bit unpleasant as it prevents using pipes to do cool things with the output.

Fixes https://github.com/Homebrew/brew/issues/14067 (kinda)