### PR TITLE
cask: don't assume that sudo has write access to the caskroom

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -79,7 +79,10 @@ module Cask
         if target.dirname.writable?
           FileUtils.move(source, target)
         else
-          command.run!("/bin/mv", args: [source, target], sudo: true)
+          # default sudo user isn't necessarily able to write to Homebrew's locations
+          # e.g. with runas_default set in the sudoers (5) file.
+          command.run!("/bin/cp", args: ["-pR", source, target], sudo: true)
+          source.rmtree
         end
 
         post_move(command)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently `brew install --cask` assumes that `sudo` has write access  to the caskroom. This is not necessarily true: a system administrator may override the default sudo user via the runas_default setting in sudoers. This user may be defined to have sufficient privileges to write to the system directory for installation but restricted from writing to Homebrew's locations.

A performance enhancement would be to change unconditional `cp -pR` to try commands (in order):
1. ~~`mv`~~ _It's better to use `cp` as the resulting file will be owned by the user that has writability in the parent's directory_
2. `cp -cpR`
3. `cp -pR`

However, the benefit might be marginal: on my system (MBP M1 Pro) copying Xcode.app with the `-c` takes ~1min vs ~2min without it.