### PR TITLE
formula_auditor: Having `HOMEBREW_PREFIX` in `keg_only` reasons is bad

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -470,7 +470,7 @@ module Homebrew
       return unless @core_tap
       return unless formula.keg_only?
 
-      keg_only_message = text.to_s.match(/keg_only\s+["'](.*)["']/)&.captures.first
+      keg_only_message = text.to_s.match(/keg_only\s+["'](.*)["']/)&.captures&.first
       return unless keg_only_message&.include?("HOMEBREW_PREFIX")
 
       problem "`keg_only` reason should not include `HOMEBREW_PREFIX` as it creates confusing `brew info` output."

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -470,7 +470,7 @@ module Homebrew
       return unless @core_tap
       return unless formula.keg_only?
 
-      keg_only_message = text.to_s.match(/keg_only\s+["'](.*)["']/).captures&.first
+      keg_only_message = text.to_s.match(/keg_only\s+["'](.*)["']/)&.captures.first
       return unless keg_only_message&.include?("HOMEBREW_PREFIX")
 
       problem "`keg_only` reason should not include `HOMEBREW_PREFIX` as it creates confusing `brew info` output."

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -466,6 +466,16 @@ module Homebrew
               "They must not be upgraded to version 7.11 or newer."
     end
 
+    def audit_keg_only_reason
+      return unless @core_tap
+      return unless formula.keg_only?
+
+      keg_only_message = text.to_s.match(/keg_only\s+["'](.*)["']/).captures&.first
+      return unless keg_only_message&.include?("HOMEBREW_PREFIX")
+
+      problem "`keg_only` reason should not include `HOMEBREW_PREFIX` as it provides confusing output."
+    end
+
     def audit_versioned_keg_only
       return unless @versioned_formula
       return unless @core_tap

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -473,7 +473,7 @@ module Homebrew
       keg_only_message = text.to_s.match(/keg_only\s+["'](.*)["']/).captures&.first
       return unless keg_only_message&.include?("HOMEBREW_PREFIX")
 
-      problem "`keg_only` reason should not include `HOMEBREW_PREFIX` as it provides confusing output."
+      problem "`keg_only` reason should not include `HOMEBREW_PREFIX` as it creates confusing `brew info` output."
     end
 
     def audit_versioned_keg_only


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #14996.
- The API JSON is generated with a `/usr/local` Homebrew prefix, but frequently now users have `/opt/homebrew` as their prefix. Since formulae `keg_only` reasons are generated by the API, this can lead to the confusing messaging that follows:

```
socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because /usr/local/bin is often writable by a non-admin user.
```

- With this change, that formula as it is now will fail `brew audit`, prompting to remove the prefix reference.

```
❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict socket_vmnet
socket_vmnet:
  * `keg_only` reason should not include `HOMEBREW_PREFIX` as it provides confusing output.
Error: 1 problem in 1 formula detected
```
