### PR TITLE
dev-cmd/contributions: CSV output of queried repos; shorter sentence

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -335,6 +335,9 @@ module Homebrew
 
       sig { returns(T.nilable(T::Boolean)) }
       def force_auto_update?; end
+
+      sig { returns(T::Boolean) }
+      def csv?; end
     end
   end
 end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -104,7 +104,7 @@ module Homebrew
           counts[:commits],
           counts[:coauthorships],
           counts[:signoffs],
-          counts.values.sum
+          counts.values.sum,
         ]
       end
       csv << [user, "*", "*", "*", "*", total(results)]

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -96,9 +96,16 @@ module Homebrew
   sig { params(user: String, results: Hash).returns(String) }
   def generate_csv(user, results)
     CSV.generate do |csv|
-      csv << %w[user repo commits coauthorships signoffs]
+      csv << %w[user repo commits coauthorships signoffs total]
       results.each do |repo, counts|
-        csv << [user, repo, counts[:commits], counts[:coauthorships], counts[:signoffs]]
+        csv << [
+          user,
+          repo,
+          counts[:commits],
+          counts[:coauthorships],
+          counts[:signoffs],
+          counts.values.sum
+        ]
       end
     end
   end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cli/parser"
+require "csv"
 
 module Homebrew
   extend T::Sig
@@ -17,7 +18,7 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def contributions_args
     Homebrew::CLI::Parser.new do
-      usage_banner "`contributions` <email|name> [<--repositories>`=`]"
+      usage_banner "`contributions` <email|name> [<--repositories>`=`] [<--csv>]"
       description <<~EOS
         Contributions to Homebrew repos for a user.
 
@@ -34,6 +35,9 @@ module Homebrew
       flag "--to=",
            description: "Date (ISO-8601 format) to stop searching contributions."
 
+      switch "--csv",
+             description: "Print a CSV of a user's contributions across repositories over the time period."
+
       named_args number: 1
     end
   end
@@ -42,9 +46,7 @@ module Homebrew
   def contributions
     args = contributions_args.parse
 
-    commits = 0
-    coauthorships = 0
-    signoffs = 0
+    results = {}
 
     all_repos = args.repositories.nil? || args.repositories.include?("all")
     repos = all_repos ? SUPPORTED_REPOS : args.repositories
@@ -56,32 +58,19 @@ module Homebrew
 
       repo_path = find_repo_path_for_repo(repo)
       unless repo_path.exist?
-
         opoo "Repository #{repo} not yet tapped! Tapping it now..."
         Tap.fetch("homebrew", repo).install
       end
 
-      commits += git_log_author_cmd(T.must(repo_path), args)
-      coauthorships += git_log_trailers_cmd(T.must(repo_path), "Co-authored-by", args)
-      signoffs += git_log_trailers_cmd(T.must(repo_path), "Signed-off-by", args)
+      results[repo] = {
+        commits:       git_log_author_cmd(T.must(repo_path), args),
+        coauthorships: git_log_trailers_cmd(T.must(repo_path), "Co-authored-by", args),
+        signoffs:      git_log_trailers_cmd(T.must(repo_path), "Signed-off-by", args),
+      }
     end
 
-    sentence = "#{args.named.first} directly authored #{commits} commits" \
-               ", co-authored #{coauthorships} commits" \
-               ", and signed-off #{signoffs} commits " \
-               "across #{all_repos ? "all Homebrew repos" : repos.to_sentence}"
-    sentence += if args.from && args.to
-      " between #{args.from} and #{args.to}"
-    elsif args.from
-      " after #{args.from}"
-    elsif args.to
-      " before #{args.to}"
-    else
-      " in all time"
-    end
-    sentence += ". Total: #{commits + coauthorships + signoffs}."
-
-    puts sentence
+    puts "The user #{args.named.first} has made #{total(results)} contributions #{time_period(args)}."
+    puts generate_csv(args.named.first, results) if args.csv?
   end
 
   sig { params(repo: String).returns(Pathname) }
@@ -89,6 +78,37 @@ module Homebrew
     return HOMEBREW_REPOSITORY if repo == "brew"
 
     Tap.fetch("homebrew", repo).path
+  end
+
+  sig { params(args: Homebrew::CLI::Args).returns(String) }
+  def time_period(args)
+    if args.from && args.to
+      "between #{args.from} and #{args.to}"
+    elsif args.from
+      "after #{args.from}"
+    elsif args.to
+      "before #{args.to}"
+    else
+      "in all time"
+    end
+  end
+
+  sig { params(user: String, results: Hash).returns(String) }
+  def generate_csv(user, results)
+    CSV.generate do |csv|
+      csv << %w[user repo commits coauthorships signoffs]
+      results.each do |repo, counts|
+        csv << [user, repo, counts[:commits], counts[:coauthorships], counts[:signoffs]]
+      end
+    end
+  end
+
+  sig { params(results: Hash).returns(Integer) }
+  def total(results)
+    results
+      .values # [{:commits=>1, :coauthorships=>0, :signoffs=>3}, {:commits=>500, :coauthorships=>2, :signoffs=>450}]
+      .map(&:values) # [[1, 0, 3], [500, 2, 450]]
+      .sum(&:sum) # 956
   end
 
   sig { params(repo_path: Pathname, args: Homebrew::CLI::Args).returns(Integer) }

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -107,6 +107,7 @@ module Homebrew
           counts.values.sum
         ]
       end
+      csv << [user, "*", "*", "*", "*", total(results)]
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/13642.
- This gives users of this command a `--csv` option to pass to... you guessed it, generate a CSV that's `pbcopy`able elsewhere, for more granular breakdowns of where a person contributed.
- Inspiration was taken from the mockup in https://github.com/Homebrew/brew/issues/13642#issuecomment-1254535251 but without the extra dependency of the TerminalTable gem.
- Always print a condensed "total contributions" sentence.

Output:

```
$ brew contributions issyl0
The user issyl0 has made 1201 contributions in all time.

$ brew contributions issyl0 --csv
user,repo,commits,coauthorships,signoffs
issyl0,brew,331,13,0
issyl0,core,473,24,326
issyl0,cask,4,0,0
issyl0,aliases,0,0,0
issyl0,autoupdate,1,0,0
issyl0,bundle,14,2,0
issyl0,command-not-found,1,0,0
issyl0,test-bot,3,0,0
issyl0,services,9,0,0
issyl0,cask-drivers,0,0,0
issyl0,cask-fonts,0,0,0
issyl0,cask-versions,0,0,0
```