### PR TITLE
Strategy: Use GET for checking response head again

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -59,6 +59,8 @@ module Homebrew
       PAGE_HEADERS_CURL_ARGS = ([
         # We only need the response head (not the body)
         "--head",
+        # Some servers may not allow a HEAD request, so we use GET
+        "--request", "GET"
       ] + DEFAULT_CURL_ARGS).freeze
 
       # `curl` arguments used in `Strategy#page_content` method.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to #15089, where `Livecheck::Strategy::PAGE_HEADERS_CURL_ARGS` was modified to use a `HEAD` request instead of `GET`. Unfortunately I wasn't able to review the PR before it was merged and the change breaks 31 previously-working `HeaderMatch` checks (see the PR description in #15099 for a detailed list).

In these cases, the server returns a 200 (OK) response when using a `HEAD` request and a `GET` request is required to trigger a redirection. Without a `location` header in the response head(s), the checks predictably return an `Unable to get versions` error.

In the long term, using a `HEAD` request as the default makes sense when we're able to manually account for checks that require a `GET` request in the relevant `livecheck` block but this isn't possible yet. In the interim time, returning to using `GET` requests by default seems sensible in light of these broken checks (i.e., breaking 33 checks to fix one feels like a poor trade-off at the moment).

-----

Being able to add to the `curl` args in a `livecheck` block is one of the initial uses cases for the `options` feature that I've been talking about for ages. I need to take another pass through that work before creating a PR but I'll try to finally get it out this weekend or next week (it's been one of the items at the top of my to-do list recently).