### PR TITLE
dev-cmd/tests: Deal with `TODO` for a BuildPulse bug that's fixed

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -60,13 +60,12 @@ module Homebrew
 
     ohai "Sending test results to BuildPulse"
 
-    # TODO: make this use `system_command!` when https://github.com/buildpulse/buildpulse-action/issues/4 is fixed
-    system_command Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
-                   args: [
-                     "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
-                     "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
-                     "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
-                   ]
+    system_command! Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
+                    args: [
+                      "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
+                      "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
+                      "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
+                    ]
   end
 
   def changed_test_files


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This does what the comment told us to do, use the bang variant of `system_command` to not swallow the errors.