### PR TITLE
Remove OpenStruct use in Tab

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -390,7 +390,6 @@ Style/NumericLiterals:
 Style/OpenStructUse:
   Exclude:
     - "Homebrew/cli/args.rb"
-    - "Homebrew/tab.rb"
     - "Taps/**/*.rb"
 
 # Rescuing `StandardError` is an understood default.

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -400,7 +400,6 @@ module Homebrew
         tab = Tab.for_keg(keg)
         original_tab = tab.dup
         tab.poured_from_bottle = false
-        tab.HEAD = nil
         tab.time = nil
         tab.changed_files = changed_files.dup
         if args.only_json_tab?

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -157,8 +157,8 @@ class Keg
     brewed_perl = runtime_dependencies&.any? { |dep| dep["full_name"] == "perl" && dep["declared_directly"] }
     perl_path = if brewed_perl || name == "perl"
       "#{HOMEBREW_PREFIX}/opt/perl/bin/perl"
-    elsif tab["built_on"].present?
-      perl_path = "/usr/bin/perl#{tab["built_on"]["preferred_perl"]}"
+    elsif tab.built_on.present?
+      perl_path = "/usr/bin/perl#{tab.built_on["preferred_perl"]}"
 
       # For `:all` bottles, we could have built this bottle with a Perl we don't have.
       # Such bottles typically don't have strict version requirements.

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -15,7 +15,10 @@ class Tab
 
   FILENAME = "INSTALL_RECEIPT.json"
 
-  attr_accessor :homebrew_version, :used_options, :unused_options, :tabfile, :built_as_bottle, :installed_as_dependency, :installed_on_request, :changed_files, :poured_from_bottle, :loaded_from_api, :time, :source_modified_time, :stdlib, :compiler, :aliases, :runtime_dependencies, :arch, :source, :built_on, :HEAD
+  attr_accessor :homebrew_version, :tabfile, :built_as_bottle, :installed_as_dependency, :installed_on_request,
+                :changed_files, :poured_from_bottle, :loaded_from_api, :time, :stdlib, :aliases, :arch, :source,
+                :built_on
+  attr_writer :used_options, :unused_options, :compiler, :runtime_dependencies, :source_modified_time
 
   # Instantiates a Tab for a new installation of a formula.
   def self.create(formula, compiler, stdlib)

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -1,22 +1,21 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cxxstdlib"
-require "ostruct"
 require "options"
 require "json"
 require "development_tools"
 require "extend/cachable"
 
-# Inherit from OpenStruct to gain a generic initialization method that takes a
-# hash and creates an attribute for each key and value. Rather than calling
-# `new` directly, use one of the class methods like {Tab.create}.
-class Tab < OpenStruct
+# Rather than calling `new` directly, use one of the class methods like {Tab.create}.
+class Tab
   extend T::Sig
 
   extend Cachable
 
   FILENAME = "INSTALL_RECEIPT.json"
+
+  attr_accessor :homebrew_version, :used_options, :unused_options, :tabfile, :built_as_bottle, :installed_as_dependency, :installed_on_request, :changed_files, :poured_from_bottle, :loaded_from_api, :time, :source_modified_time, :stdlib, :compiler, :aliases, :runtime_dependencies, :arch, :source, :built_on, :HEAD
 
   # Instantiates a Tab for a new installation of a formula.
   def self.create(formula, compiler, stdlib)
@@ -120,7 +119,7 @@ class Tab < OpenStruct
       empty
     end
 
-    tab["tabfile"] = path
+    tab.tabfile = path
     tab
   end
 
@@ -226,6 +225,10 @@ class Tab < OpenStruct
     end
   end
 
+  def initialize(attributes = {})
+    attributes.each { |key, value| instance_variable_set("@#{key}", value) }
+  end
+
   def any_args_or_options?
     !used_options.empty? || !unused_options.empty?
   end
@@ -255,15 +258,15 @@ class Tab < OpenStruct
   end
 
   def used_options
-    Options.create(super)
+    Options.create(@used_options)
   end
 
   def unused_options
-    Options.create(super)
+    Options.create(@unused_options)
   end
 
   def compiler
