### PR TITLE
when `brew cat` fails, suggest `brew info --github`

### DIFF
--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -53,7 +53,7 @@ module Homebrew
     end
 
     if Homebrew.failed?
-      $stderr.puts "The name may be wrong, or the tap hasn't been tapped."
+      $stderr.puts "The name may be wrong, or the tap hasn't been tapped. Consider using `brew info --github formula|cask [...]` instead."
       return
     end
 

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -54,7 +54,7 @@ module Homebrew
 
     if Homebrew.failed?
       $stderr.puts "The name may be wrong, or the tap hasn't been tapped."
-      $stderr.puts "Consider using `brew info --github formula|cask [...]` instead."
+      $stderr.puts "Consider using `brew info --github #{args.named.join(" ")}` instead."
       return
     end
 

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -53,8 +53,8 @@ module Homebrew
     end
 
     if Homebrew.failed?
-      $stderr.puts "The name may be wrong, or the tap hasn't been tapped."
-      $stderr.puts "Consider using `brew info --github #{args.named.join(" ")}` instead."
+      $stderr.puts "The name may be wrong, or the tap hasn't been tapped. Instead try:"
+      $stderr.puts "  brew info --github #{args.named.join(" ")}"
       return
     end
 

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -53,7 +53,8 @@ module Homebrew
     end
 
     if Homebrew.failed?
-      $stderr.puts "The name may be wrong, or the tap hasn't been tapped. Consider using `brew info --github formula|cask [...]` instead."
+      $stderr.puts "The name may be wrong, or the tap hasn't been tapped."
+      $stderr.puts "Consider using `brew info --github formula|cask [...]` instead."
       return
     end
 

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -15,12 +15,4 @@ describe "brew cat" do
       .and not_to_output.to_stderr
       .and be_a_success
   end
-
-  describe "when a source file isn't found" do
-    it "prints a suggestion to use brew info --github", :integration_test do
-      expect { brew "cat", "asdf", "bogus" }
-        .to output(/brew info --github asdf bogus/).to_stderr
-        .and be_a_failure
-    end
-  end
 end

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -15,4 +15,13 @@ describe "brew cat" do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  describe "when a source file isn't found" do
+    it "prints a suggestion to use brew info --github" , :integration_test do
+
+      expect  { brew "cat", "asdf", "bogus"}
+        .to output(/Consider using `brew info --github asdf bogus` instead/).to_stderr
+        .and be_a_failure
+    end
+  end
 end

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -17,9 +17,8 @@ describe "brew cat" do
   end
 
   describe "when a source file isn't found" do
-    it "prints a suggestion to use brew info --github" , :integration_test do
-
-      expect  { brew "cat", "asdf", "bogus"}
+    it "prints a suggestion to use brew info --github", :integration_test do
+      expect { brew "cat", "asdf", "bogus" }
         .to output(/brew info --github asdf bogus/).to_stderr
         .and be_a_failure
     end

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -20,7 +20,7 @@ describe "brew cat" do
     it "prints a suggestion to use brew info --github" , :integration_test do
 
       expect  { brew "cat", "asdf", "bogus"}
-        .to output(/Consider using `brew info --github asdf bogus` instead/).to_stderr
+        .to output(/brew info --github asdf bogus/).to_stderr
         .and be_a_failure
     end
   end


### PR DESCRIPTION
When `brew cat formula|cask` fails, add suggestion to use `brew info --github formula|cask` instead. This gives a workaround for API users that don't have taps locally for `homebrew/core` and `homebrew/cask`.

This builds on changes from #14824 which addressed #14815