### PR TITLE
HeaderMatch: Retry with a GET request

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -187,12 +187,19 @@ module Homebrew
       def self.page_headers(url, options = {})
         headers = []
 
+        args = if options[:curl_args].is_a?(Array)
+          PAGE_HEADERS_CURL_ARGS + options[:curl_args]
+        else
+          PAGE_HEADERS_CURL_ARGS
+        end
+
         [:default, :browser].each do |user_agent|
           output, _, status = curl_with_workarounds(
-            *PAGE_HEADERS_CURL_ARGS, url,
+            *args,
+            url,
             **DEFAULT_CURL_OPTIONS,
             use_homebrew_curl: options[:homebrew_curl] || false,
-            user_agent:        user_agent
+            user_agent:        user_agent,
           )
           next unless status.success?
 

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -181,17 +181,17 @@ module Homebrew
       # collected into an array of hashes.
       #
       # @param url [String] the URL to fetch
-      # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+      # @param options [Hash] options to control behavior
       # @return [Array]
-      sig { params(url: String, homebrew_curl: T::Boolean).returns(T::Array[T::Hash[String, String]]) }
-      def self.page_headers(url, homebrew_curl: false)
+      sig { params(url: String, options: T::Hash[Symbol, T.untyped]).returns(T::Array[T::Hash[String, String]]) }
+      def self.page_headers(url, options = {})
         headers = []
 
         [:default, :browser].each do |user_agent|
           output, _, status = curl_with_workarounds(
             *PAGE_HEADERS_CURL_ARGS, url,
             **DEFAULT_CURL_OPTIONS,
-            use_homebrew_curl: homebrew_curl,
+            use_homebrew_curl: options[:homebrew_curl] || false,
             user_agent:        user_agent
           )
           next unless status.success?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As mentioned in #15096, using a `HEAD` request in `Livecheck::Strategy#page_headers` breaks 31 previously-working checks using the `HeaderMatch` strategy (all casks), where a `GET` request is required for the server to redirect (or resolve):

| Cask | Response(s) | Notes |
|------|-------------|-------|
| affinity-designer | 200 | |
| affinity-photo | 200 | |
| affinity-publisher | 200 | |
| aircall | 404 | |
| authy | 403 | |
| awa | 404 | |
| bankid | 200 | |
| beeper | 404 | |
| bitwarden | 404 | |
| blackvue-viewer | 301 -> 302 -> 403 | 302 response's `location` header is correct |
| bluestacks | 405 | Has `allow: GET, POST` header |
| catlight | 405 | Has `allow: GET` header |
| confectionery | 307 | URL in `location` header times out with `HEAD` request |
| dingtalk | 405 | Has `allow: GET` header |
| dingtalk-lite | 405 | Has `allow: GET` header |
imgotv | 405 | Has `access-control-allow-methods: GET, PUT, POST, DELETE, PATCH, OPTIONS` header |
| krisp | 302 -> 404 | 302 response's `location` header is correct |
| linear-linear | 404 | |
| mixed-in-key | 404 | |
| mixed-in-key-live | 404 | |
| odrive | 405 | Has `allow: GET` header |
| prepros | 302 -> 405 | 302 response's `location` header is correct |
| roli-connect | 302 -> 403 | 302 response's `location` header is correct |
| skype | 404 | |
| skype-preview | 404 | |
| sound-siphon | 200 | |
| splashtop-business | 404 | |
| splashtop-personal | 404 | |
| splashtop-streamer | 404 | |
| ui | 404 | |
| wordpresscom | 405 | Has `allow: GET` header |

#15096 simply modifies `PAGE_HEADERS_CURL_ARGS` to use a `GET` request again but this PR instead modifies `HeaderMatch#find_versions` to add some temporary logic that will retry a request using `GET` if it fails using `HEAD` or doesn't produce version information. This allows the aforementioned checks to work again without switching all `#page_headers` requests back to `GET`.

This isn't a long-term solution, as these checks will waste a `HEAD` request before making a `GET` request. Similarly, this logic may retry a request that will also fail with a `GET` request. Overall, this results in more requests to upstream servers than necessary.

This is simply a short-term workaround until the `options` feature is available, as that will allow us to add `--request GET` to the curl args in related `livecheck` blocks instead. That's the more appropriate fix for these, as it will allow us to address these checks without the unnecessary requests involved with this retry logic.

-----

As mentioned in #15096, I'm going to try to get a PR up for the `options` feature in the coming days (it has been implemented/functional for quite some time but I need to take a final pass over it), so this `HeaderMatch` workaround will hopefully be short-lived.

For what it's worth, the changes to `Strategy#page_headers` come directly from the forthcoming `options` feature and shouldn't require any additional modifications. I've also structured the `HeaderMatch` changes to make them easy to walk back with respect to the `options` feature.