### PR TITLE
dev-cmd/generate-*-api: don't use same constant name.

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -22,7 +22,7 @@ module Homebrew
     end
   end
 
-  JSON_TEMPLATE = <<~EOS
+  CASK_JSON_TEMPLATE = <<~EOS
     ---
     layout: cask_json
     ---
@@ -56,7 +56,7 @@ module Homebrew
       json = JSON.pretty_generate(cask.to_hash_with_variations)
 
       File.write("_data/cask/#{name}.json", "#{json}\n")
-      File.write("api/cask/#{name}.json", JSON_TEMPLATE)
+      File.write("api/cask/#{name}.json", CASK_JSON_TEMPLATE)
       File.write("api/cask-source/#{name}.rb", path.read)
       File.write("cask/#{name}.html", html_template(name))
     end

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -22,7 +22,7 @@ module Homebrew
     end
   end
 
-  JSON_TEMPLATE = <<~EOS
+  FORMULA_JSON_TEMPLATE = <<~EOS
     ---
     layout: formula_json
     ---
@@ -57,7 +57,7 @@ module Homebrew
       json = JSON.pretty_generate(formula.to_hash_with_variations)
 
       File.write("_data/formula/#{name.tr("+", "_")}.json", "#{json}\n")
-      File.write("api/formula/#{name}.json", JSON_TEMPLATE)
+      File.write("api/formula/#{name}.json", FORMULA_JSON_TEMPLATE)
       File.write("formula/#{name}.html", html_template(name))
     end
 


### PR DESCRIPTION
Otherwise Ruby warns.