### PR TITLE
rubocop: Remove the final `Naming/MethodParameterName` exceptions: `pr`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -182,15 +182,10 @@ Naming/MethodName:
   AllowedPatterns:
     - '\A(fetch_)?HEAD\?\Z'
 
-# TODO: remove all of these
 Naming/MethodParameterName:
   inherit_mode:
     merge:
       - AllowedNames
-  AllowedNames:
-    [
-      "pr", # TODO: Remove if https://github.com/rubocop/rubocop/pull/11690 is merged or we change the variable names.
-    ]
 
 # Both styles are used depending on context,
 # e.g. `sha256` and `something_countable_1`.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Core RuboCop didn't want this shortening upstreamed, but that's OK!