### PR TITLE
Revert "Remove `--request GET` workaround for HEAD requests."

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -464,7 +464,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     end
 
     output, _, _status = curl_output(
-      "--location", "--silent", "--head", url.to_s,
+      "--location", "--silent", "--head", "--request", "GET", url.to_s,
       timeout: timeout
     )
     parsed_output = parse_curl_output(output)

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -59,6 +59,8 @@ module Homebrew
       PAGE_HEADERS_CURL_ARGS = ([
         # We only need the response head (not the body)
         "--head",
+        # Some servers may not allow a HEAD request, so we use GET
+        "--request", "GET"
       ] + DEFAULT_CURL_ARGS).freeze
 
       # `curl` arguments used in `Strategy#page_content` method.


### PR DESCRIPTION
This has caused a regression: https://github.com/Homebrew/brew/pull/15089#issuecomment-1490945405

Reverts Homebrew/brew#15089
Closes https://github.com/Homebrew/brew/pull/15096

