### PR TITLE
cask: support url specs in API

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -277,6 +277,14 @@ module Cask
         return api_to_local_hash(Homebrew::API.merge_variations(json_cask))
       end
 
+      url_specs = url.specs.dup
+      case url_specs[:user_agent]
+      when :default
+        url_specs.delete(:user_agent)
+      when Symbol
+        url_specs[:user_agent] = ":#{url_specs[:user_agent]}"
+      end
+
       {
         "token"                => token,
         "full_token"           => full_name,
@@ -285,6 +293,7 @@ module Cask
         "desc"                 => desc,
         "homepage"             => homepage,
         "url"                  => url,
+        "url_specs"            => url_specs,
         "appcast"              => appcast,
         "version"              => version,
         "versions"             => os_versions,

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -246,6 +246,12 @@ module Cask
 
         tap = Tap.fetch(json_cask[:tap]) if json_cask[:tap].to_s.include?("/")
 
+        user_agent = json_cask.dig(:url_specs, :user_agent)
+        json_cask[:url_specs][:user_agent] = user_agent[1..].to_sym if user_agent && user_agent[0] == ":"
+        if (using = json_cask.dig(:url_specs, :using))
+          json_cask[:url_specs][:using] = using.to_sym
+        end
+
         Cask.new(token,
                  tap:             tap,
                  source:          cask_source,
@@ -261,7 +267,7 @@ module Cask
             sha256 json_cask[:sha256]
           end
 
-          url json_cask[:url]
+          url json_cask[:url], **json_cask.fetch(:url_specs, {})
           appcast json_cask[:appcast] if json_cask[:appcast].present?
           json_cask[:name].each do |cask_name|
             name cask_name

--- a/Library/Homebrew/test/cask/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/list_spec.rb
@@ -101,6 +101,8 @@ describe Cask::Cmd::List, :cask do
             "desc": null,
             "homepage": "https://brew.sh/",
             "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip",
+            "url_specs": {
+            },
             "appcast": null,
             "version": "1.2.3",
             "versions": {
@@ -146,6 +148,8 @@ describe Cask::Cmd::List, :cask do
             "desc": "BitTorrent client",
             "homepage": "https://transmissionbt.com/",
             "url": "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg",
+            "url_specs": {
+            },
             "appcast": null,
             "version": "2.61",
             "versions": {
@@ -184,6 +188,8 @@ describe Cask::Cmd::List, :cask do
             "desc": null,
             "homepage": "https://brew.sh/",
             "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine/darwin-arm64/1.2.3/arm.zip",
+            "url_specs": {
+            },
             "appcast": null,
             "version": "1.2.3",
             "versions": {
@@ -225,6 +231,8 @@ describe Cask::Cmd::List, :cask do
             "desc": null,
             "homepage": "https://brew.sh/",
             "url": "https://brew.sh/ThirdParty.dmg",
+            "url_specs": {
+            },
             "appcast": null,
             "version": "1.2.3",
             "versions": {
@@ -263,6 +271,8 @@ describe Cask::Cmd::List, :cask do
             "desc": null,
             "homepage": "https://brew.sh/",
             "url": "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip",
+            "url_specs": {
+            },
             "appcast": null,
             "version": "1.2.3",
             "versions": {


### PR DESCRIPTION
Fixes #14728.