### PR TITLE
caveats: print sudo in caveats if service requires it

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -176,10 +176,11 @@ class Caveats
     EOS
 
     is_running_service = f.service? && quiet_system("ps aux | grep #{f.service.command&.first}")
+    startup = f.service&.requires_root? || f.plist_startup
     if is_running_service || (f.plist && quiet_system("/bin/launchctl list #{f.plist_name} &>/dev/null"))
       s << "To restart #{f.full_name} after an upgrade:"
-      s << "  #{f.plist_startup ? "sudo " : ""}brew services restart #{f.full_name}"
-    elsif f.plist_startup
+      s << "  #{startup ? "sudo " : ""}brew services restart #{f.full_name}"
+    elsif startup
       s << "To start #{f.full_name} now and restart at startup:"
       s << "  sudo brew services start #{f.full_name}"
     else

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -172,11 +172,11 @@ describe Caveats do
         end
         cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
         allow(Homebrew).to receive(:_system).and_return(true)
-        allow(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(false)
+        expect(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(false)
         expect(described_class.new(f).caveats).to include("login")
       end
 
-      it "gives information about restarting services after upgrade" do
+      it "gives information about plist_options restarting services after upgrade" do
         f = formula do
           url "foo-1.0"
           service do
@@ -187,9 +187,66 @@ describe Caveats do
         cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
         f_obj = described_class.new(f)
         allow(Homebrew).to receive(:_system).and_return(true)
-        allow(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(true)
-        expect(f_obj.caveats).to include("restart #{f.full_name}")
-        expect(f_obj.caveats).to include("sudo")
+        expect(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(true)
+        expect(f_obj.caveats).to include("  sudo brew services restart #{f.full_name}")
+      end
+
+      it "gives information about require_root restarting services after upgrade" do
+        f = formula do
+          url "foo-1.0"
+          service do
+            run [bin/"cmd"]
+            require_root true
+          end
+        end
+        cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
+        f_obj = described_class.new(f)
+        allow(Homebrew).to receive(:_system).and_return(true)
+        expect(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(true)
+        expect(f_obj.caveats).to include("  sudo brew services restart #{f.full_name}")
+      end
+
+      it "gives information about user restarting services after upgrade" do
+        f = formula do
+          url "foo-1.0"
+          service do
+            run [bin/"cmd"]
+          end
+        end
+        cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
+        f_obj = described_class.new(f)
+        allow(Homebrew).to receive(:_system).and_return(true)
+        expect(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(true)
+        expect(f_obj.caveats).to include("  brew services restart #{f.full_name}")
+      end
+
+      it "gives information about require_root starting services after upgrade" do
+        f = formula do
+          url "foo-1.0"
+          service do
+            run [bin/"cmd"]
+            require_root true
+          end
+        end
+        cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
+        f_obj = described_class.new(f)
+        allow(Homebrew).to receive(:_system).and_return(true)
+        allow(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(false)
+        expect(f_obj.caveats).to include("  sudo brew services start #{f.full_name}")
+      end
+
+      it "gives information about user starting services after upgrade" do
+        f = formula do
+          url "foo-1.0"
+          service do
+            run [bin/"cmd"]
+          end
+        end
+        cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
+        f_obj = described_class.new(f)
+        allow(Homebrew).to receive(:_system).and_return(true)
+        allow(Homebrew).to receive(:_system).with("ps aux | grep #{cmd}").and_return(false)
+        expect(f_obj.caveats).to include("  brew services start #{f.full_name}")
       end
 
       it "gives information about service manual command" do
@@ -203,7 +260,7 @@ describe Caveats do
         cmd = "#{HOMEBREW_CELLAR}/formula_name/1.0/bin/cmd"
         caveats = described_class.new(f).caveats
 
-        expect(caveats).to include("background service")
+        expect(caveats).to include("if you don't want/need a background service")
         expect(caveats).to include("VAR=\"foo\" #{cmd} start")
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Followup of https://github.com/Homebrew/brew/pull/14113, after this is released the formula in core can drop the last plist references.