### PR TITLE
Bash completions: speed up Tap completions

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -100,14 +100,14 @@ __brew_complete_outdated_casks() {
 
 __brew_complete_tapped() {
   local dir taps taplib
-  taplib="$(brew --repository)/Library/Taps"
+  taplib=${HOMEBREW_REPOSITORY:-$(brew --repository)}/Library/Taps
 
   for dir in "${taplib}"/*/*
   do
-    [[ -d "${dir}" ]] || continue
-    dir="${dir#"${taplib}"/}"
-    dir="${dir/homebrew-/}"
-    taps="${taps} ${dir}"
+    [[ -d ${dir} ]] || continue
+    dir=${dir#"${taplib}"/}
+    dir=${dir/homebrew-/}
+    taps+=" ${dir}"
   done
   __brewcomp "${taps}"
 }

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -87,14 +87,14 @@ __brew_complete_outdated_casks() {
 
 __brew_complete_tapped() {
   local dir taps taplib
-  taplib="$(brew --repository)/Library/Taps"
+  taplib=${HOMEBREW_REPOSITORY:-$(brew --repository)}/Library/Taps
 
   for dir in "${taplib}"/*/*
   do
-    [[ -d "${dir}" ]] || continue
-    dir="${dir#"${taplib}"/}"
-    dir="${dir/homebrew-/}"
-    taps="${taps} ${dir}"
+    [[ -d ${dir} ]] || continue
+    dir=${dir#"${taplib}"/}
+    dir=${dir/homebrew-/}
+    taps+=" ${dir}"
   done
   __brewcomp "${taps}"
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

* Use the `HOMEBREW_REPOSITORY` variable when it is set.
* Change `taps="${taps} ${dir}"` to `taps+=" ${dir}"`, as the latter is significantly faster.