### PR TITLE
dev-cmd/contributions: Count the number of commits a user committed

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -108,7 +108,7 @@ module Homebrew
   sig { params(totals: Hash).returns(String) }
   def generate_maintainers_csv(totals)
     CSV.generate do |csv|
-      csv << %w[user repo commits coauthorships reviews total]
+      csv << %w[user repo author committer coauthorships reviews total]
 
       totals.sort_by { |_, v| -v.values.sum }.each do |user, total|
         csv << grand_total_row(user, total)
@@ -119,12 +119,13 @@ module Homebrew
   sig { params(user: String, results: Hash, grand_total: Hash).returns(String) }
   def generate_csv(user, results, grand_total)
     CSV.generate do |csv|
-      csv << %w[user repo commits coauthorships reviews total]
+      csv << %w[user repo author committer coauthorships reviews total]
       results.each do |repo, counts|
         csv << [
           user,
           repo,
-          counts[:commits],
+          counts[:author],
+          counts[:committer],
           counts[:coauthorships],
           counts[:reviews],
           counts.values.sum,
@@ -139,7 +140,8 @@ module Homebrew
     [
       user,
       "all",
-      grand_total[:commits],
+      grand_total[:author],
+      grand_total[:committer],
       grand_total[:coauthorships],
       grand_total[:reviews],
       grand_total.values.sum,
@@ -170,7 +172,8 @@ module Homebrew
       puts "Determining contributions for #{person} on #{repo_full_name}..." if args.verbose?
 
       data[repo] = {
-        commits:       GitHub.repo_commit_count_for_user(repo_full_name, person, args),
+        author:        GitHub.repo_commit_count_for_user(repo_full_name, person, "author", args),
+        committer:     GitHub.repo_commit_count_for_user(repo_full_name, person, "committer", args),
         coauthorships: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", args),
         reviews:       GitHub.count_issues(
           "",
@@ -188,7 +191,7 @@ module Homebrew
 
   sig { params(results: Hash).returns(Hash) }
   def total(results)
-    totals = { commits: 0, coauthorships: 0, reviews: 0 }
+    totals = { author: 0, committer: 0, coauthorships: 0, reviews: 0 }
 
     # {
     #   "brew"=>{:commits=>9,:coauthorships=>6,:reviews=>1},

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -193,17 +193,13 @@ module Homebrew
   def total(results)
     totals = { author: 0, committer: 0, coauthorships: 0, reviews: 0 }
 
-    # {
-    #   "brew"=>{:commits=>9,:coauthorships=>6,:reviews=>1},
-    #   "core"=>{:commits=>15,:coauthorships=>10,:reviews=>2}
-    # }
     results.each_value do |counts|
       counts.each do |kind, count|
         totals[kind] += count
       end
     end
 
-    totals # {:commits=>24,:coauthorships=>16,:reviews=>3}
+    totals
   end
 
   sig { params(repo_path: Pathname, person: String, trailer: String, args: Homebrew::CLI::Args).returns(Integer) }

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -174,9 +174,7 @@ module Homebrew
       commits_authored = GitHub.repo_commit_count_for_user(repo_full_name, person, "author", args)
       commits_committed = GitHub.repo_commit_count_for_user(repo_full_name, person, "committer", args)
       # Only count committers where the author is not the same person. Avoid negative numbers or subtracting zero.
-      if commits_authored.positive? && commits_committed.positive?
-        commits_committed = commits_authored - commits_committed
-      end
+      commits_committed = commits_authored - commits_committed if commits_authored > commits_committed
 
       data[repo] = {
         author:        commits_authored,

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -717,10 +717,10 @@ module GitHub
     output[/^Status: (200)/, 1] != "200"
   end
 
-  def repo_commit_count_for_user(nwo, user, args)
+  def repo_commit_count_for_user(nwo, user, filter, args)
     return if Homebrew::EnvConfig.no_github_api?
 
-    params = ["author=#{user}"]
+    params = ["#{filter}=#{user}"]
     params << "since=#{DateTime.parse(args.from).iso8601}" if args.from
     params << "until=#{DateTime.parse(args.to).iso8601}" if args.to
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/13642.
- The GitHub list commits API now supports this filtering (https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#list-commits--parameters), because I wrote it. :-)
- Authoring a commit and committing a commit are two separate concepts: author is the person who wrote the code and, in old parlance, the committer is the person who applied the patch (remember when we sent patches to mailing lists?).
- In practice for us in Homebrew, this occurs when we make a change in GitHub's web editor, or, more obviously, when BrewTestBot pushes `homebrew-core` commits from users (then, `BrewTestBot` is the `committer`).

TODO:

- [x] Don't double count contributions for which the author and committer are the same. ~(See the following example for why this would be bad.)~

Example:

```
❯ brew contributions --repos=primary --user=issyl0 --csv
issyl0 contributed 1626 times in all time.
user,repo,author,committer,coauthorships,reviews,total
issyl0,brew,392,147,13,142,694
issyl0,core,473,73,24,357,927
issyl0,cask,4,0,0,1,5
issyl0,all,869,220,37,500,1626
```