### PR TITLE
Include prof gem group in sorbet workflow

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -22,6 +22,9 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems --groups=prof
+
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master
         with:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
An attempt to fix https://github.com/Homebrew/brew/pull/15119

I'm not sure how to kick off a test for this workflow, and I have issues with tapioca locally that I'm still attempting to resolve `Bundler::LockfileError: You must use Bundler 2 or greater with this lockfile.`)