### PR TITLE
Make Cask::DSL::Container#pairs a derived property (and fix YARD warning)

### DIFF
--- a/Library/Homebrew/cask/dsl/container.rb
+++ b/Library/Homebrew/cask/dsl/container.rb
@@ -9,20 +9,11 @@ module Cask
     #
     # @api private
     class Container
-      VALID_KEYS = Set.new([
-        :type,
-        :nested,
-      ]).freeze
+      attr_accessor :nested, :type
 
-      attr_accessor(*VALID_KEYS, :pairs)
-
-      def initialize(**pairs)
-        @pairs = pairs
-        pairs.each do |key, value|
-          raise "invalid container key: #{key.inspect}" unless VALID_KEYS.include?(key)
-
-          send(:"#{key}=", value)
-        end
+      def initialize(nested: nil, type: nil)
+        @nested = nested
+        @type = type
 
         return if type.nil?
         return unless UnpackStrategy.from_type(type).nil?
@@ -30,12 +21,16 @@ module Cask
         raise "invalid container type: #{type.inspect}"
       end
 
+      def pairs
+        instance_variables.to_h { |ivar| [ivar[1..].to_sym, instance_variable_get(ivar)] }.compact
+      end
+
       def to_yaml
-        @pairs.to_yaml
+        pairs.to_yaml
       end
 
       def to_s
-        @pairs.inspect
+        pairs.inspect
       end
     end
   end

--- a/Library/Homebrew/test/cask/dsl/container_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/container_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+# frozen_string_literal: true
+
+require "test/cask/dsl/shared_examples/base"
+
+describe Cask::DSL::Container do
+  subject(:container) { described_class.new(**params) }
+
+  describe "#pairs" do
+    let(:params) { { nested: "NestedApp.dmg" } }
+
+    it "returns the attributes as a hash" do
+      expect(container.pairs).to eq(nested: "NestedApp.dmg")
+    end
+  end
+
+  describe "#to_s" do
+    let(:params) { { nested: "NestedApp.dmg", type: :naked } }
+
+    it "returns the stringified attributes" do
+      expect(container.to_s).to eq('{:nested=>"NestedApp.dmg", :type=>:naked}')
+    end
+  end
+
+  describe "#to_yaml" do
+    let(:params) { { nested: "NestedApp.dmg", type: :naked } }
+
+    it "returns the attributes in YAML format" do
+      expect(container.to_yaml).to eq(<<~YAML)
+        ---
+        :nested: NestedApp.dmg
+        :type: :naked
+      YAML
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR fixes one of two warnings in YARD generation: https://github.com/Homebrew/rubydoc.brew.sh/actions/runs/3889710173/jobs/6638203664#step:7:24

It will result in `Cask::DSL::Container`'s attributes and allowed `initialize` arguments correctly appearing in the documentation at https://rubydoc.brew.sh/Cask/DSL/Container.html

It seems that the purpose of `Cask::DSL::Container#pairs` is to summarize the other attributes of `Container`. However, it is set independently of the other attributes, and thus would need to be updated if the other attributes change. This diff instead makes `pairs` a derived property, which inspects the state of the instance's attributes to determine its output.

The tests I've written verify that `to_yaml` and `to_s` are the same before and after this change. However, this is still a breaking (private API) change: `Container::VALID_KEYS` and `Container#pairs=` are removed in this PR.