### PR TITLE
cmd/update-reset: improve arg parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,8 +103,6 @@ jobs:
           brew tap homebrew/portable-ruby
           brew tap homebrew/services
 
-          brew update-reset Library/Taps/homebrew/homebrew-bundle
-
           # brew style doesn't like world writable directories
           sudo chmod -R g-w,o-w "$(brew --repo)/Library/Taps"
 

--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -1,4 +1,4 @@
-#:  * `update-reset` [<repository> ...]
+#:  * `update-reset` [<path-to-tap-repository> ...]
 #:
 #:  Fetch and reset Homebrew and all tap repositories (or any specified <repository>) using `git`(1) to their latest `origin/HEAD`.
 #:
@@ -33,7 +33,14 @@ homebrew-update-reset() {
         [[ "${option}" == *d* ]] && HOMEBREW_DEBUG=1
         ;;
       *)
-        REPOS+=("${option}")
+        if [[ -d "${option}/.git" ]]
+        then
+          REPOS+=("${option}")
+        else
+          onoe "${option} is not a Git repository!"
+          brew help update-reset
+          exit 1
+        fi
         ;;
     esac
   done

--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -33,7 +33,22 @@ homebrew-update-reset() {
         [[ "${option}" == *d* ]] && HOMEBREW_DEBUG=1
         ;;
       *)
-        REPOS+=("${option}")
+        if [[ -d "${option}" ]]
+        then
+          REPOS+=("${option}")
+        else
+          local owner="${option%/*}"
+          local name="${option#*/}"
+          name="${name#homebrew-}" # Support both homebrew/core and homebrew/homebrew-core.
+
+          local repo_path="${HOMEBREW_LIBRARY}/Taps/${owner}/homebrew-${name}"
+          if [[ -d "${repo_path}" ]]
+          then
+            REPOS+=("${repo_path}")
+          else
+            odie "Could not find tap: ${option}"
+          fi
+        fi
         ;;
     esac
   done

--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -33,22 +33,7 @@ homebrew-update-reset() {
         [[ "${option}" == *d* ]] && HOMEBREW_DEBUG=1
         ;;
       *)
-        if [[ -d "${option}" ]]
-        then
-          REPOS+=("${option}")
-        else
-          local owner="${option%/*}"
-          local name="${option#*/}"
-          name="${name#homebrew-}" # Support both homebrew/core and homebrew/homebrew-core.
-
-          local repo_path="${HOMEBREW_LIBRARY}/Taps/${owner}/homebrew-${name}"
-          if [[ -d "${repo_path}" ]]
-          then
-            REPOS+=("${repo_path}")
-          else
-            odie "Could not find tap: ${option}"
-          fi
-        fi
+        REPOS+=("${option}")
         ;;
     esac
   done


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, doing `brew update-reset homebrew/core` does nothing (not
even return an error). If you want to `update-reset` a given tap, you
must do (the equivalent of)

    brew update-reset "$(brew --repository owner/tap_name)"

This isn't very intuitive, so let's do a bit more work in argument
parsing so that the user can just pass a tap name instead of a path to a
tap.

Passing a path to a tap is also still supported.
