### PR TITLE
rubocops/cask: Check for correct stanza order within `on_*` blocks

### DIFF
--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -8,7 +8,6 @@ module RuboCop
     module AST
       class StanzaBlock
         extend T::Helpers
-        extend T::Sig
 
         sig { returns(RuboCop::AST::BlockNode) }
         attr_reader :block_node

--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -6,27 +6,58 @@ require "forwardable"
 module RuboCop
   module Cask
     module AST
-      # This class wraps the AST block node that represents the entire cask
-      # definition. It includes various helper methods to aid cops in their
-      # analysis.
-      class CaskBlock
-        extend Forwardable
+      class StanzaBlock
+        extend T::Helpers
+        extend T::Sig
 
+        sig { returns(RuboCop::AST::BlockNode) }
+        attr_reader :block_node
+
+        sig { returns(T::Array[Parser::Source::Comment]) }
+        attr_reader :comments
+
+        sig { params(block_node: RuboCop::AST::BlockNode, comments: T::Array[Parser::Source::Comment]).void }
         def initialize(block_node, comments)
           @block_node = block_node
           @comments = comments
         end
 
-        attr_reader :block_node, :comments
+        sig { returns(T::Array[Stanza]) }
+        def stanzas
+          return [] unless (block_body = block_node.block_body)
 
-        alias cask_node block_node
+          # If a block only contains one stanza, it is that stanza's direct parent, otherwise
+          # stanzas are grouped in a nested block and the block is that nested block's parent.
+          is_stanza = if block_body.begin_block?
+            ->(node) { node.parent.parent == block_node }
+          else
+            ->(node) { node.parent == block_node }
+          end
+
+          @stanzas ||= block_body.each_node
+                                 .select(&:stanza?)
+                                 .select(&is_stanza)
+                                 .map { |node| Stanza.new(node, comments) }
+        end
+      end
+
+      # This class wraps the AST block node that represents the entire cask
+      # definition. It includes various helper methods to aid cops in their
+      # analysis.
+      class CaskBlock < StanzaBlock
+        extend Forwardable
+
+        def cask_node
+          block_node
+        end
 
         def_delegator :cask_node, :block_body, :cask_body
 
         def header
-          @header ||= CaskHeader.new(cask_node.method_node)
+          @header ||= CaskHeader.new(block_node.method_node)
         end
 
+        # TODO: Use `StanzaBlock#stanzas` for all cops, where possible.
         def stanzas
           return [] unless cask_body
 
@@ -45,29 +76,6 @@ module RuboCop
           end
 
           @toplevel_stanzas ||= stanzas.select(&is_toplevel_stanza)
-        end
-
-        def sorted_toplevel_stanzas
-          @sorted_toplevel_stanzas ||= sort_stanzas(toplevel_stanzas)
-        end
-
-        private
-
-        def sort_stanzas(stanzas)
-          stanzas.sort do |s1, s2|
-            i1 = stanza_order_index(s1)
-            i2 = stanza_order_index(s2)
-            if i1 == i2 || i1.blank? || i2.blank?
-              i1 = stanzas.index(s1)
-              i2 = stanzas.index(s2)
-            end
-            i1 - i2
-          end
-        end
-
-        def stanza_order_index(stanza)
-          stanza_name = stanza.respond_to?(:method_name) ? stanza.method_name : stanza.stanza_name
-          Constants::STANZA_ORDER.index(stanza_name)
         end
       end
     end

--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -51,6 +51,10 @@ module RuboCop
           @sorted_toplevel_stanzas ||= sort_stanzas(toplevel_stanzas)
         end
 
+        def sorted_inner_stanzas(stanzas)
+          sort_stanzas(stanzas)
+        end
+
         private
 
         def sort_stanzas(stanzas)

--- a/Library/Homebrew/rubocops/cask/ast/cask_block.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_block.rb
@@ -51,10 +51,6 @@ module RuboCop
           @sorted_toplevel_stanzas ||= sort_stanzas(toplevel_stanzas)
         end
 
-        def sorted_inner_stanzas(stanzas)
-          sort_stanzas(stanzas)
-        end
-
         private
 
         def sort_stanzas(stanzas)
