### PR TITLE
Allow pip to use the local wheel cache while installing dependencies

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -304,7 +304,7 @@ module Language
         def do_install(targets)
           targets = Array(targets)
           @formula.system @venv_root/"bin/pip", "install",
-                          "-v", "--no-deps", "--no-binary", ":all:",
+                          "-v", "--no-deps", "--use-feature=no-binary-enable-wheel-cache",
                           "--ignore-installed", *targets
         end
       end

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -25,7 +25,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts a string" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
         .and_return(true)
       virtualenv.pip_install "foo"
     end
@@ -33,7 +33,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts a multi-line strings" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo", "bar")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo", "bar")
         .and_return(true)
 
       virtualenv.pip_install <<~EOS
@@ -45,12 +45,12 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts an array" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
         .and_return(true)
 
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "bar")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "bar")
         .and_return(true)
 
       virtualenv.pip_install ["foo", "bar"]
@@ -62,7 +62,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(res).to receive(:stage).and_yield
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", Pathname.pwd)
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", Pathname.pwd)
         .and_return(true)
 
       virtualenv.pip_install res


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

While debugging https://github.com/Homebrew/homebrew-core/pull/117779 locally, I noticed that a significant portion of the time was spent re-installing `setuptools` and other `install dependencies`.

When we run `pip install /path/to/dep`, it will basically always require `setuptools` and `wheel` as a build dependency. Some packages require more, such as `zipp` that needs `packaging-22.0 setuptools-65.6.3 setuptools_scm-7.0.5 tomli-2.0.1 typing-extensions-4.4.0`.

The current code is reinstalling these dependencies over and over again for every single dependency due to the `--no-binary` flag, which is really wasteful.

By passing `--use-feature=no-binary-enable-wheel-cache` it will not download any binaries from pypi but instead it will use the local cached setuptools and wheel dependencies from previous installs:

```
Processing /private/tmp/poetry--requests-20221210-38290-1j8k6b0/requests-2.28.1
  Installing build dependencies: started
  Running command pip subprocess to install build dependencies
  Collecting setuptools>=40.8.0
    Using cached setuptools-65.6.3-py3-none-any.whl (1.2 MB)
  Collecting wheel
    Using cached wheel-0.38.4-py3-none-any.whl (36 kB)
  Installing collected packages: wheel, setuptools
  Successfully installed setuptools-65.6.3 wheel-0.38.4
```

You can see this repeated installation in the [CI output here](https://github.com/Homebrew/homebrew-core/actions/runs/3663040771/jobs/6192604346#step:6:5523).

On my local machine this brings `brew install --verbose --build-bottle poetry --debug` down from 25+ minutes to ~5.
