### PR TITLE
Fix error when showing `brew config` JSON update time

### DIFF
--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -148,7 +148,7 @@ module SystemConfig
       end
 
       if (formula_json = Homebrew::API::HOMEBREW_CACHE_API/"formula.json") && formula_json.exist?
-        f.puts "Core tap JSON: #{formula_json.mtime.to_s(:short)}"
+        f.puts "Core tap JSON: #{formula_json.mtime.utc.strftime("%d %b %H:%M UTC")}"
       elsif !CoreTap.instance.installed?
         f.puts "Core tap: N/A"
       end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/14508

Now, use a different method for formatting the time. Also, let's convert to UTC since that will help compare the JSON file to others cross-timezones.
