### PR TITLE
dependency_collector: skip macOS-only requirements on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -9,6 +9,7 @@ class DependencyCollector
   undef gcc_dep_if_needed
   undef glibc_dep_if_needed
   undef init_global_dep_tree_if_needed!
+  undef parse_symbol_spec
 
   sig { params(related_formula_names: T::Set[String]).returns(T.nilable(Dependency)) }
   def gcc_dep_if_needed(related_formula_names)
@@ -31,6 +32,18 @@ class DependencyCollector
     return unless formula_for(GLIBC)
 
     Dependency.new(GLIBC)
+  end
+
+  def parse_symbol_spec(spec, tags)
+    case spec
+    when :arch                  then ArchRequirement.new(tags)
+    when :codesign              then CodesignRequirement.new(tags)
+    when :linux                 then LinuxRequirement.new(tags)
+    when :macos                 then MacOSRequirement.new(tags) if tags.empty?
+    when :maximum_macos, :xcode then nil
+    else
+      raise ArgumentError, "Unsupported special dependency #{spec.inspect}"
+    end
   end
 
   private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Concept idea for hiding macOS-specific requirements on Linux.

Before and after examples

---

tcc

```
==> Requirements
Required: macOS ✔
```
```
```

---

gcc@5
```
==> Requirements
Build: macOS ✔
```
```
```

---

root
```
==> Requirements
Required: Xcode ✔
```
```
```

---

fmdiff
```
==> Requirements
Required: macOS ✘, Xcode ✔
```
```
==> Requirements
Required: macOS ✘
```

---

tart
```
==> Requirements
Build: Xcode >= 14.1 ✔
Required: arm64 architecture ✔, macOS ✔, macOS ✘
```
```
==> Requirements
Required: arm64 architecture ✔, macOS ✘
```

---

sbjson
```
==> Requirements
Build: Xcode ✔
Required: macOS ✘
```
```
==> Requirements
Required: macOS ✘
```
