### PR TITLE
Xcode 14.3 updates

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -17,13 +17,14 @@ jobs:
   tests:
     strategy:
       matrix:
-        runner:
-          - "13-arm64-${{github.run_id}}-${{github.run_attempt}}"
-          - "12-arm64"
-          - "12-${{github.run_id}}-${{github.run_attempt}}"
-          - "11-arm64"
-          - "11-${{github.run_id}}-${{github.run_attempt}}"
-          - "10.15-${{github.run_id}}-${{github.run_attempt}}"
+        include:
+          - runner: "13-arm64-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "12-arm64-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "12-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "11-arm64"
+            cleanup: true
+          - runner: "11-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "10.15-${{github.run_id}}-${{github.run_attempt}}"
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     env:
@@ -37,9 +38,9 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - run: brew test-bot --only-cleanup-before
-        if: !contains(matrix.runner, github.run_id)
+        if: matrix.cleanup
 
       - run: brew doctor
 
       - run: brew test-bot --only-cleanup-after
-        if: always() && !contains(matrix.runner, github.run_id)
+        if: always() && matrix.cleanup

--- a/Library/Homebrew/os/mac/pkgconfig/13/expat.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/13/expat.pc
@@ -5,7 +5,7 @@ libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: expat
-Version: 2.4.8
+Version: 2.5.0
 Description: expat XML parser
 URL: https://libexpat.github.io/
 Libs: -L${libdir} -lexpat

--- a/Library/Homebrew/os/mac/pkgconfig/13/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/13/libcurl.pc
@@ -36,7 +36,7 @@ supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerber
 Name: libcurl
 URL: https://curl.se/
 Description: Library to transfer files with ftp, http, etc.
-Version: 7.84.0
+Version: 7.87.0
 Libs: -L${libdir} -lcurl
 Libs.private: -lldap -lz
 Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/13/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/13/sqlite3.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 
 Name: SQLite
 Description: SQL database engine
-Version: 3.39.4
+Version: 3.39.5
 Libs: -L${libdir} -lsqlite3
 Libs.private:
 Cflags:

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -21,10 +21,10 @@ module OS
       # This may be a beta version for a beta macOS.
       sig { params(macos: MacOS::Version).returns(String) }
       def latest_version(macos: MacOS.version)
-        latest_stable = "13.4"
+        latest_stable = "14.3"
         case macos
-        when "13" then "14.1"
-        when "12" then latest_stable
+        when "13" then latest_stable
+        when "12" then "14.2"
         when "11" then "13.2.1"
         when "10.15" then "12.4"
         when "10.14" then "11.3.1"
@@ -246,7 +246,8 @@ module OS
         when "12.0.5" then "12.5.1"
         when "13.0.0" then "13.2.1"
         when "13.1.6" then "13.4.1"
-        else               "14.1"
+        when "14.0.0" then "14.2"
+        else               "14.3"
         end
       end
 
@@ -344,8 +345,8 @@ module OS
       sig { returns(String) }
       def latest_clang_version
         case MacOS.version
-        when "13"    then "1400.0.29.202"
-        when "12"    then "1316.0.21.2.5"
+        when "13"    then "1403.0.22.14.2"
+        when "12"    then "1400.0.29.202"
         when "11"    then "1300.0.29.30"
         when "10.15" then "1200.0.32.29"
         when "10.14" then "1100.0.33.17"


### PR DESCRIPTION
* Fix broken doctor workflow which has had invalid syntax from a merged PR months ago: https://github.com/Homebrew/brew/actions/workflows/doctor.yml.
* Update pkg-config files for macOS 13.3 (don't have macOS 13 on hand but tests should pass now or if not then the error should be very clear).
* Denote Xcode 14.3 as latest, and promote Xcode 14.x on macOS 12 (finally).