### PR TITLE
Remove yaml require for 5% init speedup

### DIFF
--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -3,7 +3,6 @@
 
 require "utils/user"
 require "open3"
-require "stringio"
 
 BUG_REPORTS_URL = "https://github.com/Homebrew/homebrew-cask#reporting-bugs"
 

--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "utils/user"
-require "yaml"
 require "open3"
 require "stringio"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I noticed in profiling `brew prof --stackprof -- help` that a significant amount (> 8%) of the time was spent in `require "yaml"`:

<img width="1127" alt="Screenshot 2023-04-17 at 15 07 54" src="https://user-images.githubusercontent.com/697964/232622059-165e4805-e7f0-4e60-a62f-4bed1873a789.png">

I removed the require statement, though the realized gain was closer to 5.5%. Before:
```
$ hyperfine "brew help"
Benchmark 1: brew help
  Time (mean ± σ):      1.057 s ±  0.090 s    [User: 0.216 s, System: 0.145 s]
  Range (min … max):    1.003 s …  1.306 s    10 runs
```
After:
```
$ hyperfine "brew help"
Benchmark 1: brew help
  Time (mean ± σ):     998.5 ms ±  25.1 ms    [User: 202.6 ms, System: 132.8 ms]
  Range (min … max):   967.1 ms … 1043.2 ms    10 runs
```

Note that I can't test for the absence of `YAML` in global_spec (like we do for `I18n` and `ActiveSupport::Inflector`) bc the test infra itself includes `YAML`.

Also, I couldn't actually find reference to `yaml` in the affected file (even using case-insensive search to include the `to_yaml` 🐒 -patch). In case someone else would like to verify, these are the files that reference `yaml` in some capacity (excluding sorbet/test/vendor), but none of them seem to depend on the require statement that is removed in this PR:

```
Library/Homebrew/cask/dsl/container.rb
Library/Homebrew/dev-cmd/tap-new.rb
Library/Homebrew/livecheck/livecheck.rb
Library/Homebrew/livecheck/strategy.rb
Library/Homebrew/livecheck/strategy/electron_builder.rb
Library/Homebrew/livecheck/strategy/yaml.rb
Library/Homebrew/startup/bootsnap.rb
``` 