### PR TITLE
commands: explain change in command description splitting

### DIFF
--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -219,7 +219,9 @@ module Commands
         match_data = /^#:  (?<desc>\w.*+)$/.match(line)
         if match_data
           desc = match_data[:desc]
-          return T.must(desc).split(".").first if short
+          # The same splitting logic is used here.
+          # See comment for Ruby commands above.
+          return T.must(desc).split(/\.(?>\s|$)/).first if short
 
           return desc
         end

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -32,6 +32,11 @@ module Commands
     "lc"          => "livecheck",
     "tc"          => "typecheck",
   }.freeze
+  # This pattern is used to split descriptions at full stops. We only consider a
+  # dot as a full stop if it is either followed by a whitespace or at the end of
+  # the description. In this way we can prevent cutting off a sentence in the
+  # middle due to dots in URLs or paths.
+  DESCRIPTION_SPLITTING_PATTERN = /\.(?>\s|$)/.freeze
 
   def valid_internal_cmd?(cmd)
     require?(HOMEBREW_CMD_PATH/cmd)
@@ -203,11 +208,7 @@ module Commands
 
     if (cmd_parser = Homebrew::CLI::Parser.from_cmd_path(path))
       if short
-        # We only consider a dot as a full stop if it is either followed by a
-        # whitespace or at the end of the description. In this way we can
-        # prevent cutting off a sentence in the middle due to dots in URLs or
-        # paths.
-        cmd_parser.description.split(/\.(?>\s|$)/).first
+        cmd_parser.description.split(DESCRIPTION_SPLITTING_PATTERN).first
       else
         cmd_parser.description
       end
@@ -219,9 +220,7 @@ module Commands
         match_data = /^#:  (?<desc>\w.*+)$/.match(line)
         if match_data
           desc = match_data[:desc]
-          # The same splitting logic is used here.
-          # See comment for Ruby commands above.
-          return T.must(desc).split(/\.(?>\s|$)/).first if short
+          return T.must(desc).split(DESCRIPTION_SPLITTING_PATTERN).first if short
 
           return desc
         end

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -203,6 +203,10 @@ module Commands
 
     if (cmd_parser = Homebrew::CLI::Parser.from_cmd_path(path))
       if short
+        # We only consider a dot as a full stop if it is either followed by a
+        # whitespace or at the end of the description. In this way we can
+        # prevent cutting off a sentence in the middle due to dots in URLs or
+        # paths.
         cmd_parser.description.split(/\.(?>\s|$)/).first
       else
         cmd_parser.description


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A comment here would help the reader to understand the need for this splitting logic, which is not so straightforward.

Addresses review comment in https://github.com/Homebrew/brew/pull/15146#discussion_r1157361656.

Also, apply the same logic to shell commands. This was missed in #15146.
