### PR TITLE
devcontainer/on-create-command: fix Ubuntu 18.04, add debugging.

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
 set -e
 
+# dump information variables for debugging
+echo "==> env"
+env | grep -v TOKEN
+echo
+echo "==> /etc/os-release"
+cat /etc/os-release || true
+echo
+echo "==> /etc/lsb-release"
+cat /etc/lsb-release || true
+echo
+echo "==> /etc/issue"
+cat /etc/issue || true
+echo
+
 # fix permissions so Homebrew and Bundler don't complain
 sudo chmod -R g-w,o-w /home/linuxbrew
 
@@ -15,12 +29,18 @@ brew cleanup
 
 # install some useful development things
 sudo apt-get update
+APT_GET_INSTALL="openssh-server zsh"
+
+# Ubuntu 18.04 doesn't include zsh-autosuggestions
+if ! grep -q "Ubuntu 18.04" /etc/issue &>/dev/null
+then
+  APT_GET_INSTALL="$APT_GET_INSTALL zsh-autosuggestions"
+fi
+
 sudo apt-get install -y \
   -o Dpkg::Options::=--force-confdef \
   -o Dpkg::Options::=--force-confnew \
-  openssh-server \
-  zsh \
-  zsh-autosuggestions
+  $APT_GET_INSTALL
 
 # Start the SSH server so that `gh cs ssh` works.
 sudo service ssh start


### PR DESCRIPTION
Add some debugging information to be able to customise the prebuild/not cases for this script.

Also, handle `zsh-autosuggestions` not being available for Ubuntu 18.04.