### PR TITLE
dev-cmd/tests: temporary fix for BuildPulse failure

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -60,12 +60,12 @@ module Homebrew
 
     ohai "Sending test results to BuildPulse"
 
-    system_command! Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
-                    args: [
-                      "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
-                      "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
-                      "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
-                    ]
+    system_command Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
+                   args: [
+                     "submit", "#{HOMEBREW_LIBRARY_PATH}/test/junit",
+                     "--account-id", ENV.fetch("HOMEBREW_BUILDPULSE_ACCOUNT_ID"),
+                     "--repository-id", ENV.fetch("HOMEBREW_BUILDPULSE_REPOSITORY_ID")
+                   ]
   end
 
   def changed_test_files


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We're seeing BuildPulse failures again on some PRs so let's use `system_command` again for now. Ref: #15100, #15101, #15102.

```
==> Sending test results to BuildPulse
env: parse error on field "GithubRunID" of type "uint": strconv.ParseUint: parsing "4569488695": value out of range
Error: Failure while executing; `/usr/bin/env /home/linuxbrew/.linuxbrew/opt/buildpulse-test-reporter/bin/buildpulse-test-reporter submit /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test/junit --account-id 1503512 --repository-id 53238813` exited with 1. Here's the output:
<buildpulse> Current version: BuildPulse Test Reporter 0.24.2 (linux Homebrew go1.20.1)
<buildpulse> Initiating `submit`
<buildpulse> Received args: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test/junit --account-id 1503512 --repository-id 53238813
<buildpulse> Using working directory: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew
<buildpulse> Using default value for -repository-dir flag: .
<buildpulse> Looking for git repository at .
<buildpulse> Found git repository at .
<buildpulse> Gathering metadata to describe the build
<buildpulse> Detected build environment: github-actions
env: parse error on field "GithubRunID" of type "uint": strconv.ParseUint: parsing "4569488695": value out of range
Error: Process completed with exit code 1.
```