### PR TITLE
rubocop: Entirely disable `Metrics` cops

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -12,23 +12,8 @@ Layout/MultilineMethodCallIndentation:
   Exclude:
     - "**/*_spec.rb"
 
-# TODO: Try to bring down all metrics maximums.
-Metrics/AbcSize:
-  Max: 241
-Metrics/BlockLength:
-  Max: 86
-Metrics/BlockNesting:
-  Max: 5
-Metrics/ClassLength:
-  Max: 736
-Metrics/CyclomaticComplexity:
-  Max: 68
-Metrics/PerceivedComplexity:
-  Max: 84
-Metrics/MethodLength:
-  Max: 232
-Metrics/ModuleLength:
-  Max: 481
+Metrics:
+  Enabled: false
 
 Naming/PredicateName:
   AllowedMethods:

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -19,7 +19,7 @@ module Homebrew
 
   sig { returns(CLI::Parser) }
   def install_args
-    Homebrew::CLI::Parser.new do # rubocop:disable Metrics/BlockLength
+    Homebrew::CLI::Parser.new do
       description <<~EOS
         Install a <formula> or <cask>. Additional options specific to a <formula> may be
         appended to the command.

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -35,7 +35,7 @@ ALLOWABLE_HOMEBREW_REPOSITORY_LINKS = [
   %r{#{Regexp.escape(HOMEBREW_LIBRARY)}/Homebrew/os/(mac|linux)/pkgconfig},
 ].freeze
 
-module Homebrew # rubocop:disable Metrics/ModuleLength
+module Homebrew
   extend T::Sig
 
   module_function
@@ -591,7 +591,7 @@ module Homebrew # rubocop:disable Metrics/ModuleLength
     bottles_hash = merge_json_files(parse_json_files(args.named))
 
     any_cellars = ["any", "any_skip_relocation"]
-    bottles_hash.each do |formula_name, bottle_hash| # rubocop:disable Metrics/BlockLength
+    bottles_hash.each do |formula_name, bottle_hash|
       ohai formula_name
 
       bottle = BottleSpecification.new

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -56,7 +56,7 @@ require "api"
 #     system "make", "install"
 #   end
 # end</pre>
-class Formula # rubocop:disable Metrics/ClassLength
+class Formula
   extend T::Sig
 
   include FileUtils

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -26,7 +26,7 @@ require "service"
 # Installer for a formula.
 #
 # @api private
-class FormulaInstaller # rubocop:disable Metrics/ClassLength
+class FormulaInstaller
   extend T::Sig
 
   include FormulaCellarChecks

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -11,8 +11,6 @@ require "ruby-progressbar"
 require "uri"
 
 module Homebrew
-  # rubocop:disable Metrics/ModuleLength
-
   # The {Livecheck} module consists of methods used by the `brew livecheck`
   # command. These methods print the requested livecheck information
   # for formulae.
@@ -158,8 +156,6 @@ module Homebrew
 
     # Executes the livecheck logic for each formula/cask in the
     # `formulae_and_casks_to_check` array and prints the results.
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     sig {
       params(
         formulae_and_casks_to_check: T::Array[T.any(Formula, Cask::Cask)],
@@ -217,7 +213,6 @@ module Homebrew
         )
       end
 
-      # rubocop:disable Metrics/BlockLength
       formulae_checked = formulae_and_casks_to_check.map.with_index do |formula_or_cask, i|
         formula = formula_or_cask if formula_or_cask.is_a?(Formula)
         cask = formula_or_cask if formula_or_cask.is_a?(Cask::Cask)
@@ -383,7 +378,10 @@ module Homebrew
 
         if json
           progress&.increment
-          status_hash(formula_or_cask, "error", [e.to_s], full_name: use_full_name, verbose: verbose) unless quiet
+          unless quiet
+            status_hash(formula_or_cask, "error", [e.to_s], full_name: use_full_name,
+                                                            verbose:   verbose)
+          end
         elsif !quiet
           name = package_or_resource_name(formula_or_cask, full_name: use_full_name)
           name += " (cask)" if ambiguous_casks.include?(formula_or_cask)
@@ -627,7 +625,6 @@ module Homebrew
 
     # Identifies the latest version of the formula/cask and returns a Hash containing
     # the version information. Returns nil if a latest version couldn't be found.
-    # rubocop:disable Metrics/CyclomaticComplexity
     sig {
       params(
         formula_or_cask:            T.any(Formula, Cask::Cask),
@@ -685,7 +682,6 @@ module Homebrew
       end
 
       checked_urls = []
-      # rubocop:disable Metrics/BlockLength
       urls.each_with_index do |original_url, i|
         # Only preprocess the URL when it's appropriate
         url = if STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL.include?(livecheck_strategy)
@@ -828,12 +824,8 @@ module Homebrew
 
         return version_info
       end
-      # rubocop:enable Metrics/BlockLength
-
       nil
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
-
     # Identifies the latest version of a resource and returns a Hash containing the
     # version information. Returns nil if a latest version couldn't be found.
     sig {
@@ -876,7 +868,6 @@ module Homebrew
       urls ||= checkable_urls(resource)
 
       checked_urls = []
-      # rubocop:disable Metrics/BlockLength
       urls.each_with_index do |original_url, i|
         url = original_url.gsub(Constants::LATEST_VERSION, formula_latest)
 
@@ -1020,7 +1011,6 @@ module Homebrew
           nil
         end
       end
-      # rubocop:enable Metrics/BlockLength
       resource_version_info
     end
   end

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -443,7 +443,7 @@ module RuboCop
           install = find_method_def(body_node, :install)
           return if install.blank?
 
-          correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcmd, shell_parameter| # rubocop:disable Metrics/ParameterLists
+          correctable_shell_completion_node(install) do |node, shell, base_name, executable, subcmd, shell_parameter|
             # generate_completions_from_executable only applicable if shell is passed
             next unless shell_parameter.match?(/(bash|zsh|fish)/)
 

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -3,7 +3,7 @@
 
 require "benchmark"
 
-shared_examples "#uninstall_phase or #zap_phase" do # rubocop:disable Metrics/BlockLength
+shared_examples "#uninstall_phase or #zap_phase" do
   subject { artifact }
 
   let(:artifact_dsl_key) { described_class.dsl_key }

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -17,7 +17,7 @@ module Count
   end
 end
 
-module Homebrew # rubocop:disable Metrics/ModuleLength
+module Homebrew
   describe FormulaTextAuditor do
     alias_matcher :have_data, :be_data
     alias_matcher :have_end, :be_end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -63,7 +63,7 @@ TEST_DIRECTORIES = [
 # work when type-checking is active.
 RSpec::Sorbet.allow_doubles!
 
-RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
+RSpec.configure do |config|
   config.order = :random
 
   config.raise_errors_for_deprecations!
@@ -181,7 +181,7 @@ RSpec.configure do |config| # rubocop:disable Metrics/BlockLength
     skip "Unzip is not installed." unless which("unzip")
   end
 
-  config.around do |example| # rubocop:disable Metrics/BlockLength
+  config.around do |example|
     def find_files
       return [] unless File.exist?(TEST_TMPDIR)
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -10,7 +10,7 @@ require "system_command"
 # Wrapper functions for the GitHub API.
 #
 # @api private
-module GitHub # rubocop:disable Metrics/ModuleLength
+module GitHub
   extend T::Sig
 
   include SystemCommand::Mixin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/14685.
- These are arbitrary length limits that had a load of disables in code.
- The limits were only increasing over time rather than decreasing.
- Fixing the problematic code to be shorter would take a long time for questionable gain since the problem has been around so long.

