### PR TITLE
formula: add directory for `bash-completion@2` completions

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -921,6 +921,14 @@ class Formula
     prefix/"etc/bash_completion.d"
   end
 
+  # The directory where the formula's Bash completion files should be
+  # installed that depend on `bash-completion@2` or Bash 4+.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def bash_completion2
+    share/"bash-completion/completions"
+  end
+
   # The directory where the formula's zsh completion files should be
   # installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Occasionally, there are formulae that have Bash completions which:
- Only work with Bash 4+ (e.g. `click`-generated completions)
- Need functions from `bash-completion@2`, e.g. `fail2ban`
- Support Bash 3 but assume user has loaded extensions or installed `bash-completion*`, e.g. `cmake` - https://github.com/Homebrew/homebrew-core/pull/113569#discussion_r1035371043

For above, it may be worth installing into path for `bash-completion@2`, which at least Linux users would usually use.