### PR TITLE
cask/dsl: pass #{arch} to flight blocks

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -68,6 +68,7 @@ module Cask
 
     DSL_METHODS = Set.new([
       :appcast,
+      :arch,
       :artifacts,
       :auto_updates,
       :caveats,

--- a/Library/Homebrew/cask/dsl/base.rb
+++ b/Library/Homebrew/cask/dsl/base.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cask/utils"
+require "extend/on_system"
 
 module Cask
   class DSL
@@ -16,7 +17,7 @@ module Cask
         @command = command
       end
 
-      def_delegators :@cask, :token, :version, :caskroom_path, :staged_path, :appdir, :language
+      def_delegators :@cask, :token, :version, :caskroom_path, :staged_path, :appdir, :language, :arch
 
       def system_command(executable, **options)
         @command.run!(executable, **options)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This passes the `arch` variable from casks to `flight` blocks. Unblocks https://github.com/Homebrew/homebrew-cask/pull/143791