### PR TITLE
Allow specifying `pkg` `target:`

### DIFF
--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -18,7 +18,7 @@ module Cask
       attr_reader :path, :stanza_options
 
       def self.from_args(cask, path, **stanza_options)
-        stanza_options.assert_valid_keys!(:allow_untrusted, :choices)
+        stanza_options.assert_valid_keys!(:allow_untrusted, :choices, :target)
         new(cask, path, **stanza_options)
       end
 
@@ -54,7 +54,7 @@ module Cask
 
         args = [
           "-pkg",    path,
-          "-target", "/"
+          "-target", target
         ]
         args << "-verboseR" if verbose
         args << "-allowUntrusted" if stanza_options.fetch(:allow_untrusted, false)
@@ -65,7 +65,8 @@ module Cask
             "USER"     => User.current,
             "USERNAME" => User.current,
           }
-          command.run!("/usr/sbin/installer", sudo: true, args: args, print_stdout: true, env: env)
+          sudo = target != "CurrentUserHomeDirectory"
+          command.run!("/usr/sbin/installer", sudo: sudo, args: args, print_stdout: true, env: env)
         end
       end
 
@@ -80,6 +81,10 @@ module Cask
         ensure
           file.unlink
         end
+      end
+
+      def target
+        stanza_options.fetch(:target, "/")
       end
     end
   end

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -77,4 +77,52 @@ describe Cask::Artifact::Pkg, :cask do
       pkg.install_phase(command: fake_system_command)
     end
   end
+
+  describe "target" do
+    describe "with volume target" do
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-pkg-target")) }
+
+      it "runs the system installer on the specified pkgs with the specified target" do
+        pkg = cask.artifacts.find { |a| a.is_a?(described_class) }
+
+        expect(fake_system_command).to receive(:run!).with(
+          "/usr/sbin/installer",
+          args:         ["-pkg", cask.staged_path.join("MyFancyPkg", "Fancy.pkg"),
+                         "-target", "/Volumes/Macintosh HD2"],
+          sudo:         true,
+          print_stdout: true,
+          env:          {
+            "LOGNAME"  => ENV.fetch("USER"),
+            "USER"     => ENV.fetch("USER"),
+            "USERNAME" => ENV.fetch("USER"),
+          },
+        )
+
+        pkg.install_phase(command: fake_system_command)
+      end
+    end
+
+    describe "with CurrentUserHomeDirectory target" do
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-pkg-target-current-user-home-directory")) }
+
+      it "runs the system installer on the specified pkgs with the specified target" do
+        pkg = cask.artifacts.find { |a| a.is_a?(described_class) }
+
+        expect(fake_system_command).to receive(:run!).with(
+          "/usr/sbin/installer",
+          args:         ["-pkg", cask.staged_path.join("MyFancyPkg", "Fancy.pkg"),
+                         "-target", "CurrentUserHomeDirectory"],
+          sudo:         false,
+          print_stdout: true,
+          env:          {
+            "LOGNAME"  => ENV.fetch("USER"),
+            "USER"     => ENV.fetch("USER"),
+            "USERNAME" => ENV.fetch("USER"),
+          },
+        )
+
+        pkg.install_phase(command: fake_system_command)
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkg-target-current-user-home-directory.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkg-target-current-user-home-directory.rb
@@ -1,0 +1,11 @@
+cask "with-pkg-target-current-user-home-directory" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage "https://brew.sh/fancy-pkg"
+
+  pkg "MyFancyPkg/Fancy.pkg", target: "CurrentUserHomeDirectory"
+
+  uninstall pkgutil: "my.fancy.package"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkg-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkg-target.rb
@@ -1,0 +1,11 @@
+cask "with-pkg-target" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage "https://brew.sh/fancy-pkg"
+
+  pkg "MyFancyPkg/Fancy.pkg", target: "/Volumes/Macintosh HD2"
+
+  uninstall pkgutil: "my.fancy.package"
+end


### PR DESCRIPTION
One such target is `CurrentUserHomeDirectory`. See `installer -help`.

Required for Homebrew/homebrew-cask#139807

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
