### PR TITLE
rubocop: Disable RSpec metrics cops

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -287,15 +287,15 @@ RSpec/MessageSpies:
 RSpec/StubbedMock:
   Enabled: false
 
-# TODO: try to reduce these
+# These were ever-growing numbers, not useful.
 RSpec/ExampleLength:
-  Max: 75
+  Enabled: false
 RSpec/MultipleExpectations:
-  Max: 26
+  Enabled: false
 RSpec/NestedGroups:
-  Max: 5
+  Enabled: false
 RSpec/MultipleMemoizedHelpers:
-  Max: 12
+  Enabled: false
 
 # Annoying to have these autoremoved.
 RSpec/Focus:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- We've disabled metrics cops for method length and complexity since we were fighting them a lot and the numbers were arbitrary and growing. It feels like these RSpec metrics numbers are arbitrary too.

