### PR TITLE
Better support source builds under API mode

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1955,6 +1955,11 @@ class Formula
   end
 
   # @private
+  def tap_git_head
+    tap&.git_head
+  end
+
+  # @private
   delegate env: :"self.class"
 
   # @private
@@ -2125,7 +2130,7 @@ class Formula
       "disabled"                 => disabled?,
       "disable_date"             => disable_date,
       "disable_reason"           => disable_reason,
-      "tap_git_head"             => tap&.git_head,
+      "tap_git_head"             => tap_git_head,
     }
 
     if stable

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1181,14 +1181,12 @@ class FormulaInstaller
 
     if pour_bottle?(output_warning: true)
       formula.fetch_bottle_tab
-    elsif formula.core_formula? && !formula.tap.installed? && Homebrew::EnvConfig.install_from_api?
-      odie <<~EOS
-        Unable to build #{formula.name} from source while Homebrew/homebrew-core is
-        untapped and HOMEBREW_NO_INSTALL_FROM_API is unset! To resolve please run:
-          export HOMEBREW_NO_INSTALL_FROM_API=1
-          brew tap Homebrew/core
-        and retry.
-      EOS
+    elsif formula.core_formula? && Homebrew::EnvConfig.install_from_api?
+      url = "https://raw.githubusercontent.com/#{formula.tap.full_name}/#{formula.tap_git_head}/Formula/#{formula.name}.rb"
+      @formula = Formulary.factory(url, formula.active_spec_sym,
+                                   alias_path: formula.alias_path,
+                                   flags:      formula.class.build_flags,
+                                   from:       :formula_installer)
     else
       formula.fetch_patches
       formula.resources.each(&:fetch)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -220,6 +220,11 @@ module Formulary
       def caveats
         self.class.instance_variable_get(:@caveats_string)
       end
+
+      @tap_git_head_string = json_formula["tap_git_head"]
+      def tap_git_head
+        self.class.instance_variable_get(:@tap_git_head_string)
+      end
     end
 
     klass.loaded_from_api = true
@@ -395,24 +400,27 @@ module Formulary
 
     attr_reader :url
 
-    sig { params(url: T.any(URI::Generic, String)).void }
-    def initialize(url)
+    sig { params(url: T.any(URI::Generic, String), from: T.nilable(Symbol)).void }
+    def initialize(url, from: nil)
       @url = url
+      @from = from
       uri = URI(url)
       formula = File.basename(uri.path, ".rb")
       super formula, HOMEBREW_CACHE_FORMULA/File.basename(uri.path)
     end
 
     def load_file(flags:, ignore_errors:)
-      if %r{githubusercontent.com/[\w-]+/[\w-]+/[a-f0-9]{40}(?:/Formula)?/(?<formula_name>[\w+-.@]+).rb} =~ url
-        raise UnsupportedInstallationMethod,
-              "Installation of #{formula_name} from a GitHub commit URL is unsupported! " \
-              "`brew extract #{formula_name}` to a stable tap on GitHub instead."
-      elsif url.match?(%r{^(https?|ftp)://})
-        raise UnsupportedInstallationMethod,
-              "Non-checksummed download of #{name} formula file from an arbitrary URL is unsupported! " \
-              "`brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap " \
-              "on GitHub instead."
+      if @from != :formula_installer
+        if %r{githubusercontent.com/[\w-]+/[\w-]+/[a-f0-9]{40}(?:/Formula)?/(?<formula_name>[\w+-.@]+).rb} =~ url
+          raise UnsupportedInstallationMethod,
+                "Installation of #{formula_name} from a GitHub commit URL is unsupported! " \
+                "`brew extract #{formula_name}` to a stable tap on GitHub instead."
+        elsif url.match?(%r{^(https?|ftp)://})
+          raise UnsupportedInstallationMethod,
+                "Non-checksummed download of #{name} formula file from an arbitrary URL is unsupported! " \
+                "`brew extract` or `brew create` and `brew tap-new` to create a formula file in a tap " \
+                "on GitHub instead."
+        end
       end
       HOMEBREW_CACHE_FORMULA.mkpath
       FileUtils.rm_f(path)
@@ -664,7 +672,7 @@ module Formulary
     when HOMEBREW_BOTTLES_EXTNAME_REGEX
       return BottleLoader.new(ref)
     when URL_START_REGEX
-      return FromUrlLoader.new(ref)
+      return FromUrlLoader.new(ref, from: from)
     when HOMEBREW_TAP_FORMULA_REGEX
       if ref.start_with?("homebrew/core/") && Homebrew::EnvConfig.install_from_api?
         name = ref.split("/", 3).last

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -113,15 +113,6 @@ module Homebrew
         EOS
       end
 
-      if head && Homebrew::EnvConfig.install_from_api?
-        raise UsageError, <<~EOS
-          --HEAD is not supported with HOMEBREW_NO_INSTALL_FROM_API unset! To resolve please run:
-            export HOMEBREW_NO_INSTALL_FROM_API=1
-            brew tap Homebrew/core
-          and retry this command.
-        EOS
-      end
-
       # --HEAD, fail with no head defined
       odie "No head is defined for #{f.full_name}" if head && f.head.nil?
 


### PR DESCRIPTION
The install experience for `-s`, older macOS and non-default prefixes is very poor.

Currently, after switching to API mode by default, the state of the tap is "frozen", never updated but still used for all source installs.

This PR implements source file fetching from raw.githubusercontent.com. Now everything should work significantly more seemlessly. I've managed to remove HOMEBREW_NO_INSTALL_FROM_API messaging as a result.

A notable change is if you do have it tapped locally and make modifications, you will _need_  HOMEBREW_NO_INSTALL_FROM_API for those modifications to be used. This however makes sense and is much more consistent with how dev-cmds work.

One improvement worth doing as an iteration of this is SHA256 validation of the formula file download. We'll need to add a field to the JSON API first to do this.