### PR TITLE
Fix JSON file download failure fallback

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -54,6 +54,7 @@ module Homebrew
         raise if target.empty?
 
         opoo "#{target.basename}: update failed, falling back to cached version."
+        JSON.parse(target.read)
       rescue JSON::ParserError
         target.unlink
         retry_count += 1


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/14491

We want to actually use the old JSON file if we're falling back. Currently, we "fall back" by returning nothing which causes `CaskLoader` to assume that the API is not a viable option and skipping to loading from taps if they're available. Instead, we want to warn and then use the old version.

I think this will help with the weird cask loading errors we've been seeing. My best theory at the moment is that they happen when the API download fails and then it accidentally falls back to the taps.

---

I think this will close https://github.com/Homebrew/brew/issues/14483
