### PR TITLE
dispatch-build-bottle: cleanup

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -87,8 +87,7 @@ module Homebrew
       # These cannot be passed as nil to GitHub API
       inputs[:timeout] = args.timeout if args.timeout
       inputs[:issue] = args.issue if args.issue
-      inputs[:upload] = args.upload?.to_s if args.upload?
-      inputs[:wheezy] = args.linux_wheezy?.to_s if args.linux_wheezy?
+      inputs[:upload] = args.upload?
 
       ohai "Dispatching #{tap} bottling request of formula \"#{formula.name}\" for #{runners.join(", ")}"
       GitHub.workflow_dispatch_event(user, repo, workflow, ref, inputs)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `upload` input will be made into a boolean in
Homebrew/homebrew-core#127026.

`linux_wheezy` is no longer a valid input to the workflow, so let's get
rid of that.
