### PR TITLE
Add include_count parameter to pluralize util

### DIFF
--- a/Library/Homebrew/cask/cmd/install.rb
+++ b/Library/Homebrew/cask/cmd/install.rb
@@ -85,8 +85,7 @@ module Cask
 
         if dry_run
           if (casks_to_install = casks.reject(&:installed?).presence)
-            plural = ::Utils.pluralize("cask", casks_to_install.count)
-            ohai "Would install #{casks_to_install.count} #{plural}:"
+            ohai "Would install #{::Utils.pluralize("cask", casks_to_install.count, includecount: true)}:"
             puts casks_to_install.map(&:full_name).join(" ")
           end
           casks.each do |cask|
@@ -97,8 +96,8 @@ module Cask
                                      .map(&:name)
             next if dep_names.blank?
 
-            plural = ::Utils.pluralize("dependenc", dep_names.count, plural: "ies", singular: "y")
-            ohai "Would install #{dep_names.count} #{plural} for #{cask.full_name}:"
+            ohai "Would install #{::Utils.pluralize("dependenc", dep_names.count, plural: "ies", singular: "y",
+                                                    includecount: true)} for #{cask.full_name}:"
             puts dep_names.join(" ")
           end
           return

--- a/Library/Homebrew/cask/cmd/install.rb
+++ b/Library/Homebrew/cask/cmd/install.rb
@@ -85,7 +85,7 @@ module Cask
 
         if dry_run
           if (casks_to_install = casks.reject(&:installed?).presence)
-            ohai "Would install #{::Utils.pluralize("cask", casks_to_install.count, includecount: true)}:"
+            ohai "Would install #{::Utils.pluralize("cask", casks_to_install.count, include_count: true)}:"
             puts casks_to_install.map(&:full_name).join(" ")
           end
           casks.each do |cask|
@@ -97,7 +97,7 @@ module Cask
             next if dep_names.blank?
 
             ohai "Would install #{::Utils.pluralize("dependenc", dep_names.count, plural: "ies", singular: "y",
-                                                    includecount: true)} for #{cask.full_name}:"
+                                                    include_count: true)} for #{cask.full_name}:"
             puts dep_names.join(" ")
           end
           return

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -454,7 +454,7 @@ module Cask
       artifacts = @cask.artifacts
 
       odebug "Uninstalling artifacts"
-      odebug "#{::Utils.pluralize("artifact", artifacts.length, includecount: true)} defined", artifacts
+      odebug "#{::Utils.pluralize("artifact", artifacts.length, include_count: true)} defined", artifacts
 
       artifacts.each do |artifact|
         if artifact.respond_to?(:uninstall_phase)

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -454,7 +454,7 @@ module Cask
       artifacts = @cask.artifacts
 
       odebug "Uninstalling artifacts"
-      odebug "#{artifacts.length} #{::Utils.pluralize("artifact", artifacts.length)} defined", artifacts
+      odebug "#{::Utils.pluralize("artifact", artifacts.length, includecount: true)} defined", artifacts
 
       artifacts.each do |artifact|
         if artifact.respond_to?(:uninstall_phase)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -124,7 +124,7 @@ module Homebrew
     return unless HOMEBREW_CELLAR.exist?
 
     count = Formula.racks.length
-    puts "#{count} #{Utils.pluralize("keg", count)}, #{HOMEBREW_CELLAR.dup.abv}"
+    puts "#{Utils.pluralize("keg", count, includecount: true)}, #{HOMEBREW_CELLAR.dup.abv}"
   end
 
   sig { params(args: CLI::Args).void }

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -124,7 +124,7 @@ module Homebrew
     return unless HOMEBREW_CELLAR.exist?
 
     count = Formula.racks.length
-    puts "#{Utils.pluralize("keg", count, includecount: true)}, #{HOMEBREW_CELLAR.dup.abv}"
+    puts "#{Utils.pluralize("keg", count, include_count: true)}, #{HOMEBREW_CELLAR.dup.abv}"
   end
 
   sig { params(args: CLI::Args).void }

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -57,10 +57,10 @@ module Homebrew
         command_count += tap.command_files.size
         private_count += 1 if tap.private?
       end
