### PR TITLE
Enable cask cmd types

### DIFF
--- a/Library/Homebrew/cask/cmd/abstract_command.rb
+++ b/Library/Homebrew/cask/cmd/abstract_command.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "search"
@@ -40,12 +40,12 @@ module Cask
 
       sig { returns(String) }
       def self.command_name
-        @command_name ||= name.sub(/^.*:/, "").gsub(/(.)([A-Z])/, '\1_\2').downcase
+        @command_name ||= T.must(name).sub(/^.*:/, "").gsub(/(.)([A-Z])/, '\1_\2').downcase
       end
 
       sig { returns(T::Boolean) }
       def self.abstract?
-        name.split("::").last.match?(/^Abstract[^a-z]/)
+        T.must(name).split("::").fetch(-1).match?(/^Abstract[^a-z]/)
       end
 
       sig { returns(T::Boolean) }
@@ -56,11 +56,6 @@ module Cask
       sig { returns(String) }
       def self.help
         parser.generate_help_text
-      end
-
-      sig { returns(String) }
-      def self.short_description
-        description[/\A[^.]*\./]
       end
 
       def self.run(*args)

--- a/Library/Homebrew/cask/cmd/audit.rb
+++ b/Library/Homebrew/cask/cmd/audit.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "utils/github/actions"
@@ -13,6 +13,7 @@ module Cask
 
       def self.parser
         super do
+          T.bind(self, Homebrew::CLI::Parser)
           switch "--[no-]download",
                  description: "Audit the downloaded file"
           switch "--[no-]appcast",
@@ -43,7 +44,7 @@ module Cask
         end
         casks = casks.map { |c| CaskLoader.load(c, config: Config.from_args(args)) }
         any_named_args = casks.any?
-        casks = Cask.to_a if casks.empty?
+        casks = Cask.all if casks.empty?
 
         results = self.class.audit_casks(
           *casks,

--- a/Library/Homebrew/cask/cmd/install.rb
+++ b/Library/Homebrew/cask/cmd/install.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "cask_dependent"
@@ -27,6 +27,7 @@ module Cask
 
       def self.parser(&block)
         super do
+          T.bind(self, Homebrew::CLI::Parser)
           switch "--force",
                  description: "Force overwriting existing files."
 

--- a/Library/Homebrew/test/cask/cmd/audit_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/audit_spec.rb
@@ -10,7 +10,7 @@ describe Cask::Cmd::Audit, :cask do
 
   describe "selection of Casks to audit" do
     it "audits all Casks if no tokens are given" do
-      allow(Cask::Cask).to receive(:to_a).and_return([cask, cask])
+      allow(Cask::Cask).to receive(:all).and_return([cask, cask])
 
       expect(Cask::Auditor).to receive(:audit).twice.and_return(result)
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Note that these files are scheduled to be removed per https://github.com/Homebrew/brew/issues/14799 but these are the remaining non-test files with `typed: false`. (We can enable a cop to enforce this, but I will open that for consideration in a separate PR, if this one is approved)
