### PR TITLE
brew.sh: remove `HOMEBREW_CHANGE_ARCH_TO_ARM`

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -13,7 +13,6 @@ permissions:
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
-  HOMEBREW_CHANGE_ARCH_TO_ARM: 1
 jobs:
   tests:
     strategy:

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -13,26 +13,6 @@ case "${HOMEBREW_SYSTEM}" in
   Linux) HOMEBREW_LINUX="1" ;;
 esac
 
-if [[ "${HOMEBREW_MACOS}" == "1" ]] &&
-   [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]
-then
-  # used in vendor-install.sh
-  # shellcheck disable=SC2034
-  HOMEBREW_PHYSICAL_PROCESSOR="arm64"
-  HOMEBREW_ROSETTA="$(sysctl -n sysctl.proc_translated)"
-
-  # If we're running under macOS Rosetta 2, and it was requested by setting
-  # HOMEBREW_CHANGE_ARCH_TO_ARM (for example in CI), then we re-exec this
-  # same file under the native architecture
-  # These variables are set from the user environment.
-  # shellcheck disable=SC2154
-  if [[ "${HOMEBREW_CHANGE_ARCH_TO_ARM}" == "1" ]] &&
-     [[ "${HOMEBREW_ROSETTA}" == "1" ]]
-  then
-    exec arch -arm64e "${HOMEBREW_BREW_FILE}" "$@"
-  fi
-fi
-
 # Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
 # for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.
 # These variables are set by bin/brew
@@ -441,6 +421,13 @@ then
   HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X ${HOMEBREW_MACOS_VERSION}"
+
+  if [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]
+  then
+    # used in vendor-install.sh
+    # shellcheck disable=SC2034
+    HOMEBREW_PHYSICAL_PROCESSOR="arm64"
+  fi
 
   # Intentionally set this variable by exploding another.
   # shellcheck disable=SC2086,SC2183

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -150,6 +150,8 @@ safe_cd() {
 }
 
 brew() {
+  # This variable is set by bin/brew
+  # shellcheck disable=SC2154
   "${HOMEBREW_BREW_FILE}" "$@"
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We used to need this because the GitHub runner process was running under
Rosetta. GitHub Actions has supported native M1 runners for a few months
now, so I think it's time to remove this.
