### PR TITLE
Fix cask not found error when upgrading certain casks

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -19,7 +19,7 @@ module Cask
     extend Searchable
     include Metadata
 
-    attr_reader :token, :sourcefile_path, :source, :config, :default_config
+    attr_reader :token, :sourcefile_path, :source, :config, :default_config, :loaded_from_api
 
     attr_accessor :download, :allow_reassignment
 
@@ -44,12 +44,14 @@ module Cask
       @tap
     end
 
-    def initialize(token, sourcefile_path: nil, source: nil, tap: nil, config: nil, allow_reassignment: false, &block)
+    def initialize(token, sourcefile_path: nil, source: nil, tap: nil, config: nil, allow_reassignment: false,
+                   loaded_from_api: false, &block)
       @token = token
       @sourcefile_path = sourcefile_path
       @source = source
       @tap = tap
       @allow_reassignment = allow_reassignment
+      @loaded_from_api = loaded_from_api
       @block = block
 
       @default_config = config || Config.new
@@ -133,7 +135,10 @@ module Cask
 
     def installed_caskfile
       installed_version = timestamped_versions.last
-      metadata_main_container_path.join(*installed_version, "Casks", "#{token}.rb")
+      caskfile_dir = metadata_main_container_path.join(*installed_version, "Casks")
+      return caskfile_dir.join("#{token}.json") if caskfile_dir.join("#{token}.json").exist?
+
+      caskfile_dir.join("#{token}.rb")
     end
 
     def config_path

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -44,8 +44,8 @@ module Cask
       @tap
     end
 
-    def initialize(token, sourcefile_path: nil, source: nil, tap: nil, config: nil, allow_reassignment: false,
-                   loaded_from_api: false, &block)
+    def initialize(token, sourcefile_path: nil, source: nil, tap: nil, config: nil,
+                   allow_reassignment: false, loaded_from_api: false, &block)
       @token = token
       @sourcefile_path = sourcefile_path
       @source = source

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -386,7 +386,8 @@ module Cask
 
       return if @cask.source.blank?
 
-      (metadata_subdir/"#{@cask.token}.rb").write @cask.source
+      extension = @cask.loaded_from_api ? "json" : "rb"
+      (metadata_subdir/"#{@cask.token}.#{extension}").write @cask.source
       old_savedir&.rmtree
     end
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/14478
Fixes https://github.com/Homebrew/brew/issues/14504

This PR fixes the cask unavailable error that has appeared recently. Essentially, in cases where we don't fetch the cask source, we don't end up writing anything to the `.metadata` cask file. The `upgrade` logic requires loading the old cask from this location. This PR will write the JSON information to this location and allow that to be used to load installed casks.
