### PR TITLE
Pass `-no_fixup_chains` to linker when required

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -105,6 +105,8 @@ module Superenv
     #     have runtime detection of CPU features.
     # w - Pass -no_weak_imports to the linker
     # D - Generate debugging information
+    # f - Pass `-no_fixup_chains` to `ld` whenever it
+    #     is invoked with `-undefined dynamic_lookup`
     #
     # These flags will also be present:
     # a - apply fix for apr-1-config path

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -26,9 +26,12 @@ module SharedEnvExtension
 
   sig { returns(T::Boolean) }
   def no_fixup_chains_support?
-    return false if !MacOS::CLT.version.null? && MacOS::CLT.version < "13.0"
-    return false if !MacOS::Xcode.version.null? && MacOS::Xcode.version < "13.0"
+    ld_v = Utils.safe_popen_read("/usr/bin/ld", "-v", err: :out).lines.first.chomp
+    ld_version = Version.parse(ld_v[/\d+(\.\d+)*$/])
 
-    true
+    # This is supported starting Xcode 13, which ships ld64-711.
+    # https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes
+    # https://en.wikipedia.org/wiki/Xcode#Xcode_11.0_-_14.x_(since_SwiftUI_framework)_2
+    ld_version >= 711
   end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -26,8 +26,11 @@ module SharedEnvExtension
 
   sig { returns(T::Boolean) }
   def no_fixup_chains_support?
-    ld_v = Utils.safe_popen_read("/usr/bin/ld", "-v", err: :out).lines.first.chomp
-    ld_version = Version.parse(ld_v[/\d+(\.\d+)*$/])
+    return false if MacOS.version <= :catalina
+
+    # Note: `-version_details` is supported in Xcode 10.2 at the earliest.
+    ld_version_details = JSON.parse(Utils.safe_popen_read("/usr/bin/ld", "-version_details"))
+    ld_version = Version.parse(ld_version_details["version"])
 
     # This is supported starting Xcode 13, which ships ld64-711.
     # https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -23,4 +23,12 @@ module SharedEnvExtension
 
     true
   end
+
+  sig { returns(T::Boolean) }
+  def no_fixup_chains_support?
+    return false if !MacOS::CLT.version.null? && MacOS::CLT.version < "13.0"
+    return false if !MacOS::Xcode.version.null? && MacOS::Xcode.version < "13.0"
+
+    true
+  end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -28,7 +28,7 @@ module SharedEnvExtension
   def no_fixup_chains_support?
     return false if MacOS.version <= :catalina
 
-    # Note: `-version_details` is supported in Xcode 10.2 at the earliest.
+    # NOTE: `-version_details` is supported in Xcode 10.2 at the earliest.
     ld_version_details = JSON.parse(Utils.safe_popen_read("/usr/bin/ld", "-version_details"))
     ld_version = Version.parse(ld_version_details["version"])
 

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -101,4 +101,8 @@ module Stdenv
   def no_weak_imports
     append "LDFLAGS", "-Wl,-no_weak_imports" if no_weak_imports_support?
   end
+
+  def no_fixup_chains
+    append "LDFLAGS", "-Wl,-no_fixup_chains" if no_fixup_chains_support?
+  end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -131,6 +131,11 @@ module Superenv
     # Notably, Xcode 10.2 fixes issues where ZERO_AR_DATE affected file mtimes.
     # Xcode 11.0 contains fixes for lldb reading things built with ZERO_AR_DATE.
     self["ZERO_AR_DATE"] = "1" if MacOS::Xcode.version >= "11.0" || MacOS::CLT.version >= "11.0"
+
+    # Pass `-no_fixup_chains` whenever the linker is invoked with `-undefined dynamic_lookup`.
+    # See: https://github.com/python/cpython/issues/97524
+    #      https://github.com/pybind/pybind11/pull/4301
+    no_fixup_chains
   end
 
   def no_weak_imports
@@ -138,9 +143,6 @@ module Superenv
   end
 
   def no_fixup_chains
-    # Pass `-no_fixup_chains` whenever the linker is invoked with `-undefined dynamic_lookup`.
-    # See: https://github.com/python/cpython/issues/97524
-    #      https://github.com/pybind/pybind11/pull/4301
     append_to_cccfg "f" if no_fixup_chains_support?
   end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -136,4 +136,11 @@ module Superenv
   def no_weak_imports
     append_to_cccfg "w" if no_weak_imports_support?
   end
