### PR TITLE
Enable types in Formula files

### DIFF
--- a/Library/Homebrew/extend/object.rbi
+++ b/Library/Homebrew/extend/object.rbi
@@ -1,6 +1,0 @@
-# typed: strict
-
-class Object
-  sig { returns(T::Boolean) }
-  def present?; end
-end

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cache_store"

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "deprecate_disable"
@@ -391,7 +391,7 @@ module Homebrew
                   "canonical name (#{conflicting_formula.name}) instead of #{conflict.name}"
         end
 
-        reverse_conflict_found = false
+        reverse_conflict_found = T.let(false, T::Boolean)
         conflicting_formula.conflicts.each do |reverse_conflict|
           reverse_conflict_formula = Formulary.factory(reverse_conflict.name)
           if tap.formula_renames.key?(reverse_conflict.name) || tap.aliases.include?(reverse_conflict.name)
@@ -732,14 +732,14 @@ module Homebrew
       current_revision = formula.revision
       current_url = formula.stable.url
 
-      previous_version = nil
-      previous_version_scheme = nil
-      previous_revision = nil
+      previous_version = T.let(nil, T.nilable(Version))
+      previous_version_scheme = T.let(nil, T.nilable(Integer))
+      previous_revision = T.let(nil, T.nilable(Integer))
 
-      newest_committed_version = nil
-      newest_committed_checksum = nil
-      newest_committed_revision = nil
-      newest_committed_url = nil
+      newest_committed_version = T.let(nil, T.nilable(Version))
+      newest_committed_checksum = T.let(nil, T.nilable(String))
+      newest_committed_revision = T.let(nil, T.nilable(Integer))
+      newest_committed_url = T.let(nil, T.nilable(String))
 
       fv.rev_list("origin/HEAD") do |rev|
         begin

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/shell"
@@ -7,6 +7,17 @@ require "utils/shell"
 #
 # @api private
 module FormulaCellarChecks
+  extend T::Sig
+  extend T::Helpers
+
+  abstract!
+
+  sig { abstract.returns(Formula) }
+  def formula; end
+
+  sig { abstract.params(output: T.nilable(String)).void }
+  def problem_if_output(output); end
+
   def check_env_path(bin)
     # warn the user if stuff was installed outside of their PATH
     return unless bin.directory?
@@ -407,7 +418,7 @@ module FormulaCellarChecks
       end
     end
 
-    has_cpuid_instruction = false
+    has_cpuid_instruction = T.let(false, T::Boolean)
     Utils.popen_read(objdump, "--disassemble", file) do |io|
       until io.eof?
         instruction = io.readline.split("\t")[@instruction_column_index[objdump]]&.strip

--- a/Library/Homebrew/formula_cellar_checks.rbi
+++ b/Library/Homebrew/formula_cellar_checks.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module FormulaCellarChecks
+  include Kernel
+end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "formula"
@@ -653,7 +653,7 @@ on_request: installed_on_request?, options: options)
     inherited_options
   end
 
-  sig { params(deps: T::Array[[Formula, Options]]).void }
+  sig { params(deps: T::Array[[Dependency, Options]]).void }
   def install_dependencies(deps)
     if deps.empty? && only_deps?
       puts "All dependencies for #{formula.full_name} are satisfied."
@@ -745,7 +745,7 @@ on_request: installed_on_request?, options: options)
     fi.finish
   rescue Exception => e # rubocop:disable Lint/RescueException
     ignore_interrupts do
-      tmp_keg.rename(installed_keg) if tmp_keg && !installed_keg.directory?
+      tmp_keg.rename(installed_keg.to_s) if tmp_keg && !installed_keg.directory?
       linked_keg.link(verbose: verbose?) if keg_was_linked
     end
     raise unless e.is_a? FormulaInstallationAlreadyAttemptedError
@@ -1266,7 +1266,7 @@ on_request: installed_on_request?, options: options)
     keg.relocate_build_prefix(keg, prefix, HOMEBREW_PREFIX)
   end
 
-  sig { params(output: T.nilable(String)).void }
+  sig { override.params(output: T.nilable(String)).void }
   def problem_if_output(output)
     return unless output
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "digest/md5"
@@ -56,7 +56,7 @@ module Formulary
         namespace = Utils.deconstantize(klass.name)
         next if Utils.deconstantize(namespace) != name
 
-        remove_const(Utils.demodulize(namespace))
+        remove_const(Utils.demodulize(namespace).to_sym)
       end
     end
 
