### PR TITLE
api: respect --quiet

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -49,7 +49,7 @@ module Homebrew
       ]
       curl_args << "--progress-bar" unless Context.current.verbose?
       curl_args << "--verbose" if Homebrew::EnvConfig.curl_verbose?
-      curl_args << "--silent" unless $stdout.tty?
+      curl_args << "--silent" if !$stdout.tty? || Context.current.quiet?
 
       skip_download = target.exist? &&
                       !target.empty? &&
@@ -61,7 +61,7 @@ module Homebrew
           args = curl_args.dup
           args.prepend("--time-cond", target.to_s) if target.exist? && !target.empty?
           unless skip_download
-            ohai "Downloading #{url}" if $stdout.tty?
+            ohai "Downloading #{url}" if $stdout.tty? && !Context.current.quiet?
             # Disable retries here, we handle them ourselves below.
             Utils::Curl.curl_download(*args, url, to: target, retries: 0, show_error: false)
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Resolves #14707. Basically it respects `--quiet` when loading cask and formula JSON from the API. This applies globally.

```rb
/u/l/Homebrew (master|✚1) $ brew irb
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
irb(main):001:0> Context.current.quiet?
=> false
irb(main):002:0> Homebrew::API::Formula.all_formulae; nil
==> Downloading https://formulae.brew.sh/api/formula.json
############################################################################################################################################################################ 100.0%
=> nil
irb(main):003:0> Context.current.instance_variable_set(:@quiet, true)
=> true
irb(main):004:0> Context.current.quiet?
=> true
irb(main):005:0> Homebrew::API::Cask.all_casks; nil
=> nil
```

Side note: `brew irb` doesn't take `--quiet` for some reason. Must be a quirk of `IRB` or something.