### PR TITLE
cask/audit: improve handling `nil` in sparkle

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -582,8 +582,11 @@ module Cask
 
       return if cask_min_os == min_os_string
 
-      min_os_symbol = cask_min_os&.to_sym.inspect
-      min_os_symbol = "no minimum OS version" if min_os_symbol == "nil"
+      min_os_symbol = if cask_min_os.present?
+        cask_min_os.to_sym.inspect
+      else
+        "no minimum OS version"
+      end
       add_error "Upstream defined #{min_os_string.to_sym.inspect} as the minimum OS version " \
                 "and the cask defined #{min_os_symbol}"
     end

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -582,8 +582,9 @@ module Cask
 
       return if cask_min_os == min_os_string
 
-      min_os_symbol = cask_min_os&.to_sym.inspect || "no minimal OS version"
-      add_error "Upstream defined #{min_os_string.to_sym.inspect} as minimal OS version " \
+      min_os_symbol = cask_min_os&.to_sym.inspect
+      min_os_symbol = "no minimum OS version" if min_os_symbol == "nil"
+      add_error "Upstream defined #{min_os_string.to_sym.inspect} as the minimum OS version " \
                 "and the cask defined #{min_os_symbol}"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This further iterates on #14298. Rather than stating `nil` when a cask doesn't have a minimum OS defined, this produces a clearer message.

This also changes references to "minimal OS" to "minimum OS". This is more familiar in common parlance, and aligns with [Apple's documentation](https://developer.apple.com/documentation/bundleresources/information_property_list/minimumosversion).