### PR TITLE
items.sh: return early when no Taps directory

### DIFF
--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -8,5 +8,17 @@
 source "${HOMEBREW_LIBRARY}/Homebrew/items.sh"
 
 homebrew-formulae() {
-  homebrew-items '*\.rb' 'Casks' 's|/Formula/|/|' '^homebrew/core'
+  local formulae
+  formulae="$(homebrew-items '*\.rb' 'Casks' 's|/Formula/|/|' '^homebrew/core')"
+
+  # HOMEBREW_CACHE is set by brew.sh
+  # shellcheck disable=SC2154
+  if [[ -n "${HOMEBREW_INSTALL_FROM_API}" && -f "${HOMEBREW_CACHE}/api/formula.json" ]]
+  then
+    local api_formulae
+    api_formulae="$(ruby -e "require 'json'; JSON.parse(File.read('${HOMEBREW_CACHE}/api/formula.json')).each { |f| puts f['name'] }" 2>/dev/null)"
+    formulae="$(echo -e "${formulae}\n${api_formulae}" | sort -uf | grep .)"
+  fi
+
+  echo "${formulae}"
 }

--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -17,6 +17,7 @@ homebrew-items() {
 
   # HOMEBREW_REPOSITORY is set by brew.sh
   # shellcheck disable=SC2154
+  [[ -d "${HOMEBREW_REPOSITORY}/Library/Taps" ]] || return
   items="$(
     find "${HOMEBREW_REPOSITORY}/Library/Taps" \
       -type d \( \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Workaround for removing errors output in #14254. Will need API usage for actual completion support, but haven't had chance to look into this.

EDIT: Updated to allow completion from cached JSON to fix #14254

Haven't tested on `HOMEBREW_INSTALL_FROM_API` setup, but seemed to work when I changed Taps in following line to invalid directory:
https://github.com/Homebrew/brew/blob/884c4bec14073314ac6e8e9a6a64bc3b26161ab6/Library/Homebrew/items.sh#L21

---

e.g. changing above to `Taps2` and trying without this PR:
```console
❯ brew formulae
find: /opt/homebrew/Library/Taps2: No such file or directory

❯ brew info find: /opt/homebrew/Library/Taps2: No such file or directory
find: /opt/homebrew/Library/Taps2: No such file or directory
brew
```

with PR:
```console
❯ brew formulae


❯ brew info <TAB>
<NOTHING>
```