### PR TITLE
Allow `version :latest` if `livecheck` is `skip`.

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -307,7 +307,11 @@ module Cask
       return unless cask.version.latest?
 
       add_error "Casks with an `appcast` should not use `version :latest`." if cask.appcast
-      add_error "Casks with a `livecheck` should not use `version :latest`." if cask.livecheckable?
+
+      return unless cask.livecheckable?
+      return if cask.livecheck.skip?
+
+      add_error "Casks with a `livecheck` should not use `version :latest`."
     end
 
     sig { void }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If there is a functional livecheck, a cask should not use `version :latest`. If the livecheck has `skip`, it should still be allowed as documentation why it cannot be versioned.

Fixes the remaining CI issue in https://github.com/Homebrew/homebrew-cask/pull/141646.