### PR TITLE
rubocop: Clean up `Style/BlockDelimiters` excludes and autofix offenses

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -328,8 +328,6 @@ Style/BarePercentLiterals:
 Style/BlockDelimiters:
   BracesRequiredMethods:
     - "sig"
-  Exclude:
-    - "Homebrew/**/*_spec.rb"
 
 # Use consistent style for better readability.
 Style/CollectionMethods:

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -30,12 +30,12 @@ describe "ENV" do
       it "ensures the environment is restored" do
         before = subject.dup
 
-        expect {
+        expect do
           subject.with_build_environment do
             subject["foo"] = "bar"
             raise StandardError
           end
-        }.to raise_error(StandardError)
+        end.to raise_error(StandardError)
 
         expect(subject["foo"]).to be_nil
         expect(subject).to eq(before)

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -22,7 +22,7 @@ describe Homebrew::API::Cask do
   end
 
   describe "::all_casks" do
-    let(:casks_json) {
+    let(:casks_json) do
       <<~EOS
         [{
           "token": "foo",
@@ -32,13 +32,13 @@ describe Homebrew::API::Cask do
           "url": "https://brew.sh/bar"
         }]
       EOS
-    }
-    let(:casks_hash) {
+    end
+    let(:casks_hash) do
       {
         "foo" => { "url" => "https://brew.sh/foo" },
         "bar" => { "url" => "https://brew.sh/bar" },
       }
-    }
+    end
 
     it "returns the expected cask JSON list" do
       mock_curl_download stdout: casks_json

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -21,7 +21,7 @@ describe Homebrew::API::Formula do
   end
 
   describe "::all_formulae" do
-    let(:formulae_json) {
+    let(:formulae_json) do
       <<~EOS
         [{
           "name": "foo",
@@ -37,21 +37,21 @@ describe Homebrew::API::Formula do
           "aliases": []
         }]
       EOS
-    }
-    let(:formulae_hash) {
+    end
+    let(:formulae_hash) do
       {
         "foo" => { "url" => "https://brew.sh/foo", "aliases" => ["foo-alias1", "foo-alias2"] },
         "bar" => { "url" => "https://brew.sh/bar", "aliases" => ["bar-alias"] },
         "baz" => { "url" => "https://brew.sh/baz", "aliases" => [] },
       }
-    }
-    let(:formulae_aliases) {
+    end
+    let(:formulae_aliases) do
       {
         "foo-alias1" => "foo",
         "foo-alias2" => "foo",
         "bar-alias"  => "bar",
       }
-    }
+    end
 
     it "returns the expected formula JSON list" do
       mock_curl_download stdout: formulae_json

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -63,9 +63,9 @@ describe Homebrew::API do
 
     it "raises an error if the JSON file is invalid" do
       mock_curl_download stdout: json_invalid
-      expect {
+      expect do
         described_class.fetch_json_api_file("baz.json", target: cache_dir/"baz.json")
-      }.to raise_error(SystemExit)
+      end.to raise_error(SystemExit)
     end
   end
 
@@ -78,9 +78,9 @@ describe Homebrew::API do
 
     it "raises an error if the file does not exist" do
       mock_curl_output success: false
-      expect {
+      expect do
         described_class.fetch_homebrew_cask_source("bar", git_head: "master")
-      }.to raise_error(ArgumentError, /No valid file found/)
+      end.to raise_error(ArgumentError, /No valid file found/)
     end
   end
 end

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -50,12 +50,12 @@ describe Bottle::Filename do
   describe "::create" do
     subject { described_class.create(f, :tag, 0) }
 
-    let(:f) {
+    let(:f) do
       formula do
         url "https://brew.sh/foo.tar.gz"
         version "1.0"
       end
-    }
+    end
 
     its(:to_s) { is_expected.to eq "formula_name--1.0.tag.bottle.tar.gz" }
   end

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -13,9 +13,9 @@ describe CacheStoreDatabase do
       cache_store = instance_double(described_class, "cache_store", write_if_dirty!: nil)
       expect(described_class).to receive(:new).with(type).and_return(cache_store)
       expect(cache_store).to receive(:write_if_dirty!)
-      described_class.use(type) { |_db|
+      described_class.use(type) do |_db|
         # do nothing
-      }
+      end
     end
   end
 

--- a/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
@@ -5,11 +5,11 @@ describe Cask::Artifact::App, :cask do
   describe "activate to alternate target" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-alt-target")) }
 
-    let(:install_phase) {
+    let(:install_phase) do
       cask.artifacts.select { |a| a.is_a?(described_class) }.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
-    }
+    end
 
     let(:source_path) { cask.staged_path.join("Caffeine.app") }
     let(:target_path) { cask.config.appdir.join("AnotherName.app") }
@@ -29,7 +29,7 @@ describe Cask::Artifact::App, :cask do
     end
 
     describe "when app is in a subdirectory" do
-      let(:cask) {
+      let(:cask) do
         Cask::Cask.new("subdir") do
           url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
           homepage "https://brew.sh/local-caffeine"
@@ -37,7 +37,7 @@ describe Cask::Artifact::App, :cask do
           sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
           app "subdir/Caffeine.app", target: "AnotherName.app"
         end
-      }
+      end
 
       it "installs the given apps using the proper target directory" do
         appsubdir = cask.staged_path.join("subdir").tap(&:mkpath)

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -27,7 +27,7 @@ describe Cask::Artifact::App, :cask do
     end
 
     describe "when app is in a subdirectory" do
-      let(:cask) {
+      let(:cask) do
         Cask::Cask.new("subdir") do
           url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
           homepage "https://brew.sh/local-caffeine"
@@ -35,7 +35,7 @@ describe Cask::Artifact::App, :cask do
           sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
           app "subdir/Caffeine.app"
         end
-      }
+      end
 
       it "installs the given app using the proper target directory" do
         appsubdir = cask.staged_path.join("subdir").tap(&:mkpath)

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -2,11 +2,11 @@
 # frozen_string_literal: true
 
 describe Cask::Artifact::Binary, :cask do
-  let(:cask) {
+  let(:cask) do
     Cask::CaskLoader.load(cask_path("with-binary")).tap do |cask|
       InstallHelper.install_without_artifacts(cask)
     end
-  }
+  end
   let(:artifacts) { cask.artifacts.select { |a| a.is_a?(described_class) } }
   let(:binarydir) { cask.config.binarydir }
   let(:expected_path) { binarydir.join("binary") }
@@ -21,9 +21,9 @@ describe Cask::Artifact::Binary, :cask do
   end
 
   context "when --no-binaries is specified" do
-    let(:cask) {
+    let(:cask) do
       Cask::CaskLoader.load(cask_path("with-binary"))
-    }
+    end
 
     it "doesn't link the binary when --no-binaries is specified" do
       Cask::Installer.new(cask, binaries: false).install
@@ -41,11 +41,11 @@ describe Cask::Artifact::Binary, :cask do
   end
 
   context "when the binary is not executable" do
-    let(:cask) {
+    let(:cask) do
       Cask::CaskLoader.load(cask_path("with-non-executable-binary")).tap do |cask|
         InstallHelper.install_without_artifacts(cask)
       end
-    }
+    end
 
     let(:expected_path) { cask.config.binarydir.join("naked_non_executable") }
 
@@ -65,11 +65,11 @@ describe Cask::Artifact::Binary, :cask do
   it "avoids clobbering an existing binary by linking over it" do
     FileUtils.touch expected_path
 
-    expect {
+    expect do
       artifacts.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
-    }.to raise_error(Cask::CaskError)
+    end.to raise_error(Cask::CaskError)
 
     expect(expected_path).not_to be :symlink?
   end
@@ -77,11 +77,11 @@ describe Cask::Artifact::Binary, :cask do
   it "avoids clobbering an existing symlink" do
     expected_path.make_symlink("/tmp")
 
-    expect {
+    expect do
       artifacts.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
-    }.to raise_error(Cask::CaskError)
+    end.to raise_error(Cask::CaskError)
 
     expect(File.readlink(expected_path)).to eq("/tmp")
   end
@@ -97,11 +97,11 @@ describe Cask::Artifact::Binary, :cask do
   end
 
   context "when the binary is inside an app package" do
-    let(:cask) {
+    let(:cask) do
       Cask::CaskLoader.load(cask_path("with-embedded-binary")).tap do |cask|
         InstallHelper.install_without_artifacts(cask)
       end
-    }
+    end
 
     it "links the binary to the proper directory" do
       cask.artifacts.select { |a| a.is_a?(Cask::Artifact::App) }.each do |artifact|

--- a/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
@@ -4,13 +4,13 @@
 describe Cask::Artifact::Artifact, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("with-generic-artifact")) }
 
-  let(:install_phase) {
+  let(:install_phase) do
     lambda do
       cask.artifacts.select { |a| a.is_a?(described_class) }.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
     end
-  }
+  end
 
   let(:source_path) { cask.staged_path.join("Caffeine.app") }
   let(:target_path) { cask.config.appdir.join("Caffeine.app") }
@@ -21,25 +21,25 @@ describe Cask::Artifact::Artifact, :cask do
 
   context "without target" do
     it "fails to load" do
-      expect {
+      expect do
         Cask::CaskLoader.load(cask_path("invalid/invalid-generic-artifact-no-target"))
-      }.to raise_error(Cask::CaskInvalidError, /Generic Artifact.*requires.*target/)
+      end.to raise_error(Cask::CaskInvalidError, /Generic Artifact.*requires.*target/)
     end
   end
 
   context "with relative target" do
     it "does not fail to load" do
