### PR TITLE
Deprecate `preferred_shell` and `shell_profile`.

### DIFF
--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -43,6 +43,8 @@ module Homebrew
 
     ENV["VERBOSE"] = "1" if args.verbose?
 
+    preferred_shell = Utils::Shell.preferred_path(default: "/bin/bash")
+
     if args.cmd.present?
       safe_system(preferred_shell, "-c", args.cmd)
     elsif args.named.present?

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -218,7 +218,7 @@ module Kernel
       FileUtils.touch "#{home}/.zshrc"
     end
 
-    Process.wait fork { exec preferred_shell }
+    Process.wait fork { exec Utils::Shell.preferred_path(default: "/bin/bash") }
 
     return if $CHILD_STATUS.success?
     raise "Aborted due to non-zero exit status (#{$CHILD_STATUS.exitstatus})" if $CHILD_STATUS.exited?
@@ -528,11 +528,13 @@ module Kernel
 
   sig { returns(String) }
   def preferred_shell
-    ENV.fetch("SHELL", "/bin/sh")
+    odeprecated "preferred_shell"
+    Utils::Shell.preferred_path(default: "/bin/sh")
   end
 
   sig { returns(String) }
   def shell_profile
+    odeprecated "shell_profile"
     Utils::Shell.profile
   end
 

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -85,13 +85,13 @@ describe Utils::Shell do
     it "supports tcsh" do
       ENV["SHELL"] = "/bin/tcsh"
       expect(described_class.prepend_path_in_profile(path))
-        .to eq("echo 'setenv PATH #{path}:$PATH' >> #{shell_profile}")
+        .to eq("echo 'setenv PATH #{path}:$PATH' >> #{described_class.profile}")
     end
 
     it "supports Bash" do
       ENV["SHELL"] = "/bin/bash"
       expect(described_class.prepend_path_in_profile(path))
-        .to eq("echo 'export PATH=\"#{path}:$PATH\"' >> #{shell_profile}")
+        .to eq("echo 'export PATH=\"#{path}:$PATH\"' >> #{described_class.profile}")
     end
 
     it "supports fish" do

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -18,9 +18,14 @@ module Utils
       shell_name.to_sym if %w[bash csh fish ksh mksh sh tcsh zsh].include?(shell_name)
     end
 
+    sig { params(default: String).returns(String) }
+    def preferred_path(default: "")
+      ENV.fetch("SHELL", default)
+    end
+
     sig { returns(T.nilable(Symbol)) }
     def preferred
-      from_path(ENV.fetch("SHELL", ""))
+      from_path(preferred_path)
     end
 
     sig { returns(T.nilable(Symbol)) }


### PR DESCRIPTION
I know that we're outside our normal deprecation cycle but: these are totally broken with the API and it doesn't make sense to support them only for non-core formulae.

See https://github.com/Homebrew/homebrew-core/pull/124137 where we've removed these.