### PR TITLE
sudo: pass env variables without /usr/bin/env

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -164,13 +164,13 @@ class SystemCommand
   end
 
   sig { returns(T::Array[String]) }
-  def env_previx
+  def env_prefix
     ["/usr/bin/env", *env_args]
   end
 
   sig { returns(T::Array[String]) }
   def command_prefix
-    sudo? ? sudo_prefix : env_previx
+    sudo? ? sudo_prefix : env_prefix
   end
 
   sig { returns(T::Array[String]) }

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -121,7 +121,7 @@ class SystemCommand
 
   sig { returns(T::Array[String]) }
   def command
-    [*sudo_prefix, *env_args, executable.to_s, *expanded_args]
+    [*command_prefix, executable.to_s, *expanded_args]
   end
 
   private
@@ -154,15 +154,23 @@ class SystemCommand
 
     return [] if set_variables.empty?
 
-    ["/usr/bin/env", *set_variables]
+    set_variables
   end
 
   sig { returns(T::Array[String]) }
   def sudo_prefix
-    return [] unless sudo?
-
     askpass_flags = ENV.key?("SUDO_ASKPASS") ? ["-A"] : []
-    ["/usr/bin/sudo", *askpass_flags, "-E", "--"]
+    ["/usr/bin/sudo", *askpass_flags, "-E", *env_args, "--"]
+  end
+
+  sig { returns(T::Array[String]) }
+  def env_previx
+    ["/usr/bin/env", *env_args]
+  end
+
+  sig { returns(T::Array[String]) }
+  def command_prefix
+    sudo? ? sudo_prefix : env_previx
   end
 
   sig { returns(T::Array[String]) }

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -54,8 +54,8 @@ describe SystemCommand do
           expect(Open3)
             .to receive(:popen3)
             .with(
-              an_instance_of(Hash), ["/usr/bin/sudo", "/usr/bin/sudo"], "-E", "--",
-              "/usr/bin/env", "A=1", "B=2", "C=3", "env", *env_args, pgroup: nil
+              an_instance_of(Hash), ["/usr/bin/sudo", "/usr/bin/sudo"], "-E",
+              "A=1", "B=2", "C=3", "--", "env", *env_args, pgroup: nil
             )
             .and_wrap_original do |original_popen3, *_, &block|
               original_popen3.call("true", &block)


### PR DESCRIPTION
Using /usr/bin/env as a frontend for the actual command prevents sudoers from restricting allowed commands and configuring detailed command environment.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
