### PR TITLE
Enable typing in rubocops

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -47,6 +47,11 @@ Cask/StanzaOrder:
   Description: "Ensure that cask stanzas are sorted correctly. More info at https://docs.brew.sh/Cask-Cookbook#stanza-order"
   Enabled: true
 
+# This was intended to be an abstract Cop class for Homebrew formulae, but rubocop doesn't know that.
+# TODO: refactor this as a module for formulae Cop classes to include instead
+FormulaCop:
+  Enabled: false
+
 # enable all formulae audits
 FormulaAudit:
   Enabled: true

--- a/Library/Homebrew/rubocops/cask/extend/node.rb
+++ b/Library/Homebrew/rubocops/cask/extend/node.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RuboCop
@@ -19,10 +19,12 @@ module RuboCop
 
       def stanza?
         return true if arch_variable?
-        return false if !send_type? && !block_type?
-        return true if ON_SYSTEM_METHODS.include?(method_name)
 
-        STANZA_ORDER.include?(method_name)
+        case self
+        when RuboCop::AST::BlockNode, RuboCop::AST::SendNode
+          ON_SYSTEM_METHODS.include?(method_name) || STANZA_ORDER.include?(method_name)
+        else false
+        end
       end
 
       def heredoc?

--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RuboCop
@@ -6,6 +6,13 @@ module RuboCop
     module Cask
       # Common functionality for cops checking casks.
       module CaskHelp
+        extend T::Helpers
+        extend T::Sig
+        abstract!
+
+        sig { abstract.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }
+        def on_cask(cask_block); end
+
         def on_block(block_node)
           super if defined? super
           return unless respond_to?(:on_cask)

--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rbi
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module RuboCop::Cop::Cask::CaskHelp
+  requires_ancestor { RuboCop::Cop::Base }
+end

--- a/Library/Homebrew/rubocops/cask/mixin/on_desc_stanza.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/on_desc_stanza.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RuboCop

--- a/Library/Homebrew/rubocops/cask/mixin/on_desc_stanza.rbi
+++ b/Library/Homebrew/rubocops/cask/mixin/on_desc_stanza.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module RuboCop::Cop::Cask::OnDescStanza
+  requires_ancestor { RuboCop::Cop::Cask::Desc }
+end

--- a/Library/Homebrew/rubocops/cask/mixin/on_homepage_stanza.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/on_homepage_stanza.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RuboCop

--- a/Library/Homebrew/rubocops/cask/mixin/on_homepage_stanza.rbi
+++ b/Library/Homebrew/rubocops/cask/mixin/on_homepage_stanza.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module RuboCop::Cop::Cask::OnHomepageStanza
+  requires_ancestor { RuboCop::Cop::Cask::HomepageUrlTrailingSlash }
+end

--- a/Library/Homebrew/rubocops/cask/mixin/on_url_stanza.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/on_url_stanza.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RuboCop

--- a/Library/Homebrew/rubocops/cask/mixin/on_url_stanza.rbi
+++ b/Library/Homebrew/rubocops/cask/mixin/on_url_stanza.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module RuboCop::Cop::Cask::OnUrlStanza
+  requires_ancestor { RuboCop::Cop::Cask::UrlLegacyCommaSeparators }
+end

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "ast_constants"
@@ -58,7 +58,7 @@ module RuboCop
 
             @offensive_node = resource_block
 
-            on_system_bodies = []
+            on_system_bodies = T.let([], T::Array[[RuboCop::AST::BlockNode, RuboCop::AST::Node]])
 
             on_system_blocks.each_value do |blocks|
               blocks.each do |on_system_block|
@@ -68,7 +68,7 @@ module RuboCop
               end
             end
 
