### PR TITLE
Use JSON instead of `#inspect` to include cask container in API

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -244,7 +244,7 @@ module Cask
         "caveats"        => (to_h_string_gsubs(caveats) unless caveats.empty?),
         "depends_on"     => depends_on,
         "conflicts_with" => conflicts_with,
-        "container"      => container,
+        "container"      => container&.pairs,
         "auto_updates"   => auto_updates,
       }
     end


### PR DESCRIPTION
This PR updates the cask JSON API's `container` entry to be actual JSON instead of just a ruby `#inspect` string.

Before:
```json
{
  "container": "{:type=>:naked}"
}
```

After:
```json
{
  "container": {
    "type": "naked"
  }
}
```

---

This is technically a breaking API change, but I can't imagine anyone is using the current system since it's in this weird format. If we get a complaint, we can revert. I'm marking this as `critical` since it is blocking the next step in the API project (loading casks directly from the API).
