### PR TITLE
search: show results by platform

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -6,6 +6,7 @@ class Formula
   undef loader_path
   undef deuniversalize_machos
   undef add_global_deps_to_spec
+  undef valid_platform?
 
   sig { params(name: String, version: T.nilable(T.any(String, Integer))).returns(String) }
   def shared_library(name, version = nil)
@@ -42,5 +43,10 @@ class Formula
       ].compact.freeze
     end
     @global_deps.each { |dep| spec.dependency_collector.add(dep) }
+  end
+
+  sig { returns(T::Boolean) }
+  def valid_platform?
+    requirements.none?(MacOSRequirement)
   end
 end

--- a/Library/Homebrew/extend/os/mac/formula.rb
+++ b/Library/Homebrew/extend/os/mac/formula.rb
@@ -1,0 +1,11 @@
+# typed: true
+# frozen_string_literal: true
+
+class Formula
+  undef valid_platform?
+
+  sig { returns(T::Boolean) }
+  def valid_platform?
+    requirements.none?(LinuxRequirement)
+  end
+end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1948,6 +1948,13 @@ class Formula
     !tap.core_tap?
   end
 
+  # True if this formula can be installed on this platform
+  # Redefined in extend/os.
+  # @private
+  def valid_platform?
+    requirements.none?(MacOSRequirement) && requirements.none?(LinuxRequirement)
+  end
+
   # @private
   def print_tap_action(options = {})
     return unless tap?

--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -113,7 +113,7 @@ module Homebrew
 
         if formula&.any_version_installed?
           pretty_installed(name)
-        else
+        elsif formula.nil? || formula.valid_platform?
           name
         end
       end.compact


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Resolves #15053.

The idea here is that formulas that are only available on one OS should only show up in the search results for the platform.