### PR TITLE
rubocop/cask: Check for correct stanza grouping within `on_*` blocks

### DIFF
--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -32,7 +32,7 @@ module RuboCop
 
           @stanzas ||= cask_body.each_node
                                 .select(&:stanza?)
-                                .map { |node| Stanza.new(node) }
+                                .map { |node| Stanza.new(node, comments) }
         end
 
         def toplevel_stanzas

--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -51,6 +51,10 @@ module RuboCop
           @sorted_toplevel_stanzas ||= sort_stanzas(toplevel_stanzas)
         end
 
+        def stanzaify(nodes)
+          nodes.map { |node| Stanza.new(node, stanza_comments(node)) }
+        end
+
         private
 
         def sort_stanzas(stanzas)

--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -32,7 +32,7 @@ module RuboCop
 
           @stanzas ||= cask_body.each_node
                                 .select(&:stanza?)
-                                .map { |node| Stanza.new(node, stanza_comments(node)) }
+                                .map { |node| Stanza.new(node, cask_node) }
         end
 
         def toplevel_stanzas
@@ -51,10 +51,6 @@ module RuboCop
           @sorted_toplevel_stanzas ||= sort_stanzas(toplevel_stanzas)
         end
 
-        def stanzaify(nodes)
-          nodes.map { |node| Stanza.new(node, stanza_comments(node)) }
-        end
-
         private
 
         def sort_stanzas(stanzas)
@@ -71,17 +67,6 @@ module RuboCop
 
         def stanza_order_index(stanza)
           Constants::STANZA_ORDER.index(stanza.stanza_name)
-        end
-
-        def stanza_comments(stanza_node)
-          stanza_node.each_node.reduce([]) do |comments, node|
-            comments | comments_hash[node.loc]
-          end
-        end
-
-        def comments_hash
-          @comments_hash ||= Parser::Source::Comment
-                             .associate_locations(cask_node, comments)
         end
       end
     end

--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -32,7 +32,7 @@ module RuboCop
 
           @stanzas ||= cask_body.each_node
                                 .select(&:stanza?)
-                                .map { |node| Stanza.new(node, cask_node) }
+                                .map { |node| Stanza.new(node) }
         end
 
         def toplevel_stanzas

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -12,11 +12,12 @@ module RuboCop
       class Stanza
         extend Forwardable
 
-        def initialize(method_node)
+        def initialize(method_node, all_comments)
           @method_node = method_node
+          @all_comments = all_comments
         end
 
-        attr_reader :method_node
+        attr_reader :method_node, :all_comments
 
         alias stanza_node method_node
 
@@ -58,10 +59,7 @@ module RuboCop
         end
 
         def comments_hash
-          @comments_hash ||= Parser::Source::Comment.associate_locations(
-            stanza_node.parent,
-            comments,
-          )
+          @comments_hash ||= Parser::Source::Comment.associate_locations(stanza_node.parent, all_comments)
         end
 
         def ==(other)

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -12,12 +12,11 @@ module RuboCop
       class Stanza
         extend Forwardable
 
-        def initialize(method_node, cask_node)
+        def initialize(method_node)
           @method_node = method_node
-          @cask_node = cask_node
         end
 
-        attr_reader :method_node, :cask_node
+        attr_reader :method_node
 
         alias stanza_node method_node
 
@@ -59,7 +58,10 @@ module RuboCop
         end
 
         def comments_hash
-          @comments_hash ||= Parser::Source::Comment.associate_locations(cask_node, stanza_comments(stanza_node))
+          @comments_hash ||= Parser::Source::Comment.associate_locations(
+            stanza_node.parent,
+            stanza_comments(stanza_node),
+          )
         end
 
         def ==(other)

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -28,7 +28,7 @@ module RuboCop
         end
 
         def source_range_with_comments
-          stanza_comments(stanza_node).reduce(source_range) do |range, comment|
+          comments.reduce(source_range) do |range, comment|
             range.join(comment.loc.expression)
           end
         end
@@ -51,8 +51,8 @@ module RuboCop
           stanza_group == other.stanza_group
         end
 
-        def stanza_comments(stanza_node)
-          stanza_node.each_node.reduce([]) do |comments, node|
+        def comments
+          @comments ||= stanza_node.each_node.reduce([]) do |comments, node|
             comments | comments_hash[node.loc]
           end
         end
