### PR TITLE
Enable RSpec cops without violations

### DIFF
--- a/Library/.rubocop_rspec.yml
+++ b/Library/.rubocop_rspec.yml
@@ -5,8 +5,6 @@ RSpec/AnyInstance:
   Enabled: false
 RSpec/FilePath:
   Enabled: false
-RSpec/ImplicitBlockExpectation:
-  Enabled: false
 RSpec/SubjectStub:
   Enabled: false
 
@@ -16,8 +14,6 @@ RSpec/DescribeClass:
 RSpec/LeakyConstantDeclaration:
   Enabled: false
 RSpec/MessageSpies:
-  Enabled: false
-RSpec/RepeatedDescription:
   Enabled: false
 RSpec/StubbedMock:
   Enabled: false
@@ -37,10 +33,3 @@ RSpec/MultipleMemoizedHelpers:
 # Annoying to have these autoremoved.
 RSpec/Focus:
   AutoCorrect: false
-
-# Gets confused on these tests for a `skip` DSL
-RSpec/PendingWithoutReason:
-  Exclude:
-    - "**/dependency_expansion_spec.rb"
-    - "**/livecheck/skip_conditions_spec.rb"
-    - "**/livecheck_spec.rb"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Discovered while poking at https://github.com/Homebrew/brew/pull/14408 – these cops are disabled/excluded but don't prevent any violations. (However, note the first one is under "Intentionally disabled as it doesn't fit with our code style.", but I believe this not be true, at least at this point.)