### PR TITLE
utils/github/api: Smarter pagination in `paginate_rest`

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -256,6 +256,8 @@ module GitHub
     def paginate_rest(url, additional_query_params: nil, per_page: 100)
       (1..API_MAX_PAGES).each do |page|
         result = API.open_rest("#{url}?per_page=#{per_page}&page=#{page}&#{additional_query_params}")
+        break if result.blank?
+
         yield(result, page)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The `API_MAX_PAGES` value is 50, so for pages 1 to 50, the `paginate_rest` method was making an API call even if there was no data past, for example, page 8.
- This made `brew contributions --user=issyl0` take 11 minutes, since we made 50 API calls _per repo_ even if it was unnecessary, burning down our API allowance.
- Instead, stop looping if we detect that there's no data in `result`.
- This probably needs more testing for other parts of Homebrew that rely on `paginate_rest` and the different shapes of data it outputs.

Before:

```
❯ time brew contributions --user=issyl0          
issyl0 contributed 1233 times in all time.
brew contributions --user=issyl0  33.90s user 26.27s system 8% cpu 11:41.11 total
```

After:

```
❯ time brew contributions --user=issyl0
issyl0 contributed 1233 times in all time.
brew contributions --user=issyl0 22.12s user 14.58s system 47% cpu 1:16.95 total
```