### PR TITLE
Minor YARD improvements

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,4 +64,4 @@ jobs:
 
       - name: Process rubydoc comments
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/Library/Homebrew
-        run: bundle exec yard doc --plugin sorbet --no-output --fail-on-warning
+        run: bundle exec yard doc --no-output --fail-on-warning

--- a/Library/Homebrew/.yardopts
+++ b/Library/Homebrew/.yardopts
@@ -2,6 +2,7 @@
 --main README.md
 --markup markdown
 --no-private
+--plugin sorbet
 --load yard/ignore_directives.rb
 --template-path yard/templates
 --exclude test/

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -29,14 +29,13 @@ module Utils
     # defined by the formula, as only `HOMEBREW_PREFIX` is available
     # in the {DATAPatch embedded patch}.
     #
-    # `inreplace` supports regular expressions:
-    # <pre>inreplace "somefile.cfg", /look[for]what?/, "replace by #{bin}/tool"</pre>
+    # @example `inreplace` supports regular expressions:
+    #   inreplace "somefile.cfg", /look[for]what?/, "replace by #{bin}/tool"
     #
-    # `inreplace` supports blocks:
-    # <pre>inreplace "Makefile" do |s|
-    #   s.gsub! "/usr/local", HOMEBREW_PREFIX.to_s
-    # end
-    # </pre>
+    # @example `inreplace` supports blocks:
+    #   inreplace "Makefile" do |s|
+    #     s.gsub! "/usr/local", HOMEBREW_PREFIX.to_s
+    #   end
     #
     # @see StringInreplaceExtension
     # @api public

--- a/Library/Homebrew/yard/templates/default/docstring/html/setup.rb
+++ b/Library/Homebrew/yard/templates/default/docstring/html/setup.rb
@@ -1,7 +1,10 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 def init
+  # `sorbet` is available transitively through the `yard-sorbet` plugin, but we're
+  # outside of the standalone sorbet config, so `checked` is enabled by default
+  T.bind(self, YARD::Templates::Template, checked: false)
   super
 
   return if sections.empty?
@@ -10,5 +13,6 @@ def init
 end
 
 def internal
+  T.bind(self, YARD::Templates::Template, checked: false)
   erb(:internal) if object.has_tag?(:api) && object.tag(:api).text == "internal"
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
- Consolidate yard config under `.yardopts`
- Enable typing in yard extension
- Fix output warning:
```
$ yard doc                                                                                                       9:45:02  ☁  master ☂⚑ ⚡ ✭
[warn]: In file `utils/inreplace.rb':54: Cannot resolve link to bin from text:
	...{bin}...
Files:         498
Modules:       139 (   28 undocumented)
Classes:       481 (   56 undocumented)
Constants:     402 (  299 undocumented)
Attributes:    261 (  116 undocumented)
Methods:      3396 ( 1467 undocumented)
```
`Inreplace.inreplace` before:
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/697964/230154196-90fc994d-483c-4ec3-8f94-565d64109eb1.png">

`Inreplace.inreplace` after:
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/697964/230153906-48e4f5fa-1b5a-4d5f-b192-4361d6eb0fbb.png">
