### PR TITLE
Include aliases in formula completion

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -57,7 +57,10 @@ __brew_formulae() {
   local -a list
   local comp_cachename=brew_formulae
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew formulae) )
+    list=( 
+        ${(f)"$( brew formulae )"}
+        $HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core/Aliases/*(N)
+    )
     _store_cache $comp_cachename list
   fi
   _describe -t formulae 'all formulae' list


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

# What my changes do
* Split the output of `brew formulae` explicitly on newlines to avoid accidental splitting inside formula names.
* Add all formula aliases from `homebrew-core` to formula completion, if present in the Homebrew repo.

# Why my changes should be included
Currently, if you type, for example, `brew install gpg` and invoke completion, the first result is `gpg-suite`. This misleads you into thinking that there is no formula named `gpg` and that you should use `gpg-suite` instead, when in fact, there is an alias `gpg` that tries to point you to the formula `gnupg`.
