### PR TITLE
Escape formula path in ruby source url

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -6,6 +6,7 @@ require "extend/cachable"
 require "tab"
 require "utils/bottles"
 require "service"
+require "cgi"
 
 require "active_support/core_ext/hash/deep_transform_values"
 
@@ -257,6 +258,7 @@ module Formulary
       resource "ruby-source" do
         tap_git_head = json_formula.fetch("tap_git_head", "HEAD")
         ruby_source_path = json_formula.fetch("ruby_source_path", "Formula/#{name}.rb")
+        ruby_source_path = CGI.escape(ruby_source_path)
         ruby_source_sha256 = json_formula.dig("ruby_source_checksum", "sha256")
 
         url "https://raw.githubusercontent.com/Homebrew/homebrew-core/#{tap_git_head}/#{ruby_source_path}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #15235.

This was causing problems when trying to parse the formula name from the path when loading the formual. This didn't happen previously because downloading formula ruby source files from Github is a recent addition with the API changes.

The problem seems to come from the `AbstractFileDownloadStrategy#parse_basename` method which turns the plus symbols into spaces.

```rb
[7] brew(main)> formula = "bonnie++".f
=> #<Formula bonnie++ (stable) /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/bonnie++.rb>
[8] brew(main)> resource = formula.resource("ruby-source"); nil
=> nil
[9] brew(main)> resource.url
=> "https://raw.githubusercontent.com/Homebrew/homebrew-core/9fa25e536710603c675fe187c564cbaac45fb7d5/Formula/bonnie++.rb"
[10] brew(main)> strategy = AbstractFileDownloadStrategy.new(nil, nil, nil); nil
=> nil
[11] brew(main)> strategy.send(:parse_basename, resource.url)
=> "bonnie  .rb"
```

It looks like it is caused by the use of `URI.decode_www_form_component`.

```rb
brew(main):005:0> url = "/Homebrew/homebrew-core/9fa25e536710603c675fe187c564cbaac45fb7d5/Formula/bonnie++.rb"
=> "/Homebrew/homebrew-core/9fa25e536710603c675fe187c564cbaac45fb7d5/Formula/bonnie++.rb"
brew(main):006:0> URI.decode_www_form_component(url)
=> "/Homebrew/homebrew-core/9fa25e536710603c675fe187c564cbaac45fb7d5/Formula/bonnie  .rb"
```

https://github.com/Homebrew/brew/blob/ac0663ae5d2d4c76bb62363592d77dbad49ac30c/Library/Homebrew/download_strategy.rb#L352

Maybe we just need to escape the original URL better.

```rb
brew(main):010:0> url
=> "/Homebrew/homebrew-core/9fa25e536710603c675fe187c564cbaac45fb7d5/Formula/bonnie++.rb"
brew(main):011:0> URI.decode_www_form_component CGI.escape(url)
=> "/Homebrew/homebrew-core/9fa25e536710603c675fe187c564cbaac45fb7d5/Formula/bonnie++.rb"
```

That works but we don't actually want to escape the whole URL so we instead just escape the path when first creating the `ruby-source` resource.

Then, we must make sure the following works as expected. This is based on [this block of code](https://github.com/Homebrew/brew/blob/62d42c72f51fe08b8fe4aa25a13c59e82c77037e/Library/Homebrew/formula_installer.rb#L1196-L1205) that was failing previously.

```rb
[1] brew(main)> formula = "bonnie++".f
=> #<Formula bonnie++ (stable) /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/bonnie++.rb>
[2] brew(main)> resource = formula.resource("ruby-source"); nil
=> nil
[3] brew(main)> resource.fetch; nil
==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-core/9fa25e536710603c675fe187c564cbaac45fb7d5/Formula%2Fbonnie%2B%2B.rb
######################################################################## 100.0%
=> nil
[4] brew(main)> source_formula = Formulary.factory(
[4] brew(main)*   resource.cached_download,
[4] brew(main)*   formula.active_spec_sym,
[4] brew(main)*   alias_path: formula.alias_path,
[4] brew(main)*   flags: formula.class.build_flags,
[4] brew(main)*   from: :formula_installer
[4] brew(main)* )
=> #<Formula bonnie++ (stable) /Users/kevinrobell/Library/Caches/Homebrew/downloads/1f2743c88d65eadc21f39e76e0e1d493b333e0f150e7caeb3a89cb8be2a4280a--bonnie++.rb>
```