### PR TITLE
Auto-update from the API less often

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -58,7 +58,8 @@ module Homebrew
 
       skip_download = target.exist? &&
                       !target.empty? &&
-                      (Homebrew::EnvConfig.no_auto_update? ||
+                      (!Homebrew.auto_update_command? ||
+                        Homebrew::EnvConfig.no_auto_update? ||
                       ((Time.now - Homebrew::EnvConfig.api_auto_update_secs.to_i) < target.mtime))
       skip_download ||= Homebrew.running_as_root_but_not_owned_by_root?
 

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -269,17 +269,7 @@ auto-update() {
   # If we've checked for updates, we don't need to check again.
   export HOMEBREW_AUTO_UPDATE_CHECKED="1"
 
-  AUTO_UPDATE_COMMANDS=(
-    install
-    upgrade
-    bump-formula-pr
-    bump-cask-pr
-    bundle
-    release
-  )
-
-  if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_COMMANDS[@]}" ||
-     [[ "${HOMEBREW_COMMAND}" == "tap" && "${HOMEBREW_ARG_COUNT}" -gt 1 ]]
+  if [[ -n "${HOMEBREW_AUTO_UPDATE_COMMAND}" ]]
   then
     export HOMEBREW_AUTO_UPDATING="1"
 
@@ -814,6 +804,22 @@ then
 
   # Don't allow non-developers to customise Ruby warnings.
   unset HOMEBREW_RUBY_WARNINGS
+fi
+
+# Check for commands that should call `brew update --auto-update` first.
+AUTO_UPDATE_COMMANDS=(
+  install
+  outdated
+  upgrade
+  bump-formula-pr
+  bump-cask-pr
+  bundle
+  release
+)
+if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_COMMANDS[@]}" ||
+   [[ "${HOMEBREW_COMMAND}" == "tap" && "${HOMEBREW_ARG_COUNT}" -gt 1 ]]
+then
+  export HOMEBREW_AUTO_UPDATE_COMMAND="1"
 fi
 
 # Disable Ruby options we don't need.

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -124,6 +124,10 @@ module Homebrew
     def running_as_root_but_not_owned_by_root?
       running_as_root? && !owner_uid.zero?
     end
+
+    def auto_update_command?
+      ENV.fetch("HOMEBREW_AUTO_UPDATE_COMMAND", false).present?
+    end
   end
 end
 


### PR DESCRIPTION
Instead of doing so literally whenever we query for a formula, Instead do so only when we're in an auto-updateable command.

This better fits the existing behaviour while still updating when it's most important to do so.

Fixes https://github.com/Homebrew/brew/issues/14901