### PR TITLE
cmd/install: add messaging for installing edited formulae under API

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -196,6 +196,19 @@ module Homebrew
       )
     end
 
+    # Cover confusion from editing formulae on an install updated to 4.0.0.
+    if args.build_from_source? && !Homebrew::EnvConfig.no_install_from_api? && !Homebrew::EnvConfig.developer? &&
+       !Homebrew::EnvConfig.no_env_hints? && formulae.any?(&:core_formula?) && CoreTap.instance.installed?
+      core_path = CoreTap.instance.path
+      if (core_path.git_origin_branch.present? && !core_path.git_default_origin_branch?) || core_path.git_dirty?
+        opoo "Local changes to Homebrew/core detected."
+        puts "Homebrew no longer reads from local Homebrew/core clones by default."
+        puts "If you are intentionally making an edit to Homebrew/core formula,"
+        puts "set HOMEBREW_NO_INSTALL_FROM_API for your local clone to be used."
+        puts "If you don't know what these edits are, run `brew untap Homebrew/core`."
+      end
+    end
+
     # if the user's flags will prevent bottle only-installations when no
     # developer tools are available, we need to stop them early on
     build_flags = []

--- a/Library/Homebrew/extend/git_repository.rb
+++ b/Library/Homebrew/extend/git_repository.rb
@@ -101,6 +101,11 @@ module GitRepositoryExtension
     popen_git("log", "-1", "--pretty=%B", commit, "--", safe: safe, err: :out)&.strip
   end
 
+  sig { returns(T::Boolean) }
+  def git_dirty?
+    !system Utils::Git.git, "diff-index", "--quiet", "HEAD"
+  end
+
   private
 
   sig { params(args: T.untyped, safe: T::Boolean, err: T.nilable(Symbol)).returns(T.nilable(String)) }


### PR DESCRIPTION
`--build-from-source` intentionally takes a remote copy of the source code, for security & performance reasons (and because we don't actually update local clones anymore). For most people this works great.

There is however a little confusing for _contributors_ to Homebrew/core who are editing formulae. The workflow has changed slightly, as reflected in #14740.

This PR is to provide the same notice of change, but in env hint form.

This hint displays if `brew install` is being run under these conditions:
* `--build-from-source` is passed, and
* `HOMEBREW_NO_INSTALL_FROM_API` is _not_ set, and
* `HOMEBREW_DEVELOPER` is _not_ set, and
* `HOMEBREW_NO_ENV_HINTS` is _not_ set, and
* a Homebrew/core formula is one of the formulae is being installed, and
* Homebrew/core is tapped, and
* _either_  the current Homebrew/core git branch is not the same as the origin default (`master`) or there are uncommitted changes.

If we want, we could possibly make it a little bit smarter by checking if the uncommitted changes apply to the formulae in question or not.