### PR TITLE
rubocop: Enable `Style/AccessorGrouping` and autofix offenses

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -301,10 +301,6 @@ Sorbet/StrictSigil:
   Include:
     - "**/*.rbi"
 
-# Conflicts with type signatures on `attr_*`s.
-Style/AccessorGrouping:
-  Enabled: false
-
 # Require &&/|| instead of and/or
 Style/AndOr:
   EnforcedStyle: always

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -18,9 +18,7 @@ module PyPI
   class Package
     extend T::Sig
 
-    attr_accessor :name
-    attr_accessor :extras
-    attr_accessor :version
+    attr_accessor :name, :extras, :version
 
     sig { params(package_string: String, is_url: T::Boolean).void }
     def initialize(package_string, is_url: false)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- With RuboCop 1.48.1 this no longer reports offenses and applies bugged autocorrections for `attr`s with Sorbet `sig`s, so we can enable it.
