### PR TITLE
simplecov: Set `command_name` shorter than "all of the file paths ever"

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -8,6 +8,7 @@ SimpleCov.enable_for_subprocesses true
 SimpleCov.start do
   coverage_dir File.expand_path("../test/coverage", File.realpath(__FILE__))
   root File.expand_path("..", File.realpath(__FILE__))
+  command_name "Homebrew/brew"
 
   # enables branch coverage as well as, the default, line coverage
   enable_coverage :branch
@@ -18,9 +19,6 @@ SimpleCov.start do
   merge_timeout 86400
 
   at_fork do |pid|
-    # This needs a unique name so it won't be ovewritten
-    command_name "#{SimpleCov.command_name} (#{pid})"
-
     # be quiet, the parent process will be in charge of output and checking coverage totals
     SimpleCov.print_error_status = false
   end
@@ -31,8 +29,8 @@ SimpleCov.start do
   files = "#{SimpleCov.root}/{#{subdirs},*.rb}"
 
   if ENV["HOMEBREW_INTEGRATION_TEST"]
-    # This needs a unique name so it won't be ovewritten
-    command_name "#{ENV["HOMEBREW_INTEGRATION_TEST"]} (#{$PROCESS_ID})"
+    # This needs a unique name so it won't be overwritten
+    command_name "Homebrew/brew integration tests (#{ENV.fetch('TEST_ENV_NUMBER', $PROCESS_ID)})"
 
     # be quiet, the parent process will be in charge of output and checking coverage totals
     SimpleCov.print_error_status = false
@@ -53,7 +51,7 @@ SimpleCov.start do
       raise if $ERROR_INFO.is_a?(SystemExit)
     end
   else
-    command_name "#{command_name} (#{$PROCESS_ID})"
+    command_name "Homebrew/brew (#{ENV.fetch('TEST_ENV_NUMBER', $PROCESS_ID)})"
 
     # Not using this during integration tests makes the tests 4x times faster
     # without changing the coverage.


### PR DESCRIPTION
- Fixes #14662.
- Having `ENV["HOMEBREW_INTEGRATION_TEST"]` as part of the `command_name` for SimpleCov made the "generated report" wording _really_ long and unintelligible, since `HOMEBREW_INTEGRATION_TEST` for some reason is a list of paths, which when we run all of the tests in parallel, is a lot.
- Because of the way the tests run, this is still _a bit_ noisy, but I've assumed we still want the uniqueness (ish) of the process IDs. I'll iterate some more to trim this further, if desired.

```
Coverage report generated for Homebrew/brew (), Homebrew/brew (10), Homebrew/brew (11), Homebrew/brew (12), Homebrew/brew (13), Homebrew/brew (14), Homebrew/brew (15), Homebrew/brew (16), Homebrew/brew (2), Homebrew/brew (3), Homebrew/brew (4), Homebrew/brew (5), Homebrew/brew (6), Homebrew/brew (7), Homebrew/brew (8), Homebrew/brew (9), Homebrew/brew integration tests (), Homebrew/brew integration tests (10), Homebrew/brew integration tests (11), Homebrew/brew integration tests (12), Homebrew/brew integration tests (13), Homebrew/brew integration tests (14), Homebrew/brew integration tests (15), Homebrew/brew integration tests (16), Homebrew/brew integration tests (2), Homebrew/brew integration tests (3), Homebrew/brew integration tests (4), Homebrew/brew integration tests (5), Homebrew/brew integration tests (6), Homebrew/brew integration tests (7), Homebrew/brew integration tests (8), Homebrew/brew integration tests (9) to /usr/local/Homebrew/Library/Homebrew/test/coverage. 22236 / 32877 LOC (67.63%) covered.
```