### PR TITLE
ci: Move from Ubuntu 18.04 to Ubuntu 20.04 Actions runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -264,9 +264,9 @@ jobs:
           - name: tests (Ubuntu 22.04)
             test-flags: --coverage
             runs-on: ubuntu-22.04
-          - name: tests (Ubuntu 18.04)
+          - name: tests (Ubuntu 20.04)
             test-flags: --coverage
-            runs-on: ubuntu-18.04
+            runs-on: ubuntu-20.04
           - name: tests (macOS 12)
             test-flags: --coverage
             runs-on: macos-12
@@ -354,8 +354,8 @@ jobs:
         include:
           - name: test default formula (Ubuntu 22.04)
             runs-on: ubuntu-22.04
-          - name: test default formula (Ubuntu 18.04)
-            runs-on: ubuntu-18.04
+          - name: test default formula (Ubuntu 20.04)
+            runs-on: ubuntu-20.04
           - name: test default formula (macOS 12)
             runs-on: macos-12
     steps:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- These are deprecated and going away in less than a month. Today was another scheduled brownout from GitHub (https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/), and they've been unmarked as "required" checks in the branch protections because the images are unavailable and the jobs were failing.
