### PR TITLE
Further improvements to API handling in shell

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "extend/cachable"
+
 module Homebrew
   module API
     # Helper functions for using the formula JSON API.
@@ -8,35 +10,65 @@ module Homebrew
     # @api private
     module Formula
       class << self
+        include Cachable
         extend T::Sig
+
+        private :cache
 
         sig { params(name: String).returns(Hash) }
         def fetch(name)
           Homebrew::API.fetch "formula/#{name}.json"
         end
 
+        sig { returns(T::Boolean) }
+        def download_and_cache_data!
+          json_formulae, updated = Homebrew::API.fetch_json_api_file "formula.json",
+                                                                     target: HOMEBREW_CACHE_API/"formula.json"
+
+          cache["aliases"] = {}
+          cache["formulae"] = json_formulae.to_h do |json_formula|
+            json_formula["aliases"].each do |alias_name|
+              cache["aliases"][alias_name] = json_formula["name"]
+            end
+
+            [json_formula["name"], json_formula.except("name")]
+          end
+
+          updated
+        end
+        private :download_and_cache_data!
+
         sig { returns(Hash) }
         def all_formulae
-          @all_formulae ||= begin
-            json_formulae = Homebrew::API.fetch_json_api_file "formula.json",
-                                                              target: HOMEBREW_CACHE_API/"formula.json"
-
-            @all_aliases = {}
-            json_formulae.to_h do |json_formula|
-              json_formula["aliases"].each do |alias_name|
-                @all_aliases[alias_name] = json_formula["name"]
-              end
-
-              [json_formula["name"], json_formula.except("name")]
-            end
+          unless cache.key?("formulae")
+            json_updated = download_and_cache_data!
+            write_names_and_aliases(regenerate: json_updated)
           end
+
+          cache["formulae"]
         end
 
         sig { returns(Hash) }
         def all_aliases
-          all_formulae if @all_aliases.blank?
+          unless cache.key?("aliases")
+            json_updated = download_and_cache_data!
+            write_names_and_aliases(regenerate: json_updated)
+          end
 
-          @all_aliases
+          cache["aliases"]
+        end
+
+        sig { params(regenerate: T::Boolean).void }
+        def write_names_and_aliases(regenerate: false)
+          download_and_cache_data! unless cache.key?("formulae")
+
+          return unless Homebrew::API.write_names_file(all_formulae.keys, "formula", regenerate: regenerate)
+
+          (HOMEBREW_CACHE_API/"formula_aliases.txt").open("w") do |file|
+            all_aliases.each do |alias_name, real_name|
+              file.puts "#{alias_name}|#{real_name}"
+            end
+          end
         end
       end
     end

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -75,10 +75,10 @@ case "$*" in
     homebrew-casks
     exit 0
     ;;
-  # falls back to cmd/prefix.rb on a non-zero return
-  --prefix*)
-    source "${HOMEBREW_LIBRARY}/Homebrew/prefix.sh"
-    homebrew-prefix "$@" && exit 0
+  # falls back to cmd/--prefix.rb and cmd/--cellar.rb on a non-zero return
+  --prefix* | --cellar*)
+    source "${HOMEBREW_LIBRARY}/Homebrew/formula_path.sh"
+    homebrew-formula-path "$@" && exit 0
     ;;
 esac
 

--- a/Library/Homebrew/cmd/casks.sh
+++ b/Library/Homebrew/cmd/casks.sh
@@ -8,5 +8,14 @@
 source "${HOMEBREW_LIBRARY}/Homebrew/items.sh"
 
 homebrew-casks() {
-  homebrew-items '*/Casks/*\.rb' '' 's|/Casks/|/|' '^homebrew/cask'
+  # HOMEBREW_CACHE is set by brew.sh
+  # shellcheck disable=SC2154
+  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
+        -f "${HOMEBREW_CACHE}/api/cask_names.txt" ]]
+  then
+    cat "${HOMEBREW_CACHE}/api/cask_names.txt"
+    echo
+  else
+    homebrew-items '*/Casks/*\.rb' '' 's|/Casks/|/|' '^homebrew/cask'
+  fi
 }

--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -8,18 +8,14 @@
 source "${HOMEBREW_LIBRARY}/Homebrew/items.sh"
 
 homebrew-formulae() {
-  local formulae
-  formulae="$(homebrew-items '*\.rb' 'Casks' 's|/Formula/|/|' '^homebrew/core')"
-
   # HOMEBREW_CACHE is set by brew.sh
   # shellcheck disable=SC2154
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
-        -f "${HOMEBREW_CACHE}/api/formula.json" ]]
+        -f "${HOMEBREW_CACHE}/api/formula_names.txt" ]]
   then
-    local api_formulae
-    api_formulae="$(ruby -e "require 'json'; JSON.parse(File.read('${HOMEBREW_CACHE}/api/formula.json')).each { |f| puts f['name'] }" 2>/dev/null)"
-    formulae="$(echo -e "${formulae}\n${api_formulae}" | sort -uf | grep .)"
+    cat "${HOMEBREW_CACHE}/api/formula_names.txt"
+    echo
+  else
+    homebrew-items '*\.rb' 'Casks' 's|/Formula/|/|' '^homebrew/core'
   fi
