### PR TITLE
docs: Remove Lion reference

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -285,8 +285,7 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_NO_EMOJI:                         {
-        description: "If set, do not print `HOMEBREW_INSTALL_BADGE` on a successful build." \
-                     "\n\n    *Note:* Will only try to print emoji on OS X Lion or newer.",
+        description: "If set, do not print `HOMEBREW_INSTALL_BADGE` on a successful build.",
         boolean:     true,
       },
       HOMEBREW_NO_ENV_HINTS:                     {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2192,8 +2192,6 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_NO_EMOJI`
   <br>If set, do not print `HOMEBREW_INSTALL_BADGE` on a successful build.
 
-    *Note:* Will only try to print emoji on OS X Lion or newer.
-
 - `HOMEBREW_NO_ENV_HINTS`
   <br>If set, do not print any hints about changing Homebrew's behaviour with environment variables.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3220,9 +3220,6 @@ If set, disable all use of legacy compatibility code\.
 .br
 If set, do not print \fBHOMEBREW_INSTALL_BADGE\fR on a successful build\.
 .
-.IP
-\fINote:\fR Will only try to print emoji on OS X Lion or newer\.
-.
 .TP
 \fBHOMEBREW_NO_ENV_HINTS\fR
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
OS X Lion (10.8) was released in 2011, and support ended in 2014. Seeing as this is also 3 versions older than the oldest version of macOS (OS X El Capitan (10.11)) we support, it's time to remove this.