### PR TITLE
cli/parser: Don't treat args with `--cask` as formulae

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -301,7 +301,7 @@ module Homebrew
         # If we accept formula options, but the command isn't scoped only
         # to casks, parse once allowing invalid options so we can get the
         # remaining list containing formula names.
-        if @formula_options && argv.exclude?("--cask")
+        if @formula_options && !only_casks?(argv)
           remaining, non_options = parse_remaining(argv, ignore_invalid_options: true)
 
           argv = [*remaining, "--", *non_options]
@@ -639,6 +639,10 @@ module Homebrew
             nil
           end
         end.compact.uniq(&:name)
+      end
+
+      def only_casks?(argv)
+        argv.include?("--casks") || argv.include?("--cask")
       end
     end
 

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -298,9 +298,10 @@ module Homebrew
       def parse(argv = ARGV.freeze, ignore_invalid_options: false)
         raise "Arguments were already parsed!" if @args_parsed
 
-        # If we accept formula options, parse once allowing invalid options
-        # so we can get the remaining list containing formula names.
-        if @formula_options
+        # If we accept formula options, but the command isn't scoped only
+        # to casks, parse once allowing invalid options so we can get the
+        # remaining list containing formula names.
+        if @formula_options && argv.exclude?("--cask")
           remaining, non_options = parse_remaining(argv, ignore_invalid_options: true)
 
           argv = [*remaining, "--", *non_options]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #14438.

- For the command `brew install --cask racket`, a user was reporting the behaviour where despite `--cask` in the command, they were getting output about the `racket` formula having been renamed:

```
$ brew install --cask racket
Warning: Use minimal-racket instead of deprecated racket
==> Downloading https://mirror.racket-lang.org/installers/8.7/racket-8.7-x86_64-macosx-cs.
==> Installing Cask racket
[...]
racket was successfully installed!
```

- The "instead of deprecated ..." messaging comes from the `TapLoader` class `formula_name_path` method, so _something_ must be assuming that everything is initially a formula before _later_ learning from further args parsing that there's a `--cask` qualifier to scope to only casks.

- There are always `@formula_options` and args parsing is recursive, going through each option, so we check that the original `argv` items include a `--cask` and don't descend into the `if` that calls the `formulae` method (and hence the other formula-related checks) if that's the case.

- After this change, the "formula renames" words no longer show up.

```
$ brew install --cask racket
==> Downloading https://mirror.racket-lang.org/installers/8.7/racket-8.7-aarch64-macosx-cs.dmg
==> Installing Cask racket
[...]
racket was successfully installed!
```