### PR TITLE
Changes for 4.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,8 @@ jobs:
 
       - name: Run brew audit --skip-style on all taps
         run: brew audit --eval-all --skip-style --except=version --display-failures-only
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
 
       - name: Set up all Homebrew taps
         run: |
@@ -96,6 +98,7 @@ jobs:
           brew tap homebrew/cask-fonts
           brew tap homebrew/cask-versions
           brew tap homebrew/command-not-found
+          brew tap homebrew/core
           brew tap homebrew/formula-analytics
           brew tap homebrew/portable-ruby
           brew tap homebrew/services
@@ -109,6 +112,7 @@ jobs:
         run: brew audit --skip-style --except=version --tap=homebrew/core
         env:
           HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
+          HOMEBREW_NO_INSTALL_FROM_API: 1
 
       - name: Run brew style on official taps
         run: |

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -249,7 +249,7 @@ auto-update() {
 
     if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
     then
-      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
       then
         # 24 hours
         HOMEBREW_AUTO_UPDATE_SECS="86400"

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -24,10 +24,10 @@ module Cask
     attr_accessor :download, :allow_reassignment
 
     def self.all
-      # TODO: uncomment for 3.7.0 and ideally avoid using ARGV by moving to e.g. CLI::Parser
-      # if !ARGV.include?("--eval-all") && !Homebrew::EnvConfig.eval_all?
-      #   odeprecated "Cask::Cask#all without --all or HOMEBREW_EVAL_ALL"
-      # end
+      # TODO: ideally avoid using ARGV by moving to e.g. CLI::Parser
+      if ARGV.exclude?("--eval-all") && !Homebrew::EnvConfig.eval_all?
+        odeprecated "Cask::Cask#all without --all or HOMEBREW_EVAL_ALL"
+      end
 
       Tap.flat_map(&:cask_files).map do |f|
         CaskLoader::FromTapPathLoader.new(f).load(config: nil)

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -84,8 +84,8 @@ module Homebrew
     all = args.eval_all?
     if args.all?
       unless all
-        odeprecated "brew deps --all",
-                    "brew deps --eval-all or HOMEBREW_EVAL_ALL"
+        odisabled "brew deps --all",
+                  "brew deps --eval-all or HOMEBREW_EVAL_ALL"
       end
       all = true
     end

--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -45,7 +45,7 @@ module Homebrew
     args = desc_args.parse
 
     if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
-      odeprecated "brew desc", "brew desc --eval-all or HOMEBREW_EVAL_ALL"
+      odisabled "brew desc", "brew desc --eval-all or HOMEBREW_EVAL_ALL"
     end
 
     search_type = if args.search?

--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -14,7 +14,6 @@ homebrew-formulae() {
   # HOMEBREW_CACHE is set by brew.sh
   # shellcheck disable=SC2154
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
-        -n "${HOMEBREW_INSTALL_FROM_API}" &&
         -f "${HOMEBREW_CACHE}/api/formula.json" ]]
   then
     local api_formulae

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -110,7 +110,7 @@ module Homebrew
     elsif args.json
       all = args.eval_all?
       if !all && args.all? && !Homebrew::EnvConfig.eval_all?
-        odeprecated "brew info --all", "brew info --eval-all or HOMEBREW_EVAL_ALL"
+        odisabled "brew info --all", "brew info --eval-all or HOMEBREW_EVAL_ALL"
         all = true
       end
 

--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -38,7 +38,7 @@ module Homebrew
 
     all = args.eval_all?
     if args.all?
-      odeprecated "brew info --all", "brew info --eval-all" if !all && !Homebrew::EnvConfig.eval_all?
+      odisabled "brew info --all", "brew info --eval-all" if !all && !Homebrew::EnvConfig.eval_all?
       all = true
     end
 

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -46,7 +46,7 @@ module Homebrew
     options = { aliases: args.aliases?, no_simulate: args.no_simulate? }
     taps = if args.no_named?
       if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
