### PR TITLE
formulary: support requirements, aliases etc from API

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -154,6 +154,8 @@ class DependencyCollector
   end
 
   def parse_symbol_spec(spec, tags)
+    # When modifying this list of supported requirements, consider
+    # whether Formulary::API_SUPPORTED_REQUIREMENTS should also be changed.
     case spec
     when :arch          then ArchRequirement.new(tags)
     when :codesign      then CodesignRequirement.new(tags)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2180,14 +2180,6 @@ class Formula
       }
     end
 
-    # TODO: can we implement these in Formulary?
-    if self.class.loaded_from_api && Homebrew::EnvConfig.install_from_api?
-      json_formula = Homebrew::API::Formula.all_formulae[name]
-      json_formula = Homebrew::API.merge_variations(json_formula)
-      hsh["oldname"] = json_formula["oldname"]
-      hsh["requirements"] = json_formula["requirements"]
-    end
-
     hsh
   end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -19,6 +19,9 @@ module Formulary
 
   URL_START_REGEX = %r{(https?|ftp|file)://}.freeze
 
+  # :codesign and custom requirement classes are not supported
+  API_SUPPORTED_REQUIREMENTS = [:arch, :linux, :macos, :maximum_macos, :xcode].freeze
+
   sig { void }
   def self.enable_factory_cache!
     @factory_cache = true
@@ -212,6 +215,35 @@ module Formulary
         uses_from_macos dep
       end
 
+      json_formula["requirements"].each do |req|
+        req_name = req["name"].to_sym
+        next if API_SUPPORTED_REQUIREMENTS.exclude?(req_name)
+
+        req_version = case req_name
+        when :arch
+          req["version"]&.to_sym
+        when :macos, :maximum_macos
+          MacOSVersions::SYMBOLS.key(req["version"])
+        else
+          req["version"]
+        end
+
+        req_tags = []
+        req_tags << req_version if req_version.present?
+        req_tags += req["contexts"].map do |tag|
+          case tag
+          when String
+            tag.to_sym
+          when Hash
+            tag.deep_transform_keys(&:to_sym)
+          else
+            tag
+          end
+        end
+
+        depends_on req_name => req_tags
+      end
+
       def install
         raise "Cannot build from source from abstract formula."
       end
@@ -224,6 +256,21 @@ module Formulary
       @tap_git_head_string = json_formula["tap_git_head"]
       def tap_git_head
         self.class.instance_variable_get(:@tap_git_head_string)
+      end
+
+      @oldname_string = json_formula["oldname"]
+      def oldname
+        self.class.instance_variable_get(:@oldname_string)
+      end
+
+      @aliases_array = json_formula["aliases"]
+      def aliases
+        self.class.instance_variable_get(:@aliases_array)
+      end
+
+      @versioned_formulae_array = json_formula["versioned_formulae"]
+      def versioned_formulae_names
+        self.class.instance_variable_get(:@versioned_formulae_array)
       end
     end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -244,6 +244,15 @@ describe Formulary do
             "recommended_dependencies" => ["recommended_dep"],
             "optional_dependencies"    => ["optional_dep"],
             "uses_from_macos"          => ["uses_from_macos_dep"],
+            "requirements"             => [
+              {
+                "name"     => "xcode",
+                "cask"     => nil,
+                "download" => nil,
+                "version"  => "1.0",
+                "contexts" => ["build"],
+              },
+            ],
             "caveats"                  => "example caveat string",
           }.merge(extra_items),
         }
@@ -296,14 +305,23 @@ describe Formulary do
 
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
+
         expect(formula.keg_only_reason.reason).to eq :provided_by_macos
         if OS.mac?
           expect(formula.deps.count).to eq 5
-        elsif OS.linux?
+        else
           expect(formula.deps.count).to eq 6
         end
         expect(formula.uses_from_macos_elements).to eq ["uses_from_macos_dep"]
+
+        expect(formula.requirements.count).to eq 1
+        req = formula.requirements.first
+        expect(req).to be_an_instance_of XcodeRequirement
+        expect(req.version).to eq "1.0"
+        expect(req.tags).to eq [:build]
+
         expect(formula.caveats).to eq "example caveat string"
+
         expect {
           formula.install
         }.to raise_error("Cannot build from source from abstract formula.")


### PR DESCRIPTION
These are the last parts that were never read from the API.

For requirements, the following are not supported at this time (and are ignored gracefully):

* Codesign requirement
* Any custom requirement class, such as those in glibc (we should consider moving those to brew at some point)

After this PR, apart from the above exceptions, the output of `to_hash` should be identical between one built from API and one built from Ruby source without the aid from the API-specific code (which is now deleted).