### PR TITLE
cask: try running pkg installer without sudo first

### DIFF
--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -65,7 +65,26 @@ module Cask
             "USER"     => User.current,
             "USERNAME" => User.current,
           }
-          command.run!("/usr/sbin/installer", sudo: true, args: args, print_stdout: true, env: env)
+          result = command.run(
+            "/usr/sbin/installer",
+            sudo:         false,
+            args:         args,
+            print_stdout: true,
+            env:          env,
+            must_succeed: false,
+          )
+          if !result.success? && result.stdout.include?("run as root")
+            command.run(
+              "/usr/sbin/installer",
+              sudo:         true,
+              args:         args,
+              print_stdout: true,
+              env:          env,
+              must_succeed: true,
+            )
+          else
+            result.assert_success!
+          end
         end
       end
 


### PR DESCRIPTION
Not all packages need sudo. Those that need must use pkg's distribution file to indicate so. An attempt to install the latter will cause installer to exit with predictable output. Let's be prudent and not grant elevated priviliges to an arbitrary scripts by default.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

To test this properly I need to add another fixture, just like MyFancyPkg but with `auth="Root"` specified in the distribution file. Is there a specific procedure for crafting/verifying (stored as a zip file)?
