### PR TITLE
uses_from_macos: add mandoc to allowed list

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -85,6 +85,7 @@ module RuboCop
           groff
           gzip
           less
+          mandoc
           openssl
           perl
           php


### PR DESCRIPTION
- see https://github.com/Homebrew/homebrew-core/pull/115411

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
