### PR TITLE
Json: Add #parse_json method and tidy up tests

### DIFF
--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -7,7 +7,7 @@ module Homebrew
       # The {Json} strategy fetches content at a URL, parses it as JSON, and
       # provides the parsed data to a `strategy` block. If a regex is present
       # in the `livecheck` block, it should be passed as the second argument to
-      # the  `strategy` block.
+      # the `strategy` block.
       #
       # This is a generic strategy that doesn't contain any logic for finding
       # versions, as the structure of JSON data varies. Instead, a `strategy`

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -46,6 +46,19 @@ module Homebrew
           URL_MATCH_REGEX.match?(url)
         end
 
+        # Parses JSON text and returns the parsed data.
+        # @param content [String] the JSON text to parse
+        sig { params(content: String).returns(T.untyped) }
+        def self.parse_json(content)
+          require "json"
+
+          begin
+            JSON.parse(content)
+          rescue JSON::ParserError
+            raise "Content could not be parsed as JSON."
+          end
+        end
+
         # Parses JSON text and identifies versions using a `strategy` block.
         # If a regex is provided, it will be passed as the second argument to
         # the  `strategy` block (after the parsed JSON data).
@@ -63,12 +76,8 @@ module Homebrew
         def self.versions_from_content(content, regex = nil, &block)
           return [] if content.blank? || block.blank?
 
-          require "json"
-          json = begin
-            JSON.parse(content)
-          rescue JSON::ParserError
-            raise "Content could not be parsed as JSON."
-          end
+          json = parse_json(content)
+          return [] if json.blank?
 
           block_return_value = if regex.present?
             yield(json, regex)

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -74,6 +74,12 @@ describe Homebrew::Livecheck::Strategy::Json do
     end
   end
 
+  describe "::parse_json" do
+    it "returns an object when given valid content" do
+      expect(json.parse_json(content_simple)).to be_an_instance_of(Hash)
+    end
+  end
+
   describe "::versions_from_content" do
     it "returns an empty array when given a block but content is blank" do
       expect(json.versions_from_content("", regex) { "1.2.3" }).to eq([])

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -11,7 +11,6 @@ describe Homebrew::Livecheck::Strategy::Json do
 
   let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
 
-  let(:simple_content) { '{"version":"1.2.3"}' }
   let(:content) {
     <<~EOS
       {
@@ -40,9 +39,10 @@ describe Homebrew::Livecheck::Strategy::Json do
       }
     EOS
   }
+  let(:content_simple) { '{"version":"1.2.3"}' }
 
-  let(:simple_content_matches) { ["1.2.3"] }
   let(:content_matches) { ["1.1.2", "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"] }
+  let(:content_simple_matches) { ["1.2.3"] }
 
   let(:find_versions_return_hash) {
     {
@@ -92,10 +92,10 @@ describe Homebrew::Livecheck::Strategy::Json do
 
     it "returns an array of version strings when given content and a block" do
       # Returning a string from block
-      expect(json.versions_from_content(simple_content) { |json| json["version"] }).to eq(simple_content_matches)
-      expect(json.versions_from_content(simple_content, regex) do |json|
+      expect(json.versions_from_content(content_simple) { |json| json["version"] }).to eq(content_simple_matches)
+      expect(json.versions_from_content(content_simple, regex) do |json|
         json["version"][regex, 1]
-      end).to eq(simple_content_matches)
+      end).to eq(content_simple_matches)
 
       # Returning an array of strings from block
       expect(json.versions_from_content(content, regex) do |json, regex|
@@ -105,16 +105,16 @@ describe Homebrew::Livecheck::Strategy::Json do
     end
 
     it "allows a nil return from a block" do
-      expect(json.versions_from_content(content, regex) { next }).to eq([])
+      expect(json.versions_from_content(content_simple, regex) { next }).to eq([])
     end
 
     it "errors if a block uses two arguments but a regex is not given" do
-      expect { json.versions_from_content(simple_content) { |json, regex| json["version"][regex, 1] } }
+      expect { json.versions_from_content(content_simple) { |json, regex| json["version"][regex, 1] } }
         .to raise_error("Two arguments found in `strategy` block but no regex provided.")
     end
 
     it "errors on an invalid return type from a block" do
-      expect { json.versions_from_content(content, regex) { 123 } }
+      expect { json.versions_from_content(content_simple, regex) { 123 } }
         .to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

After working on the `Xml` strategy, I came back to the `Json` strategy to make a few changes to better align the two. For example, the `Xml` strategy provides a `#parse_xml` method that only includes the parsing logic, so other strategies can selectively use this method if that's all they need (instead of `Xml#find_versions`). This PR modifies the `Json` strategy to provide a similar `Json#parse_json` method.

This also renames the `simple_content*` variables in `json_spec` to `content_simple*`, to align the variable name with the naming convention used in the `Xml` strategy (e.g., `content_version_text`, `content_version_attr`, `content_simple`, etc.). This doesn't make a functional difference but is a little more tidy/predictable.

I've also tweaked a few tests to use `content_simple` in place of `content` in tests where the content isn't actually used (aligning with similar `Xml` tests). It doesn't make a difference other than passing a smaller string as the argument.