### PR TITLE
Cask audit: check binary signature and notarisation

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -460,7 +460,9 @@ module Cask
       return if !signing? || download.blank? || cask.url.blank?
 
       odebug "Auditing signing"
-      artifacts = cask.artifacts.select { |k| k.is_a?(Artifact::Pkg) || k.is_a?(Artifact::App) }
+      artifacts = cask.artifacts.select do |k|
+        k.is_a?(Artifact::Pkg) || k.is_a?(Artifact::App) || k.is_a?(Artifact::Binary)
+      end
 
       return if artifacts.empty?
 

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -483,7 +483,7 @@ describe Cask::Audit, :cask do
             cask 'signing-cask-test' do
               version '1.0'
               url "https://brew.sh/index.html"
-              binary 'Audit.app'
+              artifact "example.pdf", target: "/Library/Application Support/example"
             end
           RUBY
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Followup to https://github.com/Homebrew/brew/pull/15219. Expanding the signing and notarisation requirement to binaries seems like a natural progression. I haven’t checked how many casks this affects, but casks with raw binaries are a minority compared to ones with apps.