### PR TITLE
dev-cmd/contributions: Support date ranges in PR reviews query

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -175,7 +175,7 @@ module Homebrew
         commits:       GitHub.repo_commit_count_for_user(repo_full_name, person, args),
         coauthorships: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", args),
         signoffs:      git_log_trailers_cmd(T.must(repo_path), person, "Signed-off-by", args),
-        reviews:       GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person),
+        reviews:       GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, args: args),
       }
     end
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -173,11 +173,21 @@ module GitHub
   def search_query_string(*main_params, **qualifiers)
     params = main_params
 
-    params += qualifiers.flat_map do |key, value|
+    if (args = qualifiers.fetch(:args, nil))
+      params << if args.from && args.to
+        "created:#{args.from}..#{args.to}"
+      elsif args.from
+        "created:>=#{args.from}"
+      elsif args.to
+        "created:<=#{args.to}"
+      end
+    end
+
+    params += qualifiers.except(:args).flat_map do |key, value|
       Array(value).map { |v| "#{key.to_s.tr("_", "-")}:#{v}" }
     end
 
-    "q=#{URI.encode_www_form_component(params.join(" "))}&per_page=100"
+    "q=#{URI.encode_www_form_component(params.compact.join(" "))}&per_page=100"
   end
 
   def url_to(*subroutes)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Now `brew contributions --from=2023-02-23 --to=2023-02-26` works to limit the results for reviews. I forgot this in the original implementation (#14813), again, ugh.
