### PR TITLE
.devcontainer/on-create-command: Add `openssh-server` (for `gh cs ssh`)

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -18,5 +18,9 @@ sudo apt-get update
 sudo apt-get install -y \
   -o Dpkg::Options::=--force-confdef \
   -o Dpkg::Options::=--force-confnew \
+  openssh-server \
   zsh \
   zsh-autosuggestions
+
+# Start the SSH server so that `gh cs ssh` works.
+sudo service ssh start


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- My Codespaces workflow sometimes involves `gh cs ssh` for a terminal and tmux and vim (for better or for worse).
- I tried this on a `Homebrew/brew` Codespace and got the below error. But it felt weird following that instruction to the letter and bloating the Docker image which we by default keep minimal.
- If we didn't have prebuilds setup, this install would increase creation time by quite a bit. But since we do (for the main branch at least), [the `onCreateCommand` is included in those prebuilds](https://docs.github.com/en/codespaces/prebuilding-your-codespaces/about-github-codespaces-prebuilds#the-prebuild-process), so creation time of `Homebrew/brew` Codespaces in most cases should continue to be near instant.

----

Before:

```shell
❯ gh cs ssh
? Choose codespace: Homebrew/brew (master): redesigned spork
error getting ssh server details: failed to start server:
Please check if an SSH server is installed in the container.
If the docker image being used for the codespace does not have an SSH server,
install it in your Dockerfile or, for codespaces that use Debian-based images,
you can add the following to your devcontainer.json:

"features": {
    "ghcr.io/devcontainers/features/sshd:1": {
        "version": "latest"
    }
}
```

After:

```shell
❯ gh cs create -r Homebrew/brew -b codespaces-add-ssh
  ✓ Codespaces usage for this repository is paid for by Homebrew
? Devcontainer definition file: .devcontainer/devcontainer.json
? Choose Machine Type: 2 cores, 4 GB RAM, 32 GB storage
issyl0-stunning-engine-pwq675w47277qq
❯ gh cs ssh
? Choose codespace: Homebrew/brew (codespaces-add-ssh): stunning engine
Welcome to Ubuntu 22.04.1 LTS (GNU/Linux 5.4.0-1094-azure x86_64)

 [...]
linuxbrew@codespaces-f6bb09:/workspaces/brew$
```