### PR TITLE
api: use formulae.brew.sh for cask-source API again.

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -17,7 +17,7 @@ module Homebrew
 
         sig { params(token: String, git_head: T.nilable(String)).returns(String) }
         def fetch_source(token, git_head: nil)
-          Homebrew::API.fetch_file_source "Casks/#{token}.rb", repo: "Homebrew/homebrew-cask", git_head: git_head
+          Homebrew::API.fetch_homebrew_cask_source token, git_head: git_head
         end
 
         sig { returns(Hash) }

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -8,6 +8,7 @@ describe Homebrew::API::Cask do
 
   before do
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
+    Homebrew::API.clear_cache
   end
 
   def mock_curl_download(stdout:)

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -9,6 +9,10 @@ describe Homebrew::API do
   let(:json_hash) { JSON.parse(json) }
   let(:json_invalid) { '{"foo":"bar"' }
 
+  before do
+    described_class.clear_cache
+  end
+
   def mock_curl_output(stdout: "", success: true)
     curl_output = OpenStruct.new(stdout: stdout, success?: success)
     allow(Utils::Curl).to receive(:curl_output).and_return curl_output
@@ -68,15 +72,15 @@ describe Homebrew::API do
   describe "::fetch_file_source" do
     it "fetches a file" do
       mock_curl_output stdout: json
-      fetched_json = described_class.fetch_file_source("foo.json", repo: "Homebrew/homebrew-core", git_head: "master")
+      fetched_json = described_class.fetch_homebrew_cask_source("foo", git_head: "master")
       expect(fetched_json).to eq json
     end
 
     it "raises an error if the file does not exist" do
       mock_curl_output success: false
       expect {
-        described_class.fetch_file_source("bar.txt", repo: "Homebrew/homebrew-core", git_head: "master")
-      }.to raise_error(ArgumentError, /No file found/)
+        described_class.fetch_homebrew_cask_source("bar", git_head: "master")
+      }.to raise_error(ArgumentError, /No valid file found/)
     end
   end
 end


### PR DESCRIPTION
GitHub's raw endpoint is proving hilariously unreliable for us here.

Fixes https://github.com/Homebrew/homebrew-cask/issues/141436