### PR TITLE
sudo: explicitly specify the root user where necessary

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -105,42 +105,46 @@ module Cask
 
         all_services.each do |service|
           ohai "Removing launchctl service #{service}"
-          booleans.each do |with_sudo|
-            sudo_user = with_sudo ? "root" : nil
+          booleans.each do |sudo|
             plist_status = command.run(
               "/bin/launchctl",
               args:         ["list", service],
-              sudo:         with_sudo,
-              sudo_user:    sudo_user,
+              sudo:         sudo,
+              sudo_as_root: sudo,
               print_stderr: false,
             ).stdout
             if plist_status.start_with?("{")
-              command.run!("/bin/launchctl", args: ["remove", service], sudo: sudo_user)
+              command.run!(
+                "/bin/launchctl",
+                args:         ["remove", service],
+                sudo:         sudo,
+                sudo_as_root: sudo,
+              )
               sleep 1
             end
             paths = [
               +"/Library/LaunchAgents/#{service}.plist",
               +"/Library/LaunchDaemons/#{service}.plist",
             ]
-            paths.each { |elt| elt.prepend(Dir.home).freeze } unless with_sudo
+            paths.each { |elt| elt.prepend(Dir.home).freeze } unless sudo
             paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
             paths.each do |path|
-              command.run!("/bin/rm", args: ["-f", "--", path], sudo: with_sudo, sudo_user: sudo_user)
+              command.run!("/bin/rm", args: ["-f", "--", path], sudo: sudo, sudo_as_root: sudo)
             end
             # undocumented and untested: pass a path to uninstall :launchctl
             next unless Pathname(service).exist?
 
             command.run!(
               "/bin/launchctl",
-              args:      ["unload", "-w", "--", service],
-              sudo:      with_sudo,
-              sudo_user: sudo_user,
+              args:         ["unload", "-w", "--", service],
+              sudo:         sudo,
+              sudo_as_root: sudo,
             )
             command.run!(
               "/bin/rm",
-              args:      ["-f", "--", service],
-              sudo:      with_sudo,
-              sudo_user: sudo_user,
+              args:         ["-f", "--", service],
+              sudo:         sudo,
+              sudo_as_root: sudo,
             )
             sleep 1
           end
@@ -316,32 +320,32 @@ module Cask
           ohai "Unloading kernel extension #{kext}"
           is_loaded = system_command!(
             "/usr/sbin/kextstat",
-            args:      ["-l", "-b", kext],
-            sudo:      true,
-            sudo_user: "root",
+            args:         ["-l", "-b", kext],
+            sudo:         true,
+            sudo_as_root: true,
           ).stdout
           if is_loaded.length > 1
             system_command!(
               "/sbin/kextunload",
-              args:      ["-b", kext],
-              sudo:      true,
-              sudo_user: "root",
+              args:         ["-b", kext],
+              sudo:         true,
+              sudo_as_root: true,
             )
             sleep 1
           end
-          kexts = system_command!(
+          found_kexts = system_command!(
             "/usr/sbin/kextfind",
-            args:      ["-b", kext],
-            sudo:      true,
-            sudo_user: "root",
-          ).stdout
-          kexts.chomp.lines.each do |kext_path|
+            args:         ["-b", kext],
+            sudo:         true,
+            sudo_as_root: true,
+          ).stdout.chomp.lines
+          found_kexts.each do |kext_path|
             ohai "Removing kernel extension #{kext_path}"
             system_command!(
               "/bin/rm",
-              args:      ["-rf", kext_path],
-              sudo:      true,
-              sudo_user: "root",
+              args:         ["-rf", kext_path],
+              sudo:         true,
+              sudo_as_root: true,
             )
           end
         end

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -106,11 +106,13 @@ module Cask
         all_services.each do |service|
           ohai "Removing launchctl service #{service}"
           booleans.each do |with_sudo|
-            sudo_user = with_sudo ? "root" : ""
+            sudo_user = with_sudo ? "root" : nil
             plist_status = command.run(
               "/bin/launchctl",
-              args: ["list", service],
-              sudo: sudo_user, print_stderr: false
+              args:         ["list", service],
+              sudo:         with_sudo,
+              sudo_user:    sudo_user,
+              print_stderr: false,
             ).stdout
             if plist_status.start_with?("{")
               command.run!("/bin/launchctl", args: ["remove", service], sudo: sudo_user)
@@ -123,13 +125,23 @@ module Cask
             paths.each { |elt| elt.prepend(Dir.home).freeze } unless with_sudo
             paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
             paths.each do |path|
