### PR TITLE
Don't convert boolean and blank values to strings in cask artifacts API

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -290,14 +290,16 @@ module Cask
 
     def artifacts_list
       artifacts.map do |artifact|
-        next artifact.to_h if artifact.is_a? Artifact::AbstractFlightBlock
-
-        if artifact.is_a? Artifact::Relocated
+        case artifact
+        when Artifact::AbstractFlightBlock
+          artifact.to_h
+        when Artifact::Relocated
+          # Don't replace the Homebrew prefix in the source path since the source could include /usr/local
           source, *args = artifact.to_args
-          next { artifact.class.dsl_key => [to_h_string_gsubs(source, replace_prefix: false), *to_h_gsubs(args)] }
+          { artifact.class.dsl_key => [to_h_string_gsubs(source, replace_prefix: false), *to_h_gsubs(args)] }
+        else
+          { artifact.class.dsl_key => to_h_gsubs(artifact.to_args) }
         end
-
-        { artifact.class.dsl_key => to_h_gsubs(artifact.to_args) }
       end
     end
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -322,12 +322,14 @@ module Cask
       end
 
       def from_h_gsubs(value)
+        return value if value.blank?
+
         if value.respond_to? :to_h
           from_h_hash_gsubs(value)
         elsif value.respond_to? :to_a
           from_h_array_gsubs(value)
         else
-          from_h_string_gsubs(value)
+          { "true" => true, "false" => false }.fetch(value, from_h_string_gsubs(value))
         end
       end
     end


### PR DESCRIPTION
This PR fixes some more issues with loading artifacts from the cask JSON API. Now, boolean values (e.g. [`sudo: true`](https://github.com/Homebrew/homebrew-cask/blob/7e620eb67d8b9f275c99a1bda878de98a56ed84c/Casks/finch.rb#L17)) are left as-is instead of being converted to strings first. This also updates the `HOMEBREW_PREFIX` replacement logic to skip replacement of the first argument (i.e. destination) of `Relocated` artifact stanzas. This is okay to do because we should never be relocating a file from outside the cask's staging directory during the install. However, other parameters (e.g. `target`) will still have the prefix replaced as usual. This fixes issues such as in [`dotnet-sdk`](https://github.com/Homebrew/homebrew-cask/blob/7e620eb67d8b9f275c99a1bda878de98a56ed84c/Casks/dotnet-sdk.rb#L31) where the path `/usr/local` needs to appear and not be converted since the file being referenced will be in `/usr/local` even on ARM.

Related: https://github.com/orgs/Homebrew/discussions/4135 and https://github.com/Homebrew/homebrew-cask/pull/140436