### PR TITLE
Revert "Allow `resource` blocks to include `on_*` blocks or conditionals"

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -401,7 +401,6 @@ module RuboCop
 
         NO_ON_SYSTEM_METHOD_NAMES = [:install, :post_install].freeze
         NO_ON_SYSTEM_BLOCK_NAMES = [:service, :test].freeze
-        CAN_HAVE_ON_SYSTEM_BLOCK_NAMES = [:resource].freeze
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           NO_ON_SYSTEM_METHOD_NAMES.each do |formula_method_name|
@@ -421,13 +420,11 @@ module RuboCop
 
           audit_arch_conditionals(body_node,
                                   allowed_methods: NO_ON_SYSTEM_METHOD_NAMES,
-                                  allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES,
-                                  optional_blocks: CAN_HAVE_ON_SYSTEM_BLOCK_NAMES)
+                                  allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES)
 
           audit_base_os_conditionals(body_node,
                                      allowed_methods: NO_ON_SYSTEM_METHOD_NAMES,
-                                     allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES,
-                                     optional_blocks: CAN_HAVE_ON_SYSTEM_BLOCK_NAMES)
+                                     allowed_blocks:  NO_ON_SYSTEM_BLOCK_NAMES)
 
           audit_macos_version_conditionals(body_node,
                                            allowed_methods:     NO_ON_SYSTEM_METHOD_NAMES,

--- a/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
+++ b/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
@@ -78,16 +78,11 @@ module RuboCop
         end
       end
 
-      def audit_arch_conditionals(body_node, allowed_methods: [], allowed_blocks: [], optional_blocks: [])
+      def audit_arch_conditionals(body_node, allowed_methods: [], allowed_blocks: [])
         ARCH_OPTIONS.each do |arch_option|
           else_method = (arch_option == :arm) ? :on_intel : :on_arm
           if_arch_node_search(body_node, arch: :"#{arch_option}?") do |if_node, else_node|
-            next if if_node_is_allowed?(
-              if_node,
-              allowed_methods: allowed_methods,
-              allowed_blocks:  allowed_blocks,
-              optional_blocks: optional_blocks,
-            )
+            next if if_node_is_allowed?(if_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
 
             if_statement_problem(if_node, "if Hardware::CPU.#{arch_option}?", "on_#{arch_option}",
                                  else_method: else_method, else_node: else_node)
@@ -98,12 +93,7 @@ module RuboCop
           hardware_cpu_search(body_node, method: method) do |method_node|
             # These should already be caught by `if_arch_node_search`
             next if method_node.parent.source.start_with? "if #{method_node.source}"
-            next if if_node_is_allowed?(
-              method_node,
-              allowed_methods: allowed_methods,
-              allowed_blocks:  allowed_blocks,
-              optional_blocks: optional_blocks,
-            )
+            next if if_node_is_allowed?(method_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
 
             offending_node(method_node)
             problem "Don't use `#{method_node.source}`, use `on_arm` and `on_intel` blocks instead."
@@ -111,7 +101,7 @@ module RuboCop
         end
       end
 
-      def audit_base_os_conditionals(body_node, allowed_methods: [], allowed_blocks: [], optional_blocks: [])
+      def audit_base_os_conditionals(body_node, allowed_methods: [], allowed_blocks: [])
         BASE_OS_OPTIONS.each do |base_os_option|
           os_method, else_method = if base_os_option == :macos
             [:mac?, :on_linux]
@@ -119,12 +109,7 @@ module RuboCop
             [:linux?, :on_macos]
           end
           if_base_os_node_search(body_node, base_os: os_method) do |if_node, else_node|
-            next if if_node_is_allowed?(
-              if_node,
-              allowed_methods: allowed_methods,
-              allowed_blocks:  allowed_blocks,
-              optional_blocks: optional_blocks,
-            )
+            next if if_node_is_allowed?(if_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
 
             if_statement_problem(if_node, "if OS.#{os_method}", "on_#{base_os_option}",
                                  else_method: else_method, else_node: else_node)
@@ -185,16 +170,15 @@ module RuboCop
         end
       end
 
-      def if_node_is_allowed?(if_node, allowed_methods: [], allowed_blocks: [], optional_blocks: [])
+      def if_node_is_allowed?(if_node, allowed_methods: [], allowed_blocks: [])
         # TODO: check to see if it's legal
         valid = T.let(false, T::Boolean)
-        allowed_and_optional_blocks = allowed_blocks + optional_blocks
         if_node.each_ancestor do |ancestor|
           valid_method_names = case ancestor.type
           when :def
             allowed_methods
           when :block
-            allowed_and_optional_blocks
+            allowed_blocks
           else
             next
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This reverts commit b4cd90a3cc47bc2f94e4449fa99b37445b878a5f.

This should never have been merged but I didn't realise I hadn't backed it out of #15060 before it was approved and I merged it.

We had a multi-person discussion and it was decided against in https://github.com/Homebrew/homebrew-core/pull/126705#discussion_r1149545828.