### PR TITLE
formula_installer: check if dependencies have already been fetched.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1156,6 +1156,7 @@ class FormulaInstaller
   def fetch_dependencies
     return if ignore_deps?
 
+    # Don't output dependencies if we're explicitly installing them.
     deps = compute_dependencies.reject do |dep, _options|
       self.class.fetched.include?(dep.to_formula)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Given a `pkg_a` that depends on `pkg_b`, it is redundant to list `pkg_b` as a dependency when running the following commands:

- `brew install pkg_b pkg_a`
- `brew upgrade` (when both `pkg_a` and `pkg_b` are outdated)