### PR TITLE
separate default_prefix to `extend/os` files

### DIFF
--- a/Library/Homebrew/default_prefix.rb
+++ b/Library/Homebrew/default_prefix.rb
@@ -1,15 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-require "simulate_system"
-
 module Homebrew
-  # TODO: Refactor and move to extend/os
-  DEFAULT_PREFIX, DEFAULT_REPOSITORY = if OS.mac? && Hardware::CPU.arm? # rubocop:disable Homebrew/MoveToExtendOS
-    [HOMEBREW_MACOS_ARM_DEFAULT_PREFIX, HOMEBREW_MACOS_ARM_DEFAULT_REPOSITORY]
-  elsif Homebrew::SimulateSystem.simulating_or_running_on_linux?
-    [HOMEBREW_LINUX_DEFAULT_PREFIX, HOMEBREW_LINUX_DEFAULT_REPOSITORY]
-  else
-    [HOMEBREW_DEFAULT_PREFIX, HOMEBREW_DEFAULT_REPOSITORY]
-  end.freeze
+  DEFAULT_PREFIX = HOMEBREW_DEFAULT_PREFIX
+  DEFAULT_REPOSITORY = HOMEBREW_DEFAULT_REPOSITORY
 end

--- a/Library/Homebrew/extend/os/default_prefix.rb
+++ b/Library/Homebrew/extend/os/default_prefix.rb
@@ -1,0 +1,10 @@
+# typed: true
+# frozen_string_literal: true
+
+require "simulate_system"
+
+if OS.mac? && Hardware::CPU.arm?
+  require "extend/os/mac/default_prefix"
+elsif Homebrew::SimulateSystem.simulating_or_running_on_linux?
+  require "extend/os/linux/default_prefix"
+end

--- a/Library/Homebrew/extend/os/linux/default_prefix.rb
+++ b/Library/Homebrew/extend/os/linux/default_prefix.rb
@@ -1,0 +1,7 @@
+# typed: true
+# frozen_string_literal: true
+
+module Homebrew
+  DEFAULT_PREFIX = HOMEBREW_LINUX_DEFAULT_PREFIX
+  DEFAULT_REPOSITORY = HOMEBREW_LINUX_DEFAULT_REPOSITORY
+end

--- a/Library/Homebrew/extend/os/mac/default_prefix.rb
+++ b/Library/Homebrew/extend/os/mac/default_prefix.rb
@@ -1,0 +1,7 @@
+# typed: true
+# frozen_string_literal: true
+
+module Homebrew
+  DEFAULT_PREFIX = HOMEBREW_MACOS_ARM_DEFAULT_PREFIX
+  DEFAULT_REPOSITORY = HOMEBREW_MACOS_ARM_DEFAULT_REPOSITORY
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
separate `default_prefix` to `extend/os` files because of `#todo` https://github.com/Homebrew/brew/blob/c477b9aab3ef9769687dbe82c665cd067e362d6a/Library/Homebrew/default_prefix.rb#L7