-              command.run!("/bin/rm", args: ["-f", "--", path], sudo: sudo_user)
+              command.run!("/bin/rm", args: ["-f", "--", path], sudo: with_sudo, sudo_user: sudo_user)
             end
             # undocumented and untested: pass a path to uninstall :launchctl
             next unless Pathname(service).exist?
 
-            command.run!("/bin/launchctl", args: ["unload", "-w", "--", service], sudo: sudo_user)
-            command.run!("/bin/rm", args: ["-f", "--", service], sudo: sudo_user)
+            command.run!(
+              "/bin/launchctl",
+              args:      ["unload", "-w", "--", service],
+              sudo:      with_sudo,
+              sudo_user: sudo_user,
+            )
+            command.run!(
+              "/bin/rm",
+              args:      ["-f", "--", service],
+              sudo:      with_sudo,
+              sudo_user: sudo_user,
+            )
             sleep 1
           end
         end
@@ -302,15 +314,35 @@ module Cask
       def uninstall_kext(*kexts, command: nil, **_)
         kexts.each do |kext|
           ohai "Unloading kernel extension #{kext}"
-          is_loaded = system_command!("/usr/sbin/kextstat", args: ["-l", "-b", kext], sudo: "root").stdout
+          is_loaded = system_command!(
+            "/usr/sbin/kextstat",
+            args:      ["-l", "-b", kext],
+            sudo:      true,
+            sudo_user: "root",
+          ).stdout
           if is_loaded.length > 1
-            system_command!("/sbin/kextunload", args: ["-b", kext], sudo: "root")
+            system_command!(
+              "/sbin/kextunload",
+              args:      ["-b", kext],
+              sudo:      true,
+              sudo_user: "root",
+            )
             sleep 1
           end
-          kexts = system_command!("/usr/sbin/kextfind", args: ["-b", kext], sudo: "root").stdout
+          kexts = system_command!(
+            "/usr/sbin/kextfind",
+            args:      ["-b", kext],
+            sudo:      true,
+            sudo_user: "root",
+          ).stdout
           kexts.chomp.lines.each do |kext_path|
             ohai "Removing kernel extension #{kext_path}"
-            system_command!("/bin/rm", args: ["-rf", kext_path], sudo: "root")
+            system_command!(
+              "/bin/rm",
+              args:      ["-rf", kext_path],
+              sudo:      true,
+              sudo_user: "root",
+            )
           end
         end
       end

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -106,13 +106,14 @@ module Cask
         all_services.each do |service|
           ohai "Removing launchctl service #{service}"
           booleans.each do |with_sudo|
+            sudo_user = with_sudo ? "root" : ""
             plist_status = command.run(
               "/bin/launchctl",
               args: ["list", service],
-              sudo: with_sudo, print_stderr: false
+              sudo: sudo_user, print_stderr: false
             ).stdout
             if plist_status.start_with?("{")
-              command.run!("/bin/launchctl", args: ["remove", service], sudo: with_sudo)
+              command.run!("/bin/launchctl", args: ["remove", service], sudo: sudo_user)
               sleep 1
             end
             paths = [
@@ -122,13 +123,13 @@ module Cask
             paths.each { |elt| elt.prepend(Dir.home).freeze } unless with_sudo
             paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
             paths.each do |path|
-              command.run!("/bin/rm", args: ["-f", "--", path], sudo: with_sudo)
+              command.run!("/bin/rm", args: ["-f", "--", path], sudo: sudo_user)
             end
             # undocumented and untested: pass a path to uninstall :launchctl
             next unless Pathname(service).exist?
 
-            command.run!("/bin/launchctl", args: ["unload", "-w", "--", service], sudo: with_sudo)
-            command.run!("/bin/rm", args: ["-f", "--", service], sudo: with_sudo)
+            command.run!("/bin/launchctl", args: ["unload", "-w", "--", service], sudo: sudo_user)
+            command.run!("/bin/rm", args: ["-f", "--", service], sudo: sudo_user)
             sleep 1
           end
         end
@@ -301,14 +302,15 @@ module Cask
       def uninstall_kext(*kexts, command: nil, **_)
         kexts.each do |kext|
           ohai "Unloading kernel extension #{kext}"
-          is_loaded = system_command!("/usr/sbin/kextstat", args: ["-l", "-b", kext], sudo: true).stdout
+          is_loaded = system_command!("/usr/sbin/kextstat", args: ["-l", "-b", kext], sudo: "root").stdout
           if is_loaded.length > 1
-            system_command!("/sbin/kextunload", args: ["-b", kext], sudo: true)
+            system_command!("/sbin/kextunload", args: ["-b", kext], sudo: "root")
             sleep 1
           end
-          system_command!("/usr/sbin/kextfind", args: ["-b", kext], sudo: true).stdout.chomp.lines.each do |kext_path|
+          kexts = system_command!("/usr/sbin/kextfind", args: ["-b", kext], sudo: "root").stdout
+          kexts.chomp.lines.each do |kext_path|
             ohai "Removing kernel extension #{kext_path}"
-            system_command!("/bin/rm", args: ["-rf", kext_path], sudo: true)
+            system_command!("/bin/rm", args: ["-rf", kext_path], sudo: "root")
           end
         end
       end

--- a/Library/Homebrew/cask/artifact/keyboard_layout.rb
+++ b/Library/Homebrew/cask/artifact/keyboard_layout.rb
@@ -22,7 +22,12 @@ module Cask
       private
 
       def delete_keyboard_layout_cache(command: nil, **_)
-        command.run!("/bin/rm", args: ["-f", "--", "/System/Library/Caches/com.apple.IntlDataCache.le*"], sudo: true)
+        command.run!(
+          "/bin/rm",
+          args:         ["-f", "--", "/System/Library/Caches/com.apple.IntlDataCache.le*"],
+          sudo:         true,
+          sudo_as_root: true,
+        )
       end
     end
   end

--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -62,7 +62,7 @@ module Cask
             "USER"     => User.current,
             "USERNAME" => User.current,
           }
