### PR TITLE
utils/gzip: set `mtime = 1` when `mtime == 0`.

### DIFF
--- a/Library/Homebrew/utils/gzip.rb
+++ b/Library/Homebrew/utils/gzip.rb
@@ -28,11 +28,11 @@ module Utils
       # Zlib::GzipWriter does not properly handle the case of setting mtime = 0:
       # https://bugs.ruby-lang.org/issues/16285
       #
-      # This was fixed in https://github.com/ruby/zlib/pull/10. Set mtime to 0 instead
-      # of raising exception once we are using zlib gem version 1.1.0 or newer.
+      # This was fixed in https://github.com/ruby/zlib/pull/10. Remove workaround
+      # once we are using zlib gem version 1.1.0 or newer.
       if mtime.to_i.zero?
-        raise ArgumentError,
-              "Can't create reproducible gzip file without a valid mtime"
+        odebug "Setting `mtime = 1` to avoid zlib gem bug when `mtime == 0`."
+        mtime = 1
       end
 
       File.open(path, "rb") do |fp|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows us to bottle formulae whose source modified time is indeed
`0`.

Needed for Homebrew/homebrew-core#123724.
