### PR TITLE
workflows/tests: fix failing CI when Homebrew/core not present

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,8 @@ jobs:
     needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-22.04
+    env:
+      HOMEBREW_NO_INSTALL_FROM_API: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -74,8 +76,6 @@ jobs:
 
       - name: Run brew audit --skip-style on all taps
         run: brew audit --eval-all --skip-style --except=version --display-failures-only
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
 
       - name: Set up all Homebrew taps
         run: |
@@ -101,7 +101,6 @@ jobs:
         run: brew audit --skip-style --except=version --tap=homebrew/core
         env:
           HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
-          HOMEBREW_NO_INSTALL_FROM_API: 1
 
       - name: Run brew style on official taps
         run: |
@@ -264,6 +263,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
 
       - name: Cache Bundler RubyGems
         uses: actions/cache@v1


### PR DESCRIPTION
The latest GitHub images unsurprisingly don't have Homebrew/core installed anymore.