### PR TITLE
formula: fix alias loading

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1417,7 +1417,7 @@ class Formula
   end
 
   def current_installed_alias_target
-    Formulary.factory(installed_alias_path) if installed_alias_path
+    Formulary.factory(installed_alias_name) if installed_alias_path
   end
 
   # Has the target of the alias used to install this formula changed?

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1194,6 +1194,7 @@ describe Formula do
 
     let(:tab) { Tab.empty }
     let(:alias_path) { "#{CoreTap.instance.alias_dir}/bar" }
+    let(:alias_name) { "bar" }
 
     before do
       allow(described_class).to receive(:installed).and_return([f])
@@ -1215,7 +1216,7 @@ describe Formula do
 
     specify "alias changes when not changed" do
       tab.source["path"] = alias_path
-      stub_formula_loader(f, alias_path)
+      stub_formula_loader(f, alias_name)
 
       CoreTap.instance.alias_dir.mkpath
       FileUtils.ln_sf f.path, alias_path
@@ -1230,7 +1231,7 @@ describe Formula do
 
     specify "alias changes when new alias target" do
       tab.source["path"] = alias_path
-      stub_formula_loader(new_formula, alias_path)
+      stub_formula_loader(new_formula, alias_name)
 
       CoreTap.instance.alias_dir.mkpath
       FileUtils.ln_sf new_formula.path, alias_path
@@ -1245,7 +1246,7 @@ describe Formula do
 
     specify "alias changes when old formulae installed" do
       tab.source["path"] = alias_path
-      stub_formula_loader(new_formula, alias_path)
+      stub_formula_loader(new_formula, alias_name)
 
       CoreTap.instance.alias_dir.mkpath
       FileUtils.ln_sf new_formula.path, alias_path
@@ -1286,6 +1287,7 @@ describe Formula do
     end
 
     let(:alias_path) { "#{f.tap.alias_dir}/bar" }
+    let(:alias_name) { "bar" }
 
     def setup_tab_for_prefix(prefix, options = {})
       prefix.mkpath
@@ -1324,14 +1326,14 @@ describe Formula do
     example "outdated follow alias and alias unchanged" do
       f.follow_installed_alias = true
       f.build = setup_tab_for_prefix(same_prefix, path: alias_path)
-      stub_formula_loader(f, alias_path)
+      stub_formula_loader(f, alias_name)
       expect(f.outdated_kegs).to be_empty
     end
 
     example "outdated follow alias and alias changed and new target not installed" do
       f.follow_installed_alias = true
       f.build = setup_tab_for_prefix(same_prefix, path: alias_path)
-      stub_formula_loader(new_formula, alias_path)
+      stub_formula_loader(new_formula, alias_name)
 
       CoreTap.instance.alias_dir.mkpath
       FileUtils.ln_sf new_formula.path, alias_path
@@ -1342,7 +1344,7 @@ describe Formula do
     example "outdated follow alias and alias changed and new target installed" do
       f.follow_installed_alias = true
       f.build = setup_tab_for_prefix(same_prefix, path: alias_path)
-      stub_formula_loader(new_formula, alias_path)
+      stub_formula_loader(new_formula, alias_name)
       setup_tab_for_prefix(new_formula.prefix)
       expect(f.outdated_kegs).to be_empty
     end
@@ -1350,7 +1352,7 @@ describe Formula do
     example "outdated no follow alias and alias unchanged" do
       f.follow_installed_alias = false
       f.build = setup_tab_for_prefix(same_prefix, path: alias_path)
-      stub_formula_loader(f, alias_path)
+      stub_formula_loader(f, alias_name)
       expect(f.outdated_kegs).to be_empty
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR fixes alias loading for formulae installed via an alias (when outdated homebrew-core repo is present)

Steps to reproduce:

```bash
$ brew install python
$ cd `brew --repo homebrew/core`
$ # Checkout to older revision with different python alias target (pre https://github.com/Homebrew/homebrew-core/commit/d6e43416761a9b65eb7e2318444ea70da76a5e49)
$ git checkout 1ac08d3d7f3e77a50cd369d47bfe8a3f1684776d # Thu Feb 9 13:29:05 2023 +0000
```

```
$ brew outdated
python@3.11 (3.11.2_1) < python@3.10 (3.10.10)
```
