### PR TITLE
cli/parser: Better error message for cask on linux

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -332,8 +332,8 @@ module Homebrew
         set_default_options
 
         unless ignore_invalid_options
-          check_constraint_violations
           validate_options
+          check_constraint_violations
           check_named_args(named_args)
         end
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -297,7 +297,12 @@ module Homebrew
     return if name.include?("/")
 
     require "search"
-    ohai "Searching for similarly named formulae and casks..."
+
+    package_types = []
+    package_types << "formulae" unless args.cask?
+    package_types << "casks" unless args.formula?
+
+    ohai "Searching for similarly named #{package_types.join(" and ")}..."
 
     # Don't treat formula/cask name as a regex
     query = string_or_regex = name
@@ -324,6 +329,6 @@ module Homebrew
     end
     return if all_formulae.any? || all_casks.any?
 
-    odie "No formulae or casks found for #{name}."
+    odie "No #{package_types.join(" or ")} found for #{name}."
   end
 end

--- a/Library/Homebrew/extend/os/linux/parser.rb
+++ b/Library/Homebrew/extend/os/linux/parser.rb
@@ -15,9 +15,9 @@ module Homebrew
         return unless @args.respond_to?(:cask?)
         return unless @args.cask?
 
-        # NOTE: We don't raise a UsageError here because
-        # we don't want to print the help page.
-        raise "Invalid usage: Casks are not supported on Linux"
+        # NOTE: We don't raise an error here because we don't want
+        # to print the help page or a stack trace.
+        odie "Invalid `--cask` usage: Casks do not work on Linux"
       end
     end
   end

--- a/Library/Homebrew/extend/os/linux/parser.rb
+++ b/Library/Homebrew/extend/os/linux/parser.rb
@@ -15,7 +15,9 @@ module Homebrew
         return unless @args.respond_to?(:cask?)
         return unless @args.cask?
 
-        raise UsageError, "Casks are not supported on Linux"
+        # NOTE: We don't raise a UsageError here because
+        # we don't want to print the help page.
+        raise "Invalid usage: Casks are not supported on Linux"
       end
     end
   end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -564,14 +564,37 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "--cask on linux", :needs_linux do
-    subject(:parser) do
-      described_class.new do
-        switch "--cask"
+    context "without --formula switch" do
+      subject(:parser) do
+        described_class.new do
+          switch "--cask"
+        end
+      end
+
+      it "throws an error when defined" do
+        expect { parser.parse(["--cask"]) }
+          .to raise_error RuntimeError, "Invalid usage: Casks are not supported on Linux"
       end
     end
 
-    it "throws an error when defined" do
-      expect { parser.parse(["--cask"]) }.to raise_error UsageError, /Casks are not supported on Linux/
+    context "with conflicting --formula switch" do
+      subject(:parser) do
+        described_class.new do
+          switch "--cask"
+          switch "--formula"
+          conflicts "--cask", "--formula"
+        end
+      end
+
+      it "throws an error when --cask defined" do
+        expect { parser.parse(["--cask"]) }
+          .to raise_error RuntimeError, "Invalid usage: Casks are not supported on Linux"
+      end
+
+      it "throws an error when both defined" do
+        expect { parser.parse(["--cask", "--formula"]) }
+          .to raise_error RuntimeError, "Invalid usage: Casks are not supported on Linux"
+      end
     end
   end
 

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -573,7 +573,9 @@ describe Homebrew::CLI::Parser do
 
       it "throws an error when defined" do
         expect { parser.parse(["--cask"]) }
-          .to raise_error RuntimeError, "Invalid usage: Casks are not supported on Linux"
+          .to output("Error: Invalid `--cask` usage: Casks do not work on Linux\n").to_stderr
+          .and not_to_output.to_stdout
+          .and raise_exception SystemExit
       end
     end
 
@@ -588,12 +590,16 @@ describe Homebrew::CLI::Parser do
 
       it "throws an error when --cask defined" do
         expect { parser.parse(["--cask"]) }
-          .to raise_error RuntimeError, "Invalid usage: Casks are not supported on Linux"
+          .to output("Error: Invalid `--cask` usage: Casks do not work on Linux\n").to_stderr
+          .and not_to_output.to_stdout
+          .and raise_exception SystemExit
       end
 
       it "throws an error when both defined" do
         expect { parser.parse(["--cask", "--formula"]) }
-          .to raise_error RuntimeError, "Invalid usage: Casks are not supported on Linux"
+          .to output("Error: Invalid `--cask` usage: Casks do not work on Linux\n").to_stderr
+          .and not_to_output.to_stdout
+          .and raise_exception SystemExit
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes #14314.

1. Validate options before constraint violations. This allows us to error out when --cask is passed on Linux before getting a constraint violation when --cask and --formula are set.
2. Skip printing the help page when --cask is passed on Linux. The help pages don't usually mention anything useful related to casks only running on MacOS so it's just better to skip them IMO.
3. I added some regression tests.

```
/u/l/Homebrew (better-error-cask-on-linux|✚2) $ brew install -n --cask postman
Error: Invalid usage: Casks are not supported on Linux
/u/l/Homebrew (better-error-cask-on-linux|✚2) [1]$ brew install -n --cask --formula postman
Error: Invalid usage: Casks are not supported on Linux
/u/l/Homebrew (better-error-cask-on-linux|✚2) [1]$ brew install -n postman
Warning: No available formula with the name "postman". Did you mean podman or pod2man?
==> Searching for similarly named formulae and casks...
==> Formulae
podman                                                                                    pod2man

To install podman, run:
  brew install podman
```