### PR TITLE
feat: Allow passing one or more `--tap` options to `brew update` to allow specific taps to be updated

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -327,6 +327,7 @@ EOS
 homebrew-update() {
   local option
   local DIR
+  local DIRS
   local UPSTREAM_BRANCH
 
   for option in "$@"
@@ -564,7 +565,9 @@ EOS
   rm -f "${update_failed_file}"
   rm -f "${missing_remote_ref_dirs_file}"
 
-  for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
+  DIRS=("${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*)
+
+  for DIR in "${DIRS[@]}"
   do
     if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" || "${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" ]]
@@ -723,7 +726,7 @@ EOS
     export HOMEBREW_MISSING_REMOTE_REF_DIRS
   fi
 
-  for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
+  for DIR in "${DIRS[@]}"
   do
     if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]] &&
        [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&


### PR DESCRIPTION
Square distributes internal tools through a private tap of Homebrew formulas. It's common for Square engineers to have also tapped other repos of Homebrew formulas, both public and private. We have mechanisms to ensure that our internal tools are up-to-date — and we need to make a strong guarantee that those mechanisms work. However, they can currently fail to `brew update` our critical tap if any other tap is broken for any reason (e.g. its remote branch was renamed, the user's SSH key is missing, you need to be on a VPN to see some other private tap, etc). A variety of workarounds are at our disposal, but the cleanest of all would be the ability to express to `brew update` the list of taps we want to update the way we can express to `brew install` or `brew upgrade` the list of formulae we care about.

* * * *

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
