### PR TITLE
Allow --cask for linux dev cmds

### DIFF
--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -577,6 +577,14 @@ describe Homebrew::CLI::Parser do
           .and not_to_output.to_stdout
           .and raise_exception SystemExit
       end
+
+      # Developers want to be able to use `audit` and `bump`
+      # commands for formulae and casks on Linux.
+      it "succeeds for developer commands" do
+        require "dev-cmd/cat"
+        args = Homebrew.cat_args.parse(["--cask", "cask_name"])
+        expect(args.cask?).to be(true)
+      end
     end
 
     context "with conflicting --formula switch" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes https://github.com/Homebrew/brew/issues/14341.

This adds back in the ability to run dev commands with the `--cask` option on Linux. The approach here is to check whether the command is in the `dev-cmd/` folder and then skip the checks if it is. We could also approach this on a command-by-command basis by passing some sort of option to the parser's constructor but I think this is cleaner.

This will only affect 7 dev commands.
```
$ git grep 'switch "--cask"' -- '/usr/local/Homebrew/Library/Homebrew/dev-cmd'
Library/Homebrew/dev-cmd/audit.rb:      switch "--cask", "--casks",
Library/Homebrew/dev-cmd/bump.rb:      switch "--cask", "--casks",
Library/Homebrew/dev-cmd/cat.rb:      switch "--cask", "--casks",
Library/Homebrew/dev-cmd/create.rb:      switch "--cask",
Library/Homebrew/dev-cmd/edit.rb:      switch "--cask", "--casks",
Library/Homebrew/dev-cmd/livecheck.rb:      switch "--cask", "--casks",
Library/Homebrew/dev-cmd/style.rb:      switch "--cask", "--casks",
```

Of those, I'm not really sure how useful the `brew create` and `brew edit` commands would be for casks on Linux but they should all work fine. None of these commands have been modified since [passing the `--formula` option by default on Linux](https://github.com/Homebrew/brew/pull/14206) in ways that should make them unusable.