### PR TITLE
tap: return the default_remote if not installed.

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -134,7 +134,7 @@ class Tap
   # The remote path to this {Tap}.
   # e.g. `https://github.com/user/homebrew-repo`
   def remote
-    raise TapUnavailableError, name unless installed?
+    return default_remote unless installed?
 
     @remote ||= path.git_origin
   end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -185,7 +185,6 @@ describe Tap do
       setup_git_repo
 
       expect(homebrew_foo_tap.remote).to eq("https://github.com/Homebrew/homebrew-foo")
-      expect { described_class.new("Homebrew", "bar").remote }.to raise_error(TapUnavailableError)
       expect(homebrew_foo_tap).not_to have_custom_remote
 
       services_tap = described_class.new("Homebrew", "services")
@@ -213,7 +212,6 @@ describe Tap do
       setup_git_repo
 
       expect(homebrew_foo_tap.remote_repo).to eq("Homebrew/homebrew-foo")
-      expect { described_class.new("Homebrew", "bar").remote_repo }.to raise_error(TapUnavailableError)
 
       services_tap = described_class.new("Homebrew", "services")
       services_tap.path.mkpath
@@ -228,7 +226,6 @@ describe Tap do
       setup_git_repo
 
       expect(homebrew_foo_tap.remote_repo).to eq("Homebrew/homebrew-foo")
-      expect { described_class.new("Homebrew", "bar").remote_repo }.to raise_error(TapUnavailableError)
 
       services_tap = described_class.new("Homebrew", "services")
       services_tap.path.mkpath


### PR DESCRIPTION
Fixes #14656.