### PR TITLE
ElectronBuilder: Allow Date/Time deserialization

### DIFF
--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -47,7 +47,7 @@ module Homebrew
         def self.versions_from_content(content, regex = nil, &block)
           require "yaml"
 
-          yaml = YAML.safe_load(content)
+          yaml = YAML.safe_load(content, permitted_classes: [Date, Time])
           return [] if yaml.blank?
 
           if block

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -25,6 +25,15 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
       releaseDate: '2000-01-01T00:00:00.000Z'
     EOS
   }
+
+  let(:electron_builder_yaml_with_timestamp) {
+    # An electron-builder YAML file may use a timestamp instead of an explicit
+    # string value (with quotes) for `releaseDate`, so we need to make sure that
+    # `ElectronBuilder#versions_from_content` won't encounter an error in this
+    # scenario (e.g. `Tried to load unspecified class: Time`).
+    electron_builder_yaml.sub(/releaseDate:\s*'([^']+)'/, 'releaseDate: \1')
+  }
+
   let(:mac_regex) { /Example[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i }
 
   let(:versions) { ["1.2.3"] }
@@ -46,6 +55,7 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
 
     it "returns an array of version strings when given YAML text" do
       expect(electron_builder.versions_from_content(electron_builder_yaml)).to eq(versions)
+      expect(electron_builder.versions_from_content(electron_builder_yaml_with_timestamp)).to eq(versions)
     end
 
     it "returns an array of version strings when given YAML text and a block" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `ElectronBuilder` strategy uses `YAML#safe_load` to parse YAML content and this [limits deserialization to appropriate classes](https://ruby-doc.org/stdlib-2.6.10/libdoc/psych/rdoc/Psych.html#method-c-safe_load). We [recently encountered a `Tried to load unspecified class: Time` error](https://github.com/Homebrew/homebrew-cask/pull/137011) when using the `ElectronBuilder` strategy on a `latest-mac.yml` file containing `releaseDate: 2022-12-01T02:02:46.419Z`.

The electron-builder YAML files we usually encounter use single quotes around the `releaseDate` value to ensure it's treated as a string (e.g., `releaseDate: '2022-10-12T17:55:26.718Z'`) and this is what we do in `electron_builder_spec.rb`. The aforementioned YAML file doesn't use single quotes around the value, so it's treated as a timestamp and apparently this makes Psych use `Time` (which `#safe_load` doesn't allow by default).

There's something to be said for upstream simply using single quotes around this value (the electron-builder documentation seems to suggest the value should be a string) but that's not something we can directly control and we may encounter other files like this in the future. With that in mind, this PR modifies the related `#safe_load` call to allow `Time` (and `Date` for good measure), which will resolve the aforementioned error and allow the `ElectronBuilder` strategy to work as expected in this scenario.