### PR TITLE
brew.sh: auto-update on outdated.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -271,6 +271,7 @@ auto-update() {
 
   AUTO_UPDATE_COMMANDS=(
     install
+    outdated
     upgrade
     bump-formula-pr
     bump-cask-pr


### PR DESCRIPTION
It's always been a bit weird that `brew outdated; brew upgrade` can display nothing outdated but then auto-update and proceed to upgrade.