### PR TITLE
formula_auditor: allow references to closed PRs

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -829,7 +829,9 @@ module Homebrew
         next if "#{owner}/#{repo}" == formula.tap.remote_repo || owner == "Homebrew"
 
         issue = GitHub::API.open_rest("https://api.github.com/repos/#{owner}/#{repo}/issues/#{id}")
-        next if issue.blank? || issue["state"] == "open"
+        next if issue.blank?
+        next if issue["pull_request"].present?
+        next if issue["state"] == "open"
 
         issue_url = "https://github.com/#{owner}/#{repo}/#{type}/#{id}"
         problem "Formula refers to a GitHub issue or pull request that is closed: #{issue_url}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `github_issue_comment` audit disallows references to closed or
merged PRs in other repositories. We should allow those, since it is a
common pattern to reference merged PRs in formulae when adding comments
that explain changes that need to be made in future versions (e.g.
`patch` blocks).
