### PR TITLE
Add `languages` to cask API

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -246,6 +246,7 @@ module Cask
         "conflicts_with" => conflicts_with,
         "container"      => container&.pairs,
         "auto_updates"   => auto_updates,
+        "languages"      => languages,
       }
     end
 

--- a/Library/Homebrew/test/cask/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/list_spec.rb
@@ -84,7 +84,10 @@ describe Cask::Cmd::List, :cask do
   end
 
   describe "lists json" do
-    let(:casks) { ["local-caffeine", "local-transmission", "multiple-versions", "third-party/tap/third-party-cask"] }
+    let(:casks) {
+      ["local-caffeine", "local-transmission", "multiple-versions", "with-languages",
+       "third-party/tap/third-party-cask"]
+    }
     let(:expected_output) {
       <<~EOS
         [
@@ -124,7 +127,10 @@ describe Cask::Cmd::List, :cask do
             },
             "conflicts_with": null,
             "container": null,
-            "auto_updates": null
+            "auto_updates": null,
+            "languages": [
+
+            ]
           },
           {
             "token": "local-transmission",
@@ -155,7 +161,10 @@ describe Cask::Cmd::List, :cask do
             },
             "conflicts_with": null,
             "container": null,
-            "auto_updates": null
+            "auto_updates": null,
+            "languages": [
+
+            ]
           },
           {
             "token": "multiple-versions",
@@ -189,7 +198,10 @@ describe Cask::Cmd::List, :cask do
             },
             "conflicts_with": null,
             "container": null,
-            "auto_updates": null
+            "auto_updates": null,
+            "languages": [
+
+            ]
           },
           {
             "token": "third-party-cask",
@@ -220,7 +232,45 @@ describe Cask::Cmd::List, :cask do
             },
             "conflicts_with": null,
             "container": null,
-            "auto_updates": null
+            "auto_updates": null,
+            "languages": [
+
+            ]
+          },
+          {
+            "token": "with-languages",
+            "full_token": "with-languages",
+            "tap": "homebrew/cask",
+            "name": [
+
+            ],
+            "desc": null,
+            "homepage": "https://brew.sh/",
+            "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip",
+            "appcast": null,
+            "version": "1.2.3",
+            "versions": {
+            },
+            "installed": "1.2.3",
+            "outdated": false,
+            "sha256": "xyz789",
+            "artifacts": [
+              {
+                "app": [
+                  "Caffeine.app"
+                ]
+              }
+            ],
+            "caveats": null,
+            "depends_on": {
+            },
+            "conflicts_with": null,
+            "container": null,
+            "auto_updates": null,
+            "languages": [
+              "zh",
+              "en-US"
+            ]
           }
         ]
       EOS
@@ -257,7 +307,7 @@ describe Cask::Cmd::List, :cask do
     it "of given Casks" do
       expect {
         described_class.run("--json", "local-caffeine", "local-transmission", "multiple-versions",
-                            "third-party/tap/third-party-cask")
+                            "third-party/tap/third-party-cask", "with-languages")
       }.to output(expected_output).to_stdout
     end
   end


### PR DESCRIPTION
This is required to support multiple languages when installing from the API. I'll open another PR to update the API loading once this gets through formulae.brew.sh.
