### PR TITLE
dev-cmd/contributions: appropriately pluralize contribution statement

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -64,7 +64,8 @@ module Homebrew
       results[user] = scan_repositories(repos, user, args)
       grand_totals[user] = total(results[user])
 
-      puts "#{user} contributed #{grand_totals[user].values.sum} #{Utils.pluralize("time", grand_totals[user].values.sum)} #{time_period(args)}."
+      contributions = grand_totals[user].values.sum
+      puts "#{user} contributed #{contributions} #{Utils.pluralize("time", contributions)} #{time_period(args)}."
       puts generate_csv(T.must(user), results[user], grand_totals[user]) if args.csv?
       return
     end
@@ -79,7 +80,8 @@ module Homebrew
       results[username] = scan_repositories(repos, username, args)
       grand_totals[username] = total(results[username])
 
-      puts "#{username} contributed #{grand_totals[username].values.sum} #{Utils.pluralize("time", grand_totals[username].values.sum)} #{time_period(args)}."
+      contributions = grand_totals[username].values.sum
+      puts "#{username} contributed #{contributions} #{Utils.pluralize("time", contributions)} #{time_period(args)}."
     end
 
     puts generate_maintainers_csv(grand_totals) if args.csv?

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -64,8 +64,8 @@ module Homebrew
       results[user] = scan_repositories(repos, user, args)
       grand_totals[user] = total(results[user])
 
-      contributions = grand_totals[user].values.sum
-      puts "#{user} contributed #{contributions} #{Utils.pluralize("time", contributions)} #{time_period(args)}."
+      user_contrib = grand_totals[user].values.sum
+      puts "#{user} contributed #{user_contrib} #{Utils.pluralize("time", user_contrib)} #{time_period(args)}."
       puts generate_csv(T.must(user), results[user], grand_totals[user]) if args.csv?
       return
     end
@@ -80,8 +80,9 @@ module Homebrew
       results[username] = scan_repositories(repos, username, args)
       grand_totals[username] = total(results[username])
 
-      contributions = grand_totals[username].values.sum
-      puts "#{username} contributed #{contributions} #{Utils.pluralize("time", contributions)} #{time_period(args)}."
+      username_contrib = grand_totals[username].values.sum
+      puts "#{username} contributed #{username_contrib} #{Utils.pluralize("time",
+                                                                          username_contrib)} #{time_period(args)}."
     end
 
     puts generate_maintainers_csv(grand_totals) if args.csv?

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -64,7 +64,7 @@ module Homebrew
       results[user] = scan_repositories(repos, user, args)
       grand_totals[user] = total(results[user])
 
-      puts "#{user} contributed #{grand_totals[user].values.sum} times #{time_period(args)}."
+      puts "#{user} contributed #{grand_totals[user].values.sum} #{Utils.pluralize("time", grand_totals[user].values.sum)} #{time_period(args)}."
       puts generate_csv(T.must(user), results[user], grand_totals[user]) if args.csv?
       return
     end
@@ -79,7 +79,7 @@ module Homebrew
       results[username] = scan_repositories(repos, username, args)
       grand_totals[username] = total(results[username])
 
-      puts "#{username} contributed #{grand_totals[username].values.sum} times #{time_period(args)}."
+      puts "#{username} contributed #{grand_totals[username].values.sum} #{Utils.pluralize("time", grand_totals[username].values.sum)} #{time_period(args)}."
     end
 
     puts generate_maintainers_csv(grand_totals) if args.csv?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Pluralize the contribution statement appropriately

```
$ brew contributions --user dtrodrigues --from 2023-03-15T01:00:00Z --to 2023-03-15T02:00:00Z --repositories=core
dtrodrigues contributed 1 times between 2023-03-15T01:00:00Z and 2023-03-15T02:00:00Z.
```

After:
```
$ brew contributions --user dtrodrigues --from 2023-03-15T01:00:00Z --to 2023-03-15T02:00:00Z --repositories=core
dtrodrigues contributed 1 time between 2023-03-15T01:00:00Z and 2023-03-15T02:00:00Z.
```