### PR TITLE
Properly load booleans from the API

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -334,8 +334,10 @@ module Cask
           from_h_hash_gsubs(value)
         elsif value.respond_to? :to_a
           from_h_array_gsubs(value)
+        elsif value.is_a? String
+          from_h_string_gsubs(value)
         else
-          { "true" => true, "false" => false }.fetch(value, from_h_string_gsubs(value))
+          value
         end
       end
     end


### PR DESCRIPTION
Follow-up to #14503

As pointed out by @apainintheneck, now that booleans are fixed in the JSON they're actually being converted _back_ to strings by our parser. Lets fix this by only attempting to reverse-parse elements that are already strings and leaving everything else (i.e. booleans) as-is. This shouldn't be a problem because all of the things that get pushed through `to_h_string_gsubs` will end up being a string in the JSON which means it will also go back through `from_h_string_gsubs`
