### PR TITLE
Making core tap install an in-process call

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -800,7 +800,7 @@ class CoreTap < Tap
     # Tests override homebrew-core locations and we don't want to auto-tap in them.
     return if ENV["HOMEBREW_TESTS"]
 
-    safe_system HOMEBREW_BREW_FILE, "tap", instance.name
+    instance.install
   end
 
   def remote

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -87,7 +87,7 @@ module Tty
     CODES.each do |name, code|
       define_method(name) do
         @escape_sequence ||= []
-        @escape_sequence << code
+        @escape_sequence << code if @escape_sequence
         self
       end
     end

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -87,7 +87,7 @@ module Tty
     CODES.each do |name, code|
       define_method(name) do
         @escape_sequence ||= []
-        @escape_sequence << code if @escape_sequence
+        @escape_sequence << code
         self
       end
     end


### PR DESCRIPTION
This helps fixes problems with a fresh install on ARM Linux. When brew is relaunched with filtered PATH, it cannot find user installed Ruby.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ x Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
