### PR TITLE
formula_auditor: do not recommend `uses_from_macos` when macOS-only

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -283,10 +283,12 @@ module Homebrew
              dep_f.keg_only_reason.applicable? &&
              formula.requirements.none?(LinuxRequirement) &&
              !formula.tap&.audit_exception(:provided_by_macos_depends_on_allowlist, dep.name)
-            new_formula_problem(
-              "Dependency '#{dep.name}' is provided by macOS; " \
-              "please replace 'depends_on' with 'uses_from_macos'.",
-            )
+            message = if dep_f.requirements.any? { |r| r.is_a?(MacOSRequirement) && !r.version }
+              "please remove it."
+            else
+              "please replace 'depends_on' with 'uses_from_macos'."
+            end
+            new_formula_problem "Dependency '#{dep.name}' is provided by macOS; #{message}"
           end
 
           dep.options.each do |opt|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

At least impacts `libiconv`.

e.g. `simdutf`

Before, recommendation is to change to `uses_from_macos "libiconv"` which doesn't make sense given it `depends_on :macos`
```console
❯ brew audit --new-formula simdutf
simdutf:
  * New formulae in homebrew/core should not have a `bottle do` block
  * Dependency 'icu4c' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.
  * Dependency 'libiconv' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.
Error: 3 problems in 1 formula detected
```

After,
```console
❯ brew audit --new-formula simdutf
simdutf:
  * New formulae in homebrew/core should not have a `bottle do` block
  * Dependency 'icu4c' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.
  * Dependency 'libiconv' is provided by macOS; please remove it.
Error: 3 problems in 1 formula detected
```
