### PR TITLE
move `dev-cmd/bottle` methods to extend/os

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -236,8 +236,7 @@ module Homebrew
 
   def setup_tar_and_args!(args, _mtime)
     # Without --only-json-tab bottles are never reproducible
-    default_tar_args = ["tar", [].freeze].freeze
-    return default_tar_args unless args.only_json_tab?
+    ["tar", [].freeze].freeze
   end
 
   alias generic_setup_tar_and_args! setup_tar_and_args!

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -242,6 +242,16 @@ module Homebrew
 
   alias generic_setup_tar_and_args! setup_tar_and_args!
 
+  def gnutar_args(mtime)
+    # Ensure tar is set up for reproducibility.
+    # https://reproducible-builds.org/docs/archives/
+    [
+      "--format", "pax", "--owner", "0", "--group", "0", "--sort", "name", "--mtime=#{mtime}",
+      # Set exthdr names to exclude PID (for GNU tar <1.33). Also don't store atime and ctime.
+      "--pax-option", "globexthdr.name=/GlobalHead.%n,exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime"
+    ].freeze
+  end
+
   def formula_ignores(f)
     ignores = []
     cellar_regex = Regexp.escape(HOMEBREW_CELLAR)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -234,30 +234,13 @@ module Homebrew
     system "/usr/bin/sudo", "--non-interactive", "/usr/sbin/purge"
   end
 
-  def setup_tar_and_args!(args, mtime)
+  def setup_tar_and_args!(args, _mtime)
     # Without --only-json-tab bottles are never reproducible
     default_tar_args = ["tar", [].freeze].freeze
     return default_tar_args unless args.only_json_tab?
-
-    # Use gnu-tar on macOS as it can be set up for reproducibility better than libarchive.
-    begin
-      gnu_tar = Formula["gnu-tar"]
-    rescue FormulaUnavailableError
-      return default_tar_args
-    end
-
-    ensure_formula_installed!(gnu_tar, reason: "bottling")
-
-    # Ensure tar is set up for reproducibility.
-    # https://reproducible-builds.org/docs/archives/
-    gnutar_args = [
-      "--format", "pax", "--owner", "0", "--group", "0", "--sort", "name", "--mtime=#{mtime}",
-      # Set exthdr names to exclude PID (for GNU tar <1.33). Also don't store atime and ctime.
-      "--pax-option", "globexthdr.name=/GlobalHead.%n,exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime"
-    ].freeze
-
-    ["#{gnu_tar.opt_bin}/gtar", gnutar_args].freeze
   end
+
+  alias generic_setup_tar_and_args! setup_tar_and_args!
 
   def formula_ignores(f)
     ignores = []

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -275,6 +275,8 @@ module Homebrew
     ignores.compact
   end
 
+  alias generic_formula_ignores formula_ignores
+
   def bottle_formula(f, args:)
     local_bottle_json = args.json? && f.local_bottle_path.present?
 

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -234,7 +234,7 @@ module Homebrew
     system "/usr/bin/sudo", "--non-interactive", "/usr/sbin/purge"
   end
 
-  def setup_tar_and_args!(args, _mtime)
+  def setup_tar_and_args!(_args, _mtime)
     # Without --only-json-tab bottles are never reproducible
     ["tar", [].freeze].freeze
   end

--- a/Library/Homebrew/extend/os/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/dev-cmd/bottle.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/linux/dev-cmd/bottle" if OS.linux?

--- a/Library/Homebrew/extend/os/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/dev-cmd/bottle.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "extend/os/linux/dev-cmd/bottle" if OS.linux?
-
 if OS.mac?
   require "extend/os/mac/dev-cmd/bottle"
 elsif OS.linux?

--- a/Library/Homebrew/extend/os/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/dev-cmd/bottle.rb
@@ -2,3 +2,9 @@
 # frozen_string_literal: true
 
 require "extend/os/linux/dev-cmd/bottle" if OS.linux?
+
+if OS.mac?
+  require "extend/os/mac/dev-cmd/bottle"
+elsif OS.linux?
+  require "extend/os/linux/dev-cmd/bottle"
+end

