### PR TITLE
root auto-taps should be done as Homebrew user

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -125,6 +125,7 @@ begin
     with_env HOMEBREW_HELP: nil do
       tap_commands = []
       if File.exist?("/.dockerenv") ||
+         Process.uid.zero? ||
          ((cgroup = Utils.popen_read("cat", "/proc/1/cgroup").presence) &&
           %w[azpl_job actions_job docker garden kubepods].none? { |type| cgroup.include?(type) })
         brew_uid = HOMEBREW_BREW_FILE.stat.uid


### PR DESCRIPTION
This ensures that users who run `brew` ensemble commands with `sudo` for the first time don't get confusing error messages like:
```bash
$ sudo brew services list
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
Error: Failure while executing; `/opt/homebrew/bin/brew tap homebrew/services` exited with 1.
```

Closes https://github.com/Homebrew/brew/issues/14263.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
