### PR TITLE
cask: replace Caskroom in API for relocated artifacts

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -317,9 +317,12 @@ module Cask
 
     def to_h_string_gsubs(string, replace_prefix: true)
       string = string.to_s.gsub(Dir.home, "$HOME")
-      return string unless replace_prefix
 
-      string.gsub(HOMEBREW_PREFIX, "$(brew --prefix)")
+      if replace_prefix
+        string.gsub(HOMEBREW_PREFIX, "$(brew --prefix)")
+      else
+        string.gsub(Caskroom.path, "$(brew --prefix)/Caskroom")
+      end
     end
 
     def to_h_array_gsubs(array)


### PR DESCRIPTION
This is a partial fix for #14595. It doesn't cover `android-commandlinetools`, but that's the only instance I can find that would still be affected.

This will fix all the other cases, like `android-platform-tools`. A partial fix is worthwhile because there are some popular casks affected (`android-platform-tools` averages 500 installs a day), and is lower risk of causing any other issues (a full fix is likely something much more substantial, such as evaluating a cask source with a fake prefix).