-    super || DevelopmentTools.default_compiler
+    @compiler || DevelopmentTools.default_compiler
   end
 
   def parsed_homebrew_version
@@ -275,7 +278,7 @@ class Tab < OpenStruct
   def runtime_dependencies
     # Homebrew versions prior to 1.1.6 generated incorrect runtime dependency
     # lists.
-    super unless parsed_homebrew_version < "1.1.6"
+    @runtime_dependencies unless parsed_homebrew_version < "1.1.6"
   end
 
   def cxxstdlib
@@ -324,7 +327,7 @@ class Tab < OpenStruct
 
   sig { returns(Time) }
   def source_modified_time
-    Time.at(super || 0)
+    Time.at(@source_modified_time || 0)
   end
 
   def to_json(options = nil)

--- a/Library/Homebrew/test/support/lib/startup/config.rb
+++ b/Library/Homebrew/test/support/lib/startup/config.rb
@@ -47,5 +47,4 @@ TESTBALL_PATCHES_SHA256 = "799c2d551ac5c3a5759bea7796631a7906a6a24435b52261a3171
 PATCH_A_SHA256 = "83404f4936d3257e65f176c4ffb5a5b8d6edd644a21c8d8dcc73e22a6d28fcfa"
 PATCH_B_SHA256 = "57958271bb802a59452d0816e0670d16c8b70bdf6530bcf6f78726489ad89b90"
 
-TEST_SHA1   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 TEST_SHA256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -29,7 +29,6 @@ describe Tab do
       "changed_files"        => [],
       "time"                 => time,
       "source_modified_time" => 0,
-      "HEAD"                 => TEST_SHA1,
       "compiler"             => "clang",
       "stdlib"               => "libcxx",
       "runtime_dependencies" => [],
@@ -71,7 +70,6 @@ describe Tab do
     expect(tab).not_to be_head
     expect(tab.tap).to be_nil
     expect(tab.time).to be_nil
-    expect(tab.HEAD).to be_nil
     expect(tab.runtime_dependencies).to be_nil
     expect(tab.stable_version).to be_nil
     expect(tab.head_version).to be_nil
@@ -154,7 +152,6 @@ describe Tab do
   end
 
   specify "other attributes" do
-    expect(tab.HEAD).to eq(TEST_SHA1)
     expect(tab.tap.name).to eq("homebrew/core")
     expect(tab.time).to eq(time)
     expect(tab).not_to be_built_as_bottle
@@ -179,7 +176,6 @@ describe Tab do
       expect(tab.tap.name).to eq("homebrew/core")
       expect(tab.spec).to eq(:stable)
       expect(tab.time).to eq(Time.at(1_403_827_774).to_i)
-      expect(tab.HEAD).to eq(TEST_SHA1)
       expect(tab.cxxstdlib.compiler).to eq(:clang)
       expect(tab.cxxstdlib.type).to eq(:libcxx)
       expect(tab.runtime_dependencies).to eq(runtime_dependencies)
@@ -207,7 +203,6 @@ describe Tab do
       expect(tab.tap.name).to eq("homebrew/core")
       expect(tab.spec).to eq(:stable)
       expect(tab.time).to eq(Time.at(1_403_827_774).to_i)
-      expect(tab.HEAD).to eq(TEST_SHA1)
       expect(tab.cxxstdlib.compiler).to eq(:clang)
       expect(tab.cxxstdlib.type).to eq(:libcxx)
       expect(tab.runtime_dependencies).to eq(runtime_dependencies)
@@ -229,7 +224,6 @@ describe Tab do
       expect(tab.tap.name).to eq("homebrew/core")
       expect(tab.spec).to eq(:stable)
       expect(tab.time).to eq(Time.at(1_403_827_774).to_i)
-      expect(tab.HEAD).to eq(TEST_SHA1)
       expect(tab.cxxstdlib.compiler).to eq(:clang)
       expect(tab.cxxstdlib.type).to eq(:libcxx)
       expect(tab.runtime_dependencies).to be_nil


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Following up on https://github.com/Homebrew/brew/pull/14826 this removes `OpenStruct` use in `Tap` (and enables typing). I don't have direct experience with `Tap` though, so this PR should be reviewed by a critical eye by someone who does.