### PR TITLE
Include `*flight` block source in cask API

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -15,6 +15,7 @@ end
 gem "bootsnap", require: false
 gem "byebug", require: false
 gem "json_schemer", require: false
+gem "method_source", require: false
 gem "minitest", require: false
 gem "parallel_tests", require: false
 gem "ronn", require: false

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -233,6 +233,7 @@ DEPENDENCIES
   did_you_mean
   json_schemer
   mechanize
+  method_source
   minitest
   parallel_tests
   parlour

--- a/Library/Homebrew/cask/artifact/abstract_flight_block.rb
+++ b/Library/Homebrew/cask/artifact/abstract_flight_block.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "method_source"
 require "cask/artifact/abstract_artifact"
 
 module Cask
@@ -38,6 +37,8 @@ module Cask
       end
 
       def to_h
+        require "method_source"
+
         directives.transform_values(&:source)
       end
 

--- a/Library/Homebrew/cask/artifact/abstract_flight_block.rb
+++ b/Library/Homebrew/cask/artifact/abstract_flight_block.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "method_source"
 require "cask/artifact/abstract_artifact"
 
 module Cask
@@ -34,6 +35,10 @@ module Cask
 
       def summarize
         directives.keys.map(&:to_s).join(", ")
+      end
+
+      def to_h
+        directives.transform_values(&:source)
       end
 
       private

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -288,13 +288,9 @@ module Cask
 
     def artifacts_list
       artifacts.map do |artifact|
-        key, value = if artifact.is_a? Artifact::AbstractFlightBlock
-          artifact.summarize
-        else
-          [artifact.class.dsl_key, to_h_gsubs(artifact.to_args)]
-        end
+        next artifact.to_h if artifact.is_a? Artifact::AbstractFlightBlock
 
-        { key => value }
+        { artifact.class.dsl_key => to_h_gsubs(artifact.to_args) }
       end
     end
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -1,8 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "method_source"
-
 describe Cask::Cask, :cask do
   let(:cask) { described_class.new("versioned-cask") }
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+require "method_source"
+
 describe Cask::Cask, :cask do
   let(:cask) { described_class.new("versioned-cask") }
 
@@ -265,6 +267,46 @@ describe Cask::Cask, :cask do
         }
       JSON
     }
+    let(:expected_flight_variations) {
+      <<~JSON
+        {
+          "arm64_big_sur": {
+            "artifacts": [
+              {
+                "preflight": "    preflight do\\n      puts \\"preflight on Big Sur\\"\\n    end\\n"
+              },
+              {
+                "uninstall_postflight": "    uninstall_postflight do\\n      puts \\"uninstall_postflight on Big Sur\\"\\n    end\\n"
+              }
+            ]
+          },
+          "big_sur": {
+            "artifacts": [
+              {
+                "preflight": "    preflight do\\n      puts \\"preflight on Big Sur\\"\\n    end\\n"
+              },
+              {
+                "uninstall_postflight": "    uninstall_postflight do\\n      puts \\"uninstall_postflight on Big Sur\\"\\n    end\\n"
+              }
+            ]
+          },
+          "catalina": {
+            "artifacts": [
+              {
+                "preflight": "    preflight do\\n      puts \\"preflight on Catalina or older\\"\\n    end\\n"
+              }
+            ]
+          },
+          "mojave": {
+            "artifacts": [
+              {
+                "preflight": "    preflight do\\n      puts \\"preflight on Catalina or older\\"\\n    end\\n"
+              }
+            ]
+          }
+        }
+      JSON
+    }
 
     before do
       # Use a more limited symbols list to shorten the variations hash
@@ -299,6 +341,14 @@ describe Cask::Cask, :cask do
 
       expect(h).to be_a(Hash)
       expect(JSON.pretty_generate(h["variations"])).to eq expected_sha256_variations.strip
+    end
+
+    it "returns the correct variations hash for a cask with conditional flight blocks" do
+      c = Cask::CaskLoader.load("conditional-flight")
+      h = c.to_hash_with_variations
+
+      expect(h).to be_a(Hash)
+      expect(JSON.pretty_generate(h["variations"])).to eq expected_flight_variations.strip
     end
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/conditional-flight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/conditional-flight.rb
@@ -1,0 +1,21 @@
+cask "conditional-flight" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine/#{platform}/#{version}/#{arch}.zip"
+  homepage "https://brew.sh/"
+
+  on_big_sur do
+    preflight do
+      puts "preflight on Big Sur"
+    end
+    uninstall_postflight do
+      puts "uninstall_postflight on Big Sur"
+    end
+  end
+  on_catalina :or_older do
+    preflight do
+      puts "preflight on Catalina or older"
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the cask JSON API to include the Ruby source for `*flight` blocks. This will allow us to execute those blocks when loading casks from the API. See https://github.com/Homebrew/brew/pull/14304 for more discussion on this.

---

Marking as critical since this needs to get through `formulae.brew.sh` to unblock #14304
