### PR TITLE
Fix analytics handling when core/cask taps are untapped

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -110,7 +110,9 @@ module Cask
 
       install_artifacts
 
-      ::Utils::Analytics.report_event("cask_install", @cask.token, on_request: true) unless @cask.tap&.private?
+      if @cask.tap&.should_report_analytics?
+        ::Utils::Analytics.report_event("cask_install", @cask.token, on_request: true)
+      end
 
       purge_backed_up_versioned_files
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -414,7 +414,7 @@ class FormulaInstaller
     options = display_options(formula).join(" ")
     oh1 "Installing #{Formatter.identifier(formula.full_name)} #{options}".strip if show_header?
 
-    if formula.tap&.installed? && !formula.tap&.private?
+    if formula.tap&.should_report_analytics?
       action = "#{formula.full_name} #{options}".strip
       Utils::Analytics.report_event("install", action, on_request: installed_on_request?)
     end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -670,6 +670,13 @@ class Tap
     @pypi_formula_mappings = read_formula_list path/HOMEBREW_TAP_PYPI_FORMULA_MAPPINGS
   end
 
+  # @private
+  def should_report_analytics?
+    return Homebrew::EnvConfig.install_from_api? && official? unless installed?
+
+    !private?
+  end
+
   def ==(other)
     other = Tap.fetch(other) if other.is_a?(String)
     self.class == other.class && name == other.name

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -144,8 +144,7 @@ module Utils
 
       def report_build_error(exception)
         return unless exception.formula.tap
-        return unless exception.formula.tap.installed?
-        return if exception.formula.tap.private?
+        return unless exception.formula.tap.should_report_analytics?
 
         action = exception.formula.full_name
         if (options = exception.options.to_a.map(&:to_s).join(" ").presence)


### PR DESCRIPTION
After untapping a cask tap with API mode enabled, cask installs would end in an error:

```
Error: No available tap homebrew/cask.
/usr/local/Homebrew/Library/Homebrew/tap.rb:219:in `config'
/usr/local/Homebrew/Library/Homebrew/tap.rb:737:in `read_or_set_private_config'
/usr/local/Homebrew/Library/Homebrew/tap.rb:213:in `private?'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:113:in `install'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/install.rb:110:in `block in install_casks'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/install.rb:109:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/install.rb:109:in `install_casks'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:185:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:93:in `<main>'
```

When installing a formula from homebrew-core with the core tap untapped, analytics data would never be reported.

This PR fixes this.