### PR TITLE
utils/github: Fix double counting of author/committer numbers

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -171,14 +171,9 @@ module Homebrew
 
       puts "Determining contributions for #{person} on #{repo_full_name}..." if args.verbose?
 
-      commits_authored = GitHub.repo_commit_count_for_user(repo_full_name, person, "author", args)
-      commits_committed = GitHub.repo_commit_count_for_user(repo_full_name, person, "committer", args)
-      # Only count committers where the author is not the same person. Avoid negative numbers or subtracting zero.
-      commits_committed = commits_authored - commits_committed if commits_authored > commits_committed
-
       data[repo] = {
-        author:        commits_authored,
-        committer:     commits_committed,
+        author:        GitHub.count_repo_commits(repo_full_name, person, "author", args),
+        committer:     GitHub.count_repo_commits(repo_full_name, person, "committer", args),
         coauthorships: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", args),
         reviews:       GitHub.count_issues(
           "",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The usage of this in `brew contributions` wasn't correct for a user with 5 authored commits to homebrew/cask that had been committed by other people, the numbers would turn out as 5 authored, 5 committed when they should be 5 authored, 0 committed.
- I decided to do this properly by getting the SHAs for author and committer and determine the differences between the two arrays. This also accounts for when authored commits are 0, or committed commits, or both.
- Add tests, because I don't want to fix this a third time!

-----

Before:

```
issyl0 at pictor in /opt/homebrew on master
❯ brew contributions --user=issyl0 --csv
issyl0 contributed 1688 times in all time.
user,repo,author,committer,coauthorships,reviews,total
issyl0,brew,402,149,13,144,708
issyl0,core,473,73,24,357,927
issyl0,cask,4,4,0,1,9
issyl0,aliases,0,0,0,0,0
issyl0,autoupdate,1,1,0,0,2
issyl0,bundle,17,4,2,0,23
issyl0,command-not-found,1,1,0,0,2
issyl0,test-bot,3,1,0,0,4
issyl0,services,9,2,0,2,13
issyl0,cask-drivers,0,0,0,0,0
issyl0,cask-fonts,0,0,0,0,0
issyl0,cask-versions,0,0,0,0,0
issyl0,all,910,235,39,504,1688
```

After:

```
❯ brew contributions --user=issyl0 --csv  
issyl0 contributed 1660 times in all time.
user,repo,author,committer,coauthorships,reviews,total
issyl0,brew,402,3,13,144,562
issyl0,core,473,204,24,357,1058
issyl0,cask,4,0,0,1,5
issyl0,aliases,0,0,0,0,0
issyl0,autoupdate,1,0,0,0,1
issyl0,bundle,17,0,2,0,19
issyl0,command-not-found,1,0,0,0,1
issyl0,test-bot,3,0,0,0,3
issyl0,services,9,0,0,2,11
issyl0,cask-drivers,0,0,0,0,0
issyl0,cask-fonts,0,0,0,0,0
issyl0,cask-versions,0,0,0,0,0
issyl0,all,910,207,39,504,1660
```