### PR TITLE
Remove redundant String extension

### DIFF
--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -1,4 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-require "active_support/core_ext/object/blank"

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -129,8 +129,6 @@ end.compact.freeze
 
 require "set"
 
-require "extend/string"
-
 require "system_command"
 require "exceptions"
 require "utils"

--- a/Library/Homebrew/rubocops/conflicts.rb
+++ b/Library/Homebrew/rubocops/conflicts.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "rubocops/extend/formula"
-require "extend/string"
 
 module RuboCop
   module Cop

--- a/Library/Homebrew/rubocops/extend/formula.rb
+++ b/Library/Homebrew/rubocops/extend/formula.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "extend/string"
 require "rubocops/shared/helper_functions"
 
 module RuboCop

--- a/Library/Homebrew/rubocops/formula_desc.rb
+++ b/Library/Homebrew/rubocops/formula_desc.rb
@@ -3,7 +3,6 @@
 
 require "rubocops/extend/formula"
 require "rubocops/shared/desc_helper"
-require "extend/string"
 
 module RuboCop
   module Cop

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "rubocops/extend/formula"
-require "extend/string"
 
 module RuboCop
   module Cop


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is a slight extension of https://github.com/Homebrew/brew/pull/14452
`Library/Homebrew/extend/string.rb` is just a wrapper of `active_support/core_ext/object/blank`, which is already [required](https://github.com/Homebrew/brew/blob/10845a1122b916dc91d04f00a4d8b7b888d52654/Library/Homebrew/global.rb#L15) in `global.rb`.

It's also required in a few files in `Library/Homebrew/rubocops`, but none of them appear to use `blank?`.
