### PR TITLE
Remove ActiveSupport String inflections

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -199,13 +199,13 @@ module Kernel
     if s > 59
       m = s / 60
       s %= 60
-      res = +"#{m} #{"minute".pluralize(m)}"
+      res = +"#{m} #{Utils.pluralize("minute", m)}"
       return res.freeze if s.zero?
 
       res << " "
     end
 
-    res << "#{s} #{"second".pluralize(s)}"
+    res << "#{s} #{Utils.pluralize("second", s)}"
     res.freeze
   end
 

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -16,7 +16,8 @@ require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/filters"
 require "active_support/core_ext/object/try"
 require "active_support/core_ext/array/access"
-require "active_support/core_ext/string/inflections"
+require "i18n"
+require "active_support/core_ext/hash/except"
 require "active_support/core_ext/kernel/reporting"
 require "active_support/core_ext/hash/keys"
 require "active_support/core_ext/hash/deep_merge"
@@ -27,12 +28,6 @@ require "active_support/core_ext/string/indent"
 
 I18n.backend.available_locales # Initialize locales so they can be overwritten.
 I18n.backend.store_translations :en, support: { array: { last_word_connector: " and " } }
-
-ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.irregular "formula", "formulae"
-  inflect.irregular "is", "are"
-  inflect.irregular "it", "they"
-end
 
 HOMEBREW_API_DEFAULT_DOMAIN = ENV.fetch("HOMEBREW_API_DEFAULT_DOMAIN").freeze
 HOMEBREW_BOTTLE_DEFAULT_DOMAIN = ENV.fetch("HOMEBREW_BOTTLE_DEFAULT_DOMAIN").freeze

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -111,7 +111,7 @@ module Homebrew
           constant = Strategy.const_get(const_symbol)
           next unless constant.is_a?(Class)
 
-          key = const_symbol.to_s.underscore.to_sym
+          key = Utils.underscore(const_symbol).to_sym
           @strategies[key] = constant
         end
         @strategies

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -58,4 +58,39 @@ describe Utils do
       expect(described_class.pluralize("foo", 2, singular: "o", plural: "es")).to eq("fooes")
     end
   end
+
+  describe ".underscore" do
+    # commented out entries require acronyms inflections
+    let (:words) {
+      [["API", "api"],
+      ["APIController", "api_controller"],
+      ["Nokogiri::HTML", "nokogiri/html"],
+      # ["HTTPAPI", "http_api"],
+      ["HTTP::Get", "http/get"],
+      ["SSLError", "ssl_error"],
+      # ["RESTful", "restful"],
+      # ["RESTfulController", "restful_controller"],
+      # ["Nested::RESTful", "nested/restful"],
+      # ["IHeartW3C", "i_heart_w3c"],
+      # ["PhDRequired", "phd_required"],
+      # ["IRoRU", "i_ror_u"],
+      # ["RESTfulHTTPAPI", "restful_http_api"],
+      # ["HTTP::RESTful", "http/restful"],
+      # ["HTTP::RESTfulAPI", "http/restful_api"],
+      # ["APIRESTful", "api_restful"],
+      ["Capistrano", "capistrano"],
+      ["CapiController", "capi_controller"],
+      ["HttpsApis", "https_apis"],
+      ["Html5", "html5"],
+      ["Restfully", "restfully"],
+      ["RoRails", "ro_rails"]]
+    }
+
+    it "converts strings to underscore case" do
+      words.each do |camel, under|
+        expect(described_class.underscore(camel)).to eq(under)
+        expect(described_class.underscore(under)).to eq(under)
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -61,29 +61,31 @@ describe Utils do
 
   describe ".underscore" do
     # commented out entries require acronyms inflections
