### PR TITLE
Create .git/info dir if it doesn't exist

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1059,6 +1059,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
              args:  ["config", "core.sparseCheckout", "true"],
              chdir: cached_location
 
+    (git_dir/"info").mkpath
     (git_dir/"info"/"sparse-checkout").atomic_write("#{@only_path}\n")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Most of the time, a fresh repository init / clone includes a `.git/info` directory. However, if a custom git [template directory](https://git-scm.com/docs/git-init#_template_directory) is used, and that template doesn't include an `info` directory, the `.git/info` directory will be missing from the new repository checkout. That causes the sparse checkout download strategy to fail when it tries to write to `.git/info/sparse-checkout` (https://github.com/Homebrew/homebrew-cask-fonts/issues/6961). This change ensures the directory exists before writing that file.

I was able to reproduce the crash in https://github.com/Homebrew/homebrew-cask-fonts/issues/6961 by installing the font, deleting the `.git/info` directory, then reinstalling the font. After applying this change, I was unable to reproduce the crash.

Fixes https://github.com/Homebrew/homebrew-cask-fonts/issues/6961.