### PR TITLE
Use 'wslview' instead of 'xdg-open' on Windows

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -40,22 +40,12 @@ module SystemConfig
       out
     end
 
-    def wsl_version(kernel)
-      return unless /-microsoft/i.match?(kernel)
-
-      return "2 (Microsoft Store)" if Version.new(kernel[/Linux ([0-9.]*)-.*/, 1]) > Version.new("5.15")
-      return "2" if kernel.include?("-microsoft")
-      return "1" if kernel.include?("-Microsoft")
-    end
-
     def dump_verbose_config(out = $stdout)
       kernel = Utils.safe_popen_read("uname", "-mors").chomp
       dump_generic_verbose_config(out)
       out.puts "Kernel: #{kernel}"
       out.puts "OS: #{OS::Linux.os_version}"
-      if (wsl = wsl_version(kernel).presence)
-        out.puts "WSL: #{wsl}"
-      end
+      out.puts "WSL: #{OS::Linux.wsl_version}" if OS::Linux.wsl?
       out.puts "Host glibc: #{host_glibc_version}"
       out.puts "/usr/bin/gcc: #{host_gcc_version}"
       out.puts "/usr/bin/ruby: #{host_ruby_version}" if RUBY_PATH != HOST_RUBY_PATH

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "version"
+
 # Helper functions for querying operating system information.
 #
 # @api private
@@ -67,7 +69,7 @@ module OS
   elsif OS.linux?
     require "os/linux"
     ISSUES_URL = "https://docs.brew.sh/Troubleshooting"
-    PATH_OPEN = "xdg-open"
+    PATH_OPEN = (OS::Linux.wsl? ? "wslview" : "xdg-open").freeze
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -35,14 +35,18 @@ module OS
 
     sig { returns(Version) }
     def wsl_version
-      Version::NULL unless wsl?
-      kernel = OS.kernel_version.to_s
-      return Version.new("2 (Microsoft Store)") if Version.new(T.must(kernel[/^([0-9.]*)-.*/,
-                                                                             1])) > Version.new("5.15")
-      return Version.new("2") if kernel.include?("-microsoft")
-      return Version.new("1") if kernel.include?("-Microsoft")
+      return Version::NULL unless wsl?
 
-      Version::NULL
+      kernel = OS.kernel_version.to_s
+      if Version.new(T.must(kernel[/^([0-9.]*)-.*/, 1])) > Version.new("5.15")
+        Version.new("2 (Microsoft Store)")
+      elsif kernel.include?("-microsoft")
+        Version.new("2")
+      elsif kernel.include?("-Microsoft")
+        Version.new("1")
+      else
+        Version::NULL
+      end
     end
   end
 

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "utils"
+
 module OS
   # Helper module for querying system information on Linux.
   module Linux
@@ -24,6 +26,23 @@ module OS
       else
         "Unknown"
       end
+    end
+
+    sig { returns(T::Boolean) }
+    def wsl?
+      /-microsoft/i.match?(OS.kernel_version.to_s)
+    end
+
+    sig { returns(Version) }
+    def wsl_version
+      Version::NULL unless wsl?
+      kernel = OS.kernel_version.to_s
+      return Version.new("2 (Microsoft Store)") if Version.new(T.must(kernel[/^([0-9.]*)-.*/,
+                                                                             1])) > Version.new("5.15")
+      return Version.new("2") if kernel.include?("-microsoft")
+      return Version.new("1") if kernel.include?("-Microsoft")
+
+      Version::NULL
     end
   end
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -19,6 +19,7 @@ require "utils/repology"
 require "utils/svn"
 require "utils/tty"
 require "tap_constants"
+require "PATH"
 
 module Homebrew
   extend Context


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In WSL, `xdg-open` is not available -- `wslview` is. So, added `wsl?` and `wsl_version` methods to `OS::Linux` to conditionally set `PATH_OPEN`

Additional "require" statements:
- `require "PATH"` in utils.rb: needed by `PATH.new` in `which`
- `require "utils"` in linux.rb: needed by `which` in `os_version`
- `require "version"` in os.rb: needed by `sig { returns(Version) }`

To test, execute `brew docs`