### PR TITLE
Fix clang version

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -345,7 +345,7 @@ module OS
       sig { returns(String) }
       def latest_clang_version
         case MacOS.version
-        when "13"    then "1403.0.22.14.2"
+        when "13"    then "1403.0.22.14.1"
         when "12"    then "1400.0.29.202"
         when "11"    then "1300.0.29.30"
         when "10.15" then "1200.0.32.29"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The latest clang version is "1403.0.22.14.1" (see below). However brew expects "1403.0.22.14.2" to be the latest, making `brew doctor` to request an update for a non-existent version.

% /Library/Developer/CommandLineTools/usr/bin/clang --version
Apple clang version 14.0.3 (clang-1403.0.22.14.1)
Target: arm64-apple-darwin22.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

brew(main):001:0> MacOS::CLT.outdated?
=> true
brew(main):002:0> MacOS::CLT.detect_clang_version
=> "1403.0.22.14.1"
brew(main):003:0> MacOS::CLT.latest_clang_version
=> "1403.0.22.14.2"
