### PR TITLE
Add package signing configuration for GitHub Actions

### DIFF
--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -16,6 +16,9 @@ jobs:
       IDENTIFIER: sh.brew.Homebrew
       TMP_PATH: /tmp/brew
       MIN_OS: '11.0'
+      # Please replace with your team ID.
+      # https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/
+      SIGNING_IDENTITY: '***'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -25,16 +28,53 @@ jobs:
         id: print-version
         run: |
           echo "version=$(git -C brew describe --tags --always)" >> "$GITHUB_OUTPUT"
+      - name: Install the Apple certificate
+        env:
+          PKG_BUILD_CERTIFICATE_BASE64: ${{ secrets.PKG_BUILD_CERTIFICATE_BASE64 }}
+          PKG_BUILD_P12_PASSWORD: ${{ secrets.PKG_BUILD_P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH="${RUNNER_TEMP}/build_certificate.p12"
+          KEYCHAIN_PATH="${RUNNER_TEMP}/app-signing.keychain-db"
+
+          # import certificate
+          echo -n "${PKG_BUILD_CERTIFICATE_BASE64}" \
+            | base64 --decode -o "${CERTIFICATE_PATH}"
+
+          # create temporary keychain
+          security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+          security set-keychain-settings -l -u -t 21600 "${KEYCHAIN_PATH}"
+          security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_PATH}"
+
+          # import certificate into keychain
+          security import "${CERTIFICATE_PATH}" \
+            -k "${KEYCHAIN_PATH}" -t cert -f pkcs12 \
+            -P "${PKG_BUILD_P12_PASSWORD}" -A
+          security list-keychain -d user -s "${KEYCHAIN_PATH}"
       - name: Build package
         run: |
          pkgbuild --root brew \
                   --scripts brew/package/scripts \
                   --install-location "$TMP_PATH" \
                   --identifier "$IDENTIFIER" \
+                  --sign "$SIGNING_IDENTITY" \
                   --min-os-version "$MIN_OS" \
                   --filter .DS_Store \
+                  --filter "(.*)/Library/Homebrew/test/support/fixtures/" \
                   --version ${{ steps.print-version.outputs.version }} \
                   Homebrew-${{ steps.print-version.outputs.version }}.pkg
+          # Note: `Library/Homebrew/test/support/fixtures/` contains unsigned binaries.
+          #        It needs to be excluded for notarization.
+      - name: Notarize package
+        env:
+          APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        run: |
+          xcrun notarytool submit Homebrew-${{ steps.print-version.outputs.version }}.pkg \
+                --apple-id "$APPLE_ID_USERNAME" \
+                --team-id "$SIGNING_IDENTITY" \
+                --password "$APPLE_ID_PASSWORD" \
+                --wait
       - uses: actions/upload-artifact@v3
         with:
           name: Homebrew ${{ steps.print-version.outputs.version }}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

fixes https://github.com/Homebrew/install/issues/739

This PR add a signature for generated the package.

## Prerequirement


You need to create a certificate for signing. And need to put it and its password as repository secrets.
You can look detailed instruction on [GitHub's doc](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development).

You also need to create an app-specific password for notarization.


### 1. Create an app identifier

(I'm pretty sure you already registered the identifier for homebrew but I write for others who want to try this PR.)

[Register an App ID - Manage identifiers - Account - Help - Apple Developer](https://developer.apple.com/help/account/manage-identifiers/register-an-app-id)

It must be identical as `$IDENTIFIER` env variable.

I used `dev.tetra2000.brew` for testing on my private repo.


### 2. Create a `Developer ID Installer` certificate 

You need to create a Developer ID Installer certificate using an account with Account Holder role.

[Create Developer ID certificates - Create certificates - Account - Help - Apple Developer](https://developer.apple.com/help/account/create-certificates/create-developer-id-certificates/)
[Apple Developer Program Roles - Support - Apple Developer](https://developer.apple.com/support/roles/)

### 3. Generate an app-specific password

You need to generate an "app-specific password" using an account with Account Holder role.

[Sign in to apps with your Apple ID using app-specific passwords - Apple Support](https://support.apple.com/en-us/HT204397)



### 4. Add repository secrets

Export the Developer ID Installer certificate as p12 file and convert it to Base64.

```bash
$ base64 -i Certificates.p12 | pbcopy
```

Then you need to add it and its password as [repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).

You also need to add you email address of an account with Account Holder role, an app-specific password which generated in previous step.

#### Repository secret list

- `PKG_BUILD_CERTIFICATE_BASE64`: The Base64 representation of the exported Developer ID Installer certificate.
- `PKG_BUILD_P12_PASSWORD`: The password of the exported Developer ID Installer certificate.
- `APPLE_ID_USERNAME`: The email address of an account with Account Holder role
- `APPLE_ID_PASSWORD`: The app-specific password which generated in previous step

The settings page would looks like this.

<img src="https://user-images.githubusercontent.com/1459450/221329334-40492389-c6f2-4bdf-af64-edb6818b1096.png" width="640"/>


## References

- [Installing an Apple certificate on macOS runners for Xcode development - GitHub Docs](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development)
- [Automatic Code-signing and Notarization for macOS apps using GitHub Actions - Federico Terzi - A Software Engineering Journey](https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/)
- [Notarizing macOS software before distribution | Apple Developer Documentation](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution)
- [Customizing the notarization workflow | Apple Developer Documentation](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow)


## ToDos

<details>
<summary> *Resolved</summary>

### Fix verification problem


Even though it seems to have valid signature, macOS won't let me to open the package from Finder.
A package which build on my local machine with same build command has succeeded to be opened from Finder.

I'm still finding the root cause of this problem.

```
$ pkgutil --check-signature Homebrew-898cb9c5f.pkg
Package "Homebrew-898cb9c5f.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Signed with a trusted timestamp on: 2023-02-19 11:59:21 AM +0000
   Certificate Chain:
    1. Developer ID Installer: Takahiko Inayama (788YH48Y3Q)
       Expires: 2027-02-01 10:12:15 PM +0000
       SHA256 Fingerprint:
           5B 6A 24 E5 1A 63 CC 74 BB CA F5 91 71 4A F4 AE AE 24 68 43 41 8F
           6F 11 5E 22 32 79 F1 BB E0 C0
       ------------------------------------------------------------------------
    2. Developer ID Certification Authority
       Expires: 2027-02-01 10:12:15 PM +0000
       SHA256 Fingerprint:
           7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
           F2 9C 88 CF B0 B1 BA 63 58 7F
       ------------------------------------------------------------------------
    3. Apple Root CA
       Expires: 2035-02-09 9:40:36 PM +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24
```



<img width="240" alt="Screenshot 2023-02-19 at 9 00 26 PM" src="https://user-images.githubusercontent.com/1459450/219946640-317dc3bf-c80a-4501-86a6-27214aadb842.png">

<img width="480" alt="Screenshot 2023-02-19 at 9 04 37 PM" src="https://user-images.githubusercontent.com/1459450/219946799-74f578b2-cd52-4cd5-9e2b-3dd4023f2aac.png">



#### Updated:
It's likely to be related to notarization.

```
spctl --assess --verbose --type install ./Homebrew-898cb9c5f.pkg
./Homebrew-898cb9c5f.pkg: rejected
source=Unnotarized Developer ID
```




### Add notarization (optional)

I think it's not mandatory but it may be good to add a configuration for notarization.
Apple scans malicious components during notarization process.

[Notarizing macOS software before distribution | Apple Developer Documentation](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution)

It can be done from CLI but it requires you to store app-specific password for Apple ID as a repository secret.

[Customizing the notarization workflow | Apple Developer Documentation](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow)

</details>