### PR TITLE
Allow shadow clone of repo other than github.com

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -430,8 +430,8 @@ EOS
     setup_git
   fi
 
-  [[ -f "${HOMEBREW_CORE_REPOSITORY}/.git/shallow" ]] && HOMEBREW_CORE_SHALLOW=1
-  [[ -f "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask/.git/shallow" ]] && HOMEBREW_CASK_SHALLOW=1
+  [[ -f "${HOMEBREW_CORE_REPOSITORY}/.git/shallow" ]] && ( git -C "${HOMEBREW_CORE_REPOSITORY}" remote -v | grep "github.com" ) && HOMEBREW_CORE_SHALLOW=1
+  [[ -f "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask/.git/shallow" ]] && ( git -C "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" remote -v | grep "github.com" ) && HOMEBREW_CASK_SHALLOW=1
   if [[ -n "${HOMEBREW_CORE_SHALLOW}" && -n "${HOMEBREW_CASK_SHALLOW}" ]]
   then
     SHALLOW_COMMAND_PHRASE="These commands"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -430,8 +430,8 @@ EOS
     setup_git
   fi
 
-  [[ -f "${HOMEBREW_CORE_REPOSITORY}/.git/shallow" ]] && ( git -C "${HOMEBREW_CORE_REPOSITORY}" remote -v | grep "github.com" ) && HOMEBREW_CORE_SHALLOW=1
-  [[ -f "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask/.git/shallow" ]] && ( git -C "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" remote -v | grep "github.com" ) && HOMEBREW_CASK_SHALLOW=1
+  [[ -f "${HOMEBREW_CORE_REPOSITORY}/.git/shallow" ]] && (git -C "${HOMEBREW_CORE_REPOSITORY}" remote -v | grep "github.com") && HOMEBREW_CORE_SHALLOW=1
+  [[ -f "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask/.git/shallow" ]] && (git -C "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" remote -v | grep "github.com") && HOMEBREW_CASK_SHALLOW=1
   if [[ -n "${HOMEBREW_CORE_SHALLOW}" && -n "${HOMEBREW_CASK_SHALLOW}" ]]
   then
     SHALLOW_COMMAND_PHRASE="These commands"


### PR DESCRIPTION
If we use a mirror of official core repository, which not hosted on github.com, then shadow clone should be allowed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
