### PR TITLE
Fix `brew info --json` regressions around install status

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -233,7 +233,7 @@ module Cask
     def to_h
       if loaded_from_api && Homebrew::EnvConfig.install_from_api?
         json_cask = Homebrew::API::Cask.all_casks[token]
-        return Homebrew::API.merge_variations(json_cask)
+        return api_to_local_hash(Homebrew::API.merge_variations(json_cask))
       end
 
       {
@@ -262,7 +262,9 @@ module Cask
     end
 
     def to_hash_with_variations
-      return Homebrew::API::Cask.all_casks[token] if loaded_from_api && Homebrew::EnvConfig.install_from_api?
+      if loaded_from_api && Homebrew::EnvConfig.install_from_api?
+        return api_to_local_hash(Homebrew::API::Cask.all_casks[token])
+      end
 
       hash = to_h
       variations = {}
@@ -299,6 +301,13 @@ module Cask
     end
 
     private
+
+    def api_to_local_hash(hash)
+      hash["token"] = token
+      hash["installed"] = versions.last
+      hash["outdated"] = outdated?
+      hash
+    end
 
     def artifacts_list
       artifacts.map do |artifact|


### PR DESCRIPTION
#14587 unfortunately introduced some notable regressions to `brew info --json`:

* Installed version tracking stopped working, including the `outdated` boolean (quite popularly used in scripts).
* There was an API break where `"token"` was missing from casks and `"name"` was missing from formulae.

This PR:

* Adds the local install info & the token to the cask output hash.
* Largely reverts the changes to `Formula#to_hash` to instead take from the local state (our Formulary work means this works fine), except for `oldname` and `requirements`. In a future 4.0.x release, this will likely go away in favour of reading that data on the Formulary side.
* Changes `Formula#to_hash_with_variation` to take both the local hash and API hash and take the relevant bits from both.

Fixes #14600.