### PR TITLE
Fix `brew install --skip-post-install`

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -250,6 +250,7 @@ module Homebrew
       quiet:                      args.quiet?,
       verbose:                    args.verbose?,
       dry_run:                    args.dry_run?,
+      skip_post_install:          args.skip_post_install?,
     )
 
     Upgrade.check_installed_dependents(

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -281,7 +281,8 @@ module Homebrew
       debug: false,
       quiet: false,
       verbose: false,
-      dry_run: false
+      dry_run: false,
+      skip_post_install: false
     )
       formula_installers = formulae_to_install.map do |formula|
         Migrator.migrate_if_needed(formula, force: force, dry_run: dry_run)
@@ -307,6 +308,7 @@ module Homebrew
           debug:                      debug,
           quiet:                      quiet,
           verbose:                    verbose,
+          skip_post_install:          skip_post_install,
         )
 
         begin


### PR DESCRIPTION
Previous #15042 doesn't pass the flag all the way to `FormulaInstaller.new`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
