### PR TITLE
Revert "Split prof gems into their own group"

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -22,9 +22,6 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=prof
-
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=sorbet
 
       - name: Install shellcheck and shfmt
         run: brew install shellcheck shfmt
@@ -80,7 +80,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=sorbet
 
       - name: Run brew style on homebrew-core
         run: brew style --display-cop-names homebrew/core
@@ -142,7 +142,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=sorbet
 
       - name: Set up the homebrew/core tap
         run: brew tap homebrew/core
@@ -173,7 +173,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=sorbet
 
       - name: Set up Homebrew all cask taps
         run: |
@@ -209,7 +209,7 @@ jobs:
       # Can't cache this because we need to check that it doesn't fail the
       # "uncommitted RubyGems" step with a cold cache.
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=sorbet
 
       - name: Check for uncommitted RubyGems
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
@@ -318,7 +318,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=sorbet
 
       - name: Create parallel test log directory
         run: mkdir tests

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -27,8 +27,12 @@ gem "rspec-retry", require: false
 gem "rspec-sorbet", require: false
 gem "rubocop", require: false
 gem "rubocop-ast", require: false
+# NOTE: ruby-prof v1.4.3 is the last version that supports Ruby 2.6.x
+# TODO: remove explicit version when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
+gem "ruby-prof", "1.4.3", require: false
 gem "simplecov", require: false
 gem "simplecov-cobertura", require: false
+gem "stackprof", require: false
 gem "warning", require: false
 
 group :sorbet, optional: true do
@@ -36,13 +40,6 @@ group :sorbet, optional: true do
   gem "sorbet-static-and-runtime", require: false
   gem "spoom", require: false
   gem "tapioca", require: false
-end
-
-group :prof, optional: true do
-  # NOTE: ruby-prof v1.4.3 is the last version that supports Ruby 2.6.x
-  # TODO: remove explicit version when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
-  gem "ruby-prof", "1.4.3", require: false
-  gem "stackprof", require: false
 end
 
 # vendored gems

--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -24,14 +24,9 @@ module Homebrew
   def install_bundler_gems
     args = install_bundler_gems_args.parse
 
-    groups = args.groups
-
     # Clear previous settings. We want to fully replace - not append.
-    Homebrew::Settings.delete(:gemgroups) if groups
+    Homebrew::Settings.delete(:gemgroups) if args.groups
 
-    groups ||= []
-    groups |= VALID_GEM_GROUPS if groups.delete("all")
-
-    Homebrew.install_bundler_gems!(groups: groups)
+    Homebrew.install_bundler_gems!(groups: args.groups || [])
   end
 end

--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -24,8 +24,6 @@ module Homebrew
   def prof
     args = prof_args.parse
 
-    Homebrew.install_bundler_gems!(groups: ["prof"])
-
     brew_rb = (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path
     FileUtils.mkdir_p "prof"
     cmd = args.named.first
@@ -43,12 +41,16 @@ module Homebrew
     end
 
     if args.stackprof?
+      # Already installed from Gemfile but use this to setup PATH and LOADPATH
+      Homebrew.install_gem_setup_path! "stackprof"
       with_env HOMEBREW_STACKPROF: "1" do
         system(*HOMEBREW_RUBY_EXEC_ARGS, brew_rb, *args.named)
       end
       output_filename = "prof/d3-flamegraph.html"
       safe_system "stackprof --d3-flamegraph prof/stackprof.dump > #{output_filename}"
     else
+      # Already installed from Gemfile but use this to setup PATH and LOADPATH
+      Homebrew.install_gem_setup_path! "ruby-prof"
       output_filename = "prof/call_stack.html"
       safe_system "ruby-prof", "--printer=call_stack", "--file=#{output_filename}", brew_rb, "--", *args.named
     end

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -88,7 +88,7 @@ module Homebrew
   def tests
     args = tests_args.parse
 
-    Homebrew.install_bundler_gems!(groups: ["prof"])
+    Homebrew.install_bundler_gems!
 
     require "byebug" if args.byebug?
 

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -30,7 +30,7 @@ module Homebrew
 
     Homebrew.install_bundler!
 
-    ENV["BUNDLE_WITH"] = VALID_GEM_GROUPS.join(":")
+    ENV["BUNDLE_WITH"] = "sorbet"
 
     # System Ruby does not pick up the correct SDK by default.
     ENV["SDKROOT"] = MacOS.sdk_path if ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"]

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -12,8 +12,6 @@ module Homebrew
   # After updating this, run `brew vendor-gems --update=--bundler`.
   HOMEBREW_BUNDLER_VERSION = "2.3.26"
 
-  VALID_GEM_GROUPS = ["sorbet", "prof"].freeze
-
   module_function
 
   def ruby_bindir
@@ -135,9 +133,6 @@ module Homebrew
     old_bundle_with = ENV.fetch("BUNDLE_WITH", nil)
     old_bundle_frozen = ENV.fetch("BUNDLE_FROZEN", nil)
     old_sdkroot = ENV.fetch("SDKROOT", nil)
-
-    invalid_groups = groups - VALID_GEM_GROUPS
-    raise ArgumentError, "Invalid gem groups: #{invalid_groups.join(", ")}" unless invalid_groups.empty?
 
     install_bundler!
 


### PR DESCRIPTION
Reverts Homebrew/brew#15112
Reverts https://github.com/Homebrew/brew/pull/15134

This broke the Sorbet workflow (was fixed, reverting here too as this will break it) and the Vendor Gems workflow (still broken https://github.com/Homebrew/brew/actions/runs/4600329850/jobs/8137146086). The latter prevents any gem updates.

CC @Bo98 and @dduugg FYI.