### PR TITLE
Opens Formula#tap_git_head to public use, implement for Cask

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -296,7 +296,7 @@ module Cask
         "conflicts_with" => conflicts_with,
         "container"      => container&.pairs,
         "auto_updates"   => auto_updates,
-        "tap_git_head"   => tap&.git_head,
+        "tap_git_head"   => tap_git_head,
         "languages"      => languages,
       }
     end
@@ -338,6 +338,10 @@ module Cask
 
       hash["variations"] = variations
       hash
+    end
+
+    def tap_git_head
+      tap&.git_head
     end
 
     private

--- a/Library/Homebrew/cask/cask.rbi
+++ b/Library/Homebrew/cask/cask.rbi
@@ -41,5 +41,7 @@ module Cask
     def livecheck; end
 
     def livecheckable?; end
+
+    def tap_git_head; end
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1954,7 +1954,6 @@ class Formula
     ohai "#{verb} #{name} from #{tap}"
   end
 
-  # @private
   def tap_git_head
     tap&.git_head
   end

--- a/Library/Homebrew/formula.rbi
+++ b/Library/Homebrew/formula.rbi
@@ -49,6 +49,8 @@ class Formula
   def env; end
   def conflicts; end
 
+  def tap_git_head; end
+
   def self.on_system_blocks_exist?; end
   # This method is included by `OnSystem`
   def self.on_macos(&block); end


### PR DESCRIPTION
This will enable homebrew-bundle to get this information for its lockfile as [suggested][1].

[1]: https://github.com/Homebrew/brew/issues/14698#issuecomment-1435472353

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
