### PR TITLE
livecheck: Skip #preprocess_url for new strategies

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -35,9 +35,12 @@ module Homebrew
     STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL = [
       :extract_plist,
       :github_latest,
-      :page_match,
       :header_match,
+      :json,
+      :page_match,
       :sparkle,
+      :xml,
+      :yaml,
     ].freeze
 
     UNSTABLE_VERSION_KEYWORDS = %w[


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I forgot to add the new `Json`, `Xml`, and `Yaml` strategies to the list of strategies where `#preprocess_url` should be skipped and this is [causing issues for a user in their tap](https://github.com/orgs/Homebrew/discussions/4299). This is unfortunately another bug that wasn't surfaced when I tested all the related checks in our first-party taps.

In the not-too-distant future, I plan to rework how we use `#preprocess_url`. It only manipulates Git URLs at this point, so it arguably makes sense to move it into the `Git` strategy as part of some refactoring of how certain strategy `#match` methods work. Long story short, once that's done we won't have to worry about special-casing strategies with regard to `#preprocess_url`.