### PR TITLE
Use --speed-time over --max-time for API downloads

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -49,12 +49,13 @@ module Homebrew
       default_url = "#{HOMEBREW_API_DEFAULT_DOMAIN}/#{endpoint}"
       curl_args = %W[--compressed --speed-limit #{JSON_API_SPEED_MARGIN} --speed-time #{JSON_API_SPEED_TIME}]
       curl_args.prepend("--silent") unless Context.current.debug?
-      curl_args.prepend("--time-cond", target) if target.exist? && !target.empty?
 
       begin
         begin
+          args = curl_args.dup
+          args.prepend("--time-cond", target) if target.exist? && !target.empty?
           # Disable retries here, we handle them ourselves below.
-          Utils::Curl.curl_download(*curl_args, url, to: target, retries: 0, show_error: false)
+          Utils::Curl.curl_download(*args, url, to: target, retries: 0, show_error: false)
         rescue ErrorDuringExecution
           if url == default_url
             raise unless target.exist?

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -785,11 +785,16 @@ EOS
       JSON_URLS+=("${HOMEBREW_API_DEFAULT_DOMAIN}/${formula_or_cask}.json")
       for json_url in "${JSON_URLS[@]}"
       do
+        time_cond=()
+        if [[ -s "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" ]]
+        then
+          time_cond=("--time-cond" "${HOMEBREW_CACHE}/api/${formula_or_cask}.json")
+        fi
         curl \
           "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-          --fail --compressed --silent --max-time 30 \
+          --fail --compressed --silent --speed-limit 100 --speed-time 30 \
           --location --remote-time --output "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
-          --time-cond "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
+          "${time_cond[@]}" \
           --user-agent "${HOMEBREW_USER_AGENT_CURL}" \
           "${json_url}"
         curl_exit_code=$?

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -709,13 +709,6 @@ EOS
   wait
   trap - SIGINT
 
-  if [[ -f "${update_failed_file}" ]]
-  then
-    onoe <"${update_failed_file}"
-    rm -f "${update_failed_file}"
-    export HOMEBREW_UPDATE_FAILED="1"
-  fi
-
   if [[ -f "${missing_remote_ref_dirs_file}" ]]
   then
     HOMEBREW_MISSING_REMOTE_REF_DIRS="$(cat "${missing_remote_ref_dirs_file}")"
@@ -811,6 +804,13 @@ EOS
         echo "Failed to download ${formula_or_cask}.json!" >>"${update_failed_file}"
       fi
     done
+  fi
+
+  if [[ -f "${update_failed_file}" ]]
+  then
+    onoe <"${update_failed_file}"
+    rm -f "${update_failed_file}"
+    export HOMEBREW_UPDATE_FAILED="1"
   fi
 
   safe_cd "${HOMEBREW_REPOSITORY}"


### PR DESCRIPTION
Instead of forcefully killing the download after the timeout, only kill it if the speed has been < 100 bytes/s for that time period. This will cover slow connections better.

Some UX improvements very much worth making after this (separate PRs):

* Display progress bar if download is taking a while
* Option to disable the Ruby download (so `brew update` only) so that brew is at least usable on slow/patchy connections.