### PR TITLE
github_packages: additional retry of skopeo copy with backoff

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -407,7 +407,7 @@ class GitHubPackages
                      "org.opencontainers.image.ref.name" => version_rebuild)
 
     puts
-    args = ["copy", "--retry-times=5", "--all", "oci:#{root}", image_uri.to_s]
+    args = ["copy", "--retry-times=2", "--all", "oci:#{root}", image_uri.to_s]
     if dry_run
       puts "#{skopeo} #{args.join(" ")} --dest-creds=#{user}:$HOMEBREW_GITHUB_PACKAGES_TOKEN"
     else


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I hope this isn't going too far. Another failures (that aren't handled by `skopeo`, see https://github.com/Homebrew/homebrew-core/pull/125152#issuecomment-1461207051) have been seen recently:
https://github.com/Homebrew/homebrew-core/actions/runs/4370167585/jobs/7644794677
https://github.com/Homebrew/homebrew-core/actions/runs/4370971036/jobs/7646393927