### PR TITLE
Fix publish.yml workflow for taps

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -127,6 +127,7 @@ module Homebrew
 
             - name: Pull bottles
               env:
+                HOMEBREW_NO_INSTALL_FROM_API: true
                 HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
                 HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
                 HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the `pr-pull` in `publish.yml` for brew taps. Perhaps there is a better workaround, but at least this works.

See the discussion here: https://github.com/orgs/Homebrew/discussions/4340