### PR TITLE
Remove artifact debug output.

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -225,7 +225,6 @@ module Cask
       already_installed_artifacts = []
 
       odebug "Installing artifacts"
-      odebug "#{artifacts.length} #{::Utils.pluralize("artifact", artifacts.length)} defined", artifacts
 
       artifacts.each do |artifact|
         next unless artifact.respond_to?(:install_phase)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This output is way too verbose.

An artifact refers to a cask, which in turn refers to a tap, which in turn has a list of all casks_files in this tap.

When e.g. installing `font-sauce-code-pro-nerd-font` there are 28 artifacts, each of which prints every single font cask file path since these are contained in the `Font#inspect -> Cask#inspect -> Tap#inspect` output.