### PR TITLE
cask: fix writability check backing up an artifact

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -114,7 +114,7 @@ module Cask
         source.dirname.mkpath
 
         # We need to preserve extended attributes between copies.
-        command.run!("/bin/cp", args: ["-pR", target, source], sudo: !target.parent.writable?)
+        command.run!("/bin/cp", args: ["-pR", target, source], sudo: !source.parent.writable?)
 
         delete(target, force: force, command: command, **options)
       end

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -263,6 +263,11 @@ describe Cask::Artifact::App, :cask do
   end
 
   describe "uninstall_phase" do
+    after do
+      FileUtils.chmod 0755, target_path if target_path.exist?
+      FileUtils.chmod 0755, source_path if source_path.exist?
+    end
+
     it "deletes managed apps" do
       install_phase
 
@@ -271,6 +276,16 @@ describe Cask::Artifact::App, :cask do
       uninstall_phase
 
       expect(target_path).not_to exist
+    end
+
+    it "backs up read-only managed apps" do
+      install_phase
+
+      FileUtils.chmod 0544, target_path
+
+      expect { uninstall_phase }.to raise_error(Errno::ENOTEMPTY)
+
+      expect(source_path).to be_a_directory
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew uninstall --cask` during the backup step incorrectly checks parent of the source directory (`target`) for write-ability instead of the destination directory (`source`).