### PR TITLE
More tweaks to testing output and speed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_ENV_HINTS: 1
   HOMEBREW_BOOTSNAP: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
 
 concurrency:
   group: "${{ github.ref }}"
@@ -55,10 +56,6 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - run: brew test-bot --only-cleanup-before
-
-      - run: brew config
-
       - name: Cache Bundler RubyGems
         uses: actions/cache@v1
         with:
@@ -68,8 +65,6 @@ jobs:
 
       - name: Install Bundler RubyGems
         run: brew install-bundler-gems --groups=sorbet
-
-      - run: brew doctor
 
       - name: Run brew readall on all taps
         run: brew readall --eval-all --aliases
@@ -291,6 +286,10 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.test-flags }}-parallel_runtime_rspec-
 
       - name: Install brew tests dependencies
+        if: matrix.name != 'tests (generic OS)'
+        run: brew install buildpulse-test-reporter
+
+      - name: Install brew tests --online dependencies
         if: matrix.name == 'tests (online)'
         run: brew install subversion curl
 
@@ -301,9 +300,11 @@ jobs:
 
       - name: Run brew tests
         run: |
+          # brew tests
+
           # Don't attempt to use BuildPulse for generic tests.
           # Fails for no apparent reason.
-          if [[ "${{ matrix.test-flags }}" =~ "--generic" ]]
+          if [[ "${{ matrix.name }}" =~ "generic" ]]
           then
             unset HOMEBREW_BUILDPULSE_ACCESS_KEY_ID
           fi
@@ -351,5 +352,7 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
 
       - run: brew test-bot --only-formulae --only-json-tab --test-default-formula

--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -30,7 +30,7 @@ SimpleCov.start do
 
   if ENV["HOMEBREW_INTEGRATION_TEST"]
     # This needs a unique name so it won't be overwritten
-    command_name "brew_integration_#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
+    command_name "brew_i#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
 
     # be quiet, the parent process will be in charge of output and checking coverage totals
     SimpleCov.print_error_status = false
@@ -51,7 +51,7 @@ SimpleCov.start do
       raise if $ERROR_INFO.is_a?(SystemExit)
     end
   else
-    command_name "brew_#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
+    command_name "brew#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
 
     # Not using this during integration tests makes the tests 4x times faster
     # without changing the coverage.

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -62,10 +62,11 @@ module Homebrew
 
     ohai "Sending test results to BuildPulse"
 
-    safe_system Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
-                "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
-                "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
-                "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
+    result = quiet_system Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
+                          "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
+                          "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
+                          "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
+    odie "Failed to send test results to BuildPulse!" unless result
   end
 
   def changed_test_files


### PR DESCRIPTION
- Never bother to do `brew cleanup` after `brew install`
- Skip `brew test-bot --only-cleanup-before` in more places it's not needed
- Move `brew config`/`brew doctor` into the default formula run (through `brew test-bot --only-setup`)
- Install `buildpulse-test-reporter` rather than letting `brew tests` do it
- Improve the formatting of the `brew tests` step
- Further shorten the code coverage filenames
- Don't output BuildPulse results upload status unless failed