### PR TITLE
cmd/--version: don't always output homebrew/core.

### DIFF
--- a/Library/Homebrew/cmd/--version.sh
+++ b/Library/Homebrew/cmd/--version.sh
@@ -27,7 +27,11 @@ version_string() {
 
 homebrew-version() {
   echo "Homebrew ${HOMEBREW_VERSION}"
-  echo "Homebrew/homebrew-core $(version_string "${HOMEBREW_CORE_REPOSITORY}")"
+
+  if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API}" || -d "${HOMEBREW_CORE_REPOSITORY}" ]]
+  then
+    echo "Homebrew/homebrew-core $(version_string "${HOMEBREW_CORE_REPOSITORY}")"
+  fi
 
   if [[ -d "${HOMEBREW_CASK_REPOSITORY}" ]]
   then


### PR DESCRIPTION
This is more confusing than helpful if it's untapped for API usage.