### PR TITLE
formulary: respect `HOMEBREW_BOTTLE_DOMAIN` when installing from API

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -169,7 +169,12 @@ module Formulary
 
       if (bottles_stable = json_formula["bottle"]["stable"]).present?
         bottle do
-          root_url bottles_stable["root_url"]
+          if Homebrew::EnvConfig.bottle_domain != HOMEBREW_BOTTLE_DEFAULT_DOMAIN \
+              && bottles_stable["root_url"] == HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+            root_url Homebrew::EnvConfig.bottle_domain
+          else
+            root_url bottles_stable["root_url"]
+          end
           rebuild bottles_stable["rebuild"]
           bottles_stable["files"].each do |tag, bottle_spec|
             cellar = Formulary.convert_to_string_or_symbol bottle_spec["cellar"]


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Respect `HOMEBREW_BOTTLE_DOMAIN` when installing from API. This will cause downloading from `HOMEBREW_BOTTLE_DOMAIN` first when falling back to the default bottle domain if fail.