### PR TITLE
Warn more when building from source

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -162,7 +162,7 @@ rescue BuildError => e
       This build failure is expected behaviour.
       Do not create issues about this on Homebrew's GitHub repositories.
       Any opened issues will be immediately closed without response.
-      Do not ask for help from MacHomebrew on Twitter.
+      Do not ask for help from Homebrew or its maintainers on social media.
       You may ask for help in Homebrew's discussions but are unlikely to receive a response.
       Try to figure out the problem yourself and submit a fix as a pull request.
       We will review it but may or may not accept it.

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -198,14 +198,18 @@ module Homebrew
 
     # if the user's flags will prevent bottle only-installations when no
     # developer tools are available, we need to stop them early on
+    build_flags = []
     unless DevelopmentTools.installed?
-      build_flags = []
-
       build_flags << "--HEAD" if args.HEAD?
       build_flags << "--build-bottle" if args.build_bottle?
       build_flags << "--build-from-source" if args.build_from_source?
 
       raise BuildFlagsError.new(build_flags, bottled: formulae.all?(&:bottled?)) if build_flags.present?
+    end
+
+    if build_flags.present? && !Homebrew::EnvConfig.developer?
+      opoo "building from source is not supported!"
+      puts "You're on your own. Failures are expected so don't create any issues, please!"
     end
 
     installed_formulae = formulae.select do |f|

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -97,8 +97,15 @@ module Homebrew
     formulae, casks = args.named.to_formulae_and_casks(method: :resolve)
                           .partition { |o| o.is_a?(Formula) }
 
-    if args.build_from_source? && !DevelopmentTools.installed?
-      raise BuildFlagsError.new(["--build-from-source"], bottled: formulae.all?(&:bottled?))
+    if args.build_from_source?
+      unless DevelopmentTools.installed?
+        raise BuildFlagsError.new(["--build-from-source"], bottled: formulae.all?(&:bottled?))
+      end
+
+      unless Homebrew::EnvConfig.developer?
+        opoo "building from source is not supported!"
+        puts "You're on your own. Failures are expected so don't create any issues, please!"
+      end
     end
 
     Install.perform_preinstall_checks

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -125,8 +125,15 @@ module Homebrew
   def upgrade_outdated_formulae(formulae, args:)
     return false if args.cask?
 
-    if args.build_from_source? && !DevelopmentTools.installed?
-      raise BuildFlagsError.new(["--build-from-source"], bottled: formulae.all?(&:bottled?))
+    if args.build_from_source?
+      unless DevelopmentTools.installed?
+        raise BuildFlagsError.new(["--build-from-source"], bottled: formulae.all?(&:bottled?))
+      end
+
+      unless Homebrew::EnvConfig.developer?
+        opoo "building from source is not supported!"
+        puts "You're on your own. Failures are expected so don't create any issues, please!"
+      end
     end
 
     Install.perform_preinstall_checks

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -118,7 +118,7 @@ module Homebrew
           Do not create any issues about this on Homebrew's GitHub repositories.
           Do not create any issues even if you think this message is unrelated.
           Any opened issues will be immediately closed without response.
-          Do not ask for help from MacHomebrew on Twitter.
+          Do not ask for help from Homebrew or its maintainers on social media.
           You may ask for help in Homebrew's discussions but are unlikely to receive a response.
           Try to figure out the problem yourself and submit a fix as a pull request.
           We will review it but may or may not accept it.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -274,7 +274,7 @@ class FormulaInstaller
           Do not create any issues about failures building from source on Homebrew's GitHub repositories.
           Do not create any issues building from source even if you think this message is unrelated.
           Any opened issues will be immediately closed without response.
-          Do not ask for help building from source from MacHomebrew on Twitter.
+          Do not ask for help from Homebrew or its maintainers on social media.
           You may ask for help building from source in Homebrew's discussions but are unlikely to receive a response.
           If building from source fails, try to figure out the problem yourself and submit a fix as a pull request.
           We will review it but may or may not accept it.


### PR DESCRIPTION
We warn sometimes when we tell people to build from source and it's not supported but we don't actually warn non-developers when invoking the various install commands so: let's start doing so.

While we're here, also update the existing messaging to reflect the fact we're on Mastodon now too and we don't want maintainers being individually bothered about errors either.

I've tried to balance having messages here vs. having them be so long at the beginning of installation that they will be missed or be overly obnoxious.

Feedback welcome!