### PR TITLE
dev-cmd/bump: check if Repology output is a version first

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -270,7 +270,8 @@ module Homebrew
 
     return unless args.open_pr?
 
-    if repology_latest > current_version &&
+    if repology_latest.is_a?(Version) &&
+       repology_latest > current_version &&
        repology_latest > livecheck_latest &&
        formula_or_cask.livecheckable?
       puts "#{title_name} was not bumped to the Repology version because it's livecheckable."


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to: https://github.com/Homebrew/brew/pull/14190

Before:
```
Mon 05 Dec 16:16:05 ➜  Library/Homebrew stash master ✓  brew bump cortex --open-pr
==> cortex
Current formula version:  1.13.1
Latest livecheck version: 1.14.0
Latest Repology version:  present only in Homebrew
Open pull requests:       cortex 1.14.0 (https://github.com/Homebrew/homebrew-core/pull/117195)
cortex was not bumped to the Repology version because it's livecheckable.
```

After:
```
Mon 05 Dec 16:16:19 ➜  Library/Homebrew master ✗  brew bump cortex --open-pr
==> cortex
Current formula version:  1.13.1
Latest livecheck version: 1.14.0
Latest Repology version:  present only in Homebrew
Open pull requests:       cortex 1.14.0 (https://github.com/Homebrew/homebrew-core/pull/117195)
```

Basically the output about "not bumping because livecheckable" should not happen in the case software is unique to Homebrew.