### PR TITLE
Look for all packages if specified packages are not found.

### DIFF
--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -100,9 +100,8 @@ module Homebrew
 
         info_plist_paths.each(&parse_info_plist)
 
-        pkg_paths = pkgs.flat_map do |pkg|
-          Pathname.glob(dir/"**"/pkg.path.basename).sort
-        end
+        pkg_paths = pkgs.flat_map { |pkg| Pathname.glob(dir/"**"/pkg.path.basename).sort }
+        pkg_paths = Pathname.glob(dir/"**"/"*.pkg").sort if pkg_paths.empty?
 
         pkg_paths.each do |pkg_path|
           Dir.mktmpdir do |extract_dir|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

An `:extract_plist` `livecheck` on a cask containing 

```ruby
  pkg "OverDrive-Mac-Installer-Version-#{version.major_minor}.pkg"
```

will only look for packages matching the major and minor version. This makes a `livecheck` useless when e.g. 1.3.0 is released. So when no packages are able to be globbed, glob any packages instead.