### PR TITLE
cask: handle nil URLs

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -277,8 +277,8 @@ module Cask
         return api_to_local_hash(Homebrew::API.merge_variations(json_cask))
       end
 
-      url_specs = url.specs.dup
-      case url_specs[:user_agent]
+      url_specs = url&.specs.dup
+      case url_specs&.dig(:user_agent)
       when :default
         url_specs.delete(:user_agent)
       when Symbol


### PR DESCRIPTION
This generally shouldn't happen but it's probably acceptable for casks under the minimum macOS.

There are a few cases I see this happen but for above the minimum macOS. The fix here still covers them, but I'll open a change to `readall` to catch that there as I don't think the cask should be called valid in those scenarios.