### PR TITLE
rubocops: Allow `resource` blocks to include `on_*` blocks or conditionals

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -401,6 +401,7 @@ module RuboCop
 
         NO_ON_SYSTEM_METHOD_NAMES = [:install, :post_install].freeze
         NO_ON_SYSTEM_BLOCK_NAMES = [:service, :test].freeze
+        CAN_HAVE_ON_SYSTEM_BLOCK_NAMES = [:resource].freeze
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           NO_ON_SYSTEM_METHOD_NAMES.each do |formula_method_name|
@@ -420,11 +421,13 @@ module RuboCop
 
           audit_arch_conditionals(body_node,
                                   allowed_methods: NO_ON_SYSTEM_METHOD_NAMES,
-                                  allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES)
+                                  allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES,
+                                  optional_blocks: CAN_HAVE_ON_SYSTEM_BLOCK_NAMES)
 
           audit_base_os_conditionals(body_node,
                                      allowed_methods: NO_ON_SYSTEM_METHOD_NAMES,
-                                     allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES)
+                                     allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES,
+                                     optional_blocks: CAN_HAVE_ON_SYSTEM_BLOCK_NAMES)
 
           audit_macos_version_conditionals(body_node,
                                            allowed_methods:     NO_ON_SYSTEM_METHOD_NAMES,

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -57,4 +57,31 @@ describe RuboCop::Cop::FormulaAudit::Lines do
       RUBY
     end
   end
+
+  context "when auditing resource blocks" do
+    it "allows `on_*` blocks or conditionals" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          resource "bar" do
+            on_arm do
+              platform = "arm"
+            end
+            on_intel do
+              platform = "intel"
+            end
+            url "https://brew.sh/bar-\#{platform}-1.0.tgz"
+          end
+        end
+      RUBY
+
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          resource "baz" do
+            platform = Hardware::CPU.arm? ? "arm" : "intel"
+            url "https://brew.sh/baz-\#{platform}-1.0.tgz"
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was split out of #15060 because of [this comment](https://github.com/Homebrew/brew/pull/15060#issuecomment-1484167482).
- https://github.com/Homebrew/homebrew-core/pull/126705/commits/d2a58a7853e0581ceb80ab38e3244d1969fd2907 was deemed "unwiedly", but it passes the RuboCop.
- https://github.com/Homebrew/homebrew-core/pull/126705#discussion_r1148558613 is more wieldy, but needed RuboCop tweaks.
