### PR TITLE
Update documentation for `brew install` and FAQ regarding `HOMEBREW_NO_INSTALL_FROM_API`

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -78,6 +78,19 @@ module Homebrew
       end.presence
     end
 
+    if Homebrew::EnvConfig.automatically_set_no_install_from_api? &&
+       !Homebrew::EnvConfig.no_env_hints?
+      paths.each do |path|
+        next if !path.fnmatch?("**/homebrew-core/Formula/*.rb") && !path.fnmatch?("**/homebrew-cask/Casks/*.rb")
+
+        opoo <<~EOS
+          Unless `HOMEBREW_NO_INSTALL_FROM_API` is set when running
+          `brew install`, it will ignore your locally edited formula.
+        EOS
+        break
+      end
+    end
+
     if args.print_path?
       paths.each(&method(:puts))
       return

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -13,7 +13,7 @@ describe "brew edit" do
 
     setup_test_formula "testball"
 
-    expect { brew "edit", "testball", "HOMEBREW_EDITOR" => "/bin/cat" }
+    expect { brew "edit", "testball", "HOMEBREW_EDITOR" => "/bin/cat", "HOMEBREW_NO_ENV_HINTS" => "1" }
       .to output(/# something here/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -142,6 +142,8 @@ If all maintainer feedback has been addressed and all tests are passing, bump it
 
 Yes! It’s easy! Just `brew edit <formula>`. You don’t have to submit modifications back to `homebrew/core`, just edit the formula to what you personally need and `brew install <formula>`. As a bonus, `brew update` will merge your changes with upstream so you can still keep the formula up-to-date **with** your personal modifications!
 
+Note that if you are editing a core formula or cask you must set `HOMEBREW_NO_INSTALL_WITH_API=1` before using `brew install` or `brew update` otherwise they will ignore your local changes and default to the API.
+
 ## Can I make new formulae?
 
 Yes! It’s easy! Just `brew create URL`. Homebrew will then open the formula in `EDITOR` so you can edit it, but it probably already installs; try it: `brew install <formula>`. If you encounter any issues, run the command with the `--debug` switch like so: `brew install --debug <formula>`, which drops you into a debugging shell.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I was very confused why `brew install` was seemingly ignoring the changes I did through `brew edit`, only to find out after quite some time that it doesn't use the local git repository/formula anymore unless a flag is provided: [#14473](https://github.com/Homebrew/brew/issues/14473#issuecomment-1411925939)

This PR:
- Adds a line regarding `HOMEBREW_NO_INSTALL_FROM_API` to `brew install` help documentation
- Correct a (now misleading) FAQ entry on how to edit a formula, adding `HOMEBREW_NO_INSTALL_FROM_API=1` flag to the `brew install` snippet.

