### PR TITLE
Bash completions: warn and exit if POSIX mode detected

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -13,6 +13,12 @@
 %>
 # Bash completion script for brew(1)
 
+if test -v POSIXLY_CORRECT || test -o posix 
+then
+  echo "Homebrew Bash completions do not work in POSIX mode" 1>&2
+  return
+fi
+
 __brewcomp_words_include() {
   local element idx 
   for (( idx = 1; idx < COMP_CWORD; idx++ ))

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1,5 +1,11 @@
 # Bash completion script for brew(1)
 
+if test -v POSIXLY_CORRECT || test -o posix 
+then
+  echo "Homebrew Bash completions do not work in POSIX mode" 1>&2
+  return
+fi
+
 __brewcomp_words_include() {
   local element idx 
   for (( idx = 1; idx < COMP_CWORD; idx++ ))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Bash completions: test if POSIX mode is enabled, print an error message and exit out.
Fixes Homebrew/brew#14643

The check itself is written in POSIX-compliant manner.
The message is written to standard error.
I think this check shouldn't return a non-zero exit code, but I'm open to suggestions / opinions.