### PR TITLE
bump-*-pr: fix an issue when using on taps with custom remote

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -196,7 +196,7 @@ module Homebrew
   end
 
   def check_pull_requests(cask, state:, args:, version: nil)
-    tap_remote_repo = cask.tap.remote_repo || cask.tap.full_name
+    tap_remote_repo = cask.tap.full_name || cask.tap.remote_repo
     GitHub.check_for_duplicate_pull_requests(cask.token, tap_remote_repo,
                                              state:   state,
                                              version: version,

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -121,7 +121,7 @@ module Homebrew
     # spamming during normal output.
     Homebrew.install_bundler_gems!
 
-    tap_remote_repo = formula.tap.remote_repo
+    tap_remote_repo = formula.tap.full_name || formula.tap.remote_repo
     remote = "origin"
     remote_branch = formula.tap.path.git_origin_branch
     previous_branch = "-"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When using bump-*-pr commands on taps with custom remote, an error message will appear:

```
Error: Validation Failed: [{"message"=>"The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.", "resource"=>"Search", "field"=>"q", "code"=>"invalid"}]
```

I found that it is caused by wrong `repo` argument when requesting GitHub API: the remote url of the repo is passed, not the full name of the repo. So GitHub cannot find it and returns back an error.