### PR TITLE
Cleanup irb history file in tests

### DIFF
--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -6,19 +6,29 @@ require "cmd/shared_examples/args_parse"
 describe "brew irb" do
   it_behaves_like "parseable arguments"
 
-  it "starts an interactive Homebrew shell session", :integration_test do
-    setup_test_formula "testball"
+  describe "integration test" do
+    let(:history_file) { Pathname("#{Dir.home}/.brew_irb_history") }
 
-    irb_test = HOMEBREW_TEMP/"irb-test.rb"
-    irb_test.write <<~RUBY
-      "testball".f
-      :testball.f
-      exit
-    RUBY
+    after do
+      history_file.delete if history_file.exist?
+    end
 
-    expect { brew "irb", irb_test }
-      .to output(/Interactive Homebrew Shell/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
+    it "starts an interactive Homebrew shell session", :integration_test do
+      setup_test_formula "testball"
+
+      irb_test = HOMEBREW_TEMP/"irb-test.rb"
+      irb_test.write <<~RUBY
+        "testball".f
+        :testball.f
+        exit
+      RUBY
+
+      expect { brew "irb", irb_test }
+        .to output(/Interactive Homebrew Shell/).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+
+      expect(history_file).to exist
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This was caused by the irb spec which I forgot to update while working on this command a few days ago. Note that $HOME is set during the test setup so will always be correct.

### Before
```
/u/l/Homebrew (master|✔) $ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
/u/l/Homebrew (master|✔) $ brew tests --only=dev-cmd/irb
Randomized with seed 26142
1 process for 1 spec, ~ 1 spec per process
..
Took 5 seconds
/u/l/Homebrew (master|✔) $ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        Library/Homebrew/test/.brew_irb_history

nothing added to commit but untracked files present (use "git add" to track)
```

###  After
```
/u/l/Homebrew (master|✔) $ git checkout fix-irb-test
Switched to branch 'fix-irb-test'
/u/l/Homebrew (fix-irb-test|✔) $ brew tests --only=dev-cmd/irb
Randomized with seed 26186
1 process for 1 spec, ~ 1 spec per process
..
Took 5 seconds
/u/l/Homebrew (fix-irb-test|✔) $ git status
On branch fix-irb-test
nothing to commit, working tree clean
```