### PR TITLE
CI: Add audit steps for formulae and casks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,8 +122,39 @@ jobs:
                                          homebrew/cask-fonts \
                                          homebrew/cask-versions
 
-  tap-audit:
-    name: tap audit
+  formula-audit:
+    name: formula audit
+    needs: syntax
+    if: startsWith(github.repository, 'Homebrew/')
+    runs-on: ubuntu-22.04
+    env:
+      HOMEBREW_NO_INSTALL_FROM_API: 1
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems --groups=sorbet
+
+      - name: Set up the homebrew/core tap
+        run: brew tap homebrew/core
+
+      - name: Run brew readall on homebrew/core
+        run: brew readall --aliases homebrew/core
+
+      - name: Run brew audit --skip-style on homebrew/core
+        run: brew audit --skip-style --except=version --display-failures-only --tap=homebrew/core
+
+  cask-audit:
+    name: cask audit
     needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: macos-12
@@ -144,19 +175,15 @@ jobs:
       - name: Install Bundler RubyGems
         run: brew install-bundler-gems --groups=sorbet
 
-      - name: Set up Homebrew cask and formula taps
+      - name: Set up Homebrew all cask taps
         run: |
           brew tap homebrew/cask
           brew tap homebrew/cask-drivers
           brew tap homebrew/cask-fonts
           brew tap homebrew/cask-versions
-          brew tap homebrew/core
 
-      - name: Run brew readall on all taps
-        run: brew readall --eval-all --aliases
-
-      - name: Run brew audit --skip-style on formulae
-        run: brew audit --skip-style --except=version --display-failures-only --tap=homebrew/core
+      - name: Run brew readall on all casks
+        run: brew readall homebrew/cask homebrew/cask-drivers homebrew/cask-fonts homebrew/cask-versions
 
       - name: Run brew audit --skip-style on casks
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,11 +85,6 @@ jobs:
       - name: Run brew style on homebrew-core
         run: brew style --display-cop-names homebrew/core
 
-      - name: Run brew audit --skip-style on homebrew-core for macOS
-        run: brew audit --skip-style --except=version --tap=homebrew/core
-        env:
-          HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
-
       - name: Set up all Homebrew taps
         run: |
           brew tap homebrew/aliases
@@ -107,12 +102,6 @@ jobs:
 
           # brew style doesn't like world writable directories
           sudo chmod -R g-w,o-w "$(brew --repo)/Library/Taps"
-
-      - name: Run brew readall on all taps
-        run: brew readall --eval-all --aliases
-
-      - name: Run brew audit --skip-style on all taps
-        run: brew audit --eval-all --skip-style --except=version --display-failures-only
 
       - name: Run brew style on official taps
         run: |
@@ -132,6 +121,49 @@ jobs:
                                          homebrew/cask-drivers \
                                          homebrew/cask-fonts \
                                          homebrew/cask-versions
+
+  tap-audit:
+    name: tap audit
+    needs: syntax
+    if: startsWith(github.repository, 'Homebrew/')
+    runs-on: macos-12
+    env:
+      HOMEBREW_NO_INSTALL_FROM_API: 1
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems --groups=sorbet
+
+      - name: Set up Homebrew cask and formula taps
+        run: |
+          brew tap homebrew/cask
+          brew tap homebrew/cask-drivers
+          brew tap homebrew/cask-fonts
+          brew tap homebrew/cask-versions
+          brew tap homebrew/core
+
+      - name: Run brew readall on all taps
+        run: brew readall --eval-all --aliases
+
+      - name: Run brew audit --skip-style on formulae
+        run: brew audit --skip-style --except=version --display-failures-only --tap=homebrew/core
+
+      - name: Run brew audit --skip-style on casks
+        run: |
+          brew audit --skip-style --except=version --display-failures-only --tap=homebrew/cask
+          brew audit --skip-style --except=version --display-failures-only --tap=homebrew/cask-drivers
+          brew audit --skip-style --except=version --display-failures-only --tap=homebrew/cask-fonts
+          brew audit --skip-style --except=version --display-failures-only --tap=homebrew/cask-versions
 
   vendored-gems:
     name: vendored gems

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,14 +82,13 @@ jobs:
       - name: Install Bundler RubyGems
         run: brew install-bundler-gems --groups=sorbet
 
-      - name: Run brew readall on all taps
-        run: brew readall --eval-all --aliases
-
       - name: Run brew style on homebrew-core
         run: brew style --display-cop-names homebrew/core
 
-      - name: Run brew audit --skip-style on all taps
-        run: brew audit --eval-all --skip-style --except=version --display-failures-only
+      - name: Run brew audit --skip-style on homebrew-core for macOS
+        run: brew audit --skip-style --except=version --tap=homebrew/core
+        env:
+          HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
 
       - name: Set up all Homebrew taps
         run: |
@@ -109,10 +108,11 @@ jobs:
           # brew style doesn't like world writable directories
           sudo chmod -R g-w,o-w "$(brew --repo)/Library/Taps"
 
-      - name: Run brew audit --skip-style on homebrew-core for macOS
-        run: brew audit --skip-style --except=version --tap=homebrew/core
-        env:
-          HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
+      - name: Run brew readall on all taps
+        run: brew readall --eval-all --aliases
+
+      - name: Run brew audit --skip-style on all taps
+        run: brew audit --eval-all --skip-style --except=version --display-failures-only
 
       - name: Run brew style on official taps
         run: |


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Now the steps that say they run on all taps are after the one where we set up all taps. This might have been done on purpose before for performance reasons though. I'm not sure.