### PR TITLE
Add closed PR check to bump cmds

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -511,7 +511,7 @@ module GitHub
     return if pull_requests.blank?
 
     duplicates_message = <<~EOS
-      These pull requests may be duplicates:
+      These #{state} pull requests may be duplicates:
       #{pull_requests.map { |pr| "#{pr["title"]} #{pr["html_url"]}" }.join("\n")}
     EOS
     error_message = "Duplicate PRs should not be opened. Use --force to override this error."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes #14336 where we found out that the `brew bump` command was failing when there already existed a closed PR that tried to update the package to the same version. This recommended passing the `--force` flag which the `brew bump` command doesn't allow. This is expected behavior in `bump-formula-pr` that wasn't addressed in `brew bump`. The change here is to check for closed PRs in the `brew bump` command first and not allow users to force any PRs from that command because it's a convenience command for `brew bump-cask-pr` and `brew bump-formula-pr`. It also adds the closed PR check to `brew bump-cask-pr` to match the formula version of the same command.

The reason why we don't want people bumping packages that have a closed PR is because that means it was either already merged in or it requires some sort of extra attention that caused the bump to fail the first time.

One thing to keep in mind is that this will increase the number of times we query the Github API. Once more for `bump-cask-pr` and once more for `brew bump`. We could consider grabbing everything from the Github API and then splitting it into open and closed PRs in `brew bump` which would save an API request. The difference is that I think we would end up grabbing all of them meaning most of the data wouldn't be relevant to us (really old closed PRs). I'm not sure it's worth the effort (and I'm lazy).

## bump
It now checks for the closed PRs unless the user doesn't want us to hit the Github API (`--no-pull-requests`) or we've already found a matching open PR or a new version of the package isn't available.

#### No matching PRs
```
$ brew bump insomnia
==> insomnia is up to date!
Current cask version   :  2022.7.5
Latest livecheck version: 2022.7.5
Latest Repology version:  2022.7.5
Open pull requests:       none
Closed pull requests:     none
```

#### Matching open PR
```
$ brew bump --cask media-center
==> media-center
Current cask version   :  30.00.41
Latest livecheck version: 30.00.41
Latest Repology version:  present only in Homebrew
Open pull requests:       Update media-center from 30.00.41 to 30.00.45 (https://github.com/Homebrew/homebrew-cask/pull/139744)
Closed pull requests:     none
```

#### Matching closed PR
```
/u/l/Homebrew (add-closed-pr-check-to-bump-cmds|✚1) $ brew bump ott
==> ott
Current formula version:  0.32
Latest livecheck version: 0.33
Latest Repology version:  0.32
Open pull requests:       none
Closed pull requests:     ott 0.33 (https://github.com/Homebrew/homebrew-core/pull/120748)
```


## bump-cask-pr
It checks for closed PRs matching the version specified after checking for open ones.

#### Matching open PR
```
$ brew bump-cask-pr -n media-center --version=30.00.45
Error: These open pull requests may be duplicates:
Update media-center from 30.00.41 to 30.00.45 https://github.com/Homebrew/homebrew-cask/pull/139744
Duplicate PRs should not be opened. Use --force to override this error.
```

#### Matching closed PR
```
$ brew bump-cask-pr -n insomnia --version=2022.7.5
Error: These closed pull requests may be duplicates:
Update insomnia from 2022.7.4 to 2022.7.5 https://github.com/Homebrew/homebrew-cask/pull/139787
Duplicate PRs should not be opened. Use --force to override this error.
```