### PR TITLE
formula_installer: remove --env=std when building with scons

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -872,7 +872,7 @@ class FormulaInstaller
 
     if @env.present?
       args << "--env=#{@env}"
-    elsif formula.env.std? || formula.deps.select(&:build?).any? { |d| d.name == "scons" }
+    elsif formula.env.std?
       args << "--env=std"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Alternatively, could consider a way of disabling this on case-by-case basis as I am trying to figure out issues in Homebrew/homebrew-core#119502 which are coming from `--env=std`.

---

I don't know full history on this so probably need some input on exact scenarios to test. Is there particular formulae to try out?

I've personally seen more issues with `bazel` than `scons` (after this change) in case of reseting environment and we have been manually bypassing the shims for `bazel` dependents rather than handling it in `brew`.

As note, we've been building `mapnik` in homebrew-core using its bundled copy of `scons` v3.0.1, which means it has been using superenv.

I just tried locally building a modified `mapnik` (Homebrew/homebrew-core#119502), `subversion`, and `makensis` without any failure. However, it looks like only `mapnik` may be using shim compiler given that it logs `*.scons.cc` files