### PR TITLE
cmd/doctor: respect `--quiet`

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -78,6 +78,6 @@ module Homebrew
       first_warning = false
     end
 
-    puts "Your system is ready to brew." unless Homebrew.failed?
+    puts "Your system is ready to brew." if !Homebrew.failed? && !args.quiet?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

I'm often running `brew doctor` and want to only see output when something is wrong, so this allows passing `--quiet` to silence a successful doctor check

Before:

```console
$ brew doctor
Your system is ready to brew.
```

After:

```console
$ brew doctor -q
```
