### PR TITLE
workflows/tests: cache update-test's bundler.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,6 +224,16 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems
+
       - name: Run brew update-tests
         run: |
           brew update-test


### PR DESCRIPTION
This is only run on macOS for some reason but no harm in caching on both.

Should speed things up, as mentioned in https://github.com/Homebrew/brew/pull/14660#issuecomment-1434822376