### PR TITLE
Fix problem apple command line tools not being detected when path isn't set to the default path

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -267,7 +267,7 @@ module OS
       # The original Mavericks CLT package ID
       EXECUTABLE_PKG_ID = "com.apple.pkg.CLTools_Executables"
       MAVERICKS_NEW_PKG_ID = "com.apple.pkg.CLTools_Base" # obsolete
-      PKG_PATH = "/Library/Developer/CommandLineTools"
+      PKG_PATH = `/usr/bin/xcode-select -p`.chop.freeze
 
       # Returns true even if outdated tools are installed.
       sig { returns(T::Boolean) }
@@ -387,7 +387,8 @@ module OS
 
       sig { returns(T.nilable(String)) }
       def detect_clang_version
-        version_output = Utils.popen_read("#{PKG_PATH}/usr/bin/clang", "--version")
+        # When command line tools paths is set to the ones found at the xcode installation the clang binary doesn't exist, but the gcc binary exists (which is the same as clang on mac)
+        version_output = Utils.popen_read("#{PKG_PATH}/usr/bin/gcc", "--version")
         version_output[/clang-(\d+(\.\d+)+)/, 1]
       end
 
@@ -412,7 +413,9 @@ module OS
       def detect_version
         version = T.let(nil, T.nilable(String))
         [EXECUTABLE_PKG_ID, MAVERICKS_NEW_PKG_ID].each do |id|
-          next unless File.exist?("#{PKG_PATH}/usr/bin/clang")
+          # When command line tools paths is set to the ones found at the xcode installation the clang binary doesn't exist, but the gcc binary exists (which is the same as clang on mac)
+
+          next unless File.exist?("#{PKG_PATH}/usr/bin/gcc")
 
           version = MacOS.pkgutil_info(id)[/version: (.+)$/, 1]
           return version if version


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
If the path of xcode command line tools wasn't set to the default /Library/Developer/CommandLineTools, for example it was set to the tools found on an xcode installation the command line tools wouldn't be detected by homebrew.