--- a/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
@@ -1,0 +1,51 @@
+# typed: false
+# frozen_string_literal: true
+
+module Homebrew
+  extend T::Sig
+
+  module_function
+
+  def setup_tar_and_args!(args, mtime)
+    # Without --only-json-tab bottles are never reproducible
+    default_tar_args = ["tar", [].freeze].freeze
+    return default_tar_args unless args.only_json_tab?
+
+    # Ensure tar is set up for reproducibility.
+    # https://reproducible-builds.org/docs/archives/
+    gnutar_args = [
+      "--format", "pax", "--owner", "0", "--group", "0", "--sort", "name", "--mtime=#{mtime}",
+      # Set exthdr names to exclude PID (for GNU tar <1.33). Also don't store atime and ctime.
+      "--pax-option", "globexthdr.name=/GlobalHead.%n,exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime"
+    ].freeze
+
+    ["tar", gnutar_args].freeze
+  end
+
+  def formula_ignores(f)
+    ignores = []
+    cellar_regex = Regexp.escape(HOMEBREW_CELLAR)
+    prefix_regex = Regexp.escape(HOMEBREW_PREFIX)
+
+    # Ignore matches to go keg, because all go binaries are statically linked.
+    any_go_deps = f.deps.any? do |dep|
+      dep.name =~ Version.formula_optionally_versioned_regex(:go)
+    end
+    if any_go_deps
+      go_regex = Version.formula_optionally_versioned_regex(:go, full: false)
+      ignores << %r{#{cellar_regex}/#{go_regex}/[\d.]+/libexec}
+    end
+
+    ignores << case f.name
+    # On Linux, GCC installation can be moved so long as the whole directory tree is moved together:
+    # https://gcc-help.gcc.gnu.narkive.com/GnwuCA7l/moving-gcc-from-the-installation-path-is-it-allowed.
+    when Version.formula_optionally_versioned_regex(:gcc)
+      Regexp.union(%r{#{cellar_regex}/gcc}, %r{#{prefix_regex}/opt/gcc})
+    # binutils is relocatable for the same reason: https://github.com/Homebrew/brew/pull/11899#issuecomment-906804451.
+    when Version.formula_optionally_versioned_regex(:binutils)
+      %r{#{cellar_regex}/binutils}
+    end
+
+    ignores.compact
+  end
+end

--- a/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
@@ -9,15 +9,7 @@ module Homebrew
   def setup_tar_and_args!(args, mtime)
     generic_setup_tar_and_args!(args, mtime)
 
-    # Ensure tar is set up for reproducibility.
-    # https://reproducible-builds.org/docs/archives/
-    gnutar_args = [
-      "--format", "pax", "--owner", "0", "--group", "0", "--sort", "name", "--mtime=#{mtime}",
-      # Set exthdr names to exclude PID (for GNU tar <1.33). Also don't store atime and ctime.
-      "--pax-option", "globexthdr.name=/GlobalHead.%n,exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime"
-    ].freeze
-
-    ["tar", gnutar_args].freeze
+    ["tar", gnutar_args(mtime)].freeze
   end
 
   def formula_ignores(f)

--- a/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
@@ -7,7 +7,8 @@ module Homebrew
   module_function
 
   def setup_tar_and_args!(args, mtime)
-    generic_setup_tar_and_args!(args, mtime)
+    default_tar_args = generic_setup_tar_and_args!(args, mtime)
+    return default_tar_args unless args.only_json_tab?
 
     ["tar", gnutar_args(mtime)].freeze
   end

--- a/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
@@ -23,18 +23,10 @@ module Homebrew
   end
 
   def formula_ignores(f)
-    ignores = []
     cellar_regex = Regexp.escape(HOMEBREW_CELLAR)
     prefix_regex = Regexp.escape(HOMEBREW_PREFIX)
 
-    # Ignore matches to go keg, because all go binaries are statically linked.
-    any_go_deps = f.deps.any? do |dep|
-      dep.name =~ Version.formula_optionally_versioned_regex(:go)
-    end
-    if any_go_deps
-      go_regex = Version.formula_optionally_versioned_regex(:go, full: false)
-      ignores << %r{#{cellar_regex}/#{go_regex}/[\d.]+/libexec}
-    end
+    ignores = generic_formula_ignores(f)
 
     ignores << case f.name
     # On Linux, GCC installation can be moved so long as the whole directory tree is moved together:

--- a/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/linux/dev-cmd/bottle.rb
@@ -7,9 +7,7 @@ module Homebrew
   module_function
 
   def setup_tar_and_args!(args, mtime)
-    # Without --only-json-tab bottles are never reproducible
-    default_tar_args = ["tar", [].freeze].freeze
-    return default_tar_args unless args.only_json_tab?
+    generic_setup_tar_and_args!(args, mtime)
 
     # Ensure tar is set up for reproducibility.
     # https://reproducible-builds.org/docs/archives/

--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -1,0 +1,31 @@
+# typed: false
+# frozen_string_literal: true
+
+module Homebrew
+  extend T::Sig
+
+  module_function
+
+  def setup_tar_and_args!(args, mtime)
+    generic_setup_tar_and_args!(args, mtime)
+
+    # Use gnu-tar on macOS as it can be set up for reproducibility better than libarchive.
+    begin
+      gnu_tar = Formula["gnu-tar"]
+    rescue FormulaUnavailableError
+      return default_tar_args
+    end
+
+    ensure_formula_installed!(gnu_tar, reason: "bottling")
+
+    # Ensure tar is set up for reproducibility.
+    # https://reproducible-builds.org/docs/archives/
+    gnutar_args = [
+      "--format", "pax", "--owner", "0", "--group", "0", "--sort", "name", "--mtime=#{mtime}",
+      # Set exthdr names to exclude PID (for GNU tar <1.33). Also don't store atime and ctime.
+      "--pax-option", "globexthdr.name=/GlobalHead.%n,exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime"
+    ].freeze
+
+    ["#{gnu_tar.opt_bin}/gtar", gnutar_args].freeze
+  end
+end

--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -18,14 +18,6 @@ module Homebrew
 
     ensure_formula_installed!(gnu_tar, reason: "bottling")
 
-    # Ensure tar is set up for reproducibility.
-    # https://reproducible-builds.org/docs/archives/
-    gnutar_args = [
-      "--format", "pax", "--owner", "0", "--group", "0", "--sort", "name", "--mtime=#{mtime}",
-      # Set exthdr names to exclude PID (for GNU tar <1.33). Also don't store atime and ctime.
-      "--pax-option", "globexthdr.name=/GlobalHead.%n,exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime"
-    ].freeze
-
-    ["#{gnu_tar.opt_bin}/gtar", gnutar_args].freeze
+    ["#{gnu_tar.opt_bin}/gtar", gnutar_args(mtime)].freeze
   end
 end

--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -7,7 +7,8 @@ module Homebrew
   module_function
 
   def setup_tar_and_args!(args, mtime)
-    generic_setup_tar_and_args!(args, mtime)
+    default_tar_args = generic_setup_tar_and_args!(args, mtime)
+    return default_tar_args unless args.only_json_tab?
 
     # Use gnu-tar on macOS as it can be set up for reproducibility better than libarchive.
     begin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
move methods in `dev-cmd/bottle` to extend/os because of `#todo`.