### PR TITLE
fix(utils/github): failure with fine-granted api tokens

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -488,10 +488,10 @@ module GitHub
 
   def fetch_pull_requests(name, tap_remote_repo, state: nil, version: nil)
     if version.present?
-      query = "#{name} #{version}"
+      query = "#{name} #{version} is:pr"
       regex = /(^|\s)#{Regexp.quote(name)}(:|,|\s)(.*\s)?#{Regexp.quote(version)}(:|,|\s|$)/i
     else
-      query = name
+      query = "#{name} is:pr"
       regex = /(^|\s)#{Regexp.quote(name)}(:|,|\s|$)/i
     end
     issues_for_formula(query, tap_remote_repo: tap_remote_repo, state: state).select do |pr|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #14582

With fine-granted PATs, we cannot search both PRs and issues so I fix fetch_pull_requests to search only pullrequests.

I confirmed #14582 is fixed. `brew bump-formula-pr anatawa12/core/vrc-get --url https://github.com/anatawa12/vrc-get/archive/0.1.7.tar.gz --no-fork --force` works well in my env.

I think it's impossible to write tests without PATs. How should I write tests?

-----

brew tests failires:
```
Failures:

  1) pkg-config returns the correct version for libcurl
     Failure/Error: expect(pc_version("libcurl")).to eq(version)

       expected: "7.85.0"
            got: "7.84.0"

       (compared using ==)
     # ./test/os/mac/pkgconfig_spec.rb:54:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:232:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:231:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'

  2) pkg-config returns the correct version for sqlite3
     Failure/Error: expect(pc_version("sqlite3")).to eq(version)

       expected: "3.39.5"
            got: "3.39.4"

       (compared using ==)
     # ./test/os/mac/pkgconfig_spec.rb:116:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:232:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:231:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'

Finished in 28.57 seconds (files took 2.11 seconds to load)
317 examples, 2 failures

Failed examples:

rspec ./test/os/mac/pkgconfig_spec.rb:48 # pkg-config returns the correct version for libcurl
rspec ./test/os/mac/pkgconfig_spec.rb:110 # pkg-config returns the correct version for sqlite3

```