### PR TITLE
commands: fix completion descriptions

### DIFF
--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -203,7 +203,7 @@ module Commands
 
     if (cmd_parser = Homebrew::CLI::Parser.from_cmd_path(path))
       if short
-        cmd_parser.description.split(".").first
+        cmd_parser.description.split(/\.(?>\s|$)/).first
       else
         cmd_parser.description
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

The following tests failed but I don't think they are related.

<details><summary>Failures</summary>
(output truncated & reformatted)
<pre><code>
Failures:

  1) Cask::DSL language stanza when language is set explicitly to 'en' is expected to be the english version
     Failure/Error: it { is_expected.to be_the_english_version }
     ./test/cask/dsl_spec.rb:214:in `block (5 levels) in <top (required)>'
     ./test/support/helper/spec/shared_context/homebrew_cask.rb:52:in `block (2 levels) in <top (required)>'

  2) Cask::DSL language stanza when language is set explicitly to 'xx-XX' is expected to be the english version
     Failure/Error: it { is_expected.to be_the_english_version }
     ./test/cask/dsl_spec.rb:220:in `block (5 levels) in <top (required)>'
     ./test/support/helper/spec/shared_context/homebrew_cask.rb:52:in `block (2 levels) in <top (required)>'

  3) brew bottle builds a bottle for the given Formula
     Failure/Error:
       expect { brew "bottle", "--no-rebuild", "testball" }
         .to output(/testball--0\.1.*\.bottle\.tar\.gz/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     ./test/dev-cmd/bottle_spec.rb:20:in `block (2 levels) in <top (required)>'
     ./test/support/helper/spec/shared_context/integration_test.rb:50:in `block (2 levels) in <top (required)>'
</code></pre>
</details> 

-----

Currently, zsh and fish shell completions show incomplete descriptions
for certain commands. For example:

    docs                         -- Open Homebrew's online documentation (https://docs
    rbenv-sync                   -- Create symlinks for Homebrew's installed Ruby versions in ~/

This is because `Commands.command_description` produces incomplete
short descriptions for the commands having a dot (from a URL or a path)
in the first sentence; the dot is misinterpreted as a full stop:

    brew(main):001:0> Commands.command_description("docs", short: true)
    => "Open Homebrew's online documentation (https://docs"
    brew(main):002:0> Commands.command_description("rbenv-sync", short: true)
    => "Create symlinks for Homebrew's installed Ruby versions in ~/" 

We can improve the sentence splitting logic by only splitting at dots
either at the end or followed by a whitespace. Now With this change:

    brew(main):001:0> Commands.command_description("docs", short: true)
    => "Open Homebrew's online documentation (https://docs.brew.sh) in a browser"
    brew(main):002:0> Commands.command_description("rbenv-sync", short: true)
    => "Create symlinks for Homebrew's installed Ruby versions in ~/.rbenv/versions"
