### PR TITLE
rubocop: Remove comment about RSpec from `Style/BlockDelimiters` config

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -324,7 +324,6 @@ Style/AutoResourceCleanup:
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
 
-# make rspec formatting more flexible
 Style/BlockDelimiters:
   BracesRequiredMethods:
     - "sig"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- We got rid of the RSpec-related excludes in #14920. I should have got rid of this comment too.
