### PR TITLE
Fix remaining YARD exception, enable --fail-on-warning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,4 +64,4 @@ jobs:
 
       - name: Process rubydoc comments
         working-directory: Library/Homebrew
-        run: bundle exec yard doc --plugin sorbet --no-output #--fail-on-warning
+        run: bundle exec yard doc --plugin sorbet --no-output --fail-on-warning

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -19,6 +19,10 @@ module Kernel
   private :superenv?
 end
 
+# @!parse
+#  # ENV is not actually a class, but this makes `YARD` happy
+#  # @see https://rubydoc.info/stdlib/core/ENV ENV core documentation
+#  class ENV; end
 module EnvActivation
   extend T::Sig
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is a follow-up to https://github.com/Homebrew/brew/pull/14354#issuecomment-1379304944 that resolves the remaining YARD error and enables `--fail-on-warning` to the `docs` action. It does so by using YARD's [parse](https://rubydoc.info/gems/yard/file/docs/Tags.md#parse) directive to register `ENV` as a class. While `ENV` is not actually a class, this is a [common](https://rubydoc.info/stdlib/core/ENV) [workaround](https://ruby-doc.org/core-3.1.0/ENV.html) in ruby documentation.

While it would make more sense to place the `@!parse` directive near the `extend` invocation at the end of the file, YARD seems to be picky about where directives can go: a `class`/`module` declaration, a `def`, the top of the file, or in isolation. (The last one meaning that the directive is followed by 3 or more newlines, which `rubocop` didn't like.)

cc @EricFromCanada 