### PR TITLE
dev-cmd/contributions: Use GitHub APIs for commit author info

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -64,15 +64,21 @@ module Homebrew
         return ofail "Unsupported repository: #{repo}. Try one of #{SUPPORTED_REPOS.join(", ")}."
       end
 
-      tap = Tap.fetch("Homebrew", repo)
       repo_path = find_repo_path_for_repo(repo)
+      tap = Tap.fetch("homebrew", repo)
       unless repo_path.exist?
         opoo "Repository #{repo} not yet tapped! Tapping it now..."
         tap.install
       end
 
+      repo_full_name = if repo == "brew"
+        "homebrew/brew"
+      else
+        tap.full_name
+      end
+
       results[repo] = {
-        commits:       GitHub.repo_commit_count_for_user(tap.full_name, args.named.first),
+        commits:       GitHub.repo_commit_count_for_user(repo_full_name, args.named.first),
         coauthorships: git_log_trailers_cmd(T.must(repo_path), "Co-authored-by", args),
         signoffs:      git_log_trailers_cmd(T.must(repo_path), "Signed-off-by", args),
       }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -86,7 +86,7 @@ class Tap
   # e.g. `user/repo`
   attr_reader :name
 
-  # The full name of this {Tap}, including the `homebrew-` prefix.
+  # The full name of this {Tap}, including the `homebrew-` prefix unless repo == "brew".
   # It combines {#user} and 'homebrew-'-prefixed {#repo} with a slash.
   # e.g. `user/homebrew-repo`
   attr_reader :full_name
@@ -100,7 +100,7 @@ class Tap
     @user = user
     @repo = repo
     @name = "#{@user}/#{@repo}".downcase
-    @full_name = "#{@user}/homebrew-#{@repo}"
+    @full_name = (@repo == "brew") ? "#{user}/#{repo}" : "#{@user}/homebrew-#{@repo}"
     @path = TAP_DIRECTORY/@full_name.downcase
     @path.extend(GitRepositoryExtension)
     @alias_table = nil

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -86,7 +86,7 @@ class Tap
   # e.g. `user/repo`
   attr_reader :name
 
-  # The full name of this {Tap}, including the `homebrew-` prefix unless repo == "brew".
+  # The full name of this {Tap}, including the `homebrew-` prefix.
   # It combines {#user} and 'homebrew-'-prefixed {#repo} with a slash.
   # e.g. `user/homebrew-repo`
   attr_reader :full_name
@@ -100,7 +100,7 @@ class Tap
     @user = user
     @repo = repo
     @name = "#{@user}/#{@repo}".downcase
-    @full_name = (@repo == "brew") ? "#{user}/#{repo}" : "#{@user}/homebrew-#{@repo}"
+    @full_name = "#{@user}/homebrew-#{@repo}"
     @path = TAP_DIRECTORY/@full_name.downcase
     @path.extend(GitRepositoryExtension)
     @alias_table = nil

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -704,7 +704,7 @@ module GitHub # rubocop:disable Metrics/ModuleLength
     return if Homebrew::EnvConfig.no_github_api?
 
     commits = 0
-    API.paginate_rest("#{API_URL}/repos/#{nwo}/commits", query: "&author=#{user}") do |result|
+    API.paginate_rest("#{API_URL}/repos/#{nwo}/commits", additional_query_params: "author=#{user}") do |result|
       commits += result.length
     end
     commits

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -699,4 +699,14 @@ module GitHub # rubocop:disable Metrics/ModuleLength
 
     output[/^Status: (200)/, 1] != "200"
   end
+
+  def repo_commit_count_for_user(nwo, user)
+    return if Homebrew::EnvConfig.no_github_api?
+
+    commits = 0
+    API.paginate_rest("#{API_URL}/repos/#{nwo}/commits", query: "&author=#{user}") do |result|
+      commits += result.length
+    end
+    commits
+  end
 end

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -253,9 +253,9 @@ module GitHub
       end
     end
 
-    def paginate_rest(url, per_page: 100)
+    def paginate_rest(url, query: nil, per_page: 100)
       (1..API_MAX_PAGES).each do |page|
-        result = API.open_rest("#{url}?per_page=#{per_page}&page=#{page}")
+        result = API.open_rest("#{url}?per_page=#{per_page}&page=#{page}#{query}")
         yield(result, page)
       end
     end

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -253,9 +253,9 @@ module GitHub
       end
     end
 
-    def paginate_rest(url, query: nil, per_page: 100)
+    def paginate_rest(url, additional_query_params: nil, per_page: 100)
       (1..API_MAX_PAGES).each do |page|
-        result = API.open_rest("#{url}?per_page=#{per_page}&page=#{page}#{query}")
+        result = API.open_rest("#{url}?per_page=#{per_page}&page=#{page}&#{additional_query_params}")
         yield(result, page)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Using `git log` was brittle with name changes and email address changes for contributors over the years unless we made a Git `mailmap` file which brings with it its own updatedness overhead.
- Let's use the GitHub commits API (importantly _not_ the search API) so that we can give it a username and it will return contributions associated with every email address on that user's account: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits--parameters.
- This is quite significantly slower, but it's worth it for correctness especially when we get to all maintainers' contributions (in a separate PR).
- The list commits API does not (yet? 🤔) support filtering by trailers or commit "committer"s, just authors.

----

For some context: I am lucky enough to have `issyl0` in all the email addresses that I've used in the past to commit to Homebrew, so `issyl0` worked as a wide enough search string before this change. But searching for "Issy Long" omits some commits from when my Git committer name was not that.

I noticed this when doing #14722 which is moving towards using `user.full_name` (because people don't usually have their GitHub username as their committer name or email address). The numbers didn't match up between there and `master` for myself (and probably others too, since name changes are common for a variety of reasons).

This is not just about me. 😆 Moving towards using the GitHub APIs will make this more accurate at counting contributions, mean that we don't have to remember email addresses for people to accurately count every contribution they've made, and also once everything is migrated it means that we don't have to tap all the taps locally since that's time-consuming. Rate limits could potentially be a problem, but that's one of the reasons we're not using the commit _search_ API.

----

Before:

```
$ brew contributions "Issy Long"
The user Issy Long has made 1112 contributions in all time.
```

After:

```
$ brew contributions issyl0
The user issyl0 has made 1222 contributions in all time.
```