-      expect {
+      expect do
         Cask::CaskLoader.load(cask_path("generic-artifact-relative-target"))
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 
   context "with user-relative target" do
     it "does not fail to load" do
-      expect {
+      expect do
         Cask::CaskLoader.load(cask_path("generic-artifact-user-relative-target"))
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 
@@ -53,9 +53,9 @@ describe Cask::Artifact::Artifact, :cask do
   it "avoids clobbering an existing artifact" do
     target_path.mkpath
 
-    expect {
+    expect do
       install_phase.call
-    }.to raise_error(Cask::CaskError)
+    end.to raise_error(Cask::CaskError)
 
     expect(source_path).to be_a_directory
     expect(target_path).to be_a_directory

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -16,9 +16,9 @@ describe Cask::Artifact::Installer, :cask do
       let(:args) { { manual: "installer" } }
 
       it "shows a message prompting to run the installer manually" do
-        expect {
+        expect do
           installer.install_phase(command: command)
-        }.to output(%r{run the installer at:\s+#{staged_path}/installer}).to_stdout
+        end.to output(%r{run the installer at:\s+#{staged_path}/installer}).to_stdout
       end
     end
 

--- a/Library/Homebrew/test/cask/artifact/manpage_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/manpage_spec.rb
@@ -13,13 +13,13 @@ describe Cask::Artifact::Manpage, :cask do
   end
 
   context "with install" do
-    let(:install_phase) {
+    let(:install_phase) do
       lambda do
         cask.artifacts.select { |a| a.is_a?(described_class) }.each do |artifact|
           artifact.install_phase(command: NeverSudoSystemCommand, force: false)
         end
       end
-    }
+    end
 
     let(:source_path) { cask.staged_path.join("manpage.1") }
     let(:target_path) { cask.config.manpagedir.join("man1/manpage.1") }

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -4,13 +4,13 @@
 describe Cask::Artifact::Suite, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("with-suite")) }
 
-  let(:install_phase) {
+  let(:install_phase) do
     lambda do
       cask.artifacts.select { |a| a.is_a?(described_class) }.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
     end
-  }
+  end
 
   let(:target_path) { cask.config.appdir.join("Caffeine") }
   let(:source_path) { cask.staged_path.join("Caffeine") }
@@ -28,9 +28,9 @@ describe Cask::Artifact::Suite, :cask do
   it "avoids clobbering an existing suite by moving over it" do
     target_path.mkpath
 
-    expect {
+    expect do
       install_phase.call
-    }.to raise_error(Cask::CaskError)
+    end.to raise_error(Cask::CaskError)
 
     expect(source_path).to be_a_directory
     expect(target_path).to be_a_directory

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -5,11 +5,11 @@ describe Cask::Artifact::App, :cask do
   describe "multiple apps" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-two-apps-correct")) }
 
-    let(:install_phase) {
+    let(:install_phase) do
       cask.artifacts.select { |a| a.is_a?(described_class) }.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
-    }
+    end
 
     let(:source_path_mini) { cask.staged_path.join("Caffeine Mini.app") }
     let(:target_path_mini) { cask.config.appdir.join("Caffeine Mini.app") }
@@ -64,11 +64,11 @@ describe Cask::Artifact::App, :cask do
       it "when the first app of two already exists" do
         target_path_mini.mkpath
 
-        expect {
+        expect do
           expect { install_phase }.to output(<<~EOS).to_stdout
             ==> Moving App 'Caffeine Pro.app' to '#{target_path_pro}'
           EOS
-        }.to raise_error(Cask::CaskError, "It seems there is already an App at '#{target_path_mini}'.")
+        end.to raise_error(Cask::CaskError, "It seems there is already an App at '#{target_path_mini}'.")
 
         expect(source_path_mini).to be_a_directory
         expect(target_path_mini).to be_a_directory
@@ -78,11 +78,11 @@ describe Cask::Artifact::App, :cask do
       it "when the second app of two already exists" do
         target_path_pro.mkpath
 
-        expect {
+        expect do
           expect { install_phase }.to output(<<~EOS).to_stdout
             ==> Moving App 'Caffeine Mini.app' to '#{target_path_mini}'
           EOS
-        }.to raise_error(Cask::CaskError, "It seems there is already an App at '#{target_path_pro}'.")
+        end.to raise_error(Cask::CaskError, "It seems there is already an App at '#{target_path_pro}'.")
 
         expect(source_path_pro).to be_a_directory
         expect(target_path_pro).to be_a_directory

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -4,9 +4,9 @@
 describe Cask::Artifact::Zap, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("with-installable")) }
 
-  let(:zap_artifact) {
+  let(:zap_artifact) do
     cask.artifacts.find { |a| a.is_a?(described_class) }
-  }
+  end
 
   before do
     InstallHelper.install_without_artifacts(cask)

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -70,14 +70,14 @@ describe Cask::Audit, :cask do
   let(:except) { [] }
   let(:strict) { nil }
   let(:token_conflicts) { nil }
-  let(:audit) {
+  let(:audit) do
     described_class.new(cask, online:          online,
                               strict:          strict,
                               new_cask:        new_cask,
                               token_conflicts: token_conflicts,
                               only:            only,
                               except:          except)
-  }
+  end
 
   describe "#new" do
     context "when `new_cask` is specified" do

--- a/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
@@ -4,43 +4,43 @@
 describe Cask::CaskLoader::FromPathLoader do
   describe "#load" do
     context "when the file does not contain a cask" do
-      let(:path) {
+      let(:path) do
         (mktmpdir/"cask.rb").tap do |path|
           path.write <<~RUBY
             true
           RUBY
         end
-      }
+      end
 
       it "raises an error" do
-        expect {
+        expect do
           described_class.new(path).load(config: nil)
-        }.to raise_error(Cask::CaskUnreadableError, /does not contain a cask/)
+        end.to raise_error(Cask::CaskUnreadableError, /does not contain a cask/)
       end
     end
 
     context "when the file calls a non-existent method" do
-      let(:path) {
+      let(:path) do
         (mktmpdir/"cask.rb").tap do |path|
           path.write <<~RUBY
             this_method_does_not_exist
           RUBY
         end
-      }
+      end
 
       it "raises an error" do
-        expect {
+        expect do
           described_class.new(path).load(config: nil)
-        }.to raise_error(Cask::CaskUnreadableError, /undefined local variable or method/)
+        end.to raise_error(Cask::CaskUnreadableError, /undefined local variable or method/)
       end
     end
 
     context "when the file contains an outdated cask" do
       it "raises an error" do
-        expect {
+        expect do
           described_class.new(cask_path("invalid/invalid-depends-on-macos-bad-release")).load(config: nil)
-        }.to raise_error(Cask::CaskInvalidError,
-                         /invalid 'depends_on macos' value: unknown or unsupported macOS version:/)
+        end.to raise_error(Cask::CaskInvalidError,
+                           /invalid 'depends_on macos' value: unknown or unsupported macOS version:/)
       end
     end
   end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -54,9 +54,9 @@ describe Cask::Cask, :cask do
     end
 
     it "raises an error when failing to download a Cask from a URL" do
-      expect {
+      expect do
         Cask::CaskLoader.load("file://#{tap_path}/Casks/notacask.rb")
-      }.to raise_error(Cask::CaskUnavailableError)
+      end.to raise_error(Cask::CaskUnavailableError)
     end
 
     it "returns an instance of the Cask from a relative file location" do
@@ -71,9 +71,9 @@ describe Cask::Cask, :cask do
     end
 
     it "raises an error when attempting to load a Cask that doesn't exist" do
-      expect {
+      expect do
         Cask::CaskLoader.load("notacask")
-      }.to raise_error(Cask::CaskUnavailableError)
+      end.to raise_error(Cask::CaskUnavailableError)
     end
   end
 
@@ -244,7 +244,7 @@ describe Cask::Cask, :cask do
 
   describe "#to_hash_with_variations" do
     let!(:original_macos_version) { MacOS.full_version.to_s }
-    let(:expected_versions_variations) {
+    let(:expected_versions_variations) do
       <<~JSON
         {
           "arm64_big_sur": {
@@ -272,8 +272,8 @@ describe Cask::Cask, :cask do
           }
         }
       JSON
-    }
-    let(:expected_sha256_variations) {
+    end
+    let(:expected_sha256_variations) do
       <<~JSON
         {
           "monterey": {
@@ -294,7 +294,7 @@ describe Cask::Cask, :cask do
           }
         }
       JSON
-    }
+    end
 
     before do
       # Use a more limited symbols list to shorten the variations hash

--- a/Library/Homebrew/test/cask/cmd/audit_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/audit_spec.rb
@@ -164,8 +164,8 @@ describe Cask::Cmd::Audit, :cask do
 
   it "audits a sample of language when cask contains more than 10 languages" do
     allow(Cask::CaskLoader).to receive(:load).and_return(cask_with_many_languages)
-    expect {
+    expect do
       described_class.run("with-many-languages")
-    }.to output(/==> auditing a sample of available languages/im).to_stdout
+    end.to output(/==> auditing a sample of available languages/im).to_stdout
   end
 end

--- a/Library/Homebrew/test/cask/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/fetch_spec.rb
@@ -2,13 +2,13 @@
 # frozen_string_literal: true
 
 describe Cask::Cmd::Fetch, :cask do
-  let(:local_transmission) {
+  let(:local_transmission) do
     Cask::CaskLoader.load(cask_path("local-transmission"))
-  }
+  end
 
-  let(:local_caffeine) {
+  let(:local_caffeine) do
     Cask::CaskLoader.load(cask_path("local-caffeine"))
-  }
+  end
 
   it "allows downloading the installer of a Cask" do
     transmission_location = CurlDownloadStrategy.new(
@@ -53,8 +53,8 @@ describe Cask::Cmd::Fetch, :cask do
   end
 
   it "properly handles Casks that are not present" do
-    expect {
+    expect do
       described_class.run("notacask")
-    }.to raise_error(Cask::CaskUnavailableError)
+    end.to raise_error(Cask::CaskUnavailableError)
   end
 end

--- a/Library/Homebrew/test/cask/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/install_spec.rb
@@ -10,9 +10,9 @@ describe Cask::Cmd::Install, :cask do
       .*local-caffeine was successfully installed!
     EOS
 
-    expect {
+    expect do
       described_class.run("local-caffeine")
-    }.to output(output).to_stdout
+    end.to output(output).to_stdout
   end
 
   it "allows staging and activation of multiple Casks at once" do
@@ -81,19 +81,19 @@ describe Cask::Cmd::Install, :cask do
   it "prints a warning message on double install" do
     described_class.run("local-transmission")
 
-    expect {
+    expect do
       described_class.run("local-transmission")
-    }.to output(/Warning: Cask 'local-transmission' is already installed./).to_stderr
+    end.to output(/Warning: Cask 'local-transmission' is already installed./).to_stderr
   end
 
   it "allows double install with --force" do
     described_class.run("local-transmission")
 
-    expect {
-      expect {
+    expect do
+      expect do
         described_class.run("local-transmission", "--force")
-      }.to output(/It seems there is already an App at.*overwriting\./).to_stderr
-    }.to output(/local-transmission was successfully installed!/).to_stdout
+      end.to output(/It seems there is already an App at.*overwriting\./).to_stderr
+    end.to output(/local-transmission was successfully installed!/).to_stdout
   end
 
   it "skips dependencies with --skip-cask-deps" do
@@ -104,15 +104,15 @@ describe Cask::Cmd::Install, :cask do
   end
 
   it "properly handles Casks that are not present" do
-    expect {
+    expect do
       described_class.run("notacask")
-    }.to raise_error(Cask::CaskUnavailableError)
+    end.to raise_error(Cask::CaskUnavailableError)
   end
 
   it "returns a suggestion for a misspelled Cask" do
-    expect {
+    expect do
       described_class.run("localcaffeine")
-    }.to raise_error(
+    end.to raise_error(
       Cask::CaskUnavailableError,
       "Cask 'localcaffeine' is unavailable: No Cask with this name exists. " \
       "Did you mean 'local-caffeine'?",
@@ -120,9 +120,9 @@ describe Cask::Cmd::Install, :cask do
   end
 
   it "returns multiple suggestions for a Cask fragment" do
-    expect {
+    expect do
       described_class.run("local")
-    }.to raise_error(
+    end.to raise_error(
       Cask::CaskUnavailableError,
       "Cask 'local' is unavailable: No Cask with this name exists. " \
       "Did you mean one of these?\nlocal-caffeine\nlocal-transmission\n",

--- a/Library/Homebrew/test/cask/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/reinstall_spec.rb
@@ -19,9 +19,9 @@ describe Cask::Cmd::Reinstall, :cask do
       .*local-caffeine was successfully installed!
     EOS
 
-    expect {
+    expect do
       described_class.run("local-caffeine")
-    }.to output(output).to_stdout
+    end.to output(output).to_stdout
   end
 
   it "displays the reinstallation progress with zapping" do
@@ -44,9 +44,9 @@ describe Cask::Cmd::Reinstall, :cask do
       .*local-caffeine was successfully installed!
     EOS
 
-    expect {
+    expect do
       described_class.run("local-caffeine", "--zap")
-    }.to output(output).to_stdout
+    end.to output(output).to_stdout
   end
 
   it "allows reinstalling a Cask" do

--- a/Library/Homebrew/test/cask/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/uninstall_spec.rb
@@ -14,9 +14,9 @@ describe Cask::Cmd::Uninstall, :cask do
       ==> Purging files for version 1.2.3 of Cask local-caffeine
     EOS
 
-    expect {
+    expect do
       described_class.run("local-caffeine")
-    }.to output(output).to_stdout
+    end.to output(output).to_stdout
   end
 
   it "shows an error when a bad Cask is provided" do
@@ -30,9 +30,9 @@ describe Cask::Cmd::Uninstall, :cask do
   end
 
   it "tries anyway on a non-present Cask when --force is given" do
-    expect {
+    expect do
       described_class.run("local-caffeine", "--force")
-    }.not_to raise_error
+    end.not_to raise_error
   end
 
   it "can uninstall and unlink multiple Casks at once" do
@@ -67,9 +67,9 @@ describe Cask::Cmd::Uninstall, :cask do
 
     expect(cask).to be_installed
 
-    expect {
+    expect do
       described_class.run("with-uninstall-script-app", "--force")
-    }.not_to raise_error
+    end.not_to raise_error
 
     expect(cask).not_to be_installed
   end
@@ -78,12 +78,12 @@ describe Cask::Cmd::Uninstall, :cask do
     let(:token) { "versioned-cask" }
     let(:first_installed_version) { "1.2.3" }
     let(:last_installed_version) { "4.5.6" }
-    let(:timestamped_versions) {
+    let(:timestamped_versions) do
       [
         [first_installed_version, "123000"],
         [last_installed_version,  "456000"],
       ]
-    }
+    end
     let(:caskroom_path) { Cask::Caskroom.path.join(token).tap(&:mkpath) }
 
     before do
@@ -114,20 +114,20 @@ describe Cask::Cmd::Uninstall, :cask do
     end
 
     it "displays a message when versions remain installed" do
-      expect {
-        expect {
+      expect do
+        expect do
           described_class.run("versioned-cask")
-        }.not_to output.to_stderr
-      }.to output(/#{token} #{first_installed_version} is still installed./).to_stdout
+        end.not_to output.to_stderr
+      end.to output(/#{token} #{first_installed_version} is still installed./).to_stdout
     end
   end
 
   context "when Casks in Taps have been renamed or removed" do
     let(:app) { Cask::Config.new.appdir.join("ive-been-renamed.app") }
     let(:caskroom_path) { Cask::Caskroom.path.join("ive-been-renamed").tap(&:mkpath) }
-    let(:saved_caskfile) {
+    let(:saved_caskfile) do
       caskroom_path.join(".metadata", "latest", "timestamp", "Casks").join("ive-been-renamed.rb")
-    }
+    end
 
     before do
       app.tap(&:mkpath)

--- a/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
@@ -13,14 +13,14 @@ describe Cask::Cmd::Upgrade, :cask do
   let(:local_caffeine) { Cask::CaskLoader.load("local-caffeine") }
 
   context "when the upgrade is successful" do
-    let(:installed) {
+    let(:installed) do
       [
         "outdated/local-caffeine",
         "outdated/local-transmission",
         "outdated/auto-updates",
         "outdated/version-latest",
       ]
-    }
+    end
 
     before do
       installed.each { |cask| Cask::Cmd::Install.run(cask) }
@@ -178,14 +178,14 @@ describe Cask::Cmd::Upgrade, :cask do
   end
 
   context "when the upgrade is a dry run" do
-    let(:installed) {
+    let(:installed) do
       [
         "outdated/local-caffeine",
         "outdated/local-transmission",
         "outdated/auto-updates",
         "outdated/version-latest",
       ]
-    }
+    end
 
     before do
       installed.each { |cask| Cask::Cmd::Install.run(cask) }
@@ -347,12 +347,12 @@ describe Cask::Cmd::Upgrade, :cask do
   end
 
   context "when an upgrade failed" do
-    let(:installed) {
+    let(:installed) do
       [
         "outdated/bad-checksum",
         "outdated/will-fail-if-upgraded",
       ]
-    }
+    end
 
     before do
       installed.each { |cask| Cask::Cmd::Install.run(cask) }
@@ -372,9 +372,9 @@ describe Cask::Cmd::Upgrade, :cask do
       expect(will_fail_if_upgraded_path).to be_a_file
       expect(will_fail_if_upgraded.versions).to include("1.2.2")
 
-      expect {
+      expect do
         described_class.run("will-fail-if-upgraded")
-      }.to raise_error(Cask::CaskError).and output(output_reverted).to_stderr
+      end.to raise_error(Cask::CaskError).and output(output_reverted).to_stderr
 
       expect(will_fail_if_upgraded).to be_installed
       expect(will_fail_if_upgraded_path).to be_a_file
@@ -390,9 +390,9 @@ describe Cask::Cmd::Upgrade, :cask do
       expect(bad_checksum_path).to be_a_directory
       expect(bad_checksum.versions).to include("1.2.2")
 
-      expect {
+      expect do
         described_class.run("bad-checksum")
-      }.to raise_error(ChecksumMismatchError).and(not_to_output(output_reverted).to_stderr)
+      end.to raise_error(ChecksumMismatchError).and(not_to_output(output_reverted).to_stderr)
 
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory
@@ -402,13 +402,13 @@ describe Cask::Cmd::Upgrade, :cask do
   end
 
   context "when there were multiple failures" do
-    let(:installed) {
+    let(:installed) do
       [
         "outdated/bad-checksum",
         "outdated/local-transmission",
         "outdated/bad-checksum2",
       ]
-    }
+    end
 
     before do
       installed.each { |cask| Cask::Cmd::Install.run(cask) }
@@ -435,9 +435,9 @@ describe Cask::Cmd::Upgrade, :cask do
       expect(bad_checksum_2_path).to be_a_file
       expect(bad_checksum_2.versions).to include("1.2.2")
 
-      expect {
+      expect do
         described_class.run
-      }.to raise_error(Cask::MultipleCaskErrors)
+      end.to raise_error(Cask::MultipleCaskErrors)
 
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -60,10 +60,10 @@ describe Cask::Config, :cask do
   end
 
   describe "#explicit" do
-    let(:config) {
+    let(:config) do
       described_class.new(explicit: { appdir:    "/explicit/path/to/apps",
                                       languages: ["zh-TW", "en"] })
-    }
+    end
 
     it "returns directories explicitly given as arguments" do
       expect(config.explicit[:appdir]).to eq(Pathname("/explicit/path/to/apps"))
@@ -79,7 +79,7 @@ describe Cask::Config, :cask do
   end
 
   context "when installing a cask and then adding a global default dir" do
-    let(:config) {
+    let(:config) do
       json = <<~EOS
         {
           "default": {
@@ -90,7 +90,7 @@ describe Cask::Config, :cask do
         }
       EOS
       described_class.from_json(json)
-    }
+    end
 
     describe "#appdir" do
       it "honors metadata of the installed cask" do

--- a/Library/Homebrew/test/cask/conflicts_with_spec.rb
+++ b/Library/Homebrew/test/cask/conflicts_with_spec.rb
@@ -3,22 +3,22 @@
 
 describe "conflicts_with", :cask do
   describe "conflicts_with cask" do
-    let(:local_caffeine) {
+    let(:local_caffeine) do
       Cask::CaskLoader.load(cask_path("local-caffeine"))
-    }
+    end
 
-    let(:with_conflicts_with) {
+    let(:with_conflicts_with) do
       Cask::CaskLoader.load(cask_path("with-conflicts-with"))
-    }
+    end
 
     it "installs the dependency of a Cask and the Cask itself" do
       Cask::Installer.new(local_caffeine).install
 
       expect(local_caffeine).to be_installed
 
-      expect {
+      expect do
         Cask::Installer.new(with_conflicts_with).install
-      }.to raise_error(Cask::CaskConflictError, "Cask 'with-conflicts-with' conflicts with 'local-caffeine'.")
+      end.to raise_error(Cask::CaskConflictError, "Cask 'with-conflicts-with' conflicts with 'local-caffeine'.")
 
       expect(with_conflicts_with).not_to be_installed
     end

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -4,9 +4,9 @@
 # TODO: this test should be named after the corresponding class, once
 #       that class is abstracted from installer.rb
 describe "Satisfy Dependencies and Requirements", :cask do
-  subject(:install) {
+  subject(:install) do
     Cask::Installer.new(cask).install
-  }
+  end
 
   describe "depends_on cask" do
     let(:dependency) { Cask::CaskLoader.load(cask.depends_on.cask.first) }

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -54,9 +54,9 @@ describe Cask::DSL::Version, :cask do
 
   describe "#initialize" do
     it "raises an error when the version contains a slash" do
-      expect {
+      expect do
         described_class.new("0.1,../../directory/traversal")
-      }.to raise_error(TypeError, %r{invalid characters: /})
+      end.to raise_error(TypeError, %r{invalid characters: /})
     end
   end
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -14,11 +14,11 @@ describe Cask::DSL, :cask do
   end
 
   describe "when a Cask includes an unknown method" do
-    let(:attempt_unknown_method) {
+    let(:attempt_unknown_method) do
       Cask::Cask.new("unexpected-method-cask") do
         future_feature :not_yet_on_your_machine
       end
-    }
+    end
 
     it "prints a warning that it has encountered an unexpected method" do
       expected = Regexp.compile(<<~EOS.lines.map(&:chomp).join)
@@ -30,15 +30,15 @@ describe Cask::DSL, :cask do
         https://github.com/Homebrew/homebrew-cask#reporting-bugs
       EOS
 
-      expect {
+      expect do
         expect { attempt_unknown_method }.not_to output.to_stdout
-      }.to output(expected).to_stderr
+      end.to output(expected).to_stderr
     end
 
     it "will simply warn, not throw an exception" do
-      expect {
+      expect do
         attempt_unknown_method
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 
@@ -55,9 +55,9 @@ describe Cask::DSL, :cask do
       let(:token) { "invalid/invalid-header-token-mismatch" }
 
       it "raises an error" do
-        expect {
+        expect do
           cask
-        }.to raise_error(Cask::CaskTokenMismatchError, /header line does not match the file name/)
+        end.to raise_error(Cask::CaskTokenMismatchError, /header line does not match the file name/)
       end
     end
 
@@ -158,7 +158,7 @@ describe Cask::DSL, :cask do
 
   describe "language stanza" do
     context "when language is set explicitly" do
-      subject(:cask) {
+      subject(:cask) do
         Cask::Cask.new("cask-with-apps") do
           language "zh" do
             sha256 "abc123"
@@ -172,7 +172,7 @@ describe Cask::DSL, :cask do
 
           url "https://example.org/#{language}.zip"
         end
-      }
+      end
 
       matcher :be_the_chinese_version do
         match do |cask|

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -5,9 +5,9 @@ require "utils"
 
 describe Cask::Info, :cask do
   it "displays some nice info about the specified Cask" do
-    expect {
+    expect do
       described_class.info(Cask::CaskLoader.load("local-transmission"))
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       ==> local-transmission: 2.61
       https://transmissionbt.com/
       Not installed
@@ -22,9 +22,9 @@ describe Cask::Info, :cask do
   end
 
   it "prints auto_updates if the Cask has `auto_updates true`" do
-    expect {
+    expect do
       described_class.info(Cask::CaskLoader.load("with-auto-updates"))
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       ==> with-auto-updates: 1.0 (auto_updates)
       https://brew.sh/autoupdates
       Not installed
@@ -39,9 +39,9 @@ describe Cask::Info, :cask do
   end
 
   it "prints caveats if the Cask provided one" do
-    expect {
+    expect do
       described_class.info(Cask::CaskLoader.load("with-caveats"))
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       ==> with-caveats: 1.2.3
       https://brew.sh/
       Not installed
@@ -66,9 +66,9 @@ describe Cask::Info, :cask do
   end
 
   it 'does not print "Caveats" section divider if the caveats block has no output' do
-    expect {
+    expect do
       described_class.info(Cask::CaskLoader.load("with-conditional-caveats"))
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       ==> with-conditional-caveats: 1.2.3
       https://brew.sh/
       Not installed
@@ -83,9 +83,9 @@ describe Cask::Info, :cask do
   end
 
   it "prints languages specified in the Cask" do
-    expect {
+    expect do
       described_class.info(Cask::CaskLoader.load("with-languages"))
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       ==> with-languages: 1.2.3
       https://brew.sh/
       Not installed
@@ -102,9 +102,9 @@ describe Cask::Info, :cask do
   end
 
   it 'does not print "Languages" section divider if the languages block has no output' do
-    expect {
+    expect do
       described_class.info(Cask::CaskLoader.load("without-languages"))
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       ==> without-languages: 1.2.3
       https://brew.sh/
       Not installed

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -59,16 +59,16 @@ describe Cask::Installer, :cask do
 
     it "blows up on a bad checksum" do
       bad_checksum = Cask::CaskLoader.load(cask_path("bad-checksum"))
-      expect {
+      expect do
         described_class.new(bad_checksum).install
-      }.to raise_error(ChecksumMismatchError)
+      end.to raise_error(ChecksumMismatchError)
     end
 
     it "blows up on a missing checksum" do
       missing_checksum = Cask::CaskLoader.load(cask_path("missing-checksum"))
-      expect {
+      expect do
         described_class.new(missing_checksum).install
-      }.to output(/Cannot verify integrity/).to_stderr
+      end.to output(/Cannot verify integrity/).to_stderr
     end
 
     it "installs fine if sha256 :no_check is used" do
@@ -81,9 +81,9 @@ describe Cask::Installer, :cask do
 
     it "fails to install if sha256 :no_check is used with --require-sha" do
       no_checksum = Cask::CaskLoader.load(cask_path("no-checksum"))
-      expect {
+      expect do
         described_class.new(no_checksum, require_sha: true).install
-      }.to raise_error(/--require-sha/)
+      end.to raise_error(/--require-sha/)
     end
 
     it "installs fine if sha256 :no_check is used with --require-sha and --force" do
@@ -97,9 +97,9 @@ describe Cask::Installer, :cask do
     it "prints caveats if they're present" do
       with_caveats = Cask::CaskLoader.load(cask_path("with-caveats"))
 
-      expect {
+      expect do
         described_class.new(with_caveats).install
-      }.to output(/Here are some things you might want to know/).to_stdout
+      end.to output(/Here are some things you might want to know/).to_stdout
 
       expect(with_caveats).to be_installed
     end
@@ -107,9 +107,9 @@ describe Cask::Installer, :cask do
     it "prints installer :manual instructions when present" do
       with_installer_manual = Cask::CaskLoader.load(cask_path("with-installer-manual"))
 
-      expect {
+      expect do
         described_class.new(with_installer_manual).install
-      }.to output(
+      end.to output(
         <<~EOS,
           ==> Downloading file://#{HOMEBREW_LIBRARY_PATH}/test/support/fixtures/cask/caffeine.zip
           ==> Installing Cask with-installer-manual
@@ -138,9 +138,9 @@ describe Cask::Installer, :cask do
 
       described_class.new(with_auto_updates).install
 
-      expect {
+      expect do
         described_class.new(with_auto_updates, force: true).install
-      }.not_to raise_error
+      end.not_to raise_error
     end
 
     # unlike the CLI, the internal interface throws exception on double-install
@@ -153,9 +153,9 @@ describe Cask::Installer, :cask do
 
       installer.install
 
-      expect {
+      expect do
         installer.install
-      }.to raise_error(Cask::CaskAlreadyInstalledError)
+      end.to raise_error(Cask::CaskAlreadyInstalledError)
     end
 
     it "allows already-installed Casks to be installed if force is provided" do
@@ -165,9 +165,9 @@ describe Cask::Installer, :cask do
 
       described_class.new(transmission).install
 
-      expect {
+      expect do
         described_class.new(transmission, force: true).install
-      }.not_to raise_error
+      end.not_to raise_error
     end
 
     it "works naked-pkg-based Casks" do
@@ -215,9 +215,9 @@ describe Cask::Installer, :cask do
 
     it "don't print cask installed message with --quiet option" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
-      expect {
+      expect do
         described_class.new(caffeine, quiet: true).install
-      }.to output(nil).to_stdout
+      end.to output(nil).to_stdout
     end
 
     it "does NOT generate LATEST_DOWNLOAD_SHA256 file for installed Cask without version :latest" do

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -11,9 +11,9 @@ describe Cask::List, :cask do
       InstallHelper.install_with_caskfile(c)
     end
 
-    expect {
+    expect do
       described_class.list_casks
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       local-caffeine
       local-transmission
     EOS
@@ -30,9 +30,9 @@ describe Cask::List, :cask do
       InstallHelper.install_with_caskfile(c)
     end
 
-    expect {
+    expect do
       described_class.list_casks(one: true)
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       local-caffeine
       local-transmission
       third-party-cask
@@ -50,9 +50,9 @@ describe Cask::List, :cask do
       InstallHelper.install_with_caskfile(c)
     end
 
-    expect {
+    expect do
       described_class.list_casks(full_name: true)
-    }.to output(<<~EOS).to_stdout
+    end.to output(<<~EOS).to_stdout
       local-caffeine
       local-transmission
       third-party/tap/third-party-cask
@@ -60,27 +60,27 @@ describe Cask::List, :cask do
   end
 
   describe "lists versions" do
-    let!(:casks) {
+    let!(:casks) do
       ["local-caffeine",
        "local-transmission"].map(&Cask::CaskLoader.method(:load)).each(&InstallHelper.method(:install_with_caskfile))
-    }
-    let(:expected_output) {
+    end
+    let(:expected_output) do
       <<~EOS
         local-caffeine 1.2.3
         local-transmission 2.61
       EOS
-    }
+    end
 
     it "of all installed Casks" do
-      expect {
+      expect do
         described_class.list_casks(versions: true)
-      }.to output(expected_output).to_stdout
+      end.to output(expected_output).to_stdout
     end
 
     it "of given Casks" do
-      expect {
+      expect do
         described_class.list_casks(*casks, versions: true)
-      }.to output(expected_output).to_stdout
+      end.to output(expected_output).to_stdout
     end
   end
 
@@ -96,9 +96,9 @@ describe Cask::List, :cask do
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)
       end
 
-      expect {
+      expect do
         described_class.list_casks(transmission, caffeine)
-      }.to output(<<~EOS).to_stdout
+      end.to output(<<~EOS).to_stdout
         ==> App
         #{transmission.config.appdir.join("Transmission.app")} (#{transmission.config.appdir.join("Transmission.app").abv})
         ==> App

--- a/Library/Homebrew/test/cask/quarantine_spec.rb
+++ b/Library/Homebrew/test/cask/quarantine_spec.rb
@@ -37,11 +37,11 @@ describe Cask::Quarantine, :cask do
     end
 
     it "quarantines Cask audits" do
-      expect {
+      expect do
         Cask::Cmd::Audit.run("local-transmission", "--download")
-      }.to not_raise_error
-       .and output(/audit for local-transmission: passed/).to_stdout
-       .and not_to_output.to_stderr
+      end.to not_raise_error
+        .and output(/audit for local-transmission: passed/).to_stdout
+                                                           .and not_to_output.to_stderr
 
       local_transmission = Cask::CaskLoader.load(cask_path("local-transmission"))
       cached_location = Cask::Download.new(local_transmission).fetch
@@ -152,11 +152,11 @@ describe Cask::Quarantine, :cask do
     end
 
     it "does not quarantine Cask audits" do
-      expect {
+      expect do
         Cask::Cmd::Audit.run("local-transmission", "--download", "--no-quarantine")
-      }.to not_raise_error
-       .and output(/audit for local-transmission: passed/).to_stdout
-       .and not_to_output.to_stderr
+      end.to not_raise_error
+        .and output(/audit for local-transmission: passed/).to_stdout
+                                                           .and not_to_output.to_stderr
 
       local_transmission = Cask::CaskLoader.load(cask_path("local-transmission"))
       cached_location = Cask::Download.new(local_transmission).fetch

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -206,12 +206,12 @@ describe Caveats do
     end
 
     context "when f.keg_only is not nil" do
-      let(:f) {
+      let(:f) do
         formula do
           url "foo-1.0"
           keg_only "some reason"
         end
-      }
+      end
       let(:caveats) { described_class.new(f).caveats }
 
       it "tells formula is keg_only" do
@@ -252,11 +252,11 @@ describe Caveats do
     end
 
     describe "shell completions" do
-      let(:f) {
+      let(:f) do
         formula do
           url "foo-1.0"
         end
-      }
+      end
       let(:caveats) { described_class.new(f).caveats }
       let(:path) { f.prefix.resolved_path }
 

--- a/Library/Homebrew/test/checksum_verification_spec.rb
+++ b/Library/Homebrew/test/checksum_verification_spec.rb
@@ -13,27 +13,27 @@ describe Formula do
 
   describe "#brew" do
     it "does not raise an error when the checksum matches" do
-      expect {
+      expect do
         f = formula do
           sha256 TESTBALL_SHA256
         end
 
-        f.brew {
+        f.brew do
           # do nothing
-        }
-      }.not_to raise_error
+        end
+      end.not_to raise_error
     end
 
     it "raises an error when the checksum doesn't match" do
-      expect {
+      expect do
         f = formula do
           sha256 "dcbf5f44743b74add648c7e35e414076632fa3b24463d68d1f6afc5be77024f8"
         end
 
-        f.brew {
+        f.brew do
           # do nothing
-        }
-      }.to raise_error(ChecksumMismatchError)
+        end
+      end.to raise_error(ChecksumMismatchError)
     end
   end
 end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -5,24 +5,24 @@ require_relative "../../cli/parser"
 
 describe Homebrew::CLI::Parser do
   describe "test switch options" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         switch "--more-verbose", description: "Flag for higher verbosity"
         switch "--pry", env: :pry
         switch "--hidden", hidden: true
       end
-    }
+    end
 
     before do
       allow(Homebrew::EnvConfig).to receive(:pry?).and_return(true)
     end
 
     context "when using binary options" do
-      subject(:parser) {
+      subject(:parser) do
         described_class.new do
           switch "--[no-]positive"
         end
-      }
+      end
 
       it "does not create no_positive?" do
         args = parser.parse(["--no-positive"])
@@ -46,11 +46,11 @@ describe Homebrew::CLI::Parser do
     end
 
     context "when using negative options" do
-      subject(:parser) {
+      subject(:parser) do
         described_class.new do
           switch "--no-positive"
         end
-      }
+      end
 
       it "does not set the positive name" do
         args = parser.parse(["--no-positive"])
@@ -58,9 +58,9 @@ describe Homebrew::CLI::Parser do
       end
 
       it "fails when using the positive name" do
-        expect {
+        expect do
           parser.parse(["--positive"])
-        }.to raise_error(/invalid option/)
+        end.to raise_error(/invalid option/)
       end
 
       it "sets the negative name to true if the negative flag is passed" do
@@ -116,14 +116,14 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test long flag options" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         flag        "--filename=", description: "Name of the file"
         comma_array "--files",     description: "Comma-separated filenames"
         flag        "--hidden=",      hidden: true
         comma_array "--hidden-array", hidden: true
       end
-    }
+    end
 
     it "parses a long flag option with its argument" do
       args = parser.parse(["--filename=random.txt"])
@@ -147,11 +147,11 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test short flag options" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         flag "-f", "--filename=", description: "Name of the file"
       end
-    }
+    end
 
     it "parses a short flag option with its argument" do
       args = parser.parse(["--filename=random.txt"])
@@ -161,7 +161,7 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test constraints for flag options" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         flag      "--flag1="
         flag      "--flag2=", depends_on: "--flag1="
@@ -169,7 +169,7 @@ describe Homebrew::CLI::Parser do
 
         conflicts "--flag1=", "--flag3="
       end
-    }
+    end
 
     it "raises exception on depends_on constraint violation" do
       expect { parser.parse(["--flag2=flag2"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
@@ -192,13 +192,13 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test invalid constraints" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         flag      "--flag1="
         flag      "--flag2=", depends_on: "--flag1="
         conflicts "--flag1=", "--flag2="
       end
-    }
+    end
 
     it "raises exception due to invalid constraints" do
       expect { parser.parse([]) }.to raise_error(Homebrew::CLI::InvalidConstraintError)
@@ -206,7 +206,7 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test constraints for switch options" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         switch      "-a", "--switch-a", env: "switch_a"
         switch      "-b", "--switch-b", env: "switch_b"
@@ -214,7 +214,7 @@ describe Homebrew::CLI::Parser do
 
         conflicts "--switch-a", "--switch-b"
       end
-    }
+    end
 
     it "raises exception on depends_on constraint violation" do
       expect { parser.parse(["--switch-c"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
@@ -251,12 +251,12 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test immutability of args" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         switch "-a", "--switch-a"
         switch "-b", "--switch-b"
       end
-    }
+    end
 
     it "raises exception when arguments were already parsed" do
       parser.parse(["--switch-a"])
@@ -265,7 +265,7 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test inferrability of args" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         switch "--switch-a"
         switch "--switch-b"
@@ -273,7 +273,7 @@ describe Homebrew::CLI::Parser do
         flag "--flag-foo="
         comma_array "--comma-array-foo"
       end
-    }
+    end
 
     it "parses a valid switch that uses `_` instead of `-`" do
       args = parser.parse(["--switch_a"])
@@ -301,13 +301,13 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "test argv extensions" do
-    subject(:parser) {
+    subject(:parser) do
       described_class.new do
         switch "--foo"
         flag   "--bar"
         switch "-s"
       end
-    }
+    end
 
     it "#options_only" do
       args = parser.parse(["--foo", "--bar=value", "-v", "-s", "a", "b", "cdefg"])
@@ -446,16 +446,16 @@ describe Homebrew::CLI::Parser do
   end
 
   describe "named_args" do
-    let(:parser_none) {
+    let(:parser_none) do
       described_class.new do
         named_args :none
       end
-    }
-    let(:parser_number) {
+    end
+    let(:parser_number) do
       described_class.new do
         named_args number: 1
       end
-    }
+    end
 
     it "doesn't allow :none passed with a number" do
       expect do

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -4,17 +4,17 @@
 require "cmd/shared_examples/args_parse"
 
 describe "brew home" do
-  let(:testballhome_homepage) {
+  let(:testballhome_homepage) do
     Formula["testballhome"].homepage
-  }
+  end
 
-  let(:local_caffeine_path) {
+  let(:local_caffeine_path) do
     cask_path("local-caffeine")
-  }
+  end
 
-  let(:local_caffeine_homepage) {
+  let(:local_caffeine_homepage) do
     Cask::CaskLoader.load(local_caffeine_path).homepage
-  }
+  end
 
   it_behaves_like "parseable arguments"
 

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -39,9 +39,9 @@ describe "brew update-report" do
     specify "without revision variable" do
       ENV.delete_if { |k, _v| k.start_with? "HOMEBREW_UPDATE" }
 
-      expect {
+      expect do
         described_class.new(tap)
-      }.to raise_error(Reporter::ReporterRevisionUnsetError)
+      end.to raise_error(Reporter::ReporterRevisionUnsetError)
     end
 
     specify "without any changes" do

--- a/Library/Homebrew/test/compiler_failure_spec.rb
+++ b/Library/Homebrew/test/compiler_failure_spec.rb
@@ -22,9 +22,9 @@ describe CompilerFailure do
     end
 
     it "can be given an empty block" do
-      failure = described_class.create(:clang) {
+      failure = described_class.create(:clang) do
         # do nothing
-      }
+      end
       expect(failure).to fail_with(
         instance_double(CompilerSelector::Compiler, "Compiler", type: :clang, name: :clang, version: 600),
       )

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -6,14 +6,14 @@ require "dependable"
 describe Dependable do
   alias_matcher :be_a_build_dependency, :be_build
 
-  subject(:dependable) {
-    Class.new {
+  subject(:dependable) do
+    Class.new do
       include Dependable
       def initialize
         @tags = ["foo", "bar", :build]
       end
-    }.new
-  }
+    end.new
+  end
 
   specify "#options" do
     expect(dependable.options.as_flags.sort).to eq(%w[--foo --bar].sort)

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -846,19 +846,19 @@ module Homebrew
             fa.audit_deps
           end
 
-          its(:new_formula_problems) {
+          its(:new_formula_problems) do
             are_expected.to include(a_hash_including(message: a_string_matching(/is provided by macOS/)))
-          }
+          end
         end
       end
     end
 
     describe "#audit_revision_and_version_scheme" do
-      subject {
+      subject do
         fa = described_class.new(Formulary.factory(formula_path), git: true)
         fa.audit_revision_and_version_scheme
         fa.problems.first&.fetch(:message)
-      }
+      end
 
       let(:origin_tap_path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-foo" }
       let(:foo_version) { Count.increment }

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -88,14 +88,14 @@ describe "brew bottle" do
 
       # RuboCop would align the `.and` with `.to_stdout` which is too floaty.
       # rubocop:disable Layout/MultilineMethodCallIndentation
-      expect {
+      expect do
         brew "bottle",
              "--merge",
              "--write",
              "#{TEST_TMPDIR}/testball-1.0.arm64_big_sur.bottle.json",
              "#{TEST_TMPDIR}/testball-1.0.big_sur.bottle.json",
              "#{TEST_TMPDIR}/testball-1.0.catalina.bottle.json"
-      }.to output(Regexp.new(<<~'EOS')).to_stdout
+      end.to output(Regexp.new(<<~'EOS')).to_stdout
         ==> testball
           bottle do
             sha256 cellar: :any_skip_relocation, arm64_big_sur: "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
@@ -158,14 +158,14 @@ describe "brew bottle" do
 
       # RuboCop would align the `.and` with `.to_stdout` which is too floaty.
       # rubocop:disable Layout/MultilineMethodCallIndentation
-      expect {
+      expect do
         brew "bottle",
              "--merge",
              "--write",
              "#{TEST_TMPDIR}/testball-1.0.arm64_big_sur.bottle.json",
              "#{TEST_TMPDIR}/testball-1.0.big_sur.bottle.json",
              "#{TEST_TMPDIR}/testball-1.0.catalina.bottle.json"
-      }.to output(Regexp.new(<<~'EOS')).to_stdout
+      end.to output(Regexp.new(<<~'EOS')).to_stdout
         ==> testball
           bottle do
             sha256 cellar: :any_skip_relocation, arm64_big_sur: "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
@@ -226,7 +226,7 @@ describe "brew bottle" do
 
       # RuboCop would align the `.and` with `.to_stdout` which is too floaty.
       # rubocop:disable Layout/MultilineMethodCallIndentation
-      expect {
+      expect do
         brew "bottle",
              "--merge",
              "--write",
@@ -234,7 +234,7 @@ describe "brew bottle" do
              "#{TEST_TMPDIR}/testball-1.0.arm64_big_sur.bottle.json",
              "#{TEST_TMPDIR}/testball-1.0.big_sur.bottle.json",
              "#{TEST_TMPDIR}/testball-1.0.catalina.bottle.json"
-      }.to output(Regexp.new(<<~'EOS')).to_stdout
+      end.to output(Regexp.new(<<~'EOS')).to_stdout
         ==> testball
           bottle do
             sha256 cellar: :any_skip_relocation, arm64_big_sur: "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
@@ -286,7 +286,7 @@ describe "brew bottle" do
   describe Homebrew do
     subject(:homebrew) { described_class }
 
-    let(:hello_hash_big_sur) {
+    let(:hello_hash_big_sur) do
       JSON.parse stub_hash(
         name:           "hello",
         version:        "1.0",
@@ -297,8 +297,8 @@ describe "brew bottle" do
         local_filename: "hello--1.0.big_sur.bottle.tar.gz",
         sha256:         "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f",
       )
-    }
-    let(:hello_hash_catalina) {
+    end
+    let(:hello_hash_catalina) do
       JSON.parse stub_hash(
         name:           "hello",
         version:        "1.0",
@@ -309,8 +309,8 @@ describe "brew bottle" do
         local_filename: "hello--1.0.catalina.bottle.tar.gz",
         sha256:         "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac",
       )
-    }
-    let(:unzip_hash_big_sur) {
+    end
+    let(:unzip_hash_big_sur) do
       JSON.parse stub_hash(
         name:           "unzip",
         version:        "2.0",
@@ -321,8 +321,8 @@ describe "brew bottle" do
         local_filename: "unzip--2.0.big_sur.bottle.tar.gz",
         sha256:         "16cf230afdfcb6306c208d169549cf8773c831c8653d2c852315a048960d7e72",
       )
-    }
-    let(:unzip_hash_catalina) {
+    end
+    let(:unzip_hash_catalina) do
       JSON.parse stub_hash(
         name:           "unzip",
         version:        "2.0",
@@ -333,7 +333,7 @@ describe "brew bottle" do
         local_filename: "unzip--2.0.catalina.bottle.tar.gz",
         sha256:         "d9cc50eec8ac243148a121049c236cba06af4a0b1156ab397d0a2850aa79c137",
       )
-    }
+    end
 
     specify "::parse_json_files" do
       Tempfile.open("hello--1.0.big_sur.bottle.json") do |f|

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -18,7 +18,7 @@ describe CurlPostDownloadStrategy do
     end
 
     context "with :using and :data specified" do
-      let(:specs) {
+      let(:specs) do
         {
           using: :post,
           data:  {
@@ -26,7 +26,7 @@ describe CurlPostDownloadStrategy do
             is:   "good",
           },
         }
-      }
+      end
 
       it "adds the appropriate curl args" do
         expect(strategy).to receive(:system_command)

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -76,14 +76,14 @@ describe CurlDownloadStrategy do
     end
 
     context "with cookies set" do
-      let(:specs) {
+      let(:specs) do
         {
           cookies: {
             coo: "k/e",
             mon: "ster",
           },
         }
-      }
+      end
 
       it "adds the appropriate curl args and does not URL-encode the cookies" do
         expect(strategy).to receive(:system_command)

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -27,9 +27,9 @@ describe DownloadStrategyDetector do
     end
 
     it "raises an error when passed an unrecognized strategy" do
-      expect {
+      expect do
         described_class.detect("foo", Class.new)
-      }.to raise_error(TypeError)
+      end.to raise_error(TypeError)
     end
   end
 end

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -11,21 +11,21 @@ describe ErrorDuringExecution do
 
   describe "#initialize" do
     it "fails when only given a command" do
-      expect {
+      expect do
         described_class.new(command)
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it "fails when only given a status" do
-      expect {
+      expect do
         described_class.new(status: status)
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it "does not raise an error when given both a command and a status" do
-      expect {
+      expect do
         described_class.new(command, status: status)
-      }.not_to raise_error
+      end.not_to raise_error
     end
   end
 
@@ -35,33 +35,33 @@ describe ErrorDuringExecution do
     end
 
     context "when additionally given the output" do
-      let(:output) {
+      let(:output) do
         [
           [:stdout, "This still worked.\n"],
           [:stderr, "Here something went wrong.\n"],
         ]
-      }
+      end
 
       before do
         allow($stdout).to receive(:tty?).and_return(true)
       end
 
-      its(:to_s) {
+      its(:to_s) do
         expect(error.to_s).to eq <<~EOS
           Failure while executing; `false` exited with 1. Here's the output:
           This still worked.
           #{Formatter.error("Here something went wrong.\n")}
         EOS
-      }
+      end
     end
 
     context "when command arguments contain special characters" do
       let(:command) { ["env", "PATH=/bin", "cat", "with spaces"] }
 
-      its(:to_s) {
+      its(:to_s) do
         expect(error.to_s)
           .to eq 'Failure while executing; `env PATH=/bin cat with\ spaces` exited with 1.'
-      }
+      end
     end
   end
 end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -5,19 +5,19 @@ require "exceptions"
 
 describe "Exception" do
   describe MultipleVersionsInstalledError do
-    subject {
+    subject do
       described_class.new <<~EOS
         foo has multiple installed versions
         Run `brew uninstall --force foo` to remove all versions.
       EOS
-    }
+    end
 
-    its(:to_s) {
+    its(:to_s) do
       is_expected.to eq <<~EOS
         foo has multiple installed versions
         Run `brew uninstall --force foo` to remove all versions.
       EOS
-    }
+    end
   end
 
   describe NoSuchKegError do
@@ -29,9 +29,9 @@ describe "Exception" do
   describe FormulaValidationError do
     subject(:error) { described_class.new("foo", "sha257", "magic") }
 
-    its(:to_s) {
+    its(:to_s) do
       expect(error.to_s).to eq(%q(invalid attribute for formula 'foo': sha257 ("magic")))
-    }
+    end
   end
 
   describe TapFormulaOrCaskUnavailableError do
@@ -70,9 +70,9 @@ describe "Exception" do
         error.dependent = "foobar"
       end
 
-      its(:to_s) {
+      its(:to_s) do
         expect(error.to_s).to eq('No available formula with the name "foo" (dependency of foobar).')
-      }
+      end
     end
   end
 
@@ -101,17 +101,17 @@ describe "Exception" do
     context "when there are no classes" do
       let(:list) { [] }
 
-      its(:to_s) {
+      its(:to_s) do
         expect(error.to_s).to match(/Expected to find class Foo, but found no classes\./)
-      }
+      end
     end
 
     context "when the class is not derived from Formula" do
       let(:list) { [mod.const_get(:Bar)] }
 
-      its(:to_s) {
+      its(:to_s) do
         expect(error.to_s).to match(/Expected to find class Foo, but only found: Bar \(not derived from Formula!\)\./)
-      }
+      end
     end
 
     context "when the class is derived from Formula" do

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -10,9 +10,9 @@ describe "globally-scoped helper methods" do
 
   describe "#ofail" do
     it "sets Homebrew.failed to true" do
-      expect {
+      expect do
         ofail "foo"
-      }.to output("Error: foo\n").to_stderr
+      end.to output("Error: foo\n").to_stderr
 
       expect(Homebrew).to have_failed
     end
@@ -21,9 +21,9 @@ describe "globally-scoped helper methods" do
   describe "#odie" do
     it "exits with 1" do
       expect(self).to receive(:exit).and_return(1)
-      expect {
+      expect do
         odie "foo"
-      }.to output("Error: foo\n").to_stderr
+      end.to output("Error: foo\n").to_stderr
     end
   end
 
@@ -250,13 +250,13 @@ describe "globally-scoped helper methods" do
   describe "#odeprecated" do
     it "raises a MethodDeprecatedError when `disable` is true" do
       ENV.delete("HOMEBREW_DEVELOPER")
-      expect {
+      expect do
         odeprecated(
           "method", "replacement",
           caller:  ["#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/"],
           disable: true
         )
-      }.to raise_error(
+      end.to raise_error(
         MethodDeprecatedError,
         %r{method.*replacement.*homebrew/core.*/Taps/homebrew/homebrew-core/}m,
       )
@@ -281,11 +281,11 @@ describe "globally-scoped helper methods" do
     end
 
     it "restores ENV if an exception is raised" do
-      expect {
+      expect do
         with_env(PATH: "/bin") do
           raise StandardError, "boom"
         end
-      }.to raise_error(StandardError)
+      end.to raise_error(StandardError)
 
       path = ENV.fetch("PATH", nil)
       expect(path).not_to be_nil

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -8,14 +8,14 @@ describe Formatter do
   describe "::columns" do
     subject(:columns) { described_class.columns(input) }
 
-    let(:input) {
+    let(:input) do
       %w[
         aa
         bbb
         ccc
         dd
       ]
-    }
+    end
 
     it "doesn't output columns if $stdout is not a TTY." do
       allow_any_instance_of(IO).to receive(:tty?).and_return(false)

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -101,9 +101,9 @@ describe FormulaInstaller do
     expect(formula).not_to be_latest_version_installed
     expect(formula).not_to be_bottled
 
-    expect {
+    expect do
       described_class.new(formula).install
-    }.to raise_error(UnbottledError)
+    end.to raise_error(UnbottledError)
 
     expect(formula).not_to be_latest_version_installed
   end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -96,9 +96,9 @@ describe FormulaInstaller do
 
       fi = described_class.new(f)
 
-      expect {
+      expect do
         fi.check_install_sanity
-      }.to raise_error(CannotInstallFormulaError)
+      end.to raise_error(CannotInstallFormulaError)
     end
 
     it "raises on indirect cyclic dependency" do
@@ -129,9 +129,9 @@ describe FormulaInstaller do
 
       fi = described_class.new(formula1)
 
-      expect {
+      expect do
         fi.check_install_sanity
-      }.to raise_error(CannotInstallFormulaError)
+      end.to raise_error(CannotInstallFormulaError)
     end
 
     it "raises on pinned dependency" do
@@ -165,9 +165,9 @@ describe FormulaInstaller do
 
       fi = described_class.new(dependent)
 
-      expect {
+      expect do
         fi.check_install_sanity
-      }.to raise_error(CannotInstallFormulaError)
+      end.to raise_error(CannotInstallFormulaError)
     end
   end
 
@@ -175,17 +175,17 @@ describe FormulaInstaller do
     ENV["HOMEBREW_TEST_NO_EXIT_CLEANUP"] = "1"
     ENV["FAILBALL_BUILD_ERROR"] = "1"
 
-    expect {
+    expect do
       temporary_install(Failball.new)
-    }.to raise_error(BuildError)
+    end.to raise_error(BuildError)
   end
 
   specify "install fails with a RuntimeError when #install raises" do
     ENV["HOMEBREW_TEST_NO_EXIT_CLEANUP"] = "1"
 
-    expect {
+    expect do
       temporary_install(Failball.new)
-    }.to raise_error(RuntimeError)
+    end.to raise_error(RuntimeError)
   end
 
   describe "#caveats" do
@@ -210,9 +210,9 @@ describe FormulaInstaller do
       expect(formula).to receive(:launchd_service_path).and_call_original
 
       installer = described_class.new(formula)
-      expect {
+      expect do
         installer.install_service
-      }.not_to output(/Error: Failed to install service files/).to_stderr
+      end.not_to output(/Error: Failed to install service files/).to_stderr
 
       expect(path).to exist
     end
@@ -236,9 +236,9 @@ describe FormulaInstaller do
       expect(service).to receive(:command).exactly(2).and_return("/bin/sh")
 
       installer = described_class.new(formula)
-      expect {
+      expect do
         installer.install_service
-      }.not_to output(/Error: Failed to install service files/).to_stderr
+      end.not_to output(/Error: Failed to install service files/).to_stderr
 
       expect(launchd_service_path).to exist
       expect(service_path).to exist
@@ -266,9 +266,9 @@ describe FormulaInstaller do
       expect(service).to receive(:command).exactly(2).and_return("/bin/sh")
 
       installer = described_class.new(formula)
-      expect {
+      expect do
         installer.install_service
-      }.not_to output(/Error: Failed to install service files/).to_stderr
+      end.not_to output(/Error: Failed to install service files/).to_stderr
 
       expect(launchd_service_path).to exist
       expect(service_path).to exist
@@ -286,9 +286,9 @@ describe FormulaInstaller do
       expect(formula).not_to receive(:to_systemd_unit)
 
       installer = described_class.new(formula)
-      expect {
+      expect do
         installer.install_service
-      }.not_to output(/Error: Failed to install service files/).to_stderr
+      end.not_to output(/Error: Failed to install service files/).to_stderr
 
       expect(path).not_to exist
     end
@@ -304,9 +304,9 @@ describe FormulaInstaller do
       expect(formula).not_to receive(:launchd_service_path)
 
       installer = described_class.new(formula)
-      expect {
+      expect do
         installer.install_service
-      }.to output("Error: Formula specified both service and plist\n").to_stderr
+      end.to output("Error: Formula specified both service and plist\n").to_stderr
 
       expect(Homebrew).to have_failed
       expect(path).not_to exist

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -873,9 +873,9 @@ describe Formula do
 
     expect(Set.new(f2.recursive_requirements)).to eq(Set[])
     expect(
-      f2.recursive_requirements {
+      f2.recursive_requirements do
         # do nothing
-      }.to_set,
+      end.to_set,
     ).to eq(Set[xcode])
 
     requirements = f2.recursive_requirements do |_dependent, requirement|
@@ -930,7 +930,7 @@ describe Formula do
         end
       RUBY
     end
-    let(:expected_variations) {
+    let(:expected_variations) do
       <<~JSON
         {
           "arm64_big_sur": {
@@ -969,7 +969,7 @@ describe Formula do
           }
         }
       JSON
-    }
+    end
 
     before do
       # Use a more limited symbols list to shorten the variations hash

--- a/Library/Homebrew/test/formula_validation_spec.rb
+++ b/Library/Homebrew/test/formula_validation_spec.rb
@@ -7,14 +7,12 @@ describe Formula do
   describe "::new" do
     matcher :fail_with_invalid do |attr|
       match do |actual|
-        expect {
-          begin
-            actual.call
-          rescue => e
-            expect(e.attr).to eq(attr)
-            raise e
-          end
-        }.to raise_error(FormulaValidationError)
+        expect do
+          actual.call
+        rescue => e
+          expect(e.attr).to eq(attr)
+          raise e
+        end.to raise_error(FormulaValidationError)
       end
 
       def supports_block_expectations?
@@ -23,52 +21,52 @@ describe Formula do
     end
 
     it "can't override the `brew` method" do
-      expect {
+      expect do
         formula do
           def brew; end
         end
-      }.to raise_error(RuntimeError, /You cannot override Formula#brew/)
+      end.to raise_error(RuntimeError, /You cannot override Formula#brew/)
     end
 
     it "validates the `name`" do
-      expect {
+      expect do
         formula "name with spaces" do
           url "foo"
           version "1.0"
         end
-      }.to fail_with_invalid :name
+      end.to fail_with_invalid :name
     end
 
     it "validates the `url`" do
-      expect {
+      expect do
         formula do
           url ""
           version "1"
         end
-      }.to fail_with_invalid :url
+      end.to fail_with_invalid :url
     end
 
     it "validates the `version`" do
-      expect {
+      expect do
         formula do
           url "foo"
           version "version with spaces"
         end
-      }.to fail_with_invalid :version
+      end.to fail_with_invalid :version
 
-      expect {
+      expect do
         formula do
           url "foo"
           version ""
         end
-      }.to fail_with_invalid :version
+      end.to fail_with_invalid :version
 
-      expect {
+      expect do
         formula do
           url "foo"
           version nil
         end
-      }.to fail_with_invalid :version
+      end.to fail_with_invalid :version
     end
 
     specify "head-only is valid" do
@@ -80,11 +78,11 @@ describe Formula do
     end
 
     it "fails when Formula is empty" do
-      expect {
-        formula {
+      expect do
+        formula do
           # do nothing
-        }
-      }.to raise_error(FormulaSpecificationError)
+        end
+      end.to raise_error(FormulaSpecificationError)
     end
   end
 end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -70,15 +70,15 @@ describe Formulary do
     end
 
     it "raises an error if the Formula cannot be found" do
-      expect {
+      expect do
         described_class.factory("not_existed_formula")
-      }.to raise_error(FormulaUnavailableError)
+      end.to raise_error(FormulaUnavailableError)
     end
 
     it "raises an error if ref is nil" do
-      expect {
+      expect do
         described_class.factory(nil)
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     context "with sharded Formula directory" do
@@ -106,9 +106,9 @@ describe Formulary do
       end
 
       it "raises an error" do
-        expect {
+        expect do
           described_class.factory(formula_name)
-        }.to raise_error(FormulaClassUnavailableError)
+        end.to raise_error(FormulaClassUnavailableError)
       end
     end
 
@@ -200,9 +200,9 @@ describe Formulary do
       end
 
       it "raises an error when the Formula cannot be found" do
-        expect {
+        expect do
           described_class.factory("#{tap}/not_existed_formula")
-        }.to raise_error(TapFormulaUnavailableError)
+        end.to raise_error(TapFormulaUnavailableError)
       end
 
       it "returns a Formula when given a fully qualified name" do
@@ -213,9 +213,9 @@ describe Formulary do
         (another_tap.path/"Formula").mkpath
         (another_tap.path/"Formula/#{formula_name}.rb").write formula_content
 
-        expect {
+        expect do
           described_class.factory(formula_name)
-        }.to raise_error(TapFormulaAmbiguityError)
+        end.to raise_error(TapFormulaAmbiguityError)
       end
     end
 
@@ -354,9 +354,9 @@ describe Formulary do
 
         expect(formula.caveats).to eq "example caveat string"
 
-        expect {
+        expect do
           formula.install
-        }.to raise_error("Cannot build from source from abstract formula.")
+        end.to raise_error("Cannot build from source from abstract formula.")
       end
 
       it "returns a deprecated Formula when given a name" do
@@ -365,9 +365,9 @@ describe Formulary do
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.deprecated?).to be true
-        expect {
+        expect do
           formula.install
-        }.to raise_error("Cannot build from source from abstract formula.")
+        end.to raise_error("Cannot build from source from abstract formula.")
       end
 
       it "returns a disabled Formula when given a name" do
@@ -376,9 +376,9 @@ describe Formulary do
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.disabled?).to be true
-        expect {
+        expect do
           formula.install
-        }.to raise_error("Cannot build from source from abstract formula.")
+        end.to raise_error("Cannot build from source from abstract formula.")
       end
 
       it "returns a Formula with variations when given a name", :needs_macos do
@@ -439,9 +439,9 @@ describe Formulary do
     end
 
     it "raises an error if the Formula is not available" do
-      expect {
+      expect do
         described_class.to_rack("a/b/#{formula_name}")
-      }.to raise_error(TapFormulaUnavailableError)
+      end.to raise_error(TapFormulaUnavailableError)
     end
   end
 

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -5,14 +5,14 @@ require "hardware"
 
 describe Hardware::CPU do
   describe "::type" do
-    let(:cpu_types) {
+    let(:cpu_types) do
       [
         :arm,
         :intel,
         :ppc,
         :dunno,
       ]
-    }
+    end
 
     it "returns the current CPU's type as a symbol, or :dunno if it cannot be detected" do
       expect(cpu_types).to include(described_class.type)
@@ -20,7 +20,7 @@ describe Hardware::CPU do
   end
 
   describe "::family" do
-    let(:cpu_families) {
+    let(:cpu_families) do
       [
         :amd_k7,
         :amd_k8,
@@ -63,7 +63,7 @@ describe Hardware::CPU do
         :zen3,
         :dunno,
       ]
-    }
+    end
 
     it "returns the current CPU's family name as a symbol, or :dunno if it cannot be detected" do
       expect(cpu_families).to include described_class.family

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -84,9 +84,9 @@ describe Keg do
       let(:options) { { dry_run: true } }
 
       it "only prints what would be done" do
-        expect {
+        expect do
           expect(keg.link(**options)).to eq(0)
-        }.to output(<<~EOF).to_stdout
+        end.to output(<<~EOF).to_stdout
           #{HOMEBREW_PREFIX}/bin/goodbye_cruel_world
           #{HOMEBREW_PREFIX}/bin/helloworld
           #{HOMEBREW_PREFIX}/bin/hiworld
@@ -135,9 +135,9 @@ describe Keg do
 
         options[:dry_run] = true
 
-        expect {
+        expect do
           expect(keg.link(**options)).to eq(0)
-        }.to output(<<~EOF).to_stdout
+        end.to output(<<~EOF).to_stdout
           #{dst}
         EOF
 

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -6,9 +6,9 @@ require "lazy_object"
 describe LazyObject do
   describe "#initialize" do
     it "does not evaluate the block" do
-      expect { |block|
+      expect do |block|
         described_class.new(&block)
-      }.not_to yield_control
+      end.not_to yield_control
     end
   end
 

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -6,7 +6,7 @@ require "livecheck/strategy"
 describe Homebrew::Livecheck::Strategy::Apache do
   subject(:apache) { described_class }
 
-  let(:apache_urls) {
+  let(:apache_urls) do
     {
       version_dir:                    "https://www.apache.org/dyn/closer.lua?path=abc/1.2.3/def-1.2.3.tar.gz",
       version_dir_root:               "https://www.apache.org/dyn/closer.lua?path=/abc/1.2.3/def-1.2.3.tar.gz",
@@ -26,10 +26,10 @@ describe Homebrew::Livecheck::Strategy::Apache do
       mirrors_name_and_version_dir:   "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=abc/def-1.2.3/ghi-1.2.3.tar.gz",
       mirrors_name_dir_bin:           "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=abc/def/ghi-1.2.3-bin.tar.gz",
     }
-  }
+  end
   let(:non_apache_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     values = {
       version_dir:          {
         url:   "https://archive.apache.org/dist/abc/",
@@ -60,7 +60,7 @@ describe Homebrew::Livecheck::Strategy::Apache do
     values[:mirrors_name_dir_bin] = values[:name_dir_bin]
 
     values
-  }
+  end
 
   describe "::match?" do
     it "returns true for an Apache URL" do

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -6,15 +6,15 @@ require "livecheck/strategy"
 describe Homebrew::Livecheck::Strategy::Bitbucket do
   subject(:bitbucket) { described_class }
 
-  let(:bitbucket_urls) {
+  let(:bitbucket_urls) do
     {
       get:       "https://bitbucket.org/abc/def/get/1.2.3.tar.gz",
       downloads: "https://bitbucket.org/abc/def/downloads/ghi-1.2.3.tar.gz",
     }
-  }
+  end
   let(:non_bitbucket_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       get:       {
         url:   "https://bitbucket.org/abc/def/downloads/?tab=tags",
@@ -25,7 +25,7 @@ describe Homebrew::Livecheck::Strategy::Bitbucket do
         regex: /href=.*?ghi-v?(\d+(?:\.\d+)+)\.t/i,
       },
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a Bitbucket URL" do

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -6,15 +6,15 @@ require "livecheck/strategy"
 describe Homebrew::Livecheck::Strategy::Cpan do
   subject(:cpan) { described_class }
 
-  let(:cpan_urls) {
+  let(:cpan_urls) do
     {
       no_subdirectory:   "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/Brew-v1.2.3.tar.gz",
       with_subdirectory: "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/brew/brew-v1.2.3.tar.gz",
     }
-  }
+  end
   let(:non_cpan_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       no_subdirectory:   {
         url:   "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/",
@@ -25,7 +25,7 @@ describe Homebrew::Livecheck::Strategy::Cpan do
         regex: /href=.*?brew[._-]v?(\d+(?:\.\d+)*)\.t/i,
       },
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a CPAN URL" do

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -11,7 +11,7 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
 
   let(:regex) { /Example[._-]v?(\d+(?:\.\d+)+)[._-]mac\.zip/i }
 
-  let(:content) {
+  let(:content) do
     <<~EOS
       version: 1.2.3
       files:
@@ -26,19 +26,19 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
       sha512: MDXR0pxozBJjxxbtUQJOnhiaiiQkryLAwtcVjlnNiz30asm/PtSxlxWKFYN3kV/kl+jriInJrGypuzajTF6XIA==
       releaseDate: '2000-01-01T00:00:00.000Z'
     EOS
-  }
+  end
 
-  let(:content_timestamp) {
+  let(:content_timestamp) do
     # An electron-builder YAML file may use a timestamp instead of an explicit
     # string value (with quotes) for `releaseDate`, so we need to make sure that
     # `ElectronBuilder#versions_from_content` won't encounter an error in this
     # scenario (e.g. `Tried to load unspecified class: Time`).
     content.sub(/releaseDate:\s*'([^']+)'/, 'releaseDate: \1')
-  }
+  end
 
   let(:content_matches) { ["1.2.3"] }
 
-  let(:find_versions_return_hash) {
+  let(:find_versions_return_hash) do
     {
       matches: {
         "1.2.3" => Version.new("1.2.3"),
@@ -46,11 +46,11 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
       regex:   nil,
       url:     http_url,
     }
-  }
+  end
 
-  let(:find_versions_cached_return_hash) {
+  let(:find_versions_cached_return_hash) do
     find_versions_return_hash.merge({ cached: true })
-  }
+  end
 
   describe "::match?" do
     it "returns true for a YAML file URL" do

--- a/Library/Homebrew/test/livecheck/strategy/git_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/git_spec.rb
@@ -9,28 +9,28 @@ describe Homebrew::Livecheck::Strategy::Git do
   let(:git_url) { "https://github.com/Homebrew/brew.git" }
   let(:non_git_url) { "https://brew.sh/test" }
 
-  let(:tags) {
+  let(:tags) do
     {
       normal:  ["brew/1.2", "brew/1.2.1", "brew/1.2.2", "brew/1.2.3", "brew/1.2.4", "1.2.5"],
       hyphens: ["brew/1-2", "brew/1-2-1", "brew/1-2-2", "brew/1-2-3", "brew/1-2-4", "1-2-5"],
     }
-  }
+  end
 
-  let(:regexes) {
+  let(:regexes) do
     {
       standard: /^v?(\d+(?:\.\d+)+)$/i,
       hyphens:  /^v?(\d+(?:[.-]\d+)+)$/i,
       brew:     %r{^brew/v?(\d+(?:\.\d+)+)$}i,
     }
-  }
+  end
 
-  let(:versions) {
+  let(:versions) do
     {
       default:        ["1.2", "1.2.1", "1.2.2", "1.2.3", "1.2.4", "1.2.5"],
       standard_regex: ["1.2.5"],
       brew_regex:     ["1.2", "1.2.1", "1.2.2", "1.2.3", "1.2.4"],
     }
-  }
+  end
 
   describe "::tag_info", :needs_network do
     it "returns the Git tags for the provided remote URL that match the regex provided" do

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -6,20 +6,20 @@ require "livecheck/strategy/github_latest"
 describe Homebrew::Livecheck::Strategy::GithubLatest do
   subject(:github_latest) { described_class }
 
-  let(:github_urls) {
+  let(:github_urls) do
     {
       release_artifact:  "https://github.com/abc/def/releases/download/1.2.3/ghi-1.2.3.tar.gz",
       tag_archive:       "https://github.com/abc/def/archive/v1.2.3.tar.gz",
       repository_upload: "https://github.com/downloads/abc/def/ghi-1.2.3.tar.gz",
     }
-  }
+  end
   let(:non_github_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       url: "https://github.com/abc/def/releases/latest",
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a GitHub release artifact URL" do

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -9,12 +9,12 @@ describe Homebrew::Livecheck::Strategy::Gnome do
   let(:gnome_url) { "https://download.gnome.org/sources/abc/1.2/abc-1.2.3.tar.xz" }
   let(:non_gnome_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       url:   "https://download.gnome.org/sources/abc/cache.json",
       regex: /abc-(\d+(?:\.\d+)*)\.t/i,
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a GNOME URL" do

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -6,17 +6,17 @@ require "livecheck/strategy/gnu"
 describe Homebrew::Livecheck::Strategy::Gnu do
   subject(:gnu) { described_class }
 
-  let(:gnu_urls) {
+  let(:gnu_urls) do
     {
       no_version_dir: "https://ftp.gnu.org/gnu/abc/abc-1.2.3.tar.gz",
       software_page:  "https://www.gnu.org/software/abc/",
       subdomain:      "https://abc.gnu.org",
       savannah:       "https://download.savannah.gnu.org/releases/abc/abc-1.2.3.tar.gz",
     }
-  }
+  end
   let(:non_gnu_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       no_version_dir: {
         url:   "https://ftp.gnu.org/gnu/abc/",
@@ -32,7 +32,7 @@ describe Homebrew::Livecheck::Strategy::Gnu do
       },
       savannah:       {},
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a [non-Savannah] GNU URL" do

--- a/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
@@ -6,20 +6,20 @@ require "livecheck/strategy/hackage"
 describe Homebrew::Livecheck::Strategy::Hackage do
   subject(:hackage) { described_class }
 
-  let(:hackage_urls) {
+  let(:hackage_urls) do
     {
       package:   "https://hackage.haskell.org/package/abc-1.2.3/abc-1.2.3.tar.gz",
       downloads: "https://downloads.haskell.org/~abc/1.2.3/abc-1.2.3-src.tar.xz",
     }
-  }
+  end
   let(:non_hackage_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       url:   "https://hackage.haskell.org/package/abc/src/",
       regex: %r{<h3>abc-(.*?)/?</h3>}i,
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a Hackage URL" do

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -9,7 +9,7 @@ describe Homebrew::Livecheck::Strategy::HeaderMatch do
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
 
-  let(:versions) {
+  let(:versions) do
     versions = {
       content_disposition: ["1.2.3"],
       location:            ["1.2.4"],
@@ -17,9 +17,9 @@ describe Homebrew::Livecheck::Strategy::HeaderMatch do
     versions[:content_disposition_and_location] = versions[:content_disposition] + versions[:location]
 
     versions
-  }
+  end
 
-  let(:headers) {
+  let(:headers) do
     headers = {
       content_disposition: {
         "date"                => "Fri, 01 Jan 2021 01:23:45 GMT",
@@ -37,15 +37,15 @@ describe Homebrew::Livecheck::Strategy::HeaderMatch do
     headers[:content_disposition_and_location] = headers[:content_disposition].merge(headers[:location])
 
     headers
-  }
+  end
 
-  let(:regexes) {
+  let(:regexes) do
     {
       archive: /filename=brew[._-]v?(\d+(?:\.\d+)+)\.t/i,
       latest:  %r{.*?/tag/v?(\d+(?:\.\d+)+)$}i,
       loose:   /v?(\d+(?:\.\d+)+)/i,
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for an HTTP URL" do

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -11,7 +11,7 @@ describe Homebrew::Livecheck::Strategy::Json do
 
   let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
 
-  let(:content) {
+  let(:content) do
     <<~EOS
       {
         "versions": [
@@ -38,13 +38,13 @@ describe Homebrew::Livecheck::Strategy::Json do
         ]
       }
     EOS
-  }
+  end
   let(:content_simple) { '{"version":"1.2.3"}' }
 
   let(:content_matches) { ["1.1.2", "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"] }
   let(:content_simple_matches) { ["1.2.3"] }
 
-  let(:find_versions_return_hash) {
+  let(:find_versions_return_hash) do
     {
       matches: {
         "1.1.2" => Version.new("1.1.2"),
@@ -58,11 +58,11 @@ describe Homebrew::Livecheck::Strategy::Json do
       regex:   regex,
       url:     http_url,
     }
-  }
+  end
 
-  let(:find_versions_cached_return_hash) {
+  let(:find_versions_cached_return_hash) do
     find_versions_return_hash.merge({ cached: true })
-  }
+  end
 
   describe "::match?" do
     it "returns true for an HTTP URL" do

--- a/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
@@ -6,20 +6,20 @@ require "livecheck/strategy/launchpad"
 describe Homebrew::Livecheck::Strategy::Launchpad do
   subject(:launchpad) { described_class }
 
-  let(:launchpad_urls) {
+  let(:launchpad_urls) do
     {
       version_dir:    "https://launchpad.net/abc/1.2/1.2.3/+download/abc-1.2.3.tar.gz",
       trunk:          "https://launchpad.net/abc/trunk/1.2.3/+download/abc-1.2.3.tar.gz",
       code_subdomain: "https://code.launchpad.net/abc/1.2/1.2.3/+download/abc-1.2.3.tar.gz",
     }
-  }
+  end
   let(:non_launchpad_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       url: "https://launchpad.net/abc/",
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a Launchpad URL" do

--- a/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
@@ -6,15 +6,15 @@ require "livecheck/strategy/npm"
 describe Homebrew::Livecheck::Strategy::Npm do
   subject(:npm) { described_class }
 
-  let(:npm_urls) {
+  let(:npm_urls) do
     {
       typical:    "https://registry.npmjs.org/abc/-/def-1.2.3.tgz",
       org_scoped: "https://registry.npmjs.org/@example/abc/-/def-1.2.3.tgz",
     }
-  }
+  end
   let(:non_npm_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       typical:    {
         url:   "https://www.npmjs.com/package/abc?activeTab=versions",
@@ -25,7 +25,7 @@ describe Homebrew::Livecheck::Strategy::Npm do
         regex: %r{href=.*?/package/@example/abc/v/(\d+(?:\.\d+)+)"}i,
       },
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for an npm URL" do

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -11,7 +11,7 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
 
   let(:regex) { %r{href=.*?/homebrew[._-]v?(\d+(?:\.\d+)+)/?["' >]}i }
 
-  let(:content) {
+  let(:content) do
     <<~EOS
       <!DOCTYPE html>
       <html>
@@ -35,11 +35,11 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
         </body>
       </html>
     EOS
-  }
+  end
 
   let(:content_matches) { ["2.6.0", "2.5.0", "2.4.0", "2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.9.0"] }
 
-  let(:find_versions_return_hash) {
+  let(:find_versions_return_hash) do
     {
       matches: {
         "2.6.0" => Version.new("2.6.0"),
@@ -54,13 +54,13 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
       regex:   regex,
       url:     http_url,
     }
-  }
+  end
 
-  let(:find_versions_cached_return_hash) {
+  let(:find_versions_cached_return_hash) do
     return_hash = find_versions_return_hash
     return_hash[:cached] = true
     return_hash
-  }
+  end
 
   describe "::match?" do
     it "returns true for an HTTP URL" do

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -9,12 +9,12 @@ describe Homebrew::Livecheck::Strategy::Pypi do
   let(:pypi_url) { "https://files.pythonhosted.org/packages/ab/cd/efg/example-1.2.3.tar.gz" }
   let(:non_pypi_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       url:   "https://pypi.org/project/example/#files",
       regex: %r{href=.*?/packages.*?/example[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i,
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a PyPI URL" do

--- a/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
@@ -6,16 +6,16 @@ require "livecheck/strategy/sourceforge"
 describe Homebrew::Livecheck::Strategy::Sourceforge do
   subject(:sourceforge) { described_class }
 
-  let(:sourceforge_urls) {
+  let(:sourceforge_urls) do
     {
       typical:       "https://downloads.sourceforge.net/project/abc/def-1.2.3.tar.gz",
       rss:           "https://sourceforge.net/projects/abc/rss",
       rss_with_path: "https://sourceforge.net/projects/abc/rss?path=/def",
     }
-  }
+  end
   let(:non_sourceforge_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       typical: {
         url:   "https://sourceforge.net/projects/abc/rss",
@@ -25,7 +25,7 @@ describe Homebrew::Livecheck::Strategy::Sourceforge do
         regex: %r{url=.*?/abc/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i,
       },
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for a SourceForge URL" do

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -27,7 +27,7 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
 
   # The `item_hashes` data is used to create test appcast XML and expected
   # `Sparkle::Item` objects.
-  let(:item_hashes) {
+  let(:item_hashes) do
     {
       v123: {
         title:         "Version 1.2.3",
@@ -58,9 +58,9 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
         version:       "120",
       },
     }
-  }
+  end
 
-  let(:xml) {
+  let(:xml) do
     v123_item = <<~EOS
       <item>
         <title>#{item_hashes[:v123][:title]}</title>
@@ -151,11 +151,11 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
       no_items:            no_items,
       undefined_namespace: undefined_namespace,
     }
-  }
+  end
 
   let(:title_regex) { /Version\s+v?(\d+(?:\.\d+)+)\s*$/i }
 
-  let(:items) {
+  let(:items) do
     {
       v123: Homebrew::Livecheck::Strategy::Sparkle::Item.new(
         title:          item_hashes[:v123][:title],
@@ -188,9 +188,9 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
                                                     item_hashes[:v120][:version]),
       ),
     }
-  }
+  end
 
-  let(:item_arrays) {
+  let(:item_arrays) do
     item_arrays = {
       appcast:        [
         items[:v123],
@@ -221,7 +221,7 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
     item_arrays[:no_versions_item] = [no_versions_item]
 
     item_arrays
-  }
+  end
 
   let(:versions) { [items[:v123].nice_version] }
 
@@ -343,12 +343,12 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
     end
 
     it "errors on an invalid return type from a block" do
-      expect {
+      expect do
         sparkle.versions_from_content(xml[:appcast]) do |item|
           _ = item # To appease `brew style` without modifying arg name
           123
         end
-      }.to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
+      end.to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
     end
 
     it "errors if the first block argument uses an unhandled name" do

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -12,7 +12,7 @@ describe Homebrew::Livecheck::Strategy::Xml do
 
   let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
 
-  let(:content_version_text) {
+  let(:content_version_text) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
       <versions>
@@ -37,9 +37,9 @@ describe Homebrew::Livecheck::Strategy::Xml do
         <version>1.0.0-rc1</version>
       </versions>
     EOS
-  }
+  end
 
-  let(:content_version_attr) {
+  let(:content_version_attr) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
       <items>
@@ -64,26 +64,26 @@ describe Homebrew::Livecheck::Strategy::Xml do
         <item version="1.0.0-rc1" />
       </items>
     EOS
-  }
+  end
 
-  let(:content_simple) {
+  let(:content_simple) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
       <version>1.2.3</version>
     EOS
-  }
+  end
 
-  let(:content_undefined_namespace) {
+  let(:content_undefined_namespace) do
     <<~EOS
       <?xml version="1.0" encoding="utf-8"?>
       <something:version>1.2.3</something:version>
     EOS
-  }
+  end
 
   let(:content_matches) { ["1.1.2", "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"] }
   let(:content_simple_matches) { ["1.2.3"] }
 
-  let(:find_versions_return_hash) {
+  let(:find_versions_return_hash) do
     {
       matches: {
         "1.1.2" => Version.new("1.1.2"),
@@ -97,11 +97,11 @@ describe Homebrew::Livecheck::Strategy::Xml do
       regex:   regex,
       url:     http_url,
     }
-  }
+  end
 
-  let(:find_versions_cached_return_hash) {
+  let(:find_versions_cached_return_hash) do
     find_versions_return_hash.merge({ cached: true })
-  }
+  end
 
   describe "::match?" do
     it "returns true for an HTTP URL" do

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -6,7 +6,7 @@ require "livecheck/strategy/xorg"
 describe Homebrew::Livecheck::Strategy::Xorg do
   subject(:xorg) { described_class }
 
-  let(:xorg_urls) {
+  let(:xorg_urls) do
     {
       app:     "https://www.x.org/archive/individual/app/abc-1.2.3.tar.bz2",
       font:    "https://www.x.org/archive/individual/font/abc-1.2.3.tar.bz2",
@@ -14,10 +14,10 @@ describe Homebrew::Livecheck::Strategy::Xorg do
       ftp_lib: "https://ftp.x.org/archive/individual/lib/libabc-1.2.3.tar.bz2",
       pub_doc: "https://www.x.org/pub/individual/doc/abc-1.2.3.tar.bz2",
     }
-  }
+  end
   let(:non_xorg_url) { "https://brew.sh/test" }
 
-  let(:generated) {
+  let(:generated) do
     {
       app:     {
         url:   "https://www.x.org/archive/individual/app/",
@@ -40,7 +40,7 @@ describe Homebrew::Livecheck::Strategy::Xorg do
         regex: /href=.*?abc[._-]v?(\d+(?:\.\d+)+)\.t/i,
       },
     }
-  }
+  end
 
   describe "::match?" do
     it "returns true for an X.Org URL" do

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -11,7 +11,7 @@ describe Homebrew::Livecheck::Strategy::Yaml do
 
   let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
 
-  let(:content) {
+  let(:content) do
     <<~EOS
       versions:
         - version: 1.1.2
@@ -35,7 +35,7 @@ describe Homebrew::Livecheck::Strategy::Yaml do
         - version: 1.0.0-rc1
         - other: version is omitted from this object for testing
     EOS
-  }
+  end
   let(:content_simple) { "version: 1.2.3" }
 
   # This should produce a `Psych::SyntaxError` (`did not find expected comment
@@ -45,7 +45,7 @@ describe Homebrew::Livecheck::Strategy::Yaml do
   let(:content_matches) { ["1.1.2", "1.1.1", "1.1.0", "1.0.3", "1.0.2", "1.0.1", "1.0.0"] }
   let(:content_simple_matches) { ["1.2.3"] }
 
-  let(:find_versions_return_hash) {
+  let(:find_versions_return_hash) do
     {
       matches: {
         "1.1.2" => Version.new("1.1.2"),
@@ -59,11 +59,11 @@ describe Homebrew::Livecheck::Strategy::Yaml do
       regex:   regex,
       url:     http_url,
     }
-  }
+  end
 
-  let(:find_versions_cached_return_hash) {
+  let(:find_versions_cached_return_hash) do
     find_versions_return_hash.merge({ cached: true })
-  }
+  end
 
   describe "::match?" do
     it "returns true for an HTTP URL" do

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -39,9 +39,9 @@ describe Livecheck do
     end
 
     it "raises a TypeError if the argument isn't a String" do
-      expect {
+      expect do
         livecheckable_f.formula(123)
-      }.to raise_error(TypeError, "Livecheck#formula expects a String")
+      end.to raise_error(TypeError, "Livecheck#formula expects a String")
     end
   end
 
@@ -56,9 +56,9 @@ describe Livecheck do
     end
 
     it "raises a TypeError if the argument isn't a String" do
-      expect {
+      expect do
         livecheckable_c.cask(123)
-      }.to raise_error(TypeError, "Livecheck#cask expects a String")
+      end.to raise_error(TypeError, "Livecheck#cask expects a String")
     end
   end
 
@@ -73,9 +73,9 @@ describe Livecheck do
     end
 
     it "raises a TypeError if the argument isn't a Regexp" do
-      expect {
+      expect do
         livecheckable_f.regex("foo")
-      }.to raise_error(TypeError, "Livecheck#regex expects a Regexp")
+      end.to raise_error(TypeError, "Livecheck#regex expects a Regexp")
     end
   end
 
@@ -93,9 +93,9 @@ describe Livecheck do
     end
 
     it "raises a TypeError if the argument isn't a String" do
-      expect {
+      expect do
         livecheckable_f.skip(/foo/)
-      }.to raise_error(TypeError, "Livecheck#skip expects a String")
+      end.to raise_error(TypeError, "Livecheck#skip expects a String")
     end
   end
 
@@ -119,9 +119,9 @@ describe Livecheck do
     end
 
     it "raises a TypeError if the argument isn't a Symbol" do
-      expect {
+      expect do
         livecheckable_f.strategy("page_match")
-      }.to raise_error(TypeError, "Livecheck#strategy expects a Symbol")
+      end.to raise_error(TypeError, "Livecheck#strategy expects a Symbol")
     end
   end
 
@@ -152,9 +152,9 @@ describe Livecheck do
     end
 
     it "raises a TypeError if the argument isn't a String or valid Symbol" do
-      expect {
+      expect do
         livecheckable_f.url(/foo/)
-      }.to raise_error(TypeError, "Livecheck#url expects a String or valid Symbol")
+      end.to raise_error(TypeError, "Livecheck#url expects a String or valid Symbol")
     end
   end
 

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -16,9 +16,9 @@ describe LockFile do
     it "raises an error if a lock already exists" do
       lock_file.lock
 
-      expect {
+      expect do
         described_class.new("foo").lock
-      }.to raise_error(OperationInProgressError)
+      end.to raise_error(OperationInProgressError)
     end
   end
 

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -11,23 +11,23 @@ describe Messages do
 
   describe "#record_caveats" do
     it "adds a caveat" do
-      expect {
+      expect do
         messages.record_caveats(test_formula, "Zsh completions were installed")
-      }.to change(messages.caveats, :count).by(1)
+      end.to change(messages.caveats, :count).by(1)
     end
   end
 
   describe "#package_installed" do
     it "increases the package count" do
-      expect {
+      expect do
         messages.package_installed(test_formula, elapsed_time)
-      }.to change(messages, :package_count).by(1)
+      end.to change(messages, :package_count).by(1)
     end
 
     it "adds to install_times" do
-      expect {
+      expect do
         messages.package_installed(test_formula, elapsed_time)
-      }.to change(messages.install_times, :count).by(1)
+      end.to change(messages.install_times, :count).by(1)
     end
   end
 

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -57,15 +57,15 @@ describe Migrator do
 
   describe "::new" do
     it "raises an error if there is no old name" do
-      expect {
+      expect do
         described_class.new(old_formula)
-      }.to raise_error(Migrator::MigratorNoOldnameError)
+      end.to raise_error(Migrator::MigratorNoOldnameError)
     end
 
     it "raises an error if there is no old path" do
-      expect {
+      expect do
         described_class.new(new_formula)
-      }.to raise_error(Migrator::MigratorNoOldpathError)
+      end.to raise_error(Migrator::MigratorNoOldpathError)
     end
 
     it "raises an error if the Taps differ" do
@@ -76,9 +76,9 @@ describe Migrator do
       tab.source["tap"] = "homebrew/core"
       tab.write
 
-      expect {
+      expect do
         described_class.new(new_formula)
-      }.to raise_error(Migrator::MigratorDifferentTapsError)
+      end.to raise_error(Migrator::MigratorDifferentTapsError)
     end
   end
 

--- a/Library/Homebrew/test/os/mac/version_spec.rb
+++ b/Library/Homebrew/test/os/mac/version_spec.rb
@@ -58,9 +58,9 @@ describe OS::Mac::Version do
 
   describe "#new" do
     it "raises an error if the version is not a valid macOS version" do
-      expect {
+      expect do
         described_class.new("1.2")
-      }.to raise_error(MacOSVersionError, 'unknown or unsupported macOS version: "1.2"')
+      end.to raise_error(MacOSVersionError, 'unknown or unsupported macOS version: "1.2"')
     end
 
     it "creates a new version from a valid macOS version" do
@@ -71,9 +71,9 @@ describe OS::Mac::Version do
 
   describe "#from_symbol" do
     it "raises an error if the symbol is not a valid macOS version" do
-      expect {
+      expect do
         described_class.from_symbol(:foo)
-      }.to raise_error(MacOSVersionError, "unknown or unsupported macOS version: :foo")
+      end.to raise_error(MacOSVersionError, "unknown or unsupported macOS version: :foo")
     end
 
     it "creates a new version from a valid macOS version" do

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -42,13 +42,13 @@ describe Patch do
     end
 
     it "raises an error for unknown values" do
-      expect {
+      expect do
         described_class.create(Object.new)
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
 
-      expect {
+      expect do
         described_class.create(Object.new, Object.new)
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -4,8 +4,8 @@
 require "formula"
 
 describe "patching" do
-  let(:formula_subclass) {
-    Class.new(Formula) {
+  let(:formula_subclass) do
+    Class.new(Formula) do
       # These are defined within an anonymous class to avoid polluting the global namespace.
       # rubocop:disable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
       TESTBALL_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
@@ -21,8 +21,8 @@ describe "patching" do
 
       url TESTBALL_URL
       sha256 TESTBALL_SHA256
-    }
-  }
+    end
+  end
 
   def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, &block)
     formula_subclass.class_eval(&block)
@@ -65,11 +65,11 @@ describe "patching" do
 
   matcher :miss_apply do
     match do |formula|
-      expect {
+      expect do
         formula.brew do
           formula.patch
         end
-      }.to raise_error(MissingApplyError)
+      end.to raise_error(MissingApplyError)
     end
   end
 
@@ -148,7 +148,7 @@ describe "patching" do
   end
 
   specify "single_patch_dsl_with_incorrect_strip" do
-    expect {
+    expect do
       f = formula do
         patch :p0 do
           url PATCH_URL_A
@@ -157,11 +157,11 @@ describe "patching" do
       end
 
       f.brew { |formula, _staging| formula.patch }
-    }.to raise_error(BuildError)
+    end.to raise_error(BuildError)
   end
 
   specify "single_patch_dsl_with_incorrect_strip_with_apply" do
-    expect {
+    expect do
       f = formula do
         patch :p0 do
           url TESTBALL_PATCHES_URL
@@ -171,7 +171,7 @@ describe "patching" do
       end
 
       f.brew { |formula, _staging| formula.patch }
-    }.to raise_error(BuildError)
+    end.to raise_error(BuildError)
   end
 
   specify "patch_p0_dsl" do
@@ -217,7 +217,7 @@ describe "patching" do
   end
 
   specify "single_patch_dsl_with_apply_enoent_fail" do
-    expect {
+    expect do
       f = formula do
         patch do
           url TESTBALL_PATCHES_URL
@@ -227,7 +227,7 @@ describe "patching" do
       end
 
       f.brew { |formula, _staging| formula.patch }
-    }.to raise_error(BuildError)
+    end.to raise_error(BuildError)
   end
 end
 

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -93,9 +93,9 @@ describe Pathname do
     end
 
     it "preserves permissions" do
-      File.open(file, "w", 0100777) {
+      File.open(file, "w", 0100777) do
         # do nothing
-      }
+      end
       file.atomic_write("CONTENT")
       expect(file.stat.mode.to_s(8)).to eq((~File.umask & 0100777).to_s(8))
     end

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -32,15 +32,15 @@ describe PkgVersion do
     end
 
     it "raises an error if the other side isn't of the same class" do
-      expect {
+      expect do
         described_class.new(Version.create("1.0"), 0) > Object.new
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it "is not compatible with Version" do
-      expect {
+      expect do
         described_class.new(Version.create("1.0"), 0) > Version.create("1.0")
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -4,15 +4,15 @@
 require "requirements/codesign_requirement"
 
 describe CodesignRequirement do
-  subject(:requirement) {
+  subject(:requirement) do
     described_class.new([{ identity: identity, with: with, url: url }])
-  }
+  end
 
   let(:identity) { "lldb_codesign" }
   let(:with) { "LLDB" }
-  let(:url) {
+  let(:url) do
     "https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt"
-  }
+  end
 
   describe "#message" do
     it "includes all parameters" do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -7,7 +7,7 @@ require "livecheck"
 describe Resource do
   subject(:resource) { described_class.new("test") }
 
-  let(:livecheck_resource) {
+  let(:livecheck_resource) do
     described_class.new do
       url "https://brew.sh/foo-1.0.tar.gz"
       sha256 "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -17,7 +17,7 @@ describe Resource do
         regex(/foo[._-]v?(\d+(?:\.\d+)+)\.t/i)
       end
     end
-  }
+  end
 
   describe "#url" do
     it "sets the URL" do
@@ -195,8 +195,8 @@ describe Resource do
       .with(checksum)
       .and_raise(ChecksumMismatchError.new(fn, checksum, Object.new))
 
-    expect {
+    expect do
       resource.verify_download_integrity(fn)
-    }.to raise_error(ChecksumMismatchError)
+    end.to raise_error(ChecksumMismatchError)
   end
 end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -6,7 +6,7 @@ require "rubocops/urls"
 describe RuboCop::Cop::FormulaAudit::Urls do
   subject(:cop) { described_class.new }
 
-  let(:offense_list) {
+  let(:offense_list) do
     [{
       "url" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz",
       "msg" => 'Please use "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz" instead of https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz.',
@@ -181,7 +181,7 @@ describe RuboCop::Cop::FormulaAudit::Urls do
       "msg" => "Use of the svn+http:// scheme is deprecated, pass `:using => :svn` instead",
       "col" => 2,
     }]
-  }
+  end
 
   context "when auditing URLs" do
     it "reports all offenses in `offense_list`" do

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -24,9 +24,9 @@ describe Sandbox, :needs_macos do
 
   describe "#exec" do
     it "fails when writing to file not specified with ##allow_write" do
-      expect {
+      expect do
         sandbox.exec "touch", file
-      }.to raise_error(ErrorDuringExecution)
+      end.to raise_error(ErrorDuringExecution)
 
       expect(file).not_to exist
     end

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -43,9 +43,9 @@ describe Homebrew::Service do
         end
       end
 
-      expect {
+      expect do
         f.service.manual_command
-      }.to raise_error TypeError, "Service#process_type allows: 'background'/'standard'/'interactive'/'adaptive'"
+      end.to raise_error TypeError, "Service#process_type allows: 'background'/'standard'/'interactive'/'adaptive'"
     end
   end
 
@@ -58,9 +58,9 @@ describe Homebrew::Service do
         end
       end
 
-      expect {
+      expect do
         f.service.manual_command
-      }.to raise_error TypeError, "Service#keep_alive allows only [:always, :successful_exit, :crashed, :path]"
+      end.to raise_error TypeError, "Service#keep_alive allows only [:always, :successful_exit, :crashed, :path]"
     end
   end
 
@@ -96,9 +96,9 @@ describe Homebrew::Service do
         end
       end
 
-      expect {
+      expect do
         f.service.manual_command
-      }.to raise_error TypeError, "Service#run_type allows: 'immediate'/'interval'/'cron'"
+      end.to raise_error TypeError, "Service#run_type allows: 'immediate'/'interval'/'cron'"
     end
   end
 
@@ -111,9 +111,9 @@ describe Homebrew::Service do
         end
       end
 
-      expect {
+      expect do
         f.service.manual_command
-      }.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
+      end.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
     end
 
     it "throws for missing host" do
@@ -124,9 +124,9 @@ describe Homebrew::Service do
         end
       end
 
-      expect {
+      expect do
         f.service.manual_command
-      }.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
+      end.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
     end
 
     it "throws for missing port" do
@@ -137,9 +137,9 @@ describe Homebrew::Service do
         end
       end
 
-      expect {
+      expect do
         f.service.manual_command
-      }.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
+      end.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
     end
   end
 
@@ -716,9 +716,9 @@ describe Homebrew::Service do
         end
       end
 
-      expect {
+      expect do
         f.service.to_systemd_timer
-      }.to raise_error TypeError, "Service#parse_cron expects a valid cron syntax"
+      end.to raise_error TypeError, "Service#parse_cron expects a valid cron syntax"
     end
 
     it "returns valid cron timers" do

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -35,16 +35,16 @@ describe SoftwareSpec do
 
     it "raises an error when duplicate resources are defined" do
       spec.resource("foo") { url "foo-1.0" }
-      expect {
+      expect do
         spec.resource("foo") { url "foo-1.0" }
-      }.to raise_error(DuplicateResourceError)
+      end.to raise_error(DuplicateResourceError)
     end
 
     it "raises an error when accessing missing resources" do
       spec.owner = owner
-      expect {
+      expect do
         spec.resource("foo")
-      }.to raise_error(ResourceMissingError)
+      end.to raise_error(ResourceMissingError)
     end
   end
 
@@ -67,15 +67,15 @@ describe SoftwareSpec do
     end
 
     it "raises an error when it begins with dashes" do
-      expect {
+      expect do
         spec.option("--foo")
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it "raises an error when name is empty" do
-      expect {
+      expect do
         spec.option("")
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
 
     it "special cases the cxx11 option" do
@@ -112,9 +112,9 @@ describe SoftwareSpec do
     end
 
     it "raises an error when empty" do
-      expect {
+      expect do
         spec.deprecated_option({})
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 
@@ -211,9 +211,9 @@ describe SoftwareSpec do
       end
 
       it "raises an error if passing invalid OS versions" do
-        expect {
+        expect do
           spec.uses_from_macos("foo", since: :bar)
-        }.to raise_error(MacOSVersionError, "unknown or unsupported macOS version: :bar")
+        end.to raise_error(MacOSVersionError, "unknown or unsupported macOS version: :bar")
       end
     end
   end

--- a/Library/Homebrew/test/system_command_result_spec.rb
+++ b/Library/Homebrew/test/system_command_result_spec.rb
@@ -4,17 +4,17 @@
 require "system_command"
 
 describe SystemCommand::Result do
-  subject(:result) {
+  subject(:result) do
     described_class.new([], output_array, instance_double(Process::Status, exitstatus: 0, success?: true),
                         secrets: [])
-  }
+  end
 
-  let(:output_array) {
+  let(:output_array) do
     [
       [:stdout, "output\n"],
       [:stderr, "error\n"],
     ]
-  }
+  end
 
   describe "#to_ary" do
     it "can be destructed like `Open3.capture3`" do
@@ -48,7 +48,7 @@ describe SystemCommand::Result do
     subject(:result_plist) { result.plist }
 
     let(:output_array) { [[:stdout, stdout]] }
-    let(:garbage) {
+    let(:garbage) do
       <<~EOS
         Hello there! I am in no way XML am I?!?!
 
@@ -58,8 +58,8 @@ describe SystemCommand::Result do
 
         Hopefully <not> explode!
       EOS
-    }
-    let(:plist) {
+    end
+    let(:plist) do
       <<~XML
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -105,15 +105,15 @@ describe SystemCommand::Result do
         </dict>
         </plist>
       XML
-    }
+    end
 
     context "when stdout contains garbage before XML" do
-      let(:stdout) {
+      let(:stdout) do
         <<~EOS
           #{garbage}
           #{plist}
         EOS
-      }
+      end
 
       it "ignores garbage" do
         expect(result_plist["system-entities"].length).to eq(3)
@@ -132,12 +132,12 @@ describe SystemCommand::Result do
     end
 
     context "when stdout contains garbage after XML" do
-      let(:stdout) {
+      let(:stdout) do
         <<~EOS
           #{plist}
           #{garbage}
         EOS
-      }
+      end
 
       it "ignores garbage" do
         expect(result_plist["system-entities"].length).to eq(3)

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -3,7 +3,7 @@
 
 describe SystemCommand do
   describe "#initialize" do
-    subject(:command) {
+    subject(:command) do
       described_class.new(
         "env",
         args:         env_args,
@@ -11,7 +11,7 @@ describe SystemCommand do
         must_succeed: true,
         sudo:         sudo,
       )
-    }
+    end
 
     let(:env_args) { ["bash", "-c", 'printf "%s" "${A?}" "${B?}" "${C?}"'] }
     let(:env) { { "A" => "1", "B" => "2", "C" => "3" } }
@@ -40,9 +40,9 @@ describe SystemCommand do
       let(:env) { { "A" => "1", "B" => "2", "C" => nil } }
 
       it "unsets them" do
-        expect {
+        expect do
           command.run!
-        }.to raise_error(/C: parameter (null or )?not set/)
+        end.to raise_error(/C: parameter (null or )?not set/)
       end
     end
 
@@ -81,9 +81,9 @@ describe SystemCommand do
 
     context "with a command that must succeed" do
       it "throws an error" do
-        expect {
+        expect do
           described_class.run!(command)
-        }.to raise_error(ErrorDuringExecution)
+        end.to raise_error(ErrorDuringExecution)
       end
     end
 
@@ -115,12 +115,12 @@ describe SystemCommand do
 
   context "with both STDOUT and STDERR output from upstream" do
     let(:command) { "/bin/bash" }
-    let(:options) {
+    let(:options) do
       { args: [
         "-c",
         "for i in $(seq 1 2 5); do echo $i; echo $(($i + 1)) >&2; done",
       ] }
-    }
+    end
 
     shared_examples "it returns '1 2 3 4 5 6'" do
       describe "its result" do
@@ -135,9 +135,9 @@ describe SystemCommand do
     context "with default options" do
       it "echoes only STDERR" do
         expected = [2, 4, 6].map { |i| "#{i}\n" }.join
-        expect {
+        expect do
           described_class.run(command, **options)
-        }.to output(expected).to_stderr
+        end.to output(expected).to_stderr
       end
 
       include_examples("it returns '1 2 3 4 5 6'")
@@ -163,9 +163,9 @@ describe SystemCommand do
       end
 
       it "echoes nothing" do
-        expect {
+        expect do
           described_class.run(command, **options)
-        }.to output("").to_stdout
+        end.to output("").to_stdout
       end
 
       include_examples("it returns '1 2 3 4 5 6'")
@@ -178,9 +178,9 @@ describe SystemCommand do
 
       it "echoes only STDOUT" do
         expected = [1, 3, 5].map { |i| "#{i}\n" }.join
-        expect {
+        expect do
           described_class.run(command, **options)
-        }.to output(expected).to_stdout
+        end.to output(expected).to_stdout
       end
 
       include_examples("it returns '1 2 3 4 5 6'")
@@ -189,12 +189,12 @@ describe SystemCommand do
 
   context "with a very long STDERR output" do
     let(:command) { "/bin/bash" }
-    let(:options) {
+    let(:options) do
       { args: [
         "-c",
         "for i in $(seq 1 2 100000); do echo $i; echo $(($i + 1)) >&2; done",
       ] }
-    }
+    end
 
     it "returns without deadlocking", timeout: 30 do
       expect(described_class.run(command, **options)).to be_a_success
@@ -223,20 +223,20 @@ describe SystemCommand do
 
   describe "#run" do
     it "does not raise a `SystemCallError` when the executable does not exist" do
-      expect {
+      expect do
         described_class.run("non_existent_executable")
-      }.not_to raise_error
+      end.not_to raise_error
     end
 
     it 'does not format `stderr` when it starts with \r' do
-      expect {
+      expect do
         system_command \
           "bash",
           args: [
             "-c",
             'printf "\r%s" "###################                                                       27.6%" 1>&2',
           ]
-      }.to output( \
+      end.to output( \
         "\r###################                                                       27.6%",
       ).to_stderr
     end
@@ -261,46 +261,46 @@ describe SystemCommand do
     context "when given arguments with secrets" do
       it "does not leak the secrets" do
         redacted_msg = /#{Regexp.escape("username:******")}/
-        expect {
+        expect do
           described_class.run! "curl",
                                args:    %w[--user username:hunter2],
                                verbose: true,
                                secrets: %w[hunter2]
-        }.to raise_error.with_message(redacted_msg).and output(redacted_msg).to_stderr
+        end.to raise_error.with_message(redacted_msg).and output(redacted_msg).to_stderr
       end
 
       it "does not leak the secrets set by environment" do
         redacted_msg = /#{Regexp.escape("username:******")}/
-        expect {
+        expect do
           ENV["PASSWORD"] = "hunter2"
           described_class.run! "curl",
                                args:    %w[--user username:hunter2],
                                verbose: true
-        }.to raise_error.with_message(redacted_msg).and output(redacted_msg).to_stderr
+        end.to raise_error.with_message(redacted_msg).and output(redacted_msg).to_stderr
       end
     end
 
     context "when running a process that prints secrets" do
       it "does not leak the secrets" do
         redacted_msg = /#{Regexp.escape("username:******")}/
-        expect {
+        expect do
           described_class.run! "echo",
                                args:         %w[username:hunter2],
                                verbose:      true,
                                print_stdout: true,
                                secrets:      %w[hunter2]
-        }.to output(redacted_msg).to_stdout
+        end.to output(redacted_msg).to_stdout
       end
 
       it "does not leak the secrets set by environment" do
         redacted_msg = /#{Regexp.escape("username:******")}/
-        expect {
+        expect do
           ENV["PASSWORD"] = "hunter2"
           described_class.run! "echo",
                                args:         %w[username:hunter2],
                                print_stdout: true,
                                verbose:      true
-        }.to output(redacted_msg).to_stdout
+        end.to output(redacted_msg).to_stdout
       end
     end
 

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -19,7 +19,7 @@ describe Tab do
     end
   end
 
-  subject(:tab) {
+  subject(:tab) do
     described_class.new(
       "homebrew_version"     => HOMEBREW_VERSION,
       "used_options"         => used_options.as_flags,
@@ -45,7 +45,7 @@ describe Tab do
       "arch"                 => Hardware::CPU.arch,
       "built_on"             => DevelopmentTools.build_system_info,
     )
-  }
+  end
 
   let(:time) { Time.now.to_i }
   let(:unused_options) { Options.create(%w[--with-baz --without-qux]) }

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -102,17 +102,17 @@ describe Tap do
     expect(tap).to be_a(described_class)
     expect(tap.name).to eq("homebrew/foo")
 
-    expect {
+    expect do
       described_class.fetch("foo")
-    }.to raise_error(/Invalid tap name/)
+    end.to raise_error(/Invalid tap name/)
 
-    expect {
+    expect do
       described_class.fetch("homebrew/homebrew/bar")
-    }.to raise_error(/Invalid tap name/)
+    end.to raise_error(/Invalid tap name/)
 
-    expect {
+    expect do
       described_class.fetch("homebrew", "homebrew/baz")
-    }.to raise_error(/Invalid tap name/)
+    end.to raise_error(/Invalid tap name/)
   end
 
   describe "::from_path" do
@@ -280,17 +280,17 @@ describe Tap do
       already_tapped_tap = described_class.new("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
       wrong_remote = "#{homebrew_foo_tap.remote}-oops"
-      expect {
+      expect do
         already_tapped_tap.install clone_target: wrong_remote
-      }.to raise_error(TapRemoteMismatchError)
+      end.to raise_error(TapRemoteMismatchError)
     end
 
     it "raises an error when the remote for Homebrew/core doesn't match HOMEBREW_CORE_GIT_REMOTE" do
       core_tap = described_class.fetch("Homebrew", "core")
       wrong_remote = "#{Homebrew::EnvConfig.core_git_remote}-oops"
-      expect {
+      expect do
         core_tap.install clone_target: wrong_remote
-      }.to raise_error(TapCoreRemoteMismatchError)
+      end.to raise_error(TapCoreRemoteMismatchError)
     end
 
     it "raises an error when run `brew tap --custom-remote` without a custom remote (already installed)" do
@@ -298,18 +298,18 @@ describe Tap do
       already_tapped_tap = described_class.new("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
 
-      expect {
+      expect do
         already_tapped_tap.install clone_target: nil, custom_remote: true
-      }.to raise_error(TapNoCustomRemoteError)
+      end.to raise_error(TapNoCustomRemoteError)
     end
 
     it "raises an error when run `brew tap --custom-remote` without a custom remote (not installed)" do
       not_tapped_tap = described_class.new("Homebrew", "bar")
       expect(not_tapped_tap).not_to be_installed
 
-      expect {
+      expect do
         not_tapped_tap.install clone_target: nil, custom_remote: true
-      }.to raise_error(TapNoCustomRemoteError)
+      end.to raise_error(TapNoCustomRemoteError)
     end
 
     describe "force_auto_update" do
@@ -340,9 +340,9 @@ describe Tap do
     specify "Git error" do
       tap = described_class.new("user", "repo")
 
-      expect {
+      expect do
         tap.install clone_target: "file:///not/existed/remote/url"
-      }.to raise_error(ErrorDuringExecution)
+      end.to raise_error(ErrorDuringExecution)
 
       expect(tap).not_to be_installed
       expect(Tap::TAP_DIRECTORY/"user").not_to exist

--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -51,25 +51,25 @@ describe Homebrew::Uninstall do
     specify "when developer" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
 
-      expect {
+      expect do
         described_class.handle_unsatisfied_dependents(kegs_by_rack)
-      }.to output(/Warning/).to_stderr
+      end.to output(/Warning/).to_stderr
 
       expect(Homebrew).not_to have_failed
     end
 
     specify "when not developer" do
-      expect {
+      expect do
         described_class.handle_unsatisfied_dependents(kegs_by_rack)
-      }.to output(/Error/).to_stderr
+      end.to output(/Error/).to_stderr
 
       expect(Homebrew).to have_failed
     end
 
     specify "when not developer and `ignore_dependencies` is true" do
-      expect {
+      expect do
         described_class.handle_unsatisfied_dependents(kegs_by_rack, ignore_dependencies: true)
-      }.not_to output.to_stderr
+      end.not_to output.to_stderr
 
       expect(Homebrew).not_to have_failed
     end

--- a/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
@@ -4,12 +4,12 @@
 require_relative "shared_examples"
 
 describe UnpackStrategy::Bazaar do
-  let(:repo) {
+  let(:repo) do
     mktmpdir.tap do |repo|
       FileUtils.touch repo/"test"
       (repo/".bzr").mkpath
     end
-  }
+  end
   let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
@@ -4,12 +4,12 @@
 require_relative "shared_examples"
 
 describe UnpackStrategy::Cvs do
-  let(:repo) {
+  let(:repo) do
     mktmpdir.tap do |repo|
       FileUtils.touch repo/"test"
       (repo/"CVS").mkpath
     end
-  }
+  end
   let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -6,14 +6,14 @@ require_relative "shared_examples"
 describe UnpackStrategy::Directory do
   subject(:strategy) { described_class.new(path) }
 
-  let(:path) {
+  let(:path) do
     mktmpdir.tap do |path|
       FileUtils.touch path/"file"
       FileUtils.ln_s "file", path/"symlink"
       FileUtils.mkdir path/"folder"
       FileUtils.ln_s "folder", path/"folderSymlink"
     end
-  }
+  end
 
   let(:unpack_dir) { mktmpdir }
 

--- a/Library/Homebrew/test/unpack_strategy/git_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/git_spec.rb
@@ -4,7 +4,7 @@
 require_relative "shared_examples"
 
 describe UnpackStrategy::Git do
-  let(:repo) {
+  let(:repo) do
     mktmpdir.tap do |repo|
       system "git", "-C", repo, "init"
 
@@ -12,7 +12,7 @@ describe UnpackStrategy::Git do
       system "git", "-C", repo, "add", "test"
       system "git", "-C", repo, "commit", "-m", "Add `test` file."
     end
-  }
+  end
   let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
@@ -4,11 +4,11 @@
 require_relative "shared_examples"
 
 describe UnpackStrategy::Mercurial do
-  let(:repo) {
+  let(:repo) do
     mktmpdir.tap do |repo|
       (repo/".hg").mkpath
     end
-  }
+  end
   let(:path) { repo }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -10,11 +10,11 @@ describe UnpackStrategy::Tar do
   include_examples "#extract", children: ["container"]
 
   context "when TAR archive is corrupted" do
-    let(:path) {
+    let(:path) do
       (mktmpdir/"test.tar").tap do |path|
         FileUtils.touch path
       end
-    }
+    end
 
     include_examples "UnpackStrategy::detect"
   end

--- a/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
@@ -4,11 +4,11 @@
 require_relative "shared_examples"
 
 describe UnpackStrategy::Uncompressed do
-  let(:path) {
+  let(:path) do
     (mktmpdir/"test").tap do |path|
       FileUtils.touch path
     end
-  }
+  end
 
   include_examples "UnpackStrategy::detect"
 end

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -13,11 +13,11 @@ describe UnpackStrategy::Zip do
   end
 
   context "when ZIP archive is corrupted" do
-    let(:path) {
+    let(:path) do
       (mktmpdir/"test.zip").tap do |path|
         FileUtils.touch path
       end
-    }
+    end
 
     include_examples "UnpackStrategy::detect"
   end

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -9,7 +9,7 @@ describe UnpackStrategy do
 
     context "when extracting a GZIP nested in a BZIP2" do
       let(:file_name) { "file" }
-      let(:path) {
+      let(:path) do
         dir = mktmpdir
 
         (dir/"file").write "This file was inside a GZIP inside a BZIP2."
@@ -17,7 +17,7 @@ describe UnpackStrategy do
         system "bzip2", dir.children.first
 
         dir.children.first
-      }
+      end
 
       it "can extract nested archives" do
         strategy.extract_nestedly(to: unpack_dir)
@@ -30,7 +30,7 @@ describe UnpackStrategy do
       let(:directories) { "A/B/C" }
       let(:executable) { "#{directories}/executable" }
       let(:writable) { true }
-      let(:path) {
+      let(:path) do
         (mktmpdir/"file.tar").tap do |path|
           Dir.mktmpdir do |dir|
             dir = Pathname(dir)
@@ -46,7 +46,7 @@ describe UnpackStrategy do
             end
           end
         end
-      }
+      end
 
       it "does not recurse into nested directories" do
         strategy.extract_nestedly(to: unpack_dir)
@@ -73,14 +73,14 @@ describe UnpackStrategy do
 
     context "when extracting a nested archive" do
       let(:basename) { "file.xyz" }
-      let(:path) {
+      let(:path) do
         (mktmpdir/basename).tap do |path|
           mktmpdir do |dir|
             FileUtils.touch dir/"file.txt"
             system "tar", "--create", "--file", path, "--directory", dir, "file.txt"
           end
         end
-      }
+      end
 
       it "does not pass down the basename of the archive" do
         strategy.extract_nestedly(to: unpack_dir, basename: basename)

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -4,7 +4,7 @@
 require "utils/curl"
 
 describe "Utils::Curl" do
-  let(:details) {
+  let(:details) do
     details = {
       normal:     {},
       cloudflare: {},
@@ -111,17 +111,17 @@ describe "Utils::Curl" do
     ]
 
     details
-  }
+  end
 
-  let(:location_urls) {
+  let(:location_urls) do
     %w[
       https://example.com/example/
       https://example.com/example1/
       https://example.com/example2/
     ]
-  }
+  end
 
-  let(:response_hash) {
+  let(:response_hash) do
     response_hash = {}
 
     response_hash[:ok] = {
@@ -240,9 +240,9 @@ describe "Utils::Curl" do
     }
 
     response_hash
-  }
+  end
 
-  let(:response_text) {
+  let(:response_text) do
     response_text = {}
 
     response_text[:ok] = <<~EOS
@@ -279,9 +279,9 @@ describe "Utils::Curl" do
     )
 
     response_text
-  }
+  end
 
-  let(:body) {
+  let(:body) do
     body = {}
 
     body[:default] = <<~EOS
@@ -303,7 +303,7 @@ describe "Utils::Curl" do
     body[:with_http_status_line] = body[:default].sub("<html>", "HTTP/1.1 200\r\n<html>")
 
     body
-  }
+  end
 
   describe "curl_args" do
     let(:args) { ["foo"] }

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -6,19 +6,19 @@ require "utils/fork"
 describe Utils do
   describe "#safe_fork" do
     it "raises a RuntimeError on an error that isn't ErrorDuringExecution" do
-      expect {
+      expect do
         described_class.safe_fork do
           raise "this is an exception in the child"
         end
-      }.to raise_error(RuntimeError)
+      end.to raise_error(RuntimeError)
     end
 
     it "raises an ErrorDuringExecution on one in the child" do
-      expect {
+      expect do
         described_class.safe_fork do
           safe_system "/usr/bin/false"
         end
-      }.to raise_error(ErrorDuringExecution)
+      end.to raise_error(ErrorDuringExecution)
     end
   end
 end

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -62,9 +62,9 @@ describe Utils::Git do
 
     it "aborts when cherry picking an existing hash" do
       ENV["GIT_MERGE_VERBOSITY"] = "5" # Consistent output across git versions
-      expect {
+      expect do
         described_class.cherry_pick!(HOMEBREW_CACHE, file_hash1)
-      }.to raise_error(ErrorDuringExecution, /Merge conflict in README.md/)
+      end.to raise_error(ErrorDuringExecution, /Merge conflict in README.md/)
     end
   end
 

--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -8,9 +8,9 @@ describe GitHub::Actions::Annotation do
 
   describe "#new" do
     it "fails when the type is wrong" do
-      expect {
+      expect do
         described_class.new(:fatal, message, file: "file.txt")
-      }.to raise_error(ArgumentError)
+      end.to raise_error(ArgumentError)
     end
   end
 

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -59,19 +59,19 @@ describe GitHub do
 
   describe "::get_artifact_url", :needs_network do
     it "fails to find a nonexistent workflow" do
-      expect {
+      expect do
         described_class.get_artifact_url(
           described_class.get_workflow_run("Homebrew", "homebrew-core", "1"),
         )
-      }.to raise_error(/No matching check suite found/)
+      end.to raise_error(/No matching check suite found/)
     end
 
     it "fails to find artifacts that don't exist" do
-      expect {
+      expect do
         described_class.get_artifact_url(
           described_class.get_workflow_run("Homebrew", "homebrew-core", "79751", artifact_name: "false_bottles"),
         )
-      }.to raise_error(/No artifact .+ was found/)
+      end.to raise_error(/No artifact .+ was found/)
     end
 
     it "gets an artifact link" do

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -18,39 +18,39 @@ describe Utils::Inreplace do
   after { file.unlink }
 
   it "raises error if there are no files given to replace" do
-    expect {
+    expect do
       described_class.inreplace [], "d", "f"
-    }.to raise_error(Utils::Inreplace::Error)
+    end.to raise_error(Utils::Inreplace::Error)
   end
 
   it "raises error if there is nothing to replace" do
-    expect {
+    expect do
       described_class.inreplace file.path, "d", "f"
-    }.to raise_error(Utils::Inreplace::Error)
+    end.to raise_error(Utils::Inreplace::Error)
   end
 
   it "raises error if there is nothing to replace in block form" do
-    expect {
+    expect do
       described_class.inreplace(file.path) do |s|
         s.gsub!("d", "f") # rubocop:disable Performance/StringReplacement
       end
-    }.to raise_error(Utils::Inreplace::Error)
+    end.to raise_error(Utils::Inreplace::Error)
   end
 
   it "raises error if there is no make variables to replace" do
-    expect {
+    expect do
       described_class.inreplace(file.path) do |s|
         s.change_make_var! "VAR", "value"
         s.remove_make_var! "VAR2"
       end
-    }.to raise_error(Utils::Inreplace::Error)
+    end.to raise_error(Utils::Inreplace::Error)
   end
 
   describe "#inreplace_pairs" do
     it "raises error if there is no old value" do
-      expect {
+      expect do
         described_class.inreplace_pairs(file.path, [[nil, "f"]])
-      }.to raise_error(Utils::Inreplace::Error)
+      end.to raise_error(Utils::Inreplace::Error)
     end
   end
 end

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -94,9 +94,9 @@ describe Utils do
     end
 
     it "raises an error if the command fails" do
-      expect {
+      expect do
         described_class.safe_popen_write("grep", "success") { |pipe| pipe.write "failure\n" }
-      }.to raise_error(ErrorDuringExecution)
+      end.to raise_error(ErrorDuringExecution)
       expect($CHILD_STATUS).to be_a_failure
     end
   end

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -282,15 +282,15 @@ describe SPDX do
     let(:mit_forbidden) { { "MIT" => described_class.license_version_info("MIT") } }
     let(:epl_1_forbidden) { { "EPL-1.0" => described_class.license_version_info("EPL-1.0") } }
     let(:epl_1_plus_forbidden) { { "EPL-1.0+" => described_class.license_version_info("EPL-1.0+") } }
-    let(:multiple_forbidden) {
+    let(:multiple_forbidden) do
       {
         "MIT"  => described_class.license_version_info("MIT"),
         "0BSD" => described_class.license_version_info("0BSD"),
       }
-    }
+    end
     let(:any_of_license) { { any_of: ["MIT", "0BSD"] } }
     let(:all_of_license) { { all_of: ["MIT", "0BSD"] } }
-    let(:nested_licenses) {
+    let(:nested_licenses) do
       {
         any_of: [
           "MIT",
@@ -298,7 +298,7 @@ describe SPDX do
           { any_of: ["MIT", "0BSD"] },
         ],
       }
-    }
+    end
     let(:license_exception) { { "MIT" => { with: "LLVM-exception" } } }
 
     it "allows installation with no forbidden licenses" do

--- a/Library/Homebrew/test/utils/user_spec.rb
+++ b/Library/Homebrew/test/utils/user_spec.rb
@@ -16,23 +16,23 @@ describe User do
     end
 
     context "when the current user is in a console session" do
-      let(:who_output) {
+      let(:who_output) do
         <<~EOS
           #{ENV.fetch("USER")}   console  Oct  1 11:23
           #{ENV.fetch("USER")}   ttys001  Oct  1 11:25
         EOS
-      }
+      end
 
       its(:gui?) { is_expected.to be true }
     end
 
     context "when the current user is not in a console session" do
-      let(:who_output) {
+      let(:who_output) do
         <<~EOS
           #{ENV.fetch("USER")}   ttys001  Oct  1 11:25
           fake_user              ttys002  Oct  1 11:27
         EOS
-      }
+      end
 
       its(:gui?) { is_expected.to be false }
     end

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -61,7 +61,7 @@ describe Utils do
 
   describe ".underscore" do
     # commented out entries require acronyms inflections
-    let(:words) {
+    let(:words) do
       [
         ["API", "api"],
         ["APIController", "api_controller"],
@@ -86,7 +86,7 @@ describe Utils do
         ["Restfully", "restfully"],
         ["RoRails", "ro_rails"],
       ]
-    }
+    end
 
     it "converts strings to underscore case" do
       words.each do |camel, under|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The final part of #14685, maybe?!
- This will seem like a lot, but I feel like `EnforcedStyle: braces_for_chaining` config makes the most sense. It preserves a lot of the RSpec syntax we're used to in `expect {}` blocks that are chained to other things - quite a lot of them - and uses normal block syntax for non-chained methods (as the name suggests - I probably didn't need to write that down).
