### PR TITLE
dev-cmd/create: also prompt for name with `--cask`

### DIFF
--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -10,7 +10,7 @@ describe "brew create" do
   it_behaves_like "parseable arguments"
 
   it "creates a new Formula file for a given URL", :integration_test do
-    brew "create", url, "HOMEBREW_EDITOR" => "/bin/cat"
+    brew "create", "--set-name=Testball", url, "HOMEBREW_EDITOR" => "/bin/cat"
 
     expect(formula_file).to exist
     expect(formula_file.read).to match(%Q(sha256 "#{TESTBALL_SHA256}"))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`brew create --formula` prompts for a name if none is provided. This adds the same prompt to `brew create --cask`.