### PR TITLE
dev-cmd/contributions: Don't fall over if a user's profile is private

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -207,9 +207,8 @@ module Homebrew
 
   sig { params(repo_full_name: String, person: String, args: Homebrew::CLI::Args).returns(Integer) }
   def count_reviews(repo_full_name, person, args)
-    # Users who have made their contributions private are not searchable to determine counts.
-    return 0 if GitHub::API.open_rest("https://api.github.com/users/#{person}/events").empty?
-
     GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, review: "approved", args: args)
+  rescue GitHub::API::ValidationFailedError
+    0 # Users who have made their contributions private are not searchable to determine counts.
   end
 end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -208,7 +208,7 @@ module Homebrew
   sig { params(repo_full_name: String, person: String, args: Homebrew::CLI::Args).returns(Integer) }
   def count_reviews(repo_full_name, person, args)
     # Users who have made their contributions private are not searchable to determine counts.
-    return 0 if GitHub::API.open_rest("https://api.github.com/users/#{user}/events").empty?
+    return 0 if GitHub::API.open_rest("https://api.github.com/users/#{person}/events").empty?
 
     GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, review: "approved", args: args)
   end

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -209,6 +209,9 @@ module Homebrew
   def count_reviews(repo_full_name, person, args)
     GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, review: "approved", args: args)
   rescue GitHub::API::ValidationFailedError
+    if args.verbose?
+      onoe "Couldn't search GitHub for PRs by #{person}. Their profile might be private. Defaulting to 0."
+    end
     0 # Users who have made their contributions private are not searchable to determine counts.
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- It's possible to hide your contribution graph and not be searchable on GitHub. Let's make sure `brew contributions` and other things that may eventually use `count_issues` don't fall over when they encounter this scenario.
