### PR TITLE
some needs_network specs: temporarily disable.

### DIFF
--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -7,14 +7,17 @@ require "cmd/shared_examples/args_parse"
 describe "brew search" do
   it_behaves_like "parseable arguments"
 
-  it "falls back to a GitHub tap search when no formula is found", :integration_test, :needs_macos, :needs_network do
-    setup_test_formula "testball"
-    setup_remote_tap "homebrew/cask"
+  # TODO: consider re-enabling when/if we can make these not flaky.
+  #
+  # it "falls back to a GitHub tap search when no formula is found",
+  #    :integration_test, :needs_macos, :needs_network do
+  #   setup_test_formula "testball"
+  #   setup_remote_tap "homebrew/cask"
 
-    expect { brew "search", "homebrew/cask/firefox" }
-      .to output(/firefox/).to_stdout
-      .and be_a_success
-  end
+  #   expect { brew "search", "homebrew/cask/firefox" }
+  #     .to output(/firefox/).to_stdout
+  #     .and be_a_success
+  # end
 
   # doesn't actually need Linux but only want one integration test per-OS.
   it "finds formula in search", :integration_test, :need_linux do

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -7,24 +7,26 @@ describe "brew bump" do
   it_behaves_like "parseable arguments"
 
   describe "formula", :integration_test, :needs_homebrew_curl, :needs_network do
-    it "returns data for single valid specified formula" do
-      install_test_formula "testball"
+    # TODO: consider re-enabling when/if we can make these not flaky.
+    #
+    #   it "returns data for single valid specified formula" do
+    #     install_test_formula "testball"
 
-      expect { brew "bump", "testball" }
-        .to output.to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
+    #     expect { brew "bump", "testball" }
+    #       .to output.to_stdout
+    #       .and not_to_output.to_stderr
+    #       .and be_a_success
+    #   end
 
-    it "returns data for multiple valid specified formula" do
-      install_test_formula "testball"
-      install_test_formula "testball2"
+    #   it "returns data for multiple valid specified formula" do
+    #     install_test_formula "testball"
+    #     install_test_formula "testball2"
 
-      expect { brew "bump", "testball", "testball2" }
-        .to output.to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
+    #     expect { brew "bump", "testball", "testball2" }
+    #       .to output.to_stdout
+    #       .and not_to_output.to_stderr
+    #       .and be_a_success
+    #   end
 
     it "returns no data and prints a message for HEAD-only formulae" do
       content = <<~RUBY

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -6,23 +6,25 @@ require "cmd/shared_examples/args_parse"
 describe "brew prof" do
   it_behaves_like "parseable arguments"
 
-  describe "integration tests", :integration_test, :needs_network do
-    after do
-      FileUtils.rm_rf HOMEBREW_LIBRARY_PATH/"prof"
-    end
+  # TODO: consider re-enabling when/if we can make these not flaky.
+  #
+  # describe "integration tests", :integration_test, :needs_network do
+  #   after do
+  #     FileUtils.rm_rf HOMEBREW_LIBRARY_PATH/"prof"
+  #   end
 
-    it "works using ruby-prof (the default)" do
-      expect { brew "prof", "help", "HOMEBREW_BROWSER" => "echo" }
-        .to output(/^Example usage:/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
+  #   it "works using ruby-prof (the default)" do
+  #     expect { brew "prof", "help", "HOMEBREW_BROWSER" => "echo" }
+  #       .to output(/^Example usage:/).to_stdout
+  #       .and not_to_output.to_stderr
+  #       .and be_a_success
+  #   end
 
-    it "works using stackprof" do
-      expect { brew "prof", "--stackprof", "help", "HOMEBREW_BROWSER" => "echo" }
-        .to output(/^Example usage:/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
+  #   it "works using stackprof" do
+  #     expect { brew "prof", "--stackprof", "help", "HOMEBREW_BROWSER" => "echo" }
+  #       .to output(/^Example usage:/).to_stdout
+  #       .and not_to_output.to_stderr
+  #       .and be_a_success
+  #   end
+  # end
 end

--- a/Library/Homebrew/test/utils/repology_spec.rb
+++ b/Library/Homebrew/test/utils/repology_spec.rb
@@ -2,31 +2,3 @@
 # frozen_string_literal: true
 
 require "utils/repology"
-
-describe Repology do
-  describe "single_package_query", :needs_homebrew_curl, :needs_network do
-    it "returns nil for non-existent package" do
-      response = described_class.single_package_query("invalidName", repository: "homebrew")
-
-      expect(response).to be_nil
-    end
-
-    it "returns a hash for existing package" do
-      response = described_class.single_package_query("openclonk", repository: "homebrew")
-
-      expect(response).not_to be_nil
-      expect(response).to be_a(Hash)
-    end
-  end
-
-  describe "parse_api_response", :needs_homebrew_curl, :needs_network do
-    it "returns a hash of data" do
-      limit = 1
-      start_with = "x"
-      response = described_class.parse_api_response(limit, start_with, repository: "homebrew")
-
-      expect(response).not_to be_nil
-      expect(response).to be_a(Hash)
-    end
-  end
-end


### PR DESCRIPTION
These are absurdly flaky right now so let's disable them.

CC @dawidd6 in case there's other stuff related to e.g. autobump.