### PR TITLE
include `--cask` or `--formula` in `brew info --github` suggestion

### DIFF
--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -54,7 +54,9 @@ module Homebrew
 
     if Homebrew.failed?
       $stderr.puts "The name may be wrong, or the tap hasn't been tapped. Instead try:"
-      $stderr.puts "  brew info --github #{args.named.join(" ")}"
+      treat_as = "--cask " if args.cask?
+      treat_as = "--formula " if args.formula?
+      $stderr.puts "  brew info --github #{treat_as}#{args.named.join(" ")}"
       return
     end
 


### PR DESCRIPTION
If `brew cat --cask/--formula` fails, suggest `brew info --github --cask/--formula` instead of just `brew info --github`

Previous discussion/PR #14902

@muescha @MikeMcQuaid FYI