@@ -60,7 +60,7 @@ module RuboCop
         def comments_hash
           @comments_hash ||= Parser::Source::Comment.associate_locations(
             stanza_node.parent,
-            stanza_comments(stanza_node),
+            comments,
           )
         end
 

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -28,7 +28,7 @@ module RuboCop
         end
 
         def source_range_with_comments
-          comments.reduce(source_range) do |range, comment|
+          stanza_comments(stanza_node).reduce(source_range) do |range, comment|
             range.join(comment.loc.expression)
           end
         end

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -12,12 +12,12 @@ module RuboCop
       class Stanza
         extend Forwardable
 
-        def initialize(method_node, comments)
+        def initialize(method_node, cask_node)
           @method_node = method_node
-          @comments = comments
+          @cask_node = cask_node
         end
 
-        attr_reader :method_node, :comments
+        attr_reader :method_node, :cask_node
 
         alias stanza_node method_node
 
@@ -50,6 +50,16 @@ module RuboCop
 
         def same_group?(other)
           stanza_group == other.stanza_group
+        end
+
+        def stanza_comments(stanza_node)
+          stanza_node.each_node.reduce([]) do |comments, node|
+            comments | comments_hash[node.loc]
+          end
+        end
+
+        def comments_hash
+          @comments_hash ||= Parser::Source::Comment.associate_locations(cask_node, stanza_comments(stanza_node))
         end
 
         def ==(other)

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -31,7 +31,8 @@ module RuboCop
             next unless on_block.block_type?
 
             block_contents = on_block.child_nodes.select(&:begin_type?)
-            inner_stanzas = stanzaify(block_contents.map(&:child_nodes).flatten.select(&:send_type?))
+            inner_nodes = block_contents.map(&:child_nodes).flatten.select(&:send_type?)
+            inner_stanzas = inner_nodes.map { |node| RuboCop::Cask::AST::Stanza.new(node, cask_node) }
 
             add_offenses(inner_stanzas)
           end
@@ -41,7 +42,7 @@ module RuboCop
 
         attr_reader :cask_block, :line_ops
 
-        def_delegators :cask_block, :cask_node, :stanzaify, :toplevel_stanzas
+        def_delegators :cask_block, :cask_node, :toplevel_stanzas
 
         def add_offenses(stanzas)
           stanzas.each_cons(2) do |stanza, next_stanza|

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -32,7 +32,7 @@ module RuboCop
 
             block_contents = on_block.child_nodes.select(&:begin_type?)
             inner_nodes = block_contents.map(&:child_nodes).flatten.select(&:send_type?)
-            inner_stanzas = inner_nodes.map { |node| RuboCop::Cask::AST::Stanza.new(node) }
+            inner_stanzas = inner_nodes.map { |node| RuboCop::Cask::AST::Stanza.new(node, processed_source.comments) }
 
             add_offenses(inner_stanzas)
           end

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -32,7 +32,7 @@ module RuboCop
 
             block_contents = on_block.child_nodes.select(&:begin_type?)
             inner_nodes = block_contents.map(&:child_nodes).flatten.select(&:send_type?)
-            inner_stanzas = inner_nodes.map { |node| RuboCop::Cask::AST::Stanza.new(node, cask_node) }
+            inner_stanzas = inner_nodes.map { |node| RuboCop::Cask::AST::Stanza.new(node) }
 
             add_offenses(inner_stanzas)
           end

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -14,26 +14,37 @@ module RuboCop
         include CaskHelp
         include RangeHelp
 
-        MISSING_LINE_MSG = "stanza groups should be separated by a single " \
-                           "empty line"
-
-        EXTRA_LINE_MSG = "stanzas within the same group should have no lines " \
-                         "between them"
+        ON_SYSTEM_METHODS = RuboCop::Cask::Constants::ON_SYSTEM_METHODS
+        MISSING_LINE_MSG = "stanza groups should be separated by a single empty line"
+        EXTRA_LINE_MSG = "stanzas within the same group should have no lines between them"
 
         def on_cask(cask_block)
           @cask_block = cask_block
           @line_ops = {}
