### PR TITLE
cmd/prof: Fix gem errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /Library/Homebrew/.npmignore
 /Library/Homebrew/bin
 /Library/Homebrew/doc
+/Library/Homebrew/prof
 /Library/Homebrew/test/.gem
 /Library/Homebrew/test/.subversion
 /Library/Homebrew/test/coverage

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 if ENV["HOMEBREW_STACKPROF"]
+  require "rubygems"
   require "stackprof"
   StackProf.start(mode: :wall, raw: true)
 end

--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -37,7 +37,9 @@ module Homebrew
       output_filename = "prof/d3-flamegraph.html"
       safe_system "stackprof --d3-flamegraph prof/stackprof.dump > #{output_filename}"
     else
-      Homebrew.install_gem_setup_path! "ruby-prof"
+      # NOTE: ruby-prof v1.4.3 is the last version that supports Ruby 2.6.x
+      # TODO: Remove explicit version arg when we move to a newer version of Ruby
+      Homebrew.install_gem_setup_path! "ruby-prof", version: "1.4.3"
       output_filename = "prof/call_stack.html"
       safe_system "ruby-prof", "--printer=call_stack", "--file=#{output_filename}", brew_rb, "--", *args.named
     end

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -6,7 +6,7 @@ require "cmd/shared_examples/args_parse"
 describe "brew prof" do
   it_behaves_like "parseable arguments"
 
-  describe "integration tests", :integration_test do
+  describe "integration tests", :integration_test, :needs_network do
     after do
       FileUtils.rm_rf HOMEBREW_LIBRARY_PATH/"prof"
     end

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -5,4 +5,24 @@ require "cmd/shared_examples/args_parse"
 
 describe "brew prof" do
   it_behaves_like "parseable arguments"
+
+  describe "integration tests", :integration_test do
+    after do
+      FileUtils.rm_rf HOMEBREW_LIBRARY_PATH/"prof"
+    end
+
+    it "works using ruby-prof (the default)" do
+      expect { brew "prof", "help", "HOMEBREW_BROWSER" => "echo" }
+        .to output(/^Example usage:/).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
+
+    it "works using stackprof" do
+      expect { brew "prof", "--stackprof", "help", "HOMEBREW_BROWSER" => "echo" }
+        .to output(/^Example usage:/).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR fixes `brew prof` again. There were two problems.
1. `brew prof` was not working with the latest version of the `ruby-prof` gem since it now requires Ruby >= 2.7 ([source](https://github.com/ruby-prof/ruby-prof/blob/5d9ca2d9cf64fdba345f2afb6c5a8f86f87e7461/CHANGES#L6-L19)). Specifying the version was enough to fix that.
2. `brew prof --stackprof` hasn't been working for a bit and the problem was related to not being able to require the gem after installing it locally and then shelling out to brew again. By requiring the `rubygems` gem we are able to pick up the `GEM_HOME` and `GEM_PATH` environment variables that we set during the gem installation/setup process.

I also added some integration tests to make sure we get notified if these gems start failing again. I'm not sure they're really worth it though to be honest. This command is not used very frequently and it might just be better to deal with any problems whenever we want to use it instead of adding tests which are expensive not only because they are integration tests but also because they involve installing these gems in the process.