### PR TITLE
linkage_checker: add libquadmath

### DIFF
--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -23,6 +23,7 @@ class LinkageChecker
     libgcc_s.so.1
     libgomp.so.1
     libstdc++.so.6
+    libquadmath.so.0
   ].freeze
 
   def display_deprecated_warning(strict: false)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We have noticed in https://github.com/Homebrew/homebrew-core/pull/123264 that `libquadmath.so.0` is also provided by GCC.  This is primarily used by Fortran applications (in which case `libquadmath.so.0` is provided by brewed GCC), but on occasion C or C++ programs link to this as well and `brew audit` should allow linkage to the system version of this library.