### PR TITLE
CPU: fix M2 family detection

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -152,7 +152,11 @@ module Hardware
       end
 
       def sysctl_int(key)
-        sysctl_n(key).to_i
+        if (x = sysctl_n(key).to_i) >= 0
+          x
+        else
+          x & 0xffffffff
+        end
       end
 
       def sysctl_n(*keys)

--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -152,11 +152,7 @@ module Hardware
       end
 
       def sysctl_int(key)
-        if (x = sysctl_n(key).to_i) >= 0
-          x
-        else
-          x & 0xffffffff
-        end
+        sysctl_n(key).to_i & 0xffffffff
       end
 
       def sysctl_n(*keys)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

On MacBook Air with M2 chip `brew config` return `dunno` family (while `arm_blizzard_avalanche` is expected):
```
$ brew config | grep CPU
CPU: octa-core 64-bit dunno
```

And here's the corresponding `sysctl -A` output:
```
% sysctl -A | grep hw.cpufamily
hw.cpufamily: -634136515
```

It looks like some signed int32 overflow happens somewhere for `0xda33d83d`, which causes it to return a negative number.

These changes will also affect CPU family detection for `ARMv8.2-A (Monsoon, Mistral)` (https://en.wikipedia.org/wiki/Apple_A11) and for `ARMv8.0-A (Twister)` (https://en.wikipedia.org/wiki/Apple_A9 / https://en.wikipedia.org/wiki/Apple_A9X). They are used in iPhones only, so I don't think it will affect anything real.