### PR TITLE
Improve minimum macOS version audit for casks

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -567,6 +567,7 @@ module Cask
       return if item.blank?
 
       min_os = item.elements["sparkle:minimumSystemVersion"]&.text
+      min_os = "11" if min_os == "10.16"
       return if min_os.blank?
 
       begin
@@ -581,7 +582,8 @@ module Cask
 
       return if cask_min_os == min_os_string
 
-      add_error "Upstream defined #{min_os_string} as minimal OS version and the cask defined #{cask_min_os}"
+      add_error "Upstream defined #{min_os_string.to_sym.inspect} as minimal OS version " \
+                "and the cask defined #{cask_min_os.to_sym.inspect}"
     end
 
     sig { void }


### PR DESCRIPTION
This PR improves the audit that checks the minimum macOS version in casks. Now, the audit displays symbols instead of version numbers when explaining what's wrong. Ultimately, the `depends_on` line uses the OS symbol instead of the number, so it's better to just list that instead of forcing the user to convert between version numbers and symbols.

Also, the edge case where a cask specifies 10.16 as the minimum version has been handled. Now, 10.16 is treated as `:big_sur`.

For context, see https://github.com/Homebrew/homebrew-cask/pull/138579
