### PR TITLE
rubocops/caveats: Disallow ANSI escape codes

### DIFF
--- a/Library/Homebrew/rubocops/caveats.rb
+++ b/Library/Homebrew/rubocops/caveats.rb
@@ -27,9 +27,11 @@ module RuboCop
       class Caveats < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, _body_node)
           caveats_strings.each do |n|
-            next unless regex_match_group(n, /\bsetuid\b/i)
+            if regex_match_group(n, /\bsetuid\b/i)
+              problem "Don't recommend setuid in the caveats, suggest sudo instead."
+            end
 
-            problem "Don't recommend setuid in the caveats, suggest sudo instead."
+            problem "Don't use ANSI escape codes in the caveats." if regex_match_group(n, /\e/)
           end
         end
       end

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -19,5 +19,29 @@ describe RuboCop::Cop::FormulaAudit::Caveats do
         end
       RUBY
     end
+
+    it "reports an offense if an escape character is present" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
+           def caveats
+            "\\x1B"
+            ^^^^^^ Don't use ANSI escape codes in the caveats.
+          end
+        end
+      RUBY
+
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
+           def caveats
+            "\\u001b"
+            ^^^^^^^^ Don't use ANSI escape codes in the caveats.
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Formula caveats text appears on formulae.brew.sh but escape characters, as used in ANSI escape codes, should not appear in HTML (see https://github.com/Homebrew/formulae.brew.sh/pull/680, https://github.com/Homebrew/homebrew-core/pull/120530). This PR adds a RuboCop to disallow escape characters in the caveats text.