### PR TITLE
brew.sh: add `bump` to `HOMEBREW_NO_INSTALL_FROM_API` commands

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -755,6 +755,33 @@ if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/dev-cmd/${HOMEBREW_COMMAND}.sh" ]] ||
    [[ -f "${HOMEBREW_LIBRARY}/Homebrew/dev-cmd/${HOMEBREW_COMMAND}.rb" ]]
 then
   export HOMEBREW_DEVELOPER_COMMAND="1"
+
+  NO_INSTALL_FROM_API_COMMANDS=(
+    audit
+    bottle
+    bump-cask-pr
+    bump-formula-pr
+    bump-revision
+    bump-unversioned-casks
+    bump
+    cat
+    create
+    edit
+    extract
+    formula
+    livecheck
+    pr-pull
+    pr-upload
+    test
+    update-python-resources
+  )
+
+  if [[ " ${NO_INSTALL_FROM_API_COMMANDS[*]} " == *" ${HOMEBREW_COMMAND} "* ]]
+  then
+    export HOMEBREW_NO_INSTALL_FROM_API=1
+  fi
+
+  unset NO_INSTALL_FROM_API_COMMANDS
 fi
 
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]
@@ -770,26 +797,6 @@ To turn developer mode off, run $(bold "brew developer off")
 
   git config --file="${HOMEBREW_GIT_CONFIG_FILE}" --replace-all homebrew.devcmdrun true 2>/dev/null
   export HOMEBREW_DEV_CMD_RUN="1"
-fi
-
-if [[ "${HOMEBREW_COMMAND}" == "audit" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "bottle" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "bump-cask-pr" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "bump-formula-pr" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "bump-revision" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "bump-unversioned-casks" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "cat" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "create" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "edit" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "extract" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "formula" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "livecheck" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "pr-pull" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "pr-upload" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "test" ]] ||
-   [[ "${HOMEBREW_COMMAND}" == "update-python-resources" ]]
-then
-  export HOMEBREW_NO_INSTALL_FROM_API=1
 fi
 
 if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew bump` relies on `livecheck`, which we don't want to query the API
for.

Also, some small refactoring:

1. Declare the list of commands we want to set
   `HOMEBREW_NO_INSTALL_FROM_API` for as an array.
2. Only check against this list when the command being run is a
   developer command, to avoid checking the list when we know we're not
   running a dev command.
