### PR TITLE
`brew irb` improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,7 @@
 !/.dockerignore
 !/.editorconfig
 !/.gitignore
+!/.irb_config
 !/.yardopts
 !/.vale.ini
 !/.shellcheckrc

--- a/.irb_config
+++ b/.irb_config
@@ -1,0 +1,8 @@
+# Note that we use a non-standard config file name to reduce
+# name clashes with other IRB config files like `.irbrc`.
+
+require 'irb/completion'
+
+IRB.conf[:SAVE_HISTORY] = 100
+IRB.conf[:HISTORY_FILE] = "#{__dir__}/.irb_history"
+IRB.conf[:IRB_NAME] = "brew"

--- a/.irb_config
+++ b/.irb_config
@@ -1,8 +1,0 @@
-# Note that we use a non-standard config file name to reduce
-# name clashes with other IRB config files like `.irbrc`.
-
-require 'irb/completion'
-
-IRB.conf[:SAVE_HISTORY] = 100
-IRB.conf[:HISTORY_FILE] = "#{__dir__}/.irb_history"
-IRB.conf[:IRB_NAME] = "brew"

--- a/Library/Homebrew/brew_irbrc
+++ b/Library/Homebrew/brew_irbrc
@@ -1,0 +1,9 @@
+# Note: that we use a non-standard config file name to reduce
+# name clashes with other IRB config files like `.irbrc`.
+# Note #2: This doesn't work with system Ruby for some reason.
+
+require 'irb/completion'
+
+IRB.conf[:SAVE_HISTORY] = 100
+IRB.conf[:HISTORY_FILE] = "#{Dir.home}/.brew_irb_history"
+IRB.conf[:IRB_NAME] = "brew"

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -54,7 +54,6 @@ module Homebrew
     if args.pry?
       Homebrew.install_gem_setup_path! "pry"
       require "pry"
-      Pry.config.prompt_name = "brew"
     else
       require "irb"
     end
@@ -65,6 +64,11 @@ module Homebrew
 
     ohai "Interactive Homebrew Shell", "Example commands available with: `brew irb --examples`"
     if args.pry?
+      Pry.config.should_load_rc = false # skip loading .pryrc
+      Pry.config.history_file = (HOMEBREW_REPOSITORY/".pry_history").to_s
+      Pry.config.memory_size = 100 # max lines to save to history file
+      Pry.config.prompt_name = "brew"
+
       Pry.start
     else
       ENV["IRBRC"] = (HOMEBREW_REPOSITORY/".irb_config").to_s

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -67,6 +67,8 @@ module Homebrew
     if args.pry?
       Pry.start
     else
+      ENV["IRBRC"] = (HOMEBREW_REPOSITORY/".irb_config").to_s
+
       IRB.start
     end
   end

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -39,6 +39,8 @@ module Homebrew
     # work around IRB modifying ARGV.
     args = irb_args.parse(ARGV.dup.freeze)
 
+    clean_argv
+
     if args.examples?
       puts <<~EOS
         'v8'.f # => instance of the v8 formula
@@ -67,5 +69,14 @@ module Homebrew
     else
       IRB.start
     end
+  end
+
+  # Remove the `--debug`, `--verbose` and `--quiet` options which cause problems
+  # for IRB and have already been parsed by the CLI::Parser.
+  def clean_argv
+    global_options = Homebrew::CLI::Parser
+                     .global_options
+                     .flat_map { |options| options[0..1] }
+    ARGV.reject! { |arg| global_options.include?(arg) }
   end
 end

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -65,13 +65,13 @@ module Homebrew
     ohai "Interactive Homebrew Shell", "Example commands available with: `brew irb --examples`"
     if args.pry?
       Pry.config.should_load_rc = false # skip loading .pryrc
-      Pry.config.history_file = (HOMEBREW_REPOSITORY/".pry_history").to_s
+      Pry.config.history_file = "#{Dir.home}/.brew_pry_history"
       Pry.config.memory_size = 100 # max lines to save to history file
       Pry.config.prompt_name = "brew"
 
       Pry.start
     else
-      ENV["IRBRC"] = (HOMEBREW_REPOSITORY/".irb_config").to_s
+      ENV["IRBRC"] = (HOMEBREW_LIBRARY_PATH/"brew_irbrc").to_s
 
       IRB.start
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This resolves #14832.

It adds the two things mentioned in the original issue.
1. https://github.com/Homebrew/brew/pull/14892/commits/11a0ea18335cf1901e5e21c964493e2a233cc058 The ability to pass `--debug` and `--quiet` to IRB without it choking.

```rb
/u/l/Homebrew (irb-improvements|✔) $ brew irb --debug
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
irb(main):001:0> Context.current
=> #<Context::ContextStruct:0x00007fc8229a6220 @debug=true, @quiet=false, @verbose=false>
irb(main):002:0> exit
/u/l/Homebrew (irb-improvements|✔) $ brew irb --quiet
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
irb(main):001:0> Context.current
=> #<Context::ContextStruct:0x00007f8a6da71b98 @debug=false, @quiet=true, @verbose=false>
irb(main):002:0> exit
/u/l/Homebrew (irb-improvements|✔) $ brew irb --verbose
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
irb(main):001:0> Context.current
=> #<Context::ContextStruct:0x00007f80bca9e388 @debug=false, @quiet=false, @verbose=true>
irb(main):002:0> exit
```

2. https://github.com/Homebrew/brew/pull/14892/commits/6ab6d7c8eeeb51f2ae24697736d46bd5c16b3859 Local IRB history for REPL sessions.

I just added a IRB config file that gets loaded automatically if you set the `IRBRC` env variable with the path to it. It enables history which gets written to `.irb_history` in the repository directory and autocompletion. This apparently doesn't work with system Ruby for some reason but does work with portable Ruby which is better than nothing.

The only interesting thing here is that the file has a non-standard IRB config name to not clash with other IRB config files. Otherwise it would default to the closest `.irbrc`-like file which meant if you were in the brew repo directory it would get picked up instead of your global config.

References:
- [IRB Config File Rules](https://docs.ruby-lang.org/en/master/IRB.html#module-IRB-label-Configuration)
- [IRB config file resolver code](https://github.com/ruby/irb/blob/78c74d24254145a39c4d30168dbcd87dbbbc66dc/lib/irb/init.rb#L372-L411)

3. https://github.com/Homebrew/brew/pull/14892/commits/9f7ab25af5f857dcaf1fbff488ad9630c2781160 Improves the Pry config

This separates the brew pry config from the global one and adds local history. Before this was just defaulting the global config and history files.