### PR TITLE
Fix paths in bottled service files

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -392,6 +392,7 @@ module Homebrew
       begin
         keg.delete_pyc_files!
 
+        formula.service.replace_text(Dir.home, "$HOME") if formula.service?
         changed_files = keg.replace_locations_with_placeholders unless args.skip_relocation?
 
         Formula.clear_cache
@@ -483,6 +484,7 @@ module Homebrew
       ensure
         ignore_interrupts do
           original_tab&.write
+          formula.service.replace_text("$HOME", Dir.home) if formula.service?
           keg.replace_placeholders_with_locations changed_files unless args.skip_relocation?
         end
       end

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -497,5 +497,24 @@ module Homebrew
 
       timer + options.join("\n")
     end
+
+    # Replace text in-place in all service files.
+    sig { params(to_replace: String, replacement: String).void }
+    def replace_text(to_replace, replacement)
+      [
+        @formula.systemd_service_path,
+        @formula.systemd_timer_path,
+        @formula.launchd_service_path,
+      ].each do |service_path|
+        next unless service_path.exist?
+
+        service = service_path.read
+        next unless service.include?(to_replace)
+
+        service.gsub!(to_replace, replacement)
+        service_path.atomic_write(service)
+        service_path.chmod(0644)
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes #14925.

The basic idea here is to replace the home directory with the string `$HOME` when bottling and then replace it back again when pouring a bottle. This seemed like the simplest way to fix this bug.

This bug affects five formulae that use `Dir.home` in the service block.

```
/u/l/H/L/T/h/homebrew-core (master|✔) $ git grep 'working_dir Dir.home'
Formula/code-server.rb:    working_dir Dir.home
Formula/gitlab-runner.rb:    working_dir Dir.home
Formula/onedrive.rb:    working_dir Dir.home
```

```
Formula/minidlna.rb:    run [opt_sbin/"minidlnad", "-d", "-f", "#{Dir.home}/.config/minidlna/minidlna.conf",
Formula/minidlna.rb:         "-P", "#{Dir.home}/.config/minidlna/minidlna.pid"]
Formula/sleepwatcher.rb:    run [opt_sbin/"sleepwatcher", "-V", "-s", "#{Dir.home}/.sleep", "-w", "#{Dir.home}/.wakeup"]
```

I tested bottling and installing `gitlab-runner` locally and the fix worked for that case. The downside of this method though is that these five formulae will need to be rebottled.

I thought about adding a bottle test for this but I know that integration tests are precious and I wasn't sure it was worth grafting it onto the ones that already exist for that command.

We could also use `@@HOMEBREW_HOME@@` which fits more with what we do in `Keg::Relocate` for the placeholder instead of `$HOME` but I'm not sure it's necessary.  `$HOME` doesn't seem to be referenced in any service blocks right now on `homebrew/core`.
