### PR TITLE
Show casks from API as same as formulae

### DIFF
--- a/Library/Homebrew/cmd/casks.sh
+++ b/Library/Homebrew/cmd/casks.sh
@@ -8,5 +8,18 @@
 source "${HOMEBREW_LIBRARY}/Homebrew/items.sh"
 
 homebrew-casks() {
-  homebrew-items '*/Casks/*\.rb' '' 's|/Casks/|/|' '^homebrew/cask'
+  local casks
+  casks="$(homebrew-items '*/Casks/*\.rb' '' 's|/Casks/|/|' '^homebrew/cask')"
+
+  # HOMEBREW_CACHE is set by brew.sh
+  # shellcheck disable=SC2154
+  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
+        -f "${HOMEBREW_CACHE}/api/cask.json" ]]
+  then
+    local api_casks
+    api_casks="$(ruby -e "require 'json'; JSON.parse(File.read('${HOMEBREW_CACHE}/api/cask.json')).each { |f| puts f['token'] }" 2>/dev/null)"
+    casks="$(echo -e "${casks}\n${api_casks}" | sort -uf | grep .)"
+  fi
+
+  echo "${casks}"
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, `brew casks` does not show casks in casks.json taken by API.
This update allows showing these casks even if homebrew/cask is not tapped,
as same as `brew formulae`.