-    let (:words) {
-      [["API", "api"],
-      ["APIController", "api_controller"],
-      ["Nokogiri::HTML", "nokogiri/html"],
-      # ["HTTPAPI", "http_api"],
-      ["HTTP::Get", "http/get"],
-      ["SSLError", "ssl_error"],
-      # ["RESTful", "restful"],
-      # ["RESTfulController", "restful_controller"],
-      # ["Nested::RESTful", "nested/restful"],
-      # ["IHeartW3C", "i_heart_w3c"],
-      # ["PhDRequired", "phd_required"],
-      # ["IRoRU", "i_ror_u"],
-      # ["RESTfulHTTPAPI", "restful_http_api"],
-      # ["HTTP::RESTful", "http/restful"],
-      # ["HTTP::RESTfulAPI", "http/restful_api"],
-      # ["APIRESTful", "api_restful"],
-      ["Capistrano", "capistrano"],
-      ["CapiController", "capi_controller"],
-      ["HttpsApis", "https_apis"],
-      ["Html5", "html5"],
-      ["Restfully", "restfully"],
-      ["RoRails", "ro_rails"]]
+    let(:words) {
+      [
+        ["API", "api"],
+        ["APIController", "api_controller"],
+        ["Nokogiri::HTML", "nokogiri/html"],
+        # ["HTTPAPI", "http_api"],
+        ["HTTP::Get", "http/get"],
+        ["SSLError", "ssl_error"],
+        # ["RESTful", "restful"],
+        # ["RESTfulController", "restful_controller"],
+        # ["Nested::RESTful", "nested/restful"],
+        # ["IHeartW3C", "i_heart_w3c"],
+        # ["PhDRequired", "phd_required"],
+        # ["IRoRU", "i_ror_u"],
+        # ["RESTfulHTTPAPI", "restful_http_api"],
+        # ["HTTP::RESTful", "http/restful"],
+        # ["HTTP::RESTfulAPI", "http/restful_api"],
+        # ["APIRESTful", "api_restful"],
+        ["Capistrano", "capistrano"],
+        ["CapiController", "capi_controller"],
+        ["HttpsApis", "https_apis"],
+        ["Html5", "html5"],
+        ["Restfully", "restfully"],
+        ["RoRails", "ro_rails"],
+      ]
     }
 
     it "converts strings to underscore case" do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -131,4 +131,23 @@ module Utils
     suffix = (count == 1) ? singular : plural
     "#{stem}#{suffix}"
   end
+
+  # Makes an underscored, lowercase form from the expression in the string.
+  #
+  # Changes '::' to '/' to convert namespaces to paths.
+  #
+  #   underscore('ActiveModel')         # => "active_model"
+  #   underscore('ActiveModel::Errors') # => "active_model/errors"
+  #
+  # @see https://github.com/rails/rails/blob/v6.1.7.2/activesupport/lib/active_support/inflector/methods.rb#L81-L100
+  #   `ActiveSupport::Inflector.underscore`
+  sig { params(camel_cased_word: T.any(String, Symbol)).returns(String) }
+  def self.underscore(camel_cased_word)
+    return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+    word = camel_cased_word.to_s.gsub("::", "/")
+    word.gsub!(/([A-Z])(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) { ($1 || $2) << "_" }
+    word.tr!("-", "_")
+    word.downcase!
+    word
+  end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -144,8 +144,11 @@ module Utils
   sig { params(camel_cased_word: T.any(String, Symbol)).returns(String) }
   def self.underscore(camel_cased_word)
     return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+
     word = camel_cased_word.to_s.gsub("::", "/")
-    word.gsub!(/([A-Z])(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) { ($1 || $2) << "_" }
+    word.gsub!(/([A-Z])(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
+      (::Regexp.last_match(1) || ::Regexp.last_match(2)) << "_"
+    end
     word.tr!("-", "_")
     word.downcase!
     word

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -143,11 +143,11 @@ module Utils
   #   `ActiveSupport::Inflector.underscore`
   sig { params(camel_cased_word: T.any(String, Symbol)).returns(String) }
   def self.underscore(camel_cased_word)
-    return camel_cased_word unless /[A-Z-]|::/.match?(camel_cased_word)
+    return camel_cased_word.to_s unless /[A-Z-]|::/.match?(camel_cased_word)
 
     word = camel_cased_word.to_s.gsub("::", "/")
     word.gsub!(/([A-Z])(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
-      (::Regexp.last_match(1) || ::Regexp.last_match(2)) << "_"
+      T.must(::Regexp.last_match(1) || ::Regexp.last_match(2)) << "_"
     end
     word.tr!("-", "_")
     word.downcase!


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Relates to https://github.com/Homebrew/brew/issues/10508

This removes `ActiveSupport` `String` inflections. The performance impact is minimal, bc most of the time was spent in requiring `i18n`, which remains as a transitive require (I prefer to pull these out one at a time).