### PR TITLE
Restoring the original `PATH` after update

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -277,6 +277,9 @@ auto-update() {
 
     unset HOMEBREW_AUTO_UPDATING
 
+    # restore old path for user installed Ruby version.
+    export PATH=${HOMEBREW_PATH}
+
     # exec a new process to set any new environment variables.
     exec "${HOMEBREW_BREW_FILE}" "$@"
   fi

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -277,7 +277,7 @@ auto-update() {
 
     unset HOMEBREW_AUTO_UPDATING
 
-    # restore old path for user installed Ruby version.
+    # Restore user path as it'll be refiltered by HOMEBREW_BREW_FILE (bin/brew)
     export PATH=${HOMEBREW_PATH}
 
     # exec a new process to set any new environment variables.


### PR DESCRIPTION
This fix is required for ARM Linux where Homebrew Portable Ruby is not available.

Without this fix, after auto-update, `brew` is restarted with cleaned-up path.
This causes it to not find user installed Ruby by RVM or rbenv, causing brew to fail.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
