### PR TITLE
Add HOMEBREW_NO_INSTALL_FROM_API

### DIFF
--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -13,7 +13,9 @@ homebrew-formulae() {
 
   # HOMEBREW_CACHE is set by brew.sh
   # shellcheck disable=SC2154
-  if [[ -n "${HOMEBREW_INSTALL_FROM_API}" && -f "${HOMEBREW_CACHE}/api/formula.json" ]]
+  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
+        -n "${HOMEBREW_INSTALL_FROM_API}" &&
+        -f "${HOMEBREW_CACHE}/api/formula.json" ]]
   then
     local api_formulae
     api_formulae="$(ruby -e "require 'json'; JSON.parse(File.read('${HOMEBREW_CACHE}/api/formula.json')).each { |f| puts f['name'] }" 2>/dev/null)"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -385,6 +385,12 @@ user account:
 EOS
   fi
 
+  if [[ -d "${HOMEBREW_CORE_REPOSITORY}" ]] ||
+     [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+  then
+    HOMEBREW_CORE_AVAILABLE="1"
+  fi
+
   if [[ ! -w "${HOMEBREW_REPOSITORY}" ]]
   then
     odie <<EOS
@@ -399,7 +405,7 @@ EOS
   if [[ -n "${HOMEBREW_FORCE_BREWED_CA_CERTIFICATES}" && ! -f "${HOMEBREW_PREFIX}/etc/ca-certificates/cert.pem" ]]
   then
     # we cannot install Homebrew CA certificates if homebrew/core is unavailable.
-    if [[ -d "${HOMEBREW_CORE_REPOSITORY}" || -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+    if [[ -n "${HOMEBREW_CORE_AVAILABLE}" ]]
     then
       brew install ca-certificates
       setup_ca_certificates
@@ -410,7 +416,7 @@ EOS
   if [[ -n "${HOMEBREW_FORCE_BREWED_CURL}" && ! -x "${HOMEBREW_PREFIX}/opt/curl/bin/curl" ]]
   then
     # we cannot install a Homebrew cURL if homebrew/core is unavailable.
-    if [[ ! -d "${HOMEBREW_CORE_REPOSITORY}" && -z "${HOMEBREW_INSTALL_FROM_API}" ]] || ! brew install curl
+    if [[ -z "${HOMEBREW_CORE_AVAILABLE}" ]] || ! brew install curl
     then
       odie "'curl' must be installed and in your PATH!"
     fi
@@ -422,7 +428,7 @@ EOS
      [[ -n "${HOMEBREW_FORCE_BREWED_GIT}" && ! -x "${HOMEBREW_PREFIX}/opt/git/bin/git" ]]
   then
     # we cannot install a Homebrew Git if homebrew/core is unavailable.
-    if [[ ! -d "${HOMEBREW_CORE_REPOSITORY}" && -z "${HOMEBREW_INSTALL_FROM_API}" ]] || ! brew install git
+    if [[ -z "${HOMEBREW_CORE_AVAILABLE}" ]] || ! brew install git
     then
       odie "'git' must be installed and in your PATH!"
     fi
@@ -560,7 +566,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
+    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
        [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ]]
     then
@@ -720,7 +726,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
+    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
        [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ||
           "${DIR}" == "${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-cask" ]]
@@ -762,7 +768,7 @@ EOS
     fi
   done
 
-  if [[ -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
   then
     mkdir -p "${HOMEBREW_CACHE}/api"
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -226,9 +226,7 @@ module Homebrew
       },
       HOMEBREW_INSTALL_FROM_API:                 {
         description: "If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's " \
-                     "API instead of needing (large, slow) local checkouts of these repositories." \
-                     "\n\n    *Note:* Setting HOMEBREW_INSTALL_FROM_API is not compatible with Homebrew's " \
-                     "developer mode so will error (as Homebrew development needs a full clone).",
+                     "API instead of needing (large, slow) local checkouts of these repositories.",
         boolean:     true,
       },
       HOMEBREW_LIVECHECK_WATCHLIST:              {
@@ -311,6 +309,12 @@ module Homebrew
                      "cleanup installed/upgraded/reinstalled formulae or all formulae every " \
                      "`HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` days. Alternatively, HOMEBREW_NO_CLEANUP_FORMULAE " \
                      "allows specifying specific formulae to not clean up.",
+        boolean:     true,
+      },
+      HOMEBREW_NO_INSTALL_FROM_API:              {
+        description: "If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using " \
+                     "Homebrew's API even if `HOMEBREW_INSTALL_FROM_API` is set and instead use (large, slow) " \
+                     "local checkouts of these repositories.",
         boolean:     true,
       },
       HOMEBREW_NO_INSTALL_UPGRADE:               {
@@ -477,6 +481,11 @@ module Homebrew
     sig { returns(T::Boolean) }
     def cask_opts_require_sha?
       cask_opts.include?("--require-sha")
+    end
+
+    sig { returns(T::Boolean) }
+    def install_from_api?
+      ENV["HOMEBREW_NO_INSTALL_FROM_API"].blank? && ENV["HOMEBREW_INSTALL_FROM_API"].present?
     end
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2151,8 +2151,6 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_INSTALL_FROM_API`
   <br>If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API instead of needing (large, slow) local checkouts of these repositories.
 
-    *Note:* Setting HOMEBREW_INSTALL_FROM_API is not compatible with Homebrew's developer mode so will error (as Homebrew development needs a full clone).
-
 - `HOMEBREW_LIVECHECK_WATCHLIST`
   <br>Consult this file for the list of formulae to check by default when no formula argument is passed to `brew livecheck`.
 
@@ -2209,6 +2207,9 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
 - `HOMEBREW_NO_INSTALL_CLEANUP`
   <br>If set, `brew install`, `brew upgrade` and `brew reinstall` will never automatically cleanup installed/upgraded/reinstalled formulae or all formulae every `HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` days. Alternatively, HOMEBREW_NO_CLEANUP_FORMULAE allows specifying specific formulae to not clean up.
+
+- `HOMEBREW_NO_INSTALL_FROM_API`
+  <br>If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API even if `HOMEBREW_INSTALL_FROM_API` is set and instead use (large, slow) local checkouts of these repositories.
 
 - `HOMEBREW_NO_INSTALL_UPGRADE`
   <br>If set, `brew install *`formula`*` will not upgrade `*`formula`*` if it is installed but outdated.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3142,9 +3142,6 @@ Print this text before the installation summary of each successful build\.
 .br
 If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API instead of needing (large, slow) local checkouts of these repositories\.
 .
-.IP
-\fINote:\fR Setting HOMEBREW_INSTALL_FROM_API is not compatible with Homebrew\'s developer mode so will error (as Homebrew development needs a full clone)\.
-.
 .TP
 \fBHOMEBREW_LIVECHECK_WATCHLIST\fR
 .
@@ -3252,6 +3249,12 @@ If set, forbid redirects from secure HTTPS to insecure HTTP\.
 .
 .br
 If set, \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew reinstall\fR will never automatically cleanup installed/upgraded/reinstalled formulae or all formulae every \fBHOMEBREW_CLEANUP_PERIODIC_FULL_DAYS\fR days\. Alternatively, HOMEBREW_NO_CLEANUP_FORMULAE allows specifying specific formulae to not clean up\.
+.
+.TP
+\fBHOMEBREW_NO_INSTALL_FROM_API\fR
+.
+.br
+If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API even if \fBHOMEBREW_INSTALL_FROM_API\fR is set and instead use (large, slow) local checkouts of these repositories\.
 .
 .TP
 \fBHOMEBREW_NO_INSTALL_UPGRADE\fR


### PR DESCRIPTION
This allows HOMEBREW_INSTALL_FROM_API functionality to be disabled and will stick around once HOMEBREW_INSTALL_FROM_API is made the default behaviour.