### PR TITLE
formula: fix `to_hash` tampering with requirement names

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2156,9 +2156,10 @@ class Formula
     end
 
     hsh["requirements"] = requirements.map do |req|
-      req.name.prepend("maximum_") if req.try(:comparator) == "<="
+      req_name = req.name.dup
+      req_name.prepend("maximum_") if req.try(:comparator) == "<="
       {
-        "name"     => req.name,
+        "name"     => req_name,
         "cask"     => req.cask,
         "download" => req.download,
         "version"  => req.try(:version) || req.try(:arch),


### PR DESCRIPTION
Very simple and obvious fix for https://formulae.brew.sh/formula/gcc@5 outputting a requirement of:

> Maximum_maximum_maximum_maximum_maximum_maximum_maximum_maximum_maximum_maximum_maximum_maximum_maximum_macos <= 10.13 (build) 