### PR TITLE
cask/artifact/abstract_uninstall: allow wildcard entries for launchctl

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -98,7 +98,10 @@ module Cask
           all_services << service unless service.include?("*")
           next unless service.include?("*")
 
-          all_services += find_launchctl_with_wildcard(service)
+          found_services = find_launchctl_with_wildcard(service)
+          next if found_services.blank?
+
+          found_services.each { |service| all_services += service}
         end
 
         all_services.each do |service|
@@ -282,6 +285,7 @@ module Cask
       def find_launchctl_with_wildcard(search)
         regex = Regexp.escape(search).gsub("\\*", ".*")
         system_command!("/bin/launchctl", args: ["list"])
+          # skip stdout column headers
           .stdout.lines.drop(1)
           .map do |line|
             pid, _state, id = line.chomp.split("\t")

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -101,7 +101,7 @@ module Cask
           found_services = find_launchctl_with_wildcard(service)
           next if found_services.blank?
 
-          found_services.each { |service| all_services += service}
+          found_services.each { |found_service| all_services += found_service }
         end
 
         all_services.each do |service|

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -95,7 +95,7 @@ module Cask
 
         # if launchctl item contains a wildcard, find matching process(es)
         services.each do |service|
-          all_services << service
+          all_services << service unless service.include?("*")
           next unless service.include?("*")
 
           all_services += find_launchctl_with_wildcard(service)

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -101,7 +101,7 @@ module Cask
           found_services = find_launchctl_with_wildcard(service)
           next if found_services.blank?
 
-          found_services.each { |found_service| all_services += found_service }
+          found_services.each { |found_service| all_services << found_service }
         end
 
         all_services.each do |service|

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -285,8 +285,7 @@ module Cask
       def find_launchctl_with_wildcard(search)
         regex = Regexp.escape(search).gsub("\\*", ".*")
         system_command!("/bin/launchctl", args: ["list"])
-          # skip stdout column headers
-          .stdout.lines.drop(1)
+          .stdout.lines.drop(1) # skip stdout column headers
           .map do |line|
             pid, _state, id = line.chomp.split("\t")
             id if pid.to_i.nonzero? && id.match?(regex)

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -61,13 +61,39 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using launchctl with regex" do
+  context "using :launchctl with regex wildcard" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-launchctl-wildcard")) }
-    let(:launchctl_list_cmd) { %w[/bin/launchctl list] }
+    let(:launchctl_regex) { "my.fancy.package.service.*" }
+    let(:unknown_response) { "launchctl list returned unknown response\n" }
+    let(:service_info) do
+      <<~EOS
+        {
+                "LimitLoadToSessionType" = "Aqua";
+                "Label" = "my.fancy.package.service.12345";
+                "TimeOut" = 30;
+                "OnDemand" = true;
+                "LastExitStatus" = 0;
+                "ProgramArguments" = (
+                        "argument";
+                );
+        };
+      EOS
+    end
 
-    it "searches running launchctl items" do
-      expect(fake_system_command).to receive(:run)
-        .with("/bin/launchctl", args: ["list"], print_stderr: false, sudo: false)
+    it "searches installed launchctl items" do
+      expect(subject).to receive(:find_launchctl_with_wildcard)
+        .with(launchctl_regex)
+        .and_return(["my.fancy.package.service.12345"])
+
+      allow(fake_system_command).to receive(:run)
+        .with("/bin/launchctl", args: ["list", "my.fancy.package.service.12345"], print_stderr: false, sudo: false)
+        .and_return(instance_double(SystemCommand::Result, stdout: unknown_response))
+      allow(fake_system_command).to receive(:run)
+        .with("/bin/launchctl", args: ["list", "my.fancy.package.service.12345"], print_stderr: false, sudo: true)
+        .and_return(instance_double(SystemCommand::Result, stdout: service_info))
+
+      expect(fake_system_command).to receive(:run!)
+        .with("/bin/launchctl", args: ["remove", "my.fancy.package.service.12345"], sudo: true)
         .and_return(instance_double(SystemCommand::Result))
 
       subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -66,7 +66,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     let(:launchctl_list_cmd) { %w[/bin/launchctl list] }
 
     it "searches running launchctl items" do
-      allow(fake_system_command).to receive(:run)
+      expect(fake_system_command).to receive(:run)
         .with("/bin/launchctl", args: ["list"], print_stderr: false, sudo: false)
         .and_return(instance_double(SystemCommand::Result))
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl-wildcard.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl-wildcard.rb
@@ -1,0 +1,11 @@
+cask "with-uninstall-launchctl-wildcard" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
+  homepage "https://brew.sh/fancy"
+
+  app "Fancy.app"
+
+  uninstall launchctl: "my.fancy.package.service.*"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl-wildcard.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl-wildcard.rb
@@ -1,0 +1,11 @@
+cask "with-zap-launchctl-wildcard" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
+  homepage "https://brew.sh/fancy"
+
+  app "Fancy.app"
+
+  zap launchctl: "my.fancy.package.service.*"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is an initial attempt to allow wildcard entries in Cask's `uninstall launchctl` stanza. 
The code takes the list of launchctl services provided in the uninstall stanza, and when it finds an `*` it will search the loaded system `launchctl` items to find any that match, and then pass them to the existing system for uninstalling. There may well be a more efficient/effective way to do this, however I just wanted to get the ball rolling here.
This will likely require new tests to be written, I have little knowledge on unit testing so some guidance here would be great.

https://github.com/Homebrew/homebrew-cask-drivers/pull/3104
https://github.com/Homebrew/homebrew-cask/issues/79661