### PR TITLE
cmd/edit: stop double warning

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -45,7 +45,7 @@ module Homebrew
     paths = if args.named.empty?
       # Sublime requires opting into the project editing path,
       # as opposed to VS Code which will infer from the .vscode path
-      if which_editor == "subl"
+      if which_editor(silent: true) == "subl"
         ["--project", "#{HOMEBREW_REPOSITORY}/.sublime/homebrew.sublime-project"]
       else
         # If no formulae are listed, open the project root in an editor.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -361,7 +361,7 @@ module Kernel
     end.compact.uniq
   end
 
-  def which_editor
+  def which_editor(silent: false)
     editor = Homebrew::EnvConfig.editor
     return editor if editor
 
@@ -371,11 +371,13 @@ module Kernel
     end
     editor ||= "vim"
 
-    opoo <<~EOS
-      Using #{editor} because no editor was set in the environment.
-      This may change in the future, so we recommend setting EDITOR,
-      or HOMEBREW_EDITOR to your preferred text editor.
-    EOS
+    unless silent
+      opoo <<~EOS
+        Using #{editor} because no editor was set in the environment.
+        This may change in the future, so we recommend setting EDITOR,
+        or HOMEBREW_EDITOR to your preferred text editor.
+      EOS
+    end
 
     editor
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When you don't have `EDITOR` or `HOMEBREW_EDITOR` configured `brew edit` printed a double warning.

This silences the first of those.

```
# First, unset EDITOR and HOMEBREW_EDITOR.

# Second, try it on master.
/u/l/Homebrew (master|✔) $ brew edit
Warning: Using code because no editor was set in the environment.
This may change in the future, so we recommend setting EDITOR,
or HOMEBREW_EDITOR to your preferred text editor.
Editing /usr/local/Homebrew
Warning: Using code because no editor was set in the environment.
This may change in the future, so we recommend setting EDITOR,
or HOMEBREW_EDITOR to your preferred text editor.

# Third, try it on this branch.
/u/l/Homebrew (stop-double-warning-in-edit|✔) $ brew edit
Editing /usr/local/Homebrew
Warning: Using code because no editor was set in the environment.
This may change in the future, so we recommend setting EDITOR,
or HOMEBREW_EDITOR to your preferred text editor.
```