### PR TITLE
Remove bitdefender diagnostic check

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -364,19 +364,6 @@ module Homebrew
         end
       end
 
-      def check_for_bitdefender
-        if !Pathname("/Library/Bitdefender/AVP/EndpointSecurityforMac.app").exist? &&
-           !Pathname("/Library/Bitdefender/AVP/BDLDaemon").exist?
-          return
-        end
-
-        <<~EOS
-          You have installed Bitdefender. The "Traffic Scan" option interferes with
-          Homebrew's ability to download packages. See:
-            #{Formatter.url("https://github.com/Homebrew/brew/issues/5558")}
-        EOS
-      end
-
       def check_for_multiple_volumes
         return unless HOMEBREW_CELLAR.exist?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This check was added in four years ago in https://github.com/Homebrew/brew/pull/5614. We were seeing problems at the time with users not being able to download packages correctly when running BitDefender (https://github.com/Homebrew/brew/issues/4579 and https://github.com/Homebrew/brew/issues/5558).

Those issues were apparently resolved by BitDefender and we got an issue in mid 2020 asking us to remove the check since it was no longer necessary (https://github.com/Homebrew/brew/issues/7452). Since that point we haven't received anymore issues or complaints related to BitDefender in either the main `brew` repo or in the discussions (I just searched for `bitdefender` in both places).

Also, anecdotally, I haven't had any problems using `brew` and `BitDefender` at the same time on my local system.

CC: @MikeMcQuaid since you added the check and were involved in previous discussions.