### PR TITLE
brew.sh: move shared curl speed limit settings here.

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -19,11 +19,6 @@ module Homebrew
 
     HOMEBREW_CACHE_API = (HOMEBREW_CACHE/"api").freeze
 
-    # Timeout values to check for dead connections
-    # We don't use --max-time to support slow connections
-    JSON_API_SPEED_MARGIN = 100 # bytes/sec
-    JSON_API_SPEED_TIME = 10 # seconds of downloading under the margin
-
     sig { params(endpoint: String).returns(Hash) }
     def fetch(endpoint)
       return cache[endpoint] if cache.present? && cache.key?(endpoint)
@@ -47,7 +42,11 @@ module Homebrew
       retry_count = 0
       url = "#{Homebrew::EnvConfig.api_domain}/#{endpoint}"
       default_url = "#{HOMEBREW_API_DEFAULT_DOMAIN}/#{endpoint}"
-      curl_args = %W[--compressed --speed-limit #{JSON_API_SPEED_MARGIN} --speed-time #{JSON_API_SPEED_TIME}]
+      curl_args = %W[
+        --compressed
+        --speed-limit #{ENV.fetch("HOMEBREW_CURL_SPEED_LIMIT")}
+        --speed-time #{ENV.fetch("HOMEBREW_CURL_SPEED_TIME")}
+      ]
       curl_args.prepend("--silent") unless Context.current.debug?
 
       begin

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -628,6 +628,11 @@ curl_version_output="$(curl --version 2>/dev/null)"
 curl_name_and_version="${curl_version_output%% (*}"
 HOMEBREW_USER_AGENT_CURL="${HOMEBREW_USER_AGENT} ${curl_name_and_version// //}"
 
+# Timeout values to check for dead connections
+# We don't use --max-time to support slow connections
+HOMEBREW_CURL_SPEED_LIMIT=100
+HOMEBREW_CURL_SPEED_TIME=5
+
 export HOMEBREW_VERSION
 export HOMEBREW_DEFAULT_CACHE
 export HOMEBREW_CACHE
@@ -656,6 +661,8 @@ export HOMEBREW_USER_AGENT_CURL
 export HOMEBREW_API_DEFAULT_DOMAIN
 export HOMEBREW_BOTTLE_DEFAULT_DOMAIN
 export HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
+export HOMEBREW_CURL_SPEED_LIMIT
+export HOMEBREW_CURL_SPEED_TIME
 
 if [[ -n "${HOMEBREW_MACOS}" && -x "/usr/bin/xcode-select" ]]
 then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -785,7 +785,8 @@ EOS
         fi
         curl \
           "${CURL_DISABLE_CURLRC_ARGS[@]}" \
-          --fail --compressed --silent --speed-limit 100 --speed-time 30 \
+          --fail --compressed --silent \
+          --speed-limit "${HOMEBREW_CURL_SPEED_LIMIT}" --speed-time "${HOMEBREW_CURL_SPEED_TIME}" \
           --location --remote-time --output "${HOMEBREW_CACHE}/api/${formula_or_cask}.json" \
           "${time_cond[@]}" \
           --user-agent "${HOMEBREW_USER_AGENT_CURL}" \


### PR DESCRIPTION
This avoids duplication and potentially allows it to be used for various other `curl` calls.