### PR TITLE
fix: allow running bin/brew with SHELLOPTS=nounset

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -u
 
 # Fail fast with concise message when not using bash
 # Single brackets is needed here for POSIX compatibility
@@ -87,11 +88,11 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 for VAR in BAT_THEME BROWSER DISPLAY EDITOR NO_COLOR TMUX DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR CODESPACES
 do
   # Skip if variable value is empty.
-  [[ -z "${!VAR}" ]] && continue
+  [[ -z "${!VAR:-}" ]] && continue
 
   VAR_NEW="HOMEBREW_${VAR}"
   # Skip if existing HOMEBREW_* variable is set.
-  [[ -n "${!VAR_NEW}" ]] && continue
+  [[ -n "${!VAR_NEW:-}" ]] && continue
   export "${VAR_NEW}"="${!VAR}"
 done
 unset VAR VAR_NEW
@@ -113,7 +114,7 @@ fi
 # shellcheck disable=SC2154
 # Set CI variable for Azure Pipelines and Jenkins
 # (Set by default on GitHub Actions, Circle and Travis CI)
-if [[ -z "${CI}" ]] && [[ -n "${TF_BUILD}" || -n "${JENKINS_HOME}" ]]
+if [[ -z "${CI:-}" ]] && [[ -n "${TF_BUILD:-}" || -n "${JENKINS_HOME:-}" ]]
 then
   export CI="1"
 fi
@@ -137,7 +138,7 @@ ENV_VAR_NAMES=(
 for VAR in "${ENV_VAR_NAMES[@]}" "${!HOMEBREW_@}"
 do
   # Skip if variable value is empty.
-  [[ -z "${!VAR}" ]] && continue
+  [[ -z "${!VAR:-}" ]] && continue
 
   FILTERED_ENV+=("${VAR}=${!VAR}")
 done

--- a/bin/brew
+++ b/bin/brew
@@ -21,7 +21,7 @@ fi
 # Fail fast with concise message when requesting unfiltered environment.
 # This is basically odisabled so can be removed at any major release afterwards
 # and definitely if this is still here in 2023.
-if [ -n "${HOMEBREW_NO_ENV_FILTERING}" ]
+if [ -n "${HOMEBREW_NO_ENV_FILTERING:-}" ]
 then
   echo "Error: HOMEBREW_NO_ENV_FILTERING was deprecated for over a year and has now been removed (because it breaks many things)!" >&2
   exit 1

--- a/bin/brew
+++ b/bin/brew
@@ -105,7 +105,7 @@ export HOMEBREW_LIBRARY
 # set from user environment
 # shellcheck disable=SC2154
 # Use VISUAL if HOMEBREW_EDITOR and EDITOR are unset.
-if [[ -z "${HOMEBREW_EDITOR}" && -n "${VISUAL}" ]]
+if [[ -z "${HOMEBREW_EDITOR:-}" && -n "${VISUAL}" ]]
 then
   export HOMEBREW_EDITOR="${VISUAL}"
 fi

--- a/bin/brew
+++ b/bin/brew
@@ -105,7 +105,7 @@ export HOMEBREW_LIBRARY
 # set from user environment
 # shellcheck disable=SC2154
 # Use VISUAL if HOMEBREW_EDITOR and EDITOR are unset.
-if [[ -z "${HOMEBREW_EDITOR:-}" && -n "${VISUAL}" ]]
+if [[ -z "${HOMEBREW_EDITOR:-}" && -n "${VISUAL:-}" ]]
 then
   export HOMEBREW_EDITOR="${VISUAL}"
 fi

--- a/bin/brew
+++ b/bin/brew
@@ -22,7 +22,7 @@ fi
 # Fail fast with concise message when requesting unfiltered environment.
 # This is basically odisabled so can be removed at any major release afterwards
 # and definitely if this is still here in 2023.
-if [ -n "${HOMEBREW_NO_ENV_FILTERING:-}" ]
+if [[ -n "${HOMEBREW_NO_ENV_FILTERING:-}" ]]
 then
   echo "Error: HOMEBREW_NO_ENV_FILTERING was deprecated for over a year and has now been removed (because it breaks many things)!" >&2
   exit 1


### PR DESCRIPTION
A similar fix is already present on line 6.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
