### PR TITLE
dev-cmd/contributions: Count commit signoffs, too

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -44,6 +44,7 @@ module Homebrew
 
     commits = 0
     coauthorships = 0
+    signoffs = 0
 
     all_repos = args.repositories.nil? || args.repositories.include?("all")
     repos = all_repos ? SUPPORTED_REPOS : args.repositories
@@ -61,11 +62,13 @@ module Homebrew
       end
 
       commits += git_log_author_cmd(T.must(repo_path), args)
-      coauthorships += git_log_coauthor_cmd(T.must(repo_path), args)
+      coauthorships += git_log_trailers_cmd(T.must(repo_path), "Co-authored-by", args)
+      signoffs += git_log_trailers_cmd(T.must(repo_path), "Signed-off-by", args)
     end
 
-    sentence = "#{args.named.first} directly authored #{commits} commits " \
-               "and co-authored #{coauthorships} commits " \
+    sentence = "#{args.named.first} directly authored #{commits} commits" \
+               ", co-authored #{coauthorships} commits" \
+               ", and signed-off #{signoffs} commits " \
                "across #{all_repos ? "all Homebrew repos" : repos.to_sentence}"
     sentence += if args.from && args.to
       " between #{args.from} and #{args.to}"
@@ -97,10 +100,10 @@ module Homebrew
     Utils.safe_popen_read(*cmd).lines.count
   end
 
-  sig { params(repo_path: Pathname, args: Homebrew::CLI::Args).returns(Integer) }
-  def git_log_coauthor_cmd(repo_path, args)
+  sig { params(repo_path: Pathname, trailer: String, args: Homebrew::CLI::Args).returns(Integer) }
+  def git_log_trailers_cmd(repo_path, trailer, args)
     cmd = ["git", "-C", repo_path, "log", "--oneline"]
-    cmd << "--format='%(trailers:key=Co-authored-by:)'"
+    cmd << "--format='%(trailers:key=#{trailer}:)'"
     cmd << "--before=#{args.to}" if args.to
     cmd << "--after=#{args.from}" if args.from
 

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -79,7 +79,7 @@ module Homebrew
     else
       " in all time"
     end
-    sentence += "."
+    sentence += ". Total: #{commits + coauthorships + signoffs}."
 
     puts sentence
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of #13642.
- `BrewTestBot` adds `Signed-off-by` for who approved PRs (https://github.com/Homebrew/brew/blob/1cf53b4281e7bc22a8d7fc915fc6ba4576f8ef88/Library/Homebrew/dev-cmd/pr-pull.rb#L91-L93).
- Let's count these too, at least until we can get PR approvals from the GitHub API.
