### PR TITLE
cask/cmd/upgrade: fix missing versions variable

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -121,7 +121,7 @@ module Cask
 
         if manual_installer_casks.present?
           count = manual_installer_casks.count
-          ofail "Not upgrading #{count} `installer manual` #{::Utils.pluralize("cask", versions.count)}."
+          ofail "Not upgrading #{count} `installer manual` #{::Utils.pluralize("cask", count)}."
           puts manual_installer_casks.map(&:to_s)
           outdated_casks -= manual_installer_casks
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This reference to the versions variable is unnecessary. It was changed recently as a part of https://github.com/Homebrew/brew/pull/14778.

It is causing the following errors:
- https://github.com/Homebrew/homebrew-cask/issues/142050
- https://github.com/Homebrew/homebrew-cask/issues/142129

It [originally didn't reference a `versions` variable at all](https://github.com/Homebrew/brew/pull/14778/files?diff=unified&w=0#diff-6bdc1759a32b388be1e2ac3e350a817c9dcc7f097037f7092f1cb015175407c0)(look at line 124) and no other versions variable exists in the same file.

```sh
/u/l/Homebrew (master|✔) [2]$ grep -i versions '/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb'
          ofail "Not upgrading #{count} `installer manual` #{::Utils.pluralize("cask", versions.count)}."
```

A similar line exists in the `cask/cmd/uninstall` file so that probably was the source of the confusion.