### PR TITLE
metafiles: include `Cargo.lock` and `go.sum`

### DIFF
--- a/Library/Homebrew/metafiles.rb
+++ b/Library/Homebrew/metafiles.rb
@@ -12,6 +12,7 @@ module Metafiles
     .org .pod .rdoc .rst .rtf .textile .txt .wiki
   ]).freeze
   BASENAMES = Set.new(%w[about authors changelog changes history news notes notice readme todo]).freeze
+  EXTERNAL_DEPENDENCY_METADATA = Set.new(%w[Cargo.lock go.sum]).freeze
 
   module_function
 
@@ -22,6 +23,8 @@ module Metafiles
   end
 
   def copy?(file)
+    return true if EXTERNAL_DEPENDENCY_METADATA.include?(File.basename(file))
+
     file = file.downcase
     return true if LICENSES.include? file.split(/\.|-/).first
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We use `cargo` and `go` to provide external dependencies when building
some formulae. Let's install the lock files that they generate.

This will make it easier to find out the precise external dependencies
our formulae rely on, and enables auditing them for things like security
vulnerabilities.
