### PR TITLE
diagnostic: remove some checks.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -181,32 +181,6 @@ module Homebrew
         EOS
       end
 
-      # Anaconda installs multiple system & brew dupes, including OpenSSL, Python,
-      # sqlite, libpng, Qt, etc. Regularly breaks compile on Vim, MacVim and others.
-      # Is flagged as part of the *-config script checks below, but people seem
-      # to ignore those as warnings rather than extremely likely breakage.
-      def check_for_anaconda
-        return unless which("anaconda")
-        return unless which("python")
-
-        anaconda_directory = which("anaconda").realpath.dirname
-        python_binary = Utils.popen_read(which("python"), "-c", "import sys; sys.stdout.write(sys.executable)")
-        python_directory = Pathname.new(python_binary).realpath.dirname
-
-        # Only warn if Python lives with Anaconda, since is most problematic case.
-        return unless python_directory == anaconda_directory
-
-        <<~EOS
-          Anaconda is known to frequently break Homebrew builds, including Vim and
-          MacVim, due to bundling many duplicates of system and Homebrew-provided
-          tools.
-
-          If you encounter a build failure please temporarily remove Anaconda
-          from your $PATH and attempt the build again prior to reporting the
-          failure to us. Thanks!
-        EOS
-      end
-
       def __check_stray_files(dir, pattern, allow_list, message)
         return unless File.directory?(dir)
 
@@ -474,54 +448,6 @@ module Homebrew
           formulae that put executables in #{HOMEBREW_PREFIX}/sbin.
           Consider setting your PATH for example like so:
             #{Utils::Shell.prepend_path_in_profile("#{HOMEBREW_PREFIX}/sbin")}
-        EOS
-      end
-
-      def check_for_config_scripts
-        return unless HOMEBREW_CELLAR.exist?
-
-        real_cellar = HOMEBREW_CELLAR.realpath
-
-        scripts = []
-
-        allowlist = %W[
-          /bin /sbin
-          /usr/bin /usr/sbin
-          /usr/X11/bin /usr/X11R6/bin /opt/X11/bin
-          #{HOMEBREW_PREFIX}/bin #{HOMEBREW_PREFIX}/sbin
-          /Applications/Server.app/Contents/ServerRoot/usr/bin
-          /Applications/Server.app/Contents/ServerRoot/usr/sbin
-        ]
-        if OS.mac? && Hardware::CPU.physical_cpu_arm64?
-          allowlist += %W[
-            #{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/bin
-            #{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/sbin
-            #{HOMEBREW_DEFAULT_PREFIX}/bin
-            #{HOMEBREW_DEFAULT_PREFIX}/sbin
-          ]
-        end
-        allowlist.map!(&:downcase)
-
-        paths.each do |p|
-          next if allowlist.include?(p.downcase) || !File.directory?(p)
-
-          realpath = Pathname.new(p).realpath.to_s
-          next if realpath.start_with?(real_cellar.to_s, HOMEBREW_CELLAR.to_s)
-
-          scripts += Dir.chdir(p) { Dir["*-config"] }.map { |c| File.join(p, c) }
-        end
-
-        return if scripts.empty?
-
-        inject_file_list scripts, <<~EOS
-          "config" scripts exist outside your system or Homebrew directories.
-          `./configure` scripts often look for *-config scripts to determine if
-          software packages are installed, and which additional flags to use when
-          compiling and linking.
-
-          Having additional scripts in your path can confuse software installed via
-          Homebrew if the config script overrides a system or Homebrew-provided
-          script of the same name. We found the following "config" scripts:
         EOS
       end
 

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -11,21 +11,6 @@ describe Homebrew::Diagnostic::Checks do
     expect(checks.inject_file_list(%w[/a /b], "foo:\n")).to eq("foo:\n  /a\n  /b\n")
   end
 
-  specify "#check_for_anaconda" do
-    mktmpdir do |path|
-      anaconda = "#{path}/anaconda"
-      python = "#{path}/python"
-      FileUtils.touch anaconda
-      File.write(python, "#! #{`which bash`}\necho -n '#{python}'\n")
-      FileUtils.chmod 0755, anaconda
-      FileUtils.chmod 0755, python
-
-      ENV["PATH"] = "#{path}#{File::PATH_SEPARATOR}#{ENV.fetch("PATH")}"
-
-      expect(checks.check_for_anaconda).to match("Anaconda")
-    end
-  end
-
   specify "#check_access_directories" do
     skip "User is root so everything is writable." if Process.euid.zero?
     begin
@@ -88,19 +73,6 @@ describe Homebrew::Diagnostic::Checks do
       .to match("Homebrew's \"sbin\" was not found in your PATH")
   ensure
     sbin.rmtree
-  end
-
-  specify "#check_for_config_scripts" do
-    mktmpdir do |tmp|
-      file = "#{tmp}/foo-config"
-      FileUtils.touch file
-      FileUtils.chmod 0755, file
-      homebrew_path = "#{tmp}#{File::PATH_SEPARATOR}#{ENV.fetch("PATH")}"
-      stub_const("ORIGINAL_PATHS", PATH.new(homebrew_path).map { |path| Pathname.new(path).expand_path }.compact)
-
-      expect(checks.check_for_config_scripts)
-        .to match('"config" scripts exist')
-    end
   end
 
   specify "#check_for_symlinked_cellar" do


### PR DESCRIPTION
- Some of these are currently failing globally on GitHub Actions.
- Some(/all?) of these predate our use of the macOS sandbox, environment filtering, PATH filtering and pushing users much harder to use bottles instead of building from source
- I haven't seen a case for a long time where any of these actually debugged a user issue. If/when this happens: we can add a given check back.
- This should allow us to dramatically reduce the amount of cleanup that `brew test-bot` needs to do on GitHub Actions.

Fixes https://github.com/Homebrew/brew/issues/14175