### PR TITLE
bump-formula-pr: wrap release notes in <pre> tags

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -362,7 +362,7 @@ module Homebrew
         pr_message += <<~XML
           <details>
             <summary>#{pre}release notes</summary>
-            #{github_release_data["body"]}
+            <pre>#{github_release_data["body"]}</pre>
           </details>
         XML
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Continuation of #14918 - wraps the release notes in `<pre>` tags to prevent relative GitHub issue links from tagging unrelated issues - Example: https://github.com/Homebrew/homebrew-core/pull/125133