### PR TITLE
Make `str` variable names longer

### DIFF
--- a/Library/Homebrew/formula_text_auditor.rb
+++ b/Library/Homebrew/formula_text_auditor.rb
@@ -23,8 +23,8 @@ module Homebrew
       other =~ @text
     end
 
-    def include?(str)
-      @text.include? str
+    def include?(string)
+      @text.include? string
     end
 
     def to_s

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -50,14 +50,14 @@ module Formatter
   # so we always wrap one word before an option.
   # @see https://github.com/Homebrew/brew/pull/12672
   # @see https://macromates.com/blog/2006/wrapping-text-with-regular-expressions/
-  def format_help_text(str, width: 172)
+  def format_help_text(string, width: 172)
     desc = OPTION_DESC_WIDTH
     indent = width - desc
-    str.gsub(/(?<=\S) *\n(?=\S)/, " ")
-       .gsub(/([`>)\]]:) /, "\\1\n    ")
-       .gsub(/^( +-.+  +(?=\S.{#{desc}}))(.{1,#{desc}})( +|$)(?!-)\n?/, "\\1\\2\n#{" " * indent}")
-       .gsub(/^( {#{indent}}(?=\S.{#{desc}}))(.{1,#{desc}})( +|$)(?!-)\n?/, "\\1\\2\n#{" " * indent}")
-       .gsub(/(.{1,#{width}})( +|$)(?!-)\n?/, "\\1\n")
+    string.gsub(/(?<=\S) *\n(?=\S)/, " ")
+          .gsub(/([`>)\]]:) /, "\\1\n    ")
+          .gsub(/^( +-.+  +(?=\S.{#{desc}}))(.{1,#{desc}})( +|$)(?!-)\n?/, "\\1\\2\n#{" " * indent}")
+          .gsub(/^( {#{indent}}(?=\S.{#{desc}}))(.{1,#{desc}})( +|$)(?!-)\n?/, "\\1\\2\n#{" " * indent}")
+          .gsub(/(.{1,#{width}})( +|$)(?!-)\n?/, "\\1\n")
   end
 
   def url(string)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Three characters is the RuboCop limit for parameter names, but more descriptive is good.
- Requested in https://github.com/Homebrew/brew/pull/14922#pullrequestreview-1330848594, but the automerge was too quick for me to get to it.
