### PR TITLE
chore: deprecate `plist_options` in formula

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1017,8 +1017,7 @@ class Formula
   # The generated launchd {.plist} file path.
   sig { returns(Pathname) }
   def plist_path
-    # TODO: Add deprecation
-    # odeprecated "formula.plist_path", "formula.launchd_service_path"
+    odeprecated "formula.plist_path", "formula.launchd_service_path"
     launchd_service_path
   end
 
@@ -3152,8 +3151,7 @@ class Formula
     #
     # @deprecated Please use {Homebrew::Service.require_root} instead.
     def plist_options(options)
-      # TODO: Deprecate
-      # odeprecated "plist_options", "service.require_root"
+      odeprecated "plist_options", "service.require_root"
       @plist_startup = options[:startup]
       @plist_manual = options[:manual]
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1051,9 +1051,9 @@ class FormulaInstaller
 
     return unless service
 
-    plist_path = formula.plist_path
-    plist_path.atomic_write(service)
-    plist_path.chmod 0644
+    launchd_service_path = formula.launchd_service_path
+    launchd_service_path.atomic_write(service)
+    launchd_service_path.chmod 0644
     log = formula.var/"log"
     log.mkpath if service.include? log.to_s
   rescue Exception => e # rubocop:disable Lint/RescueException

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -203,11 +203,11 @@ describe FormulaInstaller do
   describe "#install_service" do
     it "works if plist is set" do
       formula = Testball.new
-      path = formula.plist_path
+      path = formula.launchd_service_path
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).twice.and_return("PLIST")
-      expect(formula).to receive(:plist_path).and_call_original
+      expect(formula).to receive(:launchd_service_path).and_call_original
 
       installer = described_class.new(formula)
       expect {
@@ -219,7 +219,7 @@ describe FormulaInstaller do
 
     it "works if service is set" do
       formula = Testball.new
-      plist_path = formula.plist_path
+      launchd_service_path = formula.launchd_service_path
       service_path = formula.systemd_service_path
       service = Homebrew::Service.new(formula)
       formula.opt_prefix.mkpath
@@ -227,7 +227,7 @@ describe FormulaInstaller do
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(true)
       expect(formula).to receive(:service).exactly(5).and_return(service)
-      expect(formula).to receive(:plist_path).and_call_original
+      expect(formula).to receive(:launchd_service_path).and_call_original
       expect(formula).to receive(:systemd_service_path).and_call_original
 
       expect(service).to receive(:timed?).and_return(false)
@@ -240,13 +240,13 @@ describe FormulaInstaller do
         installer.install_service
       }.not_to output(/Error: Failed to install service files/).to_stderr
 
-      expect(plist_path).to exist
+      expect(launchd_service_path).to exist
       expect(service_path).to exist
     end
 
     it "works if timed service is set" do
       formula = Testball.new
-      plist_path = formula.plist_path
+      launchd_service_path = formula.launchd_service_path
       service_path = formula.systemd_service_path
       timer_path = formula.systemd_timer_path
       service = Homebrew::Service.new(formula)
@@ -255,7 +255,7 @@ describe FormulaInstaller do
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(true)
       expect(formula).to receive(:service).exactly(6).and_return(service)
-      expect(formula).to receive(:plist_path).and_call_original
+      expect(formula).to receive(:launchd_service_path).and_call_original
       expect(formula).to receive(:systemd_service_path).and_call_original
       expect(formula).to receive(:systemd_timer_path).and_call_original
 
@@ -270,19 +270,19 @@ describe FormulaInstaller do
         installer.install_service
       }.not_to output(/Error: Failed to install service files/).to_stderr
 
-      expect(plist_path).to exist
+      expect(launchd_service_path).to exist
       expect(service_path).to exist
       expect(timer_path).to exist
     end
 
     it "returns without definition" do
       formula = Testball.new
-      path = formula.plist_path
+      path = formula.launchd_service_path
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(nil)
-      expect(formula).not_to receive(:plist_path)
+      expect(formula).not_to receive(:launchd_service_path)
       expect(formula).not_to receive(:to_systemd_unit)
 
       installer = described_class.new(formula)
@@ -295,13 +295,13 @@ describe FormulaInstaller do
 
     it "errors with duplicate definition" do
       formula = Testball.new
-      path = formula.plist_path
+      path = formula.launchd_service_path
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).and_return("plist")
       expect(formula).to receive(:service?).and_return(true)
       expect(formula).not_to receive(:service)
-      expect(formula).not_to receive(:plist_path)
+      expect(formula).not_to receive(:launchd_service_path)
 
       installer = described_class.new(formula)
       expect {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
