### PR TITLE
Only use OS cop internally

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -55,15 +55,13 @@ FormulaAudit:
 FormulaAuditStrict:
   Enabled: true
 
-Homebrew/MoveToExtendOS:
-  Exclude:
-    - "Homebrew/{extend,test,requirements}/**/*"
-    - "Taps/**/*"
-    - "Homebrew/os.rb"
-
 # enable all Homebrew custom cops
 Homebrew:
   Enabled: true
+
+# only used internally
+Homebrew/MoveToExtendOS:
+  Enabled: false
 
 # makes DSL usage ugly.
 Layout/SpaceBeforeBrackets:

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -2,6 +2,12 @@ inherit_from:
   - ../.rubocop_rspec.yml
   - .rubocop_todo.yml
 
+Homebrew/MoveToExtendOS:
+  Enabled: true
+  Exclude:
+    - "{extend,test,requirements}/**/*"
+    - "os.rb"
+
 # make rspec formatting more flexible
 Layout/MultilineMethodCallIndentation:
   Exclude:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should handle the problem brought up in https://github.com/Homebrew/brew/pull/14163#issuecomment-1342906045 where the `MoveToExtendOS` cop was linting taps which is not what we want.