### PR TITLE
docs: improve some `$(brew --prefix)` usage

### DIFF
--- a/docs/Gems,-Eggs-and-Perl-Modules.md
+++ b/docs/Gems,-Eggs-and-Perl-Modules.md
@@ -60,7 +60,7 @@ which therefore don’t need sudo.
 
 _This is only recommended if you **don't** use rbenv or RVM._
 
-Brewed Ruby installs executables to `$(brew --prefix)/opt/ruby/bin`
+Brewed Ruby installs executables to `$(brew --prefix ruby)/bin`
 without sudo. You should add this to your path. See the caveats in the
 `ruby` formula for up-to-date information.
 
@@ -91,7 +91,7 @@ Just install everything into the Homebrew prefix like this:
 echo "export GEM_HOME=\"$(brew --prefix)\"" >> ~/.bashrc
 ```
 
-### It doesn’t work! I get some “permissions” error when I try to install stuff!
+### It doesn’t work! I get some “permissions” error when I try to install stuff
 
 _Note that you may not want to do this, since Apple has decided it
 is not a good default._

--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -23,7 +23,7 @@ The executables are organised as follows:
 Unversioned symlinks for `python`, `python-config`, `pip` etc. are installed here:
 
 ```sh
-$(brew --prefix)/opt/python/libexec/bin
+$(brew --prefix python)/libexec/bin
 ```
 
 ## Setuptools, pip, etc.

--- a/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
+++ b/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
@@ -27,13 +27,13 @@ Useful, reliable alternatives exist should you wish to use keg-only tools outsid
 You can set flags to give configure scripts or Makefiles a nudge in the right direction. An example of flag setting:
 
 ```sh
-./configure --prefix=/Users/Dave/Downloads CFLAGS="-I$(brew --prefix)/opt/openssl/include" LDFLAGS="-L$(brew --prefix)/opt/openssl/lib"
+./configure --prefix=/Users/Dave/Downloads CFLAGS="-I$(brew --prefix openssl)/include" LDFLAGS="-L$(brew --prefix openssl)/lib"
 ```
 
 An example using `pip`:
 
 ```sh
-CFLAGS="-I$(brew --prefix)/opt/icu4c/include" LDFLAGS="-L$(brew --prefix)/opt/icu4c/lib" pip install pyicu
+CFLAGS="-I$(brew --prefix icu4c)/include" LDFLAGS="-L$(brew --prefix icu4c)/lib" pip install pyicu
 ```
 
 ### `PATH` modification
@@ -41,7 +41,7 @@ CFLAGS="-I$(brew --prefix)/opt/icu4c/include" LDFLAGS="-L$(brew --prefix)/opt/ic
 You can temporarily prepend your `PATH` with the tool’s `bin` directory, such as:
 
 ```sh
-export PATH="$(brew --prefix)/opt/openssl/bin:${PATH}"
+export PATH="$(brew --prefix openssl)/bin:${PATH}"
 ```
 
 This will prepend the directory to your `PATH`, ensuring any build script that searches the `PATH` will find it first.
@@ -55,7 +55,7 @@ If the tool you are attempting to build is [pkg-config](https://en.wikipedia.org
 An example of this is:
 
 ```sh
-export PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl/lib/pkgconfig"
+export PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig"
 ```
 
 If you’re curious about the `PKG_CONFIG_PATH` variable, `man pkg-config` goes into more detail.


### PR DESCRIPTION
Intended change: for brew docs https://docs.brew.sh/Homebrew-and-Python#python-3y to say `$(brew --prefix python)/libexec/bin` instead of `$(brew --prefix)/opt/python/libexec/bin` in order to be more robust to edge cases from package installation issues.

`brew --prefix python` errors out when the python package is not installed, so using that instead of `brew --prefix` prevents python package installation issues from silently breaking, for example, shell env scripts that add this to $PATH.

See https://github.com/orgs/Homebrew/discussions/3596#discussioncomment-5050569

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
