### PR TITLE
rubocop: Deal with `RSpec` cop TODOs

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -279,10 +279,12 @@ RSpec/FilePath:
 RSpec/SubjectStub:
   Enabled: false
 
+# We use `allow(:foo).to receive(:bar)` everywhere.
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
 # TODO: try to enable these
 RSpec/DescribeClass:
-  Enabled: false
-RSpec/MessageSpies:
   Enabled: false
 RSpec/StubbedMock:
   Enabled: false

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -274,7 +274,11 @@ Rails/ToFormattedS:
 # Intentionally disabled as it doesn't fit with our code style.
 RSpec/AnyInstance:
   Enabled: false
+RSpec/DescribeClass:
+  Enabled: false
 RSpec/FilePath:
+  Enabled: false
+RSpec/StubbedMock:
   Enabled: false
 RSpec/SubjectStub:
   Enabled: false
@@ -282,12 +286,6 @@ RSpec/SubjectStub:
 # We use `allow(:foo).to receive(:bar)` everywhere.
 RSpec/MessageSpies:
   EnforcedStyle: receive
-
-# TODO: try to enable these
-RSpec/DescribeClass:
-  Enabled: false
-RSpec/StubbedMock:
-  Enabled: false
 
 # These were ever-growing numbers, not useful.
 RSpec/ExampleLength:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- "Deal with" might be ambitious wording, since I enabled one and disabled two others, but hey!

-----

- Enable `RSpec/MessageSpies` with the "receive" style.
  - This matches the code we already have, rather than autocorrecting everything to `have_received`.
- Intentionally disable `RSpec/{DescribeClass,StubbedMock}`
  - These had a lot of offenses that were marked as "try to enable".
  - A lot of the "describe class" ones were for tests for cmds or dev-cmds, `brew typecheck` or `brew --env`, and the cop would only pass if I changed these "describe"s to `BrewTypecheck` or `Brew__Env` which seemed unhelpful.
  - The usefulness of the stubbed mocks cop is [disputed](https://github.com/rubocop/rubocop-rspec/issues/1271), and fixing the offenses (not autocorrectable) would involve us doing a fair number of changes since changing `expect` to `allow` would then force us to make each of the affected tests have `expect` assertions at the end, where they sometimes don't currently.
