### PR TITLE
Restore user path when ensuring tap exists and add `cflags` to `ccE` shims

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -134,7 +134,7 @@ class Cmd
     when :cxx
       cxxflags + args + cppflags
     when :ccE
-      args + cppflags
+      cflags + args + cppflags
     when :cpp
       args + cppflags
     when :ld

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -800,7 +800,10 @@ class CoreTap < Tap
     # Tests override homebrew-core locations and we don't want to auto-tap in them.
     return if ENV["HOMEBREW_TESTS"]
 
-    safe_system HOMEBREW_BREW_FILE, "tap", instance.name
+    # Restore user path as it'll be refiltered by HOMEBREW_BREW_FILE
+    with_env PATH: ENV.fetch("HOMEBREW_PATH") do
+      safe_system HOMEBREW_BREW_FILE, "tap", instance.name
+    end
   end
 
   def remote


### PR DESCRIPTION
These fixes are required for ARM Linux.
- When on a fresh install, brew tries to setup the core tap which fails when launched with filtered `PATH`. This is because it can't find the user-installed Ruby which is required for ARM Linux.
- If `cflags` are not passed for `ccE`, optimization is disabled, which fails `glibc` install. `glibc` being one of core libraries blocks installation of any other packages.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
