### PR TITLE
Retry `curl` with HTTP/0.9.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -463,10 +463,13 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       url = url.sub(%r{^https?://#{GitHubPackages::URL_DOMAIN}/}o, "#{domain.chomp("/")}/")
     end
 
-    output, _, _status = curl_output(
+    output, error, status = curl_output(
       "--location", "--silent", "--head", "--request", "GET", url.to_s,
       timeout: timeout
     )
+
+    odebug "Failed to get headers for #{url}", "#{error}" unless status.success?
+
     parsed_output = parse_curl_output(output)
 
     lines = output.to_s.lines.map(&:chomp)

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -468,7 +468,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       timeout: timeout
     )
 
-    odebug "Failed to get headers for #{url}", "#{error}" unless status.success?
+    odebug "Failed to get headers for #{url}", error unless status.success?
 
     parsed_output = parse_curl_output(output)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Show errors when fetching headers in debug output.

Avoid this error:

```
curl: (1) Received HTTP/0.9 when not allowed
```

Fixes CI error in https://github.com/Homebrew/homebrew-cask/pull/142880.

Alternatively, trying with only `--head` first (as opposed to `--head --request GET` seems to also fix this.