### PR TITLE
Enable typing in Ignorable

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -54,7 +54,7 @@ module Homebrew
     start_commit = T.let("", T.untyped)
     end_commit = "HEAD"
     cd HOMEBREW_REPOSITORY do
-      start_commit = if (commit = T.let(args.commit, T.nilable(String)))
+      start_commit = if (commit = args.commit)
         commit
       elsif (date = args.before)
         Utils.popen_read("git", "rev-list", "-n1", "--before=#{date}", "origin/master").chomp

--- a/Library/Homebrew/ignorable.rb
+++ b/Library/Homebrew/ignorable.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "warnings"
@@ -30,7 +30,7 @@ module Ignorable
         rescue Exception => e # rubocop:disable Lint/RescueException
           unless e.is_a?(ScriptError)
             e.extend(ExceptionMixin)
-            e.continuation = continuation
+            T.cast(e, ExceptionMixin).continuation = continuation
           end
           super(e)
         end
@@ -47,7 +47,6 @@ module Ignorable
 
   def self.unhook_raise
     Object.class_eval do
-      # False positive - https://github.com/rubocop/rubocop/issues/5022
       alias_method :raise, :original_raise
       alias_method :fail, :original_raise
       undef :original_raise

--- a/Library/Homebrew/ignorable.rbi
+++ b/Library/Homebrew/ignorable.rbi
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Ignorable
+  include Kernel
+  # This is a workaround to enable `raise` to be aliased
+  # @see https://github.com/sorbet/sorbet/issues/2378#issuecomment-569474238
+  def self.raise(*); end
+end

--- a/Library/Homebrew/sorbet/rbi/upstream.rbi
+++ b/Library/Homebrew/sorbet/rbi/upstream.rbi
@@ -1,0 +1,32 @@
+# typed: strict
+
+# This file contains temporary definitions for fixes that have
+# been submitted upstream to https://github.com/sorbet/sorbet.
+
+module Kernel
+  # @see https://github.com/sorbet/sorbet/blob/a1e8389/rbi/core/kernel.rbi#L41-L46
+  sig do
+    type_parameters(:U).params(
+      block: T.proc.params(cont: Continuation).returns(T.type_parameter(:U))
+    ).returns(T.type_parameter(:U))
+  end
+  def callcc(&block); end
+
+  # @see https://github.com/sorbet/sorbet/blob/a1e8389/rbi/core/kernel.rbi#L2348-L2363
+  sig do
+    params(
+      arg0: T.nilable(
+        T.proc.params(
+          event: String,
+          file: String,
+          line: Integer,
+          id: T.nilable(Symbol),
+          binding: T.nilable(Binding),
+          classname: Object,
+        ).returns(T.untyped)
+      )
+    ).void
+  end
+  sig { params(arg0: NilClass).returns(NilClass) }
+  def set_trace_func(arg0); end
+end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Enables typing for the `Ignorable` and `Debrew` files.

Restores the upstream.rbi file to include type definitions that are necessary but not in our version of sorbet. (They're a pair of private methods, so pretending them with `T.unsafe(self)` doesn't work.)