### PR TITLE
brew.sh: fix HOMEBREW_INSTALL_FROM_API logic.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -774,16 +774,17 @@ fi
 # folks who haven't run a HOMEBREW_DEVELOPER_COMMAND if they are in a default
 # prefix and on a supported macOS version.
 if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
-      -z "${HOMEBREW_INSTALL_FROM_API}" &&
       -z "${HOMEBREW_DEVELOPER_COMMAND}" ]] &&
    [[ -z "${HOMEBREW_MACOS_VERSION_NUMERIC}" ||
    "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "110000" ]] &&
    [[ "${HOMEBREW_PREFIX}" == "/usr/local" ||
       "${HOMEBREW_PREFIX}" == "/opt/homebrew" ||
-      "${HOMEBREW_PREFIX}" == "/home/linuxbrew/.linuxbrew" ]] &&
-   [[ -n "${HOMEBREW_DEV_CMD_RUN}" || -n "${HOMEBREW_DEVELOPER}" ]]
+      "${HOMEBREW_PREFIX}" == "/home/linuxbrew/.linuxbrew" ]]
 then
-  export HOMEBREW_INSTALL_FROM_API=1
+  if [[ -n "${HOMEBREW_DEV_CMD_RUN}" || -n "${HOMEBREW_DEVELOPER}" ]]
+  then
+    export HOMEBREW_INSTALL_FROM_API=1
+  fi
 else
   unset HOMEBREW_INSTALL_FROM_API
 fi


### PR DESCRIPTION
Ensure that we handle this a bit more correctly so it's unset more often.