### PR TITLE
sorbet: Autogenerate the RBI file for `utils/tty.rb`

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -64,6 +64,9 @@ module Homebrew
         tapioca_args = ["--exclude", *excluded_gems, "--typed-overrides", *typed_overrides]
         tapioca_args << "--all" if args.update_all?
 
+        ohai "Updating homegrown RBI files..."
+        safe_system "bundle", "exec", "ruby", "sorbet/custom_generators/tty.rb"
+
         ohai "Updating Tapioca RBI files..."
         safe_system "bundle", "exec", "tapioca", "gem", *tapioca_args
         safe_system "bundle", "exec", "parlour"

--- a/Library/Homebrew/sorbet/custom_generators/tty.rb
+++ b/Library/Homebrew/sorbet/custom_generators/tty.rb
@@ -1,12 +1,13 @@
 # typed: true
 # frozen_string_literal: true
 
+require_relative "../../global"
+require_relative "../../env_config"
 require_relative "../../utils/tty"
 
 File.open("#{File.dirname(__FILE__)}/../../utils/tty.rbi", "w") do |file|
   file.write(<<~RUBY)
     # typed: strict
-    # frozen_string_literal: true
 
     module Tty
   RUBY

--- a/Library/Homebrew/sorbet/custom_generators/tty.rb
+++ b/Library/Homebrew/sorbet/custom_generators/tty.rb
@@ -1,0 +1,30 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "../../utils/tty"
+
+File.open("#{File.dirname(__FILE__)}/../../utils/tty.rbi", "w") do |file|
+  file.write(<<~RUBY)
+    # typed: strict
+    # frozen_string_literal: true
+
+    module Tty
+  RUBY
+
+  dynamic_methods = Tty::COLOR_CODES.keys + Tty::STYLE_CODES.keys + Tty::SPECIAL_CODES.keys
+  methods = Tty.methods(false).sort.select { |method| dynamic_methods.include?(method) }
+
+  methods.each do |method|
+    return_type = (method.to_s.end_with?("?") ? T::Boolean : String)
+    signature = "sig { returns(#{return_type}) }"
+
+    file.write(<<-RUBY)
+  #{signature}
+  def self.#{method}; end
+    RUBY
+
+    file.write("\n") unless methods.last == method
+  end
+
+  file.write("end\n")
+end

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -8488,46 +8488,6 @@ class TracePoint
   def parameters(); end
 end
 
-module Tty
-  def self.blue(); end
-
-  def self.bold(); end
-
-  def self.cyan(); end
-
-  def self.default(); end
-
-  def self.down(); end
-
-  def self.erase_char(); end
-
-  def self.erase_line(); end
-
-  def self.green(); end
-
-  def self.italic(); end
-
-  def self.left(); end
-
-  def self.magenta(); end
-
-  def self.no_underline(); end
-
-  def self.red(); end
-
-  def self.reset(); end
-
-  def self.right(); end
-
-  def self.strikethrough(); end
-
-  def self.underline(); end
-
-  def self.up(); end
-
-  def self.yellow(); end
-end
-
 module URI
   include ::URI::RFC2396_REGEXP
 end

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -9,6 +9,36 @@ require "env_config"
 module Tty
   @stream = $stdout
 
+  COLOR_CODES = {
+    red:     31,
+    green:   32,
+    yellow:  33,
+    blue:    34,
+    magenta: 35,
+    cyan:    36,
+    default: 39,
+  }.freeze
+
+  STYLE_CODES = {
+    reset:         0,
+    bold:          1,
+    italic:        3,
+    underline:     4,
+    strikethrough: 9,
+    no_underline:  24,
+  }.freeze
+
+  SPECIAL_CODES = {
+    up:         "1A",
+    down:       "1B",
+    right:      "1C",
+    left:       "1D",
+    erase_line: "K",
+    erase_char: "P",
+  }.freeze
+
+  CODES = COLOR_CODES.merge(STYLE_CODES).freeze
+
   class << self
     extend T::Sig
 
@@ -41,36 +71,6 @@ module Tty
     def truncate(string)
       (w = width).zero? ? string.to_s : (string.to_s[0, w - 4] || "")
     end
-
-    COLOR_CODES = {
-      red:     31,
-      green:   32,
-      yellow:  33,
-      blue:    34,
-      magenta: 35,
-      cyan:    36,
-      default: 39,
-    }.freeze
-
-    STYLE_CODES = {
-      reset:         0,
-      bold:          1,
-      italic:        3,
-      underline:     4,
-      strikethrough: 9,
-      no_underline:  24,
-    }.freeze
-
-    SPECIAL_CODES = {
-      up:         "1A",
-      down:       "1B",
-      right:      "1C",
-      left:       "1D",
-      erase_line: "K",
-      erase_char: "P",
-    }.freeze
-
-    CODES = COLOR_CODES.merge(STYLE_CODES).freeze
 
     sig { returns(String) }
     def current_escape_sequence

--- a/Library/Homebrew/utils/tty.rbi
+++ b/Library/Homebrew/utils/tty.rbi
@@ -1,0 +1,60 @@
+# typed: strict
+
+module Tty
+  sig { returns(String) }
+  def self.blue; end
+
+  sig { returns(String) }
+  def self.bold; end
+
+  sig { returns(String) }
+  def self.cyan; end
+
+  sig { returns(String) }
+  def self.default; end
+
+  sig { returns(String) }
+  def self.down; end
+
+  sig { returns(String) }
+  def self.erase_char; end
+
+  sig { returns(String) }
+  def self.erase_line; end
+
+  sig { returns(String) }
+  def self.green; end
+
+  sig { returns(String) }
+  def self.italic; end
+
+  sig { returns(String) }
+  def self.left; end
+
+  sig { returns(String) }
+  def self.magenta; end
+
+  sig { returns(String) }
+  def self.no_underline; end
+
+  sig { returns(String) }
+  def self.red; end
+
+  sig { returns(String) }
+  def self.reset; end
+
+  sig { returns(String) }
+  def self.right; end
+
+  sig { returns(String) }
+  def self.strikethrough; end
+
+  sig { returns(String) }
+  def self.underline; end
+
+  sig { returns(String) }
+  def self.up; end
+
+  sig { returns(String) }
+  def self.yellow; end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Sort of. It's not via Parlour, because I read the docs and all it says about dynamically generating things is "of course it's better to do that", no examples. I tried my best, but Bo's work on `attr.rb` was mind-boggling.
- Instead, let's add a simple but functional generator script that I actually understand, as an alternative to maintaining these RBI files for dynamic methods manually, or as an alternative to skipping them entirely, so that we can get rid of some use of `srb rbi hidden-definitions` since that's deprecated.
- Follow up to #14651.

-----

- [x] TODO (if this is the direction we want to go): Run this script as part of `brew typecheck --update` so it gets updated with all the other RBI files periodically.

- Feel free to throw this away if this isn't the direction we want to go or if it's rubbish and/or not the Proper Way - no hard feelings! ❤️