### PR TITLE
HOMEBREW_INSTALL_FROM_API: make the default for everyone.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,8 @@ jobs:
 
       - name: Run brew audit --skip-style on all taps
         run: brew audit --eval-all --skip-style --except=version --display-failures-only
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
 
       - name: Set up all Homebrew taps
         run: |
@@ -96,6 +98,7 @@ jobs:
           brew tap homebrew/cask-fonts
           brew tap homebrew/cask-versions
           brew tap homebrew/command-not-found
+          brew tap homebrew/core
           brew tap homebrew/formula-analytics
           brew tap homebrew/portable-ruby
           brew tap homebrew/services
@@ -109,6 +112,7 @@ jobs:
         run: brew audit --skip-style --except=version --tap=homebrew/core
         env:
           HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
+          HOMEBREW_NO_INSTALL_FROM_API: 1
 
       - name: Run brew style on official taps
         run: |

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -249,7 +249,7 @@ auto-update() {
 
     if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
     then
-      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
       then
         # 24 hours
         HOMEBREW_AUTO_UPDATE_SECS="86400"
@@ -770,25 +770,6 @@ To turn developer mode off, run $(bold "brew developer off")
 
   git config --file="${HOMEBREW_GIT_CONFIG_FILE}" --replace-all homebrew.devcmdrun true 2>/dev/null
   export HOMEBREW_DEV_CMD_RUN="1"
-fi
-
-# Test HOMEBREW_INSTALL_FROM_API on HOMEBREW_DEV_CMD_RUN and HOMEBREW_DEVELOPER
-# folks who haven't run a HOMEBREW_DEVELOPER_COMMAND if they are in a default
-# prefix and on a supported macOS version.
-if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
-      -z "${HOMEBREW_DEVELOPER_COMMAND}" ]] &&
-   [[ -z "${HOMEBREW_MACOS_VERSION_NUMERIC}" ||
-   "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "110000" ]] &&
-   [[ "${HOMEBREW_PREFIX}" == "/usr/local" ||
-      "${HOMEBREW_PREFIX}" == "/opt/homebrew" ||
-      "${HOMEBREW_PREFIX}" == "/home/linuxbrew/.linuxbrew" ]]
-then
-  if [[ -n "${HOMEBREW_DEV_CMD_RUN}" || -n "${HOMEBREW_DEVELOPER}" ]]
-  then
-    export HOMEBREW_INSTALL_FROM_API=1
-  fi
-else
-  unset HOMEBREW_INSTALL_FROM_API
 fi
 
 if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh" ]]

--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -14,7 +14,6 @@ homebrew-formulae() {
   # HOMEBREW_CACHE is set by brew.sh
   # shellcheck disable=SC2154
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
-        -n "${HOMEBREW_INSTALL_FROM_API}" &&
         -f "${HOMEBREW_CACHE}/api/formula.json" ]]
   then
     local api_formulae

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -386,7 +386,7 @@ EOS
   fi
 
   if [[ -d "${HOMEBREW_CORE_REPOSITORY}" ]] ||
-     [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+     [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
     HOMEBREW_CORE_AVAILABLE="1"
   fi
@@ -566,8 +566,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
-       [[ -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
+    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" || "${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" ]]
     then
       continue
@@ -726,7 +725,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
+    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]] &&
        [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ||
           "${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" ]]
@@ -768,7 +767,7 @@ EOS
     fi
   done
 
-  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
     mkdir -p "${HOMEBREW_CACHE}/api"
 

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -225,6 +225,9 @@ module Homebrew
     ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
     ENV["HOMEBREW_SORBET_RUNTIME"] = "1"
 
+    # TODO: remove this and fix tests when possible.
+    ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+
     ENV["USER"] ||= system_command!("id", args: ["-nu"]).stdout.chomp
 
     # Avoid local configuration messing with tests, e.g. git being configured

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -41,7 +41,7 @@ module Homebrew
         description:  "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
                       "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
                       "disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.",
-        default_text: "300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set.",
+        default_text: "86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API is set.",
       },
       HOMEBREW_AUTOREMOVE:                       {
         description: "If set, calls to `brew cleanup` and `brew uninstall` will automatically " \
@@ -231,13 +231,6 @@ module Homebrew
         default_text: 'The "Beer Mug" emoji.',
         default:      "🍺",
       },
-      HOMEBREW_INSTALL_FROM_API:                 {
-        description: "If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's " \
-                     "API instead of needing (large, slow) local checkouts of these repositories. Note, this will " \
-                     "only take effect in supported configurations (i.e. using the default Homebrew prefix and, " \
-                     "if on macOS, on a supported version).",
-        boolean:     true,
-      },
       HOMEBREW_LIVECHECK_WATCHLIST:              {
         description:  "Consult this file for the list of formulae to check by default when no formula argument " \
                       "is passed to `brew livecheck`.",
@@ -321,8 +314,7 @@ module Homebrew
       },
       HOMEBREW_NO_INSTALL_FROM_API:              {
         description: "If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using " \
-                     "Homebrew's API even if `HOMEBREW_INSTALL_FROM_API` is set and instead use (large, slow) " \
-                     "local checkouts of these repositories.",
+                     "Homebrew's API and instead use (large, slow) local checkouts of these repositories.",
         boolean:     true,
       },
       HOMEBREW_NO_INSTALL_UPGRADE:               {
@@ -496,7 +488,7 @@ module Homebrew
       return false if OS.unsupported_configuration?
       return false unless Homebrew.default_prefix?
 
-      ENV["HOMEBREW_NO_INSTALL_FROM_API"].blank? && ENV["HOMEBREW_INSTALL_FROM_API"].present?
+      ENV["HOMEBREW_NO_INSTALL_FROM_API"].blank?
     end
   end
 end

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -25,16 +25,16 @@ export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebre
 
 The default Git remote will be used if the corresponding environment variable is unset.
 
-## Skip Tap Cloning (beta)
+## Default Tap Cloning
 
-You can instruct Homebrew to skip cloning the Homebrew/homebrew-core tap during installation by setting the beta `HOMEBREW_INSTALL_FROM_API` environment variable with the following:
+You can instruct Homebrew to return to pre-4.0.0 behaviour by cloning the Homebrew/homebrew-core tap during installation by setting the `HOMEBREW_NO_INSTALL_FROM_API` environment variable with the following:
 
 ```bash
-export HOMEBREW_INSTALL_FROM_API=1
+export HOMEBREW_NO_INSTALL_FROM_API=1
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
-This will make Homebrew install formulae and casks from the `homebrew/core` and `homebrew/cask` taps using Homebrew’s API instead of local checkouts of these repositories.
+This will make Homebrew install formulae and casks from the `homebrew/core` and `homebrew/cask` taps using local checkouts of these repositories instead of Homebrew’s API.
 
 Note, this will take effect in supported configurations (i.e. using the default Homebrew prefix and, if on macOS, on a supported version).
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1998,7 +1998,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_AUTO_UPDATE_SECS`
   <br>Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.
 
-  *Default:* 300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set.
+  *Default:* 86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API is set.
 
 - `HOMEBREW_AUTOREMOVE`
   <br>If set, calls to `brew cleanup` and `brew uninstall` will automatically remove unused formula dependents and if HOMEBREW_NO_INSTALL_CLEANUP is not set, `brew cleanup` will start running `brew autoremove` periodically.
@@ -2153,9 +2153,6 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
   *Default:* The "Beer Mug" emoji.
 
-- `HOMEBREW_INSTALL_FROM_API`
-  <br>If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API instead of needing (large, slow) local checkouts of these repositories. Note, this will only take effect in supported configurations (i.e. using the default Homebrew prefix and, if on macOS, on a supported version).
-
 - `HOMEBREW_LIVECHECK_WATCHLIST`
   <br>Consult this file for the list of formulae to check by default when no formula argument is passed to `brew livecheck`.
 
@@ -2212,7 +2209,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set, `brew install`, `brew upgrade` and `brew reinstall` will never automatically cleanup installed/upgraded/reinstalled formulae or all formulae every `HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` days. Alternatively, HOMEBREW_NO_CLEANUP_FORMULAE allows specifying specific formulae to not clean up.
 
 - `HOMEBREW_NO_INSTALL_FROM_API`
-  <br>If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API even if `HOMEBREW_INSTALL_FROM_API` is set and instead use (large, slow) local checkouts of these repositories.
+  <br>If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API and instead use (large, slow) local checkouts of these repositories.
 
 - `HOMEBREW_NO_INSTALL_UPGRADE`
   <br>If set, `brew install *`formula`*` will not upgrade `*`formula`*` if it is installed but outdated.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2855,7 +2855,7 @@ Prefix all download URLs, including those for bottles, with this value\. For exa
 Run \fBbrew update\fR once every \fBHOMEBREW_AUTO_UPDATE_SECS\fR seconds before some commands, e\.g\. \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew tap\fR\. Alternatively, disable auto\-update entirely with HOMEBREW_NO_AUTO_UPDATE\.
 .
 .IP
-\fIDefault:\fR 300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set\.
+\fIDefault:\fR 86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API is set\.
 .
 .TP
 \fBHOMEBREW_AUTOREMOVE\fR
@@ -3146,12 +3146,6 @@ Print this text before the installation summary of each successful build\.
 \fIDefault:\fR The "Beer Mug" emoji\.
 .
 .TP
-\fBHOMEBREW_INSTALL_FROM_API\fR
-.
-.br
-If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API instead of needing (large, slow) local checkouts of these repositories\. Note, this will only take effect in supported configurations (i\.e\. using the default Homebrew prefix and, if on macOS, on a supported version)\.
-.
-.TP
 \fBHOMEBREW_LIVECHECK_WATCHLIST\fR
 .
 .br
@@ -3260,7 +3254,7 @@ If set, \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew reinstall\fR will nev
 \fBHOMEBREW_NO_INSTALL_FROM_API\fR
 .
 .br
-If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API even if \fBHOMEBREW_INSTALL_FROM_API\fR is set and instead use (large, slow) local checkouts of these repositories\.
+If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API and instead use (large, slow) local checkouts of these repositories\.
 .
 .TP
 \fBHOMEBREW_NO_INSTALL_UPGRADE\fR


### PR DESCRIPTION
- remove all places we check the flag so it's a no-op now
- flip the messaging to refer to `HOMEBREW_NO_INSTALL_FROM_API` where relevant
- adjust the documentation

Do not merge until we're sure the next tag will be 4.0.0.

Fixes https://github.com/Homebrew/brew/issues/13794