### PR TITLE
Revert "Revert "Split prof gems into their own group"" 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=sorbet
+        run: brew install-bundler-gems --groups=all
 
       - name: Install shellcheck and shfmt
         run: brew install shellcheck shfmt
@@ -80,7 +80,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=sorbet
+        run: brew install-bundler-gems --groups=all
 
       - name: Run brew style on homebrew-core
         run: brew style --display-cop-names homebrew/core
@@ -142,7 +142,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=sorbet
+        run: brew install-bundler-gems --groups=all
 
       - name: Set up the homebrew/core tap
         run: brew tap homebrew/core
@@ -173,7 +173,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=sorbet
+        run: brew install-bundler-gems --groups=all
 
       - name: Set up Homebrew all cask taps
         run: |
@@ -209,7 +209,7 @@ jobs:
       # Can't cache this because we need to check that it doesn't fail the
       # "uncommitted RubyGems" step with a cold cache.
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=sorbet
+        run: brew install-bundler-gems --groups=all
 
       - name: Check for uncommitted RubyGems
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
@@ -318,7 +318,7 @@ jobs:
           restore-keys: ${{ runner.os }}-rubygems-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=sorbet
+        run: brew install-bundler-gems --groups=all
 
       - name: Create parallel test log directory
         run: mkdir tests

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -27,12 +27,8 @@ gem "rspec-retry", require: false
 gem "rspec-sorbet", require: false
 gem "rubocop", require: false
 gem "rubocop-ast", require: false
-# NOTE: ruby-prof v1.4.3 is the last version that supports Ruby 2.6.x
-# TODO: remove explicit version when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
-gem "ruby-prof", "1.4.3", require: false
 gem "simplecov", require: false
 gem "simplecov-cobertura", require: false
-gem "stackprof", require: false
 gem "warning", require: false
 
 group :sorbet, optional: true do
@@ -40,6 +36,13 @@ group :sorbet, optional: true do
   gem "sorbet-static-and-runtime", require: false
   gem "spoom", require: false
   gem "tapioca", require: false
+end
+
+group :prof, optional: true do
+  # NOTE: ruby-prof v1.4.3 is the last version that supports Ruby 2.6.x
+  # TODO: remove explicit version when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
+  gem "ruby-prof", "1.4.3", require: false
+  gem "stackprof", require: false
 end
 
 # vendored gems

--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -24,9 +24,14 @@ module Homebrew
   def install_bundler_gems
     args = install_bundler_gems_args.parse
 
-    # Clear previous settings. We want to fully replace - not append.
-    Homebrew::Settings.delete(:gemgroups) if args.groups
+    groups = args.groups
 
-    Homebrew.install_bundler_gems!(groups: args.groups || [])
+    # Clear previous settings. We want to fully replace - not append.
+    Homebrew::Settings.delete(:gemgroups) if groups
+
+    groups ||= []
+    groups |= VALID_GEM_GROUPS if groups.delete("all")
+
+    Homebrew.install_bundler_gems!(groups: groups)
   end
 end

--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -30,7 +30,7 @@ module Homebrew
     Homebrew::Settings.delete(:gemgroups) if groups
 
     groups ||= []
-    groups |= VALID_GEM_GROUPS if groups.delete("all")
+    groups |= Homebrew.valid_gem_groups if groups.delete("all")
 
     Homebrew.install_bundler_gems!(groups: groups)
   end

--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -24,6 +24,8 @@ module Homebrew
   def prof
     args = prof_args.parse
 
+    Homebrew.install_bundler_gems!(groups: ["prof"])
+
     brew_rb = (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path
     FileUtils.mkdir_p "prof"
     cmd = args.named.first
@@ -41,16 +43,12 @@ module Homebrew
     end
 
     if args.stackprof?
-      # Already installed from Gemfile but use this to setup PATH and LOADPATH
-      Homebrew.install_gem_setup_path! "stackprof"
       with_env HOMEBREW_STACKPROF: "1" do
         system(*HOMEBREW_RUBY_EXEC_ARGS, brew_rb, *args.named)
       end
       output_filename = "prof/d3-flamegraph.html"
       safe_system "stackprof --d3-flamegraph prof/stackprof.dump > #{output_filename}"
     else
-      # Already installed from Gemfile but use this to setup PATH and LOADPATH
-      Homebrew.install_gem_setup_path! "ruby-prof"
       output_filename = "prof/call_stack.html"
       safe_system "ruby-prof", "--printer=call_stack", "--file=#{output_filename}", brew_rb, "--", *args.named
     end

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -88,7 +88,7 @@ module Homebrew
   def tests
     args = tests_args.parse
 
-    Homebrew.install_bundler_gems!
+    Homebrew.install_bundler_gems!(groups: ["prof"])
 
     require "byebug" if args.byebug?
 

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -46,7 +46,7 @@ module Homebrew
     args = typecheck_args.parse
 
     update = args.update? || args.update_all?
-    groups = update ? VALID_GEM_GROUPS : ["sorbet"]
+    groups = update ? Homebrew.valid_gem_groups : ["sorbet"]
     Homebrew.install_bundler_gems!(groups: groups)
 
     HOMEBREW_LIBRARY_PATH.cd do

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -45,10 +45,12 @@ module Homebrew
   def self.typecheck
     args = typecheck_args.parse
 
-    Homebrew.install_bundler_gems!(groups: ["sorbet"])
+    update = args.update? || args.update_all?
+    groups = update ? VALID_GEM_GROUPS : ["sorbet"]
+    Homebrew.install_bundler_gems!(groups: groups)
 
     HOMEBREW_LIBRARY_PATH.cd do
-      if args.update? || args.update_all?
+      if update
         odisabled "brew typecheck --update --fail-if-not-changed" if args.fail_if_not_changed?
 
         excluded_gems = [

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -30,7 +30,7 @@ module Homebrew
 
     Homebrew.install_bundler!
 
-    ENV["BUNDLE_WITH"] = "sorbet"
+    ENV["BUNDLE_WITH"] = VALID_GEM_GROUPS.join(":")
 
     # System Ruby does not pick up the correct SDK by default.
     ENV["SDKROOT"] = MacOS.sdk_path if ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"]

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -30,7 +30,7 @@ module Homebrew
 
     Homebrew.install_bundler!
 
-    ENV["BUNDLE_WITH"] = VALID_GEM_GROUPS.join(":")
+    ENV["BUNDLE_WITH"] = Homebrew.valid_gem_groups.join(":")
 
     # System Ruby does not pick up the correct SDK by default.
     ENV["SDKROOT"] = MacOS.sdk_path if ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"]

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -12,6 +12,8 @@ module Homebrew
   # After updating this, run `brew vendor-gems --update=--bundler`.
   HOMEBREW_BUNDLER_VERSION = "2.3.26"
 
+  VALID_GEM_GROUPS = ["sorbet", "prof"].freeze
+
   module_function
 
   def ruby_bindir
@@ -133,6 +135,9 @@ module Homebrew
     old_bundle_with = ENV.fetch("BUNDLE_WITH", nil)
     old_bundle_frozen = ENV.fetch("BUNDLE_FROZEN", nil)
     old_sdkroot = ENV.fetch("SDKROOT", nil)
+
+    invalid_groups = groups - VALID_GEM_GROUPS
+    raise ArgumentError, "Invalid gem groups: #{invalid_groups.join(", ")}" unless invalid_groups.empty?
 
     install_bundler!
 


### PR DESCRIPTION
Reland this so we can release a new portable Ruby, this time fixing `brew typecheck --update` to install all gems.

Obsoletes the fix in #15134 so we shouldn't need to reland that.