### PR TITLE
dev-cmd/tests: better output for BuildPulse failures

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -62,11 +62,10 @@ module Homebrew
 
     ohai "Sending test results to BuildPulse"
 
-    result = quiet_system Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
-                          "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
-                          "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
-                          "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
-    odie "Failed to send test results to BuildPulse!" unless result
+    system_command! Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
+                    "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
+                    "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
+                    "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
   end
 
   def changed_test_files


### PR DESCRIPTION
The current message doesn't really tell much - let's print stderr (assuming errors go there).