### PR TITLE
Tighten `tap.formula_file?(file)` and `tap.formula_files` to not detect cask file as formula

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -569,7 +569,7 @@ class Tap
     file = Pathname.new(file) unless file.is_a? Pathname
     file = file.expand_path(path)
     return false unless ruby_file?(file)
-    return false if cask_pathname?(file)
+    return false if cask_file?(file)
 
     file.to_s.start_with?("#{formula_dir}/")
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -570,7 +570,7 @@ class Tap
     file = file.expand_path(path)
     return false unless ruby_file?(file)
 
-    file.to_s.start_with?("#{formula_dir}/")
+    file.to_s.start_with?("#{formula_dir}/") && !file.to_s.start_with?("#{cask_dir}/")
   end
 
   # return true if given path would present a {Cask} file in this {Tap}.

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -561,7 +561,7 @@ class Tap
     file.extname == ".rb"
   end
 
-  # return true if given path would present a {Formula} file in this {Tap}.
+  # returns true if given path would present a {Formula} file in this {Tap}.
   # accepts both absolute path and relative path (relative to this {Tap}'s path)
   # @private
   sig { params(file: T.any(String, Pathname)).returns(T::Boolean) }
@@ -569,11 +569,12 @@ class Tap
     file = Pathname.new(file) unless file.is_a? Pathname
     file = file.expand_path(path)
     return false unless ruby_file?(file)
+    return false if cask_pathname?(file)
 
-    file.to_s.start_with?("#{formula_dir}/") && !file.to_s.start_with?("#{cask_dir}/")
+    file.to_s.start_with?("#{formula_dir}/")
   end
 
-  # return true if given path would present a {Cask} file in this {Tap}.
+  # returns true if given path would present a {Cask} file in this {Tap}.
   # accepts both absolute path and relative path (relative to this {Tap}'s path)
   # @private
   sig { params(file: T.any(String, Pathname)).returns(T::Boolean) }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -498,7 +498,7 @@ class Tap
         formula_dir.find
       else
         formula_dir.children
-      end.select(&method(:ruby_file?))
+      end.select(&method(:formula_file?))
     else
       []
     end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document? \
    (hmm, I skipped opening an issue first)
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?\
    (Don't know why but `brew tests` failed even on `master` locally. Perhaps due to I didn't overwrite the old version ruby provided by macOS)

-----

Perhaps since commit f280ce069 (Support loading formulae/casks from subdirectories, 2023-02-24), now `tap.formula_file?(file)` is too loose.

As reported and discussed in https://github.com/Homebrew/homebrew-test-bot/issues/897, in a third-party cask tap (no formulae provided, hence no `Formula` directory), even cask files locating in `Cask` directory pass `tap.formula_file?(file)`.  I think that's wrong because a ruby file cannot both be a formula and a cask.

This PR adds a condition borrowed from `tap.cask_file?(file)` to `tap.formula_file(file)` to ensure formula files and cask files are disjoint.

I have no experience in speaking ruby, hence am not sure how much introducing a local variable holding `file.to_s` would help with the efficiency.