### PR TITLE
move two methods from download_strategy to utils/github

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -12,6 +12,7 @@ require "mechanize/version"
 require "mechanize/http/content_disposition_parser"
 
 require "utils/curl"
+require "utils/github"
 
 require "github_packages"
 
@@ -1070,7 +1071,6 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
   end
 
   def commit_outdated?(commit)
-    require "utils/github"
     @last_commit ||= GitHub.last_commit(@user, @repo, @ref)
     if @last_commit
       return true unless commit

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -12,7 +12,6 @@ require "mechanize/version"
 require "mechanize/http/content_disposition_parser"
 
 require "utils/curl"
-require "utils/github"
 
 require "github_packages"
 
@@ -1071,6 +1070,7 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
   end
 
   def commit_outdated?(commit)
+    require "utils/github"
     @last_commit ||= GitHub.last_commit(@user, @repo, @ref)
     if @last_commit
       return true unless commit

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -12,6 +12,7 @@ require "mechanize/version"
 require "mechanize/http/content_disposition_parser"
 
 require "utils/curl"
+require "utils/github"
 
 require "github_packages"
 
@@ -1069,43 +1070,13 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
     @repo = repo
   end
 
-  def github_last_commit
-    # TODO: move to Utils::GitHub
-    return if Homebrew::EnvConfig.no_github_api?
-
-    output, _, status = curl_output(
-      "--silent", "--head", "--location",
-      "-H", "Accept: application/vnd.github.sha",
-      "https://api.github.com/repos/#{@user}/#{@repo}/commits/#{@ref}"
-    )
-
-    return unless status.success?
-
-    commit = output[/^ETag: "(\h+)"/, 1]
-    version.update_commit(commit) if commit
-    commit
-  end
-
-  def multiple_short_commits_exist?(commit)
-    # TODO: move to Utils::GitHub
-    return if Homebrew::EnvConfig.no_github_api?
-
-    output, _, status = curl_output(
-      "--silent", "--head", "--location",
-      "-H", "Accept: application/vnd.github.sha",
-      "https://api.github.com/repos/#{@user}/#{@repo}/commits/#{commit}"
-    )
-
-    !(status.success? && output && output[/^Status: (200)/, 1] == "200")
-  end
-
   def commit_outdated?(commit)
-    @last_commit ||= github_last_commit
+    @last_commit ||= GitHub.last_commit(@user, @repo, @ref)
     if @last_commit
       return true unless commit
       return true unless @last_commit.start_with?(commit)
 
-      if multiple_short_commits_exist?(commit)
+      if GitHub.multiple_short_commits_exist?(@user, @repo, commit)
         true
       else
         version.update_commit(commit)

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -673,7 +673,7 @@ module GitHub
     output, _, status = curl_output(
       "--silent", "--head", "--location",
       "--header", "Accept: application/vnd.github.sha",
-      "https://api.github.com/repos/#{user}/#{repo}/commits/#{ref}"
+      url_to("repos", user, repo, "commits", ref).to_s
     )
 
     return unless status.success?
@@ -691,7 +691,7 @@ module GitHub
     output, _, status = curl_output(
       "--silent", "--head", "--location",
       "--header", "Accept: application/vnd.github.sha",
-      "https://api.github.com/repos/#{user}/#{repo}/commits/#{commit}"
+      url_to("repos", user, repo, "commits", commit).to_s
     )
 
     return true if status.success?

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -696,8 +696,7 @@ module GitHub
 
     return true if status.success?
     return true unless output
-    return true if output[/^Status: (200)/, 1] != "200"
 
-    false
+    output[/^Status: (200)/, 1] != "200"
   end
 end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -672,14 +672,16 @@ module GitHub
 
     output, _, status = curl_output(
       "--silent", "--head", "--location",
-      "-H", "Accept: application/vnd.github.sha",
+      "--header", "Accept: application/vnd.github.sha",
       "https://api.github.com/repos/#{user}/#{repo}/commits/#{ref}"
     )
 
     return unless status.success?
 
     commit = output[/^ETag: "(\h+)"/, 1]
-    version.update_commit(commit) if commit
+    return if commit.blank?
+
+    version.update_commit(commit)
     commit
   end
 
@@ -688,10 +690,14 @@ module GitHub
 
     output, _, status = curl_output(
       "--silent", "--head", "--location",
-      "-H", "Accept: application/vnd.github.sha",
+      "--header", "Accept: application/vnd.github.sha",
       "https://api.github.com/repos/#{user}/#{repo}/commits/#{commit}"
     )
 
-    !(status.success? && output && output[/^Status: (200)/, 1] == "200")
+    return true if status.success?
+    return true unless output
+    return true if output[/^Status: (200)/, 1] != "200"
+
+    false
   end
 end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -694,8 +694,8 @@ module GitHub
       url_to("repos", user, repo, "commits", commit).to_s
     )
 
-    return true if status.success?
-    return true unless output
+    return true unless status.success?
+    return true if output.blank?
 
     output[/^Status: (200)/, 1] != "200"
   end

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -3,6 +3,7 @@
 
 require "tempfile"
 require "utils/shell"
+require "utils/formatter"
 
 module GitHub
   API_URL = "https://api.github.com"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
move two methods (`github_last_commit` and `multiple_short_commits_exist` ) from `download_storategy` to `utils/github` because of `# TODO`.