### PR TITLE
Add bottle file size to GHP manifest annotations

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -356,11 +356,14 @@ class GitHubPackages
 
       documentation = "https://formulae.brew.sh/formula/#{formula_name}" if formula_core_tap
 
+      local_file_size = File.size(local_file)
+
       descriptor_annotations_hash = {
         "org.opencontainers.image.ref.name" => tag,
         "sh.brew.bottle.cpu.variant"        => cpu_variant,
         "sh.brew.bottle.digest"             => tar_gz_sha256,
         "sh.brew.bottle.glibc.version"      => glibc_version,
+        "sh.brew.bottle.size"               => local_file_size,
         "sh.brew.tab"                       => tab.to_json,
       }.reject { |_, v| v.blank? }
 


### PR DESCRIPTION
This will reduce the number of requests necessary to ascertain the size of formulas' bottle archives for analysis purposes.

Currently, getting the size of each bottle requires 1 request for the formula.json and followed by N requests per formula-version, which for most formulae is 7— more than 47k requests!

After this change, size retrieval can ascertain all bottle sizes for a formula-version in a single request, at the cost of one additional request per formula-version if that formula-version has not been rebuilt since this change was introduced.

To start, size retrieval will incur an additional request per package. Over the next few weeks and months, the retrieval will go a lot faster as all new and updated packages will require only one request.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
