### PR TITLE
Fix "undefined local variable" error in update-report

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -642,8 +642,8 @@ class ReporterHub
     dump_deleted_formula_report(report_all)
     dump_deleted_cask_report(report_all)
 
-    outdated_formulae = nil
-    outdated_casks = nil
+    outdated_formulae = []
+    outdated_casks = []
 
     if updated_formula_report && report_all
       dump_modified_formula_report
@@ -671,7 +671,7 @@ class ReporterHub
     return if outdated_formulae.blank? && outdated_casks.blank?
 
     outdated_formulae = outdated_formulae.count
-    outdated_casks = T.must(outdated_casks).count
+    outdated_casks = outdated_casks.count
 
     update_pronoun = if (outdated_formulae + outdated_casks) == 1
       "it"

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "migrator"
@@ -188,7 +188,7 @@ module Homebrew
       begin
         reporter = Reporter.new(tap)
       rescue Reporter::ReporterRevisionUnsetError => e
-        onoe "#{e.message}\n#{e.backtrace.join "\n"}" if Homebrew::EnvConfig.developer?
+        onoe "#{e.message}\n#{e.backtrace&.join("\n")}" if Homebrew::EnvConfig.developer?
         next
       end
       if reporter.updated?
@@ -315,7 +315,7 @@ module Homebrew
     return if CoreTap.instance.installed?
 
     CoreTap.ensure_installed!
-    revision = core_tap.git_head
+    revision = CoreTap.instance.git_head
     ENV["HOMEBREW_UPDATE_BEFORE_HOMEBREW_HOMEBREW_CORE"] = revision
     ENV["HOMEBREW_UPDATE_AFTER_HOMEBREW_HOMEBREW_CORE"] = revision
   end
@@ -496,7 +496,7 @@ class Reporter
             system HOMEBREW_BREW_FILE, "link", new_full_name, "--overwrite"
           end
         rescue Exception => e # rubocop:disable Lint/RescueException
-          onoe "#{e.message}\n#{e.backtrace.join "\n"}" if Homebrew::EnvConfig.developer?
+          onoe "#{e.message}\n#{e.backtrace&.join("\n")}" if Homebrew::EnvConfig.developer?
         end
         next
       end
@@ -560,7 +560,7 @@ class Reporter
       begin
         f = Formulary.factory(new_full_name)
       rescue Exception => e # rubocop:disable Lint/RescueException
-        onoe "#{e.message}\n#{e.backtrace.join "\n"}" if Homebrew::EnvConfig.developer?
+        onoe "#{e.message}\n#{e.backtrace&.join("\n")}" if Homebrew::EnvConfig.developer?
         next
       end
 
@@ -671,7 +671,7 @@ class ReporterHub
     return if outdated_formulae.blank? && outdated_casks.blank?
 
     outdated_formulae = outdated_formulae.count
-    outdated_casks = outdated_casks.count
+    outdated_casks = T.must(outdated_casks).count
 
     update_pronoun = if (outdated_formulae + outdated_casks) == 1
       "it"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Resolves an error introduced in https://github.com/Homebrew/brew/commit/2451d017f9ebbf6b3f5fd79f15e048d2c109145a#diff-05ec45190dab3db11df80b2c154648c8023837fa34917dce9d1bcde0acf9c005L282
If you have a few minutes and you're willing to untap `core`, you should be able to repro with:

```
$ brew untap homebrew/core; HOMEBREW_NO_INSTALL_FROM_API=1 brew update-report
Untapping homebrew/core...
Untapped 3 commands and 6552 formulae (15,331 files, 710.4MB).
==> Tapping homebrew/core
Cloning into '/opt/homebrew/Library/Taps/homebrew/homebrew-core'...
remote: Enumerating objects: 1429703, done.
remote: Counting objects: 100% (318/318), done.
remote: Compressing objects: 100% (157/157), done.
remote: Total 1429703 (delta 190), reused 268 (delta 161), pack-reused 1429385
Receiving objects: 100% (1429703/1429703), 549.69 MiB | 3.90 MiB/s, done.
Resolving deltas: 100% (997762/997762), done.
Tapped 3 commands and 6554 formulae (6,906 files, 604.5MB).
Error: undefined local variable or method `core_tap' for Homebrew:Module
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/opt/homebrew/Library/Homebrew/cmd/update-report.rb:318:in `install_core_tap_if_necessary'
/opt/homebrew/Library/Homebrew/cmd/update-report.rb:115:in `output_update_report'
/opt/homebrew/Library/Homebrew/cmd/update-report.rb:42:in `update_report'
/opt/homebrew/Library/Homebrew/brew.rb:93:in `<main>'
```

I've also enabled typechecking in `update-report`, which would have caught this error