### PR TITLE
Update path to system settings on Ventura

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -160,9 +160,15 @@ module Cask
 
       sig { returns(String) }
       def automation_access_instructions
+        navigation_path = if MacOS.version >= :ventura
+          "System Settings → Privacy & Security"
+        else
+          "System Preferences → Security & Privacy → Privacy"
+        end
+
         <<~EOS
           Enable Automation access for "Terminal → System Events" in:
-            System Preferences → Security & Privacy → Privacy → Automation
+            #{navigation_path} → Automation
           if you haven't already.
         EOS
       end
@@ -371,8 +377,14 @@ module Cask
           rescue Errno::EPERM
             raise if File.readable?(File.expand_path("~/Library/Application Support/com.apple.TCC"))
 
+            navigation_path = if MacOS.version >= :ventura
+              "System Settings → Privacy & Security"
+            else
+              "System Preferences → Security & Privacy → Privacy"
+            end
+
             odie "Unable to remove some files. Please enable Full Disk Access for your terminal under " \
-                 "System Preferences → Security & Privacy → Privacy → Full Disk Access."
+                 "#{navigation_path} → Full Disk Access."
           end
         end
       end

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -58,10 +58,16 @@ module Cask
       caveat :kext do
         next if MacOS.version < :high_sierra
 
+        navigation_path = if MacOS.version >= :ventura
+          "System Settings → Privacy & Security"
+        else
+          "System Preferences → Security & Privacy → General"
+        end
+
         <<~EOS
           #{@cask} requires a kernel extension to work.
           If the installation fails, retry after you enable it in:
-            System Preferences → Security & Privacy → General
+            #{navigation_path}
 
           For more information, refer to vendor documentation or this Apple Technical Note:
             #{Formatter.url("https://developer.apple.com/library/content/technotes/tn2459/_index.html")}
@@ -71,10 +77,10 @@ module Cask
       caveat :unsigned_accessibility do |access = "Accessibility"|
         # access: the category in the privacy settings the app requires.
 
-        navigation_path = if MacOS.version < :ventura
-          "System Preferences → Security & Privacy → Privacy"
-        else
+        navigation_path = if MacOS.version >= :ventura
           "System Settings → Privacy & Security"
+        else
+          "System Preferences → Security & Privacy → Privacy"
         end
 
         <<~EOS

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -318,7 +318,9 @@ module OS
 
       sig { returns(String) }
       def update_instructions
-        software_update_location = if MacOS.version >= "10.14"
+        software_update_location = if MacOS.version >= "13"
+          "System Settings"
+        elsif MacOS.version >= "10.14"
           "System Preferences"
         else
           "the App Store"

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -73,7 +73,7 @@
       ]
     }
   ],
-  "caveats": "Installing everything might take a while...\n\neverything requires a kernel extension to work.\nIf the installation fails, retry after you enable it in:\n  System Preferences → Security & Privacy → General\n\nFor more information, refer to vendor documentation or this Apple Technical Note:\n  https://developer.apple.com/library/content/technotes/tn2459/_index.html\n",
+  "caveats": "Installing everything might take a while...\n\neverything requires a kernel extension to work.\nIf the installation fails, retry after you enable it in:\n  System Settings → Privacy & Security\n\nFor more information, refer to vendor documentation or this Apple Technical Note:\n  https://developer.apple.com/library/content/technotes/tn2459/_index.html\n",
   "depends_on": {
     "cask": [
       "something"

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -73,7 +73,7 @@
       ]
     }
   ],
-  "caveats": "Installing everything might take a while...\n\neverything requires a kernel extension to work.\nIf the installation fails, retry after you enable it in:\n  System Settings → Privacy & Security\n\nFor more information, refer to vendor documentation or this Apple Technical Note:\n  https://developer.apple.com/library/content/technotes/tn2459/_index.html\n",
+  "caveats": "Installing everything might take a while...\n\neverything requires a kernel extension to work.\nIf the installation fails, retry after you enable it in:\n  System Preferences → Security & Privacy → General\n\nFor more information, refer to vendor documentation or this Apple Technical Note:\n  https://developer.apple.com/library/content/technotes/tn2459/_index.html\n",
   "depends_on": {
     "cask": [
       "something"

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -386,8 +386,8 @@ The following methods may be called to generate standard warning messages:
 | `reboot`                           | Users should reboot to complete installation.
 | `files_in_usr_local`               | The cask installs files to `/usr/local`, which may confuse Homebrew.
 | `discontinued`                     | All software development has been officially discontinued upstream.
-| `kext`                             | Users may need to enable their kexts in *System Preferences → Security & Privacy → General*.
-| `unsigned_accessibility`           | Users will need to re-enable the app on each update in *System Preferences → Security & Privacy → Privacy* as it is unsigned.
+| `kext`                             | Users may need to enable their kexts in *System Settings → Privacy & Security* (or *System Preferences → Security & Privacy → General* in earlier macOS versions).
+| `unsigned_accessibility`           | Users will need to re-enable the app on each update in *System Settings → Privacy & Security* (or *System Preferences → Security & Privacy → Privacy* in earlier macOS versions) as it is unsigned.
 | `license "web_page"`               | Users may find the software's usage license at `web_page`.
 | `free_license "web_page"`          | Users may obtain an official license to use the software at `web_page`.
 


### PR DESCRIPTION
"System Preferences" has been renamed to "System Settings" on Ventura. Privacy and security settings have moved, too. This PR makes sure these changes are reflected. (Some adjustments were already made in #14092.)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] [see below] Have you successfully run `brew tests` with your changes locally?

-----

All but one of `brew tests` passed locally. Though unrelated to this change, I don't know why this one failed (it failed on `master` too):

```
Failures:

  1) brew bottle builds a bottle for the given Formula
     Failure/Error:
       expect { brew "bottle", "--no-rebuild", "testball" }
         .to output(/testball--0\.1.*\.bottle\.tar\.gz/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success

       expected block to not output to stderr, but output "tar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\ntar: Could not open extended attribute file: Permission denied\n"
     # ./test/dev-cmd/bottle_spec.rb:20:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:50:in `block (2 levels) in <top (required)>'
```
