### PR TITLE
rubocop: Consolidate more rules into the right files

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -338,6 +338,8 @@ Style/BarePercentLiterals:
 
 # make rspec formatting more flexible
 Style/BlockDelimiters:
+  BracesRequiredMethods:
+    - "sig"
   Exclude:
     - "Homebrew/**/*_spec.rb"
     - "Homebrew/**/shared_examples/**/*.rb"

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -367,10 +367,6 @@ Style/Documentation:
     - "**/{Formula,Casks}/**/*.rb"
     - "**/*.rbi"
 
-Style/DocumentationMethod:
-  Include:
-    - "Homebrew/formula.rb"
-
 # This is quite a large change, so don't enforce this yet for formulae.
 # We should consider doing so in the future, but be aware of the impact on third-party taps.
 Style/FetchEnvVar:

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -68,9 +68,5 @@ Style/HashAsLastArrayItem:
   Exclude:
     - "test/utils/spdx_spec.rb"
 
-Style/BlockDelimiters:
-  BracesRequiredMethods:
-    - "sig"
-
 Bundler/GemFilename:
   Enabled: false

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -60,6 +60,10 @@ Style/Documentation:
     - utils/string_inreplace_extension.rb
     - version.rb
 
+Style/DocumentationMethod:
+  Include:
+    - "formula.rb"
+
 Style/HashAsLastArrayItem:
   Exclude:
     - "test/utils/spdx_spec.rb"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- `Style/DocumentationMethod` is only targetting a single file in `Library/Homebrew/`, so move it to that config file.
- Go the other way for `Style/BlockDelimiters`.