### PR TITLE
Fix logic for source install warning using API

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1181,7 +1181,7 @@ class FormulaInstaller
 
     if pour_bottle?(output_warning: true)
       formula.fetch_bottle_tab
-    elsif formula.core_formula? && !formula.tap.installed? && Homebrew::EnvConfig.install_from_api?
+    elsif formula.core_formula? && (!formula.tap.installed? || Homebrew::EnvConfig.install_from_api?)
       odie <<~EOS
         Unable to build #{formula.name} from source while Homebrew/homebrew-core is
         untapped and HOMEBREW_NO_INSTALL_FROM_API is unset! To resolve please run:


### PR DESCRIPTION
I know building from source is not supported but I would not have had any problems if the logic for this check was correct and had warned me properly.

Because I *did* have Homebrew/homebrew-core tapped I was not told I needed to set `HOMEBREW_NO_INSTALL_FROM_API`, and builds were attempted but failed in "interesting" ways leading me to chase the wrong problem(s) (why are the patches not being downloaded! why is it building the wrong version! etc.).