### PR TITLE
Enable types in dev-cmd

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cli/parser"
@@ -6,10 +6,8 @@ require "cli/parser"
 module Homebrew
   extend T::Sig
 
-  module_function
-
   sig { returns(CLI::Parser) }
-  def typecheck_args
+  def self.typecheck_args
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Check for typechecking errors using Sorbet.
@@ -44,7 +42,7 @@ module Homebrew
   end
 
   sig { void }
-  def typecheck
+  def self.typecheck
     args = typecheck_args.parse
 
     Homebrew.install_bundler_gems!(groups: ["sorbet"])
@@ -95,9 +93,10 @@ module Homebrew
 
       srb_exec += ["--ignore", args.ignore] if args.ignore.present?
       if args.file.present? || args.dir.present?
-        cd("sorbet")
-        srb_exec += ["--file", "../#{args.file}"] if args.file
-        srb_exec += ["--dir", "../#{args.dir}"] if args.dir
+        cd("sorbet") do
+          srb_exec += ["--file", "../#{args.file}"] if args.file
+          srb_exec += ["--dir", "../#{args.dir}"] if args.dir
+        end
       end
       success = system(*srb_exec)
       return if success

--- a/Library/Homebrew/dev-cmd/unpack.rb
+++ b/Library/Homebrew/dev-cmd/unpack.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "stringio"
@@ -8,10 +8,8 @@ require "cli/parser"
 module Homebrew
   extend T::Sig
 
-  module_function
-
   sig { returns(CLI::Parser) }
-  def unpack_args
+  def self.unpack_args
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Unpack the source files for <formula> into subdirectories of the current
@@ -33,7 +31,7 @@ module Homebrew
     end
   end
 
-  def unpack
+  def self.unpack
     args = unpack_args.parse
 
     formulae = args.named.to_formulae
@@ -69,10 +67,11 @@ module Homebrew
       next unless args.git?
 
       ohai "Setting up Git repository"
-      cd stage_dir
-      system "git", "init", "-q"
-      system "git", "add", "-A"
-      system "git", "commit", "-q", "-m", "brew-unpack"
+      cd(stage_dir) do
+        system "git", "init", "-q"
+        system "git", "add", "-A"
+        system "git", "commit", "-q", "-m", "brew-unpack"
+      end
     end
   end
 end

--- a/Library/Homebrew/dev-cmd/update-sponsors.rb
+++ b/Library/Homebrew/dev-cmd/update-sponsors.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cli/parser"
@@ -40,7 +40,8 @@ module Homebrew
 
     named_sponsors = []
     logo_sponsors = []
-    largest_monthly_amount = 0
+    # FIXME: This T.let should be unnecessary https://github.com/sorbet/sorbet/issues/6894
+    largest_monthly_amount = T.let(0, T.untyped)
 
     GitHub.sponsorships("Homebrew").each do |s|
       largest_monthly_amount = [s[:monthly_amount], s[:closest_tier_monthly_amount]].max

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cli/parser"

--- a/Library/Homebrew/sorbet/rbi/upstream.rbi
+++ b/Library/Homebrew/sorbet/rbi/upstream.rbi
@@ -3,6 +3,22 @@
 # This file contains temporary definitions for fixes that have
 # been submitted upstream to https://github.com/sorbet/sorbet.
 
+module FileUtils
+  # @see https://github.com/sorbet/sorbet/pull/6847
+  sig do
+    params(
+      src: T.any(String, Pathname),
+      dest: T.any(String, Pathname),
+      preserve: T.nilable(T::Boolean),
+      noop: T.nilable(T::Boolean),
+      verbose: T.nilable(T::Boolean),
+      dereference_root: T::Boolean,
+      remove_destination: T.nilable(T::Boolean)
+    ).returns(T::Array[String])
+  end
+  module_function def cp_r(src, dest, preserve: nil, noop: nil, verbose: nil, dereference_root: true, remove_destination: nil); end
+end
+
 module Kernel
   # @see https://github.com/sorbet/sorbet/blob/a1e8389/rbi/core/kernel.rbi#L41-L46
   sig do

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -418,6 +418,17 @@ module GitHub
     result["organization"]["team"]["members"]["nodes"].to_h { |member| [member["login"], member["name"]] }
   end
 
+  sig {
+    params(user: String)
+      .returns(
+        T::Array[{
+          closest_tier_monthly_amount: Integer,
+          login:                       String,
+          monthly_amount:              Integer,
+          name:                        String,
+        }],
+      )
+  }
   def self.sponsorships(user)
     has_next_page = T.let(true, T::Boolean)
     after = ""


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Enables types in the remaining dev commands. (After this change, only five non-test `typed: false` files will remain.)