### PR TITLE
Ignore livecheckable casks in `bump-unversioned-casks`.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -46,7 +46,7 @@ module Homebrew
 
     casks = args.named.to_paths(only: :cask, recurse_tap: true).map { |path| Cask::CaskLoader.load(path) }
 
-    unversioned_casks = casks.select { |cask| cask.url&.unversioned? }
+    unversioned_casks = casks.select { |cask| cask.url&.unversioned? && !cask.livecheckable? }
 
     ohai "Unversioned Casks: #{unversioned_casks.count} (#{state.size} cached)"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Once all casks have a `livecheck`, this command can be removed completely.

Most casks which are processed by this command currently can use the `:extract_plist` strategy instead.