### PR TITLE
extend/ENV/shared: use `try`.

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -289,7 +289,7 @@ module SharedEnvExtension
     gcc_version_name = "gcc@#{version}"
 
     gcc = Formulary.factory("gcc")
-    if gcc.version_suffix == version
+    if gcc.try(:version_suffix) == version
       gcc
     else
       Formulary.factory(gcc_version_name)


### PR DESCRIPTION
`version_suffix` exists (or doesn't) depending on the GCC formula being available and not loaded from the API.