### PR TITLE
Compile C / C++ code with fpic

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1515,7 +1515,7 @@ class Formula
   # Standard parameters for configure builds.
   sig { returns(T::Array[String]) }
   def std_configure_args
-    ["--disable-debug", "--disable-dependency-tracking", "--prefix=#{prefix}", "--libdir=#{lib}"]
+    ["--disable-debug", "--disable-dependency-tracking", "--with-pic", "--prefix=#{prefix}", "--libdir=#{lib}"]
   end
 
   # Standard parameters for cargo builds.
@@ -1541,6 +1541,7 @@ class Formula
       -DCMAKE_INSTALL_PREFIX=#{install_prefix}
       -DCMAKE_INSTALL_LIBDIR=#{install_libdir}
       -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON
       -DCMAKE_FIND_FRAMEWORK=#{find_framework}
       -DCMAKE_VERBOSE_MAKEFILE=ON
       -Wno-dev


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Follow-up for discussion https://github.com/Homebrew/homebrew-core/pull/112792:
- Added `--with-fpic` for configure-based projects
- Added [CMAKE_POSITION_INDEPENDENT_CODE](https://cmake.org/cmake/help/latest/variable/CMAKE_POSITION_INDEPENDENT_CODE.html) for cmake based projects.
- For meson we don't have to add anything since static libraries are built with -fpic by default (see default value for [b_staticpic](https://mesonbuild.com/Builtin-options.html#base-options))