### PR TITLE
Options: Add #to_s method

### DIFF
--- a/Library/Homebrew/options.rb
+++ b/Library/Homebrew/options.rb
@@ -146,6 +146,11 @@ class Options
   alias to_ary to_a
 
   sig { returns(String) }
+  def to_s
+    @options.map(&:to_s).join(" ")
+  end
+
+  sig { returns(String) }
   def inspect
     "#<#{self.class.name}: #{to_a.inspect}>"
   end

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -90,6 +90,14 @@ describe Options do
     expect(described_class.create(array).sort).to eq([option1, option2].sort)
   end
 
+  specify "#to_s" do
+    expect(options.to_s).to eq("")
+    options << Option.new("first")
+    expect(options.to_s).to eq("--first")
+    options << Option.new("second")
+    expect(options.to_s).to eq("--first --second")
+  end
+
   specify "#inspect" do
     expect(options.inspect).to eq("#<Options: []>")
     options << Option.new("foo")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Options` objects are converted to a string in some circumstances but this produces output like `#<Options:0x0000000102592c90>`.

For example, formulae.brew.sh contains analytics entries with incomprehensible names like `adns #<Options:0x0000000102592c90>` (see Homebrew/formulae.brew.sh#679). This shortcoming is apparent when compared to other entries like `adns --HEAD`.

The `Option` class has a `#to_s` method that returns the `flag`, so this PR simply adds an `Options#to_s` method that calls `#to_s` on each `Option` object in `@options` and joins them using spaces. This should produce more useful output when an `Options` object is converted to a string (e.g., `--first --second`).

I've added a simple test for this but it currently doesn't test options like `--first=1` (see below).

-----

In testing this, I found that options like `--first=1` end up being truncated to `--first=` due to how the text is parsed using a regex in `Options#create`. Testing this in `brew irb` produces the following output:

```
o = Options.create(["--first=1", "--second"])
=> #<Options: [#<Option: "--first=">, #<Option: "--second">]>
o.to_s
=> "--first= --second"
```

Is this intended behavior or should we rework the regex to retain the option value? If we want to rework the `Options#create` behavior, I can take care of it in a follow-up PR.