### PR TITLE
cask/audit: improve sparkle minimum version audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -583,7 +583,7 @@ module Cask
       return if cask_min_os == min_os_string
 
       add_error "Upstream defined #{min_os_string.to_sym.inspect} as minimal OS version " \
-                "and the cask defined #{cask_min_os.to_sym.inspect}"
+                "and the cask defined #{cask_min_os ? cask_min_.to_sym.inspect : "no minimal OS version"}."
     end
 
     sig { void }

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -582,8 +582,9 @@ module Cask
 
       return if cask_min_os == min_os_string
 
+      min_os_symbol = cask_min_os&.to_sym.inspect || "no minimal OS version"
       add_error "Upstream defined #{min_os_string.to_sym.inspect} as minimal OS version " \
-                "and the cask defined #{cask_min_os ? cask_min_.to_sym.inspect : "no minimal OS version"}."
+                "and the cask defined #{min_os_symbol}."
     end
 
     sig { void }

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -584,7 +584,7 @@ module Cask
 
       min_os_symbol = cask_min_os&.to_sym.inspect || "no minimal OS version"
       add_error "Upstream defined #{min_os_string.to_sym.inspect} as minimal OS version " \
-                "and the cask defined #{min_os_symbol}."
+                "and the cask defined #{min_os_symbol}"
     end
 
     sig { void }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a continuation of #14297 - where the cask doesn't specify a minimum `depends_on` the audit was erroring out with a type error. This now returns an appropriate message.

Related: https://github.com/Homebrew/homebrew-cask/pull/138667