-        odeprecated "brew readall", "brew readall --eval-all or HOMEBREW_EVAL_ALL"
+        odisabled "brew readall", "brew readall --eval-all or HOMEBREW_EVAL_ALL"
       end
       Tap
     else

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -78,7 +78,7 @@ module Homebrew
 
     if args.desc?
       if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
-        odeprecated "brew search --desc", "brew search --desc --eval-all or HOMEBREW_EVAL_ALL"
+        odisabled "brew search --desc", "brew search --desc --eval-all or HOMEBREW_EVAL_ALL"
       end
       Search.search_descriptions(string_or_regex, args)
     elsif args.pull_request?

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -386,7 +386,7 @@ EOS
   fi
 
   if [[ -d "${HOMEBREW_CORE_REPOSITORY}" ]] ||
-     [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+     [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
     HOMEBREW_CORE_AVAILABLE="1"
   fi
@@ -566,8 +566,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
-       [[ -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
+    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" || "${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" ]]
     then
       continue
@@ -726,7 +725,7 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]] &&
+    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]] &&
        [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ||
           "${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" ]]
@@ -768,7 +767,7 @@ EOS
     fi
   done
 
-  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_INSTALL_FROM_API}" ]]
+  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
     mkdir -p "${HOMEBREW_CACHE}/api"
 

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -109,14 +109,14 @@ module Homebrew
       all = args.eval_all?
       if args.all?
         unless all
-          odeprecated "brew uses --all",
-                      "brew uses --eval-all or HOMEBREW_EVAL_ALL"
+          odisabled "brew uses --all",
+                    "brew uses --eval-all or HOMEBREW_EVAL_ALL"
         end
         all = true
       end
 
       if !args.installed? && !(all || Homebrew::EnvConfig.eval_all?)
-        odeprecated "brew uses", "brew uses --eval-all or HOMEBREW_EVAL_ALL"
+        odisabled "brew uses", "brew uses --eval-all or HOMEBREW_EVAL_ALL"
       end
       if show_formulae_and_casks || args.formula?
         deps += args.installed? ? Formula.installed : Formula.all

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -134,17 +134,16 @@ module Homebrew
       [Formula.installed, Cask::Caskroom.casks]
     elsif args.no_named?
       if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
-        odeprecated "brew audit",
-                    "brew audit --eval-all or HOMEBREW_EVAL_ALL"
+        odisabled "brew audit",
+                  "brew audit --eval-all or HOMEBREW_EVAL_ALL"
       end
       no_named_args = true
       [Formula.all, Cask::Cask.all]
     else
-      # TODO: Add deprecation
-      # if args.named.any? { |named_arg| named_arg.end_with?(".rb") }
-      #   odeprecated "brew audit [path ...]",
-      #               "brew audit [name ...]"
-      # end
+      if args.named.any? { |named_arg| named_arg.end_with?(".rb") }
+        odeprecated "brew audit [path ...]",
+                    "brew audit [name ...]"
+      end
 
       args.named.to_formulae_and_casks
           .partition { |formula_or_cask| formula_or_cask.is_a?(Formula) }

--- a/Library/Homebrew/dev-cmd/generate-man-completions.rb
+++ b/Library/Homebrew/dev-cmd/generate-man-completions.rb
@@ -30,7 +30,7 @@ module Homebrew
   def generate_man_completions
     args = generate_man_completions_args.parse
 
-    odeprecated "brew generate-man-completions --fail-if-not-changed" if args.fail_if_not_changed?
+    odisabled "brew generate-man-completions --fail-if-not-changed" if args.fail_if_not_changed?
 
     Commands.rebuild_internal_commands_completion_list
     Manpages.regenerate_man_pages(quiet: args.quiet?)

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -59,7 +59,7 @@ module Homebrew
 
     all = args.eval_all?
     if args.all?
