### PR TITLE
rubocop: Clean up some `Exclude`s

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -323,11 +323,6 @@ Lint/DuplicateBranch:
     - "/**/{Formula,Casks}/*.rb"
     - "**/{Formula,Casks}/*.rb"
 
-# needed for lazy_object magic
-Naming/MemoizedInstanceVariableName:
-  Exclude:
-    - "Homebrew/lazy_object.rb"
-
 # useful for metaprogramming in RSpec
 Lint/ConstantDefinitionInBlock:
   Exclude:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -323,11 +323,6 @@ Lint/DuplicateBranch:
     - "/**/{Formula,Casks}/*.rb"
     - "**/{Formula,Casks}/*.rb"
 
-# useful for metaprogramming in RSpec
-Lint/ConstantDefinitionInBlock:
-  Exclude:
-    - "**/*_spec.rb"
-
 # so many of these in formulae and can't be autocorrected
 Lint/ParenthesesAsGroupedExpression:
   Exclude:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -311,12 +311,6 @@ Layout/FirstHashElementIndentation:
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 
-Lint/RequireRelativeSelfPath:
-  # bugged on formula-analytics
-  # https://github.com/Homebrew/brew/pull/12152/checks?check_run_id=3755137378#step:15:60
-  Exclude:
-    - "Taps/homebrew/homebrew-formula-analytics/*/*.rb"
-
 Lint/DuplicateBranch:
   Exclude:
     - "Taps/*/*/*.rb"

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -87,5 +87,4 @@ Style/BlockDelimiters:
     - "sig"
 
 Bundler/GemFilename:
-  Exclude:
-    - "utils/gems.rb"
+  Enabled: false

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -17,18 +17,10 @@ Metrics/AbcSize:
   Max: 241
 Metrics/BlockLength:
   Max: 86
-  Exclude:
-    # TODO: extract more of the bottling logic
-    - "dev-cmd/bottle.rb"
-    - "test/**/*"
-    - "cmd/install.rb"
 Metrics/BlockNesting:
   Max: 5
 Metrics/ClassLength:
   Max: 736
-  Exclude:
-    - "formula.rb"
-    - "formula_installer.rb"
 Metrics/CyclomaticComplexity:
   Max: 68
 Metrics/PerceivedComplexity:
@@ -37,12 +29,6 @@ Metrics/MethodLength:
   Max: 232
 Metrics/ModuleLength:
   Max: 481
-  Exclude:
-    # TODO: extract more of the bottling logic
-    - "dev-cmd/bottle.rb"
-    # TODO: try break this down
-    - "utils/github.rb"
-    - "test/**/*"
 
 Naming/PredicateName:
   # Can't rename these.

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -12,11 +12,6 @@ Layout/MultilineMethodCallIndentation:
   Exclude:
     - "**/*_spec.rb"
 
-# `formula do` uses nested method definitions
-Lint/NestedMethodDefinition:
-  Exclude:
-    - "test/**/*"
-
 # TODO: Try to bring down all metrics maximums.
 Metrics/AbcSize:
   Max: 241

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -19,7 +19,7 @@ module Homebrew
 
   sig { returns(CLI::Parser) }
   def install_args
