### PR TITLE
os.rb: fix for WSL systems without wslview

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -69,7 +69,11 @@ module OS
   elsif OS.linux?
     require "os/linux"
     ISSUES_URL = "https://docs.brew.sh/Troubleshooting"
-    PATH_OPEN = (OS::Linux.wsl? ? "wslview" : "xdg-open").freeze
+    PATH_OPEN = if OS::Linux.wsl? && (wslview = which("wslview").presence)
+      wslview.to_s
+    else
+      "xdg-open"
+    end.freeze
   end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a fix for WSL systems that don't have `wslview` but do have `xdg-open`. Related to #14822 
