### PR TITLE
Don't allow HOMEBREW_INSTALL_FROM_API when building from source

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -41,7 +41,7 @@ Metrics/PerceivedComplexity:
 Metrics/MethodLength:
   Max: 232
 Metrics/ModuleLength:
-  Max: 463
+  Max: 466
   Exclude:
     # TODO: extract more of the bottling logic
     - "dev-cmd/bottle.rb"

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -199,7 +199,7 @@ rescue MethodDeprecatedError => e
   exit 1
 rescue Exception => e # rubocop:disable Lint/RescueException
   onoe e
-  if internal_cmd && defined?(OS::ISSUES_URL)
+  if internal_cmd && !OS.unsupported_configuration?
     if Homebrew::EnvConfig.no_auto_update?
       $stderr.puts "#{Tty.bold}Do not report this issue until you've run `brew update` and tried again.#{Tty.reset}"
     else

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -771,13 +771,21 @@ To turn developer mode off, run $(bold "brew developer off")
 fi
 
 # Test HOMEBREW_INSTALL_FROM_API on HOMEBREW_DEV_CMD_RUN and HOMEBREW_DEVELOPER
-# folks who haven't run a HOMEBREW_DEVELOPER_COMMAND.
+# folks who haven't run a HOMEBREW_DEVELOPER_COMMAND if they are in a default
+# prefix and on a supported macOS version.
 if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
       -z "${HOMEBREW_INSTALL_FROM_API}" &&
       -z "${HOMEBREW_DEVELOPER_COMMAND}" ]] &&
+   [[ -z "${HOMEBREW_MACOS_VERSION_NUMERIC}" ||
+   "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "110000" ]] &&
+   [[ "${HOMEBREW_PREFIX}" == "/usr/local" ||
+      "${HOMEBREW_PREFIX}" == "/opt/homebrew" ||
+      "${HOMEBREW_PREFIX}" == "/home/linuxbrew/.linuxbrew" ]] &&
    [[ -n "${HOMEBREW_DEV_CMD_RUN}" || -n "${HOMEBREW_DEVELOPER}" ]]
 then
   export HOMEBREW_INSTALL_FROM_API=1
+else
+  unset HOMEBREW_INSTALL_FROM_API
 fi
 
 if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh" ]]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -226,7 +226,9 @@ module Homebrew
       },
       HOMEBREW_INSTALL_FROM_API:                 {
         description: "If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's " \
-                     "API instead of needing (large, slow) local checkouts of these repositories.",
+                     "API instead of needing (large, slow) local checkouts of these repositories. Note, this will " \
+                     "only take effect in supported configurations (i.e. using the default Homebrew prefix and, " \
+                     "if on macOS, on a supported version).",
         boolean:     true,
       },
       HOMEBREW_LIVECHECK_WATCHLIST:              {
@@ -484,6 +486,9 @@ module Homebrew
 
     sig { returns(T::Boolean) }
     def install_from_api?
+      return false if OS.unsupported_configuration?
+      return false unless Homebrew.default_prefix?
+
       ENV["HOMEBREW_NO_INSTALL_FROM_API"].blank? && ENV["HOMEBREW_INSTALL_FROM_API"].present?
     end
   end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -524,7 +524,7 @@ class BuildError < RuntimeError
       end
     end
 
-    if formula.tap && defined?(OS::ISSUES_URL)
+    if formula.tap && !OS.unsupported_configuration?
       if formula.tap.official?
         puts Formatter.error(Formatter.url(OS::ISSUES_URL), label: "READ THIS")
       elsif (issues_url = formula.tap.issues_url)

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -69,4 +69,9 @@ module OS
     ISSUES_URL = "https://docs.brew.sh/Troubleshooting"
     PATH_OPEN = "xdg-open"
   end
+
+  sig { returns(T::Boolean) }
+  def self.unsupported_configuration?
+    !defined?(OS::ISSUES_URL)
+  end
 end

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -36,6 +36,8 @@ export HOMEBREW_INSTALL_FROM_API=1
 
 This will make Homebrew install formulae and casks from the `homebrew/core` and `homebrew/cask` taps using Homebrew’s API instead of local checkouts of these repositories.
 
+Note, this will take effect in supported configurations (i.e. using the default Homebrew prefix and, if on macOS, on a supported version).
+
 ## Unattended installation
 
 If you want a non-interactive run of the Homebrew installer that doesn't prompt for passwords (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2149,7 +2149,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   *Default:* The "Beer Mug" emoji.
 
 - `HOMEBREW_INSTALL_FROM_API`
-  <br>If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API instead of needing (large, slow) local checkouts of these repositories.
+  <br>If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API instead of needing (large, slow) local checkouts of these repositories. Note, this will only take effect in supported configurations (i.e. using the default Homebrew prefix and, if on macOS, on a supported version).
 
 - `HOMEBREW_LIVECHECK_WATCHLIST`
   <br>Consult this file for the list of formulae to check by default when no formula argument is passed to `brew livecheck`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3140,7 +3140,7 @@ Print this text before the installation summary of each successful build\.
 \fBHOMEBREW_INSTALL_FROM_API\fR
 .
 .br
-If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API instead of needing (large, slow) local checkouts of these repositories\.
+If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API instead of needing (large, slow) local checkouts of these repositories\. Note, this will only take effect in supported configurations (i\.e\. using the default Homebrew prefix and, if on macOS, on a supported version)\.
 .
 .TP
 \fBHOMEBREW_LIVECHECK_WATCHLIST\fR


### PR DESCRIPTION
When either being in a non-default prefix or being on an unsupported macOS version we expect most things to be built from source. In that environment, do not allow `HOMEBREW_INSTALL_FROM_API` to be set.

Fixes #14475