### PR TITLE
HOMEBREW_INSTALL_FROM_API: various improvements.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -91,8 +91,15 @@ begin
 
   if internal_cmd || Commands.external_ruby_v2_cmd_path(cmd)
     if Commands::INSTALL_FROM_API_FORBIDDEN_COMMANDS.include?(cmd) &&
+       !CoreTap.instance.installed? &&
        Homebrew::EnvConfig.install_from_api? && !Homebrew::EnvConfig.developer?
-      odie "This command cannot be run while HOMEBREW_INSTALL_FROM_API is set!"
+      odie <<~EOS
+        This command cannot be run while Homebrew/homebrew-core is untapped and
+        HOMEBREW_NO_INSTALL_FROM_API is unset! To resolve please run:
+          brew tap Homebrew/core
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+        and retry this command.
+      EOS
     end
 
     Homebrew.send Commands.method_name(cmd)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -146,10 +146,6 @@ module Homebrew
   def install
     args = install_args.parse
 
-    if args.build_from_source? && Homebrew::EnvConfig.install_from_api?
-      raise UsageError, "--build-from-source is not supported when using HOMEBREW_INSTALL_FROM_API."
-    end
-
     if args.env.present?
       # Can't use `replacement: false` because `install_args` are used by
       # `build.rb`. Instead, `hide_from_man_page` and don't do anything with

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -94,10 +94,6 @@ module Homebrew
   def reinstall
     args = reinstall_args.parse
 
-    if args.build_from_source? && Homebrew::EnvConfig.install_from_api?
-      raise UsageError, "--build-from-source is not supported when using HOMEBREW_INSTALL_FROM_API."
-    end
-
     formulae, casks = args.named.to_formulae_and_casks(method: :resolve)
                           .partition { |o| o.is_a?(Formula) }
 

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -64,7 +64,10 @@ module Homebrew
         message = if Homebrew::EnvConfig.install_from_api?
           <<~EOS
             #{not_exist_message}
-            This is expected with HOMEBREW_INSTALL_FROM_API set!
+            This is expected with HOMEBREW_NO_INSTALL_FROM_API unset! To resolve please run:
+              brew tap Homebrew/core
+              export HOMEBREW_NO_INSTALL_FROM_API=1
+            and retry this command.
           EOS
         elsif args.cask?
           <<~EOS

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1181,8 +1181,14 @@ class FormulaInstaller
 
     if pour_bottle?(output_warning: true)
       formula.fetch_bottle_tab
-    elsif formula.core_formula? && Homebrew::EnvConfig.install_from_api?
-      odie "Unable to build #{formula.name} from source with HOMEBREW_INSTALL_FROM_API."
+    elsif formula.core_formula? && !formula.tap.installed? && Homebrew::EnvConfig.install_from_api?
+      odie <<~EOS
+        Unable to build #{formula.name} from source while Homebrew/homebrew-core is
+        untapped and HOMEBREW_NO_INSTALL_FROM_API is unset! To resolve please run:
+          brew tap Homebrew/core
+          export HOMEBREW_NO_INSTALL_FROM_API=1
+        and retry.
+      EOS
     else
       formula.fetch_patches
       formula.resources.each(&:fetch)


### PR DESCRIPTION
- flip the messaging to refer to `HOMEBREW_NO_INSTALL_FROM_API` where relevant
- remove some duplicate checks
- better scope checks to just core tap formulae

Extracted from #14412