-          command.run!("/usr/sbin/installer", sudo: "root", args: args, print_stdout: true, env: env)
+          command.run!("/usr/sbin/installer", sudo: true, sudo_user: "root", args: args, print_stdout: true, env: env)
         end
       end
 

--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -62,7 +62,14 @@ module Cask
             "USER"     => User.current,
             "USERNAME" => User.current,
           }
-          command.run!("/usr/sbin/installer", sudo: true, sudo_user: "root", args: args, print_stdout: true, env: env)
+          command.run!(
+            "/usr/sbin/installer",
+            sudo:         true,
+            sudo_as_root: true,
+            args:         args,
+            print_stdout: true,
+            env:          env,
+          )
         end
       end
 

--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -62,7 +62,7 @@ module Cask
             "USER"     => User.current,
             "USERNAME" => User.current,
           }
-          command.run!("/usr/sbin/installer", sudo: true, args: args, print_stdout: true, env: env)
+          command.run!("/usr/sbin/installer", sudo: "root", args: args, print_stdout: true, env: env)
         end
       end
 

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -30,9 +30,10 @@ module Cask
         odebug "Deleting pkg files"
         @command.run!(
           "/usr/bin/xargs",
-          args:  ["-0", "--", "/bin/rm", "--"],
-          input: pkgutil_bom_files.join("\0"),
-          sudo:  "root",
+          args:      ["-0", "--", "/bin/rm", "--"],
+          input:     pkgutil_bom_files.join("\0"),
+          sudo:      true,
+          sudo_user: "root",
         )
       end
 
@@ -40,9 +41,10 @@ module Cask
         odebug "Deleting pkg symlinks and special files"
         @command.run!(
           "/usr/bin/xargs",
-          args:  ["-0", "--", "/bin/rm", "--"],
-          input: pkgutil_bom_specials.join("\0"),
-          sudo:  "root",
+          args:      ["-0", "--", "/bin/rm", "--"],
+          input:     pkgutil_bom_specials.join("\0"),
+          sudo:      true,
+          sudo_user: "root",
         )
       end
 
@@ -59,7 +61,7 @@ module Cask
     sig { void }
     def forget
       odebug "Unregistering pkg receipt (aka forgetting)"
-      @command.run!("/usr/sbin/pkgutil", args: ["--forget", package_id], sudo: "root")
+      @command.run!("/usr/sbin/pkgutil", args: ["--forget", package_id], sudo: true, sudo_user: "root")
     end
 
     sig { returns(T::Array[Pathname]) }
@@ -112,9 +114,10 @@ module Cask
     def rmdir(path)
       @command.run!(
         "/usr/bin/xargs",
-        args:  ["-0", "--", RMDIR_SH.to_s],
-        input: Array(path).join("\0"),
-        sudo:  "root",
+        args:      ["-0", "--", RMDIR_SH.to_s],
+        input:     Array(path).join("\0"),
+        sudo:      true,
+        sudo_user: "root",
       )
     end
 

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -32,7 +32,7 @@ module Cask
           "/usr/bin/xargs",
           args:  ["-0", "--", "/bin/rm", "--"],
           input: pkgutil_bom_files.join("\0"),