-      info = Utils.pluralize("tap", tap_count, includecount: true)
+      info = Utils.pluralize("tap", tap_count, include_count: true)
       info += ", #{private_count} private"
-      info += ", #{Utils.pluralize("formula", formula_count, plural: "e", includecount: true)}"
-      info += ", #{Utils.pluralize("command", command_count, includecount: true)}"
+      info += ", #{Utils.pluralize("formula", formula_count, plural: "e", include_count: true)}"
+      info += ", #{Utils.pluralize("command", command_count, include_count: true)}"
       info += ", #{Tap::TAP_DIRECTORY.dup.abv}" if Tap::TAP_DIRECTORY.directory?
       puts info
     else

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -57,10 +57,10 @@ module Homebrew
         command_count += tap.command_files.size
         private_count += 1 if tap.private?
       end
-      info = "#{tap_count} #{Utils.pluralize("tap", tap_count)}"
+      info = Utils.pluralize("tap", tap_count, includecount: true)
       info += ", #{private_count} private"
-      info += ", #{formula_count} #{Utils.pluralize("formula", formula_count, plural: "e")}"
-      info += ", #{command_count} #{Utils.pluralize("command", command_count)}"
+      info += ", #{Utils.pluralize("formula", formula_count, plural: "e", includecount: true)}"
+      info += ", #{Utils.pluralize("command", command_count, includecount: true)}"
       info += ", #{Tap::TAP_DIRECTORY.dup.abv}" if Tap::TAP_DIRECTORY.directory?
       puts info
     else

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -233,8 +233,7 @@ module Homebrew
 
     unless updated_taps.empty?
       auto_update_header args: args
-      noun = Utils.pluralize("tap", updated_taps.count)
-      puts "Updated #{updated_taps.count} #{noun} (#{updated_taps.to_sentence})."
+      puts "Updated #{Utils.pluralize("tap", updated_taps.count, includecount: true)} (#{updated_taps.to_sentence})."
       updated = true
     end
 
@@ -656,12 +655,12 @@ class ReporterHub
       output_dump_formula_or_cask_report "Outdated Casks", outdated_casks
     elsif report_all
       if (changed_formulae = select_formula_or_cask(:M).count) && changed_formulae.positive?
-        noun = Utils.pluralize("formula", changed_formulae, plural: "e")
-        ohai "Modified Formulae", "Modified #{changed_formulae} #{noun}."
+        ohai "Modified Formulae",
+             "Modified #{Utils.pluralize("formula", changed_formulae, plural: "e", includecount: true)}."
       end
 
       if (changed_casks = select_formula_or_cask(:MC).count) && changed_casks.positive?
-        ohai "Modified Casks", "Modified #{changed_casks} #{Utils.pluralize("cask", changed_casks)}."
+        ohai "Modified Casks", "Modified #{Utils.pluralize("cask", changed_casks, includecount: true)}."
       end
     else
       outdated_formulae = Formula.installed.select(&:outdated?).map(&:name)

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -233,7 +233,7 @@ module Homebrew
 
     unless updated_taps.empty?
       auto_update_header args: args
-      puts "Updated #{Utils.pluralize("tap", updated_taps.count, includecount: true)} (#{updated_taps.to_sentence})."
+      puts "Updated #{Utils.pluralize("tap", updated_taps.count, include_count: true)} (#{updated_taps.to_sentence})."
       updated = true
     end
 
@@ -656,11 +656,11 @@ class ReporterHub
     elsif report_all
       if (changed_formulae = select_formula_or_cask(:M).count) && changed_formulae.positive?
         ohai "Modified Formulae",
-             "Modified #{Utils.pluralize("formula", changed_formulae, plural: "e", includecount: true)}."
+             "Modified #{Utils.pluralize("formula", changed_formulae, plural: "e", include_count: true)}."
       end
 
       if (changed_casks = select_formula_or_cask(:MC).count) && changed_casks.positive?
