### PR TITLE
audit: use `full_name` for `formula`/`cask` audit

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -216,10 +216,10 @@ module Homebrew
     if args.no_audit?
       ohai "Skipping `brew audit`"
     elsif args.online?
-      system HOMEBREW_BREW_FILE, "audit", "--cask", "--online", cask.sourcefile_path
+      system HOMEBREW_BREW_FILE, "audit", "--cask", "--online", cask.full_name
       failed_audit = !$CHILD_STATUS.success?
     else
-      system HOMEBREW_BREW_FILE, "audit", "--cask", cask.sourcefile_path
+      system HOMEBREW_BREW_FILE, "audit", "--cask", cask.full_name
       failed_audit = !$CHILD_STATUS.success?
     end
     return unless failed_audit

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -478,10 +478,10 @@ module Homebrew
     if args.no_audit?
       ohai "Skipping `brew audit`"
     elsif audit_args.present?
-      system HOMEBREW_BREW_FILE, "audit", *audit_args, formula.name
+      system HOMEBREW_BREW_FILE, "audit", *audit_args, formula.full_name
       failed_audit = !$CHILD_STATUS.success?
     else
-      system HOMEBREW_BREW_FILE, "audit", formula.name
+      system HOMEBREW_BREW_FILE, "audit", formula.full_name
       failed_audit = !$CHILD_STATUS.success?
     end
     return unless failed_audit

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -478,10 +478,10 @@ module Homebrew
     if args.no_audit?
       ohai "Skipping `brew audit`"
     elsif audit_args.present?
-      system HOMEBREW_BREW_FILE, "audit", *audit_args, formula.path
+      system HOMEBREW_BREW_FILE, "audit", *audit_args, formula.name
       failed_audit = !$CHILD_STATUS.success?
     else
-      system HOMEBREW_BREW_FILE, "audit", formula.path
+      system HOMEBREW_BREW_FILE, "audit", formula.name
       failed_audit = !$CHILD_STATUS.success?
     end
     return unless failed_audit


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

followup of #14285

current issue
```
Error: Calling brew audit [path ...] is deprecated! Use brew audit [name ...] instead.
```