@@ -70,7 +66,8 @@ module RuboCop
         end
 
         def stanza_order_index(stanza)
-          Constants::STANZA_ORDER.index(stanza.stanza_name)
+          stanza_name = stanza.respond_to?(:method_name) ? stanza.method_name : stanza.stanza_name
+          Constants::STANZA_ORDER.index(stanza_name)
         end
       end
     end

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -23,6 +23,7 @@ module RuboCop
 
         def_delegator :stanza_node, :parent, :parent_node
         def_delegator :stanza_node, :arch_variable?
+        def_delegator :stanza_node, :on_system_block?
 
         def source_range
           stanza_node.location_expression
@@ -48,6 +49,10 @@ module RuboCop
           Constants::STANZA_GROUP_HASH[stanza_name]
         end
 
+        def stanza_index
+          Constants::STANZA_ORDER.index(stanza_name)
+        end
+
         def same_group?(other)
           stanza_group == other.stanza_group
         end
@@ -65,7 +70,6 @@ module RuboCop
         def ==(other)
           self.class == other.class && stanza_node == other.stanza_node
         end
-
         alias eql? ==
 
         Constants::STANZA_ORDER.each do |stanza_name|

--- a/Library/Homebrew/rubocops/cask/extend/node.rb
+++ b/Library/Homebrew/rubocops/cask/extend/node.rb
@@ -5,6 +5,8 @@ module RuboCop
   module AST
     # Extensions for RuboCop's AST Node class.
     class Node
+      extend T::Sig
+
       include RuboCop::Cask::Constants
 
       def_node_matcher :method_node, "{$(send ...) (block $(send ...) ...)}"
@@ -15,10 +17,16 @@ module RuboCop
       def_node_matcher :val_node,    "{(pair _ $_) (hash (pair _ $_) ...)}"
 
       def_node_matcher :cask_block?, "(block (send nil? :cask ...) args ...)"
-      def_node_matcher :on_system_block?, "(block (send nil? {#{ON_SYSTEM_METHODS.map(&:inspect).join(" ")}} ...) args ...)"
+      def_node_matcher :on_system_block?,
+                       "(block (send nil? {#{ON_SYSTEM_METHODS.map(&:inspect).join(" ")}} ...) args ...)"
       def_node_matcher :arch_variable?, "(lvasgn _ (send nil? :on_arch_conditional ...))"
 
       def_node_matcher :begin_block?, "(begin ...)"
+
+      sig { returns(T::Boolean) }
+      def cask_on_system_block?
+        (on_system_block? && each_ancestor.any?(&:cask_block?)) || false
+      end
 
       def stanza?
         return true if arch_variable?

--- a/Library/Homebrew/rubocops/cask/extend/node.rb
+++ b/Library/Homebrew/rubocops/cask/extend/node.rb
@@ -14,7 +14,8 @@ module RuboCop
       def_node_matcher :key_node,    "{(pair $_ _) (hash (pair $_ _) ...)}"
       def_node_matcher :val_node,    "{(pair _ $_) (hash (pair _ $_) ...)}"
 
-      def_node_matcher :cask_block?, "(block (send nil? :cask _) args ...)"
+      def_node_matcher :cask_block?, "(block (send nil? :cask ...) args ...)"
+      def_node_matcher :on_system_block?, "(block (send nil? {#{ON_SYSTEM_METHODS.map(&:inspect).join(" ")}} ...) args ...)"
       def_node_matcher :arch_variable?, "(lvasgn _ (send nil? :on_arch_conditional ...))"
 
       def_node_matcher :begin_block?, "(begin ...)"

--- a/Library/Homebrew/rubocops/cask/extend/node.rb
+++ b/Library/Homebrew/rubocops/cask/extend/node.rb
@@ -5,8 +5,6 @@ module RuboCop
   module AST
     # Extensions for RuboCop's AST Node class.
     class Node
-      extend T::Sig
-
       include RuboCop::Cask::Constants
 
       def_node_matcher :method_node, "{$(send ...) (block $(send ...) ...)}"

--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
@@ -6,31 +6,39 @@ module RuboCop
     module Cask
       # Common functionality for cops checking casks.
       module CaskHelp
