### PR TITLE
cask/audit: Pass a URL's `referer` through to cURL

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -805,7 +805,7 @@ module Cask
 
       if cask.url && !cask.url.using
         validate_url_for_https_availability(cask.url, "binary URL", cask.token, cask.tap,
-                                            user_agents: [cask.url.user_agent])
+                                            user_agents: [cask.url.user_agent], referer: cask.url&.referer)
       end
 
       if cask.appcast && appcast?

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -371,6 +371,14 @@ describe "Utils::Curl" do
       expect { curl_args(*args, retry_max_time: "test") }.to raise_error(TypeError)
     end
 
+    it "uses `--referer` when :referer is present" do
+      expect(curl_args(*args, referer: "https://brew.sh").join(" ")).to include("--referer https://brew.sh")
+    end
+
+    it "doesn't use `--referer` when :referer is nil" do
+      expect(curl_args(*args, referer: nil).join(" ")).not_to include("--referer")
+    end
+
     it "uses HOMEBREW_USER_AGENT_FAKE_SAFARI when `:user_agent` is `:browser` or `:fake`" do
       expect(curl_args(*args, user_agent: :browser).join(" "))
         .to include("--user-agent #{HOMEBREW_USER_AGENT_FAKE_SAFARI}")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #14607.
- Some casks have URL arguments like "referer" (spelled wrong, that's intentional in the HTTP spec).
- The audit for one such cask, `iThoughtsX`, was failing because the "referer" wasn't getting passed through to cURL so the access would 404.

TODO:

- [x] The rest of the PR checklist.
- [x] Add some tests.
- [x] Test audits with casks without referer URL parts.

----

Before:

```
❯ brew audit --cask --online --appcast --signing 'ithoughtsx'
[...]
audit for ithoughtsx: failed
 - The binary URL https://cdn.toketaware.com?download=iThoughtsX.zip is not reachable (HTTP status code 404)
 - Version '9.2.0' differs from '9.3.0' retrieved by livecheck.
 - Version '9.2.0' differs from '9.3.0' retrieved by livecheck.
Error: 2 problems in 1 cask detected
```

After:

```
❯ brew audit --cask --online --appcast --signing 'ithoughtsx'
[...]
audit for ithoughtsx: failed
 - Version '9.2.0' differs from '9.3.0' retrieved by livecheck.
 - Version '9.2.0' differs from '9.3.0' retrieved by livecheck.
Error: 1 problem in 1 cask detected
```
