### PR TITLE
cask: remove old prefix placeholder

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -23,9 +23,6 @@ module Cask
     HOMEBREW_PREFIX_PLACEHOLDER = "$HOMEBREW_PREFIX"
     APPDIR_PLACEHOLDER = "$APPDIR"
 
-    # TODO: can be removed when API JSON is regenerated with HOMEBREW_PREFIX_PLACEHOLDER.
-    HOMEBREW_OLD_PREFIX_PLACEHOLDER = "$(brew --prefix)"
-
     attr_reader :token, :sourcefile_path, :source, :config, :default_config, :loader
     attr_accessor :download, :allow_reassignment
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -326,13 +326,10 @@ module Cask
       end
 
       def from_h_string_gsubs(string, appdir)
-        # TODO: HOMEBREW_OLD_PREFIX_PLACEHOLDER can be removed when API JSON is
-        #       regenerated with HOMEBREW_PREFIX_PLACEHOLDER.
         string.to_s
               .gsub(Cask::HOME_PLACEHOLDER, Dir.home)
               .gsub(Cask::HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
               .gsub(Cask::APPDIR_PLACEHOLDER, appdir)
-              .gsub(Cask::HOMEBREW_OLD_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
       end
 
       def from_h_array_gsubs(array, appdir)


### PR DESCRIPTION
This was just a temporary workaround while we
waited for the API to regenerate the JSON content.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is just a follow-up to changing the prefix placeholder for casks in https://github.com/Homebrew/brew/pull/14615. It should be fine now since it's been around a month since the original PR and the API JSON gets reloaded for users every day or so. There is an edge case where someone is on the most recent brew version but has a really old `cask.json` file but I doubt that's worth worrying about.