### PR TITLE
Python: allow --no-build-isolation for pip install

### DIFF
--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -67,6 +67,14 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
       virtualenv.pip_install res
     end
+
+    it "works without build isolation" do
+      expect(formula).to receive(:system)
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "--no-build-isolation", "foo")
+        .and_return(true)
+      virtualenv.pip_install("foo", build_isolation: false)
+    end
   end
 
   describe "#pip_install_and_link" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Python's packaging system is (seemingly) constantly in a state of flux. The current best practice is to put packaging information into a file called `pyproject.toml`, [as documented by `pip`](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/). When using `pyproject.toml` for building packages, the first step of the process is to create an isolated build environment for installing build dependencies.

However, this isolated build environment is not always desirable. By definition, an isolated build environment can't take advantage of dependencies that are already present on the system. Homebrew already sets up isolated build environments, but in such a way that the build environment _does_ have access to other Homebrew packages marked as dependencies in the formula. This becomes important when a build dependency is difficult to build locally, and has been packaged in Homebrew specifically for that purpose, like the `pytorch` formula.

This pull request adds a `build_isolation` flag to the Homebrew methods related to running `pip install`. By passing `build_isolation: false`, a formula can indicate that the `pip install` command should be run with the `--no-build-isolation` flag, [which disables build isolation in `pip`](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#disabling-build-isolation). This should be only beneficial for formulae built in completely isolated build environments, like on GitHub Actions. It may present some small amount of risk for formulae build locally on a user's computer, which probably does not have the same level of build isolation -- but considering that this is an opt-in feature, it seems worth providing this option to formula authors.

This is my first time sending a pull request to the `brew` repo, so if I've done something wrong, please let me know!