-        extend T::Helpers
+        prepend CommentsHelp
 
-        abstract!
-
-        sig { abstract.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }
+        sig { overridable.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }
         def on_cask(cask_block); end
 
+        sig { overridable.params(cask_stanza_block: RuboCop::Cask::AST::StanzaBlock).void }
         def on_cask_stanza_block(cask_stanza_block); end
 
+        # FIXME: Workaround until https://github.com/rubocop/rubocop/pull/11858 is released.
+        def find_end_line(node)
+          return node.loc.end.line if node.block_type? || node.numblock_type?
+
+          super
+        end
+
+        sig { params(block_node: RuboCop::AST::BlockNode).void }
         def on_block(block_node)
           super if defined? super
 
-          if respond_to?(:on_cask_stanza_block) && (block_node.cask_block? || block_node.on_system_block?)
-            on_cask_stanza_block(block_node)
-          end
+          return if !block_node.cask_block? && !block_node.cask_on_system_block?
 
-          if respond_to?(:on_cask) && block_node.cask_block?
-            comments = processed_source.comments
-            cask_block = RuboCop::Cask::AST::CaskBlock.new(block_node, comments)
-            on_cask(cask_block)
-          end
+          comments = comments_in_range(block_node).to_a
+          stanza_block = RuboCop::Cask::AST::StanzaBlock.new(block_node, comments)
+          on_cask_stanza_block(stanza_block)
+
+          return unless block_node.cask_block?
+
+          cask_block = RuboCop::Cask::AST::CaskBlock.new(block_node, comments)
+          on_cask(cask_block)
         end
 
         def on_system_methods(cask_stanzas)
-          cask_stanzas.select { |s| RuboCop::Cask::Constants::ON_SYSTEM_METHODS.include?(s.stanza_name) }
+          cask_stanzas.select(&:on_system_block?)
         end
 
         def inner_stanzas(block_node, comments)

--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
@@ -13,14 +13,20 @@ module RuboCop
         sig { abstract.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }
         def on_cask(cask_block); end
 
+        def on_cask_stanza_block(cask_stanza_block); end
+
         def on_block(block_node)
           super if defined? super
-          return unless respond_to?(:on_cask)
-          return unless block_node.cask_block?
 
-          comments = processed_source.comments
-          cask_block = RuboCop::Cask::AST::CaskBlock.new(block_node, comments)
-          on_cask(cask_block)
+          if respond_to?(:on_cask_stanza_block) && (block_node.cask_block? || block_node.on_system_block?)
+            on_cask_stanza_block(block_node)
+          end
+
+          if respond_to?(:on_cask) && block_node.cask_block?
+            comments = processed_source.comments
+            cask_block = RuboCop::Cask::AST::CaskBlock.new(block_node, comments)
+            on_cask(cask_block)
+          end
         end
 
         def on_system_methods(cask_stanzas)

--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
@@ -22,6 +22,16 @@ module RuboCop
           cask_block = RuboCop::Cask::AST::CaskBlock.new(block_node, comments)
           on_cask(cask_block)
         end
+
+        def on_system_methods(cask_stanzas)
+          cask_stanzas.select { |s| RuboCop::Cask::Constants::ON_SYSTEM_METHODS.include?(s.stanza_name) }
+        end
+
+        def inner_stanzas(block_node, comments)
+          block_contents = block_node.child_nodes.select(&:begin_type?)
+          inner_nodes = block_contents.map(&:child_nodes).flatten.select(&:send_type?)
+          inner_nodes.map { |n| RuboCop::Cask::AST::Stanza.new(n, comments) }
+        end
       end
     end
   end

--- a/Library/Homebrew/rubocops/cask/no_overrides.rb
+++ b/Library/Homebrew/rubocops/cask/no_overrides.rb
@@ -21,7 +21,7 @@ module RuboCop
         def on_cask(cask_block)
           cask_stanzas = cask_block.toplevel_stanzas
 
-          return unless (on_blocks = on_system_methods(cask_stanzas)).any?
+          return if (on_blocks = on_system_methods(cask_stanzas)).none?
 
           stanzas_in_blocks = on_system_stanzas(on_blocks)
 

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -23,7 +23,7 @@ module RuboCop
           cask_stanzas = cask_block.toplevel_stanzas
           add_offenses(cask_stanzas)
 
