### PR TITLE
fix: fix undefined 'git_origin_branch' methods

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -123,7 +123,7 @@ module Homebrew
 
     tap_remote_repo = formula.tap.full_name || formula.tap.remote_repo
     remote = "origin"
-    remote_branch = formula.tap.path.git_origin_branch
+    remote_branch = formula.tap.git_repo.origin_branch_name
     previous_branch = "-"
 
     check_open_pull_requests(formula, tap_remote_repo, args: args)

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -576,7 +576,7 @@ module GitHub
     old_contents = info[:old_contents]
     additional_files = info[:additional_files] || []
     remote = info[:remote] || "origin"
-    remote_branch = info[:remote_branch] || tap.path.git_origin_branch
+    remote_branch = info[:remote_branch] || tap.git_repo.origin_branch_name
     branch = info[:branch_name]
     commit_message = info[:commit_message]
     previous_branch = info[:previous_branch] || "-"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

Introduced in #15032. create_bump_pr fails as `git_origin` was renamed to `origin_url`
```
/opt/homebrew/Library/Homebrew/utils/github.rb:579:in `create_bump_pr'
/opt/homebrew/Library/Homebrew/dev-cmd/bump-cask-pr.rb:215:in `bump_cask_pr'
/opt/homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```
-----

Fixes #15245.
