### PR TITLE
cmd/install: fail when pkg not found

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -276,6 +276,8 @@ module Homebrew
     $stderr.puts e.backtrace if Homebrew::EnvConfig.developer?
     ofail e.message
   rescue FormulaOrCaskUnavailableError, Cask::CaskUnavailableError => e
+    Homebrew.failed = true
+
     # formula name or cask token
     name = e.try(:name) || e.token
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This resolves #14361.

The idea here is to facilitate scripting by always failing whenever a package is not installed successfully. This is
how the upgrade and reinstall commands work but not install because we also search for similar package names before terminating.

The only thing to consider here is if anyone relies on the current behavior which would return success if the package didn't exist but a package with a similar name does exist. I can't see how this behavior would be useful for scripting or something you could consistently rely on so I think it's probably fine to change that behavior.

### New Behavior
```
/u/l/Homebrew (fail-on-pkg-not-found-in-install|✔) $ HOMEBREW_NO_AUTO_UPDATE=1 brew install -n virtualsox
Warning: No available formula with the name "virtualsox". Did you mean virtualpg, virtuoso or virtualenv?
==> Searching for similarly named formulae and casks...
==> Formulae
virtualpg                              virtuoso                               virtualenv ✔

To install virtualpg, run:
  brew install virtualpg

==> Casks
virtual-ii         virtualbox ✔       virtualbox6        virtualc64         virtualgl          virtualhostx

To install virtual-ii, run:
  brew install --cask virtual-ii
/u/l/Homebrew (fail-on-pkg-not-found-in-install|✔) [1]$ echo $status
1
```