-
-  echo "${formulae}"
 }

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -146,6 +146,12 @@ module Homebrew
       end
     end
 
+    # Check if we can parse the JSON and do any Ruby-side follow-up.
+    if Homebrew::EnvConfig.install_from_api?
+      Homebrew::API::Formula.write_names_and_aliases
+      Homebrew::API::Cask.write_names
+    end
+
     Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
     return if Homebrew::EnvConfig.disable_load_formula?
 

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -796,9 +796,15 @@ EOS
       done
       if [[ ${curl_exit_code} -eq 0 ]]
       then
+        touch "${HOMEBREW_CACHE}/api/${formula_or_cask}.json"
         CURRENT_JSON_BYTESIZE="$(wc -c "${HOMEBREW_CACHE}"/api/"${formula_or_cask}".json)"
         if [[ "${INITIAL_JSON_BYTESIZE}" != "${CURRENT_JSON_BYTESIZE}" ]]
         then
+          rm -f "${HOMEBREW_CACHE}/api/${formula_or_cask}_names.txt"
+          if [[ "${formula_or_cask}" == "formula" ]]
+          then
+            rm -f "${HOMEBREW_CACHE}/api/formula_aliases.txt"
+          fi
           HOMEBREW_UPDATED="1"
         fi
       else

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -51,13 +51,13 @@ describe Homebrew::API do
 
     it "fetches a JSON file" do
       mock_curl_download stdout: json
-      fetched_json = described_class.fetch_json_api_file("foo.json", target: cache_dir/"foo.json")
+      fetched_json, = described_class.fetch_json_api_file("foo.json", target: cache_dir/"foo.json")
       expect(fetched_json).to eq json_hash
     end
 
     it "updates an existing JSON file" do
       mock_curl_download stdout: json
-      fetched_json = described_class.fetch_json_api_file("bar.json", target: cache_dir/"bar.json")
+      fetched_json, = described_class.fetch_json_api_file("bar.json", target: cache_dir/"bar.json")
       expect(fetched_json).to eq json_hash
     end
 


### PR DESCRIPTION
This follows on from the `brew --prefix` API improvements to get rid of the shell out to Ruby and read a file that gets generated on the Ruby side during an API auto-update.

There's a few parts here:

* The generated files are placed in `HOMEBREW_CACHE_API/parsed`.
* They are only generated in Ruby, so we need `brew update-report` to try invoke that post-update.
* `brew update` deletes the parsed files after an update to signal they should be regenerated. The Ruby auto-update signals back a boolean.
* It regenerates only when necessary to avoid unnecessary file writes (which matters for sandboxed use).

I've also:

* Updated `brew casks` to support the API (it previously only read local taps).
* Added shell-side support for API aliases in `brew --prefix` (for #14663).
* Added support for `brew --cellar <formula>`, using most of the existing `brew --prefix <formula>` implementation (also for #14663).

---

Copying across some benchmarks from #14622.

Worst case prior to #14622 (or prior to this PR for `--cellar`):

```
# Will be slower with poorer networks
$ hyperfine --warmup 3 "HOMEBREW_API_AUTO_UPDATE_SECS=0 brew --prefix hello"
Benchmark 1: HOMEBREW_API_AUTO_UPDATE_SECS=0 brew --prefix hello
  Time (mean ± σ):      2.416 s ±  0.162 s    [User: 1.542 s, System: 0.690 s]
  Range (min … max):    2.242 s …  2.844 s    10 runs
```

Best case before #14622 (or prior to this PR for `--cellar`):

```
$ hyperfine --warmup 3 "HOMEBREW_NO_AUTO_UPDATE=1 brew --prefix hello"
Benchmark 1: HOMEBREW_NO_AUTO_UPDATE=1 brew --prefix hello
  Time (mean ± σ):      1.831 s ±  0.083 s    [User: 1.259 s, System: 0.503 s]
  Range (min … max):    1.748 s …  2.011 s    10 runs
```

After #14622 but before this PR for `--prefix`:

```
$ hyperfine --warmup 3 "brew --prefix hello"
Benchmark 1: brew --prefix hello
  Time (mean ± σ):     787.8 ms ±  13.3 ms    [User: 665.9 ms, System: 106.0 ms]
  Range (min … max):   768.8 ms … 808.1 ms    10 runs
```

After this PR:

```
$ hyperfine --warmup 3 "brew --prefix hello"
Benchmark 1: brew --prefix hello
  Time (mean ± σ):      41.5 ms ±   7.9 ms    [User: 16.2 ms, System: 20.7 ms]
  Range (min … max):    28.5 ms …  58.0 ms    70 runs
```

Aliases:

```
$ hyperfine --warmup 3 "brew --prefix python"
Benchmark 1: brew --prefix python
  Time (mean ± σ):      64.7 ms ±   9.9 ms    [User: 26.8 ms, System: 32.3 ms]
  Range (min … max):    42.7 ms …  84.6 ms    50 runs
```
