### PR TITLE
Enable UnpackStrategy types

### DIFF
--- a/Library/Homebrew/extend/object.rbi
+++ b/Library/Homebrew/extend/object.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+
+class Object
+  sig { returns(T::Boolean) }
+  def present?; end
+end

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -11,8 +11,6 @@ module UnpackStrategy
       include UnpackStrategy
       include SystemCommand::Mixin
 
-      
-
       sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
       def extract_to_dir(unpack_dir, basename:, verbose:)
         with_env(TZ: "UTC") do

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -11,7 +11,7 @@ module UnpackStrategy
       include UnpackStrategy
       include SystemCommand::Mixin
 
-      using Magic
+      
 
       sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
       def extract_to_dir(unpack_dir, basename:, verbose:)

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rbi
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rbi
@@ -1,9 +1,5 @@
 # typed: strict
 
-module UnpackStrategy
-  class Zip
-    module MacOSZipExtension
-      include Kernel
-    end
-  end
+module UnpackStrategy::Zip::MacOSZipExtension
+  include Kernel
 end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -466,6 +466,28 @@ class Pathname
   def rpaths
     []
   end
+
+  def magic_number
+    @magic_number ||= if directory?
+      ""
+    else
+      # Length of the longest regex (currently Tar).
+      # The `T.let` is a workaround until we have https://github.com/sorbet/sorbet/pull/6865
+      T.let(binread(262), T.nilable(String)) || ""
+    end
+  end
+
+  def file_type
+    @file_type ||= system_command("file", args: ["-b", self], print_stderr: false)
+                   .stdout.chomp
+  end
+
+  def zipinfo
+    @zipinfo ||= system_command("zipinfo", args: ["-1", self], print_stderr: false)
+                 .stdout
+                 .encode(Encoding::UTF_8, invalid: :replace)
+                 .split("\n")
+  end
 end
 
 require "extend/os/pathname"

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -472,8 +472,8 @@ class Pathname
     @magic_number ||= if directory?
       ""
     else
-      max_magic_number_length = 262
       # Length of the longest regex (currently Tar).
+      max_magic_number_length = 262
       # FIXME: The `T.let` is a workaround until we have https://github.com/sorbet/sorbet/pull/6865
       T.let(binread(max_magic_number_length), T.nilable(String)) || ""
     end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -467,6 +467,7 @@ class Pathname
     []
   end
 
+  sig { returns(String) }
   def magic_number
     @magic_number ||= if directory?
       ""
@@ -477,11 +478,13 @@ class Pathname
     end
   end
 
+  sig { returns(String) }
   def file_type
     @file_type ||= system_command("file", args: ["-b", self], print_stderr: false)
                    .stdout.chomp
   end
 
+  sig { returns(T::Array[String]) }
   def zipinfo
     @zipinfo ||= system_command("zipinfo", args: ["-1", self], print_stderr: false)
                  .stdout

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -472,9 +472,10 @@ class Pathname
     @magic_number ||= if directory?
       ""
     else
+      max_magic_number_length = 262
       # Length of the longest regex (currently Tar).
-      # The `T.let` is a workaround until we have https://github.com/sorbet/sorbet/pull/6865
-      T.let(binread(262), T.nilable(String)) || ""
+      # FIXME: The `T.let` is a workaround until we have https://github.com/sorbet/sorbet/pull/6865
+      T.let(binread(max_magic_number_length), T.nilable(String)) || ""
     end
   end
 

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -159,9 +159,9 @@ module UnpackStrategy
   # Helper method for iterating over directory trees.
   sig {
     params(
-        pathname: Pathname,
-        _block: T.proc.params(path: Pathname).void,
-      ).returns(T.nilable(Pathname))
+      pathname: Pathname,
+      _block:   T.proc.params(path: Pathname).void,
+    ).returns(T.nilable(Pathname))
   }
   def each_directory(pathname, &_block)
     pathname.find do |path|

--- a/Library/Homebrew/unpack_strategy.rbi
+++ b/Library/Homebrew/unpack_strategy.rbi
@@ -3,14 +3,3 @@
 module UnpackStrategy
   include Kernel
 end
-
-class Pathname
-  sig { returns(String) }
-  def magic_number; end
-
-  sig { returns(String) }
-  def file_type; end
-
-  sig { returns(T::Array[String]) }
-  def zipinfo; end
-end

