### PR TITLE
completions/bash/brew: Fix testing for POSIX mode in bash >= 3.2.57

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1,6 +1,6 @@
 # Bash completion script for brew(1)
 
-if test -v POSIXLY_CORRECT || test -o posix 
+if [[ -n ${POSIXLY_CORRECT} ]] || shopt -oq posix
 then
   echo "Homebrew Bash completions do not work in POSIX mode" 1>&2
   return


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/14643

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~ N/A
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The test for POSIX mode introduced in https://github.com/Homebrew/brew/pull/14669 rely on bash features introduced in 4.2 which is head of 3.2.57, the default available on macOS.

```
+++ [[ brew != @(*~|*.bak|*.swp|\#*\#|*.dpkg*|*.rpm@(orig|new|save)|Makefile*) ]]
+++ [[ -f /opt/homebrew/etc/bash_completion.d/brew ]]
+++ [[ -r /opt/homebrew/etc/bash_completion.d/brew ]]
+++ . /opt/homebrew/etc/bash_completion.d/brew
++++ test -v POSIXLY_CORRECT
bash: test: -v: unary operator expected
++++ test -o posix
++++ complete -o bashdefault -o default -F _brew brew
```

I think that it's reasonable to assume that anyone attempting to source this bash completion will be attempting to source it from bash so maintaining strict POSIX compliance within the completion script itself seems counter-productive.

Rather than using bash 4.2 features we can achieve the same goal with features available in 3.2.57 and up.

The changes in this PR result in

```
bash-3.2.57$ compgen -v BASH_VERSION POSIXLY_CORRECT; shopt -o posix
BASH_VERSION
posix          	off
bash-3.2.57$ source /opt/homebrew/etc/profile.d/bash_completion.sh
bash-3.2.57$ /bin/bash --norc --posix
bash-3.2.57$ compgen -v BASH_VERSION POSIXLY_CORRECT; shopt -o posix
BASH_VERSION
posix          	on
bash-3.2.57$ source /opt/homebrew/etc/profile.d/bash_completion.sh
Homebrew Bash completions do not work in POSIX mode
…
bash-3.2.57$ /opt/homebrew/bin/bash --norc
bash-5.2.15$ compgen -v BASH_VERSION POSIXLY_CORRECT; shopt -o posix
BASH_VERSION
posix          	off
bash-5.2.15$ source /opt/homebrew/etc/profile.d/bash_completion.sh
bash-5.2.15$ /opt/homebrew/bin/bash --norc --posix
bash-5.2.15$ compgen -v BASH_VERSION POSIXLY_CORRECT; shopt -o posix
BASH_VERSION
posix          	on
bash-5.2.15$ source /opt/homebrew/completions/bash/brew
Homebrew Bash completions do not work in POSIX mode
…
```

and if we wanted to be strictly POSIX for some reason we could follow the advice in the [faq](https://mywiki.wooledge.org/BashFAQ/083) which I'm sure could be made to result in similar behavior.