### PR TITLE
dev-cmd/pr-*: remove `--commit-bottles-to-pr-branch`

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -74,7 +74,7 @@ module Homebrew
       pr_urls << pr["html_url"]
     end
 
-    publish_args = ["pr-publish", "--commit-bottles-to-pr-branch"]
+    publish_args = ["pr-publish"]
     publish_args << "--tap=#{tap}" if tap
     publish_args << "--workflow=#{args.workflow}" if args.workflow
     publish_args << "--autosquash" if args.autosquash?

--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -16,8 +16,6 @@ module Homebrew
         Publish bottles for a pull request with GitHub Actions.
         Requires write access to the repository.
       EOS
-      switch "--commit-bottles-to-pr-branch",
-             description: "Push bottle commits to the pull request branch."
       switch "--autosquash",
              description: "If supported on the target tap, automatically reformat and reword commits " \
                           "to our preferred format."
@@ -50,9 +48,8 @@ module Homebrew
     ref = args.branch || "master"
 
     inputs = {
-      commit_bottles_to_pr_branch: args.commit_bottles_to_pr_branch?,
-      autosquash:                  args.autosquash?,
-      large_runner:                args.large_runner?,
+      autosquash:   args.autosquash?,
+      large_runner: args.large_runner?,
     }
     inputs[:message] = args.message if args.message.presence
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will be made the default by Homebrew/homebrew-core#127021.
Additionally, branch protection rules will make it so that attempting to
push to master will fail, so we may as well not have to carry this flag
around.
