### PR TITLE
export `HOMEBREW_API_MAX_TIME` for JSON API

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -19,9 +19,6 @@ module Homebrew
 
     HOMEBREW_CACHE_API = (HOMEBREW_CACHE/"api").freeze
 
-    # Set a longer timeout just for large(r) files.
-    JSON_API_MAX_TIME = 10
-
     sig { params(endpoint: String).returns(Hash) }
     def fetch(endpoint)
       return cache[endpoint] if cache.present? && cache.key?(endpoint)
@@ -52,7 +49,7 @@ module Homebrew
         begin
           # Disable retries here, we handle them ourselves below.
           Utils::Curl.curl_download(*curl_args, url, to: target,
-                                    max_time: JSON_API_MAX_TIME, retries: 0,
+                                    max_time: Homebrew::EnvConfig.api_max_time.to_i, retries: 0,
                                     show_error: false)
         rescue ErrorDuringExecution
           if url == default_url

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -787,7 +787,7 @@ EOS
       do
         curl \
           "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-          --fail --compressed --silent --max-time 10 \
+          --fail --compressed --silent --max-time "${HOMEBREW_API_MAX_TIME}" \
           --location --remote-time --output "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
           --time-cond "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
           --user-agent "${HOMEBREW_USER_AGENT_CURL}" \

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -24,7 +24,7 @@ module Homebrew
       },
       HOMEBREW_API_MAX_TIME:                     {
         description: "Maximum time (seconds) allowed for Homebrew JSON API.",
-        default:     10,
+        default:     30,
       },
       HOMEBREW_ARCH:                             {
         description: "Linux only: Pass this value to a type name representing the compiler's `-march` option.",

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -22,6 +22,10 @@ module Homebrew
         default_text: "`https://formulae.brew.sh/api`.",
         default:      HOMEBREW_API_DEFAULT_DOMAIN,
       },
+      HOMEBREW_API_MAX_TIME:                     {
+        description: "Maximum time (seconds) allowed for Homebrew JSON API.",
+        default:     10,
+      },
       HOMEBREW_ARCH:                             {
         description: "Linux only: Pass this value to a type name representing the compiler's `-march` option.",
         default:     "native",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1990,7 +1990,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_API_MAX_TIME`
   <br>Maximum time (seconds) allowed for Homebrew JSON API.
 
-  *Default:* `10`.
+  *Default:* `30`.
 
 - `HOMEBREW_ARCH`
   <br>Linux only: Pass this value to a type name representing the compiler's `-march` option.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -352,7 +352,7 @@ is already installed but outdated.
 * `--keep-tmp`:
   Retain the temporary files created during installation.
 * `--debug-symbols`:
-  Generate debug symbols on build. Source will be retained in a cache directory. 
+  Generate debug symbols on build. Source will be retained in a cache directory.
 * `--build-bottle`:
   Prepare the formula for eventual bottling during installation, skipping any post-install steps.
 * `--bottle-arch`:
@@ -561,7 +561,7 @@ reinstalled formulae or, every 30 days, for all formulae.
 * `--keep-tmp`:
   Retain the temporary files created during installation.
 * `--debug-symbols`:
-  Generate debug symbols on build. Source will be retained in a cache directory. 
+  Generate debug symbols on build. Source will be retained in a cache directory.
 * `--display-times`:
   Print install times for each formula at the end of the run.
 * `-g`, `--git`:
@@ -753,7 +753,7 @@ upgraded formulae or, every 30 days, for all formulae.
 * `--keep-tmp`:
   Retain the temporary files created during installation.
 * `--debug-symbols`:
-  Generate debug symbols on build. Source will be retained in a cache directory. 
+  Generate debug symbols on build. Source will be retained in a cache directory.
 * `--display-times`:
   Print install times for each package at the end of the run.
 * `--cask`:
@@ -1986,6 +1986,11 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>Use this URL as the download mirror for Homebrew JSON API. If metadata files at that URL are temporarily unavailable, the default API domain will be used as a fallback mirror.
 
   *Default:* `https://formulae.brew.sh/api`.
+
+- `HOMEBREW_API_MAX_TIME`
+  <br>Maximum time (seconds) allowed for Homebrew JSON API.
+
+  *Default:* `10`.
 
 - `HOMEBREW_ARCH`
   <br>Linux only: Pass this value to a type name representing the compiler's `-march` option.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2834,6 +2834,15 @@ Use this URL as the download mirror for Homebrew JSON API\. If metadata files at
 \fIDefault:\fR \fBhttps://formulae\.brew\.sh/api\fR\.
 .
 .TP
+\fBHOMEBREW_API_MAX_TIME\fR
+.
+.br
+Maximum time (seconds) allowed for Homebrew JSON API.\.
+.
+.IP
+\fIDefault:\fR \fB10\fR\.
+.
+.TP
 \fBHOMEBREW_ARCH\fR
 .
 .br
@@ -3463,4 +3472,3 @@ See our issues on GitHub:
 .
 .br
 \fIhttps://github\.com/Homebrew/homebrew\-cask/issues\fR
-

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2840,7 +2840,7 @@ Use this URL as the download mirror for Homebrew JSON API\. If metadata files at
 Maximum time (seconds) allowed for Homebrew JSON API.\.
 .
 .IP
-\fIDefault:\fR \fB10\fR\.
+\fIDefault:\fR \fB30\fR\.
 .
 .TP
 \fBHOMEBREW_ARCH\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#14516 may be caused by a slow network because the `curl` timeout is too short (10 seconds for 19M Bytes).

This PR export a new `HOMEBREW_API_MAX_TIME` to set the `curl --max-time` parameter, I guess it would be better to set the timeout to 30 or 60 seconds