### PR TITLE
analytics: improve InfluxDB cardinality

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -112,8 +112,9 @@ module Cask
 
       install_artifacts
 
-      if @cask.tap&.should_report_analytics?
-        ::Utils::Analytics.report_event(:cask_install, @cask.token, on_request: true)
+      if (tap = @cask.tap) && tap.should_report_analytics?
+        ::Utils::Analytics.report_event(:cask_install, package_name: @cask.token, tap_name: tap.name,
+on_request: true)
       end
 
       purge_backed_up_versioned_files

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -414,9 +414,9 @@ class FormulaInstaller
     options = display_options(formula).join(" ")
     oh1 "Installing #{Formatter.identifier(formula.full_name)} #{options}".strip if show_header?
 
-    if formula.tap&.should_report_analytics?
-      action = "#{formula.full_name} #{options}".strip
-      Utils::Analytics.report_event(:formula_install, action, on_request: installed_on_request?)
+    if (tap = formula.tap) && tap.should_report_analytics?
+      Utils::Analytics.report_event(:formula_install, package_name: formula.name, tap_name: tap.name,
+on_request: installed_on_request?, options: options)
     end
 
     self.class.attempted << formula


### PR DESCRIPTION
- roll InfluxDB token (we need to report to a new bucket to fix implicit schema)
- adjust various parameters
- separate default tags and fields
- send more fields and fewer tags (tags should have low cardinality)
- use `--data-binary` to match InfluxDB documentation
- use hour precision for greater InfluxDB performance
- pass through tap name, formula/cask name, options separately
- pass `devcmdrun` as a tag
- avoid sending very high-cardinality OS_VERSION values