### PR TITLE
dev-cmd/edit: handle editing with `install_from_api`.

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -206,14 +206,14 @@ module Cask
     end
 
     def self.path(ref)
-      self.for(ref).path
+      self.for(ref, need_path: true).path
     end
 
     def self.load(ref, config: nil)
       self.for(ref).load(config: config)
     end
 
-    def self.for(ref)
+    def self.for(ref, need_path: false)
       [
         FromInstanceLoader,
         FromContentLoader,
@@ -232,7 +232,7 @@ module Cask
         return loader_class.new(ref)
       end
 
-      if Homebrew::EnvConfig.install_from_api? && Homebrew::API::CaskSource.available?(ref)
+      if Homebrew::EnvConfig.install_from_api? && !need_path && Homebrew::API::CaskSource.available?(ref)
         return FromContentLoader.new(Homebrew::API::CaskSource.fetch(ref))
       end
 

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -55,15 +55,26 @@ module Homebrew
       args.named.to_paths.select do |path|
         next path if path.exist?
 
-        message = if args.cask?
+        not_exist_message = if args.cask?
+          "#{path.basename(".rb")} doesn't exist on disk."
+        else
+          "#{path} doesn't exist on disk."
+        end
+
+        message = if Homebrew::EnvConfig.install_from_api?
           <<~EOS
-            #{path.basename(".rb")} doesn't exist on disk. \
+            #{not_exist_message}
+            This is expected with HOMEBREW_INSTALL_FROM_API set!
+          EOS
+        elsif args.cask?
+          <<~EOS
+            #{not_exist_message}
             Run #{Formatter.identifier("brew create --cask --set-name #{path.basename(".rb")} $URL")} \
             to create a new cask!
           EOS
         else
           <<~EOS
-            #{path} doesn't exist on disk. \
+            #{not_exist_message}
             Run #{Formatter.identifier("brew create --formula --set-name #{path.basename} $URL")} \
             to create a new formula!
           EOS


### PR DESCRIPTION
Before this change, this would fail every time, even when available on disk (which was not the case for formulae).

With this change, it will attempt to find it from a tap on disk and only fail if it cannot be found in any.

Open to feedback from @Rylan12 and others on approach, this may not be the best one.