### PR TITLE
Fix `brew search` for `HOMEBREW_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -137,6 +137,10 @@ module Homebrew
         c.sub(%r{^homebrew/cask.*/}, "")
       end
 
+      if !Tap.fetch("homebrew/cask").installed? && Homebrew::EnvConfig.install_from_api?
+        cask_tokens += Homebrew::API::Cask.all_casks.keys
+      end
+
       results = cask_tokens.extend(Searchable)
                            .search(string_or_regex)
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -927,6 +927,20 @@ class CoreTap < Tap
   def alias_file_to_name(file)
     file.basename.to_s
   end
+
+  # @private
+  def aliases
+    return super if installed? || !Homebrew::EnvConfig.install_from_api?
+
+    Homebrew::API::Formula.all_aliases.keys
+  end
+
+  # @private
+  def formula_names
+    return super if installed? || !Homebrew::EnvConfig.install_from_api?
+
+    Homebrew::API::Formula.all_formulae.keys
+  end
 end
 
 # Permanent configuration per {Tap} using `git-config(1)`.


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/14009

This (long overdue) PR fixes `brew search` for `HOMEBREW_INSTALL_FROM_API`. Now, `brew search` will use the API to generate its list of formula/cask names if the user has set `HOMEBREW_INSTALL_FROM_API` _and_ the respective homebrew/core or homebrew/cask tap is not installed.