-    Homebrew::CLI::Parser.new do
+    Homebrew::CLI::Parser.new do # rubocop:disable Metrics/BlockLength
       description <<~EOS
         Install a <formula> or <cask>. Additional options specific to a <formula> may be
         appended to the command.

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -35,7 +35,7 @@ ALLOWABLE_HOMEBREW_REPOSITORY_LINKS = [
   %r{#{Regexp.escape(HOMEBREW_LIBRARY)}/Homebrew/os/(mac|linux)/pkgconfig},
 ].freeze
 
-module Homebrew
+module Homebrew # rubocop:disable Metrics/ModuleLength
   extend T::Sig
 
   module_function
@@ -591,7 +591,7 @@ module Homebrew
     bottles_hash = merge_json_files(parse_json_files(args.named))
 
     any_cellars = ["any", "any_skip_relocation"]
-    bottles_hash.each do |formula_name, bottle_hash|
+    bottles_hash.each do |formula_name, bottle_hash| # rubocop:disable Metrics/BlockLength
       ohai formula_name
 
       bottle = BottleSpecification.new

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -56,7 +56,7 @@ require "api"
 #     system "make", "install"
 #   end
 # end</pre>
-class Formula
+class Formula # rubocop:disable Metrics/ClassLength
   extend T::Sig
 
   include FileUtils

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -26,7 +26,7 @@ require "service"
 # Installer for a formula.
 #
 # @api private
-class FormulaInstaller
+class FormulaInstaller # rubocop:disable Metrics/ClassLength
   extend T::Sig
 
   include FormulaCellarChecks

--- a/Library/Homebrew/lazy_object.rb
+++ b/Library/Homebrew/lazy_object.rb
@@ -10,9 +10,11 @@ class LazyObject < Delegator
   end
 
   def __getobj__
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     return @__delegate__ if defined?(@__delegate__)
 
     @__delegate__ = @__callable__.call
+    # rubocop:enable Naming/MemoizedInstanceVariableName
   end
 
   def __setobj__(callable)

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -3,7 +3,7 @@
 
 require "benchmark"
 
-shared_examples "#uninstall_phase or #zap_phase" do
+shared_examples "#uninstall_phase or #zap_phase" do # rubocop:disable Metrics/BlockLength
   subject { artifact }
 
   let(:artifact_dsl_key) { described_class.dsl_key }

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -17,7 +17,7 @@ module Count
   end
 end
 
-module Homebrew
+module Homebrew # rubocop:disable Metrics/ModuleLength
   describe FormulaTextAuditor do
     alias_matcher :have_data, :be_data
     alias_matcher :have_end, :be_end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -90,11 +90,11 @@ describe "Exception" do
     let(:mod) do
       Module.new do
         # These are defined within an anonymous module to avoid polluting the global namespace.
-        # rubocop:disable RSpec/LeakyConstantDeclaration
+        # rubocop:disable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
         class Bar < Requirement; end
 
         class Baz < Formula; end
-        # rubocop:enable RSpec/LeakyConstantDeclaration
+        # rubocop:enable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
       end
     end
 

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -7,7 +7,7 @@ describe "patching" do
   let(:formula_subclass) {
     Class.new(Formula) {
       # These are defined within an anonymous class to avoid polluting the global namespace.
-      # rubocop:disable RSpec/LeakyConstantDeclaration
+      # rubocop:disable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
       TESTBALL_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
       TESTBALL_PATCHES_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1-patches.tgz"
       PATCH_URL_A = "file://#{TEST_FIXTURE_DIR}/patches/noop-a.diff"
@@ -17,7 +17,7 @@ describe "patching" do
       APPLY_A = "noop-a.diff"
       APPLY_B = "noop-b.diff"
       APPLY_C = "noop-c.diff"
-      # rubocop:enable RSpec/LeakyConstantDeclaration
+      # rubocop:enable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
 
       url TESTBALL_URL
       sha256 TESTBALL_SHA256

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -63,7 +63,7 @@ TEST_DIRECTORIES = [
 # work when type-checking is active.
 RSpec::Sorbet.allow_doubles!
 
-RSpec.configure do |config|
+RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
   config.order = :random
 
   config.raise_errors_for_deprecations!
@@ -181,7 +181,7 @@ RSpec.configure do |config|
     skip "Unzip is not installed." unless which("unzip")
   end
 
-  config.around do |example|
+  config.around do |example| # rubocop:disable Metrics/BlockLength
     def find_files
       return [] unless File.exist?(TEST_TMPDIR)
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -10,7 +10,7 @@ require "system_command"
 # Wrapper functions for the GitHub API.
 #
 # @api private
-module GitHub
+module GitHub # rubocop:disable Metrics/ModuleLength
   extend T::Sig
 
   include SystemCommand::Mixin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of #14685.
- Clean up some old excludes that are no longer necessary, add in-line disables for some other rules and entirely disable some rules.