### PR TITLE
Allow multiple macOS requirements

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -126,7 +126,7 @@ class Requirement
   alias eql? ==
 
   def hash
-    [name, tags].hash
+    [self.class, name, tags].hash
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -88,6 +88,15 @@ class MacOSRequirement < Requirement
     end
   end
 
+  def ==(other)
+    super(other) && comparator == other.comparator && version == other.version
+  end
+  alias eql? ==
+
+  def hash
+    [super, comparator, version].hash
+  end
+
   sig { returns(String) }
   def inspect
     "#<#{self.class.name}: version#{@comparator}#{@version.to_s.inspect} #{tags.inspect}>"


### PR DESCRIPTION
We store requirements in a set which means we strip out any duplicate requirements.

However, this was too strict for macOS requirements, as the uniqueness checks did not consider different comparators and versions.

This meant that:

```
depends_on macos: :mojave
depends_on maximum_macos: :big_sur
```

would incorrectly be combined to only one of them - usually the first.

Now with the changes in this PR, macOS requirements will only be combined if they are truly identical (e.g. if `depends_on macos: :mojave` appeared twice).