### PR TITLE
workflows/sponsors-maintainers-man-completions: fix git-try-push failure

### DIFF
--- a/.github/workflows/sponsors-maintainers-man-completions.yml
+++ b/.github/workflows/sponsors-maintainers-man-completions.yml
@@ -121,7 +121,6 @@ jobs:
           directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
           branch: ${{ steps.update.outputs.branch }}
           force: true
-          origin_branch: "master"
 
       - name: Open a pull request
         if: steps.update.outputs.pull_request == 'true'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I *think* this should actually fix the failure seen in https://github.com/Homebrew/brew/actions/runs/4651602426/jobs/8231313421. `origin_branch` falls back to `branch`. This means that the `git-try-push` step will now push to and rebase on the same remote branch. (Previously, it rebased on `master`, not the branch to push to.)

Note that this also means the branch `${{ steps.update.outputs.branch }}` (`sponsors-maintainers-man-completions` or PR branch) will not be rebased onto `origin/master`.
