### PR TITLE
version: fix bad regexps in version parsers

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -467,7 +467,7 @@ class Version
     # e.g. https://github.com/dlang/dmd/archive/v2.074.0-beta1.tar.gz
     # e.g. https://github.com/dlang/dmd/archive/v2.074.0-rc1.tar.gz
     # e.g. https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-src.zip
-    StemParser.new(/[.-vV]?(#{NUMERIC_WITH_DOTS}#{PRERELEASE_SUFFIX})/),
+    StemParser.new(/[-.vV]?(#{NUMERIC_WITH_DOTS}#{PRERELEASE_SUFFIX})/),
 
     # e.g. foobar4.5.1
     StemParser.new(/(#{NUMERIC_WITH_OPTIONAL_DOTS})$/),
@@ -505,7 +505,7 @@ class Version
     StemParser.new(/\.v(\d+[a-z]?)/),
 
     # e.g. https://secure.php.net/get/php-7.1.10.tar.bz2/from/this/mirror
-    UrlParser.new(/[.-vV]?(#{NUMERIC_WITH_DOTS}#{PRERELEASE_SUFFIX}?)/),
+    UrlParser.new(/[-.vV]?(#{NUMERIC_WITH_DOTS}#{PRERELEASE_SUFFIX}?)/),
   ].freeze
   private_constant :VERSION_PARSERS
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The character class `[.-v]` is interpreted as all the characters between `.` and `v`, which is clearly not what is intended here.

Here's an example of what this fixes. Before:

    ❯ brew ruby -e 'puts Version.detect("https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0-rc1/llvm-project-16.0.0rc1.src.tar.xz")'
    6.0.0rc1

After:

    ❯ brew ruby -e 'puts Version.detect("https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0-rc1/llvm-project-16.0.0rc1.src.tar.xz")'
    16.0.0rc1

The problem here is that `1` is a match for `/[.-v]/`.

    ❯ brew ruby -e 'puts /[.-v]/.match("1")'
    1