### PR TITLE
python: reinstate pip's `--no-binary`

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -304,7 +304,8 @@ module Language
         def do_install(targets)
           targets = Array(targets)
           @formula.system @venv_root/"bin/pip", "install",
-                          "-v", "--no-deps", "--use-feature=no-binary-enable-wheel-cache",
+                          "-v", "--no-deps", "--no-binary", ":all:",
+                          "--use-feature=no-binary-enable-wheel-cache",
                           "--ignore-installed", *targets
         end
       end

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -24,7 +24,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
   describe "#pip_install" do
     it "accepts a string" do
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
               "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
         .and_return(true)
       virtualenv.pip_install "foo"
@@ -32,7 +32,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
     it "accepts a multi-line strings" do
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
               "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo", "bar")
         .and_return(true)
 
@@ -44,12 +44,12 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
     it "accepts an array" do
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
               "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
         .and_return(true)
 
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
               "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "bar")
         .and_return(true)
 
@@ -61,7 +61,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
       expect(res).to receive(:stage).and_yield
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
               "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", Pathname.pwd)
         .and_return(true)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

This was accidentally dropped in #14239, but it's still needed: https://github.com/Homebrew/brew/pull/14239#issuecomment-1358926865
