### PR TITLE
Update GitHubPackages for new Tab implementation

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -315,28 +315,28 @@ class GitHubPackages
       tar_gz_sha256 = write_tar_gz(local_file, blobs)
 
       tab = tag_hash["tab"]
-      architecture = TAB_ARCH_TO_PLATFORM_ARCHITECTURE[tab["arch"].presence || bottle_tag.arch.to_s]
-      raise TypeError, "unknown tab['arch']: #{tab["arch"]}" if architecture.blank?
+      architecture = TAB_ARCH_TO_PLATFORM_ARCHITECTURE[tab.arch.presence || bottle_tag.arch.to_s]
+      raise TypeError, "unknown tab.arch: #{tab.arch}" if architecture.blank?
 
-      os = if tab["built_on"].present? && tab["built_on"]["os"].present?
-        BUILT_ON_OS_TO_PLATFORM_OS[tab["built_on"]["os"]]
+      os = if tab["built_on"].present? && tab.built_on["os"].present?
+        BUILT_ON_OS_TO_PLATFORM_OS[tab.built_on["os"]]
       elsif bottle_tag.linux?
         "linux"
       else
         "darwin"
       end
-      raise TypeError, "unknown tab['built_on']['os']: #{tab["built_on"]["os"]}" if os.blank?
+      raise TypeError, "unknown tab.built_on['os']: #{tab.built_on["os"]}" if os.blank?
 
-      os_version = tab["built_on"]["os_version"].presence if tab["built_on"].present?
+      os_version = tab.built_on["os_version"].presence if tab.built_on.present?
       case os
       when "darwin"
         os_version ||= "macOS #{bottle_tag.to_macos_version}"
       when "linux"
         os_version&.delete_suffix!(" LTS")
         os_version ||= OS::LINUX_CI_OS_VERSION
-        glibc_version = tab["built_on"]["glibc_version"].presence if tab["built_on"].present?
+        glibc_version = tab.built_on["glibc_version"].presence if tab.built_on.present?
         glibc_version ||= OS::LINUX_GLIBC_CI_VERSION
-        cpu_variant = tab["oldest_cpu_family"] || Hardware::CPU::INTEL_64BIT_OLDEST_CPU.to_s
+        cpu_variant = tab.built_on&.(:[], "oldest_cpu_family") || Hardware::CPU::INTEL_64BIT_OLDEST_CPU.to_s
       end
 
       platform_hash = {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Quick follow-up to https://github.com/Homebrew/brew/pull/14981
I think `GitHubPackages` uses `Tab`, but doesn't have sufficient tests or type annotations to have been caught automatically.
If this is a concern, we could potentially define a compatibility layer in `Tab`, something like this (maybe with an `odeprecated` message):
```ruby
def []=(key, value)
  self.send("#{key}=", value)
end
def [](key)
  self.send(key)
end
```

This PR should probably be manually tested by someone who understands both `GitHubPackages` uses `Tab` before going in.