### PR TITLE
api: warn rather than fail if we've got a cached version.

### DIFF
--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -46,7 +46,7 @@ describe Homebrew::API::Cask do
     it "fetches the source of a cask (defaulting to master when no `git_head` is passed)" do
       curl_output = OpenStruct.new(stdout: "foo", success?: true)
       expect(Utils::Curl).to receive(:curl_output)
-        .with("--fail", "https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/foo.rb", max_time: 5)
+        .with("--fail", "https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/foo.rb")
         .and_return(curl_output)
       described_class.fetch_source("foo", git_head: nil)
     end


### PR DESCRIPTION
Rather than failing every time we fail to update (breaking most usage while offline) instead only fail if we cannot obtain the JSON and we don't have a valid local file we can use.

Also tweak the timeout and retry logic and values to make a bit more sense in this context and not be so noisy when offline.

Fixes #14451
Fixes #14455
Fixes #14462
Fixes #14489