### PR TITLE
docker: stop building Ubuntu 16.04 image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["16.04", "18.04", "20.04", "22.04"]
+        version: ["18.04", "20.04", "22.04"]
     steps:
       - name: Checkout
         uses: actions/checkout@main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,30 +189,6 @@ jobs:
           docker tag brew "homebrew/ubuntu22.04:master"
           docker push "homebrew/ubuntu22.04:master"
 
-      - name: Build deprecated 16.04 Docker image
-        if: github.ref == 'refs/heads/master'
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
-        run: |
-          echo "homebrew/ubuntu16.04:master is deprecated and will soon be retired. Use homebrew/ubuntu22.04:master or homebrew/ubuntu18.04 or homebrew/brew. For CI, homebrew/ubuntu22.04:master is recommended." > .docker-deprecate
-          docker build -t brew-deprecated --build-arg=version=16.04 \
-               --label org.opencontainers.image.created="$(date --rfc-3339=seconds --utc)" \
-               --label org.opencontainers.image.url="https://brew.sh" \
-               --label org.opencontainers.image.documentation="https://docs.brew.sh" \
-               --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}" \
-               --label org.opencontainers.image.revision="${GITHUB_SHA}" \
-               --label org.opencontainers.image.vendor="${GITHUB_REPOSITORY_OWNER}" \
-               --label org.opencontainers.image.licenses="BSD-2-Clause" \
-               --label org.opencontainers.image.support.end-of-support="2022-09-07T00:00:00Z" \
-               .
-
-      - name: Deploy the deprecated 16.04 Docker image to GitHub Packages and Docker Hub
-        if: github.ref == 'refs/heads/master'
-        run: |
-          docker tag brew-deprecated "ghcr.io/homebrew/ubuntu16.04:master"
-          docker push "ghcr.io/homebrew/ubuntu16.04:master"
-          docker tag brew-deprecated "homebrew/ubuntu16.04:master"
-          docker push "homebrew/ubuntu16.04:master"
-
   update-test:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
   g++ \
   gawk \
   git \
+  gpg \
   less \
   libz-dev \
   locales \
@@ -37,7 +38,6 @@ RUN apt-get update \
   uuid-runtime \
   tzdata \
   jq \
-  && if [ "$(. /etc/lsb-release; echo "${DISTRIB_RELEASE}" | cut -d. -f1)" -ge 18 ]; then apt-get install -y --no-install-recommends gpg; fi \
   && if [ "$(. /etc/lsb-release; echo "${DISTRIB_RELEASE}" | cut -d. -f1)" -ge 22 ]; then apt-get install -y --no-install-recommends gh skopeo; fi \
   && apt-get remove --purge -y software-properties-common \
   && apt-get autoremove --purge -y \

--- a/docs/Linux-CI.md
+++ b/docs/Linux-CI.md
@@ -1,6 +1,6 @@
 # Linux CI in `homebrew/core`
 
-We currently use Ubuntu 16.04 for bottling in `homebrew/core`.
+We currently use Ubuntu 22.04 for bottling in `homebrew/core`.
 
 ## Ubuntu vs. other Linux distributions
 
@@ -12,7 +12,8 @@ Our bottles are compatible with other distributions like Debian/CentOS, even whe
 
 ## Past and next versions
 
-We are currently moving our CI to Ubuntu 22.04. This work will probably be done before end of 2022.
+We have moved our CI to Ubuntu 22.04
+
 Moving from Ubuntu 16.04 to Ubuntu 22.04 (and thus skipping version 18.04 and 20.04) took longer than expected.
 
 We plan to proceed with regular updates from 2022 onwards. We aim to use the latest Ubuntu LTS version for our CI.


### PR DESCRIPTION
This is too slow to be building every time and we're long past the deprecation date.

We talked about pushing some sort of error script here. Anyone is welcome to do that as a one-off but we need to remove this image.

Fixes https://github.com/Homebrew/brew/issues/14661