### PR TITLE
Use `install-info` from `texinfo` if not available in `/usr/bin`

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -344,13 +344,23 @@ class Pathname
   end
 
   # @private
+  def which_install_info
+    @which_install_info ||=
+      if File.executable?("/usr/bin/install-info")
+        "/usr/bin/install-info"
+      elsif Formula["texinfo"].any_version_installed?
+        Formula["texinfo"].opt_bin/"install-info"
+      end
+  end
+
+  # @private
   def install_info
-    quiet_system "/usr/bin/install-info", "--quiet", to_s, "#{dirname}/dir"
+    quiet_system(which_install_info, "--quiet", to_s, "#{dirname}/dir")
   end
 
   # @private
   def uninstall_info
-    quiet_system "/usr/bin/install-info", "--delete", "--quiet", to_s, "#{dirname}/dir"
+    quiet_system(which_install_info, "--delete", "--quiet", to_s, "#{dirname}/dir")
   end
 
   # Writes an exec script in this folder for each target pathname.


### PR DESCRIPTION
`install-info` is not shipped with macOS Ventura and some Linux distros. This commit uses `install-info` from `texinfo` formula if it is not available in `/usr/bin`.

See: https://github.com/Homebrew/discussions/discussions/4306

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
