### PR TITLE
Minor Kernel cleanup

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -351,16 +351,6 @@ module Kernel
     # rubocop:enable Style/GlobalVars
   end
 
-  sig { returns(String) }
-  def capture_stderr
-    old = $stderr
-    $stderr = StringIO.new
-    yield
-    $stderr.string
-  ensure
-    $stderr = old
-  end
-
   def redirect_stdout(file)
     out = $stdout.dup
     $stdout.reopen(file)
@@ -426,17 +416,6 @@ module Kernel
 
   def paths
     @paths ||= ORIGINAL_PATHS.uniq.map(&:to_s)
-  end
-
-  def parse_author!(author)
-    match_data = /^(?<name>[^<]+?)[ \t]*<(?<email>[^>]+?)>$/.match(author)
-    if match_data
-      name = match_data[:name]
-      email = match_data[:email]
-    end
-    raise UsageError, "Unable to parse name and email." if name.blank? && email.blank?
-
-    { name: name, email: email }
   end
 
   def disk_usage_readable(size_in_bytes)

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -182,14 +182,6 @@ describe "globally-scoped helper methods" do
     expect(which_editor).to eq("vemate -w")
   end
 
-  specify "#capture_stderr" do
-    err = capture_stderr do
-      $stderr.print "test"
-    end
-
-    expect(err).to eq("test")
-  end
-
   describe "#pretty_duration" do
     it "converts seconds to a human-readable string" do
       expect(pretty_duration(1)).to eq("1 second")

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -200,19 +200,6 @@ describe "globally-scoped helper methods" do
     end
   end
 
-  specify "#parse_author!" do
-    parse_error_msg = /Unable to parse name and email/
-
-    expect(parse_author!("John Doe <john.doe@example.com>"))
-      .to eq({ name: "John Doe", email: "john.doe@example.com" })
-    expect { parse_author!("") }
-      .to raise_error(parse_error_msg)
-    expect { parse_author!("John Doe") }
-      .to raise_error(parse_error_msg)
-    expect { parse_author!("<john.doe@example.com>") }
-      .to raise_error(parse_error_msg)
-  end
-
   specify "#disk_usage_readable" do
     expect(disk_usage_readable(1)).to eq("1B")
     expect(disk_usage_readable(1000)).to eq("1000B")

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -33,6 +33,19 @@ describe Utils do
     end
   end
 
+  specify ".parse_author!" do
+    parse_error_msg = /Unable to parse name and email/
+
+    expect(described_class.parse_author!("John Doe <john.doe@example.com>"))
+      .to eq({ name: "John Doe", email: "john.doe@example.com" })
+    expect { described_class.parse_author!("") }
+      .to raise_error(parse_error_msg)
+    expect { described_class.parse_author!("John Doe") }
+      .to raise_error(parse_error_msg)
+    expect { described_class.parse_author!("<john.doe@example.com>") }
+      .to raise_error(parse_error_msg)
+  end
+
   describe ".pluralize" do
     it "combines the stem with the default suffix based on the count" do
       expect(described_class.pluralize("foo", 0)).to eq("foos")

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -132,6 +132,18 @@ module Utils
     "#{stem}#{suffix}"
   end
 
+  sig { params(author: String).returns({ email: String, name: String }) }
+  def self.parse_author!(author)
+    match_data = /^(?<name>[^<]+?)[ \t]*<(?<email>[^>]+?)>$/.match(author)
+    if match_data
+      name = match_data[:name]
+      email = match_data[:email]
+    end
+    raise UsageError, "Unable to parse name and email." if name.blank? && email.blank?
+
+    { name: T.must(name), email: T.must(email) }
+  end
+
   # Makes an underscored, lowercase form from the expression in the string.
   #
   # Changes '::' to '/' to convert namespaces to paths.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
`capture_stderr` appears to be unused as of https://github.com/Homebrew/brew/pull/6534/files#diff-26cf784bce69883e02a2c58db0c9666d7e626c488675b48fe344e909fa34f5d7L23

The [two](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bottle.rb#L730) [instances](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/pr-pull.rb#L430) of `parse_author!` were already in the `Utils` namespace, so I relocated that method.