### PR TITLE
Improve homebrew/{core,cask} autotapping.

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -41,7 +41,7 @@ Metrics/PerceivedComplexity:
 Metrics/MethodLength:
   Max: 232
 Metrics/ModuleLength:
-  Max: 473
+  Max: 475
   Exclude:
     # TODO: extract more of the bottling logic
     - "dev-cmd/bottle.rb"

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -782,32 +782,36 @@ if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/dev-cmd/${HOMEBREW_COMMAND}.sh" ]] ||
 then
   export HOMEBREW_DEVELOPER_COMMAND="1"
 
-  NO_INSTALL_FROM_API_COMMANDS=(
-    audit
-    bottle
-    bump-cask-pr
-    bump-formula-pr
-    bump-revision
-    bump-unversioned-casks
-    bump
-    cat
-    create
-    edit
-    extract
-    formula
-    livecheck
-    pr-pull
-    pr-upload
-    test
-    update-python-resources
-  )
-
-  if check-array-membership "${HOMEBREW_COMMAND}" "${NO_INSTALL_FROM_API_COMMANDS[@]}"
+  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
-    export HOMEBREW_NO_INSTALL_FROM_API=1
-  fi
+    NO_INSTALL_FROM_API_COMMANDS=(
+      audit
+      bottle
+      bump-cask-pr
+      bump-formula-pr
+      bump-revision
+      bump-unversioned-casks
+      bump
+      cat
+      create
+      edit
+      extract
+      formula
+      livecheck
+      pr-pull
+      pr-upload
+      test
+      update-python-resources
+    )
 
-  unset NO_INSTALL_FROM_API_COMMANDS
+    if check-array-membership "${HOMEBREW_COMMAND}" "${NO_INSTALL_FROM_API_COMMANDS[@]}"
+    then
+      export HOMEBREW_NO_INSTALL_FROM_API=1
+      export HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API=1
+    fi
+
+    unset NO_INSTALL_FROM_API_COMMANDS
+  fi
 fi
 
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -271,6 +271,7 @@ module Homebrew
   def install_core_tap_if_necessary
     return if ENV["HOMEBREW_UPDATE_TEST"]
     return if Homebrew::EnvConfig.install_from_api?
+    return if Homebrew::EnvConfig.automatically_set_no_install_from_api?
 
     core_tap = CoreTap.instance
     return if core_tap.installed?

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -490,6 +490,11 @@ module Homebrew
     end
 
     sig { returns(T::Boolean) }
+    def automatically_set_no_install_from_api?
+      ENV["HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API"].present?
+    end
+
+    sig { returns(T::Boolean) }
     def install_from_api?
       return false if OS.unsupported_configuration?
       return false unless Homebrew.default_prefix?

--- a/Library/Homebrew/extend/os/mac/tap.rb
+++ b/Library/Homebrew/extend/os/mac/tap.rb
@@ -5,6 +5,7 @@ class Tap
   def self.install_default_cask_tap_if_necessary(force: false)
     return false if default_cask_tap.installed?
     return false if Homebrew::EnvConfig.install_from_api?
+    return false if Homebrew::EnvConfig.automatically_set_no_install_from_api?
     return false if !force && Tap.untapped_official_taps.include?(default_cask_tap.name)
 
     default_cask_tap.install

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -796,6 +796,7 @@ class CoreTap < Tap
   def self.ensure_installed!
     return if instance.installed?
     return if Homebrew::EnvConfig.install_from_api?
+    return if Homebrew::EnvConfig.automatically_set_no_install_from_api?
 
     # Tests override homebrew-core locations and we don't want to auto-tap in them.
     return if ENV["HOMEBREW_TESTS"]


### PR DESCRIPTION
Don't automatically tap these when running a developer command that's not using the API.

Fixes #14606