### PR TITLE
rubyext: align workaround with upstream

### DIFF
--- a/Library/Homebrew/rubyext/rubygems/defaults/operating_system.rb
+++ b/Library/Homebrew/rubyext/rubygems/defaults/operating_system.rb
@@ -1,19 +1,31 @@
-# typed: strict
+# typed: false
 # frozen_string_literal: true
 
-require "etc"
-
 # Fixes universal-ruby getting confused whether to install arm64 or x86_64 macOS versions.
-# https://github.com/rubygems/rubygems/issues/4234
-# This can be removed when either:
-# - We stop using system Ruby
-# - System Ruby is updated with this patch (shipped with Ruby 3.1 or later):
-#   https://github.com/ruby/ruby/commit/96ce1d9a0ff64494753ad4730f36a0cd7e7a89e7
-# - The Rubygems PR https://github.com/rubygems/rubygems/pull/4238 is merged
-#   AND we install a new enough Rubygems which includes the said patch, instead of relying the system's version.
-platform = Gem::Platform.local.dup
-platform.cpu = Etc.uname[:machine] if platform.os == "darwin" && platform.cpu == "universal"
-Gem.platforms[Gem.platforms.index(Gem::Platform.local)] = platform
+# This can be removed when integrated into Bundler: https://github.com/rubygems/rubygems/pull/5978
+module Gem
+  # @private
+  class Specification
+    if /^universal\.(?<arch>.*?)-/ =~ (CROSS_COMPILING || RUBY_PLATFORM)
+      local_platform = Platform.local
+      if local_platform.cpu == "universal"
+        ORIGINAL_LOCAL_PLATFORM = local_platform.to_s.freeze
+
+        local_platform.cpu = if arch == "arm64e" # arm64e is only permitted for Apple system binaries
+          "arm64"
+        else
+          arch
+        end
+
+        def extensions_dir
+          Gem.default_ext_dir_for(base_dir) ||
+            File.join(base_dir, "extensions", ORIGINAL_LOCAL_PLATFORM,
+                      Gem.extension_api_version)
+        end
+      end
+    end
+  end
+end
 
 # This doesn't currently exist in system Ruby but it's safer to check.
 orig_file = File.join(RbConfig::CONFIG["rubylibdir"], "rubygems", "defaults", "operating_system")


### PR DESCRIPTION
This is a direct copy paste from what is being proposed upstream, so what's here will eventually become default behaviour.

Might cover #14083, I don't know - this is a completely blind fix but it makes sense to try anyway.