### PR TITLE
increase `JSON_API_MAX_TIME`

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -20,7 +20,7 @@ module Homebrew
     HOMEBREW_CACHE_API = (HOMEBREW_CACHE/"api").freeze
 
     # Set a longer timeout just for large(r) files.
-    JSON_API_MAX_TIME = 10
+    JSON_API_MAX_TIME = 30
 
     sig { params(endpoint: String).returns(Hash) }
     def fetch(endpoint)

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -787,7 +787,7 @@ EOS
       do
         curl \
           "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-          --fail --compressed --silent --max-time 10 \
+          --fail --compressed --silent --max-time 30 \
           --location --remote-time --output "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
           --time-cond "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
           --user-agent "${HOMEBREW_USER_AGENT_CURL}" \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#14516 may be caused by a slow network because the curl timeout is too short (10 seconds for 19M Bytes).

This PR export increase the JSON_API_MAX_TIME to 30 seconds, instead of #14566