### PR TITLE
rubocop: Further trim `Naming/MethodParameterName` allowlist

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -191,7 +191,6 @@ Naming/MethodParameterName:
     [
       "a",
       "b",
-      "f",
       "o",
       "pr",
     ]

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -191,8 +191,6 @@ Naming/MethodParameterName:
     [
       "a",
       "b",
-      "c1",
-      "c2",
       "e",
       "f",
       "o",

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -189,7 +189,6 @@ Naming/MethodParameterName:
       - AllowedNames
   AllowedNames:
     [
-      "o",
       "pr",
     ]
 

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -191,7 +191,6 @@ Naming/MethodParameterName:
     [
       "a",
       "b",
-      "e",
       "f",
       "o",
       "pr",

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -189,8 +189,6 @@ Naming/MethodParameterName:
       - AllowedNames
   AllowedNames:
     [
-      "a",
-      "b",
       "o",
       "pr",
     ]

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -189,7 +189,7 @@ Naming/MethodParameterName:
       - AllowedNames
   AllowedNames:
     [
-      "pr",
+      "pr", # TODO: Remove if https://github.com/rubocop/rubocop/pull/11690 is merged or we change the variable names.
     ]
 
 # Both styles are used depending on context,

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -198,19 +198,19 @@ class Build
     keg.detect_cxx_stdlibs(skip_executables: true)
   end
 
-  def fixopt(f)
-    path = if f.linked_keg.directory? && f.linked_keg.symlink?
-      f.linked_keg.resolved_path
-    elsif f.prefix.directory?
-      f.prefix
-    elsif (kids = f.rack.children).size == 1 && kids.first.directory?
+  def fixopt(formula)
+    path = if formula.linked_keg.directory? && formula.linked_keg.symlink?
+      formula.linked_keg.resolved_path
+    elsif formula.prefix.directory?
+      formula.prefix
+    elsif (kids = formula.rack.children).size == 1 && kids.first.directory?
       kids.first
     else
       raise
     end
     Keg.new(path).optlink(verbose: args.verbose?)
   rescue
-    raise "#{f.opt_prefix} not present or broken\nPlease reinstall #{f.full_name}. Sorry :("
+    raise "#{formula.opt_prefix} not present or broken\nPlease reinstall #{formula.full_name}. Sorry :("
   end
 end
 

--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -68,21 +68,21 @@ class BuildEnvironment
     KEYS & env.keys
   end
 
-  sig { params(env: T::Hash[String, T.nilable(T.any(String, Pathname))], f: IO).void }
-  def self.dump(env, f = $stdout)
+  sig { params(env: T::Hash[String, T.nilable(T.any(String, Pathname))], out: IO).void }
+  def self.dump(env, out = $stdout)
     keys = self.keys(env)
     keys -= %w[CC CXX OBJC OBJCXX] if env["CC"] == env["HOMEBREW_CC"]
 
     keys.each do |key|
       value = env.fetch(key)
 
-      s = +"#{key}: #{value}"
+      string = +"#{key}: #{value}"
       case key
       when "CC", "CXX", "LD"
-        s << " => #{Pathname.new(value).realpath}" if value.present? && File.symlink?(value)
+        string << " => #{Pathname.new(value).realpath}" if value.present? && File.symlink?(value)
       end
-      s.freeze
-      f.puts s
+      string.freeze
+      out.puts string
     end
   end
 end

--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -18,9 +18,9 @@ class BuildEnvironment
     self
   end
 
-  sig { params(o: Symbol).returns(T.self_type) }
-  def <<(o)
-    @settings << o
+  sig { params(option: Symbol).returns(T.self_type) }
+  def <<(option)
+    @settings << option
     self
   end
 

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -155,21 +155,21 @@ module Homebrew
       @cleaned_up_paths = Set.new
     end
 
-    def self.install_formula_clean!(f, dry_run: false)
+    def self.install_formula_clean!(formula, dry_run: false)
       return if Homebrew::EnvConfig.no_install_cleanup?
-      return unless f.latest_version_installed?
-      return if skip_clean_formula?(f)
+      return unless formula.latest_version_installed?
+      return if skip_clean_formula?(formula)
 
       if dry_run
-        ohai "Would run `brew cleanup #{f}`"
+        ohai "Would run `brew cleanup #{formula}`"
       else
-        ohai "Running `brew cleanup #{f}`..."
+        ohai "Running `brew cleanup #{formula}`..."
       end
 
       puts_no_install_cleanup_disable_message_if_not_already!
       return if dry_run
 
-      Cleanup.new.cleanup_formula(f)
+      Cleanup.new.cleanup_formula(formula)
     end
 
     def self.puts_no_install_cleanup_disable_message
@@ -187,11 +187,11 @@ module Homebrew
       @puts_no_install_cleanup_disable_message_if_not_already = true
     end
 
-    def self.skip_clean_formula?(f)
+    def self.skip_clean_formula?(formula)
       return false if Homebrew::EnvConfig.no_cleanup_formulae.blank?
 
       @skip_clean_formulae ||= Homebrew::EnvConfig.no_cleanup_formulae.split(",")
-      @skip_clean_formulae.include?(f.name) || (@skip_clean_formulae & f.aliases).present?
+      @skip_clean_formulae.include?(formula.name) || (@skip_clean_formulae & formula.aliases).present?
     end
 
     def self.periodic_clean_due?

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -249,11 +249,11 @@ module Homebrew
     "digraph {\n#{dot_code}\n}"
   end
 
-  def self.graph_deps(f, dep_graph:, recursive:, args:)
-    return if dep_graph.key?(f)
+  def self.graph_deps(formula, dep_graph:, recursive:, args:)
+    return if dep_graph.key?(formula)
 
-    dependables = dependables(f, args: args)
-    dep_graph[f] = dependables
+    dependables = dependables(formula, args: args)
+    dep_graph[formula] = dependables
     return unless recursive
 
     dependables.each do |dep|
@@ -274,19 +274,19 @@ module Homebrew
     end
   end
 
-  def self.dependables(f, args:)
+  def self.dependables(formula, args:)
     includes, ignores = args_includes_ignores(args)
-    deps = @use_runtime_dependencies ? f.runtime_dependencies : f.deps
+    deps = @use_runtime_dependencies ? formula.runtime_dependencies : formula.deps
     deps = reject_ignores(deps, ignores, includes)
-    reqs = reject_ignores(f.requirements, ignores, includes) if args.include_requirements?
+    reqs = reject_ignores(formula.requirements, ignores, includes) if args.include_requirements?
     reqs ||= []
     reqs + deps
   end
 
-  def self.recursive_deps_tree(f, dep_stack:, prefix:, recursive:, args:)
-    dependables = dependables(f, args: args)
+  def self.recursive_deps_tree(formula, dep_stack:, prefix:, recursive:, args:)
+    dependables = dependables(formula, args: args)
     max = dependables.length - 1
-    dep_stack.push f.name
+    dep_stack.push formula.name
     dependables.each_with_index do |dep, i|
       tree_lines = if i == max
         "└──"

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -138,10 +138,10 @@ module Homebrew
     opoo "Resource #{resource.name} reports different sha256: #{e.expected}"
   end
 
-  def self.fetch_formula(f, args:)
-    fetch_fetchable f, args: args
+  def self.fetch_formula(formula, args:)
+    fetch_fetchable formula, args: args
   rescue ChecksumMismatchError => e
-    retry if retry_fetch?(f, args: args)
+    retry if retry_fetch?(formula, args: args)
     opoo "Formula reports different sha256: #{e.expected}"
   end
 
@@ -159,18 +159,18 @@ module Homebrew
     Homebrew.failed = true
   end
 
-  def self.retry_fetch?(f, args:)
+  def self.retry_fetch?(formula, args:)
     @fetch_tries ||= Hash.new { |h, k| h[k] = 1 }
-    if args.retry? && (@fetch_tries[f] < FETCH_MAX_TRIES)
-      wait = 2 ** @fetch_tries[f]
-      remaining = FETCH_MAX_TRIES - @fetch_tries[f]
+    if args.retry? && (@fetch_tries[formula] < FETCH_MAX_TRIES)
+      wait = 2 ** @fetch_tries[formula]
+      remaining = FETCH_MAX_TRIES - @fetch_tries[formula]
       what = Utils.pluralize("tr", remaining, plural: "ies", singular: "y")
 
       ohai "Retrying download in #{wait}s... (#{remaining} #{what} left)"
       sleep wait
 
-      f.clear_cache
-      @fetch_tries[f] += 1
+      formula.clear_cache
+      @fetch_tries[formula] += 1
       true
     else
       Homebrew.failed = true
@@ -178,15 +178,15 @@ module Homebrew
     end
   end
 
-  def self.fetch_fetchable(f, args:)
-    f.clear_cache if args.force?
+  def self.fetch_fetchable(formula, args:)
+    formula.clear_cache if args.force?
 
-    already_fetched = f.cached_download.exist?
+    already_fetched = formula.cached_download.exist?
 
     begin
-      download = f.fetch(verify_download_integrity: false)
+      download = formula.fetch(verify_download_integrity: false)
     rescue DownloadError
-      retry if retry_fetch?(f, args: args)
+      retry if retry_fetch?(formula, args: args)
       raise
     end
 
@@ -195,6 +195,6 @@ module Homebrew
     puts "Downloaded to: #{download}" unless already_fetched
     puts "SHA256: #{download.sha256}"
 
-    f.verify_download_integrity(download)
+    formula.verify_download_integrity(download)
   end
 end

--- a/Library/Homebrew/debrew.rb
+++ b/Library/Homebrew/debrew.rb
@@ -98,22 +98,22 @@ module Debrew
     end
   end
 
-  def self.debug(e)
-    raise(e) if !active? || !debugged_exceptions.add?(e) || !try_lock
+  def self.debug(exception)
+    raise(exception) if !active? || !debugged_exceptions.add?(exception) || !try_lock
 
     begin
-      puts e.backtrace.first.to_s
-      puts Formatter.error(e, label: e.class.name)
+      puts exception.backtrace.first.to_s
+      puts Formatter.error(exception, label: exception.class.name)
 
       loop do
         Menu.choose do |menu|
           menu.prompt = "Choose an action: "
 
           menu.choice(:raise) { raise(e) }
-          menu.choice(:ignore) { return :ignore } if e.is_a?(Ignorable::ExceptionMixin)
-          menu.choice(:backtrace) { puts e.backtrace }
+          menu.choice(:ignore) { return :ignore } if exception.is_a?(Ignorable::ExceptionMixin)
+          menu.choice(:backtrace) { puts exception.backtrace }
 
-          if e.is_a?(Ignorable::ExceptionMixin)
+          if exception.is_a?(Ignorable::ExceptionMixin)
             menu.choice(:irb) do
               puts "When you exit this IRB session, execution will continue."
               set_trace_func proc { |event, _, _, id, binding, klass|

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -114,11 +114,11 @@ module Homebrew
     end
   end
 
-  def retry_test?(f, args:)
+  def retry_test?(formula, args:)
     @test_failed ||= Set.new
-    if args.retry? && @test_failed.add?(f)
-      oh1 "Testing #{f.full_name} (again)"
-      f.clear_cache
+    if args.retry? && @test_failed.add?(formula)
+      oh1 "Testing #{formula.full_name} (again)"
+      formula.clear_cache
       ENV["RUST_BACKTRACE"] = "full"
       true
     else

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -569,8 +569,8 @@ module Homebrew
         EOS
       end
 
-      def __check_linked_brew(f)
-        f.installed_prefixes.each do |prefix|
+      def __check_linked_brew(formula)
+        formula.installed_prefixes.each do |prefix|
           prefix.find do |src|
             next if src == prefix
 

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -162,33 +162,33 @@ module Kernel
     odeprecated(method, replacement, options)
   end
 
-  def pretty_installed(f)
+  def pretty_installed(formula)
     if !$stdout.tty?
-      f.to_s
+      formula.to_s
     elsif Homebrew::EnvConfig.no_emoji?
-      Formatter.success("#{Tty.bold}#{f} (installed)#{Tty.reset}")
+      Formatter.success("#{Tty.bold}#{formula} (installed)#{Tty.reset}")
     else
-      "#{Tty.bold}#{f} #{Formatter.success("✔")}#{Tty.reset}"
+      "#{Tty.bold}#{formula} #{Formatter.success("✔")}#{Tty.reset}"
     end
   end
 
-  def pretty_outdated(f)
+  def pretty_outdated(formula)
     if !$stdout.tty?
-      f.to_s
+      formula.to_s
     elsif Homebrew::EnvConfig.no_emoji?
-      Formatter.error("#{Tty.bold}#{f} (outdated)#{Tty.reset}")
+      Formatter.error("#{Tty.bold}#{formula} (outdated)#{Tty.reset}")
     else
-      "#{Tty.bold}#{f} #{Formatter.warning("⚠")}#{Tty.reset}"
+      "#{Tty.bold}#{formula} #{Formatter.warning("⚠")}#{Tty.reset}"
     end
   end
 
-  def pretty_uninstalled(f)
+  def pretty_uninstalled(formula)
     if !$stdout.tty?
-      f.to_s
+      formula.to_s
     elsif Homebrew::EnvConfig.no_emoji?
-      Formatter.error("#{Tty.bold}#{f} (uninstalled)#{Tty.reset}")
+      Formatter.error("#{Tty.bold}#{formula} (uninstalled)#{Tty.reset}")
     else
-      "#{Tty.bold}#{f} #{Formatter.error("✘")}#{Tty.reset}"
+      "#{Tty.bold}#{formula} #{Formatter.error("✘")}#{Tty.reset}"
     end
   end
 
@@ -209,10 +209,10 @@ module Kernel
     res.freeze
   end
 
-  def interactive_shell(f = nil)
-    unless f.nil?
-      ENV["HOMEBREW_DEBUG_PREFIX"] = f.prefix
-      ENV["HOMEBREW_DEBUG_INSTALL"] = f.full_name
+  def interactive_shell(formula = nil)
+    unless formula.nil?
+      ENV["HOMEBREW_DEBUG_PREFIX"] = formula.prefix
+      ENV["HOMEBREW_DEBUG_INSTALL"] = formula.full_name
     end
 
     if Utils::Shell.preferred == :zsh && (home = Dir.home).start_with?(HOMEBREW_TEMP.resolved_path.to_s)

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -38,12 +38,12 @@ module SystemConfig
       @clt ||= MacOS::CLT.version if MacOS::CLT.installed?
     end
 
-    def dump_verbose_config(f = $stdout)
-      dump_generic_verbose_config(f)
-      f.puts "macOS: #{MacOS.full_version}-#{kernel}"
-      f.puts "CLT: #{clt || "N/A"}"
-      f.puts "Xcode: #{xcode || "N/A"}"
-      f.puts "Rosetta 2: #{Hardware::CPU.in_rosetta2?}" if Hardware::CPU.physical_cpu_arm64?
+    def dump_verbose_config(out = $stdout)
+      dump_generic_verbose_config(out)
+      out.puts "macOS: #{MacOS.full_version}-#{kernel}"
+      out.puts "CLT: #{clt || "N/A"}"
+      out.puts "Xcode: #{xcode || "N/A"}"
+      out.puts "Rosetta 2: #{Hardware::CPU.in_rosetta2?}" if Hardware::CPU.physical_cpu_arm64?
     end
   end
 end

--- a/Library/Homebrew/fetch.rb
+++ b/Library/Homebrew/fetch.rb
@@ -6,16 +6,16 @@ module Homebrew
   module Fetch
     extend T::Sig
 
-    sig { params(f: Formula, args: CLI::Args).returns(T::Boolean) }
-    def fetch_bottle?(f, args:)
-      bottle = f.bottle
+    sig { params(formula: Formula, args: CLI::Args).returns(T::Boolean) }
+    def fetch_bottle?(formula, args:)
+      bottle = formula.bottle
 
       return true if args.force_bottle? && bottle.present?
-      return true if args.bottle_tag.present? && f.bottled?(args.bottle_tag)
+      return true if args.bottle_tag.present? && formula.bottled?(args.bottle_tag)
 
       bottle.present? &&
-        f.pour_bottle? &&
-        args.build_from_source_formulae.exclude?(f.full_name) &&
+        formula.pour_bottle? &&
+        args.build_from_source_formulae.exclude?(formula.full_name) &&
         bottle.compatible_locations?
     end
   end

--- a/Library/Homebrew/formula_pin.rb
+++ b/Library/Homebrew/formula_pin.rb
@@ -7,22 +7,22 @@ require "keg"
 #
 # @api private
 class FormulaPin
-  def initialize(f)
-    @f = f
+  def initialize(formula)
+    @formula = formula
   end
 
   def path
-    HOMEBREW_PINNED_KEGS/@f.name
+    HOMEBREW_PINNED_KEGS/@formula.name
   end
 
   def pin_at(version)
     HOMEBREW_PINNED_KEGS.mkpath
-    version_path = @f.rack/version
+    version_path = @formula.rack/version
     path.make_relative_symlink(version_path) if !pinned? && version_path.exist?
   end
 
   def pin
-    pin_at(@f.installed_kegs.map(&:version).max)
+    pin_at(@formula.installed_kegs.map(&:version).max)
   end
 
   def unpin
@@ -35,7 +35,7 @@ class FormulaPin
   end
 
   def pinnable?
-    !@f.installed_prefixes.empty?
+    !@formula.installed_prefixes.empty?
   end
 
   def pinned_version

--- a/Library/Homebrew/options.rb
+++ b/Library/Homebrew/options.rb
@@ -139,8 +139,8 @@ class Options
     map(&:flag)
   end
 
-  def include?(o)
-    any? { |opt| opt == o || opt.name == o || opt.flag == o }
+  def include?(option)
+    any? { |opt| opt == option || opt.name == option || opt.flag == option }
   end
 
   alias to_ary to_a

--- a/Library/Homebrew/options.rb
+++ b/Library/Homebrew/options.rb
@@ -155,10 +155,10 @@ class Options
     "#<#{self.class.name}: #{to_a.inspect}>"
   end
 
-  def self.dump_for_formula(f)
-    f.options.sort_by(&:flag).each do |opt|
+  def self.dump_for_formula(formula)
+    formula.options.sort_by(&:flag).each do |opt|
       puts "#{opt.flag}\n\t#{opt.description}"
     end
-    puts "--HEAD\n\tInstall HEAD version" if f.head
+    puts "--HEAD\n\tInstall HEAD version" if formula.head
   end
 end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -117,11 +117,11 @@ module OS
       sdk_locator.sdk_if_applicable(version)
     end
 
-    def sdk_for_formula(f, version = nil, check_only_runtime_requirements: false)
+    def sdk_for_formula(formula, version = nil, check_only_runtime_requirements: false)
       # If the formula requires Xcode, don't return the CLT SDK
       # If check_only_runtime_requirements is true, don't necessarily return the
       # Xcode SDK if the XcodeRequirement is only a build or test requirement.
-      return Xcode.sdk if f.requirements.any? do |req|
+      return Xcode.sdk if formula.requirements.any? do |req|
         next false unless req.is_a? XcodeRequirement
         next false if check_only_runtime_requirements && req.build? && !req.test?
 

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -214,13 +214,13 @@ module RuboCop
         end
 
         # Method to report and correct component precedence violations.
-        def component_problem(c1, c2)
+        def component_problem(component1, component2)
           return if tap_style_exception? :components_order_exceptions
 
-          problem "`#{format_component(c1)}` (line #{line_number(c1)}) " \
-                  "should be put before `#{format_component(c2)}` " \
-                  "(line #{line_number(c2)})" do |corrector|
-            reorder_components(corrector, c1, c2)
+          problem "`#{format_component(component1)}` (line #{line_number(component1)}) " \
+                  "should be put before `#{format_component(component2)}` " \
+                  "(line #{line_number(component2)})" do |corrector|
+            reorder_components(corrector, component1, component2)
           end
         end
 

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -139,43 +139,43 @@ module SystemConfig
       end
     end
 
-    def core_tap_config(f = $stdout)
+    def core_tap_config(out = $stdout)
       if CoreTap.instance.installed?
-        f.puts "Core tap origin: #{core_tap_origin}"
-        f.puts "Core tap HEAD: #{core_tap_head}"
-        f.puts "Core tap last commit: #{core_tap_last_commit}"
-        f.puts "Core tap branch: #{core_tap_branch}"
+        out.puts "Core tap origin: #{core_tap_origin}"
+        out.puts "Core tap HEAD: #{core_tap_head}"
+        out.puts "Core tap last commit: #{core_tap_last_commit}"
+        out.puts "Core tap branch: #{core_tap_branch}"
       end
 
       if (formula_json = Homebrew::API::HOMEBREW_CACHE_API/"formula.jws.json") && formula_json.exist?
-        f.puts "Core tap JSON: #{formula_json.mtime.utc.strftime("%d %b %H:%M UTC")}"
+        out.puts "Core tap JSON: #{formula_json.mtime.utc.strftime("%d %b %H:%M UTC")}"
       elsif !CoreTap.instance.installed?
-        f.puts "Core tap: N/A"
+        out.puts "Core tap: N/A"
       end
     end
 
-    def homebrew_config(f = $stdout)
-      f.puts "HOMEBREW_VERSION: #{HOMEBREW_VERSION}"
-      f.puts "ORIGIN: #{origin}"
-      f.puts "HEAD: #{head}"
-      f.puts "Last commit: #{last_commit}"
+    def homebrew_config(out = $stdout)
+      out.puts "HOMEBREW_VERSION: #{HOMEBREW_VERSION}"
+      out.puts "ORIGIN: #{origin}"
+      out.puts "HEAD: #{head}"
+      out.puts "Last commit: #{last_commit}"
     end
 
-    def homebrew_env_config(f = $stdout)
-      f.puts "HOMEBREW_PREFIX: #{HOMEBREW_PREFIX}"
+    def homebrew_env_config(out = $stdout)
+      out.puts "HOMEBREW_PREFIX: #{HOMEBREW_PREFIX}"
       {
         HOMEBREW_REPOSITORY: Homebrew::DEFAULT_REPOSITORY,
         HOMEBREW_CELLAR:     Homebrew::DEFAULT_CELLAR,
       }.freeze.each do |key, default|
         value = Object.const_get(key)
-        f.puts "#{key}: #{value}" if value.to_s != default.to_s
+        out.puts "#{key}: #{value}" if value.to_s != default.to_s
       end
 
       Homebrew::EnvConfig::ENVS.each do |env, hash|
         method_name = Homebrew::EnvConfig.env_method_name(env, hash)
 
         if hash[:boolean]
-          f.puts "#{env}: set" if Homebrew::EnvConfig.send(method_name)
+          out.puts "#{env}: set" if Homebrew::EnvConfig.send(method_name)
           next
         end
 
@@ -184,26 +184,26 @@ module SystemConfig
         next if (default = hash[:default].presence) && value.to_s == default.to_s
 
         if ENV.sensitive?(env)
-          f.puts "#{env}: set"
+          out.puts "#{env}: set"
         else
-          f.puts "#{env}: #{value}"
+          out.puts "#{env}: #{value}"
         end
       end
-      f.puts "Homebrew Ruby: #{describe_homebrew_ruby}"
+      out.puts "Homebrew Ruby: #{describe_homebrew_ruby}"
     end
 
-    def host_software_config(f = $stdout)
-      f.puts "Clang: #{describe_clang}"
-      f.puts "Git: #{describe_git}"
-      f.puts "Curl: #{describe_curl}"
+    def host_software_config(out = $stdout)
+      out.puts "Clang: #{describe_clang}"
+      out.puts "Git: #{describe_git}"
+      out.puts "Curl: #{describe_curl}"
     end
 
-    def dump_verbose_config(f = $stdout)
-      homebrew_config(f)
-      core_tap_config(f)
-      homebrew_env_config(f)
-      f.puts hardware if hardware
-      host_software_config(f)
+    def dump_verbose_config(out = $stdout)
+      homebrew_config(out)
+      core_tap_config(out)
+      homebrew_env_config(out)
+      out.puts hardware if hardware
+      host_software_config(out)
     end
     alias dump_generic_verbose_config dump_verbose_config
   end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -143,37 +143,37 @@ class Tab < OpenStruct
 
   # Returns a {Tab} for an already installed formula,
   # or a fake one if the formula is not installed.
-  def self.for_formula(f)
+  def self.for_formula(formula)
     paths = []
 
-    paths << f.opt_prefix.resolved_path if f.opt_prefix.symlink? && f.opt_prefix.directory?
+    paths << formula.opt_prefix.resolved_path if formula.opt_prefix.symlink? && formula.opt_prefix.directory?
 
-    paths << f.linked_keg.resolved_path if f.linked_keg.symlink? && f.linked_keg.directory?
+    paths << formula.linked_keg.resolved_path if formula.linked_keg.symlink? && formula.linked_keg.directory?
 
-    if (dirs = f.installed_prefixes).length == 1
+    if (dirs = formula.installed_prefixes).length == 1
       paths << dirs.first
     end
 
-    paths << f.latest_installed_prefix
+    paths << formula.latest_installed_prefix
 
-    path = paths.map { |pn| pn/FILENAME }.find(&:file?)
+    path = paths.map { |pathname| pathname/FILENAME }.find(&:file?)
 
     if path
       tab = from_file(path)
-      used_options = remap_deprecated_options(f.deprecated_options, tab.used_options)
+      used_options = remap_deprecated_options(formula.deprecated_options, tab.used_options)
       tab.used_options = used_options.as_flags
     else
       # Formula is not installed. Return a fake tab.
       tab = empty
-      tab.unused_options = f.options.as_flags
+      tab.unused_options = formula.options.as_flags
       tab.source = {
-        "path"     => f.specified_path.to_s,
-        "tap"      => f.tap&.name,
-        "spec"     => f.active_spec_sym.to_s,
+        "path"     => formula.specified_path.to_s,
+        "tap"      => formula.tap&.name,
+        "spec"     => formula.active_spec_sym.to_s,
         "versions" => {
-          "stable"         => f.stable&.version.to_s,
-          "head"           => f.head&.version.to_s,
-          "version_scheme" => f.version_scheme,
+          "stable"         => formula.stable&.version.to_s,
+          "head"           => formula.head&.version.to_s,
+          "version_scheme" => formula.version_scheme,
         },
       }
     end

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -10,7 +10,7 @@ describe Caveats do
   let(:f) { formula { url "foo-1.0" } }
 
   specify "#f" do
-    expect(caveats.f).to eq(f)
+    expect(caveats.formula).to eq(f)
   end
 
   describe "#empty?" do

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -49,22 +49,22 @@ describe FormulaInstaller do
     expect(formula).not_to be_latest_version_installed
   end
 
-  def test_basic_formula_setup(f)
+  def test_basic_formula_setup(formula)
     # Test that things made it into the Keg
-    expect(f.bin).to be_a_directory
+    expect(formula.bin).to be_a_directory
 
-    expect(f.libexec).to be_a_directory
+    expect(formula.libexec).to be_a_directory
 
-    expect(f.prefix/"main.c").not_to exist
+    expect(formula.prefix/"main.c").not_to exist
 
     # Test that things made it into the Cellar
-    keg = Keg.new f.prefix
+    keg = Keg.new formula.prefix
     keg.link
 
     bin = HOMEBREW_PREFIX/"bin"
     expect(bin).to be_a_directory
 
-    expect(f.libexec).to be_a_directory
+    expect(formula.libexec).to be_a_directory
   end
 
   # This test wraps expect() calls in `test_basic_formula_setup`

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -423,13 +423,13 @@ module Homebrew
       end
     end
 
-    def depends_on(a, b)
-      if a.any_installed_keg
+    def depends_on(one, two)
+      if one.any_installed_keg
          &.runtime_dependencies
-         &.any? { |d| d["full_name"] == b.full_name }
+         &.any? { |dependency| dependency["full_name"] == two.full_name }
         1
       else
-        a <=> b
+        one <=> two
       end
     end
     private_class_method :depends_on

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -283,10 +283,10 @@ module Utils
         end
       end
 
-      def formula_output(f, args:)
+      def formula_output(formula, args:)
         return if Homebrew::EnvConfig.no_analytics? || Homebrew::EnvConfig.no_github_api?
 
-        json = Homebrew::API::Formula.fetch f.name
+        json = Homebrew::API::Formula.fetch formula.name
         return if json.blank? || json["analytics"].blank?
 
         get_analytics(json, args: args)

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -19,22 +19,22 @@ module Utils
                          arch:   HOMEBREW_PROCESSOR.downcase.to_sym)
       end
 
-      def built_as?(f)
-        return false unless f.latest_version_installed?
+      def built_as?(formula)
+        return false unless formula.latest_version_installed?
 
-        tab = Tab.for_keg(f.latest_installed_prefix)
+        tab = Tab.for_keg(formula.latest_installed_prefix)
         tab.built_as_bottle
       end
 
-      def file_outdated?(f, file)
+      def file_outdated?(formula, file)
         filename = file.basename.to_s
-        return false if f.bottle.blank?
+        return false if formula.bottle.blank?
 
         bottle_ext, bottle_tag, = extname_tag_rebuild(filename)
         return false if bottle_ext.blank?
         return false if bottle_tag != tag.to_s
 
-        bottle_url_ext, = extname_tag_rebuild(f.bottle.url)
+        bottle_url_ext, = extname_tag_rebuild(formula.bottle.url)
 
         bottle_ext && bottle_url_ext && bottle_ext != bottle_url_ext
       end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -653,9 +653,9 @@ class Version
 
   private
 
-  sig { params(a: Integer, b: Integer).returns(Integer) }
-  def max(a, b)
-    (a > b) ? a : b
+  sig { params(first: Integer, second: Integer).returns(Integer) }
+  def max(first, second)
+    (first > second) ? first : second
   end
 
   sig { returns(T::Array[Token]) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The most blast radius change here is "f" => "formula". I ran `brew typecheck` which caught some occurrences I hadn't picked up, I ran `brew tests` which caught some more, and I ran `brew style` which caught even more. Worth a second set of eyes though?