### PR TITLE
Warn (instead of failing) when `brew cleanup` is unable to remove a keg because it's owned by root

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -68,7 +68,7 @@ module Homebrew
 
     return if cleanup.unremovable_kegs.empty?
 
-    ofail <<~EOS
+    opoo <<~EOS
       Could not cleanup old kegs! Fix your permissions on:
         #{cleanup.unremovable_kegs.join "\n  "}
     EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

### Why?

There are some formulae (like [dnsmasq](https://github.com/Homebrew/homebrew-core/blob/282b8f3948c751a9eb61a4555b1c61e547489a6e/Formula/dnsmasq.rb#L66)) that tell `brew services` to require that they be run as root. When running them as root, `brew` chowns the keg to root:
```
Warning: Taking root:admin ownership of some dnsmasq paths:
  /opt/homebrew/Cellar/dnsmasq/2.88/sbin
  /opt/homebrew/Cellar/dnsmasq/2.88/sbin/dnsmasq
  /opt/homebrew/opt/dnsmasq
  /opt/homebrew/opt/dnsmasq/sbin
  /opt/homebrew/var/homebrew/linked/dnsmasq
This will require manual removal of these paths using `sudo rm` on
brew upgrade/reinstall/uninstall.
```
This causes `brew cleanup` to fail with the message:
```
Error: Could not cleanup old kegs! Fix your permissions on:
  /opt/homebrew/Cellar/dnsmasq/2.87
```

I'd suggest that this isn't a proper failure because the dnsmasq formula is owned by root according to Homebrew's design, and there's nothing about this scenario that is "broken".
