### PR TITLE
:bug: Don't substitute $HOME in variables starting with HOME (e.g. $HOMEBREW_PREFIX)

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -312,7 +312,7 @@ module Cask
 
       def from_h_string_gsubs(string)
         string.to_s
-              .gsub("$HOME", Dir.home)
+              .gsub(/\$HOME(?!\w)/, Dir.home)
               .gsub("$(brew --prefix)", HOMEBREW_PREFIX)
       end
 


### PR DESCRIPTION
There's a step in cask-loader that replaces all occurences of `$HOME` with the user's home directory (`/Users/foo`). This is done just by substituting occurrences of `$HOME` in the string.

Unfortunately, this also replaces `$HOMEBREW_PREFIX` with `/Users/fooBREW_PREFIX`.

This change instead does a regex match for the substitution, substituting only if `$HOME` isn't followed by an alphanumeric character.

Installation of google-cloud-sdk was failing on my system because of this. It installed successfully after this edit.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Note: I ran `brew tests`, but it had these two failures:
1. Cask::Quarantine by default quarantines Cask audits
2. Cask::Quarantine when disabled does not quarantine Cask audits

Both these failed with the error `The homepage URL https://transmissionbt.com/ is not reachable (HTTP status code 503)`, which I believe is not related to my change