### PR TITLE
formula: Use `HOMEBREW_PREFIX` placeholder `keg_only` reason

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2096,7 +2096,7 @@ class Formula
       "version_scheme"           => version_scheme,
       "bottle"                   => {},
       "keg_only"                 => keg_only?,
-      "keg_only_reason"          => keg_only_reason&.to_hash,
+      "keg_only_reason"          => keg_only_reason.gsub(HOMEBREW_PREFIX, HOMEBREW_PREFIX_PLACEHOLDER)&.to_hash,
       "options"                  => [],
       "build_dependencies"       => dependencies.select(&:build?)
                                                 .map(&:name)
@@ -3201,9 +3201,6 @@ class Formula
     # <pre>keg_only :versioned_formulae</pre>
     # <pre>keg_only "because I want it so"</pre>
     def keg_only(reason, explanation = "")
-      if !Homebrew::EnvConfig.no_install_from_api? && reason.is_a?(String)
-        reason = reason.gsub(HOMEBREW_PREFIX, HOMEBREW_PREFIX_PLACEHOLDER)
-      end
       @keg_only_reason = KegOnlyReason.new(reason, explanation)
     end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3201,6 +3201,9 @@ class Formula
     # <pre>keg_only :versioned_formulae</pre>
     # <pre>keg_only "because I want it so"</pre>
     def keg_only(reason, explanation = "")
+      if !Homebrew::EnvConfig.no_install_from_api? && reason.is_a?(String)
+        reason = reason.gsub(HOMEBREW_PREFIX, HOMEBREW_PREFIX_PLACEHOLDER)
+      end
       @keg_only_reason = KegOnlyReason.new(reason, explanation)
     end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -181,6 +181,12 @@ module Formulary
         end
       end
 
+      if (keg_only_reason = json_formula["keg_only_reason"]).present?
+        reason = keg_only_reason["reason"]&.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+        reason = Formulary.convert_to_string_or_symbol reason
+        keg_only reason, keg_only_reason["explanation"]
+      end
+
       if (deprecation_date = json_formula["deprecation_date"]).present?
         reason = Formulary.convert_to_deprecate_disable_reason_string_or_symbol json_formula["deprecation_reason"]
         deprecate! date: deprecation_date, because: reason
@@ -262,14 +268,6 @@ module Formulary
       def caveats
         self.class.instance_variable_get(:@caveats_string)
             &.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
-      end
-
-      @keg_only_reason = json_formula["keg_only_reason"]
-      def keg_only_reason
-        return unless (keg_only_reason = self.class.instance_variable_get(:@keg_only_reason))
-
-        reason = keg_only_reason["reason"]&.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
-        KegOnlyReason.new(Formulary.convert_to_string_or_symbol(reason), keg_only_reason["explanation"])
       end
 
       @tap_git_head_string = json_formula["tap_git_head"]

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -181,11 +181,6 @@ module Formulary
         end
       end
 
-      if (keg_only_reason = json_formula["keg_only_reason"]).present?
-        reason = Formulary.convert_to_string_or_symbol keg_only_reason["reason"]
-        keg_only reason, keg_only_reason["explanation"]
-      end
-
       if (deprecation_date = json_formula["deprecation_date"]).present?
         reason = Formulary.convert_to_deprecate_disable_reason_string_or_symbol json_formula["deprecation_reason"]
         deprecate! date: deprecation_date, because: reason
@@ -267,6 +262,14 @@ module Formulary
       def caveats
         self.class.instance_variable_get(:@caveats_string)
             &.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+      end
+
+      @keg_only_reason = json_formula["keg_only_reason"]
+      def keg_only_reason
+        return unless (keg_only_reason = self.class.instance_variable_get(:@keg_only_reason))
+
+        reason = keg_only_reason["reason"]&.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+        KegOnlyReason.new(Formulary.convert_to_string_or_symbol(reason), keg_only_reason["explanation"])
       end
 
       @tap_git_head_string = json_formula["tap_git_head"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #14996.
- Suggested in https://github.com/Homebrew/brew/pull/15003#issuecomment-1474882176.
- Otherwise the `keg_only` message produces confusing `brew info` output
  when generated on a `/usr/local`-prefixed Homebrew install but
  installed on a `/opt/homebrew`-prefixed install.

Before:

```
$ brew info socket_vmnet
[...]
socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because /usr/local/bin is often writable by a non-admin user.
```

After:

Apply the following diff to overwrite the formula JSON with `$HOMEBREW_PREFIX` placeholders:

```diff
index 20d758bc9..c8257a260 100644
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -267,7 +267,8 @@ module Formulary
       @keg_only_reason = json_formula["keg_only_reason"]
       def keg_only_reason
         keg_only_reason = self.class.instance_variable_get(:@keg_only_reason)
-        reason = keg_only_reason["reason"]&.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+        reason = keg_only_reason["reason"]&.gsub("/usr/local", HOMEBREW_PREFIX)
+        reason = reason&.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
         KegOnlyReason.new(Formulary.convert_to_string_or_sym
bol(reason), keg_only_reason["explanation"])
       end
```

then reinstall, then run:

```
$ HOMEBREW_NO_INSTALL_FROM_API= brew info socket_vmnet
[...]
socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because /opt/homebrew/bin is often writable by a non-admin user.
```

This does not add the placeholder prefix for non-API installs:

```
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall -s socket_vmnet
[...]
socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because /opt/homebrew/bin is often writable by a non-admin user.
```