### PR TITLE
Strategy#from_url: Amend conditions for Json

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -162,7 +162,7 @@ module Homebrew
             next if (livecheck_strategy != strategy_symbol) || !block_provided
           elsif strategy.const_defined?(:PRIORITY) &&
                 !strategy::PRIORITY.positive? &&
-                from_symbol(livecheck_strategy) != strategy
+                livecheck_strategy != strategy_symbol
             # Ignore strategies with a priority of 0 or lower, unless the
             # strategy is specified in the `livecheck` block
             next

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -151,15 +151,15 @@ module Homebrew
         ).returns(T::Array[T.untyped])
       }
       def from_url(url, livecheck_strategy: nil, url_provided: false, regex_provided: false, block_provided: false)
-        usable_strategies = strategies.values.select do |strategy|
+        usable_strategies = strategies.select do |strategy_symbol, strategy|
           if strategy == PageMatch
             # Only treat the strategy as usable if the `livecheck` block
             # contains a regex and/or `strategy` block
             next if !regex_provided && !block_provided
           elsif strategy == Json
             # Only treat the strategy as usable if the `livecheck` block
-            # contains a `strategy` block
-            next unless block_provided
+            # specifies the strategy and contains a `strategy` block
+            next if (livecheck_strategy != strategy_symbol) || !block_provided
           elsif strategy.const_defined?(:PRIORITY) &&
                 !strategy::PRIORITY.positive? &&
                 from_symbol(livecheck_strategy) != strategy
@@ -169,7 +169,7 @@ module Homebrew
           end
 
           strategy.respond_to?(:match?) && strategy.match?(url)
-        end
+        end.values
 
         # Sort usable strategies in descending order by priority, using the
         # DEFAULT_PRIORITY when a strategy doesn't contain a PRIORITY constant


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When the `Json` strategy was introduced, I forgot to also ensure that it's only treated as usable (in `Strategy#from_url`) if a `livecheck` block uses `strategy :json`. As a result, `Json` is incorrectly treated as a usable strategy for all formulae/casks that contain a `strategy` block.

Since all of these `livecheck` blocks specify a strategy, this bug doesn't meaningfully impact livecheck's behavior (i.e., these checks continue to use their explicitly-specified strategy). The only practical difference is that `Json` incorrectly appears in the list of usable strategies in livecheck's verbose JSON output.

This PR modifies `Strategy#from_url` to address this issue. The easiest way to enforce this rule involved passing in the `@strategies` key (a symbol) into the `select` block, so we can compare it to `livecheck_strategy` (the strategy symbol specified in the `livecheck` block). Passing the strategy symbol into the `#from_url` `select` block means that we can also get rid of a `#from_symbol` call in a different conditional branch, as we can directly compare the `livecheck_strategy` symbol to `strategy_symbol`.

-----

I compared the `Strategy#from_url` output for all of the first-party formulae/casks without/with the changes in this PR and this is working as expected. The sole change is that `Json` is only listed as a usable strategy when a `livecheck` block uses `strategy :json` and provides a `strategy` block.