### PR TITLE
test/rubocops/formula_desc: Add some tests I should have written in 2017

### DIFF
--- a/Library/Homebrew/test/rubocops/formula_desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_spec.rb
@@ -118,12 +118,19 @@ describe RuboCop::Cop::FormulaAudit::Desc do
       RUBY
     end
 
-    it "reports an offense when the description ends with a full stop" do
+    it "report and corrects an offense when the description ends with a full stop" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           desc 'Description with a full stop at the end.'
-                                                       ^ Description shouldn\'t end with a full stop.
+                                                       ^ Description shouldn't end with a full stop.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          desc 'Description with a full stop at the end'
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/formula_desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_spec.rb
@@ -128,6 +128,15 @@ describe RuboCop::Cop::FormulaAudit::Desc do
       RUBY
     end
 
+    it "does not report an offense when the description ends with 'etc.'" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          desc 'Description of a thing and some more things and some more etc.'
+        end
+      RUBY
+    end
+
     it "reports and corrects all rules for description text" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- In 2017 almost to the day, I made my first set of contributions to Homebrew. They added a RuboCop rule for ensuring that formula descriptions can't end in a full stop apart from "etc.". https://github.com/Homebrew/brew/pull/3411
- Back then I was asked to write tests for those additions, but for some reason I didn't - lack of time or confidence, who knows!
- Tonight, five years later (!), someone asked me how long I'd been contributing to Homebrew, so I rediscovered that first PR and I was embarrassed by past Issy. So here are some tests for those RuboCops.

😳 😬
