### PR TITLE
Revert "Revert "Fix permissions before moving extracted files.""

### DIFF
--- a/Library/Homebrew/test/.rubocop.yml
+++ b/Library/Homebrew/test/.rubocop.yml
@@ -4,3 +4,13 @@ inherit_from:
 RSpec:
   Include:
     - ./*
+
+RSpec/ContextWording:
+  Prefixes:
+    - when
+    - with
+    - without
+    - if
+    - unless
+    - for
+    - which

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -3,6 +3,27 @@
 
 require "system_command"
 
+# Helper module for iterating over directory trees.
+#
+# @api private
+module PathnameEachDirectory
+  refine Pathname do
+    extend T::Sig
+
+    sig {
+      type_parameters(:T)
+        .params(
+          _block: T.proc.params(path: Pathname).returns(T.type_parameter(:T)),
+        ).returns(T.type_parameter(:T))
+    }
+    def each_directory(&_block)
+      find do |path|
+        yield path if path.directory?
+      end
+    end
+  end
+end
+
 # Module containing all available strategies for unpacking archives.
 #
 # @api private
@@ -11,6 +32,8 @@ module UnpackStrategy
   extend T::Helpers
 
   include SystemCommand::Mixin
+
+  using PathnameEachDirectory
 
   # Helper module for identifying the file type.
   module Magic
@@ -164,15 +187,20 @@ module UnpackStrategy
       children = tmp_unpack_dir.children
 
       if children.count == 1 && !children.first.directory?
-        FileUtils.chmod "+rw", children.first, verbose: verbose
-
         s = UnpackStrategy.detect(children.first, prioritize_extension: prioritize_extension)
 
         s.extract_nestedly(to: to, verbose: verbose, prioritize_extension: prioritize_extension)
+
         next
       end
 
-      FileUtils.chmod_R "u+w", tmp_unpack_dir, force: true, verbose: verbose
+      # Ensure all extracted directories are writable.
+      tmp_unpack_dir.each_directory do |path|
+        next if path.writable?
+
+        FileUtils.chmod "u+w", path, verbose: verbose
+      end
+
       Directory.new(tmp_unpack_dir).extract(to: to, verbose: verbose)
     end
   end

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -172,9 +172,8 @@ module UnpackStrategy
         next
       end
 
+      FileUtils.chmod_R "u+w", tmp_unpack_dir, force: true, verbose: verbose
       Directory.new(tmp_unpack_dir).extract(to: to, verbose: verbose)
-
-      FileUtils.chmod_R "+w", tmp_unpack_dir, force: true, verbose: verbose
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Reverts https://github.com/Homebrew/brew/pull/14729.

Now uses `u+w` instead of only `+w` to fix permissions only for extracted directories.
