### PR TITLE
test/cask/dsl_spec: fix test for certain locale settings

### DIFF
--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -17,13 +17,13 @@ class Locale
   LANGUAGE_REGEX = /(?:[a-z]{2,3})/.freeze
   private_constant :LANGUAGE_REGEX
 
-  # ISO 3166-1 or UN M.49
-  REGION_REGEX = /(?:[A-Z]{2}|\d{3})/.freeze
-  private_constant :REGION_REGEX
-
   # ISO 15924
   SCRIPT_REGEX = /(?:[A-Z][a-z]{3})/.freeze
   private_constant :SCRIPT_REGEX
+
+  # ISO 3166-1 or UN M.49
+  REGION_REGEX = /(?:[A-Z]{2}|\d{3})/.freeze
+  private_constant :REGION_REGEX
 
   LOCALE_REGEX = /\A((?:#{LANGUAGE_REGEX}|#{REGION_REGEX}|#{SCRIPT_REGEX})(?:-|$)){1,3}\Z/.freeze
   private_constant :LOCALE_REGEX
@@ -56,18 +56,18 @@ class Locale
 
     return unless scanner.eos?
 
-    new(language, region, script)
+    new(language, script, region)
   end
 
-  attr_reader :language, :region, :script
+  attr_reader :language, :script, :region
 
-  def initialize(language, region, script)
+  def initialize(language, script, region)
     raise ArgumentError, "#{self.class} cannot be empty" if language.nil? && region.nil? && script.nil?
 
     {
       language: language,
-      region:   region,
       script:   script,
+      region:   region,
     }.each do |key, value|
       next if value.nil?
 
@@ -84,7 +84,7 @@ class Locale
       return false if other.nil?
     end
 
-    [:language, :region, :script].all? do |var|
+    [:language, :script, :region].all? do |var|
       if other.public_send(var).nil?
         true
       else
@@ -99,7 +99,7 @@ class Locale
       return false if other.nil?
     end
 
-    [:language, :region, :script].all? do |var|
+    [:language, :script, :region].all? do |var|
       public_send(var) == other.public_send(var)
     end
   end
@@ -112,6 +112,6 @@ class Locale
 
   sig { returns(String) }
   def to_s
-    [@language, @region, @script].compact.join("-")
+    [@language, @script, @region].compact.join("-")
   end
 end

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -165,7 +165,7 @@ describe Cask::DSL, :cask do
             "zh-CN"
           end
 
-          language "en-US", default: true do
+          language "en", default: true do
             sha256 "xyz789"
             "en-US"
           end

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -7,13 +7,13 @@ describe Locale do
   describe "::parse" do
     it "parses a string in the correct format" do
       expect(described_class.parse("zh")).to eql(described_class.new("zh", nil, nil))
-      expect(described_class.parse("zh-CN")).to eql(described_class.new("zh", "CN", nil))
-      expect(described_class.parse("zh-Hans")).to eql(described_class.new("zh", nil, "Hans"))
-      expect(described_class.parse("zh-Hans-CN")).to eql(described_class.new("zh", "CN", "Hans"))
+      expect(described_class.parse("zh-CN")).to eql(described_class.new("zh", nil, "CN"))
+      expect(described_class.parse("zh-Hans")).to eql(described_class.new("zh", "Hans", nil))
+      expect(described_class.parse("zh-Hans-CN")).to eql(described_class.new("zh", "Hans", "CN"))
     end
 
     it "correctly parses a string with a UN M.49 region code" do
-      expect(described_class.parse("es-419")).to eql(described_class.new("es", "419", nil))
+      expect(described_class.parse("es-419")).to eql(described_class.new("es", nil, "419"))
     end
 
     describe "raises a ParserError when given" do
@@ -42,13 +42,13 @@ describe Locale do
 
     it "raises a ParserError when one of the arguments does not match the locale format" do
       expect { described_class.new("ZH", nil, nil) }.to raise_error(Locale::ParserError)
-      expect { described_class.new(nil, "cn", nil) }.to raise_error(Locale::ParserError)
-      expect { described_class.new(nil, nil, "hans") }.to raise_error(Locale::ParserError)
+      expect { described_class.new(nil, "hans", nil) }.to raise_error(Locale::ParserError)
+      expect { described_class.new(nil, nil, "cn") }.to raise_error(Locale::ParserError)
     end
   end
 
   describe "#include?" do
-    subject { described_class.new("zh", "CN", "Hans") }
+    subject { described_class.new("zh", "Hans", "CN") }
 
     it { is_expected.to include("zh") }
     it { is_expected.to include("zh-CN") }
@@ -59,7 +59,7 @@ describe Locale do
   end
 
   describe "#eql?" do
-    subject(:locale) { described_class.new("zh", "CN", "Hans") }
+    subject(:locale) { described_class.new("zh", "Hans", "CN") }
 
     context "when all parts match" do
       it { is_expected.to eql("zh-Hans-CN") }
@@ -84,9 +84,9 @@ describe Locale do
     let(:locale_groups) { [["zh"], ["zh-TW"]] }
 
     it "finds best matching language code, independent of order" do
-      expect(described_class.new("zh", "TW", nil).detect(locale_groups)).to eql(["zh-TW"])
-      expect(described_class.new("zh", "TW", nil).detect(locale_groups.reverse)).to eql(["zh-TW"])
-      expect(described_class.new("zh", "CN", "Hans").detect(locale_groups)).to eql(["zh"])
+      expect(described_class.new("zh", nil, "TW").detect(locale_groups)).to eql(["zh-TW"])
+      expect(described_class.new("zh", nil, "TW").detect(locale_groups.reverse)).to eql(["zh-TW"])
+      expect(described_class.new("zh", "Hans", "CN").detect(locale_groups)).to eql(["zh"])
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As I mentioned in #15146, two `Cask::DSL` tests failed on my local machine, even on `master`. `git bisect` suggested that it was #14998 that introduced those failures. It turned out that the tests here could fail under certain locale settings, like this one below:

```console
$ defaults read -g AppleLanguages
(
    "en-GB",
    "zh-Hans-SG"
)
```

This is not actually a regression. With the aforementioned locale settings, an explicit `let(:languages) { ["en"] }` setting would result in locales being considered in the following order: `en`, `en-GB`, `zh-Hans-SG`. For each of them, the `detect` method from `Locale` is called, with `locale_groups` as `[["zh"], ["en-US"]]`, the list of locales defined in the test cask.

https://github.com/Homebrew/brew/blob/5c56cb73c6e278d180fd1daeaec2d4d9f7fc734e/Library/Homebrew/locale.rb#L108-L111

Neither of `en` and `en-GB` satisfies the `detect` conditions. (Note that `Locale.parse("en").include?("en-US")` evaluates to `false`.) But `zh-Hans-SG` does (because `Locale.parse("zh-Hans-SG").include?("zh")` is `true`). So, despite having `:languages` set to `en`, the Chinese locale was still used.

This could be fixed by generalising the test cask's English locale settings from `en-US` to `en` (df39280d559e9ce17ff58c69b57f1ec0768bbd35). This is already the case for most existing casks:

```console
$ grep 'language "en.*", default: true' Casks/*.rb
Casks/battle-net.rb:  language "en", default: true do
Casks/cave-story.rb:  language "en", default: true do
Casks/firefox.rb:  language "en", default: true do
Casks/libreoffice-language-pack.rb:    language "en-GB", default: true do
Casks/libreoffice-language-pack.rb:    language "en-GB", default: true do
Casks/openoffice.rb:  language "en", default: true do
Casks/seamonkey.rb:  language "en-US", default: true do
Casks/thunderbird.rb:  language "en", default: true do
Casks/wondershare-edrawmax.rb:  language "en", default: true do
```

Note that this should make the language stanza tests independent of locale settings, because `zh` and `en` should be able to capture all the test cases.

In addition, this PR also changes the order of locale segments to always match the standard format (`script` comes before `region`). This changes the interface, but it does not actually require changes outside the `Locale` class, because `Locale` instances are always constructed with the `parse` method.