-        ohai "Modified Casks", "Modified #{Utils.pluralize("cask", changed_casks, includecount: true)}."
+        ohai "Modified Casks", "Modified #{Utils.pluralize("cask", changed_casks, include_count: true)}."
       end
     else
       outdated_formulae = Formula.installed.select(&:outdated?).map(&:name)

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -275,21 +275,21 @@ module Homebrew
     if total_problems_count.positive?
       puts new_formula_problem_lines.map { |s| "  #{s}" }
 
-      errors_summary = Utils.pluralize("problem", total_problems_count, includecount: true)
+      errors_summary = Utils.pluralize("problem", total_problems_count, include_count: true)
 
       error_sources = []
       if formula_count.positive?
-        error_sources << Utils.pluralize("formula", formula_count, plural: "e", includecount: true)
+        error_sources << Utils.pluralize("formula", formula_count, plural: "e", include_count: true)
       end
-      error_sources << Utils.pluralize("cask", cask_count, includecount: true) if cask_count.positive?
-      error_sources << Utils.pluralize("tap", tap_count, includecount: true) if tap_count.positive?
+      error_sources << Utils.pluralize("cask", cask_count, include_count: true) if cask_count.positive?
+      error_sources << Utils.pluralize("tap", tap_count, include_count: true) if tap_count.positive?
 
       errors_summary += " in #{error_sources.to_sentence}" if error_sources.any?
 
       errors_summary += " detected"
 
       if corrected_problem_count.positive?
-        errors_summary += ", #{Utils.pluralize("problem", corrected_problem_count, includecount: true)} corrected"
+        errors_summary += ", #{Utils.pluralize("problem", corrected_problem_count, include_count: true)} corrected"
       end
 
       ofail errors_summary

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -275,22 +275,21 @@ module Homebrew
     if total_problems_count.positive?
       puts new_formula_problem_lines.map { |s| "  #{s}" }
 
-      errors_summary = "#{total_problems_count} #{Utils.pluralize("problem", total_problems_count)}"
+      errors_summary = Utils.pluralize("problem", total_problems_count, includecount: true)
 
       error_sources = []
       if formula_count.positive?
-        error_sources << "#{formula_count} #{Utils.pluralize("formula", formula_count, plural: "e")}"
+        error_sources << Utils.pluralize("formula", formula_count, plural: "e", includecount: true)
       end
-      error_sources << "#{cask_count} #{Utils.pluralize("cask", cask_count)}" if cask_count.positive?
-      error_sources << "#{tap_count} #{Utils.pluralize("tap", tap_count)}" if tap_count.positive?
+      error_sources << Utils.pluralize("cask", cask_count, includecount: true) if cask_count.positive?
+      error_sources << Utils.pluralize("tap", tap_count, includecount: true) if tap_count.positive?
 
       errors_summary += " in #{error_sources.to_sentence}" if error_sources.any?
 
       errors_summary += " detected"
 
       if corrected_problem_count.positive?
-        noun = Utils.pluralize("problem", corrected_problem_count)
-        errors_summary += ", #{corrected_problem_count} #{noun} corrected"
+        errors_summary += ", #{Utils.pluralize("problem", corrected_problem_count, includecount: true)} corrected"
       end
 
       ofail errors_summary

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -65,7 +65,7 @@ module Homebrew
       grand_totals[user] = total(results[user])
 
       puts "#{user} contributed #{Utils.pluralize("time", grand_totals[user].values.sum,
-                                                  includecount: true)} #{time_period(args)}."
+                                                  include_count: true)} #{time_period(args)}."
       puts generate_csv(T.must(user), results[user], grand_totals[user]) if args.csv?
       return
     end
@@ -81,7 +81,7 @@ module Homebrew
       grand_totals[username] = total(results[username])
 
       puts "#{username} contributed #{Utils.pluralize("time", grand_totals[username].values.sum,
-                                                      includecount: true)} #{time_period(args)}."
+                                                      include_count: true)} #{time_period(args)}."
     end
 
     puts generate_maintainers_csv(grand_totals) if args.csv?

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -64,8 +64,8 @@ module Homebrew
       results[user] = scan_repositories(repos, user, args)
       grand_totals[user] = total(results[user])
 
