### PR TITLE
Tweak cask-source API handling

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -23,23 +23,20 @@ module Homebrew
     HOMEBREW_CACHE_API = (HOMEBREW_CACHE/"api").freeze
     MAX_RETRIES = 3
 
-    sig { params(endpoint: String, json: T::Boolean).returns(T.any(String, Hash)) }
-    def fetch(endpoint, json: true)
+    sig { params(endpoint: String).returns(Hash) }
+    def fetch(endpoint)
       return cache[endpoint] if cache.present? && cache.key?(endpoint)
 
       api_url = "#{API_DOMAIN}/#{endpoint}"
       output = Utils::Curl.curl_output("--fail", api_url, max_time: 5)
       raise ArgumentError, "No file found at #{Tty.underline}#{api_url}#{Tty.reset}" unless output.success?
 
-      cache[endpoint] = if json
-        JSON.parse(output.stdout)
-      else
-        output.stdout
-      end
+      cache[endpoint] = JSON.parse(output.stdout)
     rescue JSON::ParserError
       raise ArgumentError, "Invalid JSON file: #{Tty.underline}#{api_url}#{Tty.reset}"
     end
 
+    sig { params(endpoint: String, target: Pathname).returns(Hash) }
     def fetch_json_api_file(endpoint, target:)
       retry_count = 0
 
@@ -57,6 +54,19 @@ module Homebrew
 
         retry
       end
+    end
+
+    sig { params(token: String, git_head: T.nilable(String)).returns(String) }
+    def fetch_source(token, git_head: nil)
+      git_head ||= "master"
+      endpoint = "#{git_head}/Casks/#{token}.rb"
+      return cache[endpoint] if cache.present? && cache.key?(endpoint)
+
+      raw_url = "https://raw.githubusercontent.com/Homebrew/homebrew-cask/#{endpoint}"
+      output = Utils::Curl.curl_output("--fail", raw_url, max_time: 5)
+      raise ArgumentError, "No file found at #{Tty.underline}#{raw_url}#{Tty.reset}" unless output.success?
+
+      cache[endpoint] = output.stdout
     end
   end
 end

--- a/Library/Homebrew/api/cask-source.rb
+++ b/Library/Homebrew/api/cask-source.rb
@@ -10,10 +10,10 @@ module Homebrew
       class << self
         extend T::Sig
 
-        sig { params(token: String).returns(Hash) }
-        def fetch(token)
+        sig { params(token: String, git_head: T.nilable(String)).returns(Hash) }
+        def fetch(token, git_head: nil)
           token = token.sub(%r{^homebrew/cask/}, "")
-          Homebrew::API.fetch "cask-source/#{token}.rb", json: false
+          Homebrew::API.fetch_source token, git_head: git_head
         end
 
         sig { params(token: String).returns(T::Boolean) }

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -246,6 +246,7 @@ module Cask
         "conflicts_with" => conflicts_with,
         "container"      => container&.pairs,
         "auto_updates"   => auto_updates,
+        "tap_git_head"   => tap&.git_head,
       }
     end
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -214,7 +214,7 @@ module Cask
 
         # Use the cask-source API if there are any `*flight` blocks
         if json_cask[:artifacts].any? { |artifact| FLIGHT_STANZAS.include?(artifact.keys.first) }
-          cask_source = Homebrew::API::CaskSource.fetch(token)
+          cask_source = Homebrew::API::CaskSource.fetch(token, git_head: json_cask[:tap_git_head])
           return FromContentLoader.new(cask_source).load(config: config)
         end
 
@@ -222,7 +222,9 @@ module Cask
         json_cask[:artifacts] = json_cask[:artifacts].map(&method(:from_h_hash_gsubs))
         json_cask[:caveats] = from_h_string_gsubs(json_cask[:caveats])
 
-        Cask.new(token, source: cask_source, config: config) do
+        tap = Tap.fetch(json_cask[:tap]) if json_cask[:tap].to_s.include?("/")
+
+        Cask.new(token, tap: tap, source: cask_source, config: config) do
           version json_cask[:version]
 
           if json_cask[:sha256] == "no_check"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2126,6 +2126,7 @@ class Formula
       "disabled"                 => disabled?,
       "disable_date"             => disable_date,
       "disable_reason"           => disable_reason,
+      "tap_git_head"             => tap&.git_head,
     }
 
     if stable

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -141,11 +141,15 @@ module SystemConfig
 
     def core_tap_config(f = $stdout)
       if CoreTap.instance.installed?
-        f.puts "Core tap ORIGIN: #{core_tap_origin}"
+        f.puts "Core tap origin: #{core_tap_origin}"
         f.puts "Core tap HEAD: #{core_tap_head}"
         f.puts "Core tap last commit: #{core_tap_last_commit}"
         f.puts "Core tap branch: #{core_tap_branch}"
-      else
+      end
+
+      if (formula_json = Homebrew::API::HOMEBREW_CACHE_API/"formula.json") && formula_json.exist?
+        f.puts "Core tap JSON: #{formula_json.mtime.to_s(:short)}"
+      elsif !CoreTap.instance.installed?
         f.puts "Core tap: N/A"
       end
     end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -178,7 +178,7 @@ class Tap
   def git_head
     raise TapUnavailableError, name unless installed?
 
-    path.git_head
+    @git_head ||= path.git_head
   end
 
   # Time since last git commit for this {Tap}.


### PR DESCRIPTION
- Use raw.githubusercontent.com to download cask source rather than formulae.brew.sh. This allows us to remove these files
- output the tap's current `HEAD` for both formulae and cask JSON
- use this `HEAD` for the cask-source API to get the exact file on raw.githubusercontent.com rather than just whatever is newest (which is what the previous API did)
- set the `Tap` correctly when creating a `Cask` from the API
- if the `formula.json` file exists: print its modified time include `brew config`
- memoize `tap.git_head` as we'll be calling it a lot in the same process with the same value

@Rylan12 would appreciate if you can kick the tires on this a bit. Feel free to merge when you're happy or commit to it and then merge if you want changes. Thanks ❤️ 🙇🏻 