### PR TITLE
Fix `{MacOS,Xcode}Requirement` handling and improve output

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -159,8 +159,10 @@ module Homebrew
 
     sig { params(json: Hash).returns(Hash) }
     def self.merge_variations(json)
-      if (bottle_tag = ::Utils::Bottles.tag.to_s.presence) &&
-         (variations = json["variations"].presence) &&
+      bottle_tag = ::Utils::Bottles::Tag.new(system: Homebrew::SimulateSystem.current_os,
+                                             arch:   Homebrew::SimulateSystem.current_arch)
+
+      if (variations = json["variations"].presence) &&
          (variation = variations[bottle_tag].presence)
         json = json.merge(variation)
       end

--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -163,7 +163,7 @@ module Homebrew
                                              arch:   Homebrew::SimulateSystem.current_arch)
 
       if (variations = json["variations"].presence) &&
-         (variation = variations[bottle_tag].presence)
+         (variation = variations[bottle_tag.to_s].presence)
         json = json.merge(variation)
       end
 

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -4,6 +4,7 @@
 require "cli/parser"
 require "formula"
 require "api"
+require "os/mac/xcode"
 
 module Homebrew
   extend T::Sig

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -51,12 +51,12 @@ class MacOSRequirement < Requirement
   end
 
   def version_specified?
-    OS.mac? && @version
+    @version.present?
   end
 
   satisfy(build_env: false) do
     T.bind(self, MacOSRequirement)
-    next Array(@version).any? { |v| MacOS.version.public_send(@comparator, v) } if version_specified?
+    next Array(@version).any? { |v| MacOS.version.public_send(@comparator, v) } if OS.mac? && version_specified?
     next true if OS.mac?
     next true if @version
 
@@ -68,7 +68,7 @@ class MacOSRequirement < Requirement
 
     case @comparator
     when ">="
-      "macOS #{@version.pretty_name} or newer is required for this software."
+      "This software does not run on macOS versions older than #{@version.pretty_name}."
     when "<="
       case type
       when :formula
@@ -82,10 +82,10 @@ class MacOSRequirement < Requirement
     else
       if @version.respond_to?(:to_ary)
         *versions, last = @version.map(&:pretty_name)
-        return "macOS #{versions.join(", ")} or #{last} is required for this software."
+        return "This software does not run on macOS versions other than #{versions.join(", ")} and #{last}."
       end
 
-      "macOS #{@version.pretty_name} is required for this software."
+      "This software does not run on macOS versions other than #{@version.pretty_name}."
     end
   end
 
@@ -107,9 +107,9 @@ class MacOSRequirement < Requirement
   def display_s
     if version_specified?
       if @version.respond_to?(:to_ary)
-        "macOS #{@comparator} #{version.join(" / ")}"
+        "macOS #{@comparator} #{version.join(" / ")} (or Linux)"
       else
-        "macOS #{@comparator} #{@version}"
+        "macOS #{@comparator} #{@version} (or Linux)"
       end
     else
       "macOS"

--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -58,9 +58,9 @@ class XcodeRequirement < Requirement
   end
 
   def display_s
-    return name.capitalize unless @version
+    return "#{name.capitalize} (on macOS)" unless @version
 
-    "#{name.capitalize} >= #{@version}"
+    "#{name.capitalize} >= #{@version} (on macOS)"
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Closes #14563.

This PR fixes some issues with `MacOSRequirement` handling and related `brew info`/`brew unbottled` output on Linux. I have not (yet) added tests but would be happy to if we feel that it is important to add some for these cases.

Prior to this PR, on Linux:
```
linuxbrew@0e6abcd7b4ed:~/.linuxbrew/Homebrew$ brew info tart
...
==> Requirements
Build: Xcode >= 14.1 ✔
Required: arm64 architecture ✘, macOS ✔, macOS ✘
...

linuxbrew@0e6abcd7b4ed:~/.linuxbrew/Homebrew$ brew unbottled --tag big_sur tart
==> Populating dependency tree...
==> :big_sur bottle status
tart: requires Linux
```

After this PR, on Linux:
```
linuxbrew@0e6abcd7b4ed:~/.linuxbrew/Homebrew$ brew info tart
...
==> Requirements
Build: Xcode >= 14.1 (on macOS) ✔
Required: arm64 architecture ✘, macOS >= 12 (or Linux) ✔, macOS ✘
...

linuxbrew@0e6abcd7b4ed:~/.linuxbrew/Homebrew$ brew unbottled --tag big_sur tart
==> Populating dependency tree...
==> :big_sur bottle status
tart: doesn't support this macOS
```

Some problems that remain (on macOS and Linux):
```
➜ brew unbottled --tag arm64_monterey tart
==> Populating dependency tree...
==> :arm64_monterey bottle status
tart: doesn't support this macOS
```
However, there is an `arm64_monterey` bottle for this formula. This has to do with the `Xcode.latest_version` and the fact that `tart`'s minimum Xcode requirement of 14.1 is satisfied only from Monterey 12.5.

Questions:
* How do we handle the `XcodeRequirment` inaccuracies?
* Would it be easier to just remove some functionality of `brew info/unbottled` on Linux for macOS-only formulae?