### PR TITLE
dev-cmd/contributions: Only count approving reviews

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -172,7 +172,14 @@ module Homebrew
       data[repo] = {
         commits:       GitHub.repo_commit_count_for_user(repo_full_name, person, args),
         coauthorships: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", args),
-        reviews:       GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, args: args),
+        reviews:       GitHub.count_issues(
+          "",
+          is:          "pr",
+          repo:        repo_full_name,
+          reviewed_by: person,
+          review:      "approved",
+          args:        args,
+        ),
       }
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- The `reviewed-by` filter retrieved all reviews for a user, including those they'd added to their own PRs. Since it's impossible to click the "approve" button on one's own PR, filter this to `review:approved` to get "further project goals" kinds of reviews.
- Suggested in https://github.com/Homebrew/brew/pull/14813#discussion_r1118696385.
- Shorten a variable name so I didn't have to split the `count_issues` call onto multiple lines since the indentation looked funky when I tried it.