-      odeprecated "brew livecheck --all", "brew livecheck --eval-all" if !all && !Homebrew::EnvConfig.eval_all?
+      odisabled "brew livecheck --all", "brew livecheck --eval-all" if !all && !Homebrew::EnvConfig.eval_all?
       all = true
     end
 

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -225,6 +225,9 @@ module Homebrew
     ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
     ENV["HOMEBREW_SORBET_RUNTIME"] = "1"
 
+    # TODO: remove this and fix tests when possible.
+    ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+
     ENV["USER"] ||= system_command!("id", args: ["-nu"]).stdout.chomp
 
     # Avoid local configuration messing with tests, e.g. git being configured

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -51,7 +51,7 @@ module Homebrew
 
     HOMEBREW_LIBRARY_PATH.cd do
       if args.update? || args.update_all?
-        odeprecated "brew typecheck --update --fail-if-not-changed" if args.fail_if_not_changed?
+        odisabled "brew typecheck --update --fail-if-not-changed" if args.fail_if_not_changed?
 
         excluded_gems = [
           "did_you_mean", # RBI file is already provided by Sorbet

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -56,7 +56,7 @@ module Homebrew
     all = args.eval_all?
     if args.total?
       if !all && !Homebrew::EnvConfig.eval_all?
-        odeprecated "brew unbottled --total", "brew unbottled --total --eval-all or HOMEBREW_EVAL_ALL"
+        odisabled "brew unbottled --total", "brew unbottled --total --eval-all or HOMEBREW_EVAL_ALL"
       end
       all = true
     end
@@ -100,7 +100,7 @@ module Homebrew
       formulae = all_formulae = args.named.to_formulae
     elsif args.dependents?
       if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
-        odeprecated "brew unbottled --dependents", "brew unbottled --all --dependents or HOMEBREW_EVAL_ALL"
+        odisabled "brew unbottled --dependents", "brew unbottled --all --dependents or HOMEBREW_EVAL_ALL"
       end
       formulae = all_formulae = Formula.all
 

--- a/Library/Homebrew/dev-cmd/update-license-data.rb
+++ b/Library/Homebrew/dev-cmd/update-license-data.rb
@@ -28,7 +28,7 @@ module Homebrew
 
   def update_license_data
     args = update_license_data_args.parse
-    odeprecated "brew update-license-data --fail-if-not-changed" if args.fail_if_not_changed?
+    odisabled "brew update-license-data --fail-if-not-changed" if args.fail_if_not_changed?
 
     SPDX.download_latest_license_data!
     diff = system_command "git", args: [

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -41,7 +41,7 @@ module Homebrew
         description:  "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
                       "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
                       "disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.",
-        default_text: "300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set.",
+        default_text: "86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API is set.",
       },
       HOMEBREW_AUTOREMOVE:                       {
         description: "If set, calls to `brew cleanup` and `brew uninstall` will automatically " \
@@ -231,13 +231,6 @@ module Homebrew
         default_text: 'The "Beer Mug" emoji.',
         default:      "🍺",
       },
-      HOMEBREW_INSTALL_FROM_API:                 {
-        description: "If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's " \
-                     "API instead of needing (large, slow) local checkouts of these repositories. Note, this will " \
-                     "only take effect in supported configurations (i.e. using the default Homebrew prefix and, " \
-                     "if on macOS, on a supported version).",
-        boolean:     true,
-      },
       HOMEBREW_LIVECHECK_WATCHLIST:              {
         description:  "Consult this file for the list of formulae to check by default when no formula argument " \
                       "is passed to `brew livecheck`.",
@@ -321,8 +314,7 @@ module Homebrew
       },
       HOMEBREW_NO_INSTALL_FROM_API:              {
         description: "If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using " \
-                     "Homebrew's API even if `HOMEBREW_INSTALL_FROM_API` is set and instead use (large, slow) " \
-                     "local checkouts of these repositories.",
+                     "Homebrew's API and instead use (large, slow) local checkouts of these repositories.",
         boolean:     true,
       },
       HOMEBREW_NO_INSTALL_UPGRADE:               {
@@ -496,7 +488,7 @@ module Homebrew
       return false if OS.unsupported_configuration?
       return false unless Homebrew.default_prefix?
 
-      ENV["HOMEBREW_NO_INSTALL_FROM_API"].blank? && ENV["HOMEBREW_INSTALL_FROM_API"].present?
+      ENV["HOMEBREW_NO_INSTALL_FROM_API"].blank?
     end
   end
 end

--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -14,7 +14,6 @@ class LinkageChecker
     libdl.so.2
     libm.so.6
     libmvec.so.1
-    libnsl.so.1
     libnss_files.so.2
     libpthread.so.0
     libresolv.so.2
@@ -41,13 +40,9 @@ class LinkageChecker
     # If there's no library deprecated/disabled handling left:
     # - Remove the `display_` overrides here and the associated generic aliases in HOMEBREW_LIBRARY/linkage_checker.rb
 
-    odisabled "linkage to libcrypt.so.1", "libcrypt.so.2 in the libxcrypt formula" if @libcrypt_found
-
     return unless @libnsl_found
 
-    odeprecated "linkage to libnsl.so.1", "libnsl.so.3 in the libnsl formula",
-                disable:                fail_on_libnsl1?(strict: strict),
-                disable_for_developers: false
+    odisabled "linkage to libnsl.so.1", "libnsl.so.3 in the libnsl formula"
   end
 
   def display_normal_output
@@ -61,19 +56,14 @@ class LinkageChecker
   end
 
   def broken_library_linkage?(test: false, strict: false)
-    generic_broken_library_linkage?(test: test, strict: strict) || (fail_on_libnsl1?(strict: strict) && @libnsl_found)
+    generic_broken_library_linkage?(test: test, strict: strict) || @libnsl_found
   end
 
   private
 
-  def fail_on_libnsl1?(strict:)
-    strict || ENV["HOMEBREW_DISALLOW_LIBNSL1"].present?
-  end
-
   def check_dylibs(rebuild_cache:)
     generic_check_dylibs(rebuild_cache: rebuild_cache)
 
-    @libcrypt_found = true if @system_dylibs.any? { |s| File.basename(s) == "libcrypt.so.1" }
     @libnsl_found = true if @system_dylibs.any? { |s| File.basename(s) == "libnsl.so.1" }
 
     # glibc and gcc are implicit dependencies.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1017,8 +1017,7 @@ class Formula
   # The generated launchd {.plist} file path.
   sig { returns(Pathname) }
   def plist_path
-    # TODO: Add deprecation
-    # odeprecated "formula.plist_path", "formula.launchd_service_path"
+    odeprecated "formula.plist_path", "formula.launchd_service_path"
     launchd_service_path
   end
 
@@ -1836,10 +1835,10 @@ class Formula
   # this should only be used when users specify `--all` to a command
   # @private
   def self.all
-    # TODO: uncomment for 3.7.0 and ideally avoid using ARGV by moving to e.g. CLI::Parser
-    # if !ARGV.include?("--eval-all") && !Homebrew::EnvConfig.eval_all?
-    #   odeprecated "Formula#all without --all or HOMEBREW_EVAL_ALL"
-    # end
+    # TODO: ideally avoid using ARGV by moving to e.g. CLI::Parser
+    if ARGV.exclude?("--eval-all") && !Homebrew::EnvConfig.eval_all?
+      odeprecated "Formula#all without --all or HOMEBREW_EVAL_ALL"
+    end
 
     files.map do |file|
       Formulary.factory(file)
@@ -3165,8 +3164,7 @@ class Formula
     #
     # @deprecated Please use {Homebrew::Service.require_root} instead.
     def plist_options(options)
-      # TODO: Deprecate
-      # odeprecated "plist_options", "service.require_root"
+      odeprecated "plist_options", "service.require_root"
       @plist_startup = options[:startup]
       @plist_manual = options[:manual]
     end
@@ -3451,6 +3449,7 @@ class Formula
 
     # Permit links to certain libraries that don't exist. Available on Linux only.
     def ignore_missing_libraries(*libs)
+      odeprecated "ignore_missing_libraries"
       unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
         raise FormulaSpecificationError, "#{__method__} is available on Linux only"
       end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1051,9 +1051,9 @@ class FormulaInstaller
 
     return unless service
 
-    plist_path = formula.plist_path
-    plist_path.atomic_write(service)
-    plist_path.chmod 0644
+    launchd_service_path = formula.launchd_service_path
+    launchd_service_path.atomic_write(service)
+    launchd_service_path.chmod 0644
     log = formula.var/"log"
     log.mkpath if service.include? log.to_s
   rescue Exception => e # rubocop:disable Lint/RescueException

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -131,7 +131,6 @@ module RuboCop
             fails_with
             resource
             patch
-            ignore_missing_libraries
           ]
           on_system_allowed_methods += on_system_methods.map(&:to_s)
           _, offensive_node = check_order(component_precedence_list, on_system_block.body)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -203,11 +203,11 @@ describe FormulaInstaller do
   describe "#install_service" do
     it "works if plist is set" do
       formula = Testball.new
-      path = formula.plist_path
+      path = formula.launchd_service_path
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).twice.and_return("PLIST")
-      expect(formula).to receive(:plist_path).and_call_original
+      expect(formula).to receive(:launchd_service_path).and_call_original
 
       installer = described_class.new(formula)
       expect {
@@ -219,7 +219,7 @@ describe FormulaInstaller do
 
     it "works if service is set" do
       formula = Testball.new
-      plist_path = formula.plist_path
+      launchd_service_path = formula.launchd_service_path
       service_path = formula.systemd_service_path
       service = Homebrew::Service.new(formula)
       formula.opt_prefix.mkpath
@@ -227,7 +227,7 @@ describe FormulaInstaller do
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(true)
       expect(formula).to receive(:service).exactly(5).and_return(service)
-      expect(formula).to receive(:plist_path).and_call_original
+      expect(formula).to receive(:launchd_service_path).and_call_original
       expect(formula).to receive(:systemd_service_path).and_call_original
 
       expect(service).to receive(:timed?).and_return(false)
@@ -240,13 +240,13 @@ describe FormulaInstaller do
         installer.install_service
       }.not_to output(/Error: Failed to install service files/).to_stderr
 
-      expect(plist_path).to exist
+      expect(launchd_service_path).to exist
       expect(service_path).to exist
     end
 
     it "works if timed service is set" do
       formula = Testball.new
-      plist_path = formula.plist_path
+      launchd_service_path = formula.launchd_service_path
       service_path = formula.systemd_service_path
       timer_path = formula.systemd_timer_path
       service = Homebrew::Service.new(formula)
@@ -255,7 +255,7 @@ describe FormulaInstaller do
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(true)
       expect(formula).to receive(:service).exactly(6).and_return(service)
-      expect(formula).to receive(:plist_path).and_call_original
+      expect(formula).to receive(:launchd_service_path).and_call_original
       expect(formula).to receive(:systemd_service_path).and_call_original
       expect(formula).to receive(:systemd_timer_path).and_call_original
 
@@ -270,19 +270,19 @@ describe FormulaInstaller do
         installer.install_service
       }.not_to output(/Error: Failed to install service files/).to_stderr
 
-      expect(plist_path).to exist
+      expect(launchd_service_path).to exist
       expect(service_path).to exist
       expect(timer_path).to exist
     end
 
     it "returns without definition" do
       formula = Testball.new
-      path = formula.plist_path
+      path = formula.launchd_service_path
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(nil)
-      expect(formula).not_to receive(:plist_path)
+      expect(formula).not_to receive(:launchd_service_path)
       expect(formula).not_to receive(:to_systemd_unit)
 
       installer = described_class.new(formula)
