### PR TITLE
show/check Homebrew branch

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -519,6 +519,17 @@ module Homebrew
         examine_git_origin(repo, Homebrew::EnvConfig.brew_git_remote)
       end
 
+      def check_brew_git_branch
+        repo = HOMEBREW_REPOSITORY.dup.extend(GitRepositoryExtension)
+        return if repo.git_default_origin_branch?
+
+        <<~EOS
+          Homebrew is not on the default git origin branch and may not receive
+          updates. If this is a surprise to you, check out the default branch with:
+            git -C $(brew --repo) checkout #{repo.git_origin_branch}"
+        EOS
+      end
+
       def check_coretap_integrity
         coretap = CoreTap.instance
         unless coretap.installed?

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -53,6 +53,11 @@ module SystemConfig
     end
 
     sig { returns(String) }
+    def branch
+      homebrew_repo.git_branch || "(none)"
+    end
+
+    sig { returns(String) }
     def core_tap_head
       CoreTap.instance.git_head || "(none)"
     end
@@ -155,6 +160,7 @@ module SystemConfig
       f.puts "ORIGIN: #{origin}"
       f.puts "HEAD: #{head}"
       f.puts "Last commit: #{last_commit}"
+      f.puts "Branch: #{branch}"
     end
 
     def homebrew_env_config(f = $stdout)


### PR DESCRIPTION
Because anyone can forget they're on a different branch, and wonder why `brew update` isn't pulling in the latest changes (https://github.com/orgs/Homebrew/discussions/4105#discussioncomment-4658869).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
