### PR TITLE
formulary: fix uses_from_macos handling on macOS

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -194,14 +194,14 @@ module Formulary
       end
 
       json_formula["dependencies"].each do |dep|
-        next if uses_from_macos_names.include? dep
+        next if uses_from_macos_names.include?(dep) && !Homebrew::SimulateSystem.simulating_or_running_on_macos?
 
         depends_on dep
       end
 
       [:build, :test, :recommended, :optional].each do |type|
         json_formula["#{type}_dependencies"].each do |dep|
-          next if uses_from_macos_names.include? dep
+          next if uses_from_macos_names.include?(dep) && !Homebrew::SimulateSystem.simulating_or_running_on_macos?
 
           depends_on dep => type
         end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -273,6 +273,16 @@ describe Formulary do
         }
       end
 
+      let(:older_macos_variations_json) do
+        {
+          "variations" => {
+            Utils::Bottles.tag.to_s => {
+              "dependencies" => ["uses_from_macos_dep"],
+            },
+          },
+        }
+      end
+
       let(:linux_variations_json) do
         {
           "variations" => {
@@ -338,6 +348,7 @@ describe Formulary do
         expect(formula).to be_a(Formula)
         expect(formula.deps.count).to eq 6
         expect(formula.deps.map(&:name).include?("variations_dep")).to be true
+        expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be false
       end
 
       it "returns a Formula without duplicated deps and uses_from_macos with variations on Linux", :needs_linux do
@@ -347,6 +358,16 @@ describe Formulary do
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.deps.count).to eq 6
+        expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be true
+      end
+
+      it "returns a Formula with the correct uses_from_macos dep on older macOS", :needs_macos do
+        allow(Homebrew::API::Formula)
+          .to receive(:all_formulae).and_return formula_json_contents(older_macos_variations_json)
+
+        formula = described_class.factory(formula_name)
+        expect(formula).to be_a(Formula)
+        expect(formula.deps.count).to eq 5
         expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be true
       end
     end


### PR DESCRIPTION
I initially thought #14535 to be a weird thing with the Cocoapods formula, but it actually has far greater scope than anticipated. Even with the `on_arm` stuff removed, any macOS prior to `since` still didn't work properly.

The cause was our dependency deduplication going on here. There is nothing to deduplicate on macOS however (`uses_from_macos` is no-op and we don't pass `since` as we do variations instead) so the fix is trivial: don't try to deduplicate on macOS!

Test included.

Fixes #14535.