### PR TITLE
Retry if DMG BOM is empty.

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -27,6 +27,14 @@ module UnpackStrategy
       ]).freeze
       private_constant :DMG_METADATA
 
+      class Error < RuntimeError; end
+
+      class EmptyError < Error
+        def initialize(path)
+          super "BOM for path '#{path}' is empty."
+        end
+      end
+
       refine Pathname do
         extend T::Sig
 
@@ -61,7 +69,7 @@ module UnpackStrategy
 
           bom_paths = result.stdout.split("\0")
 
-          raise "BOM for path '#{self}' is empty." if bom_paths.empty?
+          raise EmptyError, self if bom_paths.empty?
 
           bom_paths
             .reject { |path| Pathname(path).dmg_metadata? }
@@ -123,11 +131,26 @@ module UnpackStrategy
 
       sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
       def extract_to_dir(unpack_dir, basename:, verbose:)
+        bom = begin
+          tries ||= 10
+
+          path.bom
+        rescue Bom::EmptyError => e
+          raise "#{e} No retries left." if (tries -= 1).zero?
+
+          sleep 1
+          retry
+        end
+
+        # TODO: Remove this if we actually ever hit this, i.e. if we actually found
+        #       some files after waiting longer for the DMG to be mounted.
+        raise "BOM for path '#{path}' was empty but retrying for #{10 - tries} seconds helped." if tries != 10
+
         Tempfile.open(["", ".bom"]) do |bomfile|
           bomfile.close
 
           Tempfile.open(["", ".list"]) do |filelist|
-            filelist.puts(path.bom)
+            filelist.puts(bom)
             filelist.close
 
             system_command! "mkbom",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This error is pretty much impossible to reproduce and only happens rarely on CI.

My naive guess is that mounting a DMG on CI is slow sometimes meaning we try finding files which aren't mounted yet. Not sure if that's actually how `hdiutil` works but we'll see.

Fail in both cases, so we actually see if retrying fixes this or not.
