### PR TITLE
dev-cmd/bump: don't use Repology version if livecheckable

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -207,9 +207,8 @@ module Homebrew
     return "unable to get versions" if version_info.blank?
 
     latest = version_info[:latest]
-    strategy = version_info[:meta][:strategy]
 
-    [Version.new(latest), strategy]
+    Version.new(latest)
   rescue => e
     "error: #{e}"
   end
@@ -235,7 +234,7 @@ module Homebrew
       version_name = "cask version   "
     end
 
-    livecheck_latest, livecheck_strategy = livecheck_result(formula_or_cask)
+    livecheck_latest = livecheck_result(formula_or_cask)
 
     repology_latest = if repositories.present?
       Repology.latest_version(repositories)
@@ -245,7 +244,7 @@ module Homebrew
 
     new_version = if livecheck_latest.is_a?(Version) && livecheck_latest > current_version
       livecheck_latest
-    elsif repology_latest.is_a?(Version) && repology_latest > current_version && livecheck_strategy != "GithubLatest"
+    elsif repology_latest.is_a?(Version) && repology_latest > current_version && !formula_or_cask.livecheckable?
       repology_latest
     end.presence
 
@@ -273,9 +272,8 @@ module Homebrew
 
     if repology_latest > current_version &&
        repology_latest > livecheck_latest &&
-       livecheck_strategy == "GithubLatest"
-      puts "#{title_name} was not bumped to the Repology version because that " \
-           "version is not the latest release on GitHub."
+       formula_or_cask.livecheckable?
+      puts "#{title_name} was not bumped to the Repology version because it's livecheckable."
     end
 
     return unless new_version


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should fix issues like one seen in https://github.com/Homebrew/homebrew-core/pull/116956 when the Repology version is greater than the one we get from Livecheck and the strategy is different than GithubLatest.

Basically if we define a livecheck block, I think we want the Livecheck to be the top priority over Repology.
If we don't define the livecheck block, then Repology data should be equal to what Livecheck returns.