### PR TITLE
dev-cmd/style: Properly clean up the `--display-cop-names` option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install shellcheck and shfmt
         run: brew install shellcheck shfmt
 
-      - run: brew style --display-cop-names
+      - run: brew style
 
       - run: brew typecheck
 
@@ -83,7 +83,7 @@ jobs:
         run: brew install-bundler-gems --groups=sorbet
 
       - name: Run brew style on homebrew-core
-        run: brew style --display-cop-names homebrew/core
+        run: brew style homebrew/core
 
       - name: Set up all Homebrew taps
         run: |
@@ -105,22 +105,22 @@ jobs:
 
       - name: Run brew style on official taps
         run: |
-          brew style --display-cop-names homebrew/bundle \
-                                         homebrew/services \
-                                         homebrew/test-bot
+          brew style homebrew/bundle \
+                     homebrew/services \
+                     homebrew/test-bot
 
-          brew style --display-cop-names homebrew/aliases\
-                                         homebrew/autoupdate\
-                                         homebrew/command-not-found \
-                                         homebrew/formula-analytics \
-                                         homebrew/portable-ruby
+          brew style homebrew/aliases \
+                     homebrew/autoupdate\
+                     homebrew/command-not-found \
+                     homebrew/formula-analytics \
+                     homebrew/portable-ruby
 
       - name: Run brew style on cask taps
         run: |
-          brew style --display-cop-names homebrew/cask \
-                                         homebrew/cask-drivers \
-                                         homebrew/cask-fonts \
-                                         homebrew/cask-versions
+          brew style homebrew/cask \
+                     homebrew/cask-drivers \
+                     homebrew/cask-fonts \
+                     homebrew/cask-versions
 
   formula-audit:
     name: formula audit

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -60,7 +60,8 @@ module Homebrew
       switch "--fix",
              description: "Fix style violations automatically using RuboCop's auto-correct feature."
       switch "--display-cop-names",
-             description: "Include the RuboCop cop name for each violation in the output."
+             description: "Include the RuboCop cop name for each violation in the output. This is the default.",
+             hidden:      true
       switch "--display-filename",
              description: "Prefix every line of output with the file or formula name being audited, to " \
                           "make output easy to grep."
@@ -92,9 +93,6 @@ module Homebrew
       conflicts "--only", "--except"
       conflicts "--only-cops", "--except-cops", "--strict"
       conflicts "--only-cops", "--except-cops", "--only"
-      conflicts "--display-cop-names", "--skip-style"
-      conflicts "--display-cop-names", "--only-cops"
-      conflicts "--display-cop-names", "--except-cops"
       conflicts "--formula", "--cask"
       conflicts "--installed", "--all"
 
@@ -208,7 +206,6 @@ module Homebrew
         spdx_license_data:   spdx_license_data,
         spdx_exception_data: spdx_exception_data,
         style_offenses:      style_offenses&.for_path(f.path),
-        display_cop_names:   args.display_cop_names?,
       }.compact
 
       audit_proc = proc { FormulaAuditor.new(f, **options).tap(&:audit) }

--- a/Library/Homebrew/dev-cmd/style.rb
+++ b/Library/Homebrew/dev-cmd/style.rb
@@ -24,7 +24,8 @@ module Homebrew
       switch "--fix",
              description: "Fix style violations automatically using RuboCop's auto-correct feature."
       switch "--display-cop-names",
-             description: "Include the RuboCop cop name for each violation in the output."
+             description: "Include the RuboCop cop name for each violation in the output.",
+             hidden:      true
       switch "--reset-cache",
              description: "Reset the RuboCop cache."
       switch "--formula", "--formulae",
@@ -58,11 +59,10 @@ module Homebrew
     except_cops = args.except_cops
 
     options = {
-      fix:               args.fix?,
-      display_cop_names: args.display_cop_names?,
-      reset_cache:       args.reset_cache?,
-      debug:             args.debug?,
-      verbose:           args.verbose?,
+      fix:         args.fix?,
+      reset_cache: args.reset_cache?,
+      debug:       args.debug?,
+      verbose:     args.verbose?,
     }
     if only_cops
       options[:only_cops] = only_cops

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -101,7 +101,6 @@ module Homebrew
       end
 
       args += ["--extra-details"] if verbose
-      args += ["--display-cop-names"] if display_cop_names || verbose
 
       if except_cops
         except_cops.map! { |cop| RuboCop::Cop::Cop.registry.qualified_cop_name(cop.to_s, "") }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- I remember making these changes as part of the RuboCop bump Dependabot PR (#15136), but I must have not actually pushed them. Odd.
