### PR TITLE
install: check for `--only-dependencies` flag earlier

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -174,15 +174,15 @@ module Homebrew
               The currently linked version is: #{formula.linked_version}
             EOS
           end
+        elsif only_dependencies
+          msg = nil
+          return true
         elsif !formula.linked? || formula.keg_only?
           msg = <<~EOS
             #{msg}, it's just not linked.
             To link this version, run:
               brew link #{formula}
           EOS
-        elsif only_dependencies
-          msg = nil
-          return true
         else
           msg = if quiet
             nil


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, doing `brew install --only-dependencies` with an unlinked
formula does nothing and returns a message saying the formula is already
installed but just not linked.

I think that we should just install the dependencies as requested here
instead of complaining that the formula isn't linked.

Before:

    ❯ brew unlink adplug
    Unlinking /usr/local/Cellar/adplug/2.3.3... 8 symlinks removed.
    ❯ brew install --only-dependencies adplug
    Warning: adplug 2.3.3 is already installed, it's just not linked.
    To link this version, run:
      brew link adplug

After:

    ❯ brew install --only-dependencies adplug
    ==> Fetching dependencies for adplug: libbinio
    ==> Fetching libbinio
    ==> Downloading https://ghcr.io/v2/homebrew/core/libbinio/manifests/1.5
    [snip]

See Homebrew/homebrew-core#127133 for additional context.
