### PR TITLE
docs/FAQ: fix HOMEBREW_NO_INSTALL_FROM_API mention

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -142,7 +142,7 @@ If all maintainer feedback has been addressed and all tests are passing, bump it
 
 Yes! It’s easy! Just `brew edit <formula>`. You don’t have to submit modifications back to `homebrew/core`, just edit the formula to what you personally need and `brew install <formula>`. As a bonus, `brew update` will merge your changes with upstream so you can still keep the formula up-to-date **with** your personal modifications!
 
-Note that if you are editing a core formula or cask you must set `HOMEBREW_NO_INSTALL_WITH_API=1` before using `brew install` or `brew update` otherwise they will ignore your local changes and default to the API.
+Note that if you are editing a core formula or cask you must set `HOMEBREW_NO_INSTALL_FROM_API=1` before using `brew install` or `brew update` otherwise they will ignore your local changes and default to the API.
 
 ## Can I make new formulae?
 


### PR DESCRIPTION
There is no `HOMEBREW_NO_INSTALL_WITH_API`; it should be `HOMEBREW_NO_INSTALL_FROM_API`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
