### PR TITLE
extend/time: restore rfc3339 method

### DIFF
--- a/Library/Homebrew/extend/time.rb
+++ b/Library/Homebrew/extend/time.rb
@@ -16,3 +16,8 @@ module TimeRemaining
     end
   end
 end
+
+class Time
+  # Backwards compatibility for formulae that used this ActiveSupport extension
+  alias rfc3339 xmlschema
+end


### PR DESCRIPTION
This was lost in #14502.

Unfortuately this method _is_ used in third-party taps so compatibility needs to be kept, or a deprecation path introduced.

Given the extremely trivial nature of supporting it, I've just restored the alias. If anyone feels strongly about deprecating, submit a PR to do so - you could maybe even move it to the mostly forgotten `compat` folder too.