### PR TITLE
livecheck_version: only split on commas in cask version

### DIFF
--- a/Library/Homebrew/livecheck/livecheck_version.rb
+++ b/Library/Homebrew/livecheck/livecheck_version.rb
@@ -19,7 +19,7 @@ module Homebrew
         when Formula, Resource
           [version]
         when Cask::Cask
-          version.to_s.split(/[,:]/).map { |s| Version.new(s) }
+          version.to_s.split(",").map { |s| Version.new(s) }
         else
           T.absurd(package_or_resource)
         end

--- a/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
@@ -21,20 +21,16 @@ describe Homebrew::Livecheck::LivecheckVersion do
   specify "::create" do
     expect(described_class.create(formula, Version.new("1.1.6")).versions).to eq ["1.1.6"]
     expect(described_class.create(formula, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0,1.8.0"]
-    expect(described_class.create(formula, Version.new("1.0,100:1426778671")).versions).to eq ["1.0,100:1426778671"]
     expect(described_class.create(formula, Version.new("0.17.0,20210111183933,226")).versions)
       .to eq ["0.17.0,20210111183933,226"]
 
     expect(described_class.create(cask, Version.new("1.1.6")).versions).to eq ["1.1.6"]
     expect(described_class.create(cask, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0", "1.8.0"]
-    expect(described_class.create(cask, Version.new("1.0,100:1426778671")).versions)
-      .to eq ["1.0", "100", "1426778671"]
     expect(described_class.create(cask, Version.new("0.17.0,20210111183933,226")).versions)
       .to eq ["0.17.0", "20210111183933", "226"]
 
     expect(described_class.create(resource, Version.new("1.1.6")).versions).to eq ["1.1.6"]
     expect(described_class.create(resource, Version.new("2.19.0,1.8.0")).versions).to eq ["2.19.0,1.8.0"]
-    expect(described_class.create(resource, Version.new("1.0,100:1426778671")).versions).to eq ["1.0,100:1426778671"]
     expect(described_class.create(resource, Version.new("0.17.0,20210111183933,226")).versions)
       .to eq ["0.17.0,20210111183933,226"]
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some leftover Cask colon versioning.