-      user_contrib = grand_totals[user].values.sum
-      puts "#{user} contributed #{user_contrib} #{Utils.pluralize("time", user_contrib)} #{time_period(args)}."
+      puts "#{user} contributed #{Utils.pluralize("time", grand_totals[user].values.sum,
+                                                  includecount: true)} #{time_period(args)}."
       puts generate_csv(T.must(user), results[user], grand_totals[user]) if args.csv?
       return
     end
@@ -80,9 +80,8 @@ module Homebrew
       results[username] = scan_repositories(repos, username, args)
       grand_totals[username] = total(results[username])
 
-      username_contrib = grand_totals[username].values.sum
-      puts "#{username} contributed #{username_contrib} #{Utils.pluralize("time",
-                                                                          username_contrib)} #{time_period(args)}."
+      puts "#{username} contributed #{Utils.pluralize("time", grand_totals[username].values.sum,
+                                                      includecount: true)} #{time_period(args)}."
     end
 
     puts generate_maintainers_csv(grand_totals) if args.csv?

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -908,7 +908,7 @@ module Homebrew
               0
             end
 
-            "#{tap.path} (#{Utils.pluralize("cask", cask_count, includecount: true)})"
+            "#{tap.path} (#{Utils.pluralize("cask", cask_count, include_count: true)})"
           end
         end)
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -908,7 +908,7 @@ module Homebrew
               0
             end
 
-            "#{tap.path} (#{cask_count} #{Utils.pluralize("cask", cask_count)})"
+            "#{tap.path} (#{Utils.pluralize("cask", cask_count, includecount: true)})"
           end
         end)
 

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -199,13 +199,13 @@ module Kernel
     if seconds > 59
       minutes = seconds / 60
       seconds %= 60
-      res = +Utils.pluralize("minute", minutes, includecount: true)
+      res = +Utils.pluralize("minute", minutes, include_count: true)
       return res.freeze if seconds.zero?
 
       res << " "
     end
 
-    res << Utils.pluralize("second", seconds, includecount: true)
+    res << Utils.pluralize("second", seconds, include_count: true)
     res.freeze
   end
 

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -199,13 +199,13 @@ module Kernel
     if seconds > 59
       minutes = seconds / 60
       seconds %= 60
-      res = +"#{minutes} #{Utils.pluralize("minute", minutes)}"
+      res = +Utils.pluralize("minute", minutes, includecount: true)
       return res.freeze if seconds.zero?
 
       res << " "
     end
 
-    res << "#{seconds} #{Utils.pluralize("second", seconds)}"
+    res << Utils.pluralize("second", seconds, includecount: true)
     res.freeze
   end
 

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -326,8 +326,8 @@ module Homebrew
 
       if dry_run
         if (formulae_name_to_install = formulae_to_install.map(&:name))
-          plural = Utils.pluralize("formula", formulae_name_to_install.count, plural: "e")
-          ohai "Would install #{formulae_name_to_install.count} #{plural}:"
+          ohai "Would install #{Utils.pluralize("formula", formulae_name_to_install.count,
+                                                plural: "e", includecount: true)}:"
           puts formulae_name_to_install.join(" ")
 
           formula_installers.each do |fi|
@@ -355,8 +355,8 @@ module Homebrew
     def print_dry_run_dependencies(formula, dependencies, &block)
       return if dependencies.empty?
 
-      plural = Utils.pluralize("dependenc", dependencies.count, plural: "ies", singular: "y")
-      ohai "Would install #{dependencies.count} #{plural} for #{formula.name}:"
+      ohai "Would install #{Utils.pluralize("dependenc", dependencies.count, plural: "ies", singular: "y",
+                                            includecount: true)} for #{formula.name}:"
       formula_names = dependencies.map(&:first).map(&:to_formula).map(&block)
       puts formula_names.join(" ")
     end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -327,7 +327,7 @@ module Homebrew
       if dry_run
         if (formulae_name_to_install = formulae_to_install.map(&:name))
           ohai "Would install #{Utils.pluralize("formula", formulae_name_to_install.count,
