### PR TITLE
Remove `--request GET` workaround for HEAD requests.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -464,7 +464,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     end
 
     output, _, _status = curl_output(
-      "--location", "--silent", "--head", "--request", "GET", url.to_s,
+      "--location", "--silent", "--head", url.to_s,
       timeout: timeout
     )
     parsed_output = parse_curl_output(output)

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -59,8 +59,6 @@ module Homebrew
       PAGE_HEADERS_CURL_ARGS = ([
         # We only need the response head (not the body)
         "--head",
-        # Some servers may not allow a HEAD request, so we use GET
-        "--request", "GET"
       ] + DEFAULT_CURL_ARGS).freeze
 
       # `curl` arguments used in `Strategy#page_content` method.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since https://github.com/Homebrew/brew/pull/14946 is getting stale as we cannot find an example of a server that doesn't support `--head` alone, let's just remove the workaround and properly re-add it as a fallback instead of the default case if/when we encounter such a server.

Also fixes CI for https://github.com/Homebrew/homebrew-cask/pull/144110.