### PR TITLE
Delete a Cask RuboCop test for an edge case that is not fixed

### DIFF
--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -579,38 +579,5 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
 
       include_examples "autocorrects source"
     end
-
-    # TODO: Maybe this should be fixed too?
-    describe "inner erroneously grouped nested livecheck block contents are ignored" do
-      let(:source) do
-        <<~CASK
-          cask 'foo' do
-            on_arm do
-              version "1.0.2"
-              sha256 :no_check
-
-              url "https://foo.brew.sh/foo-arm.zip"
-
-              livecheck do
-                url "https://foo.brew.sh/foo-arm-versions.html"
-              end
-            end
-            on_intel do
-              version "0.9.8"
-              sha256 :no_check
-
-              url "https://foo.brew.sh/foo-intel.zip"
-
-              livecheck do
-                regex(/RegExhibit\s+(\d+(?:.\d+)+)/i)
-                url "https://foo.brew.sh/foo-intel-versions.html"
-              end
-            end
-          end
-        CASK
-      end
-
-      include_examples "does not report any offenses"
-    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This test tests nothing. And the TODO comment is wrong (https://github.com/Homebrew/brew/pull/15211/files#r1164491120).
- We _could_ fix it, but it's a very edgy edge case which pertains to `livecheck` blocks which currently don't have stanza grouping or ordering cop support. If we decide in the future to add these, we can add this back too (provided I remember).
- Also I think I may have got confused with the stanza grouping vs. stanza ordering cops when writing this, rendering this test more useless.