### PR TITLE
Fix access to `livecheck` constants in formulae

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -65,6 +65,7 @@ class Formula
   include Utils::Shell
   include Context
   include OnSystem::MacOSAndLinux
+  include Homebrew::Livecheck::Constants
   extend Forwardable
   extend Cachable
   extend Predicable
@@ -3278,7 +3279,6 @@ class Formula
     def livecheck(&block)
       return @livecheck unless block
 
-      include Homebrew::Livecheck::Constants
       @livecheckable = true
       @livecheck.instance_eval(&block)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If a formula-level `livecheck` block doesn't exist, then the `Homebrew::Livecheck::Constants` module is never included and so it isn't possible to access these constants from a resource's `livecheck` block. This PR includes the module irrespective of the existence of a formula-level `livecheck` block.

I wasn't able to fix this by just including `Homebrew::Livecheck::Constants` in `resource.rb` (the `livecheck` method in the `Resource` class specifically, not a Ruby expert) so I went with this instead.