### PR TITLE
Don't preprocess URL for `:extract_plist` strategy.

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -33,6 +33,7 @@ module Homebrew
     ].freeze
 
     STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL = [
+      :extract_plist,
       :github_latest,
       :page_match,
       :header_match,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Extracting versions from a `.plist` always requires the unchanged URL for a given cask.

Fixes CI failure in https://github.com/Homebrew/homebrew-cask/pull/141646.