### PR TITLE
workflows/sponsors-maintainers-man-completions: only run on branches

### DIFF
--- a/.github/workflows/sponsors-maintainers-man-completions.yml
+++ b/.github/workflows/sponsors-maintainers-man-completions.yml
@@ -2,6 +2,8 @@ name: Update sponsors, maintainers, manpage and completions
 
 on:
   push:
+    branches:
+      - "**"
     paths:
       - .github/workflows/sponsors-maintainers-man-completions.yml
       - README.md


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This prevents running the jobs on tags. It can be dangerous to force-push a tag, even though previous workflow runs actually failed.

Example of previous failure: https://github.com/Homebrew/brew/actions/runs/4657211778/jobs/8241583576
