### PR TITLE
Cleanup `brew prof`

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -7,7 +7,9 @@ if ENV["HOMEBREW_STACKPROF"]
 end
 
 raise "HOMEBREW_BREW_FILE was not exported! Please call bin/brew directly!" unless ENV["HOMEBREW_BREW_FILE"]
-raise "#{__FILE__} must not be loaded via `require`." if $PROGRAM_NAME != __FILE__
+if $PROGRAM_NAME != __FILE__ && !$PROGRAM_NAME.end_with?("/bin/ruby-prof")
+  raise "#{__FILE__} must not be loaded via `require`."
+end
 
 std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is just a cleanup of `brew prof` which isn't working correctly right now.

First off there is an error when using `brew prof` that is caused by check to make sure this file is never loaded by `require`. I added an exception so that `ruby-prof` can load it fixing the following error message.

```
$ brew prof ls
/usr/local/Homebrew/Library/Homebrew/brew.rb:10:in `<top (required)>': /usr/local/Homebrew/Library/Homebrew/brew.rb must not be loaded via `require`. (RuntimeError)
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/bin/ruby-prof:291:in `load'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/bin/ruby-prof:291:in `block in run'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/bin/ruby-prof:290:in `profile'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/bin/ruby-prof:290:in `run'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/bin/ruby-prof:328:in `<top (required)>'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/ruby-prof:23:in `load'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/ruby-prof:23:in `<main>'
```

Second, I'm having a problem loading the `stack prof` gem. Not sure if this just a local problem so I'd be happy if someone else could try reproducing it. I don't have a fix for this either.

```
$ brew prof --stackprof ls
==> Installing 'stackprof' gem
Fetching stackprof-0.2.23.gem
Building native extensions. This could take a while...
/usr/local/Homebrew/Library/Homebrew/brew.rb:5:in `require': cannot load such file -- stackprof (LoadError)
        from /usr/local/Homebrew/Library/Homebrew/brew.rb:5:in `<main>'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/stackprof-0.2.23/lib/stackprof/report.rb:13:in `binread': No such file or directory @ rb_sysopen - prof/stackprof.dump (Errno::ENOENT)
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/stackprof-0.2.23/lib/stackprof/report.rb:13:in `from_file'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/stackprof-0.2.23/bin/stackprof:79:in `<top (required)>'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/stackprof:23:in `load'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/stackprof:23:in `<main>'
Error: Failure while executing; `stackprof\ --d3-flamegraph\ prof/stackprof.dump\ \>\ prof/d3-flamegraph.html` exited with 1.
$ brew prof --stackprof ls
/usr/local/Homebrew/Library/Homebrew/brew.rb:5:in `require': cannot load such file -- stackprof (LoadError)
        from /usr/local/Homebrew/Library/Homebrew/brew.rb:5:in `<main>'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/stackprof-0.2.23/lib/stackprof/report.rb:13:in `binread': No such file or directory @ rb_sysopen - prof/stackprof.dump (Errno::ENOENT)
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/stackprof-0.2.23/lib/stackprof/report.rb:13:in `from_file'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/stackprof-0.2.23/bin/stackprof:79:in `<top (required)>'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/stackprof:23:in `load'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/stackprof:23:in `<main>'
Error: Failure while executing; `stackprof\ --d3-flamegraph\ prof/stackprof.dump\ \>\ prof/d3-flamegraph.html` exited with 1.
```