### PR TITLE
caveats: Update message displayed by unsigned_accessibility

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -69,14 +69,20 @@ module Cask
       end
 
       caveat :unsigned_accessibility do |access = "Accessibility"|
-        # access: the category in System Preferences > Security & Privacy > Privacy the app requires.
+        # access: the category in the privacy settings the app requires.
+
+        if MacOS.version < :ventura
+          navigation_path = "System Preferences → Security & Privacy → Privacy"
+        else
+          navigation_path = "System Settings → Privacy & Security"
+        end
 
         <<~EOS
           #{@cask} is not signed and requires Accessibility access,
           so you will need to re-grant Accessibility access every time the app is updated.
 
           Enable or re-enable it in:
-            System Preferences → Security & Privacy → Privacy → #{access}
+            #{navigation_path} → #{access}
           To re-enable, untick and retick #{@cask}.app.
         EOS
       end

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -71,10 +71,10 @@ module Cask
       caveat :unsigned_accessibility do |access = "Accessibility"|
         # access: the category in the privacy settings the app requires.
 
-        if MacOS.version < :ventura
-          navigation_path = "System Preferences → Security & Privacy → Privacy"
+        navigation_path = if MacOS.version < :ventura
+          "System Preferences → Security & Privacy → Privacy"
         else
-          navigation_path = "System Settings → Privacy & Security"
+          "System Settings → Privacy & Security"
         end
 
         <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

On macOS Ventura, the System Preferences App was updated to System Settings.
This PR updates the navigation path displayed by the `unsigned_accessibility` caveat to reflect these changes.