### PR TITLE
Refactor away rspec-wait

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -25,7 +25,6 @@ gem "rspec-its", require: false
 gem "rspec_junit_formatter", require: false
 gem "rspec-retry", require: false
 gem "rspec-sorbet", require: false
-gem "rspec-wait", require: false
 gem "rubocop", require: false
 gem "rubocop-ast", require: false
 gem "simplecov", require: false

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -128,8 +128,6 @@ GEM
     rspec-sorbet (1.9.1)
       sorbet-runtime
     rspec-support (3.12.0)
-    rspec-wait (0.0.9)
-      rspec (>= 3, < 4)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.44.0)
@@ -248,7 +246,6 @@ DEPENDENCIES
   rspec-its
   rspec-retry
   rspec-sorbet
-  rspec-wait
   rspec_junit_formatter
   rubocop
   rubocop-ast

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -27,7 +27,6 @@ end
 
 require "rspec/its"
 require "rspec/github"
-require "rspec/wait"
 require "rspec/retry"
 require "rspec/sorbet"
 require "rubocop/rspec/support"

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -196,10 +196,8 @@ describe SystemCommand do
       ] }
     }
 
-    it "returns without deadlocking" do
-      wait(30).for {
-        described_class.run(command, **options)
-      }.to be_a_success
+    it "returns without deadlocking", timeout: 30 do
+      expect(described_class.run(command, **options)).to be_a_success
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Per the [suggestion](https://github.com/Homebrew/brew/pull/14419/files#r1086642346) of @MikeMcQuaid, this PR removes `rspec-wait`. The test dependency [dates](https://github.com/Homebrew/brew/pull/725/files#diff-09713da39d1e96f1440269271cc7435a3f25b835a0b21c80a34d2accbe986cc2R136) to at least 2016, but since there is now a [built-in](https://github.com/Homebrew/brew/commit/4bc174cc628010daac0a9605f0e62363042583b0) timeout mechanism, I converted the existing use of `wait` to that style instead. (I confirmed that I was able to induce a test failure with a sufficiently low `timeout` value.)