-          return unless (on_blocks = on_system_methods(cask_stanzas)).any?
+          return if (on_blocks = on_system_methods(cask_stanzas)).none?
 
           on_blocks.map(&:method_node).select(&:block_type?).each do |on_block|
             stanzas = inner_stanzas(on_block, processed_source.comments)

--- a/Library/Homebrew/rubocops/cask/stanza_order.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_order.rb
@@ -37,12 +37,13 @@ module RuboCop
         def add_offenses(stanzas, inner: false)
           sorted_stanzas = inner ? sorted_inner_stanzas(stanzas) : sorted_toplevel_stanzas
           offending_stanzas(stanzas, sorted_stanzas).each do |stanza|
+            puts "offending stanza: #{stanza.stanza_name}"
             message = format(MESSAGE, stanza: stanza.stanza_name)
             add_offense(stanza.source_range_with_comments, message: message) do |corrector|
               correct_stanza_index = stanzas.index(stanza)
               correct_stanza = sorted_stanzas[correct_stanza_index]
-              corrector.replace(stanza.source_range_with_comments,
-                                correct_stanza.source_with_comments)
+              puts "correct stanza: #{correct_stanza.stanza_name}"
+              corrector.replace(stanza.source_range_with_comments, correct_stanza.source_with_comments)
             end
           end
         end

--- a/Library/Homebrew/rubocops/cask/stanza_order.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_order.rb
@@ -36,7 +36,7 @@ module RuboCop
 
         def add_offenses(stanzas, inner: false)
           sorted_stanzas = inner ? sorted_inner_stanzas(stanzas) : sorted_toplevel_stanzas
-          offending_stanzas(stanzas, inner: inner).each do |stanza|
+          offending_stanzas(stanzas, sorted_stanzas).each do |stanza|
             message = format(MESSAGE, stanza: stanza.stanza_name)
             add_offense(stanza.source_range_with_comments, message: message) do |corrector|
               correct_stanza_index = stanzas.index(stanza)
@@ -47,8 +47,7 @@ module RuboCop
           end
         end
 
-        def offending_stanzas(stanzas, inner: false)
-          sorted_stanzas = inner ? sorted_inner_stanzas(stanzas) : sorted_toplevel_stanzas
+        def offending_stanzas(stanzas, sorted_stanzas)
           stanza_pairs = stanzas.zip(sorted_stanzas)
           stanza_pairs.each_with_object([]) do |stanza_pair, offending_stanzas|
             stanza, sorted_stanza = *stanza_pair

--- a/Library/Homebrew/rubocops/cask/stanza_order.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_order.rb
@@ -42,6 +42,12 @@ module RuboCop
           end
         end
 
+        def on_new_investigation
+          super
+
+          ignored_nodes.clear
+        end
+
         private
 
         def sort_stanzas(stanzas)

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -6373,6 +6373,8 @@ class RuboCop::AST::Node
 
   def method_node(param0=T.unsafe(nil)); end
 
+  def on_system_block?(param0=T.unsafe(nil)); end
+
   def val_node(param0=T.unsafe(nil)); end
 end
 
@@ -6505,11 +6507,60 @@ class RuboCop::Cask::AST::Stanza
 end
 
 module RuboCop::Cop::Cask::CaskHelp
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+module RuboCop::Cop::Cask::CaskHelp
   extend ::T::Private::Abstract::Hooks
   extend ::T::InterfaceWrapper::Helpers
 end
 
+class RuboCop::Cop::Cask::Desc
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+class RuboCop::Cop::Cask::HomepageUrlTrailingSlash
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+class RuboCop::Cop::Cask::NoDslVersion
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+class RuboCop::Cop::Cask::NoOverrides
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+module RuboCop::Cop::Cask::OnDescStanza
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+module RuboCop::Cop::Cask::OnHomepageStanza
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+class RuboCop::Cop::Cask::OnSystemConditionals
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+module RuboCop::Cop::Cask::OnUrlStanza
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+class RuboCop::Cop::Cask::StanzaGrouping
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+class RuboCop::Cop::Cask::StanzaOrder
+  include ::RuboCop::Cop::CommentsHelp
+end
+
+class RuboCop::Cop::Cask::Url
+  include ::RuboCop::Cop::CommentsHelp
+end
+
 class RuboCop::Cop::Cask::Variables