-          add_offenses
+          cask_stanzas = cask_block.toplevel_stanzas
+          add_offenses(cask_stanzas)
+
+          # If present, check grouping of stanzas within `on_*` blocks.
+          return unless (on_blocks = cask_stanzas.select { |s| ON_SYSTEM_METHODS.include?(s.stanza_name) }).any?
+
+          on_blocks.map(&:method_node).each do |on_block|
+            next unless on_block.block_type?
+
+            block_contents = on_block.child_nodes.select(&:begin_type?)
+            inner_stanzas = stanzaify(block_contents.map(&:child_nodes).flatten.select(&:send_type?))
+
+            add_offenses(inner_stanzas)
+          end
         end
 
         private
 
         attr_reader :cask_block, :line_ops
 
-        def_delegators :cask_block, :cask_node, :toplevel_stanzas
+        def_delegators :cask_block, :cask_node, :stanzaify, :toplevel_stanzas
 
-        def add_offenses
-          toplevel_stanzas.each_cons(2) do |stanza, next_stanza|
+        def add_offenses(stanzas)
+          stanzas.each_cons(2) do |stanza, next_stanza|
             next unless next_stanza
 
             if missing_line_after?(stanza, next_stanza)

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -506,20 +506,76 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
     include_examples "autocorrects source"
   end
 
-  # TODO: detect incorrectly grouped stanzas in nested expressions
-  context "when stanzas are nested in a conditional expression" do
-    let(:source) do
-      <<~CASK
-        cask 'foo' do
-          if true
-            version :latest
+  context "when stanzas are nested one-level in `on_*` blocks" do
+    describe "basic nesting" do
+      let(:source) do
+        <<~CASK
+          cask 'foo' do
+            on_arm do
+              version "1.0.2"
 
-            sha256 :no_check
+              sha256 :no_check
+            end
+            on_intel do
+              version "0.9.8"
+              sha256 :no_check
+              url "https://foo.brew.sh/foo-intel.zip"
+            end
           end
-        end
-      CASK
+        CASK
+      end
+
+      let(:correct_source) do
+        <<~CASK
+          cask 'foo' do
+            on_arm do
+              version "1.0.2"
+              sha256 :no_check
+            end
+            on_intel do
+              version "0.9.8"
+              sha256 :no_check
+
+              url "https://foo.brew.sh/foo-intel.zip"
+            end
+          end
+        CASK
+      end
+
+      include_examples "autocorrects source"
     end
 
-    include_examples "does not report any offenses"
+    # TODO: Maybe this should be fixed too?
+    describe "inner erroneously grouped nested livecheck block contents are ignored" do
+      let(:source) do
+        <<~CASK
+          cask 'foo' do
+            on_arm do
+              version "1.0.2"
+              sha256 :no_check
+
+              url "https://foo.brew.sh/foo-arm.zip"
+
+              livecheck do
+                url "https://foo.brew.sh/foo-arm-versions.html"
+              end
+            end
+            on_intel do
+              version "0.9.8"
+              sha256 :no_check
+
+              url "https://foo.brew.sh/foo-intel.zip"
+
+              livecheck do
+                regex(/RegExhibit\s+(\d+(?:.\d+)+)/i)
+                url "https://foo.brew.sh/foo-intel-versions.html"
+              end
+            end
+          end
+        CASK
+      end
+
+      include_examples "does not report any offenses"
+    end
   end
 end

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -545,6 +545,41 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
       include_examples "autocorrects source"
     end
 
+    describe "nested `on_*` blocks with comments" do
+      let(:source) do
+        <<~CASK
+          cask 'foo' do
+            on_arm do
+              version "1.0.2"
+
+              sha256 :no_check # comment on same line
+            end
+            on_intel do
+              version "0.9.8"
+              sha256 :no_check
+            end
+          end
+        CASK
+      end
+
+      let(:correct_source) do
+        <<~CASK
+          cask 'foo' do
+            on_arm do
+              version "1.0.2"
+              sha256 :no_check # comment on same line
+            end
+            on_intel do
+              version "0.9.8"
+              sha256 :no_check
+            end
+          end
+        CASK
+      end
+
+      include_examples "autocorrects source"
+    end
+
     # TODO: Maybe this should be fixed too?
     describe "inner erroneously grouped nested livecheck block contents are ignored" do
       let(:source) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- A variant of this was an ancient TODO from 2018 (with `if/else` conditionals).
- Now in 2023 we have `on_*` blocks within Casks that are very common.
- The most common stanzas present inside `on_*` blocks are `version`, `sha256` and `url`. So I feel like it's worth keeping a consistent style for these inside and outside `on_*` blocks?
- Companion PRs to auto-fix the Cask taps offenses are linked below.