### PR TITLE
cask: remove os_versions

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -114,24 +114,6 @@ module Cask
                           .reverse
     end
 
-    def os_versions
-      # TODO: use #to_hash_with_variations instead once all casks use on_system blocks
-      @os_versions ||= begin
-        version_os_hash = {}
-        actual_version = MacOS.full_version.to_s
-
-        MacOSVersions::SYMBOLS.each do |os_name, os_version|
-          MacOS.full_version = os_version
-          cask = CaskLoader.load(full_name)
-          version_os_hash[os_name] = cask.version if cask.version != version
-        end
-
-        version_os_hash
-      ensure
-        MacOS.full_version = actual_version if actual_version
-      end
-    end
-
     def full_name
       return token if tap.nil?
       return token if tap.user == "Homebrew"
@@ -307,7 +289,6 @@ module Cask
         "url_specs"            => url_specs,
         "appcast"              => appcast,
         "version"              => version,
-        "versions"             => os_versions,
         "installed"            => versions.last,
         "outdated"             => outdated?,
         "sha256"               => sha256,

--- a/Library/Homebrew/test/support/fixtures/cask/caffeine.json
+++ b/Library/Homebrew/test/support/fixtures/cask/caffeine.json
@@ -10,8 +10,6 @@
   "url": "https://www.example.com/cask/caffeine.zip",
   "appcast": null,
   "version": "1.2.3",
-  "versions": {
-  },
   "installed": null,
   "outdated": false,
   "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -16,8 +16,6 @@
   },
   "appcast": null,
   "version": "1.2.3",
-  "versions": {
-  },
   "installed": null,
   "outdated": false,
   "sha256": "c64c05bdc0be845505d6e55e69e696a7f50d40846e76155f0c85d5ff5e7bbb84",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #15227.

## Overview
This was originally used by the API but was replaced months ago by `SimulateSystem`. Essentially, it's only current use was in the `Cask::Cask#to_h` method but is not used internally at all when creating cask instances from the API JSON.

## Details
It was added to brew in https://github.com/Homebrew/brew/pull/11915 and added to the `formulae.brew.sh` website in https://github.com/Homebrew/formulae.brew.sh/pull/539. The use in the `formulae.brew.sh` website was later removed in https://github.com/Homebrew/formulae.brew.sh/commit/b5704d4e26835d07c8aa5bbcb7ed25ac2a08a405 so the only remaining references are in the main brew repo.

The `Cask::Cask#os_versions` method was only called in `Cask::Cask#to_h` to create the `versions` field in the JSON representation. It is not referenced at all in `Cask::CaskLoader` so isn't needed when loading cask instances from the JSON.

An added bonus is that removing this will speed up JSON generation a lot. It was very slow before because it required reloading casks a bunch of times.

### Before
 ![Screen Shot 2023-04-16 at 1 56 55 PM](https://user-images.githubusercontent.com/42982186/232342147-5b69ff5b-b2ea-4574-8889-0c76b333acd2.png)

### After
![Screen Shot 2023-04-16 at 1 54 10 PM](https://user-images.githubusercontent.com/42982186/232342155-51277b0f-34ff-4c78-80aa-69a367d7d8b5.png)

I also updated some test fixtures to remove the `versions` field.


