### PR TITLE
Speed up `deleted_reason` method

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -154,14 +154,17 @@ module Homebrew
             end
           end
 
-          # Check if the formula has been deleted in the last month.
-          diff_command = ["git", "diff", "--diff-filter=D", "--name-only",
-                          "@{'1 month ago'}", "--", relative_path]
-          deleted_formula = Utils.popen_read(*diff_command)
+          # Optimization for the core tap which has many monthly commits
+          if tap.core_tap?
+            # Check if the formula has been deleted in the last month.
+            diff_command = ["git", "diff", "--diff-filter=D", "--name-only",
+                            "@{'1 month ago'}", "--", relative_path]
+            deleted_formula = Utils.popen_read(*diff_command)
 
-          if deleted_formula.blank?
-            ofail "No previously deleted formula found." unless silent
-            return
+            if deleted_formula.blank?
+              ofail "No previously deleted formula found." unless silent
+              return
+            end
           end
 
           # Find commit where formula was deleted in the last month.

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -75,16 +75,28 @@ describe Homebrew::MissingFormula do
       end
     end
 
-    context "with a deleted formula" do
-      let(:formula) { "homebrew/foo/deleted-formula" }
+    shared_examples "it detects deleted formulae" do
+      context "with a deleted formula" do
+        let(:formula) { "homebrew/foo/deleted-formula" }
 
-      it { is_expected.not_to be_nil }
+        it { is_expected.not_to be_nil }
+      end
+
+      context "with a formula that never existed" do
+        let(:formula) { "homebrew/foo/missing-formula" }
+
+        it { is_expected.to be_nil }
+      end
     end
 
-    context "with a formula that never existed" do
-      let(:formula) { "homebrew/foo/missing-formula" }
+    include_examples "it detects deleted formulae"
 
-      it { is_expected.to be_nil }
+    describe "on the core tap" do
+      before do
+        allow_any_instance_of(Tap).to receive(:core_tap?).and_return(true)
+      end
+
+      include_examples "it detects deleted formulae"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When playing around with brew a few days ago I realized that one of the reasons that `brew search` and `brew info` can be slow sometimes for me is because of the following `git log` command in `MissingFormula.deleted_reason`.

https://github.com/Homebrew/brew/blob/b683bebd24b5003b47e722116eb2a0989e1e7111/Library/Homebrew/missing_formula.rb#L157-L159

```sh
$ time brew info unknown_formula
Error: No available formula with the name "unknown_formula".
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.

________________________________________________________
Executed in    9.96 secs    fish           external
   usr time    8.72 secs   13.84 millis    8.71 secs
   sys time    1.03 secs    2.77 millis    1.02 secs

$ pwd
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
$ time git log --since='1 month ago'\
            --diff-filter=D --max-count=1\
            --format=%H\\\\n%h\\\\n%B -- Formula/unknown_formula.rb

________________________________________________________
Executed in    7.38 secs    fish           external
   usr time    7.31 secs  209.00 micros    7.31 secs
   sys time    0.07 secs  603.00 micros    0.07 secs
```

After investigating a little more I found out that we default to searching the core tap when a formula is not found by name in any of the taps. This `git log` command searches linearly through the last months worth of commits which is thousands of commits on the core tap. I decided to limit this optimization to the core tap because I don't think that any other taps are active enough for this to be a performance issue. Does anyone know if there are any other taps of a similar size out there?

```sh
$ pwd
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
$ git log --since='1 month ago' --pretty=oneline | wc -l
   10213
$ git log --before='1 month ago' --after='2 month ago'\
                                         --pretty=oneline | wc -l
    5195
$ git log --before='2 month ago' --after='3 month ago'\
                                         --pretty=oneline | wc -l
    4852
```

To speed this up I just check to see if the formula existed in a commit from a month ago before doing the entire `git log` command. The tradeoff here is that we will miss any formulas that were introduced less than a month ago and then removed. That seems unlikely but it is a tradeoff. I tend to think it's more likely that people will search for something that doesn't exist or make a typo. Also, we don't remove that many formulae every month. In the past month, the only one we removed was `ksh` but that now points to `ksh93` because `deleted_reason` never actually gets called when searching for deprecated formulae.

```sh
$ pwd
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core
$ git log --diff-filter=D --since='1 year ago' --pretty=oneline | wc -l
     101
```

We removed 101 formulae over the past year but it's very inconsistent from month to month (as I already mentioned we've only removed one in the past month).

Here are some before and after benchmarks.

### Before
```sh
$ time brew info unknown_formula
Error: No available formula with the name "unknown_formula".
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.

________________________________________________________
Executed in    9.68 secs    fish           external
   usr time    8.48 secs  196.00 micros    8.48 secs
   sys time    1.00 secs  515.00 micros    1.00 secs

$ time brew info jjrnl
Error: No available formula with the name "jjrnl". Did you mean jrnl?
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.

________________________________________________________
Executed in    6.10 secs    fish           external
   usr time    4.96 secs  191.00 micros    4.96 secs
   sys time    1.00 secs  584.00 micros    1.00 secs

$ time brew search unknown_formula
Error: No formulae or casks found for "unknown_formula".

________________________________________________________
Executed in   15.13 secs    fish           external
   usr time   10.76 secs  207.00 micros   10.76 secs
   sys time    2.24 secs  642.00 micros    2.23 secs

$ time brew search jjrnl
==> Formulae
jrnl ✔

________________________________________________________
Executed in    9.80 secs    fish           external
   usr time    7.16 secs  198.00 micros    7.16 secs
   sys time    1.85 secs  551.00 micros    1.85 secs
```

### After
```sh
$ time brew info unknown_formula
Error: No available formula with the name "unknown_formula".
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.

________________________________________________________
Executed in    2.39 secs    fish           external
   usr time    1.25 secs  190.00 micros    1.25 secs
   sys time    0.99 secs  563.00 micros    0.99 secs

$ time brew info jjrnl
Error: No available formula with the name "jjrnl". Did you mean jrnl?
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.

________________________________________________________
Executed in    2.38 secs    fish           external
   usr time    1.22 secs  198.00 micros    1.22 secs
   sys time    1.00 secs  529.00 micros    1.00 secs

$ time brew search unknown_formula
Error: No formulae or casks found for "unknown_formula".

________________________________________________________
Executed in    6.20 secs    fish           external
   usr time    3.45 secs  199.00 micros    3.45 secs
   sys time    1.84 secs  611.00 micros    1.84 secs

$ time brew search jjrnl
==> Formulae
jrnl ✔

________________________________________________________
Executed in    6.18 secs    fish           external
   usr time    3.44 secs  202.00 micros    3.44 secs
   sys time    1.87 secs  617.00 micros    1.87 secs
```

Is this a worthwhile tradeoff to speed up `brew search` and `brew info`? Also, I'd be interested to see what the benchmarks look like on newer macs.