### PR TITLE
Change HOMEBREW_INSTALL_FROM_API update frequency

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -249,7 +249,14 @@ auto-update() {
 
     if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
     then
-      HOMEBREW_AUTO_UPDATE_SECS="300"
+      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+      then
+        # 24 hours
+        HOMEBREW_AUTO_UPDATE_SECS="86400"
+      else
+        # 5 minutes
+        HOMEBREW_AUTO_UPDATE_SECS="300"
+      fi
     fi
 
     # Skip auto-update if the repository has been updated in the

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -31,10 +31,10 @@ module Homebrew
                      "`http://localhost:8080/v2/homebrew/core/gettext/manifests/0.21`",
       },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
-        description: "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
-                     "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
-                     "disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.",
-        default:     300,
+        description:  "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
+                      "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
+                      "disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.",
+        default_text: "300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set.",
       },
       HOMEBREW_AUTOREMOVE:                       {
         description: "If set, calls to `brew cleanup` and `brew uninstall` will automatically " \

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -28,15 +28,15 @@ describe Homebrew::EnvConfig do
     end
   end
 
-  describe ".auto_update_secs" do
+  describe ".cleanup_periodic_full_days" do
     it "returns value if set" do
-      ENV["HOMEBREW_AUTO_UPDATE_SECS"] = "360"
-      expect(env_config.auto_update_secs).to eql("360")
+      ENV["HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS"] = "360"
+      expect(env_config.cleanup_periodic_full_days).to eql("360")
     end
 
     it "returns default if unset" do
-      ENV["HOMEBREW_AUTO_UPDATE_SECS"] = nil
-      expect(env_config.auto_update_secs).to eql("300")
+      ENV["HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS"] = nil
+      expect(env_config.cleanup_periodic_full_days).to eql("30")
     end
   end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1993,7 +1993,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_AUTO_UPDATE_SECS`
   <br>Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.
 
-  *Default:* `300`.
+  *Default:* 300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set.
 
 - `HOMEBREW_AUTOREMOVE`
   <br>If set, calls to `brew cleanup` and `brew uninstall` will automatically remove unused formula dependents and if HOMEBREW_NO_INSTALL_CLEANUP is not set, `brew cleanup` will start running `brew autoremove` periodically.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2846,7 +2846,7 @@ Prefix all download URLs, including those for bottles, with this value\. For exa
 Run \fBbrew update\fR once every \fBHOMEBREW_AUTO_UPDATE_SECS\fR seconds before some commands, e\.g\. \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew tap\fR\. Alternatively, disable auto\-update entirely with HOMEBREW_NO_AUTO_UPDATE\.
 .
 .IP
-\fIDefault:\fR \fB300\fR\.
+\fIDefault:\fR 300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set\.
 .
 .TP
 \fBHOMEBREW_AUTOREMOVE\fR


### PR DESCRIPTION
This doesn't need to be nearly as often for HOMEBREW_INSTALL_FROM_API users because we're getting the latest information from the API when needed rather than just at `brew update` time.