### PR TITLE
Prevent `brew casks` from finding formulae at tap root

### DIFF
--- a/Library/Homebrew/cmd/casks.sh
+++ b/Library/Homebrew/cmd/casks.sh
@@ -8,5 +8,5 @@
 source "${HOMEBREW_LIBRARY}/Homebrew/items.sh"
 
 homebrew-casks() {
-  homebrew-items 'Formula' 's|/Casks/|/|' '^homebrew/cask'
+  homebrew-items '*/Casks/*\.rb' '' 's|/Casks/|/|' '^homebrew/cask'
 }

--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -8,5 +8,5 @@
 source "${HOMEBREW_LIBRARY}/Homebrew/items.sh"
 
 homebrew-formulae() {
-  homebrew-items 'Casks' 's|/Formula/|/|' '^homebrew/core'
+  homebrew-items '*\.rb' 'Casks' 's|/Formula/|/|' '^homebrew/core'
 }

--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -1,9 +1,10 @@
 homebrew-items() {
   local items
   local sed_extended_regex_flag
-  local find_filter="$1"
-  local sed_filter="$2"
-  local grep_filter="$3"
+  local find_include_filter="$1"
+  local find_exclude_filter="$2"
+  local sed_filter="$3"
+  local grep_filter="$4"
 
   # HOMEBREW_MACOS is set by brew.sh
   # shellcheck disable=SC2154
@@ -19,14 +20,14 @@ homebrew-items() {
   items="$(
     find "${HOMEBREW_REPOSITORY}/Library/Taps" \
       -type d \( \
-      -name "${find_filter}" -o \
+      -name "${find_exclude_filter}" -o \
       -name cmd -o \
       -name .github -o \
       -name lib -o \
       -name spec -o \
       -name vendor \
       \) \
-      -prune -false -o -name '*\.rb' |
+      -prune -false -o -path "${find_include_filter}" |
       sed "${sed_extended_regex_flag}" \
         -e 's/\.rb//g' \
         -e 's_.*/Taps/(.*)/(home|linux)brew-_\1/_' \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently, `brew casks` will print names of formulae defined at the root of a tap repository. e.g. for [this tap](https://github.com/cartr/homebrew-qt4):

```
$ brew tap cartr/qt4
# …
Tapped 23 formulae (43 files, 222.1KB).

$ brew casks | grep 'cartr/qt4'
cartr/qt4/automoc4
cartr/qt4/coin@3.1.3
cartr/qt4/cuty_capt
cartr/qt4/ezlupdate
# …
```

I'm assuming this is a bug, so here is my best attempt at a fix.

All tests pass, but I'm not sure any exist for `brew formulae` and `brew casks`. From my manual testing, they appear to now work as I would expect.