### PR TITLE
doctor: add -u flag to suggested git stash command

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -672,7 +672,7 @@ module Homebrew
             If this is a surprise to you, then you should stash these modifications.
             Stashing returns Homebrew to a pristine state but can be undone
             should you later need to do so for some reason.
-              cd #{path} && git stash && git clean -d -f
+              cd #{path} && git stash -u && git clean -d -f
           EOS
 
           modified = status.split("\n")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I was running `brew doctor` in my local machine when it returned a warning that my installation has uncommitted changes

```
Warning: You have uncommitted modifications to Homebrew/homebrew-core.
If this is a surprise to you, then you should stash these modifications.
Stashing returns Homebrew to a pristine state but can be undone
should you later need to do so for some reason.
  cd /opt/homebrew/Library/Taps/homebrew/homebrew-core && git stash && git clean -d -f

Uncommitted files:
  ?? Formula/pingu.rb
```

There was a formula that I started working on but I never actually completed it and it had just been sitting uncommitted. The suggested `git stash` command saves any modified files, but it doesn't include new files, which resulted in `git clean -d -f` deleting the file without being saved.

I added the [`-u` option](https://git-scm.com/docs/git-stash#Documentation/git-stash.txt--u) to git stash in order to include untracked files in the stash as well.
