### PR TITLE
utils/github: Tiny improvements, boolean methods end in `?` and remove unnecessary `.delete_prefix("/")`

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -147,7 +147,7 @@ module GitHub
     API.open_rest(url, data: data, scopes: scopes)
   end
 
-  def check_fork_exists(repo, org: nil)
+  def fork_exists?(repo, org: nil)
     _, reponame = repo.split("/")
 
     username = org || API.open_rest(url_to("user")) { |json| json["login"] }
@@ -555,7 +555,7 @@ module GitHub
   def forked_repo_info!(tap_remote_repo, org: nil)
     response = create_fork(tap_remote_repo, org: org)
     # GitHub API responds immediately but fork takes a few seconds to be ready.
-    sleep 1 until check_fork_exists(tap_remote_repo, org: org)
+    sleep 1 until fork_exists?(tap_remote_repo, org: org)
     remote_url = if system("git", "config", "--local", "--get-regexp", "remote..*.url", "git@github.com:.*")
       response.fetch("ssh_url")
     else

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -61,21 +61,7 @@ module GitHub
   end
 
   def search_code(repo: nil, user: "Homebrew", path: ["Formula", "Casks", "."], filename: nil, extension: "rb")
-    matches = search_results_items(
-      "code",
-      user:      user,
-      path:      path,
-      filename:  filename,
-      extension: extension,
-      repo:      repo,
-    )
-    return matches if matches.blank?
-
-    matches.map do |match|
-      # .sub workaround for GitHub returning preceding /
-      match["path"] = match["path"].delete_prefix("/")
-      match
-    end
+    search_results_items("code", user: user, path: path, filename: filename, extension: extension, repo: repo)
   end
 
   def issues_for_formula(name, tap: CoreTap.instance, tap_remote_repo: tap&.full_name, state: nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Tiny cleanup.
- It's Ruby style convention that methods that return only booleans end with a question mark.
- And I noticed that the GitHub code search API no longer returns a leading `/` on a file's `path` anymore, so we don't need the `delete_prefix("/")` workaround from 2020.
