### PR TITLE
Enable use of latest formula version in resource `livecheck` URLs

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -142,6 +142,13 @@ class Livecheck
     end
   end
 
+  # Returns a placeholder string that will be replaced with a formula's latest
+  # version in livecheck URLs for its resources.
+  # @return String
+  def latest_version
+    "<FORMULA_LATEST_VERSION>"
+  end
+
   delegate version: :@package_or_resource
   delegate arch: :@package_or_resource
   private :version, :arch

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -295,6 +295,7 @@ module Homebrew
             else
               res_version_info = resource_version(
                 resource,
+                latest.to_s,
                 json:    json,
                 debug:   debug,
                 quiet:   quiet,
@@ -836,15 +837,17 @@ module Homebrew
     # version information. Returns nil if a latest version couldn't be found.
     sig {
       params(
-        resource: Resource,
-        json:     T::Boolean,
-        debug:    T::Boolean,
-        quiet:    T::Boolean,
-        verbose:  T::Boolean,
+        resource:       Resource,
+        formula_latest: String,
+        json:           T::Boolean,
+        debug:          T::Boolean,
+        quiet:          T::Boolean,
+        verbose:        T::Boolean,
       ).returns(Hash)
     }
     def resource_version(
       resource,
+      formula_latest,
       json: false,
       debug: false,
       quiet: false,
@@ -874,12 +877,11 @@ module Homebrew
       checked_urls = []
       # rubocop:disable Metrics/BlockLength
       urls.each_with_index do |original_url, i|
+        url = original_url.gsub(/<FORMULA_LATEST_VERSION>/, formula_latest)
+
         # Only preprocess the URL when it's appropriate
-        url = if STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL.include?(livecheck_strategy)
-          original_url
-        else
-          preprocess_url(original_url)
-        end
+        url = preprocess_url(url) unless STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL.include?(livecheck_strategy)
+
         next if checked_urls.include?(url)
 
         strategies = Strategy.from_url(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See https://github.com/Homebrew/homebrew-core/pull/112155#issuecomment-1355090824 for a great explanation from @samford. In short, we require access to the formula's latest version as found by `livecheck` in URLs for resource `livecheck` blocks – this is required for multiple formulae including `influxdb`, `flux`, `luvit`, etc.

This PR:
* Adds a method to the `livecheck` DSL to return a placeholder string (`<FORMULA_LATEST_VERSION>`)
* Enables the replacement of this placeholder string with a formula's latest version in its resources' `livecheck` URLs 

I briefly tested this with the `pkg-config-wrapper` resource in `influxdb` and it seems to work fine.

The `livecheck` block for the resource:
```
livecheck do
      url "https://raw.githubusercontent.com/influxdata/influxdb/v#{latest_version}/go.mod"
      regex(/(pkg-config\sv)+(\d+(?:\.\d+)+)/i)
      strategy :page_match do |page, regex|
        page.scan(regex).map { |match| match[1] }
      end
    end
```

The result:
```
...

Resource:         pkg-config-wrapper
Livecheckable?:   Yes

URL:              https://raw.githubusercontent.com/influxdata/influxdb/v<FORMULA_LATEST_VERSION>/go.mod
URL (processed):  https://raw.githubusercontent.com/influxdata/influxdb/v2.6.0/go.mod
Strategies:       PageMatch
Strategy:         PageMatch
Regex:            /(pkg-config\sv)+(\d+(?:\.\d+)+)/i

Matched Versions:
0.2.11 => #<Version:0x00007fc40c9d4608 @version="0.2.11", @detected_from_url=false>

...

  pkg-config-wrapper: 0.2.11 ==> 0.2.11
```