--- a/Library/Homebrew/unpack_strategy/air.rb
+++ b/Library/Homebrew/unpack_strategy/air.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".air"]

--- a/Library/Homebrew/unpack_strategy/bazaar.rb
+++ b/Library/Homebrew/unpack_strategy/bazaar.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Bazaar < Directory
     extend T::Sig
 
-    using Magic
+    
 
     def self.can_extract?(path)
       super && (path/".bzr").directory?

--- a/Library/Homebrew/unpack_strategy/bazaar.rb
+++ b/Library/Homebrew/unpack_strategy/bazaar.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Bazaar < Directory
     extend T::Sig
 
-    
-
     def self.can_extract?(path)
       super && (path/".bzr").directory?
     end

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".bz2"]

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".cab"]

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/compress.rb
+++ b/Library/Homebrew/unpack_strategy/compress.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Compress < Tar
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/compress.rb
+++ b/Library/Homebrew/unpack_strategy/compress.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Compress < Tar
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".Z"]

--- a/Library/Homebrew/unpack_strategy/cvs.rb
+++ b/Library/Homebrew/unpack_strategy/cvs.rb
@@ -6,8 +6,6 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking CVS repositories.
   class Cvs < Directory
-    
-
     def self.can_extract?(path)
       super && (path/"CVS").directory?
     end

--- a/Library/Homebrew/unpack_strategy/cvs.rb
+++ b/Library/Homebrew/unpack_strategy/cvs.rb
@@ -6,7 +6,7 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking CVS repositories.
   class Cvs < Directory
-    using Magic
+    
 
     def self.can_extract?(path)
       super && (path/"CVS").directory?

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       []

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -99,10 +99,10 @@ module UnpackStrategy
             # For HFS, just use <mount-path>
             # For APFS, find the <physical-store> corresponding to <mount-path>
             eject_paths = disk_info.plist
-                                  .fetch("APFSPhysicalStores", [])
-                                  .map { |store| store["APFSPhysicalStore"] }
-                                  .compact
-                                  .presence || [path]
+                                   .fetch("APFSPhysicalStores", [])
+                                   .map { |store| store["APFSPhysicalStore"] }
+                                   .compact
+                                   .presence || [path]
 
             eject_paths.each do |eject_path|
               system_command! "diskutil",

--- a/Library/Homebrew/unpack_strategy/executable.rb
+++ b/Library/Homebrew/unpack_strategy/executable.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Executable < Uncompressed
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".sh", ".bash"]

--- a/Library/Homebrew/unpack_strategy/executable.rb
+++ b/Library/Homebrew/unpack_strategy/executable.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Executable < Uncompressed
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -11,7 +11,7 @@ module UnpackStrategy
     include UnpackStrategy
     extend SystemCommand::Mixin
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -11,8 +11,6 @@ module UnpackStrategy
     include UnpackStrategy
     extend SystemCommand::Mixin
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       []

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       []

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/git.rb
+++ b/Library/Homebrew/unpack_strategy/git.rb
@@ -6,8 +6,6 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Git repositories.
   class Git < Directory
-    
-
     def self.can_extract?(path)
       super && (path/".git").directory?
     end

--- a/Library/Homebrew/unpack_strategy/git.rb
+++ b/Library/Homebrew/unpack_strategy/git.rb
@@ -6,7 +6,7 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Git repositories.
   class Git < Directory
-    using Magic
+    
 
     def self.can_extract?(path)
       super && (path/".git").directory?

--- a/Library/Homebrew/unpack_strategy/gzip.rb
+++ b/Library/Homebrew/unpack_strategy/gzip.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".gz"]

--- a/Library/Homebrew/unpack_strategy/gzip.rb
+++ b/Library/Homebrew/unpack_strategy/gzip.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/jar.rb
+++ b/Library/Homebrew/unpack_strategy/jar.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Jar < Uncompressed
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/jar.rb
+++ b/Library/Homebrew/unpack_strategy/jar.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Jar < Uncompressed
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".apk", ".jar"]

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".lha", ".lzh"]

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/lua_rock.rb
+++ b/Library/Homebrew/unpack_strategy/lua_rock.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class LuaRock < Uncompressed
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".rock"]

