### PR TITLE
dev-cmd/contributions: Add `--repositories=primary` to scan only `brew,core,cask`

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -9,8 +9,9 @@ module Homebrew
 
   module_function
 
+  PRIMARY_REPOS = %w[brew core cask].freeze
   SUPPORTED_REPOS = [
-    %w[brew core cask],
+    PRIMARY_REPOS,
     OFFICIAL_CMD_TAPS.keys.map { |t| t.delete_prefix("homebrew/") },
     OFFICIAL_CASK_TAPS.reject { |t| t == "cask" },
   ].flatten.freeze
@@ -28,7 +29,8 @@ module Homebrew
       comma_array "--repositories",
                   description: "Specify a comma-separated (no spaces) list of repositories to search. " \
                                "Supported repositories: #{SUPPORTED_REPOS.map { |t| "`#{t}`" }.to_sentence}." \
-                               "Omitting this flag, or specifying `--repositories=all`, will search all repositories."
+                               "Omitting this flag, or specifying `--repositories=all`, searches all repositories." \
+                               "Use `--repositories=primary` to search only the main repositories: brew,core,cask."
       flag "--from=",
            description: "Date (ISO-8601 format) to start searching contributions."
 
@@ -49,7 +51,13 @@ module Homebrew
     results = {}
 
     all_repos = args.repositories.nil? || args.repositories.include?("all")
-    repos = all_repos ? SUPPORTED_REPOS : args.repositories
+    repos = if all_repos
+      SUPPORTED_REPOS
+    elsif args.repositories.include?("primary")
+      PRIMARY_REPOS
+    else
+      args.repositories
+    end
 
     repos.each do |repo|
       if SUPPORTED_REPOS.exclude?(repo)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/13642.
- For annual "has this person contributed enough", we focus on the main Homebrew repos: brew, core and cask. Let's make that easier than `--repositories=brew,core,cask`.
