### PR TITLE
Use type-safe exhaustiveness checking

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -53,7 +53,7 @@ module Homebrew
       end
 
       command ||= on_system_conditional(macos: macos, linux: linux)
-      case T.unsafe(command)
+      case command
       when nil
         @run
       when String, Pathname
@@ -67,61 +67,61 @@ module Homebrew
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def working_dir(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @working_dir
       when String, Pathname
         @working_dir = path.to_s
       else
-        raise TypeError, "Service#working_dir expects a String"
+        T.absurd(path)
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def root_dir(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @root_dir
       when String, Pathname
         @root_dir = path.to_s
       else
-        raise TypeError, "Service#root_dir expects a String or Pathname"
+        T.absurd(path)
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def input_path(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @input_path
       when String, Pathname
         @input_path = path.to_s
       else
-        raise TypeError, "Service#input_path expects a String or Pathname"
+        T.absurd(path)
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def log_path(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @log_path
       when String, Pathname
         @log_path = path.to_s
       else
-        raise TypeError, "Service#log_path expects a String"
+        T.absurd(path)
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def error_log_path(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @error_log_path
       when String, Pathname
         @error_log_path = path.to_s
       else
-        raise TypeError, "Service#error_log_path expects a String"
+        T.absurd(path)
       end
     end
 
@@ -130,7 +130,7 @@ module Homebrew
         .returns(T.nilable(T::Hash[Symbol, T.untyped]))
     }
     def keep_alive(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @keep_alive
       when true, false
@@ -143,19 +143,19 @@ module Homebrew
 
         @keep_alive = value
       else
-        raise TypeError, "Service#keep_alive expects a Boolean or Hash"
+        T.absurd(value)
       end
     end
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def require_root(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @require_root
       when true, false
         @require_root = value
       else
-        raise TypeError, "Service#require_root expects a Boolean"
+        T.absurd(value)
       end
     end
 
@@ -169,19 +169,19 @@ module Homebrew
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def run_at_load(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @run_at_load
       when true, false
         @run_at_load = value
       else
-        raise TypeError, "Service#run_at_load expects a Boolean"
+        T.absurd(value)
       end
     end
 
     sig { params(value: T.nilable(String)).returns(T.nilable(T::Hash[Symbol, String])) }
     def sockets(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @sockets
       when String
@@ -191,7 +191,7 @@ module Homebrew
         type, host, port = match.captures
         @sockets = { host: host, port: port, type: type }
       else
-        raise TypeError, "Service#sockets expects a String"
+        T.absurd(value)
       end
     end
 
@@ -205,31 +205,31 @@ module Homebrew
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def launch_only_once(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @launch_only_once
       when true, false
         @launch_only_once = value
       else
-        raise TypeError, "Service#launch_only_once expects a Boolean"
+        T.absurd(value)
       end
     end
 
     sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
     def restart_delay(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @restart_delay
       when Integer
         @restart_delay = value
       else
-        raise TypeError, "Service#restart_delay expects an Integer"
+        T.absurd(value)
       end
     end
 
     sig { params(value: T.nilable(Symbol)).returns(T.nilable(Symbol)) }
     def process_type(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @process_type
       when :background, :standard, :interactive, :adaptive
@@ -239,13 +239,13 @@ module Homebrew
                          "'#{PROCESS_TYPE_BACKGROUND}'/'#{PROCESS_TYPE_STANDARD}'/" \
                          "'#{PROCESS_TYPE_INTERACTIVE}'/'#{PROCESS_TYPE_ADAPTIVE}'"
       else
-        raise TypeError, "Service#process_type expects a Symbol"
+        T.absurd(value)
       end
     end
 
     sig { params(value: T.nilable(Symbol)).returns(T.nilable(Symbol)) }
     def run_type(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @run_type
       when :immediate, :interval, :cron
@@ -253,31 +253,31 @@ module Homebrew
       when Symbol
         raise TypeError, "Service#run_type allows: '#{RUN_TYPE_IMMEDIATE}'/'#{RUN_TYPE_INTERVAL}'/'#{RUN_TYPE_CRON}'"
       else
-        raise TypeError, "Service#run_type expects a Symbol"
+        T.absurd(value)
       end
     end
 
     sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
     def interval(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @interval
       when Integer
         @interval = value
       else
-        raise TypeError, "Service#interval expects an Integer"
+        T.absurd(value)
       end
     end
 
     sig { params(value: T.nilable(String)).returns(T.nilable(Hash)) }
     def cron(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @cron
       when String
         @cron = parse_cron(T.must(value))
       else
-        raise TypeError, "Service#cron expects a String"
+        T.absurd(value)
       end
     end
 
@@ -329,23 +329,23 @@ module Homebrew
 
     sig { params(variables: T::Hash[Symbol, String]).returns(T.nilable(T::Hash[Symbol, String])) }
     def environment_variables(variables = {})
-      case T.unsafe(variables)
+      case variables
       when Hash
         @environment_variables = variables.transform_values(&:to_s)
       else
-        raise TypeError, "Service#environment_variables expects a hash"
+        T.absurd(variables)
       end
     end
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def macos_legacy_timers(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @macos_legacy_timers
       when true, false
         @macos_legacy_timers = value
       else
-        raise TypeError, "Service#macos_legacy_timers expects a Boolean"
+        T.absurd(value)
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This change allows sorbet to catch non-exhaustive type checking, rather than strictly relying on runtime behavior.
(See also sorbet [docs](https://sorbet.org/docs/exhaustiveness) for more info.)