### PR TITLE
Allow fetching for different arch.

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -322,29 +322,32 @@ module Cask
 
       hash_keys_to_skip = %w[outdated installed versions]
 
-      if @dsl.on_system_blocks_exist?
-        [:arm, :intel].each do |arch|
-          MacOSVersions::SYMBOLS.each_key do |os_name|
-            bottle_tag = ::Utils::Bottles::Tag.new(system: os_name, arch: arch)
-            next unless bottle_tag.valid_combination?
+      begin
+        if @dsl.on_system_blocks_exist?
+          [:arm, :intel].each do |arch|
+            MacOSVersions::SYMBOLS.each_key do |os_name|
+              bottle_tag = ::Utils::Bottles::Tag.new(system: os_name, arch: arch)
+              next unless bottle_tag.valid_combination?
 
-            Homebrew::SimulateSystem.os = os_name
-            Homebrew::SimulateSystem.arch = arch
+              Homebrew::SimulateSystem.os = os_name
+              Homebrew::SimulateSystem.arch = arch
 
-            refresh
+              refresh
 
-            to_h.each do |key, value|
-              next if hash_keys_to_skip.include? key
-              next if value.to_s == hash[key].to_s
+              to_h.each do |key, value|
+                next if hash_keys_to_skip.include? key
+                next if value.to_s == hash[key].to_s
 
-              variations[bottle_tag.to_sym] ||= {}
-              variations[bottle_tag.to_sym][key] = value
+                variations[bottle_tag.to_sym] ||= {}
+                variations[bottle_tag.to_sym][key] = value
+              end
             end
           end
         end
+      ensure
+        Homebrew::SimulateSystem.clear
       end
 
-      Homebrew::SimulateSystem.clear
       refresh
 
       hash["variations"] = variations

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -20,6 +20,10 @@ module Homebrew
         Download a bottle (if available) or source packages for <formula>e
         and binaries for <cask>s. For files, also print SHA-256 checksums.
       EOS
+      # This is needed for testing cask downloads on CI.
+      flag "--arch=",
+           description: "Download for the given arch.",
+           hidden:      true
       flag "--bottle-tag=",
            description: "Download a bottle for given tag."
       switch "--HEAD",
@@ -65,6 +69,10 @@ module Homebrew
 
   def self.fetch
     args = fetch_args.parse
+
+    if (arch = args.arch)
+      SimulateSystem.arch = arch.to_sym
+    end
 
     bucket = if args.deps?
       args.named.to_formulae_and_casks.flat_map do |formula_or_cask|

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -144,7 +144,7 @@ module Homebrew
 
               replacement_pairs << [new_hash_cask.sha256.to_s, download.sha256]
             end
-
+          ensure
             Homebrew::SimulateSystem.clear
           end
         elsif new_hash.present?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2219,33 +2219,35 @@ class Formula
 
     os_versions = [*MacOSVersions::SYMBOLS.keys, :linux]
 
-    if path.exist? && self.class.on_system_blocks_exist?
-      formula_contents = path.read
-      [:arm, :intel].each do |arch|
-        os_versions.each do |os_name|
-          bottle_tag = Utils::Bottles::Tag.new(system: os_name, arch: arch)
-          next unless bottle_tag.valid_combination?
+    begin
+      if path.exist? && self.class.on_system_blocks_exist?
+        formula_contents = path.read
+        [:arm, :intel].each do |arch|
+          os_versions.each do |os_name|
+            bottle_tag = Utils::Bottles::Tag.new(system: os_name, arch: arch)
+            next unless bottle_tag.valid_combination?
 
-          Homebrew::SimulateSystem.os = os_name
-          Homebrew::SimulateSystem.arch = arch
+            Homebrew::SimulateSystem.os = os_name
+            Homebrew::SimulateSystem.arch = arch
 
-          variations_namespace = Formulary.class_s("Variations#{bottle_tag.to_sym.capitalize}")
-          variations_formula_class = Formulary.load_formula(name, path, formula_contents, variations_namespace,
-                                                            flags: self.class.build_flags, ignore_errors: true)
-          variations_formula = variations_formula_class.new(name, path, :stable,
-                                                            alias_path: alias_path, force_bottle: force_bottle)
+            variations_namespace = Formulary.class_s("Variations#{bottle_tag.to_sym.capitalize}")
+            variations_formula_class = Formulary.load_formula(name, path, formula_contents, variations_namespace,
+                                                              flags: self.class.build_flags, ignore_errors: true)
+            variations_formula = variations_formula_class.new(name, path, :stable,
+                                                              alias_path: alias_path, force_bottle: force_bottle)
 
-          variations_formula.to_hash.each do |key, value|
-            next if value.to_s == hash[key].to_s
+            variations_formula.to_hash.each do |key, value|
+              next if value.to_s == hash[key].to_s
 
-            variations[bottle_tag.to_sym] ||= {}
-            variations[bottle_tag.to_sym][key] = value
+              variations[bottle_tag.to_sym] ||= {}
+              variations[bottle_tag.to_sym][key] = value
+            end
           end
         end
       end
+    ensure
+      Homebrew::SimulateSystem.clear
     end
-
-    Homebrew::SimulateSystem.clear
 
     hash["variations"] = variations
     hash

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -103,13 +103,15 @@ module Readall
             bottle_tag = Utils::Bottles::Tag.new(system: os_name, arch: arch)
             next unless bottle_tag.valid_combination?
 
-            Homebrew::SimulateSystem.arch = arch
-            Homebrew::SimulateSystem.os = os_name
+            begin
+              Homebrew::SimulateSystem.arch = arch
+              Homebrew::SimulateSystem.os = os_name
 
-            success = false unless valid_formulae?(tap.formula_files, bottle_tag: bottle_tag)
-            success = false unless valid_casks?(tap.cask_files, bottle_tag: bottle_tag)
-
-            Homebrew::SimulateSystem.clear
+              success = false unless valid_formulae?(tap.formula_files, bottle_tag: bottle_tag)
+              success = false unless valid_casks?(tap.cask_files, bottle_tag: bottle_tag)
+            ensure
+              Homebrew::SimulateSystem.clear
+            end
           end
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add `--arch` flag for `brew fetch` to allow testing ARM cask downloads in CI. Also add `ensure` before all `Homebrew::SimulateSystem.clear`s.