### PR TITLE
cask/auditor: only audit 10 languages by default on casks with many languages

### DIFF
--- a/Library/Homebrew/cask/auditor.rb
+++ b/Library/Homebrew/cask/auditor.rb
@@ -55,12 +55,12 @@ module Cask
       errors = Set.new
 
       if !language && language_blocks
-        if language_blocks.length > LANGUAGE_BLOCK_LIMIT && !@audit_new_cask
+        sample_languages = if language_blocks.length > LANGUAGE_BLOCK_LIMIT && !@audit_new_cask
           sample_keys = language_blocks.keys.sample(LANGUAGE_BLOCK_LIMIT)
-          sample_languages = language_blocks.select { |k| sample_keys.include?(k) }
           ohai "Auditing a sample of available languages: #{sample_keys.map { |lang| lang[0].to_s }.to_sentence}"
+          language_blocks.select { |k| sample_keys.include?(k) }
         else
-          sample_languages = language_blocks
+          language_blocks
         end
 
         sample_languages.each_key do |l|

--- a/Library/Homebrew/cask/auditor.rb
+++ b/Library/Homebrew/cask/auditor.rb
@@ -48,12 +48,22 @@ module Cask
       @except = except
     end
 
+    LANGUAGE_BLOCK_LIMIT = 10
+
     def audit
       warnings = Set.new
       errors = Set.new
 
       if !language && language_blocks
-        language_blocks.each_key do |l|
+        if language_blocks.length > LANGUAGE_BLOCK_LIMIT && !@audit_new_cask
+          sample_keys = language_blocks.keys.sample(LANGUAGE_BLOCK_LIMIT)
+          sample_languages = language_blocks.select { |k| sample_keys.include?(k) }
+          ohai "Auditing a sample of available languages: #{sample_keys.map { |lang| lang[0].to_s }.to_sentence}"
+        else
+          sample_languages = language_blocks
+        end
+
+        sample_languages.each_key do |l|
           audit = audit_languages(l)
           summary = audit.summary(include_passed: output_passed?, include_warnings: output_warnings?)
           if summary.present? && output_summary?(audit)

--- a/Library/Homebrew/test/cask/cmd/audit_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/audit_spec.rb
@@ -5,6 +5,7 @@ require "cask/auditor"
 
 describe Cask::Cmd::Audit, :cask do
   let(:cask) { Cask::Cask.new("cask") }
+  let(:cask_with_many_languages) { Cask::CaskLoader.load(cask_path("with-many-languages")) }
   let(:result) { { warnings: Set.new, errors: Set.new } }
 
   describe "selection of Casks to audit" do
@@ -159,5 +160,12 @@ describe Cask::Cmd::Audit, :cask do
       .and_return(result)
 
     described_class.run("casktoken")
+  end
+
+  it "audits a sample of language when cask contains more than 10 languages" do
+    allow(Cask::CaskLoader).to receive(:load).and_return(cask_with_many_languages)
+    expect {
+      described_class.run("with-many-languages")
+    }.to output(/==> auditing a sample of available languages/im).to_stdout
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
@@ -46,9 +46,9 @@ cask "with-many-languages" do
     "th"
   end
 
-  name "Caffeine"
-  desc "Keep your mac awake"
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "Caffeine"
+  desc "Keep your computer awake"
   homepage "https://brew.sh/"
 
   app "Caffeine.app"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
@@ -48,7 +48,7 @@ cask "with-many-languages" do
 
   name "Caffeine"
   desc "Keep your mac awake"
-  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine#{version}.zip"
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   homepage "https://brew.sh/"
 
   app "Caffeine.app"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-many-languages.rb
@@ -1,0 +1,55 @@
+cask "with-many-languages" do
+  version "1.2.3"
+
+  language "en", default: true do
+    sha256 :no_check
+    "en"
+  end
+  language "cs" do
+    sha256 :no_check
+    "cs"
+  end
+  language "es-AR" do
+    sha256 :no_check
+    "es-AR"
+  end
+  language "ff" do
+    sha256 :no_check
+    "ff"
+  end
+  language "fi" do
+    sha256 :no_check
+    "fi"
+  end
+  language "gn" do
+    sha256 :no_check
+    "gn"
+  end
+  language "gu" do
+    sha256 :no_check
+    "gu"
+  end
+  language "ko" do
+    sha256 :no_check
+    "ko"
+  end
+  language "ru" do
+    sha256 :no_check
+    "ru"
+  end
+  language "sv" do
+    sha256 :no_check
+    "sv"
+  end
+  language "th" do
+    sha256 :no_check
+    "th"
+  end
+
+  name "Caffeine"
+  desc "Keep your mac awake"
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine#{version}.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a flag `--[no-]sample-languages` to cask auditing. We have a couple of casks that contain a lot of languages (Firefox is upwards of 50) - this causes CI to timeout because it takes too long to download and audit every available binary.
This change would enable us to optionally add a flag `--sample-languages` to grab a subset of 10 languages at random for testing.

I am yet to write tests, but will do so ASAP.

Related Cask PR: https://github.com/Homebrew/homebrew-cask/pull/141357

CC: @p-linnane 