### PR TITLE
service: handle string run cmd

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -569,7 +569,7 @@ module Homebrew
             [key.to_sym, run_cmd]
           end
         else
-          raise ArgumentError, "Unexepected run command: #{api_hash["run"]}"
+          raise ArgumentError, "Unexpected run command: #{api_hash["run"]}"
         end
 
       hash[:keep_alive] = api_hash["keep_alive"].transform_keys(&:to_sym) if api_hash.key?("keep_alive")

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -975,5 +975,37 @@ describe Homebrew::Service do
     it "replaces placeholders with local paths" do
       expect(described_class.deserialize(serialized_hash)).to eq(deserialized_hash)
     end
+
+    describe "run command" do
+      it "handles String argument correctly" do
+        expect(described_class.deserialize({
+          "run" => "$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd",
+        })).to eq({
+          run: "#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd",
+        })
+      end
+
+      it "handles Array argument correctly" do
+        expect(described_class.deserialize({
+          "run" => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "--option"],
+        })).to eq({
+          run: ["#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd", "--option"],
+        })
+      end
+
+      it "handles Hash argument correctly" do
+        expect(described_class.deserialize({
+          "run" => {
+            "linux" => "$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd",
+            "macos" => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "--option"],
+          },
+        })).to eq({
+          run: {
+            linux: "#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd",
+            macos: ["#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd", "--option"],
+          },
+        })
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a very bad bug that snuck in after #15007. Essentially, it didn't come up during testing because of a bug in my testing script. The `Service#run` handles strings by turning them into arrays. The string argument gets turned into an array internally but we skip that to preserve all args in the `@run_params` variable. That means that we have to handle strings when deserializing too.

This affects 58 services by my count and makes the services impossible to install correctly since the path deserialization doesn't work at all.

```
appium
arangodb
artifactory
asimov
auditbeat
automysqlbackup
bazarr
beanstalkd
bitcoin
bitlbee
black
blazegraph
carrot2
cassandra-reaper
chronograf
clash
clipper
code-server
collector-sidecar
couchdb-lucene
couchdb
daemontools
davmail
docuum
filebeat
freediameter
fuseki
gearman
groestlcoin
heartbeat
icecream
immudb
influxdb
ircd-hybrid
jackett
jobber
kibana@6
knot
lldpd
logstash
metabase
metricbeat
mpdas
nats-server
nats-streaming-server
openiked
opensearch-dashboards
opensearch
opentsdb
orientdb
packetbeat
pdns
pdnsd
rabbitmq
redshift
tailscale
tor
trezor-bridge
yorkie
```

I've updated the [testing script](https://gist.github.com/apainintheneck/6ed138ac7214788cd20bb7da82f7aa36) from before to not skip services without commands which was something I did early on because of one false positive. I also added some more testing around the different run command parameter types.