### PR TITLE
analytics: report to InfluxDB by default.

### DIFF
--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -162,7 +162,6 @@ describe Utils::Analytics do
       ENV.delete("HOMEBREW_NO_ANALYTICS_THIS_RUN")
       ENV.delete("HOMEBREW_NO_ANALYTICS")
       ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
-      ENV["HOMEBREW_ANALYTICS_ENABLE_INFLUX"] = "true"
       ENV["HOMEBREW_DEVELOPER"] = "1"
       expect(described_class).to receive(:deferred_curl).once
       described_class.report_influx(:install, action, true, developer: true, CI: true)

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -76,8 +76,6 @@ module Utils
                additional_tags: T::Hash[Symbol, T.untyped]).void
       }
       def report_influx(measurement, package_and_options, on_request, additional_tags = {})
-        return unless ENV["HOMEBREW_ANALYTICS_ENABLE_INFLUX"]
-
         # Append general information to device information
         tags = additional_tags.merge(package_and_options: package_and_options, on_request: !on_request.nil?)
                               .compact_blank


### PR DESCRIPTION
Now that this is ready: let's roll it out to everyone in 4.0.0.

Do not merge until we've done some final testing.