### PR TITLE
dev-cmd/contributions: Stats for all maintainers

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -338,6 +338,9 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def csv?; end
+
+      sig { returns(T.nilable(String)) }
+      def user; end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of #13642.
- With `brew contributions maintainers`, this will output a list of stats (across the specified time period, or all time) for people in the "maintainers" team on GitHub.
- This assumes that their Git committer details are the same as their name is set to on GitHub. There's a TODO here to work out how to do this better.
- Show an error message if trying to generate a CSV for the full maintainer list, since I haven't worked out how to best show all of that info yet (or even how best to show only the totals across everything for every user) in that format.
