### PR TITLE
Add `HOMEBREW_DEFER_API_UPDATES`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -266,7 +266,7 @@ auto-update() {
 
     if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
     then
-      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
+      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -z "${HOMEBREW_DEFER_API_UPDATES}" ]]
       then
         # 24 hours
         HOMEBREW_AUTO_UPDATE_SECS="86400"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -785,7 +785,7 @@ EOS
         fi
         curl \
           "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-          --fail --compressed --silent --speed-limit 100 --speed-time 30 \
+          --fail --compressed --silent --speed-limit 100 --speed-time 10 \
           --location --remote-time --output "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
           "${time_cond[@]}" \
           --user-agent "${HOMEBREW_USER_AGENT_CURL}" \

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -41,7 +41,8 @@ module Homebrew
         description:  "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
                       "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
                       "disable auto-update entirely with HOMEBREW_NO_AUTO_UPDATE.",
-        default_text: "86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API is set.",
+        default_text: "86400 (24 hours) or 300 (5 minutes) if HOMEBREW_NO_INSTALL_FROM_API or " \
+                      "HOMEBREW_DEFER_API_UPDATES is set.",
       },
       HOMEBREW_AUTOREMOVE:                       {
         description: "If set, calls to `brew cleanup` and `brew uninstall` will automatically " \
@@ -150,6 +151,10 @@ module Homebrew
       },
       HOMEBREW_DISPLAY_INSTALL_TIMES:            {
         description: "If set, print install times for each formula at the end of the run.",
+        boolean:     true,
+      },
+      HOMEBREW_DEFER_API_UPDATES:                {
+        description: "If set, API data will only be fetched on `brew update`.",
         boolean:     true,
       },
       HOMEBREW_EDITOR:                           {


### PR DESCRIPTION
On slow or patchy internet connections, or areas with poor network links to GitHub, API mode may render `brew` unusable.

In the absense of a mirror, such users are likely to tightly control auto-updates to intervals that is more suitable for their internet connection (e.g. nightly run). Data capped users (1GB mobile plans) may also need to limit activity.

API mode however opens a connection every time, including in commands that previously didn't need online such as `brew uninstall`, local tap work or even a simple `brew --prefix hello` (prefix.sh does not support API-only setups so prefix.rb is used). `brew --prefix <formula>` in particular is something used a lot in build scripts etc, so should be able to work offline and not be super slow, waiting for a timeout to expire.

Currently, the only solution is to disable API mode entirely. This PR adds a middle ground where users can still have the security and speed benefits of API mode without surrendering any form of control over network requests. This will hopefully mean less people suggesting `HOMEBREW_NO_INSTALL_FROM_API` which has become a bit too common sadly (but understandable).

I personally would likely use this while travelling.