### PR TITLE
cask: don't attempt to make a directory that already exists.

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -70,10 +70,13 @@ module Cask
         end
 
         ohai "Moving #{self.class.english_name} '#{source.basename}' to '#{target}'"
-        if target.dirname.ascend.find(&:directory?).writable?
-          target.dirname.mkpath
-        else
-          command.run!("/bin/mkdir", args: ["-p", target.dirname], sudo: true)
+
+        unless target.dirname.exist?
+          if target.dirname.ascend.find(&:directory?).writable?
+            target.dirname.mkpath
+          else
+            command.run!("/bin/mkdir", args: ["-p", target.dirname], sudo: true)
+          end
         end
 
         if target.dirname.writable?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes `brew install --cask` behavior when it tries to `mkdir` even if the directory (e.g. /Applications) already exists.

Also see this comment: https://github.com/Homebrew/brew/commit/e09eaf5b3144983b792ff71167274f8da2cd356c#r32244581