### PR TITLE
github_packages: fix bottle manifest schema violation

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -363,7 +363,7 @@ class GitHubPackages
         "sh.brew.bottle.cpu.variant"        => cpu_variant,
         "sh.brew.bottle.digest"             => tar_gz_sha256,
         "sh.brew.bottle.glibc.version"      => glibc_version,
-        "sh.brew.bottle.size"               => local_file_size,
+        "sh.brew.bottle.size"               => local_file_size.to_s,
         "sh.brew.tab"                       => tab.to_json,
       }.reject { |_, v| v.blank? }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

According to [^1] [^2], image manifest annotations need to be a string-string map.

This should fix the errors seen in Homebrew/homebrew-core#128517, Homebrew/homebrew-core#128558, et al.

[^1]: https://github.com/opencontainers/image-spec/blob/2879913ce4bc229704bf0d67b280929007b06b94/schema/image-manifest-schema.json#L35
[^2]: https://github.com/opencontainers/image-spec/blob/2879913ce4bc229704bf0d67b280929007b06b94/schema/defs-descriptor.json#L22