### PR TITLE
Set `HOMEBREW_NO_INSTALL_FROM_API` for certain commands

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -90,18 +90,6 @@ begin
   end
 
   if internal_cmd || Commands.external_ruby_v2_cmd_path(cmd)
-    if Commands::INSTALL_FROM_API_FORBIDDEN_COMMANDS.include?(cmd) &&
-       !CoreTap.instance.installed? &&
-       Homebrew::EnvConfig.install_from_api? && !Homebrew::EnvConfig.developer?
-      odie <<~EOS
-        This command cannot be run while Homebrew/homebrew-core is untapped and
-        HOMEBREW_NO_INSTALL_FROM_API is unset! To resolve please run:
-          export HOMEBREW_NO_INSTALL_FROM_API=1
-          brew tap Homebrew/core
-        and retry this command.
-      EOS
-    end
-
     Homebrew.send Commands.method_name(cmd)
   elsif (path = Commands.external_ruby_cmd_path(cmd))
     require?(path)

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -772,6 +772,26 @@ To turn developer mode off, run $(bold "brew developer off")
   export HOMEBREW_DEV_CMD_RUN="1"
 fi
 
+if [[ "${HOMEBREW_COMMAND}" == "audit" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "bottle" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "bump-cask-pr" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "bump-formula-pr" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "bump-revision" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "bump-unversioned-casks" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "cat" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "create" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "edit" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "extract" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "formula" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "livecheck" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "pr-pull" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "pr-upload" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "test" ]] ||
+   [[ "${HOMEBREW_COMMAND}" == "update-python-resources" ]]
+then
+  export HOMEBREW_NO_INSTALL_FROM_API=1
+fi
+
 if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh" ]]
 then
   HOMEBREW_BASH_COMMAND="${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh"

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -33,25 +33,6 @@ module Commands
     "tc"          => "typecheck",
   }.freeze
 
-  INSTALL_FROM_API_FORBIDDEN_COMMANDS = %w[
-    audit
-    bottle
-    bump-cask-pr
-    bump-formula-pr
-    bump-revision
-    bump-unversioned-casks
-    cat
-    create
-    edit
-    extract
-    formula
-    livecheck
-    pr-pull
-    pr-upload
-    test
-    update-python-resources
-  ].freeze
-
   def valid_internal_cmd?(cmd)
     require?(HOMEBREW_CMD_PATH/cmd)
   end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -61,15 +61,7 @@ module Homebrew
           "#{path} doesn't exist on disk."
         end
 
-        message = if Homebrew::EnvConfig.install_from_api?
-          <<~EOS
-            #{not_exist_message}
-            This is expected with HOMEBREW_NO_INSTALL_FROM_API unset! To resolve please run:
-              export HOMEBREW_NO_INSTALL_FROM_API=1
-              brew tap Homebrew/core
-            and retry this command.
-          EOS
-        elsif args.cask?
+        message = if args.cask?
           <<~EOS
             #{not_exist_message}
             Run #{Formatter.identifier("brew create --cask --set-name #{path.basename(".rb")} $URL")} \


### PR DESCRIPTION
This should hopefully make the developer experience much better without requiring anyone to actually set `HOMEBREW_NO_INSTALL_FROM_API`. Now, when anyone runs a command that _requires_ the taps to be checked out, we internally set `HOMEBREW_NO_INSTALL_FROM_API` which will ensure that those taps are available and (if necessary) up to date.

Fixes https://github.com/Homebrew/brew/issues/14519