### PR TITLE
Enable typing in Requirement classes

### DIFF
--- a/Library/Homebrew/requirements/codesign_requirement.rb
+++ b/Library/Homebrew/requirements/codesign_requirement.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # A requirement on a code-signing identity.
@@ -11,8 +11,8 @@ class CodesignRequirement < Requirement
 
   def initialize(tags)
     options = tags.shift
-    raise ArgumentError("CodesignRequirement requires an options Hash!") unless options.is_a?(Hash)
-    raise ArgumentError("CodesignRequirement requires an identity key!") unless options.key?(:identity)
+    raise ArgumentError, "CodesignRequirement requires an options Hash!" unless options.is_a?(Hash)
+    raise ArgumentError, "CodesignRequirement requires an identity key!" unless options.key?(:identity)
 
     @identity = options.fetch(:identity)
     @with = options.fetch(:with, "code signing")
@@ -21,6 +21,7 @@ class CodesignRequirement < Requirement
   end
 
   satisfy(build_env: false) do
+    T.bind(self, CodesignRequirement)
     mktemp do
       FileUtils.cp "/usr/bin/false", "codesign_check"
       quiet_system "/usr/bin/codesign", "-f", "-s", @identity,

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "requirement"
@@ -55,6 +55,7 @@ class MacOSRequirement < Requirement
   end
 
   satisfy(build_env: false) do
+    T.bind(self, MacOSRequirement)
     next Array(@version).any? { |v| MacOS.version.public_send(@comparator, v) } if version_specified?
     next true if OS.mac?
     next true if @version
@@ -115,10 +116,10 @@ class MacOSRequirement < Requirement
     end
   end
 
-  def to_json(*args)
+  def to_json(options)
     comp = @comparator.to_s
-    return { comp => @version.map(&:to_s) }.to_json(*args) if @version.is_a?(Array)
+    return { comp => @version.map(&:to_s) }.to_json(options) if @version.is_a?(Array)
 
-    { comp => [@version.to_s] }.to_json(*args)
+    { comp => [@version.to_s] }.to_json(options)
   end
 end

--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "requirement"
@@ -13,7 +13,10 @@ class XcodeRequirement < Requirement
 
   attr_reader :version
 
-  satisfy(build_env: false) { xcode_installed_version }
+  satisfy(build_env: false) do
+    T.bind(self, XcodeRequirement)
+    xcode_installed_version
+  end
 
   def initialize(tags = [])
     @version = tags.shift if tags.first.to_s.match?(/(\d\.)+\d/)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Enables typing in `Requirement` subclasses, using a mix of `T.bind`, splat argument fixes, and class instantiation errors.