### PR TITLE
Fix `install` <cask> `--dry-run`

### DIFF
--- a/Library/Homebrew/cask/cmd/install.rb
+++ b/Library/Homebrew/cask/cmd/install.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require "cask_dependent"
+
 module Cask
   class Cmd
     # Cask implementation of the `brew install` command.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes the following error, when running `brew install` <cask> `--dry-run`:
~~~ sh
> brew install <cask> --dry-run
==> Would install 1 cask:
<cask>
Error: uninitialized constant Cask::Cmd::Install::CaskDependent
/usr/local/Homebrew/Library/Homebrew/cask/cmd/install.rb:94:in `block in install_casks'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/install.rb:93:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/install.rb:93:in `install_casks'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:192:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in `<main>'
~~~