### PR TITLE
Allow `brew info --json=v2` without taps with JSON API

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -108,5 +108,16 @@ module Homebrew
 
       cache[endpoint] = output.stdout
     end
+
+    sig { params(json: Hash).returns(Hash) }
+    def merge_variations(json)
+      if (bottle_tag = ::Utils::Bottles.tag.to_s.presence) &&
+         (variations = json["variations"].presence) &&
+         (variation = variations[bottle_tag].presence)
+        json = json.merge(variation)
+      end
+
+      json.except("variations")
+    end
   end
 end

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -231,6 +231,11 @@ module Cask
     alias == eql?
 
     def to_h
+      if loaded_from_api && Homebrew::EnvConfig.install_from_api?
+        json_cask = Homebrew::API::Cask.all_casks[token]
+        return Homebrew::API.merge_variations(json_cask)
+      end
+
       {
         "token"          => token,
         "full_token"     => full_name,
@@ -257,6 +262,8 @@ module Cask
     end
 
     def to_hash_with_variations
+      return Homebrew::API::Cask.all_casks[token] if loaded_from_api && Homebrew::EnvConfig.install_from_api?
+
       hash = to_h
       variations = {}
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -228,13 +228,7 @@ module Cask
         json_cask = @from_json || Homebrew::API::Cask.all_casks[token]
         cask_source = JSON.pretty_generate(json_cask)
 
-        if (bottle_tag = ::Utils::Bottles.tag.to_s.presence) &&
-           (variations = json_cask["variations"].presence) &&
-           (variation = variations[bottle_tag].presence)
-          json_cask = json_cask.merge(variation)
-        end
-
-        json_cask.deep_symbolize_keys!
+        json_cask = Homebrew::API.merge_variations(json_cask).deep_symbolize_keys
 
         # Use the cask-source API if there are any `*flight` blocks or the cask has multiple languages
         if json_cask[:artifacts].any? { |artifact| FLIGHT_STANZAS.include?(artifact.keys.first) } ||

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -135,12 +135,7 @@ module Formulary
 
     class_s = Formulary.class_s(name)
     json_formula = Homebrew::API::Formula.all_formulae[name]
-
-    if (bottle_tag = Utils::Bottles.tag.to_s.presence) &&
-       (variations = json_formula["variations"].presence) &&
-       (variation = variations[bottle_tag].presence)
-      json_formula = json_formula.merge(variation)
-    end
+    json_formula = Homebrew::API.merge_variations(json_formula)
 
     uses_from_macos_names = json_formula["uses_from_macos"].map do |dep|
       next dep unless dep.is_a? Hash

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -997,25 +997,6 @@ describe Formula do
     end
   end
 
-  specify "#to_recursive_bottle_hash" do
-    f1 = formula "foo" do
-      url "foo-1.0"
-
-      bottle do
-        sha256 cellar: :any, Utils::Bottles.tag.to_sym => TEST_SHA256
-        sha256 cellar: :any, foo:                         TEST_SHA256
-      end
-    end
-
-    h = f1.to_recursive_bottle_hash
-
-    expect(h).to be_a(Hash)
-    expect(h["name"]).to eq "foo"
-    expect(h["bottles"].keys).to eq [Utils::Bottles.tag.to_s, "x86_64_foo"]
-    expect(h["bottles"][Utils::Bottles.tag.to_s].keys).to eq ["url"]
-    expect(h["dependencies"]).to eq []
-  end
-
   describe "#eligible_kegs_for_cleanup" do
     it "returns Kegs eligible for cleanup" do
       f1 = Class.new(Testball) do

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -375,12 +375,12 @@ _brew__s() {
 # brew abv
 _brew_abv() {
   _arguments \
-    '(--bottle)--analytics[List global Homebrew analytics data or, if specified, installation and build error data for formula (provided neither `HOMEBREW_NO_ANALYTICS` nor `HOMEBREW_NO_GITHUB_API` are set)]' \
+    '--analytics[List global Homebrew analytics data or, if specified, installation and build error data for formula (provided neither `HOMEBREW_NO_ANALYTICS` nor `HOMEBREW_NO_GITHUB_API` are set)]' \
     '--category[Which type of analytics data to retrieve. The value for category must be `install`, `install-on-request` or `build-error`; `cask-install` or `os-version` may be specified if formula is not. The default is `install`]' \
     '--days[How many days of analytics data to retrieve. The value for days must be `30`, `90` or `365`. The default is `30`]' \
     '--debug[Display any debugging information]' \
     '(--installed)--eval-all[Evaluate all available formulae and casks, whether installed or not, to print their JSON. Implied if `HOMEBREW_EVAL_ALL` is set]' \
-    '(--bottle)--github[Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask]' \
+    '--github[Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask]' \
     '--help[Show this message]' \
     '(--eval-all --all)--installed[Print JSON of formulae that are currently installed]' \
     '--json[Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew]' \
@@ -391,7 +391,7 @@ _brew_abv() {
     '(--cask)--formula[Treat all named arguments as formulae]' \
     '*::formula:__brew_formulae' \
     - cask \
-    '(--formula --bottle)--cask[Treat all named arguments as casks]' \
+    '(--formula)--cask[Treat all named arguments as casks]' \
     '*::cask:__brew_casks'
 }
 
@@ -950,12 +950,12 @@ _brew_homepage() {
 # brew info
 _brew_info() {
   _arguments \
-    '(--bottle)--analytics[List global Homebrew analytics data or, if specified, installation and build error data for formula (provided neither `HOMEBREW_NO_ANALYTICS` nor `HOMEBREW_NO_GITHUB_API` are set)]' \
+    '--analytics[List global Homebrew analytics data or, if specified, installation and build error data for formula (provided neither `HOMEBREW_NO_ANALYTICS` nor `HOMEBREW_NO_GITHUB_API` are set)]' \
     '--category[Which type of analytics data to retrieve. The value for category must be `install`, `install-on-request` or `build-error`; `cask-install` or `os-version` may be specified if formula is not. The default is `install`]' \
     '--days[How many days of analytics data to retrieve. The value for days must be `30`, `90` or `365`. The default is `30`]' \
     '--debug[Display any debugging information]' \
     '(--installed)--eval-all[Evaluate all available formulae and casks, whether installed or not, to print their JSON. Implied if `HOMEBREW_EVAL_ALL` is set]' \
-    '(--bottle)--github[Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask]' \
+    '--github[Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask]' \
     '--help[Show this message]' \
     '(--eval-all --all)--installed[Print JSON of formulae that are currently installed]' \
     '--json[Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew]' \
@@ -966,7 +966,7 @@ _brew_info() {
     '(--cask)--formula[Treat all named arguments as formulae]' \
     '*::formula:__brew_formulae' \
     - cask \
-    '(--formula --bottle)--cask[Treat all named arguments as casks]' \
+    '(--formula)--cask[Treat all named arguments as casks]' \
     '*::cask:__brew_casks'
 }
 


### PR DESCRIPTION
We should allow `brew info --json=v2` even without the taps installed. We can just pass the downloaded JSON file along without needing to regerate the data using `#to_h` on the formulae and casks. I've tested this locally without homebrew/core or homebrew/cask and it seems to work with an without `--variations`, with `--installed`, and with `--all --eval-all`.

One thing to note: when you run `brew info --json` it will merge in the correct OS variations which I think makes the most sense since someone running that command probably cares about what's currently on their system. `brew info --json --variations`, however, will return the complete with-variations JSON file. This is consistent with the way things work with `HOMEBREW_NO_INSTALL_FROM_API`.

Also, while we're at it, let's fully remove the bottle API. It's already been removed from formulae.brew.sh and the `--bottle` switch to turn it on was hidden. I don't think we'll need to do any deprecations for it but we should revert that part if anyone complains.