### PR TITLE
formula: show stderr by default when generating completions

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1781,8 +1781,11 @@ class Formula
       popen_read_args << shell_parameter if shell_parameter.present?
       popen_read_args.flatten!
 
+      popen_read_options = {}
+      popen_read_options[:err] = :err unless ENV["HOMEBREW_STDERR"]
+
       script_path.dirname.mkpath
-      script_path.write Utils.safe_popen_read(popen_read_env, *popen_read_args)
+      script_path.write Utils.safe_popen_read(popen_read_env, *popen_read_args, **popen_read_options)
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

NOTE: Open to other suggestions as not familiar with popen code path and if there is any odd behavior of outputting stderr.

Added this as currently trying to debug failing `generate_completions_from_executable` on CI is difficult since popen defaults to sending stderr to /dev/null which is where most failing commands end up outputting failures
https://github.com/Homebrew/brew/blob/0e56c86c89b572f2daf26270fab26782f3cf2b51/Library/Homebrew/utils/popen.rb#L53

This leads to hard to figure out failures without locally retesting, e.g.: 
- https://github.com/Homebrew/homebrew-core/pull/116583#issuecomment-1356761947
- https://github.com/Homebrew/homebrew-core/pull/118475#issuecomment-1357753530