### PR TITLE
lock_file: better message if too many open files

### DIFF
--- a/Library/Homebrew/lock_file.rb
+++ b/Library/Homebrew/lock_file.rb
@@ -42,7 +42,11 @@ class LockFile
   def create_lockfile
     return if @lockfile.present? && !@lockfile.closed?
 
-    @lockfile = @path.open(File::RDWR | File::CREAT)
+    begin
+      @lockfile = @path.open(File::RDWR | File::CREAT)
+    rescue Errno::EMFILE
+      odie "The maximum number of open files on this system has been reached. Use `ulimit -n` to increase this limit."
+    end
     @lockfile.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I ran into the same issue reported in https://github.com/Homebrew/brew/issues/11530 (somehow my `ulimit -n` was only 256), but I found the error message a bit confusing, and it took me a while to find the recommendation to adjust `ulimit -n`. I've added a `rescue Errno::EMFILE` around the offending call in `lock_file.rb` and added an `onoe` message  that recommends using `ulimit -n` to increase the maximum number of open files.

~~~
$ brew upgrade osrf/simulation/gz-sim7 --debug
...
==> Upgrading osrf/simulation/gz-sim7
  7.3.0 -> 7.4.0 

Error: Consider using `ulimit -n` to increase the maximum number of open files allowed on this system.
Error: Too many open files @ rb_sysopen - /usr/local/var/homebrew/locks/gz-physics6.formula.lock
/usr/local/Homebrew/Library/Homebrew/lock_file.rb:46:in `initialize'
/usr/local/Homebrew/Library/Homebrew/lock_file.rb:46:in `open'
/usr/local/Homebrew/Library/Homebrew/lock_file.rb:46:in `open'
/usr/local/Homebrew/Library/Homebrew/lock_file.rb:46:in `create_lockfile'
/usr/local/Homebrew/Library/Homebrew/lock_file.rb:20:in `lock'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1352:in `lock'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:1293:in `each'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:1293:in `lock'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:376:in `install'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:203:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:176:in `upgrade_formula'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:86:in `block in upgrade_formulae'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:85:in `each'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:85:in `upgrade_formulae'
/usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:194:in `upgrade_outdated_formulae'
/usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:116:in `upgrade'
/usr/local/Homebrew/Library/Homebrew/brew.rb:93:in `<main>'
~~~
