### PR TITLE
rubocop: Trim exclude paths without offenses; move some more config

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -10,7 +10,6 @@ inherit_mode:
   merge:
     - Include
     - Exclude
-    - AllowedMethods
 
 AllCops:
   TargetRubyVersion: 2.6

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -395,6 +395,10 @@ Style/HashAsLastArrayItem:
     - "/**/Formula/**/*.rb"
     - "**/Formula/**/*.rb"
 
+# would rather freeze too much than too little
+Style/MutableConstant:
+  EnforcedStyle: strict
+
 # Zero-prefixed octal literals are widely used and understood.
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
@@ -471,7 +475,3 @@ Style/UnlessLogicalOperators:
 # a bit confusing to non-Rubyists but useful for longer arrays
 Style/WordArray:
   MinSize: 4
-
-# would rather freeze too much than too little
-Style/MutableConstant:
-  EnforcedStyle: strict

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -342,11 +342,6 @@ Style/BlockDelimiters:
   Exclude:
     - "Homebrew/**/*_spec.rb"
 
-# TODO: remove this when possible.
-Style/ClassVars:
-  Exclude:
-    - "**/developer/bin/*"
-
 # Use consistent style for better readability.
 Style/CollectionMethods:
   Enabled: true
@@ -385,11 +380,6 @@ Style/FrozenStringLiteralComment:
     - "Homebrew/test/**/Casks/**/*.rb"
     - "**/*.rbi"
     - "**/Brewfile"
-
-# TODO: remove this when possible.
-Style/GlobalVars:
-  Exclude:
-    - "**/developer/bin/*"
 
 # potential for errors in formulae too high with this
 Style/GuardClause:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -341,7 +341,6 @@ Style/BlockDelimiters:
     - "sig"
   Exclude:
     - "Homebrew/**/*_spec.rb"
-    - "Homebrew/**/shared_examples/**/*.rb"
 
 # TODO: remove this when possible.
 Style/ClassVars:

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -16,6 +16,9 @@ Layout/MultilineMethodCallIndentation:
     - "**/*_spec.rb"
 
 Naming/PredicateName:
+  inherit_mode:
+    merge:
+      - AllowedMethods
   AllowedMethods:
     - is_32_bit?
     - is_64_bit?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/14685.
- rubocop: Trim `Style/BlockDelimiters` exclude paths without offenses
- rubocop: Move `AllowedMethods` inheritance to the cop it's used in
- rubocop: Switch to Cask-specific `Style/ClassVars` in-line disables
