### PR TITLE
Enable Style/OpenStructUse cop

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -425,9 +425,16 @@ Style/NumericLiterals:
   Exclude:
     - "**/Brewfile"
 
-# OpenStruct is a nice helper.
+# TODO: These are pre-existing violations and should be fixed.
 Style/OpenStructUse:
-  Enabled: false
+  Exclude:
+    - "Homebrew/cli/args.rb"
+    - "Homebrew/cmd/uses.rb"
+    - "Homebrew/completions.rb"
+    - "Homebrew/manpages.rb"
+    - "Homebrew/tab.rb"
+    - "Homebrew/test/api/cask_spec.rb"
+    - "Homebrew/test/api_spec.rb"
 
 # Rescuing `StandardError` is an understood default.
 Style/RescueStandardError:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -429,12 +429,8 @@ Style/NumericLiterals:
 Style/OpenStructUse:
   Exclude:
     - "Homebrew/cli/args.rb"
-    - "Homebrew/cmd/uses.rb"
-    - "Homebrew/completions.rb"
-    - "Homebrew/manpages.rb"
     - "Homebrew/tab.rb"
-    - "Homebrew/test/api/cask_spec.rb"
-    - "Homebrew/test/api_spec.rb"
+    - "Taps/**/*.rb"
 
 # Rescuing `StandardError` is an understood default.
 Style/RescueStandardError:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -425,7 +425,8 @@ Style/NumericLiterals:
   Exclude:
     - "**/Brewfile"
 
-# TODO: These are pre-existing violations and should be fixed.
+# TODO: These are pre-existing violations and should be corrected
+#   to define methods so that call sites can be type-checked.
 Style/OpenStructUse:
   Exclude:
     - "Homebrew/cli/args.rb"

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -67,7 +67,10 @@ module Homebrew
       opoo e
       used_formulae_missing = true
       # If the formula doesn't exist: fake the needed formula object name.
+      # This is a legacy use of OpenStruct that should be refactored.
+      # rubocop:disable Style/OpenStructUse
       args.named.map { |name| OpenStruct.new name: name, full_name: name }
+      # rubocop:enable Style/OpenStructUse
     end
 
     use_runtime_dependents = args.installed? &&

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -49,7 +49,7 @@ describe Homebrew::API::Cask do
 
   describe "::fetch_source" do
     it "fetches the source of a cask (defaulting to master when no `git_head` is passed)" do
-      curl_output = OpenStruct.new(stdout: "foo", success?: true)
+      curl_output = instance_double(SystemCommand::Result, stdout: "foo", success?: true)
       expect(Utils::Curl).to receive(:curl_output)
         .with("--fail", "https://raw.githubusercontent.com/Homebrew/homebrew-cask/master/Casks/foo.rb")
         .and_return(curl_output)

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -14,7 +14,7 @@ describe Homebrew::API do
   end
 
   def mock_curl_output(stdout: "", success: true)
-    curl_output = OpenStruct.new(stdout: stdout, success?: success)
+    curl_output = instance_double(SystemCommand::Result, stdout: stdout, success?: success)
     allow(Utils::Curl).to receive(:curl_output).and_return curl_output
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
I would like us to enable the `Style/OpenStructUse` cop. The official RuboCop [docs](https://docs.rubocop.org/rubocop/cops_style.html) cite "performance, version compatibility, and potential security issues", but an add'l issue in this repo is that it [breaks](https://sorbet.run/#%23%20typed%3A%20true%0A%0Afoo%20%3D%20OpenStruct.new%0Afoo%5B%3Aa%5D%20%3D%20'a'%0Afoo.a) typechecking.