### PR TITLE
Remove useless T.unsafe wrappers

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -95,7 +95,7 @@ module Homebrew
                         .reject { |line| line.start_with?("#") || line.blank? }
                         .map(&:strip)
 
-        named_args = T.unsafe(CLI::NamedArgs).new(*names, parent: args)
+        named_args = CLI::NamedArgs.new(*names, parent: args)
         named_args.to_formulae_and_casks(ignore_unavailable: true)
       rescue Errno::ENOENT => e
         onoe e

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1152,7 +1152,7 @@ class Formula
         ENV.activate_extensions!
 
         etc_var_dirs = [bottle_prefix/"etc", bottle_prefix/"var"]
-        T.unsafe(Find).find(*etc_var_dirs.select(&:directory?)) do |path|
+        Find.find(*etc_var_dirs.select(&:directory?)) do |path|
           path = Pathname.new(path)
           path.extend(InstallRenamed)
           path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
@@ -2672,7 +2672,7 @@ class Formula
     out.close
     args.map!(&:to_s)
     begin
-      T.unsafe(Kernel).exec(cmd, *args)
+      Kernel.exec(cmd, *args)
     rescue
       nil
     end

--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -99,7 +99,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -102,7 +102,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -86,7 +86,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -54,7 +54,7 @@ module Homebrew
                   "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
           end
 
-          T.unsafe(Yaml).find_versions(
+          Yaml.find_versions(
             url:              url,
             regex:            regex,
             provided_content: provided_content,

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -98,7 +98,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || DEFAULT_REGEX, **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || DEFAULT_REGEX, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -88,7 +88,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          version_data = T.unsafe(PageMatch).find_versions(
+          version_data = PageMatch.find_versions(
             url:   generated[:url],
             regex: regex || generated[:regex],
             **unused,

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -98,7 +98,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -84,7 +84,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -81,7 +81,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || DEFAULT_REGEX, **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || DEFAULT_REGEX, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -79,7 +79,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -93,7 +93,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -98,7 +98,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, **unused, &block)
           generated = generate_input_values(url)
 
-          T.unsafe(PageMatch).find_versions(
+          PageMatch.find_versions(
             url:   generated[:url] || url,
             regex: regex || generated[:regex],
             **unused,

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -123,7 +123,7 @@ module Homebrew
 
           # Use the cached page content to avoid duplicate fetches
           cached_content = @page_data[generated_url]
-          match_data = T.unsafe(PageMatch).find_versions(
+          match_data = PageMatch.find_versions(
             url:              generated_url,
             regex:            regex || generated[:regex],
             provided_content: cached_content,

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -101,7 +101,7 @@ class Sandbox
     begin
       command = [SANDBOX_EXEC, "-f", seatbelt.path, *args]
       # Start sandbox in a pseudoterminal to prevent access of the parent terminal.
-      T.unsafe(PTY).spawn(*command) do |r, w, pid|
+      PTY.spawn(*command) do |r, w, pid|
         # Set the PTY's window size to match the parent terminal.
         # Some formula tests are sensitive to the terminal size and fail if this is not set.
         winch = proc do |_sig|

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -200,7 +200,7 @@ class SystemCommand
     pid = T.let(nil, T.nilable(Integer))
     raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = ignore_interrupts do
       Open3.popen3(env, [executable, executable], *args, **options)
-       .tap { |*, wait_thr| pid = wait_thr.pid }
+           .tap { |*, wait_thr| pid = wait_thr.pid }
     end
 
     write_input_to(raw_stdin)

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -199,7 +199,7 @@ class SystemCommand
 
     pid = T.let(nil, T.nilable(Integer))
     raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = ignore_interrupts do
-      T.unsafe(Open3).popen3(env, [executable, executable], *args, **options)
+      Open3.popen3(env, [executable, executable], *args, **options)
        .tap { |*, wait_thr| pid = wait_thr.pid }
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`T.unsafe` around a class/module should be unnecessary now that we [suppress](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/sorbet/config#L5) splat errors. In this case, I was able to remove the wrapper around every match for `git grep -E 'T.unsafe\([[:upper:]]'` without introducing any errors.