### PR TITLE
Fix locale parsing

### DIFF
--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -47,12 +47,12 @@ class Locale
       return if (sep && scanner.eos?) || (sep.nil? && !scanner.eos?)
     end
 
-    if (region = scanner.scan(REGION_REGEX))
+    if (script = scanner.scan(SCRIPT_REGEX))
       sep = scanner.scan(/-/)
       return if (sep && scanner.eos?) || (sep.nil? && !scanner.eos?)
     end
 
-    script = scanner.scan(SCRIPT_REGEX)
+    region = scanner.scan(REGION_REGEX)
 
     return unless scanner.eos?
 

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -53,7 +53,7 @@ describe Locale do
     it { is_expected.to include("zh") }
     it { is_expected.to include("zh-CN") }
     it { is_expected.to include("CN") }
-    it { is_expected.to include("CN-Hans") }
+    it { is_expected.to include("Hans-CN") }
     it { is_expected.to include("Hans") }
     it { is_expected.to include("zh-Hans-CN") }
   end

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -9,7 +9,7 @@ describe Locale do
       expect(described_class.parse("zh")).to eql(described_class.new("zh", nil, nil))
       expect(described_class.parse("zh-CN")).to eql(described_class.new("zh", "CN", nil))
       expect(described_class.parse("zh-Hans")).to eql(described_class.new("zh", nil, "Hans"))
-      expect(described_class.parse("zh-CN-Hans")).to eql(described_class.new("zh", "CN", "Hans"))
+      expect(described_class.parse("zh-Hans-CN")).to eql(described_class.new("zh", "CN", "Hans"))
     end
 
     it "correctly parses a string with a UN M.49 region code" do
@@ -22,6 +22,7 @@ describe Locale do
       end
 
       it "a string in a wrong format" do
+        expect { described_class.parse("zh-CN-Hans") }.to raise_error(Locale::ParserError)
         expect { described_class.parse("zh_CN_Hans") }.to raise_error(Locale::ParserError)
         expect { described_class.parse("zhCNHans") }.to raise_error(Locale::ParserError)
         expect { described_class.parse("zh-CN_Hans") }.to raise_error(Locale::ParserError)
@@ -54,14 +55,14 @@ describe Locale do
     it { is_expected.to include("CN") }
     it { is_expected.to include("CN-Hans") }
     it { is_expected.to include("Hans") }
-    it { is_expected.to include("zh-CN-Hans") }
+    it { is_expected.to include("zh-Hans-CN") }
   end
 
   describe "#eql?" do
     subject(:locale) { described_class.new("zh", "CN", "Hans") }
 
     context "when all parts match" do
-      it { is_expected.to eql("zh-CN-Hans") }
+      it { is_expected.to eql("zh-Hans-CN") }
       it { is_expected.to eql(locale) }
     end
 
@@ -69,7 +70,7 @@ describe Locale do
       it { is_expected.not_to eql("zh") }
       it { is_expected.not_to eql("zh-CN") }
       it { is_expected.not_to eql("CN") }
-      it { is_expected.not_to eql("CN-Hans") }
+      it { is_expected.not_to eql("Hans-CN") }
       it { is_expected.not_to eql("Hans") }
     end
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -647,7 +647,7 @@ installer script: "#{staged_path}/install.sh"
 
 ### Stanza: `language`
 
-The `language` stanza can match [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language codes, script codes ([ISO 15924](https://en.wikipedia.org/wiki/ISO_15924)), and regional identifiers ([ISO 3166-1 Alpha 2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)), or a combination thereof.
+The `language` stanza can match [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language codes, script codes ([ISO 15924](https://en.wikipedia.org/wiki/ISO_15924)) and regional identifiers ([ISO 3166-1 Alpha 2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)), or a combination thereof.
 
 US English should always be used as the default language:
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -647,7 +647,7 @@ installer script: "#{staged_path}/install.sh"
 
 ### Stanza: `language`
 
-The `language` stanza can match [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language codes, regional identifiers ([ISO 3166-1 Alpha 2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)) and script codes ([ISO 15924](https://en.wikipedia.org/wiki/ISO_15924)), or a combination thereof.
+The `language` stanza can match [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language codes, script codes ([ISO 15924](https://en.wikipedia.org/wiki/ISO_15924)), and regional identifiers ([ISO 3166-1 Alpha 2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)), or a combination thereof.
 
 US English should always be used as the default language:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The locale module has been parsing locale strings in the wrong format. The correct format is "language-script-region" instead of "language-region-script". This wrong format broke the system language parsing.

```shell
> defaults read -g AppleLanguages
(
    "zh-Hans-CN"
)
```

Besides the real output above, you can also refer to: https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags.