### PR TITLE
Add `curl_head` method.

### DIFF
--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -9,12 +9,38 @@ describe CurlGitHubPackagesDownloadStrategy do
   let(:name) { "foo" }
   let(:url) { "https://#{GitHubPackages::URL_DOMAIN}/v2/homebrew/core/spec_test/manifests/1.2.3" }
   let(:version) { "1.2.3" }
-  let(:specs) { {} }
+  let(:specs) { { headers: ["Accept: application/vnd.oci.image.index.v1+json"] } }
   let(:authorization) { nil }
+  let(:head_response) do
+    <<~HTTP
+      HTTP/2 200\r
+      content-length: 12671\r
+      content-type: application/vnd.oci.image.index.v1+json\r
+      docker-content-digest: sha256:7d752ee92d9120e3884b452dce15328536a60d468023ea8e9f4b09839a5442e5\r
+      docker-distribution-api-version: registry/2.0\r
+      etag: "sha256:7d752ee92d9120e3884b452dce15328536a60d468023ea8e9f4b09839a5442e5"\r
+      date: Sun, 02 Apr 2023 22:45:08 GMT\r
+      x-github-request-id: 8814:FA5A:14DAFB5:158D7A2:642A0574\r
+    HTTP
+  end
 
   describe "#fetch" do
     before do
       stub_const("HOMEBREW_GITHUB_PACKAGES_AUTH", authorization) if authorization.present?
+
+      allow(strategy).to receive(:system_command)
+        .with(
+          /curl/,
+          hash_including(args: array_including("--head")),
+        )
+        .twice
+        .and_return(instance_double(
+                      SystemCommand::Result,
+                      success?:    true,
+                      exit_status: instance_double(Process::Status, exitstatus: 0),
+                      stdout:      head_response,
+                    ))
+
       strategy.temporary_path.dirname.mkpath
       FileUtils.touch strategy.temporary_path
     end

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -10,9 +10,28 @@ describe CurlPostDownloadStrategy do
   let(:url) { "https://example.com/foo.tar.gz" }
   let(:version) { "1.2.3" }
   let(:specs) { {} }
+  let(:head_response) do
+    <<~HTTP
+      HTTP/1.1 200\r
+      Content-Disposition: attachment; filename="foo.tar.gz"
+    HTTP
+  end
 
   describe "#fetch" do
     before do
+      allow(strategy).to receive(:system_command)
+        .with(
+          /curl/,
+          hash_including(args: array_including("--head")),
+        )
+        .twice
+        .and_return(instance_double(
+                      SystemCommand::Result,
+                      success?:    true,
+                      exit_status: instance_double(Process::Status, exitstatus: 0),
+                      stdout:      head_response,
+                    ))
+
       strategy.temporary_path.dirname.mkpath
       FileUtils.touch strategy.temporary_path
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

@samford, I hope you didn't start on the `curl_head` method yet.

This re-adds the `--request GET` workaround, but now `--head` is tried first and a retry with `--request GET` is only done if we didn't get a `Content-Disposition` header, which is the only relevant header containing the resolved filename of a download.