-                                                plural: "e", includecount: true)}:"
+                                                plural: "e", include_count: true)}:"
           puts formulae_name_to_install.join(" ")
 
           formula_installers.each do |fi|
@@ -356,7 +356,7 @@ module Homebrew
       return if dependencies.empty?
 
       ohai "Would install #{Utils.pluralize("dependenc", dependencies.count, plural: "ies", singular: "y",
-                                            includecount: true)} for #{formula.name}:"
+                                            include_count: true)} for #{formula.name}:"
       formula_names = dependencies.map(&:first).map(&:to_formula).map(&block)
       puts formula_names.join(" ")
     end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -475,15 +475,15 @@ class Tap
     contents = []
 
     if (command_count = command_files.count).positive?
-      contents << "#{command_count} #{Utils.pluralize("command", command_count)}"
+      contents << Utils.pluralize("command", command_count, includecount: true)
     end
 
     if (cask_count = cask_files.count).positive?
-      contents << "#{cask_count} #{Utils.pluralize("cask", cask_count)}"
+      contents << Utils.pluralize("cask", cask_count, includecount: true)
     end
 
     if (formula_count = formula_files.count).positive?
-      contents << "#{formula_count} #{Utils.pluralize("formula", formula_count, plural: "e")}"
+      contents << Utils.pluralize("formula", formula_count, plural: "e", includecount: true)
     end
 
     contents

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -475,15 +475,15 @@ class Tap
     contents = []
 
     if (command_count = command_files.count).positive?
-      contents << Utils.pluralize("command", command_count, includecount: true)
+      contents << Utils.pluralize("command", command_count, include_count: true)
     end
 
     if (cask_count = cask_files.count).positive?
-      contents << Utils.pluralize("cask", cask_count, includecount: true)
+      contents << Utils.pluralize("cask", cask_count, include_count: true)
     end
 
     if (formula_count = formula_files.count).positive?
-      contents << Utils.pluralize("formula", formula_count, plural: "e", includecount: true)
+      contents << Utils.pluralize("formula", formula_count, plural: "e", include_count: true)
     end
 
     contents

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -70,6 +70,12 @@ describe Utils do
       expect(described_class.pluralize("foo", 1, singular: "o", plural: "es")).to eq("fooo")
       expect(described_class.pluralize("foo", 2, singular: "o", plural: "es")).to eq("fooes")
     end
+
+    it "includes the count when requested" do
+      expect(described_class.pluralize("foo", 0, includecount: true)).to eq("0 foos")
+      expect(described_class.pluralize("foo", 1, includecount: true)).to eq("1 foo")
+      expect(described_class.pluralize("foo", 2, includecount: true)).to eq("2 foos")
+    end
   end
 
   describe ".underscore" do

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -72,9 +72,9 @@ describe Utils do
     end
 
     it "includes the count when requested" do
-      expect(described_class.pluralize("foo", 0, includecount: true)).to eq("0 foos")
-      expect(described_class.pluralize("foo", 1, includecount: true)).to eq("1 foo")
-      expect(described_class.pluralize("foo", 2, includecount: true)).to eq("2 foos")
+      expect(described_class.pluralize("foo", 0, include_count: true)).to eq("0 foos")
+      expect(described_class.pluralize("foo", 1, include_count: true)).to eq("1 foo")
+      expect(described_class.pluralize("foo", 2, include_count: true)).to eq("2 foos")
     end
   end
 

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -310,10 +310,10 @@ module Homebrew
       if upgradeable_dependents.blank?
         ohai "No outdated dependents to upgrade!" unless dry_run
       else
-        dependent_plural = Utils.pluralize("dependent", upgradeable_dependents.count)
         formula_plural = Utils.pluralize("formula", installed_formulae.count, plural: "e")
         upgrade_verb = dry_run ? "Would upgrade" : "Upgrading"
