### PR TITLE
dev-cmd/cat: accept multiple formula/cask arguments

### DIFF
--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -22,7 +22,7 @@ module Homebrew
 
       conflicts "--formula", "--cask"
 
-      named_args [:formula, :cask], number: 1
+      named_args [:formula, :cask], min: 1
     end
   end
 
@@ -44,6 +44,6 @@ module Homebrew
       "cat"
     end
 
-    safe_system pager, args.named.to_paths.first
+    safe_system pager, *args.named.to_paths
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

"cat" is short for "concatenate" (and not "dump to stdout"), so it seems
a little silly for `brew cat` to not be able to concatenate
formulae/casks.

Let's fix that.
