### PR TITLE
caveats: Remove extra blank line between `keg_only` and other caveats

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -94,7 +94,7 @@ class Caveats
         end
       end
     end
-    s << "\n"
+    s
   end
 
   private

--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -94,6 +94,7 @@ class Caveats
         end
       end
     end
+    s << "\n" unless s.end_with?("\n")
     s
   end
 

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -249,6 +249,32 @@ describe Caveats do
           expect(caveats).to include("#{f.opt_share}/pkgconfig")
         end
       end
+
+      context "when joining different caveat types together" do
+        let(:f) do
+          formula do
+            url "foo-1.0"
+            keg_only "some reason"
+
+            def caveats
+              "something else"
+            end
+
+            service do
+              run [bin/"cmd"]
+            end
+          end
+        end
+
+        let(:caveats) { described_class.new(f).caveats }
+
+        it "adds the correct amount of new lines to the output" do
+          expect(caveats).to include("something else")
+          expect(caveats).to include("keg-only")
+          expect(caveats).to include("if you don't want/need a background service")
+          expect(caveats.count("\n")).to eq(9)
+        end
+      end
     end
 
     describe "shell completions" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was pointed out by Carlo in https://github.com/Homebrew/brew/issues/14925#issuecomment-1473303922, it annoyed me the moment I saw it too, and it was a very quick fix.
- The caveats items are joined by "\n" before being displayed, so the extra `\n` here when generating the `keg_only_text` meant that there were two blank lines which looked weird. This `keg_only_text` method is only used here so it doesn't affect anywhere else we show the `keg_only` message, if there are any other places.

-----

Before:

```
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info socket_vmnet
[...]
==> Caveats
socket_vmnet requires root privileges so you will need to run
  `sudo /opt/homebrew/opt/socket_vmnet/socket_vmnet` or `sudo brew services start socket_vmnet`.
You should be certain that you trust any software you grant root privileges.

socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because /opt/homebrew/bin is often writable by a non-admin user.


To restart socket_vmnet after an upgrade:
  sudo brew services restart socket_vmnet
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/socket_vmnet/bin/socket_vmnet --vmnet-gateway=192.168.105.1 /opt/homebrew/var/run/socket_vmnet
```

After:

```
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info socket_vmnet
[...]
==> Caveats
socket_vmnet requires root privileges so you will need to run
  `sudo /opt/homebrew/opt/socket_vmnet/socket_vmnet` or `sudo brew services start socket_vmnet`.
You should be certain that you trust any software you grant root privileges.

socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because /opt/homebrew/bin is often writable by a non-admin user.

To restart socket_vmnet after an upgrade:
  sudo brew services restart socket_vmnet
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/socket_vmnet/bin/socket_vmnet --vmnet-gateway=192.168.105.1 /opt/homebrew/var/run/socket_vmnet
```