### PR TITLE
Tweak `version :latest` docs.

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -705,11 +705,12 @@ Every `livecheck` block must contain a `url`, which can be either a string or a 
 
 Additionally, a `livecheck` should specify which `strategy` should be used to extract the version:
 
-| `strategy`      | description |
-|---------------- | ----------- |
-| `:header_match` | extract version from HTTP headers (e.g. `Location` or `Content-Disposition`)
-| `:page_match`   | extract version from page contents
-| `:sparkle`      | extract version from Sparkle appcast contents
+| `strategy`       | description |
+|----------------- | ----------- |
+| `:header_match`  | extract version from HTTP headers (e.g. `Location` or `Content-Disposition`)
+| `:page_match`    | extract version from page contents
+| `:sparkle`       | extract version from Sparkle appcast contents
+| `:extract_plist` | extract version from a `.plist` in the downloaded artifact
 
 Here is a basic example, extracting a simple version from a page:
 
@@ -1210,42 +1211,33 @@ This is possible by returning a two-element array as a block result. The first e
 
 `version`, while related to the app’s own versioning, doesn’t have to follow it exactly. It is common to change it slightly so it can be [interpolated](https://en.wikipedia.org/wiki/String_interpolation#Ruby_/_Crystal) in other stanzas, usually in `url` to create a cask that only needs `version` and `sha256` changes when updated. This can be taken further, when needed, with [Ruby String methods](https://ruby-doc.org/core/String.html).
 
-For example, instead of:
+For example, instead of
 
 ```ruby
 version "1.2.3"
 url "https://example.com/file-version-123.dmg"
 ```
 
-we can use:
+we can use
 
 ```ruby
 version "1.2.3"
 url "https://example.com/file-version-#{version.delete('.')}.dmg"
 ```
 
-We can also leverage the power of regular expressions. So instead of:
+We can also leverage the power of regular expressions. So instead of
 
 ```ruby
 version "1.2.3build4"
 url "https://example.com/1.2.3/file-version-1.2.3build4.dmg"
 ```
 
-we can use:
+we can use
 
 ```ruby
 version "1.2.3build4"
 url "https://example.com/#{version.sub(%r{build\d+}, '')}/file-version-#{version}.dmg"
 ```
-
-#### `version :latest`
-
-The special value `:latest` is used in casks for which either:
-
-1. `url` doesn’t contain a version, or
-2. having a correct value for `version` is too difficult or impractical, even with our automated systems.
-
-Example: [chromium.rb](https://github.com/Homebrew/homebrew-cask/blob/f3e9de24ba57d7b1d949132504e581759725d0c5/Casks/chromium.rb#L4)
 
 #### `version` Methods
 
@@ -1267,6 +1259,16 @@ The examples above can become hard to read, however. Since many of these changes
 Similar to `dots_to_hyphens`, we provide methods for all logical permutations of `{dots,hyphens,underscores}_to_{dots,hyphens,underscores}`. The same applies to `no_dots` in the form of `no_{dots,hyphens,underscores}`, with an extra `no_dividers` that applies all these at once.
 
 Finally, there is `csv` which returns an array of comma-separated values. `csv`, `before_comma` and `after_comma` are extra-special to allow for otherwise complex cases, and should be used sparingly. There should be no more than two of `,` per `version`.
+
+#### `version :latest`
+
+The special value `:latest` is used when
+
+* `url` does not contain any version information and there is no way to retrieve
+  the version using a `livecheck`, or
+* having a correct value for `version` is too difficult or impractical, even with our automated systems. For example,
+  [chromium.rb](https://github.com/Homebrew/homebrew-cask/blob/f3e9de24ba57d7b1d949132504e581759725d0c5/Casks/chromium.rb#L4)
+  releases multiple versions a day.
 
 ### Stanza: `zap`
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`version :latest` should only be used If the `url` is unversioned and there is no way to add a `livecheck`. If the `url` is unversioned and a `livecheck` is possible, a cask should still always versioned.

Also added the `:extract_plist` strategy since this is preferable to not having a version.