@@ -295,13 +295,13 @@ describe FormulaInstaller do
 
     it "errors with duplicate definition" do
       formula = Testball.new
-      path = formula.plist_path
+      path = formula.launchd_service_path
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).and_return("plist")
       expect(formula).to receive(:service?).and_return(true)
       expect(formula).not_to receive(:service)
-      expect(formula).not_to receive(:plist_path)
+      expect(formula).not_to receive(:launchd_service_path)
 
       installer = described_class.new(formula)
       expect {

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1845,54 +1845,6 @@ describe Formula do
     end
   end
 
-  describe "#ignore_missing_libraries" do
-    after do
-      Homebrew::SimulateSystem.clear
-    end
-
-    it "adds library to allowed_missing_libraries on Linux", :needs_linux do
-      Homebrew::SimulateSystem.clear
-      f = formula do
-        url "foo-1.0"
-
-        ignore_missing_libraries "bar.so"
-      end
-      expect(f.class.allowed_missing_libraries.to_a).to eq(["bar.so"])
-    end
-
-    it "adds library to allowed_missing_libraries on macOS when simulating Linux", :needs_macos do
-      Homebrew::SimulateSystem.os = :linux
-      f = formula do
-        url "foo-1.0"
-
-        ignore_missing_libraries "bar.so"
-      end
-      expect(f.class.allowed_missing_libraries.to_a).to eq(["bar.so"])
-    end
-
-    it "raises an error on macOS", :needs_macos do
-      Homebrew::SimulateSystem.clear
-      expect {
-        formula do
-          url "foo-1.0"
-
-          ignore_missing_libraries "bar.so"
-        end
-      }.to raise_error("ignore_missing_libraries is available on Linux only")
-    end
-
-    it "raises an error on Linux when simulating macOS", :needs_linux do
-      Homebrew::SimulateSystem.os = :macos
-      expect {
-        formula do
-          url "foo-1.0"
-
-          ignore_missing_libraries "bar.so"
-        end
-      }.to raise_error("ignore_missing_libraries is available on Linux only")
-    end
-  end
-
   describe "#generate_completions_from_executable" do
     let(:f) do
       Class.new(Testball) do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -398,9 +398,8 @@ module Kernel
   end
 
   # GZips the given paths, and returns the gzipped paths.
-  # TODO: Add deprecation
-  # odeprecated "Utils.gzip" "Utils::Gzip.compress"
   def gzip(*paths)
+    odeprecated "Utils.gzip", "Utils::Gzip.compress"
     Utils::Gzip.compress(*paths)
   end
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -25,16 +25,16 @@ export HOMEBREW_CORE_GIT_REMOTE="..."  # put your Git mirror of Homebrew/homebre
 
 The default Git remote will be used if the corresponding environment variable is unset.
 
-## Skip Tap Cloning (beta)
+## Default Tap Cloning
 
-You can instruct Homebrew to skip cloning the Homebrew/homebrew-core tap during installation by setting the beta `HOMEBREW_INSTALL_FROM_API` environment variable with the following:
+You can instruct Homebrew to return to pre-4.0.0 behaviour by cloning the Homebrew/homebrew-core tap during installation by setting the `HOMEBREW_NO_INSTALL_FROM_API` environment variable with the following:
 
 ```bash
-export HOMEBREW_INSTALL_FROM_API=1
+export HOMEBREW_NO_INSTALL_FROM_API=1
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
-This will make Homebrew install formulae and casks from the `homebrew/core` and `homebrew/cask` taps using Homebrew’s API instead of local checkouts of these repositories.
+This will make Homebrew install formulae and casks from the `homebrew/core` and `homebrew/cask` taps using local checkouts of these repositories instead of Homebrew’s API.
 
 Note, this will take effect in supported configurations (i.e. using the default Homebrew prefix and, if on macOS, on a supported version).
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1998,7 +1998,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_AUTO_UPDATE_SECS`
   <br>Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.
 
-  *Default:* 300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set.
+  *Default:* 86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API is set.
 
 - `HOMEBREW_AUTOREMOVE`
   <br>If set, calls to `brew cleanup` and `brew uninstall` will automatically remove unused formula dependents and if HOMEBREW_NO_INSTALL_CLEANUP is not set, `brew cleanup` will start running `brew autoremove` periodically.
@@ -2153,9 +2153,6 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
   *Default:* The "Beer Mug" emoji.
 
-- `HOMEBREW_INSTALL_FROM_API`
-  <br>If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API instead of needing (large, slow) local checkouts of these repositories. Note, this will only take effect in supported configurations (i.e. using the default Homebrew prefix and, if on macOS, on a supported version).
-
 - `HOMEBREW_LIVECHECK_WATCHLIST`
   <br>Consult this file for the list of formulae to check by default when no formula argument is passed to `brew livecheck`.
 
@@ -2212,7 +2209,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set, `brew install`, `brew upgrade` and `brew reinstall` will never automatically cleanup installed/upgraded/reinstalled formulae or all formulae every `HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS` days. Alternatively, HOMEBREW_NO_CLEANUP_FORMULAE allows specifying specific formulae to not clean up.
 
 - `HOMEBREW_NO_INSTALL_FROM_API`
-  <br>If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API even if `HOMEBREW_INSTALL_FROM_API` is set and instead use (large, slow) local checkouts of these repositories.
+  <br>If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew's API and instead use (large, slow) local checkouts of these repositories.
 
 - `HOMEBREW_NO_INSTALL_UPGRADE`
   <br>If set, `brew install *`formula`*` will not upgrade `*`formula`*` if it is installed but outdated.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2855,7 +2855,7 @@ Prefix all download URLs, including those for bottles, with this value\. For exa
 Run \fBbrew update\fR once every \fBHOMEBREW_AUTO_UPDATE_SECS\fR seconds before some commands, e\.g\. \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew tap\fR\. Alternatively, disable auto\-update entirely with HOMEBREW_NO_AUTO_UPDATE\.
 .
 .IP
-\fIDefault:\fR 300 (5 minutes) or 86400 (24 hours) if HOMEBREW_INSTALL_FROM_API is set\.
+\fIDefault:\fR 86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API is set\.
 .
 .TP
 \fBHOMEBREW_AUTOREMOVE\fR
@@ -3146,12 +3146,6 @@ Print this text before the installation summary of each successful build\.
 \fIDefault:\fR The "Beer Mug" emoji\.
 .
 .TP
-\fBHOMEBREW_INSTALL_FROM_API\fR
-.
-.br
-If set, install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API instead of needing (large, slow) local checkouts of these repositories\. Note, this will only take effect in supported configurations (i\.e\. using the default Homebrew prefix and, if on macOS, on a supported version)\.
-.
-.TP
 \fBHOMEBREW_LIVECHECK_WATCHLIST\fR
 .
 .br
@@ -3260,7 +3254,7 @@ If set, \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew reinstall\fR will nev
 \fBHOMEBREW_NO_INSTALL_FROM_API\fR
 .
 .br
-If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API even if \fBHOMEBREW_INSTALL_FROM_API\fR is set and instead use (large, slow) local checkouts of these repositories\.
+If set, do not install formulae and casks in homebrew/core and homebrew/cask taps using Homebrew\'s API and instead use (large, slow) local checkouts of these repositories\.
 .
 .TP
 \fBHOMEBREW_NO_INSTALL_UPGRADE\fR


### PR DESCRIPTION
When we're ready for the next branch to be 4.0.0:
- re-enable `HOMEBREW_INSTALL_FROM_API` as the default
- re-apply the deprecations