+  include ::RuboCop::Cop::CommentsHelp
   def variable_assignment(param0); end
 end
 

--- a/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
+++ b/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
@@ -39,8 +39,24 @@ module CaskCop
     expect(actual.location.source).to eq(expected[:source])
   end
 
+  # TODO: Replace with `expect_correction` from `rubocop-rspec`.
   def expect_autocorrected_source(source, correct_source)
-    new_source = autocorrect_source(source)
-    expect(new_source).to eq(Array(correct_source).join("\n"))
+    correct_source = Array(correct_source).join("\n")
+
+    current_source = source
+
+    # RuboCop runs auto-correction in a loop to handle nested offenses.
+    loop do
+      current_source = autocorrect_source(current_source)
+
+      if (ignored_nodes = cop.instance_variable_get(:@ignored_nodes)) && ignored_nodes.any?
+        ignored_nodes.clear
+        next
+      end
+
+      break
+    end
+
+    expect(current_source).to eq correct_source
   end
 end

--- a/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
+++ b/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
@@ -27,11 +27,11 @@ module CaskCop
     offenses = inspect_source(source)
     expect(offenses.size).to eq(expected_offenses.size)
     expected_offenses.zip(offenses).each do |expected, actual|
-      expect_offense(expected, actual)
+      expect_offense2(expected, actual)
     end
   end
 
-  def expect_offense(expected, actual)
+  def expect_offense2(expected, actual)
     expect(actual.message).to eq(expected[:message])
     expect(actual.severity).to eq(expected[:severity])
     expect(actual.line).to eq(expected[:line])

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -3,10 +3,8 @@
 require "rubocops/rubocop-cask"
 require "test/rubocops/cask/shared_examples/cask_cop"
 
-describe RuboCop::Cop::Cask::StanzaOrder do
+describe RuboCop::Cop::Cask::StanzaOrder, :config do
   include CaskCop
-
-  subject(:cop) { described_class.new }
 
   context "when there is only one stanza" do
     let(:source) do
