### PR TITLE
shims/super/cc: unset RUBYLIB

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -5,6 +5,7 @@ then
   echo "${0##*/}: The build tool has reset ENV; --env=std required." >&2
   exit 1
 fi
+unset RUBYLIB
 exec "${HOMEBREW_RUBY_PATH}" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -x "$0" "$@"
 #!/usr/bin/env ruby -W0
 


### PR DESCRIPTION
While `--disable=rubyopt` will disable usage of the RUBYOPT env, it does not disable RUBYLIB which can equally break things as seen in https://github.com/Homebrew/homebrew-core/pull/116659. Ruby 3.1.3's build now sets RUBYLIB while building native gems, and this RUBYLIB will point to Ruby 3.1 libraries while we are running Ruby 2.6 for the compiler shim.

```
/private/tmp/ruby-20221130-70653-1yc6ogm/ruby-3.1.3/.ext/common/pathname.rb:13:in `require': incompatible library version - /private/tmp/ruby-20221130-70653-1yc6ogm/ruby-3.1.3/.ext/x86_64-darwin21/pathname.bundle (LoadError)
	from /private/tmp/ruby-20221130-70653-1yc6ogm/ruby-3.1.3/.ext/common/pathname.rb:13:in `<top (required)>'
	from /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang:11:in `require'
	from /usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang:11:in `<main>'
```

This partially restores the behaviour prior to https://github.com/Homebrew/brew/commit/ef2e297d3b084c2ae28088f5749fe2365839f2e5.