@@ -67,6 +67,7 @@ module Formulary
   module PathnameWriteMkpath
     refine Pathname do
       def write(content, offset = nil, **open_args)
+        T.bind(self, Pathname)
         raise "Will not overwrite #{self}" if exist? && !offset && !open_args[:mode]&.match?(/^a\+?$/)
 
         dirname.mkpath
@@ -132,7 +133,7 @@ module Formulary
     namespace = "FormulaNamespaceAPI#{Digest::MD5.hexdigest(name)}"
 
     mod = Module.new
-    remove_const(namespace) if const_defined?(namespace)
+    remove_const(namespace.to_sym) if const_defined?(namespace)
     const_set(namespace, mod)
 
     mod.const_set(:BUILD_FLAGS, flags)
@@ -268,6 +269,7 @@ module Formulary
         service_hash = Homebrew::Service.deserialize(service_hash)
         run_params = service_hash.delete(:run)
         service do
+          T.bind(self, Homebrew::Service)
           if run_params.is_a?(Hash)
             run(**run_params)
           else
@@ -306,7 +308,7 @@ module Formulary
       end
     end
 
-    klass.loaded_from_api = true
+    T.cast(klass, T.class_of(Formula)).loaded_from_api = true
     mod.const_set(class_s, klass)
 
     cache[:api] ||= {}
@@ -351,7 +353,7 @@ module Formulary
 
   def self.class_s(name)
     class_name = name.capitalize
-    class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
+    class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { T.must(Regexp.last_match(1)).upcase }
     class_name.tr!("+", "x")
     class_name.sub!(/(.)@(\d)/, "\\1AT\\2")
     class_name
@@ -489,17 +491,17 @@ module Formulary
     def initialize(url, from: nil)
       @url = url
       @from = from
-      uri = URI(url)
-      formula = File.basename(uri.path, ".rb")
-      super formula, HOMEBREW_CACHE_FORMULA/File.basename(uri.path)
+      uri_path = T.must(URI(url).path)
+      formula = File.basename(uri_path, ".rb")
+      super formula, HOMEBREW_CACHE_FORMULA/File.basename(uri_path)
     end
 
     def load_file(flags:, ignore_errors:)
       if @from != :formula_installer
-        if %r{githubusercontent.com/[\w-]+/[\w-]+/[a-f0-9]{40}(?:/Formula)?/(?<formula_name>[\w+-.@]+).rb} =~ url
+        if (md = %r{githubusercontent.com/[\w-]+/[\w-]+/[a-f0-9]{40}(?:/Formula)?/(?<name>[\w+-.@]+).rb}.match(url))
           raise UnsupportedInstallationMethod,
-                "Installation of #{formula_name} from a GitHub commit URL is unsupported! " \
-                "`brew extract #{formula_name}` to a stable tap on GitHub instead."
+                "Installation of #{md[:name]} from a GitHub commit URL is unsupported! " \
+                "`brew extract #{md[:name]}` to a stable tap on GitHub instead."
         elsif url.match?(%r{^(https?|ftp)://})
           raise UnsupportedInstallationMethod,
                 "Non-checksummed download of #{name} formula file from an arbitrary URL is unsupported! " \
@@ -512,8 +514,8 @@ module Formulary
       curl_download url, to: path
       super
     rescue MethodDeprecatedError => e
-      if %r{github.com/(?<user>[\w-]+)/(?<repo>[\w-]+)/} =~ url
-        e.issues_url = "https://github.com/#{user}/#{repo}/issues/new"
+      if (match_data = %r{github.com/(?<user>[\w-]+)/(?<repo>[\w-]+)/}.match(url))
+        e.issues_url = "https://github.com/#{match_data[:user]}/#{match_data[:repo]}/issues/new"
       end
       raise
     end

--- a/Library/Homebrew/formulary.rbi
+++ b/Library/Homebrew/formulary.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Formulary
+  include Kernel
+end

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -28,6 +28,7 @@ class Resource
   # formula name before initialization of the formula.
   attr_accessor :name
 
+  sig { params(name: T.nilable(String), block: T.nilable(T.proc.bind(Resource).void)).void }
   def initialize(name = nil, &block)
     # Ensure this is synced with `initialize_dup` and `freeze` (excluding simple objects like integers and booleans)
     @name = name


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Enables typing in files relating to `Formula`. (After this change there are ~26 non-test files with typing disabled remaining)