### PR TITLE
Bash completions: simplify code

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -21,30 +21,12 @@ then
   return
 fi
 
-__brewcomp_words_include() {
-  local element idx 
-  for (( idx = 1; idx < COMP_CWORD; idx++ ))
-  do
-    element=${COMP_WORDS[idx]}
-    [[ -n ${element} && ${element} == "$1" ]] && return 0
-  done
-  return 1
-}
-
 __brewcomp() {
   # break $1 on space, tab, and newline characters,
   # and turn it into a newline separated list of words
-  local list s sep=$'\n' IFS=$' \t\n'
+  local list
   local cur=${COMP_WORDS[COMP_CWORD]}
-
-  for s in $1
-  do
-    __brewcomp_words_include "${s}" || list+="${s}${sep}"
-  done
-
-  list=${list%"${sep}"}
-
-  IFS="${sep}"
+  list=$(echo "$1" | tr '[:space:]' '\n' | sort -u)
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${list}" -- "${cur}")
 }
 

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -8,30 +8,12 @@ then
   return
 fi
 
-__brewcomp_words_include() {
-  local element idx 
-  for (( idx = 1; idx < COMP_CWORD; idx++ ))
-  do
-    element=${COMP_WORDS[idx]}
-    [[ -n ${element} && ${element} == "$1" ]] && return 0
-  done
-  return 1
-}
-
 __brewcomp() {
   # break $1 on space, tab, and newline characters,
   # and turn it into a newline separated list of words
-  local list s sep=$'\n' IFS=$' \t\n'
+  local list
   local cur=${COMP_WORDS[COMP_CWORD]}
-
-  for s in $1
-  do
-    __brewcomp_words_include "${s}" || list+="${s}${sep}"
-  done
-
-  list=${list%"${sep}"}
-
-  IFS="${sep}"
+  list=$(echo "$1" | tr '[:space:]' '\n' | sort -u)
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${list}" -- "${cur}")
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Replace a function and a for-loop with a one-liner.

The for-loop inside `__brewcomp` repetitively calls `__brewcomp_words_include` in order to create a list of unique elements from `$1`. Here, I'm replacing this for loop along with (no-longer-used) `__brewcomp_words_include` function with a one-liner that does resort to using `tr` and `sort` but is easier to understand and maintain.