### PR TITLE
OS: Fix supported prefix check

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -59,8 +59,8 @@ module OS
     if !OS::Mac.version.prerelease? &&
        !OS::Mac.version.outdated_release? &&
        ARGV.none? { |v| v.start_with?("--cc=") } &&
-       (HOMEBREW_PREFIX == HOMEBREW_DEFAULT_PREFIX ||
-       (HOMEBREW_PREFIX == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX && Hardware::CPU.arm?))
+       (HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX ||
+       (HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX && Hardware::CPU.arm?))
       ISSUES_URL = "https://docs.brew.sh/Troubleshooting"
     end
     PATH_OPEN = "/usr/bin/open"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`HOMEBREW_PREFIX` is a Pathname; `HOMEBREW_DEFAULT_PREFIX` and `HOMEBREW_MACOS_ARM_DEFAULT_PREFIX` are strings.

### Before
```rb
/u/l/Homebrew (master|✔) $ brew irb
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
irb(main):001:0> HOMEBREW_PREFIX
=> #<Pathname:/usr/local>
irb(main):002:0> HOMEBREW_DEFAULT_PREFIX
=> "/usr/local"          
irb(main):003:0> HOMEBREW_PREFIX == HOMEBREW_DEFAULT_PREFIX
=> false                 
irb(main):004:0> HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX
=> true   
```

This became obvious to me after https://github.com/Homebrew/brew/pull/14480 got merged in and `HOMEBREW_INSTALL_FROM_API` stopped working for me. It was because the `ISSUES_URL` variable wasn't getting set and that is used in `OS.unsupported_configuration?`.

```rb
  sig { returns(T::Boolean) }
  def self.unsupported_configuration?
    !defined?(OS::ISSUES_URL)
  end
```

