### PR TITLE
bin/brew: refine generation of `HOMEBREW_*` env vars

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -85,7 +85,17 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
-for VAR in BAT_CONFIG_PATH BAT_THEME BROWSER DISPLAY EDITOR NO_COLOR TMUX DBUS_SESSION_BUS_ADDRESS XDG_RUNTIME_DIR CODESPACES
+
+# These variables are allowed to be set by the user as, e.g., `HOMEBREW_BROWSER`.
+MANPAGE_VARS=(
+  BAT_CONFIG_PATH
+  BAT_THEME
+  BROWSER
+  DISPLAY
+  EDITOR
+  NO_COLOR
+)
+for VAR in "${MANPAGE_VARS[@]}"
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR:-}" ]] && continue
@@ -95,7 +105,26 @@ do
   [[ -n "${!VAR_NEW:-}" ]] && continue
   export "${VAR_NEW}"="${!VAR}"
 done
-unset VAR VAR_NEW
+
+# We don't want to take the user's value for, e.g., `HOMEBREW_PATH` here!
+USED_BY_HOMEBREW_VARS=(
+  CODESPACES
+  DBUS_SESSION_BUS_ADDRESS
+  PATH
+  TMUX
+  XDG_RUNTIME_DIR
+)
+for VAR in "${USED_BY_HOMEBREW_VARS[@]}"
+do
+  # Skip if variable value is empty.
+  [[ -z "${!VAR:-}" ]] && continue
+
+  # We unconditionally override `HOMEBREW_*` here.
+  VAR_NEW="HOMEBREW_${VAR}"
+  export "${VAR_NEW}"="${!VAR}"
+done
+
+unset VAR VAR_NEW MANPAGE_VARS USED_BY_HOMEBREW_VARS
 
 export HOMEBREW_BREW_FILE
 export HOMEBREW_PREFIX
@@ -118,11 +147,6 @@ if [[ -z "${CI:-}" ]] && [[ -n "${TF_BUILD:-}" || -n "${JENKINS_HOME:-}" ]]
 then
   export CI="1"
 fi
-
-# save the existing user path as HOMEBREW_PATH so it can be queried by
-# e.g. brew doctor later.
-HOMEBREW_PATH="${PATH}"
-export HOMEBREW_PATH
 
 # filter the user environment
 PATH="/usr/bin:/bin:/usr/sbin:/sbin"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We inherit some variables from the user's environment but prefix them
with `HOMEBREW_`. This is the case for (1) variables documented in the
manpage and also for some (2) variables used internally by `brew`.

We currently treat both types identically, but we should not. In
particular, we allow users to override type (1), but we don't want to do
this for type (2).

This was partially fixed in f4103e5d61526cfbf7f31540ba45ec171adc452e,
but that fix did not go far enough. Some variables that the user should
not be allowed to override can still be overridden.

This change completes the partial fix and refactors the code so that
we're less likely to mistakenly conflate the two types of variables in
the future.
