### PR TITLE
Remove explicit error for empty BOM retry.

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -132,19 +132,15 @@ module UnpackStrategy
       sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
       def extract_to_dir(unpack_dir, basename:, verbose:)
         bom = begin
-          tries ||= 10
+          tries ||= 3
 
           path.bom
         rescue Bom::EmptyError => e
-          raise "#{e} No retries left." if (tries -= 1).zero?
+          raise e if (tries -= 1).zero?
 
           sleep 1
           retry
         end
-
-        # TODO: Remove this if we actually ever hit this, i.e. if we actually found
-        #       some files after waiting longer for the DMG to be mounted.
-        raise "BOM for path '#{path}' was empty but retrying for #{10 - tries} seconds helped." if tries != 10
 
         Tempfile.open(["", ".bom"]) do |bomfile|
           bomfile.close


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Retrying works, so remove the explicit error.

Saw it here: https://github.com/reitermarkus/dotfiles/actions/runs/4408439611/jobs/7859591762#step:3:12561