-            message = nil
+            message = T.let(nil, T.nilable(String))
             allowed_methods = [
               [:url, :sha256],
               [:url, :mirror, :sha256],
@@ -97,7 +97,7 @@ module RuboCop
               break
             end
 
-            if message.present?
+            if message
               problem message
               next
             end
@@ -199,7 +199,7 @@ module RuboCop
           end
 
           # Check if each present_components is above rest of the present_components
-          offensive_nodes = nil
+          offensive_nodes = T.let(nil, T.nilable(T::Array[RuboCop::AST::Node]))
           present_components.take(present_components.size - 1).each_with_index do |preceding_component, p_idx|
             next if preceding_component.empty?
 

--- a/Library/Homebrew/rubocops/extend/formula.rb
+++ b/Library/Homebrew/rubocops/extend/formula.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/shared/helper_functions"
@@ -27,6 +27,10 @@ module RuboCop
         @formula_name = Pathname.new(@file_path).basename(".rb").to_s
         @tap_style_exceptions = nil
         audit_formula(node, class_node, parent_class_node, @body)
+      end
+
+      def audit_formula(node, class_node, parent_class_node, body_node)
+        raise NotImplementedError, "Subclasses must implement this method."
       end
 
       # Yields to block when there is a match.

--- a/Library/Homebrew/rubocops/extend/formula.rb
+++ b/Library/Homebrew/rubocops/extend/formula.rb
@@ -21,7 +21,6 @@ module RuboCop
         @file_path = processed_source.buffer.name
         return unless file_path_allowed?
         return unless formula_class?(node)
-        return unless respond_to?(:audit_formula)
 
         class_node, parent_class_node, @body = *node
         @formula_name = Pathname.new(@file_path).basename(".rb").to_s

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -686,13 +686,13 @@ module RuboCop
           end
 
           find_instance_method_call(body_node, :version, :==) do |method|
-            next unless parameters_passed?(method, "HEAD")
+            next unless parameters_passed?(method, ["HEAD"])
 
             problem "Use 'build.head?' instead of inspecting 'version'"
           end
 
           find_instance_method_call(body_node, "ARGV", :include?) do |method|
-            next unless parameters_passed?(method, "--HEAD")
+            next unless parameters_passed?(method, ["--HEAD"])
 
             problem "Use \"if build.head?\" instead"
           end

--- a/Library/Homebrew/rubocops/platform.rb
+++ b/Library/Homebrew/rubocops/platform.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 module RuboCop

--- a/Library/Homebrew/rubocops/shared/desc_helper.rb
+++ b/Library/Homebrew/rubocops/shared/desc_helper.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/shared/helper_functions"
@@ -85,7 +85,9 @@ module RuboCop
       # Auto correct desc problems. `regex_match_group` must be called before this to populate @offense_source_range.
       def desc_problem(message)
         add_offense(@offensive_source_range, message: message) do |corrector|
-          /\A(?<quote>["'])(?<correction>.*)(?:\k<quote>)\Z/ =~ @offensive_node.source
+          match_data = @offensive_node.source.match(/\A(?<quote>["'])(?<correction>.*)(?:\k<quote>)\Z/)
+          correction = match_data[:correction]
+          quote = match_data[:quote]
 
           next if correction.nil?
 

--- a/Library/Homebrew/rubocops/shared/desc_helper.rbi
+++ b/Library/Homebrew/rubocops/shared/desc_helper.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module RuboCop::Cop::DescHelper
+  requires_ancestor { RuboCop::Cop::Base }
+end

--- a/Library/Homebrew/rubocops/shared/helper_functions.rb
+++ b/Library/Homebrew/rubocops/shared/helper_functions.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocop"
@@ -14,6 +14,7 @@ module RuboCop
     #
     # @api private
     module HelperFunctions
+      extend T::Sig
       include RangeHelp
 
       # Checks for regex match of pattern in the node and
@@ -49,6 +50,7 @@ module RuboCop
       end
 
       # Returns the line number of the node.
+      sig { params(node: RuboCop::AST::Node).returns(Integer) }
       def line_number(node)
         node.loc.line
       end
@@ -166,7 +168,7 @@ module RuboCop
       def find_method_with_args(node, method_name, *args)
         methods = find_every_method_call_by_name(node, method_name)
         methods.each do |method|
-          next unless parameters_passed?(method, *args)
+          next unless parameters_passed?(method, args)
           return true unless block_given?
 
           yield method
@@ -358,7 +360,7 @@ module RuboCop
       # Returns true if the given parameters are present in method call
       # and sets the method call as the offending node.
       # Params can be string, symbol, array, hash, matching regex.
-      def parameters_passed?(method_node, *params)
+      def parameters_passed?(method_node, params)
         method_params = parameters(method_node)
         @offensive_node = method_node
         params.all? do |given_param|

--- a/Library/Homebrew/rubocops/shared/helper_functions.rbi
+++ b/Library/Homebrew/rubocops/shared/helper_functions.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+
+module RuboCop::Cop::HelperFunctions
+  include Kernel
+  requires_ancestor { RuboCop::Cop::Base }
+end

--- a/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
+++ b/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "macos_versions"
@@ -172,7 +172,7 @@ module RuboCop
 
       def if_node_is_allowed?(if_node, allowed_methods: [], allowed_blocks: [])
         # TODO: check to see if it's legal
-        valid = false
+        valid = T.let(false, T::Boolean)
         if_node.each_ancestor do |ancestor|
           valid_method_names = case ancestor.type
           when :def

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -59,20 +59,20 @@ module RuboCop
           end
 
           find_method_with_args(body_node, :system, "dep", "ensure") do |d|
-            next if parameters_passed?(d, /vendor-only/)
+            next if parameters_passed?(d, [/vendor-only/])
             next if @formula_name == "goose" # needed in 2.3.0
 
             problem "use \"dep\", \"ensure\", \"-vendor-only\""
           end
 
           find_method_with_args(body_node, :system, "cargo", "build") do |m|
-            next if parameters_passed?(m, /--lib/)
+            next if parameters_passed?(m, [/--lib/])
 
             problem "use \"cargo\", \"install\", *std_cargo_args"
           end
 
           find_every_method_call_by_name(body_node, :system).each do |m|
-            next unless parameters_passed?(m, /make && make/)
+            next unless parameters_passed?(m, [/make && make/])
 
             offending_node(m)
             problem "Use separate `make` calls"

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "rubocops/extend/formula"
@@ -88,7 +88,7 @@ module RuboCop
           audit_urls(urls, http_to_https_patterns) do |_, url, index|
             # It's fine to have a plain HTTP mirror further down the mirror list.
             https_url = url.dup.insert(4, "s")
-            https_index = nil
+            https_index = T.let(nil, T.nilable(Integer))
             audit_urls(urls, https_url) do |_, _, found_https_index|
               https_index = found_https_index
             end
@@ -286,7 +286,7 @@ module RuboCop
         sig { params(url: String).returns(String) }
         def get_pypi_url(url)
           package_file = File.basename(url)
-          package_name = package_file.match(/^(.+)-[a-z0-9.]+$/)[1]
+          package_name = T.must(package_file.match(/^(.+)-[a-z0-9.]+$/))[1]
           "https://pypi.org/project/#{package_name}/#files"
         end
       end

--- a/Library/Homebrew/sorbet/config
+++ b/Library/Homebrew/sorbet/config
@@ -1,8 +1,4 @@
---dir
-.
-
---ignore
-/vendor
-
---ignore
-/test/.gem
+--dir=.
+--enable-experimental-requires-ancestor
+--ignore=/vendor
+--ignore=/test/.gem


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This changes enables typing for everything under `Library/Homebrew/rubocops`.

The most significant change here is probably enabling `--enable-experimental-requires-ancestor` [flag](https://sorbet.org/docs/requires-ancestor) in sorbet. Since the feature "is experimental and might be changed or removed without notice", i've put every use of `requires_ancestror` in an `rbi` file, so that the runtime does depend on a potentially breaking change. (However, since `sorbet-runtime` appears to be vendored, this may be overkill.)