### PR TITLE
Enable RSpec/LeakyConstantDeclaration

### DIFF
--- a/Library/.rubocop_rspec.yml
+++ b/Library/.rubocop_rspec.yml
@@ -13,8 +13,6 @@ RSpec/SubjectStub:
 # TODO: try to enable these
 RSpec/DescribeClass:
   Enabled: false
-RSpec/LeakyConstantDeclaration:
-  Enabled: false
 RSpec/MessageSpies:
   Enabled: false
 RSpec/RepeatedDescription:

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -89,9 +89,12 @@ describe "Exception" do
 
     let(:mod) do
       Module.new do
+        # These are defined within an anonymous module to avoid polluting the global namespace.
+        # rubocop:disable RSpec/LeakyConstantDeclaration
         class Bar < Requirement; end
 
         class Baz < Formula; end
+        # rubocop:enable RSpec/LeakyConstantDeclaration
       end
     end
 

--- a/Library/Homebrew/test/formula_free_port_spec.rb
+++ b/Library/Homebrew/test/formula_free_port_spec.rb
@@ -9,16 +9,15 @@ module Homebrew
     include described_class
 
     describe "#free_port" do
-      # IANA suggests user port from 1024 to 49151
-      # and dynamic port for 49152 to 65535
-      # http://www.iana.org/assignments/port-numbers
-      MIN_PORT = 1024
-      MAX_PORT = 65535
-
       it "returns a free TCP/IP port" do
+        # IANA suggests user port from 1024 to 49151
+        # and dynamic port for 49152 to 65535
+        # http://www.iana.org/assignments/port-numbers
+        min_port = 1024
+        max_port = 65535
         port = free_port
 
-        expect(port).to be_between(MIN_PORT, MAX_PORT)
+        expect(port).to be_between(min_port, max_port)
         expect { TCPServer.new(port).close }.not_to raise_error
       end
     end

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -4,15 +4,17 @@
 require "formula"
 
 describe "patching" do
-  TESTBALL_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-  TESTBALL_PATCHES_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1-patches.tgz"
-  PATCH_URL_A = "file://#{TEST_FIXTURE_DIR}/patches/noop-a.diff"
-  PATCH_URL_B = "file://#{TEST_FIXTURE_DIR}/patches/noop-b.diff"
-  PATCH_A_CONTENTS = File.read("#{TEST_FIXTURE_DIR}/patches/noop-a.diff").freeze
-  PATCH_B_CONTENTS = File.read("#{TEST_FIXTURE_DIR}/patches/noop-b.diff").freeze
-  APPLY_A = "noop-a.diff"
-  APPLY_B = "noop-b.diff"
-  APPLY_C = "noop-c.diff"
+  before do
+    stub_const("TESTBALL_URL", "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz")
+    stub_const("TESTBALL_PATCHES_URL", "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1-patches.tgz")
+    stub_const("PATCH_URL_A", "file://#{TEST_FIXTURE_DIR}/patches/noop-a.diff")
+    stub_const("PATCH_URL_B", "file://#{TEST_FIXTURE_DIR}/patches/noop-b.diff")
+    stub_const("PATCH_A_CONTENTS", File.read("#{TEST_FIXTURE_DIR}/patches/noop-a.diff").freeze)
+    stub_const("PATCH_B_CONTENTS", File.read("#{TEST_FIXTURE_DIR}/patches/noop-b.diff").freeze)
+    stub_const("APPLY_A", "noop-a.diff")
+    stub_const("APPLY_B", "noop-b.diff")
+    stub_const("APPLY_C", "noop-c.diff")
+  end
 
   def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, &block)
     Class.new(Formula) {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Another follow-up to https://github.com/Homebrew/brew/pull/14408

The cop [documentation](https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecleakyconstantdeclaration) makes a pretty compelling case for this one, and it only requires touching three test files to enable.
