### PR TITLE
dev-cmd/bump-{cask,formula}-pr: `args.message` is before the default

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -41,7 +41,7 @@ module Homebrew
       flag   "--version=",
              description: "Specify the new <version> for the cask."
       flag   "--message=",
-             description: "Append <message> to the default pull request message."
+             description: "Prepend <message> to the default pull request message."
       flag   "--url=",
              description: "Specify the <URL> for the new download."
       flag   "--sha256=",

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -60,7 +60,7 @@ module Homebrew
                           "that `--version=0` can be used to delete an existing version override from a " \
                           "formula if it has become redundant."
       flag   "--message=",
-             description: "Append <message> to the default pull request message."
+             description: "Prepend <message> to the default pull request message."
       flag   "--url=",
              description: "Specify the <URL> for the new download. If a <URL> is specified, the <SHA-256> " \
                           "checksum of the new download should also be specified."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- "Append" is the wrong word for the `--message` arg description since the `bump-formula-pr --message` gets added at the start.