### PR TITLE
rubocops/cask: Clean up unnecessary `require`s

### DIFF
--- a/Library/Homebrew/rubocops/cask/desc.rb
+++ b/Library/Homebrew/rubocops/cask/desc.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "forwardable"
-require "uri"
 require "rubocops/cask/mixin/on_desc_stanza"
 require "rubocops/shared/desc_helper"
 

--- a/Library/Homebrew/rubocops/cask/url_legacy_comma_separators.rb
+++ b/Library/Homebrew/rubocops/cask/url_legacy_comma_separators.rb
@@ -1,9 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "forwardable"
-require "uri"
-
 module RuboCop
   module Cop
     module Cask


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- I suspect these were copy-pasted from other cops, like I did in https://github.com/Homebrew/brew/pull/14886#discussion_r1125569999.
- The "forwardable" require is unnecesary if the cop doesn't `extend Forwardable` and use `def_delegator`.
- The "uri" require is unnecessary if the cop doesn't call `URI` methods.
