### PR TITLE
Permit multiple `uninstall` stanzas in casks (short-term fix)

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -185,10 +185,6 @@ module Cask
     def check_single_uninstall_zap
       odebug "Auditing single uninstall_* and zap stanzas"
 
-      if cask.artifacts.count { |k| k.is_a?(Artifact::Uninstall) } > 1
-        add_error "only a single uninstall stanza is allowed"
-      end
-
       count = cask.artifacts.count do |k|
         k.is_a?(Artifact::PreflightBlock) &&
           k.directives.key?(:uninstall_preflight)

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -600,28 +600,6 @@ describe Cask::Audit, :cask do
       end
     end
 
-    describe "uninstall stanza checks" do
-      let(:message) { "only a single uninstall stanza is allowed" }
-
-      context "when the Cask has no uninstall stanza" do
-        let(:cask_token) { "with-zap-rmdir" }
-
-        it { is_expected.not_to fail_with(message) }
-      end
-
-      context "when the Cask has only one uninstall stanza" do
-        let(:cask_token) { "with-uninstall-rmdir" }
-
-        it { is_expected.not_to fail_with(message) }
-      end
-
-      context "when the Cask has multiple uninstall stanzas" do
-        let(:cask_token) { "with-uninstall-multi" }
-
-        it { is_expected.to fail_with(message) }
-      end
-    end
-
     describe "uninstall_preflight stanza checks" do
       let(:message) { "only a single uninstall_preflight stanza is allowed" }
 


### PR DESCRIPTION
Longer-term solution is described [here](https://github.com/Homebrew/brew/issues/14365#issuecomment-1398214354).

Resolves #14365.

CC @MikeMcQuaid

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----