-        ohai "#{upgrade_verb} #{upgradeable_dependents.count} #{dependent_plural} of upgraded #{formula_plural}:"
+        ohai "#{upgrade_verb} #{Utils.pluralize("dependent", upgradeable_dependents.count,
+                                                includecount: true)} of upgraded #{formula_plural}:"
         Upgrade.puts_no_installed_dependents_check_disable_message_if_not_already!
         formulae_upgrades = upgradeable_dependents.map do |f|
           name = f.full_specified_name
@@ -386,9 +386,8 @@ module Homebrew
       if reinstallable_broken_dependents.blank?
         ohai "No broken dependents to reinstall!"
       else
-        count = reinstallable_broken_dependents.count
-        plural = Utils.pluralize("dependent", reinstallable_broken_dependents.count)
-        ohai "Reinstalling #{count} #{plural} with broken linkage from source:"
+        ohai "Reinstalling #{Utils.pluralize("dependent", reinstallable_broken_dependents.count,
+                                             includecount: true)} with broken linkage from source:"
         Upgrade.puts_no_installed_dependents_check_disable_message_if_not_already!
         puts reinstallable_broken_dependents.map(&:full_specified_name)
                                             .join(", ")

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -313,7 +313,7 @@ module Homebrew
         formula_plural = Utils.pluralize("formula", installed_formulae.count, plural: "e")
         upgrade_verb = dry_run ? "Would upgrade" : "Upgrading"
         ohai "#{upgrade_verb} #{Utils.pluralize("dependent", upgradeable_dependents.count,
-                                                includecount: true)} of upgraded #{formula_plural}:"
+                                                include_count: true)} of upgraded #{formula_plural}:"
         Upgrade.puts_no_installed_dependents_check_disable_message_if_not_already!
         formulae_upgrades = upgradeable_dependents.map do |f|
           name = f.full_specified_name
@@ -387,7 +387,7 @@ module Homebrew
         ohai "No broken dependents to reinstall!"
       else
         ohai "Reinstalling #{Utils.pluralize("dependent", reinstallable_broken_dependents.count,
-                                             includecount: true)} with broken linkage from source:"
+                                             include_count: true)} with broken linkage from source:"
         Upgrade.puts_no_installed_dependents_check_disable_message_if_not_already!
         puts reinstallable_broken_dependents.map(&:full_specified_name)
                                             .join(", ")

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -126,10 +126,14 @@ module Utils
 
   # A lightweight alternative to `ActiveSupport::Inflector.pluralize`:
   # Combines `stem` with the `singular` or `plural` suffix based on `count`.
-  sig { params(stem: String, count: Integer, plural: String, singular: String).returns(String) }
-  def self.pluralize(stem, count, plural: "s", singular: "")
+  # Adds a prefix of the count value if `includecount` is set to true.
+  sig {
+    params(stem: String, count: Integer, plural: String, singular: String, includecount: T::Boolean).returns(String)
+  }
+  def self.pluralize(stem, count, plural: "s", singular: "", includecount: false)
+    prefix = includecount ? "#{count} " : ""
     suffix = (count == 1) ? singular : plural
-    "#{stem}#{suffix}"
+    "#{prefix}#{stem}#{suffix}"
   end
 
   sig { params(author: String).returns({ email: String, name: String }) }

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -126,12 +126,12 @@ module Utils
 
   # A lightweight alternative to `ActiveSupport::Inflector.pluralize`:
   # Combines `stem` with the `singular` or `plural` suffix based on `count`.
-  # Adds a prefix of the count value if `includecount` is set to true.
+  # Adds a prefix of the count value if `include_count` is set to true.
   sig {
-    params(stem: String, count: Integer, plural: String, singular: String, includecount: T::Boolean).returns(String)
+    params(stem: String, count: Integer, plural: String, singular: String, include_count: T::Boolean).returns(String)
   }
-  def self.pluralize(stem, count, plural: "s", singular: "", includecount: false)
-    prefix = includecount ? "#{count} " : ""
+  def self.pluralize(stem, count, plural: "s", singular: "", include_count: false)
+    prefix = include_count ? "#{count} " : ""
     suffix = (count == 1) ? singular : plural
     "#{prefix}#{stem}#{suffix}"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds an argument, `include_count`, to the `pluralize` util which includes the value of `count` in the string returned by the function. 