### PR TITLE
Remove redundant rubocop configs

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -76,10 +76,6 @@ Layout/SpaceBeforeBrackets:
     - "/**/{Formula,Casks}/*.rb"
     - "**/{Formula,Casks}/*.rb"
 
-# Use `<<~` for heredocs.
-Layout/HeredocIndentation:
-  Enabled: true
-
 # Keyword arguments don't have the same readability
 # problems as normal parameters.
 Metrics/ParameterLists:
@@ -117,7 +113,6 @@ Naming/VariableNumber:
 
 # Require &&/|| instead of and/or
 Style/AndOr:
-  Enabled: true
   EnforcedStyle: always
 
 # Avoid leaking resources.
@@ -145,24 +140,12 @@ Style/FetchEnvVar:
 Style/FormatStringToken:
   EnforcedStyle: annotated
 
-# autocorrectable and more readable
-Style/HashEachMethods:
-  Enabled: true
-Style/HashTransformKeys:
-  Enabled: true
-Style/HashTransformValues:
-  Enabled: true
-
 # Allow for license expressions
 Style/HashAsLastArrayItem:
   Exclude:
     - "Taps/*/*/*.rb"
     - "/**/Formula/*.rb"
     - "**/Formula/*.rb"
-
-# Enabled now LineLength is lowish.
-Style/IfUnlessModifier:
-  Enabled: true
 
 # Only use this for numbers >= `1_000_000`.
 Style/NumericLiterals:
@@ -295,10 +278,6 @@ Layout/EndAlignment:
 
 # conflicts with DSL-style path concatenation with `/`
 Layout/SpaceAroundOperators:
-  Enabled: false
-
-# layout is not configurable (https://github.com/rubocop-hq/rubocop/issues/6254).
-Layout/RescueEnsureAlignment:
   Enabled: false
 
 # significantly less indentation involved; more consistent
@@ -452,11 +431,6 @@ Sorbet/StrictSigil:
 Sorbet/ConstantsFromStrings:
   Enabled: false
 
-# Avoid false positives on modifiers used on symbols of methods
-# See https://github.com/rubocop-hq/rubocop/issues/5953
-Style/AccessModifierDeclarations:
-  Enabled: false
-
 # Conflicts with type signatures on `attr_*`s.
 Style/AccessorGrouping:
   Enabled: false
@@ -506,10 +480,6 @@ Style/GuardClause:
     - "Taps/*/*/*.rb"
     - "/**/{Formula,Casks}/*.rb"
     - "**/{Formula,Casks}/*.rb"
-
-# avoid hash rockets where possible
-Style/HashSyntax:
-  EnforcedStyle: ruby19
 
 # OpenStruct is a nice helper.
 Style/OpenStructUse:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR removes some redundant `.rubocop.yml` entries (which reviewers can confirm with `rubocop --show-cops`). It also enables two cops that were disabled due to linked issues that have since been fixed, and which also do not trigger violations (`Layout/RescueEnsureAlignment` and `Style/AccessModifierDeclarations`).