### PR TITLE
cask/cask: fix non-absolute home error.

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -19,7 +19,8 @@ module Cask
     extend Searchable
     include Metadata
 
-    HOME_PLACEHOLDER = "$HOME"
+    # Needs a leading slash to avoid `File.expand.path` complaining about non-absolute home.
+    HOME_PLACEHOLDER = "/$HOME"
     HOMEBREW_PREFIX_PLACEHOLDER = "$HOMEBREW_PREFIX"
     APPDIR_PLACEHOLDER = "$APPDIR"
 


### PR DESCRIPTION
Needs a leading slash to avoid `File.expand.path` complaining about non-absolute home.

See https://github.com/Homebrew/formulae.brew.sh/actions/runs/4176240259/jobs/7232266415#step:4:24