### PR TITLE
formula: deprecate `ignore_missing_libraries`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3438,6 +3438,7 @@ class Formula
 
     # Permit links to certain libraries that don't exist. Available on Linux only.
     def ignore_missing_libraries(*libs)
+      odeprecated "ignore_missing_libraries"
       unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
         raise FormulaSpecificationError, "#{__method__} is available on Linux only"
       end

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -131,7 +131,6 @@ module RuboCop
             fails_with
             resource
             patch
-            ignore_missing_libraries
           ]
           on_system_allowed_methods += on_system_methods.map(&:to_s)
           _, offensive_node = check_order(component_precedence_list, on_system_block.body)

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1841,54 +1841,6 @@ describe Formula do
     end
   end
 
-  describe "#ignore_missing_libraries" do
-    after do
-      Homebrew::SimulateSystem.clear
-    end
-
-    it "adds library to allowed_missing_libraries on Linux", :needs_linux do
-      Homebrew::SimulateSystem.clear
-      f = formula do
-        url "foo-1.0"
-
-        ignore_missing_libraries "bar.so"
-      end
-      expect(f.class.allowed_missing_libraries.to_a).to eq(["bar.so"])
-    end
-
-    it "adds library to allowed_missing_libraries on macOS when simulating Linux", :needs_macos do
-      Homebrew::SimulateSystem.os = :linux
-      f = formula do
-        url "foo-1.0"
-
-        ignore_missing_libraries "bar.so"
-      end
-      expect(f.class.allowed_missing_libraries.to_a).to eq(["bar.so"])
-    end
-
-    it "raises an error on macOS", :needs_macos do
-      Homebrew::SimulateSystem.clear
-      expect {
-        formula do
-          url "foo-1.0"
-
-          ignore_missing_libraries "bar.so"
-        end
-      }.to raise_error("ignore_missing_libraries is available on Linux only")
-    end
-
-    it "raises an error on Linux when simulating macOS", :needs_linux do
-      Homebrew::SimulateSystem.os = :macos
-      expect {
-        formula do
-          url "foo-1.0"
-
-          ignore_missing_libraries "bar.so"
-        end
-      }.to raise_error("ignore_missing_libraries is available on Linux only")
-    end
-  end
-
   describe "#generate_completions_from_executable" do
     let(:f) do
       Class.new(Testball) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We removed all uses of this method in Homebrew/core. See Homebrew/homebrew-core#111297.