### PR TITLE
Add HOMEBREW_API_AUTO_UPDATE_SECS

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -276,7 +276,7 @@ auto-update() {
       fi
     fi
 
-    # Skip auto-update if the repository has been updated in the
+    # Skip auto-update if the Homebrew/brew repository has been checked in the
     # last $HOMEBREW_AUTO_UPDATE_SECS.
     repo_fetch_head="${HOMEBREW_REPOSITORY}/.git/FETCH_HEAD"
     if [[ -f "${repo_fetch_head}" ]] &&

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -37,6 +37,12 @@ module Homebrew
                      "to instead be downloaded from " \
                      "`http://localhost:8080/v2/homebrew/core/gettext/manifests/0.21`",
       },
+      HOMEBREW_API_AUTO_UPDATE_SECS:             {
+        description: "Check Homebrew's API for new formulae or cask data every " \
+                     "`HOMEBREW_API_AUTO_UPDATE_SECS` seconds. Alternatively, disable API auto-update " \
+                     "checks entirely with HOMEBREW_NO_AUTO_UPDATE.",
+        default:     1800,
+      },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
         description:  "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
                       "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1995,6 +1995,11 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_ARTIFACT_DOMAIN`
   <br>Prefix all download URLs, including those for bottles, with this value. For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a formula with the URL `https://example.com/foo.tar.gz` to instead download from `http://localhost:8080/https://example.com/foo.tar.gz`. Bottle URLs however, have their domain replaced with this prefix. This results in e.g. `https://ghcr.io/v2/homebrew/core/gettext/manifests/0.21` to instead be downloaded from `http://localhost:8080/v2/homebrew/core/gettext/manifests/0.21`
 
+- `HOMEBREW_API_AUTO_UPDATE_SECS`
+  <br>Check Homebrew's API for new formulae or cask data every `HOMEBREW_API_AUTO_UPDATE_SECS` seconds. Alternatively, disable API auto-update checks entirely with HOMEBREW_NO_AUTO_UPDATE.
+
+  *Default:* `1800`.
+
 - `HOMEBREW_AUTO_UPDATE_SECS`
   <br>Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, disable auto-update entirely with `HOMEBREW_NO_AUTO_UPDATE`.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2849,6 +2849,15 @@ Linux only: Pass this value to a type name representing the compiler\'s \fB\-mar
 Prefix all download URLs, including those for bottles, with this value\. For example, \fBHOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080\fR will cause a formula with the URL \fBhttps://example\.com/foo\.tar\.gz\fR to instead download from \fBhttp://localhost:8080/https://example\.com/foo\.tar\.gz\fR\. Bottle URLs however, have their domain replaced with this prefix\. This results in e\.g\. \fBhttps://ghcr\.io/v2/homebrew/core/gettext/manifests/0\.21\fR to instead be downloaded from \fBhttp://localhost:8080/v2/homebrew/core/gettext/manifests/0\.21\fR
 .
 .TP
+\fBHOMEBREW_API_AUTO_UPDATE_SECS\fR
+.
+.br
+Check Homebrew\'s API for new formulae or cask data every \fBHOMEBREW_API_AUTO_UPDATE_SECS\fR seconds\. Alternatively, disable API auto\-update checks entirely with HOMEBREW_NO_AUTO_UPDATE\.
+.
+.IP
+\fIDefault:\fR \fB1800\fR\.
+.
+.TP
 \fBHOMEBREW_AUTO_UPDATE_SECS\fR
 .
 .br


### PR DESCRIPTION
This sets the default and allows customising how often we try to download files from the API.

This does not affect `brew update` as we want to always check every time on an explicit call.

@Bo98 @Rylan12 @carlocab Feel free to push directly to this PR and merge as desired. I will be unlikely to be able to make any more code changes here until Monday and would like to land this (or something like it) as soon as possible before then to allow it to bake.