### PR TITLE
Bash completions: clean up basic functions

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -14,41 +14,27 @@
 # Bash completion script for brew(1)
 
 __brewcomp_words_include() {
-  local i=1
-  while [[ "${i}" -lt "${COMP_CWORD}" ]]
+  local element idx 
+  for (( idx = 1; idx < COMP_CWORD; idx++ ))
   do
-    if [[ "${COMP_WORDS[i]}" = "$1" ]]
-    then
-      return 0
-    fi
-    (( i++ ))
+    element=${COMP_WORDS[idx]}
+    [[ -n ${element} && ${element} == "$1" ]] && return 0
   done
   return 1
-}
-
-# Find the previous non-switch word
-__brewcomp_prev() {
-  local idx="$((COMP_CWORD - 1))"
-  local prv="${COMP_WORDS[idx]}"
-  while [[ "${prv}" = -* ]]
-  do
-    (( idx-- ))
-    prv="${COMP_WORDS[idx]}"
-  done
-  echo "${prv}"
 }
 
 __brewcomp() {
   # break $1 on space, tab, and newline characters,
   # and turn it into a newline separated list of words
   local list s sep=$'\n' IFS=$' \t\n'
-  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local cur=${COMP_WORDS[COMP_CWORD]}
 
   for s in $1
   do
-    __brewcomp_words_include "${s}" && continue
-    list="${list}${s}${sep}"
+    __brewcomp_words_include "${s}" || list+="${s}${sep}"
   done
+
+  list=${list%"${sep}"}
 
   IFS="${sep}"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${list}" -- "${cur}")

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1,41 +1,27 @@
 # Bash completion script for brew(1)
 
 __brewcomp_words_include() {
-  local i=1
-  while [[ "${i}" -lt "${COMP_CWORD}" ]]
+  local element idx 
+  for (( idx = 1; idx < COMP_CWORD; idx++ ))
   do
-    if [[ "${COMP_WORDS[i]}" = "$1" ]]
-    then
-      return 0
-    fi
-    (( i++ ))
+    element=${COMP_WORDS[idx]}
+    [[ -n ${element} && ${element} == "$1" ]] && return 0
   done
   return 1
-}
-
-# Find the previous non-switch word
-__brewcomp_prev() {
-  local idx="$((COMP_CWORD - 1))"
-  local prv="${COMP_WORDS[idx]}"
-  while [[ "${prv}" = -* ]]
-  do
-    (( idx-- ))
-    prv="${COMP_WORDS[idx]}"
-  done
-  echo "${prv}"
 }
 
 __brewcomp() {
   # break $1 on space, tab, and newline characters,
   # and turn it into a newline separated list of words
   local list s sep=$'\n' IFS=$' \t\n'
-  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local cur=${COMP_WORDS[COMP_CWORD]}
 
   for s in $1
   do
-    __brewcomp_words_include "${s}" && continue
-    list="${list}${s}${sep}"
+    __brewcomp_words_include "${s}" || list+="${s}${sep}"
   done
+
+  list=${list%"${sep}"}
 
   IFS="${sep}"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${list}" -- "${cur}")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

* (updated) `__brewcomp_words_include()`: simplified
* (removed) `__brewcomp_prev()`: unused.
* `__brewcomp()`: 
    * changed `list="${list}${s}${sep}"` to `list+="${s}${sep}"` (to speed things up)
    * replaced `&& continue; action` with `|| action`