### PR TITLE
Load casks from the JSON API with `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -10,13 +10,6 @@ module Homebrew
       class << self
         extend T::Sig
 
-        MAX_RETRIES = 3
-
-        sig { returns(String) }
-        def cached_cask_json_file
-          HOMEBREW_CACHE_API/"cask.json"
-        end
-
         sig { params(name: String).returns(Hash) }
         def fetch(name)
           Homebrew::API.fetch "cask/#{name}.json"
@@ -25,24 +18,7 @@ module Homebrew
         sig { returns(Hash) }
         def all_casks
           @all_casks ||= begin
-            retry_count = 0
-
-            url = "https://formulae.brew.sh/api/cask.json"
-            json_casks = begin
-              curl_args = %W[--compressed --silent #{url}]
-              if cached_cask_json_file.exist? && !cached_cask_json_file.empty?
-                curl_args.prepend("--time-cond", cached_cask_json_file)
-              end
-              curl_download(*curl_args, to: cached_cask_json_file, max_time: 5)
-
-              JSON.parse(cached_cask_json_file.read)
-            rescue JSON::ParserError
-              cached_cask_json_file.unlink
-              retry_count += 1
-              odie "Cannot download non-corrupt #{url}!" if retry_count > MAX_RETRIES
-
-              retry
-            end
+            json_casks = Homebrew::API.fetch_json_api_file "cask.json", target: HOMEBREW_CACHE_API/"cask.json"
 
             json_casks.to_h do |json_cask|
               [json_cask["token"], json_cask.except("token")]

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -10,9 +10,44 @@ module Homebrew
       class << self
         extend T::Sig
 
+        MAX_RETRIES = 3
+
+        sig { returns(String) }
+        def cached_cask_json_file
+          HOMEBREW_CACHE_API/"cask.json"
+        end
+
         sig { params(name: String).returns(Hash) }
         def fetch(name)
           Homebrew::API.fetch "cask/#{name}.json"
+        end
+
+        sig { returns(Hash) }
+        def all_casks
+          @all_casks ||= begin
+            retry_count = 0
+
+            url = "https://formulae.brew.sh/api/cask.json"
+            json_casks = begin
+              curl_args = %W[--compressed --silent #{url}]
+              if cached_cask_json_file.exist? && !cached_cask_json_file.empty?
+                curl_args.prepend("--time-cond", cached_cask_json_file)
+              end
+              curl_download(*curl_args, to: cached_cask_json_file, max_time: 5)
+
+              JSON.parse(cached_cask_json_file.read)
+            rescue JSON::ParserError
+              cached_cask_json_file.unlink
+              retry_count += 1
+              odie "Cannot download non-corrupt #{url}!" if retry_count > MAX_RETRIES
+
+              retry
+            end
+
+            json_casks.to_h do |json_cask|
+              [json_cask["token"], json_cask.except("token")]
+            end
+          end
         end
       end
     end

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -18,8 +18,8 @@ module Homebrew
         sig { returns(Hash) }
         def all_casks
           @all_casks ||= begin
-            json_casks = Homebrew::API.fetch_json_api_file "cask.json", 
-                         target: HOMEBREW_CACHE_API/"cask.json"
+            json_casks = Homebrew::API.fetch_json_api_file "cask.json",
+                                                           target: HOMEBREW_CACHE_API/"cask.json"
 
             json_casks.to_h do |json_cask|
               [json_cask["token"], json_cask.except("token")]

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -18,7 +18,8 @@ module Homebrew
         sig { returns(Hash) }
         def all_casks
           @all_casks ||= begin
-            json_casks = Homebrew::API.fetch_json_api_file "cask.json", target: HOMEBREW_CACHE_API/"cask.json"
+            json_casks = Homebrew::API.fetch_json_api_file "cask.json", 
+                         target: HOMEBREW_CACHE_API/"cask.json"
 
             json_casks.to_h do |json_cask|
               [json_cask["token"], json_cask.except("token")]

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -10,19 +10,6 @@ module Homebrew
       class << self
         extend T::Sig
 
-        MAX_RETRIES = 3
-
-        sig { returns(String) }
-        def formula_api_path
-          "formula"
-        end
-        alias generic_formula_api_path formula_api_path
-
-        sig { returns(String) }
-        def cached_formula_json_file
-          HOMEBREW_CACHE_API/"#{formula_api_path}.json"
-        end
-
         sig { params(name: String).returns(Hash) }
         def fetch(name)
           Homebrew::API.fetch "#{formula_api_path}/#{name}.json"
@@ -31,24 +18,8 @@ module Homebrew
         sig { returns(Hash) }
         def all_formulae
           @all_formulae ||= begin
-            retry_count = 0
-
-            url = "https://formulae.brew.sh/api/formula.json"
-            json_formulae = begin
-              curl_args = %W[--compressed --silent #{url}]
-              if cached_formula_json_file.exist? && !cached_formula_json_file.empty?
-                curl_args.prepend("--time-cond", cached_formula_json_file)
-              end
-              curl_download(*curl_args, to: cached_formula_json_file, max_time: 5)
-
-              JSON.parse(cached_formula_json_file.read)
-            rescue JSON::ParserError
-              cached_formula_json_file.unlink
-              retry_count += 1
-              odie "Cannot download non-corrupt #{url}!" if retry_count > MAX_RETRIES
-
-              retry
-            end
+            json_formulae = Homebrew::API.fetch_json_api_file "formula.json",
+                                                              target: HOMEBREW_CACHE_API/"formula.json"
 
             @all_aliases = {}
             json_formulae.to_h do |json_formula|

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -12,7 +12,7 @@ module Homebrew
 
         sig { params(name: String).returns(Hash) }
         def fetch(name)
-          Homebrew::API.fetch "#{formula_api_path}/#{name}.json"
+          Homebrew::API.fetch "formula/#{name}.json"
         end
 
         sig { returns(Hash) }

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -263,7 +263,11 @@ module Cask
 
           json_cask[:artifacts].each do |artifact|
             key = artifact.keys.first
-            send(key, *artifact[key])
+            if FLIGHT_STANZAS.include?(key)
+              instance_eval(artifact[key])
+            else
+              send(key, *artifact[key])
+            end
           end
 
           caveats json_cask[:caveats] if json_cask[:caveats].present?

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -557,11 +557,10 @@ module Homebrew
           "date"     => Pathname(filename.to_s).mtime.strftime("%F"),
           "tags"     => {
             bottle_tag.to_s => {
-              "filename"              => filename.url_encode,
-              "local_filename"        => filename.to_s,
-              "sha256"                => sha256,
-              "formulae_brew_sh_path" => Homebrew::API::Formula.formula_api_path,
-              "tab"                   => tab.to_bottle_hash,
+              "filename"       => filename.url_encode,
+              "local_filename" => filename.to_s,
+              "sha256"         => sha256,
+              "tab"            => tab.to_bottle_hash,
             },
           },
         },

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -354,8 +354,7 @@ class GitHubPackages
 
       config_json_sha256, config_json_size = write_image_config(platform_hash, tar_sha256.hexdigest, blobs)
 
-      formulae_dir = tag_hash["formulae_brew_sh_path"]
-      documentation = "https://formulae.brew.sh/#{formulae_dir}/#{formula_name}" if formula_core_tap
+      documentation = "https://formulae.brew.sh/formula/#{formula_name}" if formula_core_tap
 
       descriptor_annotations_hash = {
         "org.opencontainers.image.ref.name" => tag,

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -1,0 +1,44 @@
+# typed: false
+# frozen_string_literal: true
+
+require "api"
+
+describe Homebrew::API::Cask do
+  let(:cache_dir) { mktmpdir }
+
+  before do
+    stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+  end
+
+  def mock_curl_download(stdout:)
+    allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
+      kwargs[:to].write stdout
+    end
+  end
+
+  describe "::all_casks" do
+    let(:casks_json) {
+      <<~EOS
+        [{
+          "token": "foo",
+          "url": "https://brew.sh/foo"
+        }, {
+          "token": "bar",
+          "url": "https://brew.sh/bar"
+        }]
+      EOS
+    }
+    let(:casks_hash) {
+      {
+        "foo" => { "url" => "https://brew.sh/foo" },
+        "bar" => { "url" => "https://brew.sh/bar" },
+      }
+    }
+
+    it "returns the expected cask JSON list" do
+      mock_curl_download stdout: casks_json
+      casks_output = described_class.all_casks
+      expect(casks_output).to eq casks_hash
+    end
+  end
+end

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -1,0 +1,64 @@
+# typed: false
+# frozen_string_literal: true
+
+require "api"
+
+describe Homebrew::API::Formula do
+  let(:cache_dir) { mktmpdir }
+
+  before do
+    stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+  end
+
+  def mock_curl_download(stdout:)
+    allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
+      kwargs[:to].write stdout
+    end
+  end
+
+  describe "::all_formulae" do
+    let(:formulae_json) {
+      <<~EOS
+        [{
+          "name": "foo",
+          "url": "https://brew.sh/foo",
+          "aliases": ["foo-alias1", "foo-alias2"]
+        }, {
+          "name": "bar",
+          "url": "https://brew.sh/bar",
+          "aliases": ["bar-alias"]
+        }, {
+          "name": "baz",
+          "url": "https://brew.sh/baz",
+          "aliases": []
+        }]
+      EOS
+    }
+    let(:formulae_hash) {
+      {
+        "foo" => { "url" => "https://brew.sh/foo", "aliases" => ["foo-alias1", "foo-alias2"] },
+        "bar" => { "url" => "https://brew.sh/bar", "aliases" => ["bar-alias"] },
+        "baz" => { "url" => "https://brew.sh/baz", "aliases" => [] },
+      }
+    }
+    let(:formulae_aliases) {
+      {
+        "foo-alias1" => "foo",
+        "foo-alias2" => "foo",
+        "bar-alias"  => "bar",
+      }
+    }
+
+    it "returns the expected formula JSON list" do
+      mock_curl_download stdout: formulae_json
+      formulae_output = described_class.all_formulae
+      expect(formulae_output).to eq formulae_hash
+    end
+
+    it "returns the expected formula alias list" do
+      mock_curl_download stdout: formulae_json
+      aliases_output = described_class.all_aliases
+      expect(aliases_output).to eq formulae_aliases
+    end
+  end
+end

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -7,10 +7,17 @@ describe Homebrew::API do
   let(:text) { "foo" }
   let(:json) { '{"foo":"bar"}' }
   let(:json_hash) { JSON.parse(json) }
+  let(:json_invalid) { '{"foo":"bar"' }
 
   def mock_curl_output(stdout: "", success: true)
     curl_output = OpenStruct.new(stdout: stdout, success?: success)
     allow(Utils::Curl).to receive(:curl_output).and_return curl_output
+  end
+
+  def mock_curl_download(stdout:)
+    allow(Utils::Curl).to receive(:curl_download) do |*_args, **kwargs|
+      kwargs[:to].write stdout
+    end
   end
 
   describe "::fetch" do
@@ -34,6 +41,33 @@ describe Homebrew::API do
     it "raises an error if the JSON file is invalid" do
       mock_curl_output stdout: text
       expect { described_class.fetch("baz.txt") }.to raise_error(ArgumentError, /Invalid JSON file/)
+    end
+  end
+
+  describe "::fetch_json_api_file" do
+    let!(:cache_dir) { mktmpdir }
+
+    before do
+      (cache_dir/"bar.json").write "tmp"
+    end
+
+    it "fetches a JSON file" do
+      mock_curl_download stdout: json
+      fetched_json = described_class.fetch_json_api_file("foo.json", target: cache_dir/"foo.json")
+      expect(fetched_json).to eq json_hash
+    end
+
+    it "updates an existing JSON file" do
+      mock_curl_download stdout: json
+      fetched_json = described_class.fetch_json_api_file("bar.json", target: cache_dir/"bar.json")
+      expect(fetched_json).to eq json_hash
+    end
+
+    it "raises an error if the JSON file is invalid" do
+      mock_curl_download stdout: json_invalid
+      expect {
+        described_class.fetch_json_api_file("baz.json", target: cache_dir/"baz.json")
+      }.to raise_error(SystemExit)
     end
   end
 end


### PR DESCRIPTION
This PR updates the method for loading casks when `HOMEBREW_INSTALL_FROM_API` is set. Now, casks are loaded directly from the JSON API in the same way that formulae are. I've started to test this out locally and haven't had any issues so far (outside of the ones listed below).

It's worth noting that the old `cask-source` API is still being used to write the cask source to the `.metadata` folder. This is similar to the way that formula bottles also contain the formula file, except that the source for casks are retrieved using the API rather than a bottle.

Also, a nice little side effect of this PR is that `brew edit` now works for casks with `HOMEBREW_INSTALL_FROM_API` (while the taps are installed, of course)

---

Here are some known issues:
- Casks with `{uninstall_,}{pre,post}flight` stanzas will currently ignore those when installing and uninstalling. This can cause issues in casks like `vlc` which rely on these blocks to create files that will be referenced by the regular artifact stanzas. This is a relatively significant issue that is probably worth brainstorming about sooner rather than later since it does technically cause a regression from the old API-install behavior for casks.
