### PR TITLE
add explicit version for GitHub API

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -192,6 +192,7 @@ module GitHub
 
       token = credentials
       args += ["--header", "Authorization: token #{token}"] unless credentials_type == :none
+      args += ["--header", "X-GitHub-Api-Version:2022-11-28"]
 
       data_tmpfile = nil
       if data


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Now that GitHub has a versioned API, explicitly pass the API version in requests: https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28