### PR TITLE
Fix `ruby_source_path` in Ventura `systemsettings-caveats` fixture JSON

### DIFF
--- a/Library/Homebrew/test/support/fixtures/cask/everything-systemsettings-caveats.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything-systemsettings-caveats.json
@@ -93,7 +93,7 @@
     "en",
     "eo"
   ],
-  "ruby_source_path": "Formula/everything.rb",
+  "ruby_source_path": "Casks/everything.rb",
   "ruby_source_checksum": {
     "sha256": "b2707d1952f02c3fa566b7ad2a707a847a959d36f51d3dee642dbe5deec12f27"
   }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Cask source paths were added to the API in 844db75361. The main `everything.json` file was updated with the new data in that commit, but this one was missed causing local test failures.

Before:

```
Cask::Cask#to_h when loaded from cask file returns expected hash
  Failure/Error: expect(JSON.pretty_generate(hash)).to eq(expected_json_after_ventura)
    [...]

    Diff:
    @@ -93,7 +93,7 @@
        "en",
        "eo"
      ],
    -  "ruby_source_path": "Formula/everything.rb",
    +  "ruby_source_path": "Casks/everything.rb",
      "ruby_source_checksum": {
        "sha256": "b2707d1952f02c3fa566b7ad2a707a847a959d36f51d3dee642dbe5deec12f27"
      }

  # ./test/cask/cask_spec.rb:231:in `block (4 levels) in <top (required)>'
  # ./test/support/helper/spec/shared_context/homebrew_cask.rb:52:in `block (2 levels) in <top (required)>'
```
