### PR TITLE
utils/github/actions: remove `Error` class

### DIFF
--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -27,7 +27,7 @@ module GitHub
       delimiter = "ghadelimiter_#{SecureRandom.uuid}"
 
       if name.include?(delimiter) || value.include?(delimiter)
-        raise Error, "`name` and `value` must not contain the delimiter"
+        raise "`name` and `value` must not contain the delimiter"
       end
 
       <<~EOS
@@ -103,10 +103,6 @@ module GitHub
       def relevant?
         @file.descend.next.to_s != ".."
       end
-    end
-
-    # Generic GitHub Actions error.
-    class Error < RuntimeError
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As pointed out in https://github.com/Homebrew/brew/pull/15002#discussion_r1141081780, we don't really need the `Error` class as we're not rescuing from it anywhere. Let's avoid having unnecessary code 😅.