### PR TITLE
brew Bash completions: use HOMEBREW cache and repo env vars

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -100,18 +100,24 @@ __brew_complete_tapped() {
 }
 
 __brew_complete_commands() {
+  # Auto-complete Homebrew commands
+  # Do NOT auto-complete "*instal" aliases for "*install" commands
+
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local cmds
-  HOMEBREW_CACHE=$(brew --cache)
-  HOMEBREW_REPOSITORY=$(brew --repo)
-  # Do not auto-complete "*instal" or "*uninstal" aliases for "*install" commands.
-  if [[ -f "${HOMEBREW_CACHE}/all_commands_list.txt" ]]
+
+  if [[ -n ${__HOMEBREW_COMMANDS} ]]
+  then
+    cmds=${__HOMEBREW_COMMANDS}
+  elif [[ -n ${HOMEBREW_CACHE:-} && -f ${HOMEBREW_CACHE}/all_commands_list.txt ]]
   then
     cmds="$(< "${HOMEBREW_CACHE}/all_commands_list.txt" \grep -v instal$)"
-  else
+  elif [[ -n ${HOMEBREW_REPOSITORY:-} && -f ${HOMEBREW_REPOSITORY}/completions/internal_commands_list.txt ]]
+  then
     cmds="$(< "${HOMEBREW_REPOSITORY}/completions/internal_commands_list.txt" \grep -v instal$)"
   fi
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${cmds}" -- "${cur}")
+  export __HOMEBREW_COMMANDS=${cmds}
 }
 
 # compopt is only available in newer versions of bash


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

1. I propose to use HOMEBREW_CACHE and HOMEBREW_REPOSITORY if they're set in the environment already in `__brew_complete_commands` function.

2. I propose to consider doing this outside of the `__brew_complete_commands` function when the script is sourced.


```
$ time for i in {1..300}; do a=${HOMEBREW_CACHE:-$(brew --cache)}; done

real    0m0.064s
user    0m0.023s
sys     0m0.039s

$ time for i in {1..300}; do a=$(brew --cache); done

real    0m10.005s
user    0m3.448s
sys     0m4.929s
```