### PR TITLE
Add error message with instructions for the missing cask file

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -150,7 +150,7 @@ module Cask
           if !c.installed_caskfile.exist? && c.tap.to_s == "homebrew/cask" &&
              Homebrew::API::Cask.all_casks.key?(c.token)
             odie <<~EOS
-              The cask '#{c.token}' was not properly installed and cannot be upgraded. To fix this, run:
+              The cask '#{c.token}' was affected by a bug and cannot be upgraded as-is. To fix this, run:
                 brew reinstall --cask --force #{c.token}
             EOS
           end

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -146,7 +146,17 @@ module Cask
 
         caught_exceptions = []
 
-        upgradable_casks = outdated_casks.map { |c| [CaskLoader.load(c.installed_caskfile), c] }
+        upgradable_casks = outdated_casks.map do |c|
+          if !c.installed_caskfile.exist? && c.tap.to_s == "homebrew/cask" &&
+             Homebrew::API::Cask.all_casks.key?(c.token)
+            odie <<~EOS
+              The cask '#{c.token}' was not properly installed and cannot be upgraded. To fix this, run:
+                brew reinstall --cask --force #{c.token}
+            EOS
+          end
+
+          [CaskLoader.load(c.installed_caskfile), c]
+        end
 
         puts upgradable_casks
           .map { |(old_cask, new_cask)| "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}" }


### PR DESCRIPTION
Follow up to https://github.com/Homebrew/brew/pull/14506

We should show a better error message in this case. Now, it shows:

```console
$ brew upgrade --cask emacs
==> Upgrading 1 outdated package:
Error: The cask 'emacs' was not properly installed and cannot be upgraded. To fix this, run:
  brew reinstall --cask --force emacs
```

I would have liked to actually fix this so no alternate command is needed, but I think that would end up being too much work and too janky so this is the second best option.