-          sudo:  true,
+          sudo:  "root",
         )
       end
 
@@ -42,7 +42,7 @@ module Cask
           "/usr/bin/xargs",
           args:  ["-0", "--", "/bin/rm", "--"],
           input: pkgutil_bom_specials.join("\0"),
-          sudo:  true,
+          sudo:  "root",
         )
       end
 
@@ -59,7 +59,7 @@ module Cask
     sig { void }
     def forget
       odebug "Unregistering pkg receipt (aka forgetting)"
-      @command.run!("/usr/sbin/pkgutil", args: ["--forget", package_id], sudo: true)
+      @command.run!("/usr/sbin/pkgutil", args: ["--forget", package_id], sudo: "root")
     end
 
     sig { returns(T::Array[Pathname]) }
@@ -114,7 +114,7 @@ module Cask
         "/usr/bin/xargs",
         args:  ["-0", "--", RMDIR_SH.to_s],
         input: Array(path).join("\0"),
-        sudo:  true,
+        sudo:  "root",
       )
     end
 

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -30,10 +30,10 @@ module Cask
         odebug "Deleting pkg files"
         @command.run!(
           "/usr/bin/xargs",
-          args:      ["-0", "--", "/bin/rm", "--"],
-          input:     pkgutil_bom_files.join("\0"),
-          sudo:      true,
-          sudo_user: "root",
+          args:         ["-0", "--", "/bin/rm", "--"],
+          input:        pkgutil_bom_files.join("\0"),
+          sudo:         true,
+          sudo_as_root: true,
         )
       end
 
@@ -41,10 +41,10 @@ module Cask
         odebug "Deleting pkg symlinks and special files"
         @command.run!(
           "/usr/bin/xargs",
-          args:      ["-0", "--", "/bin/rm", "--"],
-          input:     pkgutil_bom_specials.join("\0"),
-          sudo:      true,
-          sudo_user: "root",
+          args:         ["-0", "--", "/bin/rm", "--"],
+          input:        pkgutil_bom_specials.join("\0"),
+          sudo:         true,
+          sudo_as_root: true,
         )
       end
 
@@ -61,7 +61,12 @@ module Cask
     sig { void }
     def forget
       odebug "Unregistering pkg receipt (aka forgetting)"
-      @command.run!("/usr/sbin/pkgutil", args: ["--forget", package_id], sudo: true, sudo_user: "root")
+      @command.run!(
+        "/usr/sbin/pkgutil",
+        args:         ["--forget", package_id],
+        sudo:         true,
+        sudo_as_root: true,
+      )
     end
 
     sig { returns(T::Array[Pathname]) }
@@ -114,10 +119,10 @@ module Cask
     def rmdir(path)
       @command.run!(
         "/usr/bin/xargs",
-        args:      ["-0", "--", RMDIR_SH.to_s],
-        input:     Array(path).join("\0"),
-        sudo:      true,
-        sudo_user: "root",
+        args:         ["-0", "--", RMDIR_SH.to_s],
+        input:        Array(path).join("\0"),
+        sudo:         true,
+        sudo_as_root: true,
       )
     end
 

--- a/Library/Homebrew/sorbet/rbi/parlour.rbi
+++ b/Library/Homebrew/sorbet/rbi/parlour.rbi
@@ -108,6 +108,9 @@ class SystemCommand
   def sudo?; end
 
   sig { returns(T::Boolean) }
