### PR TITLE
`update`: increase max time for API JSON updates

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -780,7 +780,7 @@ EOS
       fi
       curl \
         "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-        --fail --compressed --silent --max-time 5 \
+        --fail --compressed --silent --max-time 10 \
         --location --remote-time --output "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
         --time-cond "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
         --user-agent "${HOMEBREW_USER_AGENT_CURL}" \


### PR DESCRIPTION
Follow-up to #14491

Increase the max-time for the `formula.json` and `cask.json` file downloads to 10 to bring it in line with the one set in `Homebrew::API`
