### PR TITLE
formula_creator: use tool-agnostic meson commands

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -168,11 +168,9 @@ module Homebrew
         <% elsif mode == :go %>
             system "go", "build", *std_go_args(ldflags: "-s -w")
         <% elsif mode == :meson %>
-            mkdir "build" do
-              system "meson", *std_meson_args, ".."
-              system "ninja", "-v"
-              system "ninja", "install", "-v"
-            end
+            system "meson", "setup", "build", *std_meson_args
+            system "meson", "compile", "-C", "build", "--verbose"
+            system "meson", "install", "-C", "build"
         <% elsif mode == :node %>
             system "npm", "install", *Language::Node.std_npm_install_args(libexec)
             bin.install_symlink Dir["\#{libexec}/bin/*"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Similar to CMake changes. This uses Meson's standard workflow which we have started to use in core formulae.