+  def sudo_as_root?; end
+
+  sig { returns(T::Boolean) }
   def print_stdout?; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -64,7 +64,7 @@ class SystemCommand
     params(
       executable:   T.any(String, Pathname),
       args:         T::Array[T.any(String, Integer, Float, URI::Generic)],
-      sudo:         T::Boolean,
+      sudo:         T.any(T::Boolean, String),
       env:          T::Hash[String, String],
       input:        T.any(String, T::Array[String]),
       must_succeed: T::Boolean,
@@ -122,7 +122,12 @@ class SystemCommand
 
   attr_reader :executable, :args, :input, :chdir, :env
 
-  attr_predicate :sudo?, :print_stdout?, :print_stderr?, :must_succeed?
+  attr_predicate :print_stdout?, :print_stderr?, :must_succeed?
+
+  sig { returns(T::Boolean) }
+  def sudo?
+    @sudo != false && @sudo != ""
+  end
 
   sig { returns(T::Boolean) }
   def debug?
@@ -153,8 +158,9 @@ class SystemCommand
 
   sig { returns(T::Array[String]) }
   def sudo_prefix
+    user_flags = @sudo.is_a?(String) ? ["-u", @sudo] : []
     askpass_flags = ENV.key?("SUDO_ASKPASS") ? ["-A"] : []
-    ["/usr/bin/sudo", *askpass_flags, "-E", *env_args, "--"]
+    ["/usr/bin/sudo", *user_flags, *askpass_flags, "-E", *env_args, "--"]
   end
 
   sig { returns(T::Array[String]) }

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -16,6 +16,7 @@ describe Cask::Artifact::Pkg, :cask do
         "/usr/sbin/installer",
         args:         ["-pkg", cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/"],
         sudo:         true,
+        sudo_as_root: true,
         print_stdout: true,
         env:          {
           "LOGNAME"  => ENV.fetch("USER"),
@@ -65,6 +66,7 @@ describe Cask::Artifact::Pkg, :cask do
           cask.staged_path.join("/tmp/choices.xml")
         ],
         sudo:         true,
+        sudo_as_root: true,
         print_stdout: true,
         env:          {
           "LOGNAME"  => ENV.fetch("USER"),

--- a/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
@@ -67,7 +67,11 @@ shared_examples Cask::Staged do
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
 
     expect(fake_system_command).to receive(:run!)
-      .with("/usr/sbin/chown", args: ["-R", "--", "fake_user:staff", fake_pathname, fake_pathname], sudo: true)
+      .with(
+        "/usr/sbin/chown",
+        args: ["-R", "--", "fake_user:staff", fake_pathname, fake_pathname],
+        sudo: true,
+      )
 
     staged.set_ownership([fake_pathname.to_s, fake_pathname.to_s])
   end
@@ -78,7 +82,11 @@ shared_examples Cask::Staged do
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
 
     expect(fake_system_command).to receive(:run!)
-      .with("/usr/sbin/chown", args: ["-R", "--", "other_user:other_group", fake_pathname], sudo: true)
+      .with(
+        "/usr/sbin/chown",
+        args: ["-R", "--", "other_user:other_group", fake_pathname],
+        sudo: true,
+      )
 
     staged.set_ownership(fake_pathname.to_s, user: "other_user", group: "other_group")
   end

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -63,8 +63,9 @@ describe Cask::Pkg, :cask do
 
         expect(fake_system_command).to receive(:run!).with(
           "/usr/sbin/pkgutil",
-          args: ["--forget", "my.fake.pkg"],
-          sudo: true,
+          args:         ["--forget", "my.fake.pkg"],
+          sudo:         true,
+          sudo_as_root: true,
         )
 
         pkg.uninstall
@@ -114,9 +115,10 @@ describe Cask::Pkg, :cask do
       allow(fake_system_command).to receive(:run!).and_call_original
       expect(fake_system_command).to receive(:run!).with(
         "/usr/bin/xargs",
-        args:  ["-0", "--", a_string_including("rmdir")],
-        input: [fake_dir].join("\0"),
-        sudo:  true,
+        args:         ["-0", "--", a_string_including("rmdir")],
+        input:        [fake_dir].join("\0"),
+        sudo:         true,
+        sudo_as_root: true,
       ).and_return(instance_double(SystemCommand::Result, stdout: ""))
 
       pkg.uninstall

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
@@ -15,7 +15,8 @@ cask "with-uninstall-script-app" do
   end
 
   uninstall script: {
-    executable: "#{appdir}/MyFancyApp.app/uninstall.sh",
-    sudo:       false,
+    executable:   "#{appdir}/MyFancyApp.app/uninstall.sh",
+    sudo:         false,
+    sudo_as_root: false,
   }
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-user-relative.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-user-relative.rb
@@ -15,7 +15,8 @@ cask "with-uninstall-script-user-relative" do
   end
 
   uninstall script: {
-    executable: "~/MyFancyApp.app/uninstall.sh",
-    sudo:       false,
+    executable:   "~/MyFancyApp.app/uninstall.sh",
+    sudo:         false,
+    sudo_as_root: false,
   }
 end

--- a/Library/Homebrew/test/support/helper/cask/never_sudo_system_command.rb
+++ b/Library/Homebrew/test/support/helper/cask/never_sudo_system_command.rb
@@ -5,6 +5,6 @@ require "system_command"
 
 class NeverSudoSystemCommand < SystemCommand
   def self.run(command, **options)
-    super(command, **options.merge(sudo: false))
+    super(command, **options.merge(sudo: false, sudo_as_root: false))
   end
 end


### PR DESCRIPTION
With sudoers one may override default sudo user. This mostly works provided the admin configured the replacement appropriately. However there are exceptions that absolutely must be run by root such as /usr/sbin/installer and, under certain circumstances, /bin/launchctl.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
