### PR TITLE
dev-cmd/audit: enable --[no-]signing flag for audits

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -53,7 +53,7 @@ module Homebrew
       switch "--[no-]appcast",
              description: "Audit the appcast."
       switch "--[no-]signing",
-             description: "Audit for signed apps, which is required on ARM"
+             description: "Audit for signed apps, which are required on ARM"
       switch "--token-conflicts",
              description: "Audit for token conflicts."
       flag   "--tap=",

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -52,6 +52,8 @@ module Homebrew
                           "`--strict` and `--online`."
       switch "--[no-]appcast",
              description: "Audit the appcast."
+      switch "--[no-]signing",
+             description: "Audit for signed apps, which is required on ARM"
       switch "--token-conflicts",
              description: "Audit for token conflicts."
       flag   "--tap=",
@@ -234,6 +236,8 @@ module Homebrew
         download:              nil,
         # No need for `|| nil` for `--[no-]appcast` because boolean switches are already `nil` if not passed
         appcast:               args.appcast?,
+        # No need for `|| nil` for `--[no-]signing` because boolean switches are already `nil` if not passed
+        signing:               args.signing?,
         online:                args.online? || nil,
         strict:                args.strict? || nil,
         new_cask:              args.new_cask? || nil,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Enables the `--[no-]signing` flag for auditing casks.

Should fix the error on - https://github.com/Homebrew/homebrew-cask/pull/137074