### PR TITLE
rubocops: Detect unordered stanzas in non-`on_*` blocks in formulae

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -27,6 +27,11 @@ module RuboCop
             [{ name: :patch, type: :method_call }, { name: :patch, type: :block_call }],
           ]
 
+          head_blocks = find_blocks(body_node, :head)
+          head_blocks.each do |head_block|
+            check_block_component_order(FORMULA_COMPONENT_PRECEDENCE_LIST, head_block)
+          end
+
           on_system_methods.each do |on_method|
             on_method_blocks = find_blocks(body_node, on_method)
             next if on_method_blocks.empty?
@@ -41,6 +46,8 @@ module RuboCop
 
           resource_blocks = find_blocks(body_node, :resource)
           resource_blocks.each do |resource_block|
+            check_block_component_order(FORMULA_COMPONENT_PRECEDENCE_LIST, resource_block)
+
             on_system_blocks = {}
 
             on_system_methods.each do |on_method|
@@ -109,6 +116,11 @@ module RuboCop
               end
             end
           end
+        end
+
+        def check_block_component_order(component_precedence_list, block)
+          @present_components, offensive_node = check_order(component_precedence_list, block.body)
+          component_problem(*offensive_node) if offensive_node
         end
 
         def check_on_system_block_content(component_precedence_list, on_system_block)

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -401,6 +401,7 @@ module RuboCop
 
         NO_ON_SYSTEM_METHOD_NAMES = [:install, :post_install].freeze
         NO_ON_SYSTEM_BLOCK_NAMES = [:service, :test].freeze
+        CAN_HAVE_ON_SYSTEM_BLOCK_NAMES = [:resource].freeze
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           NO_ON_SYSTEM_METHOD_NAMES.each do |formula_method_name|
@@ -420,11 +421,13 @@ module RuboCop
 
           audit_arch_conditionals(body_node,
                                   allowed_methods: NO_ON_SYSTEM_METHOD_NAMES,
-                                  allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES)
+                                  allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES,
+                                  optional_blocks: CAN_HAVE_ON_SYSTEM_BLOCK_NAMES)
 
           audit_base_os_conditionals(body_node,
                                      allowed_methods: NO_ON_SYSTEM_METHOD_NAMES,
-                                     allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES)
+                                     allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES,
+                                     optional_blocks: CAN_HAVE_ON_SYSTEM_BLOCK_NAMES)
 
           audit_macos_version_conditionals(body_node,
                                            allowed_methods:     NO_ON_SYSTEM_METHOD_NAMES,

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -803,7 +803,37 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    context "when in a head block" do
+      it "reports an offense if stanzas inside `head` blocks are out of order" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            homepage "https://brew.sh"
+
+            head do
+              depends_on "bar"
+              url "https://github.com/foo/foo.git", branch: "main"
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `url` (line 6) should be put before `depends_on` (line 5)
+            end
+          end
+        RUBY
+      end
+    end
+
     context "when in a resource block" do
+      it "reports an offense if stanzas inside `resource` blocks are out of order" do
+        expect_offense(<<~RUBY)
+          class Foo < Formula
+            homepage "https://brew.sh"
+
+            resource do
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              url "https://brew.sh/resource1.tar.gz"
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `url` (line 6) should be put before `sha256` (line 5)
+            end
+          end
+        RUBY
+      end
+
       it "reports no offenses for a valid `on_macos` and `on_linux` block" do
         expect_no_offenses(<<~RUBY)
           class Foo < Formula
@@ -1106,15 +1136,14 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-              on_intel do
-                url "https://brew.sh/resource2.tar.gz"
-                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
-              end
-
               on_arm do
               ^^^^^^^^^ `on_arm` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
                 url "https://brew.sh/resource2.tar.gz"
+              end
+              on_intel do
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
             end
           end
@@ -1127,11 +1156,6 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-              on_intel do
-                url "https://brew.sh/resource2.tar.gz"
-                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
-              end
-
               on_arm do
                 if foo == :bar
                   url "https://brew.sh/resource2.tar.gz"
@@ -1140,6 +1164,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
                   url "https://brew.sh/resource1.tar.gz"
                   sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
                 end
+              end
+              on_intel do
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
             end
           end
@@ -1152,11 +1180,6 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-              on_intel do
-                url "https://brew.sh/resource2.tar.gz"
-                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
-              end
-
               on_arm do
               ^^^^^^^^^ `on_arm` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 if foo == :bar
@@ -1166,6 +1189,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
                   sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
                   url "https://brew.sh/resource1.tar.gz"
                 end
+              end
+              on_intel do
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
             end
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The formula part of #14017.
- Previously this components order cop only checked for correct stanza order inside `on_*` blocks and at the top-level. This commit extends this cop to also check for correct stanza order inside `head` and `resource` blocks. This is a positive change since it standardizes the order in all of the places, making formulae more readable.

-----

TODO:

- [ ] Are there any other kinds of blocks that we should consider asserting the inner order of?
- [x] Make a sample PR in `Homebrew/homebrew-core` with the problems that this reveals, to sanity check that it really does the right thing - there probably are some edge cases
  - https://github.com/Homebrew/homebrew-core/pull/126705
