### PR TITLE
Avoid mutating the script argument in place

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -99,7 +99,12 @@ module Cask
         description = key ? "#{stanza} #{key.inspect}" : stanza.to_s
 
         # backward-compatible string value
-        arguments = { executable: arguments } if arguments.is_a?(String)
+        if arguments.is_a?(String)
+          arguments = { executable: arguments }
+        else
+          # Avoid mutating the original argument
+          arguments = arguments.dup
+        end
 
         # key sanity
         permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :print_stdout, :print_stderr]


### PR DESCRIPTION
Mutating the argument in place, and in particular deleting the `:executable` entry, leads to a bug when the same code path leading to read_script_arguments is invoked twice, like in
https://github.com/Homebrew/homebrew-cask/pull/139749

This commit makes a shallow copy of the argument, so that it can be safely mutated in the rest of the method.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
