### PR TITLE
download_strategy: handle incorrectly quoted filename* headers

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -483,7 +483,13 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
       if (filename_with_encoding = content_disposition.parameters["filename*"])
         encoding, encoded_filename = filename_with_encoding.split("''", 2)
-        filename = URI.decode_www_form_component(encoded_filename).encode(encoding) if encoding && encoded_filename
+        # If the `filename*` has incorrectly added double quotes, e.g.
+        #   content-disposition: attachment; filename="myapp-1.2.3.pkg"; filename*=UTF-8''"myapp-1.2.3.pkg"
+        # Then the encoded_filename will come back as the empty string, in which case we should fall back to the
+        # `filename` parameter.
+        if encoding && encoded_filename.present?
+          filename = URI.decode_www_form_component(encoded_filename).encode(encoding)
+        end
       end
 
       # Servers may include '/' in their Content-Disposition filename header. Take only the basename of this, because:

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -487,7 +487,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         #   content-disposition: attachment; filename="myapp-1.2.3.pkg"; filename*=UTF-8''"myapp-1.2.3.pkg"
         # Then the encoded_filename will come back as the empty string, in which case we should fall back to the
         # `filename` parameter.
-        if encoding && encoded_filename.present?
+        if encoding.present? && encoded_filename.present?
           filename = URI.decode_www_form_component(encoded_filename).encode(encoding)
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

#### Commits _(oldest to newest)_

160e7da779 download_strategy: handle incorrectly quoted filename* headers

Some servers erroneously double-quote the filename in the filename*
header. This is (as far as I can tell from the spec) a bug in the
server, and should be fixed there.

In general though using `""` as the filename seems like behaviour worth
handling in brew anyway, as there may be other places where the parser
returns an empty string.

Co-authored-by: Mike McQuaid <mike@mikemcquaid.com>

<br/>