@@ -55,13 +53,13 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     end
     let(:expected_offenses) do
       [{
-        message:  "Cask/StanzaOrder: `sha256` stanza out of order",
+        message:  "`sha256` stanza out of order",
         severity: :convention,
         line:     2,
         column:   2,
         source:   "sha256 :no_check",
       }, {
-        message:  "Cask/StanzaOrder: `version` stanza out of order",
+        message:  "`version` stanza out of order",
         severity: :convention,
         line:     3,
         column:   2,
@@ -95,19 +93,19 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     end
     let(:expected_offenses) do
       [{
-        message:  "Cask/StanzaOrder: `version` stanza out of order",
+        message:  "`version` stanza out of order",
         severity: :convention,
         line:     2,
         column:   2,
         source:   "version :latest",
       }, {
-        message:  "Cask/StanzaOrder: `sha256` stanza out of order",
+        message:  "`sha256` stanza out of order",
         severity: :convention,
         line:     3,
         column:   2,
         source:   "sha256 :no_check",
       }, {
-        message:  "Cask/StanzaOrder: `arch` stanza out of order",
+        message:  "`arch` stanza out of order",
         severity: :convention,
         line:     4,
         column:   2,
@@ -143,13 +141,13 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     end
     let(:expected_offenses) do
       [{
-        message:  "Cask/StanzaOrder: `sha256` stanza out of order",
+        message:  "`sha256` stanza out of order",
         severity: :convention,
         line:     3,
         column:   2,
         source:   "sha256 :no_check",
       }, {
-        message:  "Cask/StanzaOrder: `on_arch_conditional` stanza out of order",
+        message:  "`on_arch_conditional` stanza out of order",
         severity: :convention,
         line:     5,
         column:   2,
@@ -185,13 +183,13 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     end
     let(:expected_offenses) do
       [{
-        message:  "Cask/StanzaOrder: `on_arch_conditional` stanza out of order",
+        message:  "`on_arch_conditional` stanza out of order",
         severity: :convention,
         line:     2,
         column:   2,
         source:   'folder = on_arch_conditional arm: "darwin-arm64", intel: "darwin"',
       }, {
-        message:  "Cask/StanzaOrder: `arch` stanza out of order",
+        message:  "`arch` stanza out of order",
         severity: :convention,
         line:     3,
         column:   2,
@@ -231,26 +229,26 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     end
     let(:expected_offenses) do
       [{
-        message:  "Cask/StanzaOrder: `url` stanza out of order",
+        message:  "`url` stanza out of order",
         severity: :convention,
         line:     2,
         column:   2,
         source:   "url 'https://foo.brew.sh/foo.zip'",
       }, {
-        message:  "Cask/StanzaOrder: `uninstall` stanza out of order",
+        message:  "`uninstall` stanza out of order",
         severity: :convention,
         line:     3,
         column:   2,
         source:   "uninstall :quit => 'com.example.foo'," \
                   "\n            :kext => 'com.example.foo.kext'",
       }, {
-        message:  "Cask/StanzaOrder: `version` stanza out of order",
+        message:  "`version` stanza out of order",
         severity: :convention,
         line:     5,
         column:   2,
         source:   "version :latest",
       }, {
-        message:  "Cask/StanzaOrder: `sha256` stanza out of order",
+        message:  "`sha256` stanza out of order",
         severity: :convention,
         line:     7,
         column:   2,
@@ -500,63 +498,66 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     include_examples "autocorrects source"
   end
 
-  context "when the `on_os` stanzas and their contents are out of order" do
-    let(:source) do
-      <<~CASK
-        cask "foo" do
-          on_ventura do
-            sha256 "abc123"
-            version :latest
-            url "https://foo.brew.sh/foo-ventura.zip"
-          end
-          on_catalina do
-            sha256 "def456"
-            version "0.7"
-            url "https://foo.brew.sh/foo-catalina.zip"
-          end
-          on_mojave do
-            version :latest
-            sha256 "ghi789"
-            url "https://foo.brew.sh/foo-mojave.zip"
-          end
-          on_big_sur do
-            sha256 "jkl012"
-            version :latest
-
-            url "https://foo.brew.sh/foo-big-sur.zip"
-          end
+  it "registers an offense when `on_os` stanzas and their contents are out of order" do
+    expect_offense <<~CASK
+      cask "foo" do
+        on_ventura do
+        ^^^^^^^^^^^^^ `on_ventura` stanza out of order
+          sha256 "abc123"
+          ^^^^^^^^^^^^^^^ `sha256` stanza out of order
+          version :latest
+          ^^^^^^^^^^^^^^^ `version` stanza out of order
+          url "https://foo.brew.sh/foo-ventura.zip"
         end
-      CASK
-    end
-
-    let(:correct_source) do
-      <<~CASK
-        cask "foo" do
-          on_mojave do
-            version :latest
-            sha256 "ghi789"
-            url "https://foo.brew.sh/foo-mojave.zip"
-          end
-          on_catalina do
-            version "0.7"
-            sha256 "def456"
-            url "https://foo.brew.sh/foo-catalina.zip"
-          end
-          on_big_sur do
-            version :latest
-            sha256 "jkl012"
-
-            url "https://foo.brew.sh/foo-big-sur.zip"
-          end
-          on_ventura do
-            version :latest
-            sha256 "abc123"
-            url "https://foo.brew.sh/foo-ventura.zip"
-          end
+        on_catalina do
+          sha256 "def456"
+          ^^^^^^^^^^^^^^^ `sha256` stanza out of order
+          version "0.7"
+          ^^^^^^^^^^^^^ `version` stanza out of order
+          url "https://foo.brew.sh/foo-catalina.zip"
         end
-      CASK
-    end
+        on_mojave do
+        ^^^^^^^^^^^^ `on_mojave` stanza out of order
+          version :latest
+          sha256 "ghi789"
+          url "https://foo.brew.sh/foo-mojave.zip"
+        end
+        on_big_sur do
+        ^^^^^^^^^^^^^ `on_big_sur` stanza out of order
+          sha256 "jkl012"
+          ^^^^^^^^^^^^^^^ `sha256` stanza out of order
+          version :latest
+          ^^^^^^^^^^^^^^^ `version` stanza out of order
 
-    include_examples "autocorrects source"
+          url "https://foo.brew.sh/foo-big-sur.zip"
+        end
+      end
+    CASK
+
+    expect_correction <<~CASK
+      cask "foo" do
+        on_mojave do
+          version :latest
+          sha256 "ghi789"
+          url "https://foo.brew.sh/foo-mojave.zip"
+        end
+        on_catalina do
+          version "0.7"
+          sha256 "def456"
+          url "https://foo.brew.sh/foo-catalina.zip"
+        end
+        on_big_sur do
+          version :latest
+          sha256 "jkl012"
+
+          url "https://foo.brew.sh/foo-big-sur.zip"
+        end
+        on_ventura do
+          version :latest
+          sha256 "abc123"
+          url "https://foo.brew.sh/foo-ventura.zip"
+        end
+      end
+    CASK
   end
 end

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -489,8 +489,8 @@ describe RuboCop::Cop::Cask::StanzaOrder do
           end
           on_intel do
             version :latest
-            sha256 :no_check
 
+            sha256 :no_check
             url "https://foo.brew.sh/foo-intel.zip"
           end
         end
@@ -533,24 +533,24 @@ describe RuboCop::Cop::Cask::StanzaOrder do
       <<~CASK
         cask "foo" do
           on_mojave do
-            version "0.6"
+            version :latest
             sha256 "ghi789"
             url "https://foo.brew.sh/foo-mojave.zip"
           end
           on_catalina do
-            sha256 "def456"
             version "0.7"
+            sha256 "def456"
             url "https://foo.brew.sh/foo-catalina.zip"
           end
           on_big_sur do
-            version "0.8"
+            version :latest
             sha256 "jkl012"
 
             url "https://foo.brew.sh/foo-big-sur.zip"
           end
           on_ventura do
             version :latest
-            sha256 :no_check
+            sha256 "abc123"
             url "https://foo.brew.sh/foo-ventura.zip"
           end
         end

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -458,15 +458,15 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     include_examples "autocorrects source"
   end
 
-  context "when `on_arch` blocks are out of order" do
+  context "when `on_arch` blocks and their contents are out of order" do
     let(:source) do
       <<~CASK
         cask 'foo' do
           on_intel do
+            url "https://foo.brew.sh/foo-intel.zip"
+
             version :latest
             sha256 :no_check
-
-            url "https://foo.brew.sh/foo-intel.zip"
           end
           on_arm do
             version :latest
@@ -476,22 +476,6 @@ describe RuboCop::Cop::Cask::StanzaOrder do
           end
         end
       CASK
-    end
-
-    let(:expected_offenses) do
-      [{
-        message:  "Cask/StanzaOrder: `on_intel` stanza out of order",
-        severity: :convention,
-        line:     2,
-        column:   2,
-        source:   "on_intel do\n    version :latest\n    sha256 :no_check\n\n    url \"https://foo.brew.sh/foo-intel.zip\"\n  end", # rubocop:disable Layout/LineLength
-      }, {
-        message:  "Cask/StanzaOrder: `on_arm` stanza out of order",
-        severity: :convention,
-        line:     8,
-        column:   2,
-        source:   "on_arm do\n    version :latest\n    sha256 :no_check\n\n    url \"https://foo.brew.sh/foo-arm.zip\"\n  end", # rubocop:disable Layout/LineLength
-      }]
     end
 
     let(:correct_source) do
@@ -507,45 +491,6 @@ describe RuboCop::Cop::Cask::StanzaOrder do
             version :latest
             sha256 :no_check
 
-            url "https://foo.brew.sh/foo-intel.zip"
-          end
-        end
-      CASK
-    end
-
-    include_examples "reports offenses"
-    include_examples "autocorrects source"
-  end
-
-  context "when the `on_arch` blocks contents are out of order" do
-    let(:source) do
-      <<~CASK
-        cask 'foo' do
-          on_arm do
-            url "https://foo.brew.sh/foo-arm.zip"
-            sha256 "123abc"
-            version "1.0"
-          end
-          on_intel do
-            url "https://foo.brew.sh/foo-intel.zip"
-            sha256 "abc123"
-            version "0.9" # comment here
-          end
-        end
-      CASK
-    end
-
-    let(:correct_source) do
-      <<~CASK
-        cask 'foo' do
-          on_arm do
-            version "1.0"
-            sha256 "123abc"
-            url "https://foo.brew.sh/foo-arm.zip"
-          end
-          on_intel do
-            version "0.9" # comment here
-            sha256 "abc123"
             url "https://foo.brew.sh/foo-intel.zip"
           end
         end
@@ -555,80 +500,63 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     include_examples "autocorrects source"
   end
 
-  context "when the on_os stanzas are out of order" do
+  context "when the `on_os` stanzas and their contents are out of order" do
     let(:source) do
       <<~CASK
         cask "foo" do
           on_ventura do
-            sha256 :no_check
+            sha256 "abc123"
+            version :latest
             url "https://foo.brew.sh/foo-ventura.zip"
           end
           on_catalina do
-            sha256 :no_check
+            sha256 "def456"
+            version "0.7"
             url "https://foo.brew.sh/foo-catalina.zip"
           end
           on_mojave do
-            sha256 :no_check
+            version :latest
+            sha256 "ghi789"
             url "https://foo.brew.sh/foo-mojave.zip"
           end
           on_big_sur do
-            sha256 :no_check
+            sha256 "jkl012"
+            version :latest
+
             url "https://foo.brew.sh/foo-big-sur.zip"
           end
-
-          name "Foo"
         end
       CASK
-    end
-
-    let(:expected_offenses) do
-      [{
-        message:  "Cask/StanzaOrder: `on_ventura` stanza out of order",
-        severity: :convention,
-        line:     2,
-        column:   2,
-        source:   "on_ventura do\n    sha256 :no_check\n    url \"https://foo.brew.sh/foo-ventura.zip\"\n  end",
-      }, {
-        message:  "Cask/StanzaOrder: `on_mojave` stanza out of order",
-        severity: :convention,
-        line:     10,
-        column:   2,
-        source:   "on_mojave do\n    sha256 :no_check\n    url \"https://foo.brew.sh/foo-mojave.zip\"\n  end",
-      }, {
-        message:  "Cask/StanzaOrder: `on_big_sur` stanza out of order",
-        severity: :convention,
-        line:     14,
-        column:   2,
-        source:   "on_big_sur do\n    sha256 :no_check\n    url \"https://foo.brew.sh/foo-big-sur.zip\"\n  end",
-      }]
     end
 
     let(:correct_source) do
       <<~CASK
         cask "foo" do
           on_mojave do
-            sha256 :no_check
+            version "0.6"
+            sha256 "ghi789"
             url "https://foo.brew.sh/foo-mojave.zip"
           end
           on_catalina do
-            sha256 :no_check
+            sha256 "def456"
+            version "0.7"
             url "https://foo.brew.sh/foo-catalina.zip"
           end
           on_big_sur do
-            sha256 :no_check
+            version "0.8"
+            sha256 "jkl012"
+
             url "https://foo.brew.sh/foo-big-sur.zip"
           end
           on_ventura do
+            version :latest
             sha256 :no_check
             url "https://foo.brew.sh/foo-ventura.zip"
           end
-
-          name "Foo"
         end
       CASK
     end
 
-    include_examples "reports offenses"
     include_examples "autocorrects source"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Follow-up to #15211 to fix more TODOs but in a different cop.

-----

- Now that we detect correct stanza _grouping_ within `on_*` blocks in Casks, correct stanza _ordering_ in `on_*` blocks was the next logical step. For example, `url` has to come after `version` and `sha256` in an `on_macos` or `on_intel` block for consistency with the top-level stanza order we enforce elsewhere.
- Still not doing the nested `on_os` inside `on_arch`, that felt excessive for an edge case that isn't present in more than a few real Casks we have. I removed the test with that specific TODO. If anyone feels strongly I can look at it again, though.