### PR TITLE
Fix `HOMEBREW_BAT_CONFIG_PATH`

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -55,7 +55,7 @@ module Homebrew
       },
       HOMEBREW_BAT_CONFIG_PATH:                  {
         description:  "Use this as the `bat` configuration file.",
-        default_text: "`$HOME/.config/bat/config`.",
+        default_text: "`$BAT_CONFIG_PATH`.",
       },
       HOMEBREW_BAT_THEME:                        {
         description:  "Use this as the `bat` theme for syntax highlighting.",

--- a/bin/brew
+++ b/bin/brew
@@ -85,7 +85,7 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
-for VAR in BAT_THEME BROWSER DISPLAY EDITOR NO_COLOR TMUX DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR CODESPACES
+for VAR in BAT_CONFIG_PATH BAT_THEME BROWSER DISPLAY EDITOR NO_COLOR TMUX DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR CODESPACES
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR:-}" ]] && continue

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2009,7 +2009,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_BAT_CONFIG_PATH`
   <br>Use this as the `bat` configuration file.
 
-  *Default:* `$HOME/.config/bat/config`.
+  *Default:* `$BAT_CONFIG_PATH`.
 
 - `HOMEBREW_BAT_THEME`
   <br>Use this as the `bat` theme for syntax highlighting.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2876,7 +2876,7 @@ If set, use \fBbat\fR for the \fBbrew cat\fR command\.
 Use this as the \fBbat\fR configuration file\.
 .
 .IP
-\fIDefault:\fR \fB$HOME/\.config/bat/config\fR\.
+\fIDefault:\fR \fB$BAT_CONFIG_PATH\fR\.
 .
 .TP
 \fBHOMEBREW_BAT_THEME\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`HOMEBREW_BAT_CONFIG_PATH` should respect [`BAT_CONFIG_PATH`](https://github.com/sharkdp/bat#configuration-file), in the same way that `HOMEBREW_BAT_THEME` [reflects](https://github.com/Homebrew/brew/pull/13385/files#diff-a8ebbe0466e56bdb9c7ebc74d5ffbd383b8c0902fcb5146cb1960e3d69dadeb1R78) `BAT_THEME`.

Previous, for context:
https://github.com/Homebrew/brew/pull/7488
https://github.com/Homebrew/brew/pull/11975
https://github.com/Homebrew/brew/pull/13385