### PR TITLE
bump-formula-pr: add release notes to commit message

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -346,6 +346,8 @@ module Homebrew
       EOS
     end
 
+    commit_message = "#{formula.name} #{new_formula_version}"
+
     if new_url =~ %r{^https://github\.com/([\w-]+)/([\w-]+)/archive/refs/tags/(v?[.0-9]+)\.tar\.}
       owner = Regexp.last_match(1)
       repo = Regexp.last_match(2)
@@ -360,11 +362,20 @@ module Homebrew
       if github_release_data.present?
         pre = "pre" if github_release_data["prerelease"].present?
         pr_message += <<~XML
+
           <details>
-            <summary>#{pre}release notes</summary>
-            <pre>#{github_release_data["body"]}</pre>
+          <summary>#{pre}release notes</summary>
+
+          #{github_release_data["body"]}
+
           </details>
         XML
+
+        commit_message += <<~MESSAGE
+
+          #{pre}release notes:
+          #{github_release_data["body"]}
+        MESSAGE
       end
     end
 
@@ -375,7 +386,7 @@ module Homebrew
       remote:           remote,
       remote_branch:    remote_branch,
       branch_name:      "bump-#{formula.name}-#{new_formula_version}",
-      commit_message:   "#{formula.name} #{new_formula_version}",
+      commit_message:   commit_message,
       previous_branch:  previous_branch,
       tap:              formula.tap,
       tap_remote_repo:  tap_remote_repo,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think the release notes are a useful addition to commit messages.

Also, let's improve the formatting of the release notes in the PR body.
Currently, they are added in a fixed-width font inside a code block
(see, for example, Homebrew/homebrew-core#127924), but that doesn't seem
appropriate.
