### PR TITLE
cask/artifact/stage_only: allow string argument.

### DIFF
--- a/Library/Homebrew/cask/artifact/stage_only.rb
+++ b/Library/Homebrew/cask/artifact/stage_only.rb
@@ -12,7 +12,7 @@ module Cask
       extend T::Sig
 
       def self.from_args(cask, *args, **kwargs)
-        if args != [true] || kwargs.present?
+        if (args != [true] && args != ["true"]) || kwargs.present?
           raise CaskInvalidError.new(cask.token, "'stage_only' takes only a single argument: true")
         end
 


### PR DESCRIPTION
This is what's passed from the JSON API.

Fixes https://github.com/Homebrew/brew/issues/14433
