### PR TITLE
cask/installer: ensure config_path exists.

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -388,6 +388,7 @@ module Cask
     end
 
     def save_config_file
+      @cask.config_path.dirname.mkpath
       @cask.config_path.atomic_write(@cask.config.to_json)
     end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -377,18 +377,21 @@ module Cask
       self.class.caveats(@cask)
     end
 
+    def metadata_subdir
+      @metadata_subdir ||= @cask.metadata_subdir("Casks", timestamp: :now, create: true)
+    end
+
     def save_caskfile
       old_savedir = @cask.metadata_timestamped_path
 
       return if @cask.source.blank?
 
-      savedir = @cask.metadata_subdir("Casks", timestamp: :now, create: true)
-      (savedir/"#{@cask.token}.rb").write @cask.source
+      (metadata_subdir/"#{@cask.token}.rb").write @cask.source
       old_savedir&.rmtree
     end
 
     def save_config_file
-      @cask.config_path.dirname.mkpath
+      metadata_subdir
       @cask.config_path.atomic_write(@cask.config.to_json)
     end
 


### PR DESCRIPTION
I encountered this when installing `microsoft-edge`.

Perhaps `HOMEBREW_INSTALL_FROM_API` related CC @Rylan12 