### PR TITLE
api: avoid unnecessary file write operation

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -82,7 +82,7 @@ module Homebrew
           opoo "#{target.basename}: update failed, falling back to cached version."
         end
 
-        FileUtils.touch target
+        FileUtils.touch(target) unless skip_download
         JSON.parse(target.read)
       rescue JSON::ParserError
         target.unlink


### PR DESCRIPTION
Fixes the `HOMEBREW_NO_AUTO_UPDATE` part of #14663.

`File.touch` always modifies the file, even if it already exists, because it refreshes mtime etc.