### PR TITLE
utils/github: Add date filtering to the commit author API query

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -70,7 +70,6 @@ module Homebrew
 
     maintainers = GitHub.members_by_team("Homebrew", "maintainers")
     maintainers.each do |username, _|
-      puts "Determining contributions for #{username}..." if args.verbose?
       # TODO: Using the GitHub username to scan the `git log` undercounts some
       # contributions as people might not always have configured their Git
       # committer details to match the ones on GitHub.

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -143,7 +143,7 @@ module Homebrew
       puts "Determining contributions for #{person} on #{repo_full_name}..." if args.verbose?
 
       data[repo] = {
-        commits:       GitHub.repo_commit_count_for_user(repo_full_name, person),
+        commits:       GitHub.repo_commit_count_for_user(repo_full_name, person, args),
         coauthorships: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", args),
         signoffs:      git_log_trailers_cmd(T.must(repo_path), person, "Signed-off-by", args),
       }

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -700,11 +700,15 @@ module GitHub
     output[/^Status: (200)/, 1] != "200"
   end
 
-  def repo_commit_count_for_user(nwo, user)
+  def repo_commit_count_for_user(nwo, user, args)
     return if Homebrew::EnvConfig.no_github_api?
 
+    params = ["author=#{user}"]
+    params << "since=#{DateTime.parse(args.from).iso8601}" if args.from
+    params << "until=#{DateTime.parse(args.to).iso8601}" if args.to
+
     commits = 0
-    API.paginate_rest("#{API_URL}/repos/#{nwo}/commits", additional_query_params: "author=#{user}") do |result|
+    API.paginate_rest("#{API_URL}/repos/#{nwo}/commits", additional_query_params: params.join("&")) do |result|
       commits += result.length
     end
     commits


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- I missed the date filtering off the original implementation of the author API query - oops. This gives parity with the `git log` implementation.
- Also reduce verbosity of `brew contributions --verbose` a little since it annoyed me.