### PR TITLE
utils/github/actions: add `format_multiline_string` method

### DIFF
--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "securerandom"
 require "utils/tty"
 
 module GitHub
@@ -16,6 +17,24 @@ module GitHub
       string.gsub("%", "%25")
             .gsub("\n", "%0A")
             .gsub("\r", "%0D")
+    end
+
+    sig { params(name: String, value: String).returns(String) }
+    def self.format_multiline_string(name, value)
+      # Format multiline strings for environment files
+      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+
+      delimiter = "ghadelimiter_#{SecureRandom.uuid}"
+
+      if name.include?(delimiter) || value.include?(delimiter)
+        raise Error, "`name` and `value` must not contain the delimiter"
+      end
+
+      <<~EOS
+        #{name}<<#{delimiter}
+        #{value}
+        #{delimiter}
+      EOS
     end
 
     # Helper class for formatting annotations on GitHub Actions.
@@ -84,6 +103,10 @@ module GitHub
       def relevant?
         @file.descend.next.to_s != ".."
       end
+    end
+
+    # Generic GitHub Actions error.
+    class Error < RuntimeError
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Needed for https://github.com/Homebrew/actions/pull/336, see @Bo98's comment:

> Escaping works differently now so this doesn't work. The new way to do it is:
> 
> ```
> {name}<<{delimiter}
> {value}
> {delimiter}
> ```
> 
> For security reasons `delimiter` must be randomly generated and unique to each run (e.g. UUID v4). It should also be something that doesn't appear in the `message`. It may be worth having a new method in `Homebrew/brew`.
> 
> See https://github.com/actions/toolkit/blob/b00a9fd033f4b30f2355acd212f531ecbbb9b38f/packages/core/src/file-command.ts#L27-L47 for an example implementation in JavaScript.