### PR TITLE
utils/gems: use env shebang when installing gems

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -81,7 +81,8 @@ module Homebrew
       ohai_if_defined "Installing '#{name}' gem"
       # `document: []` is equivalent to --no-document
       # `build_args: []` stops ARGV being used as a default
-      specs = Gem.install name, version, document: [], build_args: []
+      # `env_shebang: true` makes shebangs generic to allow switching between system and Portable Ruby
+      specs = Gem.install name, version, document: [], build_args: [], env_shebang: true
     end
 
     specs += specs.flat_map(&:runtime_dependencies)


### PR DESCRIPTION
This allows switching between portable and system Ruby without having to manually reinstall the gem.

This wasn't an issue previously under Bundler as we used a shim which had its own shebang. And under Bundler 1, our PATH priority was different in that it never actually used the installed executable and used the one that shipped with Ruby instead (albeit still the newly installed core Bundler lib files).

This fix does not affect existing installs, so anybody who updated in the last 8 hours will have the issue if they switch Rubies in the future. This will eventually fix itself when we next update Bundler, which I'll probably do when 2.3.27 is released at the end of the month just to make sure.