### PR TITLE
rubocops/cask: Ensure that "verified" URLs with paths end with "/"

### DIFF
--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -24,6 +24,7 @@ module RuboCop
         def on_url_stanza(stanza)
           return if stanza.stanza_node.block_type?
 
+          url_string = stanza.stanza_node.first_argument.str_content
           hash_node = stanza.stanza_node.last_argument
           return unless hash_node.hash_type?
 
@@ -40,7 +41,9 @@ module RuboCop
               end
             end
 
-            next unless value_node.str_content.gsub(%r{https?://}, "").include?("/") # Skip if the stanza has no path.
+            # Skip if the URL and the verified value are the same.
+            next if value_node.str_content == url_string.delete_prefix("https://").delete_prefix("http://")
+            # Skip if the verified value ends with a slash.
             next if value_node.str_content.end_with?("/")
 
             add_offense(

--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -43,6 +43,8 @@ module RuboCop
 
             # Skip if the URL and the verified value are the same.
             next if value_node.source == url_stanza.source.gsub(%r{^"https?://}, "\"")
+            # Skip if the URL has two path components, eg: `https://github.com/google/fonts.git`.
+            next if url_stanza.source.gsub(%r{^"https?://}, "\"").count("/") == 2
             # Skip if the verified value ends with a slash.
             next if value_node.str_content.end_with?("/")
 

--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -9,12 +9,12 @@ module RuboCop
       # @example
       #   # bad
       #   url "https://example.com/download/foo.dmg",
-      #     verified: "https://example.com/download"
+      #       verified: "https://example.com/download"
       #
       #
       #   # good
       #   url "https://example.com/download/foo.dmg",
-      #     verified: "example.com/download/"
+      #       verified: "example.com/download/"
       #
       class Url < Base
         extend AutoCorrector

--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -24,7 +24,7 @@ module RuboCop
         def on_url_stanza(stanza)
           return if stanza.stanza_node.block_type?
 
-          url_string = stanza.stanza_node.first_argument.str_content
+          url_stanza = stanza.stanza_node.first_argument
           hash_node = stanza.stanza_node.last_argument
           return unless hash_node.hash_type?
 
@@ -42,7 +42,7 @@ module RuboCop
             end
 
             # Skip if the URL and the verified value are the same.
-            next if value_node.str_content == url_string.delete_prefix("https://").delete_prefix("http://")
+            next if value_node.source == url_stanza.source.gsub(%r{^"https?://}, "\"")
             # Skip if the verified value ends with a slash.
             next if value_node.str_content.end_with?("/")
 

--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -35,7 +35,7 @@ module RuboCop
             if value_node.source.start_with?(%r{^"https?://})
               add_offense(
                 value_node.source_range,
-                message: "Verified URL parameter value should not start with https:// or http://.",
+                message: "Verified URL parameter value should not contain a URL scheme.",
               ) do |corrector|
                 corrector.replace(value_node.source_range, value_node.source.gsub(%r{^"https?://}, "\""))
               end

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -104,16 +104,31 @@ describe RuboCop::Cop::Cask::Url do
   end
 
   context "when the URL does not end with a slash" do
-    let(:source) do
-      <<~CASK
-        cask "foo" do
-          url "https://github.com/Foo",
-              verified: "github.com/Foo"
-        end
-      CASK
+    describe "and it has one path component" do
+      let(:source) do
+        <<~CASK
+          cask "foo" do
+            url "https://github.com/Foo",
+                verified: "github.com/Foo"
+          end
+        CASK
+      end
+
+      include_examples "does not report any offenses"
     end
 
-    include_examples "does not report any offenses"
+    describe "and it has two path components" do
+      let(:source) do
+        <<~CASK
+          cask "foo" do
+            url "https://github.com/foo/foo.git",
+                verified: "github.com/foo/foo"
+          end
+        CASK
+      end
+
+      include_examples "does not report any offenses"
+    end
   end
 
   context "when the url ends with a / and the verified value does too" do

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Cask::Url do
 
     let(:expected_offenses) do
       [{
-        message:  "Verified URL parameter value should not start with https:// or http://.",
+        message:  "Verified URL parameter value should not contain a URL scheme.",
         severity: :convention,
         line:     3,
         column:   16,

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -54,4 +54,50 @@ describe RuboCop::Cop::Cask::Url do
     include_examples "reports offenses"
     include_examples "autocorrects source"
   end
+
+  context "when url 'verified' value has a path component that ends with a /" do
+    let(:source) do
+      <<~CASK
+        cask "foo" do
+          url "https://example.com/download/foo-v1.2.0.dmg",
+            verified: "example.com/download/"
+        end
+      CASK
+    end
+
+    include_examples "does not report any offenses"
+  end
+
+  context "when the url 'verified' value has a path component that doesn't end with a /" do
+    let(:source) do
+      <<~CASK
+        cask "foo" do
+          url "https://example.com/download/foo-v1.2.0.dmg",
+            verified: "example.com/download"
+        end
+      CASK
+    end
+
+    let(:expected_offenses) do
+      [{
+        message:  "Verified URL parameter value should end with a /.",
+        severity: :convention,
+        line:     3,
+        column:   14,
+        source:   "\"example.com/download\"",
+      }]
+    end
+
+    let(:correct_source) do
+      <<~CASK
+        cask "foo" do
+          url "https://example.com/download/foo-v1.2.0.dmg",
+            verified: "example.com/download/"
+        end
+      CASK
+    end
+
+    include_examples "reports offenses"
+    include_examples "autocorrects source"
+  end
 end

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -175,6 +175,20 @@ describe RuboCop::Cop::Cask::Url do
     include_examples "does not report any offenses"
   end
 
+  context "when the url has interpolation in it and the verified url ends with a /" do
+    let(:source) do
+      <<~CASK
+        cask "foo" do
+          version "1.2.3"
+          url "https://example.com/download/foo-v\#{version}.dmg",
+              verified: "example.com/download/"
+        end
+      CASK
+    end
+
+    include_examples "does not report any offenses"
+  end
+
   context "when the url 'verified' value has a path component that doesn't end with a /" do
     let(:source) do
       <<~CASK

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-              verified: "example.com"
+              verified: "example.com/download/"
         end
       CASK
     end
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-              verified: "https://example.com"
+              verified: "https://example.com/download/"
         end
       CASK
     end
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Cask::Url do
         severity: :convention,
         line:     3,
         column:   16,
-        source:   "\"https://example.com\"",
+        source:   "\"https://example.com/download/\"",
       }]
     end
 
@@ -46,7 +46,114 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-              verified: "example.com"
+              verified: "example.com/download/"
+        end
+      CASK
+    end
+
+    include_examples "reports offenses"
+    include_examples "autocorrects source"
+  end
+
+  context "when url 'verified' value does not have a path component" do
+    context "when the URL ends with a slash" do
+      let(:source) do
+        <<~CASK
+          cask "foo" do
+            url "https://example.org/",
+                verified: "example.org/"
+          end
+        CASK
+      end
+
+      include_examples "does not report any offenses"
+    end
+
+    context "when the URL does not end with a slash" do
+      let(:source) do
+        <<~CASK
+          cask "foo" do
+            url "https://example.org/",
+                verified: "example.org"
+          end
+        CASK
+      end
+
+      let(:expected_offenses) do
+        [{
+          message:  "Verified URL parameter value should end with a /.",
+          severity: :convention,
+          line:     3,
+          column:   16,
+          source:   "\"example.org\"",
+        }]
+      end
+
+      let(:correct_source) do
+        <<~CASK
+          cask "foo" do
+            url "https://example.org/",
+                verified: "example.org/"
+          end
+        CASK
+      end
+
+      include_examples "reports offenses"
+      include_examples "autocorrects source"
+    end
+  end
+
+  context "when the URL does not end with a slash" do
+    let(:source) do
+      <<~CASK
+        cask "foo" do
+          url "https://github.com/Foo",
+              verified: "github.com/Foo"
+        end
+      CASK
+    end
+
+    include_examples "does not report any offenses"
+  end
+
+  context "when the url ends with a / and the verified value does too" do
+    let(:source) do
+      <<~CASK
+        cask "foo" do
+          url "https://github.com/",
+              verified: "github.com/"
+        end
+      CASK
+    end
+
+    include_examples "does not report any offenses"
+  end
+
+  context "when the url ends with a / and the verified value does not" do
+    let(:source) do
+      <<~CASK
+        cask "foo" do
+          url "https://github.com/",
+              verified: "github.com"
+        end
+      CASK
+    end
+
+    let(:expected_offenses) do
+      [{
+        message:  "Verified URL parameter value should end with a /.",
+        severity: :convention,
+        line:     3,
+        column:   16,
+        source:   "\"github.com\"",
+      }]
+    end
+
+    let(:correct_source) do
+      <<~CASK
+        cask "foo" do
+          url "https://github.com/",
+              verified: "github.com/"
         end
       CASK
     end
@@ -59,8 +166,8 @@ describe RuboCop::Cop::Cask::Url do
     let(:source) do
       <<~CASK
         cask "foo" do
-          url "https://example.com/download/foo-v1.2.0.dmg",
-              verified: "example.com/download/"
+          url "https://github.com/Foo/foo/releases/download/v1.2.0/foo-v1.2.0.dmg",
+              verified: "github.com/Foo/foo/"
         end
       CASK
     end
@@ -72,8 +179,8 @@ describe RuboCop::Cop::Cask::Url do
     let(:source) do
       <<~CASK
         cask "foo" do
-          url "https://example.com/download/foo-v1.2.0.dmg",
-              verified: "example.com/download"
+          url "https://github.com/Foo/foo/releases/download/v1.2.0/foo-v1.2.0.dmg",
+              verified: "github.com/Foo/foo"
         end
       CASK
     end
@@ -84,15 +191,15 @@ describe RuboCop::Cop::Cask::Url do
         severity: :convention,
         line:     3,
         column:   16,
-        source:   "\"example.com/download\"",
+        source:   "\"github.com/Foo/foo\"",
       }]
     end
 
     let(:correct_source) do
       <<~CASK
         cask "foo" do
-          url "https://example.com/download/foo-v1.2.0.dmg",
-              verified: "example.com/download/"
+          url "https://github.com/Foo/foo/releases/download/v1.2.0/foo-v1.2.0.dmg",
+              verified: "github.com/Foo/foo/"
         end
       CASK
     end

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-            verified: "example.com"
+              verified: "example.com"
         end
       CASK
     end
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-            verified: "https://example.com"
+              verified: "https://example.com"
         end
       CASK
     end
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Cask::Url do
         message:  "Verified URL parameter value should not start with https:// or http://.",
         severity: :convention,
         line:     3,
-        column:   14,
+        column:   16,
         source:   "\"https://example.com\"",
       }]
     end
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-            verified: "example.com"
+              verified: "example.com"
         end
       CASK
     end
@@ -60,7 +60,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-            verified: "example.com/download/"
+              verified: "example.com/download/"
         end
       CASK
     end
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-            verified: "example.com/download"
+              verified: "example.com/download"
         end
       CASK
     end
@@ -83,7 +83,7 @@ describe RuboCop::Cop::Cask::Url do
         message:  "Verified URL parameter value should end with a /.",
         severity: :convention,
         line:     3,
-        column:   14,
+        column:   16,
         source:   "\"example.com/download\"",
       }]
     end
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Cask::Url do
       <<~CASK
         cask "foo" do
           url "https://example.com/download/foo-v1.2.0.dmg",
-            verified: "example.com/download/"
+              verified: "example.com/download/"
         end
       CASK
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #15108.
- These were [being fixed manually](https://github.com/Homebrew/homebrew-cask/pull/144179#issuecomment-1489857249), so let's make a RuboCop for any further occurrences since this is [a good rule to enforce](https://github.com/Homebrew/homebrew-cask/pull/80965#issuecomment-616232313).