+
+  def no_fixup_chains
+    # Pass `-no_fixup_chains` whenever the linker is invoked with `-undefined dynamic_lookup`.
+    # See: https://github.com/python/cpython/issues/97524
+    #      https://github.com/pybind/pybind11/pull/4301
+    append_to_cccfg "f" if no_fixup_chains_support?
+  end
 end

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -221,7 +221,7 @@ class Cmd
       args << "-Wl,-undefined,dynamic_lookup"
     when /^-isysroot=/, /^--sysroot=/
       if mac?
-        sdk = arg.split("=")[1..-1].join("=")
+        sdk = arg.split("=", 2).last
         # We set the sysroot for macOS SDKs
         args << arg unless sdk.downcase.include? "osx"
       else
@@ -420,6 +420,7 @@ class Cmd
 
   def no_fixup_chains?
     return false unless config.include?("f")
+    return false unless calls_ld?
     return true if @args.include?("-Wl,-undefined,dynamic_lookup")
 
     args_consecutive_pairs = @args.each_cons(2)
@@ -428,6 +429,19 @@ class Cmd
 
     # The next flag would produce an error, but we fix it in `refurbish_arg`.
     @args.include?("-undefineddynamic_lookup")
+  end
+
+  def calls_ld?
+    return true if mode == :ld
+    return false unless [:ccld, :cxxld].include?(mode)
+
+    fuse_ld_flags = @args.find_all { |arg| arg.match?(/^-fuse-ld=/) }
+    return true if fuse_ld_flags.empty?
+
+    fuse_ld_flag = fuse_ld_flags.last.strip
+    fuse_ld_arg = fuse_ld_flag.split("=", 2).last
+
+    (fuse_ld_arg == "ld") || fuse_ld_arg.end_with("/usr/bin/ld")
   end
 
   def canonical_path(path)

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -318,9 +318,11 @@ class Cmd
     when :ld
       args << "-headerpad_max_install_names"
       args << "-no_weak_imports" if no_weak_imports?
+      args << "-no_fixup_chains" if no_fixup_chains?
     when :ccld, :cxxld
       args << "-Wl,-headerpad_max_install_names"
       args << "-Wl,-no_weak_imports" if no_weak_imports?
+      args << "-Wl,-no_fixup_chains" if no_fixup_chains?
     end
     args
   end
@@ -414,6 +416,18 @@ class Cmd
 
   def debug_symbols?
     config.include?("D")
+  end
+
+  def no_fixup_chains?
+    return false unless config.include?("f")
+    return true if @args.include?("-Wl,-undefined,dynamic_lookup")
+
+    args_consecutive_pairs = @args.each_cons(2)
+    return true if args_consecutive_pairs.include?(["-undefined", "dynamic_lookup"])
+    return true if args_consecutive_pairs.include?(["-Wl,-undefined", "-Wl,dynamic_lookup"])
+
+    # The next flag would produce an error, but we fix it in `refurbish_arg`.
+    @args.include?("-undefineddynamic_lookup")
   end
 
   def canonical_path(path)

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -441,7 +441,7 @@ class Cmd
     fuse_ld_flag = fuse_ld_flags.last.strip
     fuse_ld_arg = fuse_ld_flag.split("=", 2).last
 
-    (fuse_ld_arg == "ld") || fuse_ld_arg.end_with("/usr/bin/ld")
+    (fuse_ld_arg == "ld") || fuse_ld_arg.end_with?("/usr/bin/ld")
   end
 
   def canonical_path(path)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Invoking `ld` with `-undefined dynamic_lookup` emits a warning starting
Xcode 14:

    ld: warning: -undefined dynamic_lookup may not work with chained fixups

Chained fixups is a linker optimisation that results in faster binary
load times, and is enabled by default starting Xcode 13 when the target
is macOS 12 or newer.

However, this interacts poorly with `-undefined dynamic_lookup`, and
Xcode will disable chained fixups when it is invoked with this flag
starting Xcode 14.3. Until then, we may be shipping binaries that are
broken in subtle ways, so let's disable chained fixups when necessary
instead.

I patterned the changes here after the handling of `-no_weak_imports`.
The only difference is that we need to check the flags that were passed
to the linker first to see if we do need to disable chained fixups.

For additional context, see:

https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes
https://www.wwdcnotes.com/notes/wwdc22/110362/
https://www.emergetools.com/blog/posts/iOS15LaunchTime
https://github.com/python/cpython/issues/97524
https://github.com/pybind/pybind11/pull/4301
