### PR TITLE
formula: add missing extend/os require

### DIFF
--- a/Library/Homebrew/extend/os/formula.rb
+++ b/Library/Homebrew/extend/os/formula.rb
@@ -1,4 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "extend/os/linux/formula" if OS.linux?
+if OS.mac?
+  require "extend/os/mac/formula"
+elsif OS.linux?
+  require "extend/os/linux/formula"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows `Formula#valid_platform?` to work correctly on MacOS. It was left out of #15072 by accident. This meant MacOS only formulae were left out of search results.

## How it should work

### MacOS

```
/u/l/Homebrew (search-by-platform|✔) $ brew search xmount
==> Casks
mounty
/u/l/Homebrew (search-by-platform|✚1) $ brew search chisel
==> Formulae
chisel
```

### Linux

```
/u/l/Homebrew (search-by-platform|✚1) $ brew search xmount
==> Formulae
xmount
/u/l/Homebrew (search-by-platform|✚1) $ brew search chisel
Error: No formulae or casks found for "chisel".
```