### PR TITLE
Fix `depends_on arch:` when loading casks from API

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -240,6 +240,12 @@ module Cask
 
           if json_cask[:depends_on].present?
             dep_hash = json_cask[:depends_on].to_h do |dep_key, dep_value|
+              if dep_key == :arch
+                next [:arch, :intel] if dep_value.first[:type] == "intel"
+
+                next [:arch, :arm64]
+              end
+
               next [dep_key, dep_value] unless dep_key == :macos
 
               dep_type = dep_value.keys.first

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -240,6 +240,8 @@ module Cask
 
           if json_cask[:depends_on].present?
             dep_hash = json_cask[:depends_on].to_h do |dep_key, dep_value|
+              # Arch dependencies are encoded like `{ type: :intel, bits: 64 }`
+              # but `depends_on arch:` only accepts `:intel` or `:arm64`
               if dep_key == :arch
                 next [:arch, :intel] if dep_value.first[:type] == "intel"
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-cask/issues/139214

This PR handles `depends_on arch:` lines correctly. The API contains a larger JSON object that can't be passed directly to the `depends_on` method, so we have to extract the arch symbol from that object.