--- a/Library/Homebrew/unpack_strategy/lua_rock.rb
+++ b/Library/Homebrew/unpack_strategy/lua_rock.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class LuaRock < Uncompressed
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".lz"]

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".lzma"]

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/mercurial.rb
+++ b/Library/Homebrew/unpack_strategy/mercurial.rb
@@ -6,8 +6,6 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Mercurial repositories.
   class Mercurial < Directory
-    
-
     def self.can_extract?(path)
       super && (path/".hg").directory?
     end

--- a/Library/Homebrew/unpack_strategy/mercurial.rb
+++ b/Library/Homebrew/unpack_strategy/mercurial.rb
@@ -6,7 +6,7 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Mercurial repositories.
   class Mercurial < Directory
-    using Magic
+    
 
     def self.can_extract?(path)
       super && (path/".hg").directory?

--- a/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
+++ b/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class MicrosoftOfficeXml < Uncompressed
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [

--- a/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
+++ b/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class MicrosoftOfficeXml < Uncompressed
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/otf.rb
+++ b/Library/Homebrew/unpack_strategy/otf.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Otf < Uncompressed
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/otf.rb
+++ b/Library/Homebrew/unpack_strategy/otf.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Otf < Uncompressed
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".otf"]

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".7z"]

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/pax.rb
+++ b/Library/Homebrew/unpack_strategy/pax.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".pax"]

--- a/Library/Homebrew/unpack_strategy/pax.rb
+++ b/Library/Homebrew/unpack_strategy/pax.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/pkg.rb
+++ b/Library/Homebrew/unpack_strategy/pkg.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Pkg < Uncompressed
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/pkg.rb
+++ b/Library/Homebrew/unpack_strategy/pkg.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Pkg < Uncompressed
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".pkg", ".mkpg"]

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".rar"]

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
+++ b/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class SelfExtractingExecutable < GenericUnar
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
+++ b/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class SelfExtractingExecutable < GenericUnar
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       []

--- a/Library/Homebrew/unpack_strategy/sit.rb
+++ b/Library/Homebrew/unpack_strategy/sit.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Sit < GenericUnar
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".sit"]

--- a/Library/Homebrew/unpack_strategy/sit.rb
+++ b/Library/Homebrew/unpack_strategy/sit.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Sit < GenericUnar
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -6,7 +6,7 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Subversion repositories.
   class Subversion < Directory
-    using Magic
+    
 
     def self.can_extract?(path)
       super && (path/".svn").directory?

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -6,8 +6,6 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Subversion repositories.
   class Subversion < Directory
-    
-
     def self.can_extract?(path)
       super && (path/".svn").directory?
     end

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -11,8 +11,6 @@ module UnpackStrategy
     include UnpackStrategy
     extend SystemCommand::Mixin
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -11,7 +11,7 @@ module UnpackStrategy
     include UnpackStrategy
     extend SystemCommand::Mixin
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/ttf.rb
+++ b/Library/Homebrew/unpack_strategy/ttf.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
   class Ttf < Uncompressed
     extend T::Sig
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".ttc", ".ttf"]

--- a/Library/Homebrew/unpack_strategy/ttf.rb
+++ b/Library/Homebrew/unpack_strategy/ttf.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
   class Ttf < Uncompressed
     extend T::Sig
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/xar.rb
+++ b/Library/Homebrew/unpack_strategy/xar.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".xar"]

--- a/Library/Homebrew/unpack_strategy/xar.rb
+++ b/Library/Homebrew/unpack_strategy/xar.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".xz"]

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".zip"]

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -8,8 +8,6 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".zst"]

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
 
     include UnpackStrategy
 
-    using Magic
+    
 
     sig { returns(T::Array[String]) }
     def self.extensions


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
- Removes `Pathname` refinements in two modules, `PathnameEachDirectory` and `Bom`, that were confined to the file they were defined in, and which better written as utility functions.
- Converts the `Pathname` refinements in another module, `Magic`, to monkey-patch `Pathname` instead. (This was already being included in 34 files, so it was already basically a monkey-patch). Monkey-patching isn't great, but it's still generally better than using refinements for reasons discussed in https://github.com/Homebrew/brew/pull/15018
- Various other small fixes to enable typing