### PR TITLE
Enable RSpec/NoExpectationExample

### DIFF
--- a/Library/.rubocop_rspec.yml
+++ b/Library/.rubocop_rspec.yml
@@ -15,8 +15,6 @@ RSpec/MessageSpies:
   Enabled: false
 RSpec/StubbedMock:
   Enabled: false
-RSpec/NoExpectationExample:
-  Enabled: false
 
 # TODO: try to reduce these
 RSpec/ExampleLength:

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -67,6 +67,8 @@ describe FormulaInstaller do
     expect(f.libexec).to be_a_directory
   end
 
+  # This test wraps expect() calls in `test_basic_formula_setup`
+  # rubocop:disable RSpec/NoExpectationExample
   specify "basic bottle install" do
     allow(DevelopmentTools).to receive(:installed?).and_return(false)
     Homebrew.install_args.parse(["testball_bottle"])
@@ -74,6 +76,7 @@ describe FormulaInstaller do
       test_basic_formula_setup(f)
     end
   end
+  # rubocop:enable RSpec/NoExpectationExample
 
   specify "basic bottle install with cellar information on sha256 line" do
     allow(DevelopmentTools).to receive(:installed?).and_return(false)

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -268,6 +268,8 @@ describe Keg do
       expect(lib.children.length).to eq(2)
     end
 
+    # This is a legacy violation that would benefit from a clear expectation.
+    # rubocop:disable RSpec/NoExpectationExample
     it "removes broken symlinks that conflict with directories" do
       a = HOMEBREW_CELLAR/"a"/"1.0"
       (a/"lib"/"foo").mkpath
@@ -280,6 +282,7 @@ describe Keg do
 
       keg.link
     end
+    # rubocop:enable RSpec/NoExpectationExample
   end
 
   describe "#optlink" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Last follow-up to https://github.com/Homebrew/brew/pull/14408 that pertains to enabling `.rubocop_rspec.yml` cops with zero-to-few violations.