### PR TITLE
Enable Style/InvertibleUnlessCondition cop

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -373,6 +373,17 @@ Style/HashAsLastArrayItem:
     - "/**/Formula/**/*.rb"
     - "**/Formula/**/*.rb"
 
+Style/InvertibleUnlessCondition:
+  inherit_mode:
+    override:
+      - InverseMethods
+  Enabled: true
+  InverseMethods:
+    # Favor `if a != b` over `unless a == b`
+    :==: :!=
+    # Unset this (prefer `unless a.zero?` over `if a.nonzero?`)
+    :zero?:
+
 # would rather freeze too much than too little
 Style/MutableConstant:
   EnforcedStyle: strict

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -374,9 +374,6 @@ Style/HashAsLastArrayItem:
     - "**/Formula/**/*.rb"
 
 Style/InvertibleUnlessCondition:
-  inherit_mode:
-    override:
-      - InverseMethods
   Enabled: true
   InverseMethods:
     # Favor `if a != b` over `unless a == b`

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -249,12 +249,12 @@ module Cask
       # :signal should come after :quit so it can be used as a backup when :quit fails
       def uninstall_signal(*signals, command: nil, **_)
         signals.each do |pair|
-          raise CaskInvalidError.new(cask, "Each #{stanza} :signal must consist of 2 elements.") unless pair.size == 2
+          raise CaskInvalidError.new(cask, "Each #{stanza} :signal must consist of 2 elements.") if pair.size != 2
 
           signal, bundle_id = pair
           ohai "Signalling '#{signal}' to application ID '#{bundle_id}'"
           pids = running_processes(bundle_id).map(&:first)
-          next unless pids.any?
+          next if pids.none?
 
           # Note that unlike :quit, signals are sent from the current user (not
           # upgraded to the superuser). This is a todo item for the future, but

--- a/Library/Homebrew/cask/artifact/installer.rb
+++ b/Library/Homebrew/cask/artifact/installer.rb
@@ -57,7 +57,7 @@ module Cask
           args = { script: args }
         end
 
-        unless args.keys.count == 1
+        if args.keys.count != 1
           raise CaskInvalidError.new(
             cask,
             "invalid 'installer' stanza: Only one of #{VALID_KEYS.inspect} is permitted.",

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -143,7 +143,7 @@ module Cask
         k.is_a?(Artifact::PostflightBlock) &&
           k.directives.key?(:postflight)
       end
-      return unless count > 1
+      return if count <= 1
 
       add_error "only a single postflight stanza is allowed"
     end
@@ -166,7 +166,7 @@ module Cask
 
       add_error "only a single uninstall_postflight stanza is allowed" if count > 1
 
-      return unless cask.artifacts.count { |k| k.is_a?(Artifact::Zap) } > 1
+      return if cask.artifacts.count { |k| k.is_a?(Artifact::Zap) } <= 1
 
       add_error "only a single zap stanza is allowed"
     end
@@ -210,7 +210,7 @@ module Cask
       return unless cask.version
 
       odebug "Auditing version :latest does not appear as a string ('latest')"
-      return unless cask.version.raw_version == "latest"
+      return if cask.version.raw_version != "latest"
 
       add_error "you should use version :latest instead of version 'latest'"
     end
@@ -251,7 +251,7 @@ module Cask
 
       odebug "Auditing sha256 is not a known invalid value"
       empty_sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-      return unless cask.sha256 == empty_sha256
+      return if cask.sha256 != empty_sha256
 
       add_error "cannot use the sha256 for an empty string: #{empty_sha256}"
     end
@@ -442,7 +442,7 @@ module Cask
 
     sig { void }
     def audit_livecheck_unneeded_long_version
-      return unless cask.livecheck.strategy == :sparkle
+      return if cask.livecheck.strategy != :sparkle
       return unless cask.version.csv.second
       return if cask.url.to_s.include? cask.version.csv.second
       return if cask.version.csv.third.present? && cask.url.to_s.include?(cask.version.csv.third)
@@ -526,7 +526,7 @@ module Cask
     def audit_livecheck_min_os
       return unless online?
       return unless cask.livecheckable?
-      return unless cask.livecheck.strategy == :sparkle
+      return if cask.livecheck.strategy != :sparkle
 
       out, _, status = curl_output("--fail", "--silent", "--location", cask.livecheck.url)
       return unless status.success?

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -275,7 +275,7 @@ module Cask
                 next [:arch, :arm64]
               end
 
-              next [dep_key, dep_value] unless dep_key == :macos
+              next [dep_key, dep_value] if dep_key != :macos
 
               dep_type = dep_value.keys.first
               if dep_type == :==
@@ -294,7 +294,7 @@ module Cask
 
           if json_cask[:container].present?
             container_hash = json_cask[:container].to_h do |container_key, container_value|
-              next [container_key, container_value] unless container_key == :type
+              next [container_key, container_value] if container_key != :type
 
               [container_key, container_value.to_sym]
             end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -177,7 +177,7 @@ on_request: true)
 
     def verify_has_sha
       odebug "Checking cask has checksum"
-      return unless @cask.sha256 == :no_check
+      return if @cask.sha256 != :no_check
 
       raise CaskError, <<~EOS
         Cask '#{@cask}' does not have a sha256 checksum defined and was not installed.

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -485,7 +485,7 @@ module Homebrew
           # Clean up old *.pyc files in the top-level __pycache__.
           if child.basename.to_s == "__pycache__"
             child.find do |path|
-              next unless path.extname == ".pyc"
+              next if path.extname != ".pyc"
               next unless self.class.prune?(path, days)
 
               unused_pyc_files << path

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -107,7 +107,7 @@ module Homebrew
               raise
             end
 
-            warn_if_cask_conflicts(name, "formula") unless only == :formula
+            warn_if_cask_conflicts(name, "formula") if only != :formula
             return formula
           rescue FormulaUnreadableError, FormulaClassUnavailableError,
                  TapFormulaUnreadableError, TapFormulaClassUnavailableError => e

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -209,8 +209,8 @@ class PrettyListing
       elsif block_given? && yield(pn)
         puts pn
         other = "other "
-      else
-        remaining_root_files << pn unless pn.basename.to_s == ".DS_Store"
+      elsif pn.basename.to_s != ".DS_Store"
+        remaining_root_files << pn
       end
     end
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -377,7 +377,7 @@ class Reporter
       src = Pathname.new paths.first
       dst = Pathname.new paths.last
 
-      next unless dst.extname == ".rb"
+      next if dst.extname != ".rb"
 
       if paths.any? { |p| tap.cask_file?(p) }
         case status
@@ -505,7 +505,7 @@ class Reporter
       next unless (dir = HOMEBREW_CELLAR/name).exist? # skip if formula is not installed.
 
       tabs = dir.subdirs.map { |d| Tab.for_keg(Keg.new(d)) }
-      next unless tabs.first.tap == tap # skip if installed formula is not from this tap.
+      next if tabs.first.tap != tap # skip if installed formula is not from this tap.
 
       new_tap = Tap.fetch(new_tap_name)
       # For formulae migrated to cask: Auto-install cask or provide install instructions.

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -306,7 +306,7 @@ module Homebrew
 
     commits = GitHub.pull_request_commits(user, repo, pull_request)
     safe_system "git", "-C", path, "fetch", "--quiet", "--force", "origin", commits.last
-    ohai "Using #{commits.count} commit#{"s" unless commits.count == 1} from ##{pull_request}"
+    ohai "Using #{commits.count} commit#{"s" if commits.count != 1} from ##{pull_request}"
     Utils::Git.cherry_pick!(path, "--ff", "--allow-empty", *commits, verbose: args.verbose?, resolve: args.resolve?)
   end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -500,7 +500,7 @@ module Homebrew
         return unless Utils::Git.available?
 
         autocrlf = HOMEBREW_REPOSITORY.cd { `git config --get core.autocrlf`.chomp }
-        return unless autocrlf == "true"
+        return if autocrlf != "true"
 
         <<~EOS
           Suspicious Git newline settings found.
@@ -786,7 +786,7 @@ module Homebrew
             next unless dir.exist?
 
             dir.children.each do |path|
-              next unless path.extname == ".rb"
+              next if path.extname != ".rb"
 
               bad_tap_files[tap] ||= []
               bad_tap_files[tap] << path

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -37,7 +37,7 @@ module Stdenv
 
     self["MAKEFLAGS"] = "-j#{make_jobs}"
 
-    unless HOMEBREW_PREFIX.to_s == "/usr/local"
+    if HOMEBREW_PREFIX.to_s != "/usr/local"
       # /usr/local is already an -isystem and -L directory so we skip it
       self["CPPFLAGS"] = "-isystem#{HOMEBREW_PREFIX}/include"
       self["LDFLAGS"] = "-L#{HOMEBREW_PREFIX}/lib"

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -14,7 +14,7 @@ module SharedEnvExtension
 
   sig { returns(T::Boolean) }
   def no_weak_imports_support?
-    return false unless compiler == :clang
+    return false if compiler != :clang
 
     return false if !MacOS::Xcode.version.null? && MacOS::Xcode.version < "8.0"
     return false if !MacOS::CLT.version.null? && MacOS::CLT.version < "8.0"

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -51,7 +51,7 @@ class Keg
                   !bad_name.start_with?(HOMEBREW_TEMP.realpath.to_s)
 
           new_name = fixed_name(file, bad_name)
-          change_install_name(bad_name, new_name, file) unless new_name == bad_name
+          change_install_name(bad_name, new_name, file) if new_name != bad_name
         end
 
         each_linkage_for(file, :rpaths) do |bad_name|

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -285,7 +285,7 @@ class Pathname
     raise ChecksumMissingError if expected.blank?
 
     actual = Checksum.new(sha256.downcase)
-    raise ChecksumMismatchError.new(self, expected, actual) unless expected == actual
+    raise ChecksumMismatchError.new(self, expected, actual) if expected != actual
   end
 
   alias to_str to_s

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1216,7 +1216,7 @@ class Formula
   # @private
   def link_overwrite?(path)
     # Don't overwrite files not created by Homebrew.
-    return false unless path.stat.uid == HOMEBREW_BREW_FILE.stat.uid
+    return false if path.stat.uid != HOMEBREW_BREW_FILE.stat.uid
 
     # Don't overwrite files belong to other keg except when that
     # keg's formula is deleted.
@@ -1352,7 +1352,7 @@ class Formula
     @lock.lock
     return unless oldname
     return unless (oldname_rack = HOMEBREW_CELLAR/oldname).exist?
-    return unless oldname_rack.resolved_path == rack
+    return if oldname_rack.resolved_path != rack
 
     @oldname_lock = FormulaLock.new(oldname)
     @oldname_lock.lock
@@ -2501,7 +2501,7 @@ class Formula
             while (buf = rd.gets)
               log.puts buf
               # make sure dots printed with interval of at least 1 min.
-              next unless (Time.now - last_dot) > 60
+              next if (Time.now - last_dot) <= 60
 
               print "."
               $stdout.flush

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -430,7 +430,7 @@ module Homebrew
     end
 
     def audit_postgresql
-      return unless formula.name == "postgresql"
+      return if formula.name != "postgresql"
       return unless @core_tap
 
       major_version = formula.version.major.to_i

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -332,7 +332,7 @@ module FormulaCellarChecks
     mismatches = {}
     keg.binary_executable_or_library_files.each do |file|
       farch = file.arch
-      mismatches[file] = farch unless farch == Hardware::CPU.arch
+      mismatches[file] = farch if farch != Hardware::CPU.arch
     end
     return if mismatches.empty?
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -356,7 +356,7 @@ class FormulaInstaller
     return if @compute_dependencies.blank?
 
     compute_dependencies(use_cache: false) if @compute_dependencies.any? do |dep, options|
-      next false unless dep.tags == [:build, :test]
+      next false if dep.tags != [:build, :test]
 
       fetch_dependencies
       install_dependency(dep, options)

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -131,7 +131,7 @@ class GitHubRunnerMatrix
       )
       @runners << create_runner(:macos, :x86_64, spec, macos_version)
 
-      next unless macos_version >= :big_sur
+      next if macos_version < :big_sur
 
       # Use bare metal runner when testing dependents on ARM64 Monterey.
       use_ephemeral = macos_version >= (@dependent_matrix ? :ventura : :monterey)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -606,13 +606,13 @@ module Homebrew
       when Formula
         [:stable, :head].each do |spec_name|
           next unless (spec = formula_or_cask.send(spec_name))
-          next unless spec.using == :homebrew_curl
+          next if spec.using != :homebrew_curl
 
           domain = Addressable::URI.parse(spec.url)&.domain
           homebrew_curl_root_domains << domain if domain.present?
         end
       when Cask::Cask
-        return false unless formula_or_cask.url.using == :homebrew_curl
+        return false if formula_or_cask.url.using != :homebrew_curl
 
         domain = Addressable::URI.parse(formula_or_cask.url.to_s)&.domain
         homebrew_curl_root_domains << domain if domain.present?

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -48,7 +48,7 @@ module ELFShim
 
   def elf?
     return @elf if defined? @elf
-    return @elf = false unless read(MAGIC_NUMBER_ASCII.size, MAGIC_NUMBER_OFFSET) == MAGIC_NUMBER_ASCII
+    return @elf = false if read(MAGIC_NUMBER_ASCII.size, MAGIC_NUMBER_OFFSET) != MAGIC_NUMBER_ASCII
 
     # Check that this ELF file is for Linux or System V.
     # OS_ABI is often set to 0 (System V), regardless of the target platform.

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -78,14 +78,14 @@ module Homebrew
         end
       end
 
-      return unless url_strategy == DownloadStrategyDetector.detect("", using)
+      return if url_strategy != DownloadStrategyDetector.detect("", using)
 
       problem "Redundant :using value in URL"
     end
 
     def audit_checksum
       return if spec_name == :head
-      return unless DownloadStrategyDetector.detect(url, using) <= CurlDownloadStrategy
+      return if DownloadStrategyDetector.detect(url, using) > CurlDownloadStrategy
 
       problem "Checksum is missing" if checksum.blank?
     end

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -85,7 +85,9 @@ module Homebrew
 
     def audit_checksum
       return if spec_name == :head
-      return if DownloadStrategyDetector.detect(url, using) > CurlDownloadStrategy
+      # rubocop:disable Style/InvertibleUnlessCondition (non-invertible)
+      return unless DownloadStrategyDetector.detect(url, using) <= CurlDownloadStrategy
+      # rubocop:enable Style/InvertibleUnlessCondition
 
       problem "Checksum is missing" if checksum.blank?
     end

--- a/Library/Homebrew/rubocops/cask/no_overrides.rb
+++ b/Library/Homebrew/rubocops/cask/no_overrides.rb
@@ -23,7 +23,7 @@ module RuboCop
           cask_stanzas = cask_block.toplevel_stanzas
 
           # Skip if there are no `on_*` blocks.
-          return unless (on_blocks = cask_stanzas.select { |s| ON_SYSTEM_METHODS.include?(s.stanza_name) }).any?
+          return if (on_blocks = cask_stanzas.select { |s| ON_SYSTEM_METHODS.include?(s.stanza_name) }).none?
 
           stanzas_in_blocks = on_system_stanzas(on_blocks)
 

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -25,7 +25,7 @@ module RuboCop
           add_offenses(cask_stanzas)
 
           # If present, check grouping of stanzas within `on_*` blocks.
-          return unless (on_blocks = cask_stanzas.select { |s| ON_SYSTEM_METHODS.include?(s.stanza_name) }).any?
+          return if (on_blocks = cask_stanzas.select { |s| ON_SYSTEM_METHODS.include?(s.stanza_name) }).none?
 
           on_blocks.map(&:method_node).each do |on_block|
             next unless on_block.block_type?

--- a/Library/Homebrew/rubocops/cask/stanza_order.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_order.rb
@@ -43,7 +43,7 @@ module RuboCop
           stanza_pairs = toplevel_stanzas.zip(sorted_toplevel_stanzas)
           stanza_pairs.each_with_object([]) do |stanza_pair, offending_stanzas|
             stanza, sorted_stanza = *stanza_pair
-            offending_stanzas << stanza unless stanza == sorted_stanza
+            offending_stanzas << stanza if stanza != sorted_stanza
           end
         end
       end

--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -29,7 +29,7 @@ module RuboCop
           return unless hash_node.hash_type?
 
           hash_node.each_pair do |key_node, value_node|
-            next unless key_node.source == "verified"
+            next if key_node.source != "verified"
             next unless value_node.str_type?
 
             if value_node.source.start_with?(%r{^"https?://})

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -38,7 +38,7 @@ module RuboCop
         def audit_formula(_node, class_node, parent_class_node, _body_node)
           begin_pos = start_column(parent_class_node)
           end_pos = end_column(class_node)
-          return unless begin_pos-end_pos != 3
+          return if begin_pos-end_pos == 3
 
           problem "Use a space in class inheritance: " \
                   "class #{@formula_name.capitalize} < #{class_name(parent_class_node)}"
@@ -208,7 +208,7 @@ module RuboCop
           return if body_node.nil?
 
           # Enforce use of OpenMPI for MPI dependency in core
-          return unless formula_tap == "homebrew-core"
+          return if formula_tap != "homebrew-core"
 
           find_method_with_args(body_node, :depends_on, "mpich") do
             problem "Formulae in homebrew/core should use 'depends_on \"open-mpi\"' " \
@@ -228,7 +228,7 @@ module RuboCop
           return if body_node.nil?
 
           # Disallow use of PyOxidizer as a dependency in core
-          return unless formula_tap == "homebrew-core"
+          return if formula_tap != "homebrew-core"
 
           find_method_with_args(body_node, :depends_on, "pyoxidizer") do
             problem "Formulae in homebrew/core should not use '#{@offensive_node.source}'."
@@ -466,7 +466,7 @@ module RuboCop
             replacement_args = %w[]
             replacement_args << executable.source
             replacement_args << subcmd.source
-            replacement_args << "base_name: \"#{base_name}\"" unless base_name == @formula_name
+            replacement_args << "base_name: \"#{base_name}\"" if base_name != @formula_name
             replacement_args << "shells: [:#{shell}]"
             unless shell_parameter_format.nil?
               replacement_args << "shell_parameter_format: #{shell_parameter_format.inspect}"
@@ -546,7 +546,7 @@ module RuboCop
             # the rest are kwargs we need to filter out
             method_commands = node.arguments.filter { |arg| arg.send_type? || arg.str_type? }
             next_method_commands = offenses[i + 1].arguments.filter { |arg| arg.send_type? || arg.str_type? }
-            unless method_commands == next_method_commands
+            if method_commands != next_method_commands
               shells.delete_at(i)
               next
             end
@@ -594,7 +594,7 @@ module RuboCop
           # Check for long inreplace block vars
           find_all_blocks(body_node, :inreplace) do |node|
             block_arg = node.arguments.children.first
-            next unless block_arg.source.size > 1
+            next if block_arg.source.size <= 1
 
             problem "\"inreplace <filenames> do |s|\" is preferred over \"|#{block_arg.source}|\"."
           end
@@ -792,7 +792,7 @@ module RuboCop
           end
 
           find_instance_method_call(body_node, "Dir", :[]) do |method|
-            next unless parameters(method).size == 1
+            next if parameters(method).size != 1
 
             path = parameters(method).first
             next unless path.str_type?

--- a/Library/Homebrew/rubocops/shared/helper_functions.rb
+++ b/Library/Homebrew/rubocops/shared/helper_functions.rb
@@ -109,7 +109,7 @@ module RuboCop
         return if node.nil?
 
         node.each_child_node(:send) do |method_node|
-          next unless method_node.method_name == method_name
+          next if method_node.method_name != method_name
 
           @offensive_node = method_node
           return method_node
@@ -217,7 +217,7 @@ module RuboCop
         return if node.nil?
 
         node.each_descendant(:const) do |const_node|
-          next unless const_node.const_name == const_name
+          next if const_node.const_name != const_name
 
           @offensive_node = const_node
           yield const_node if block_given?
@@ -290,7 +290,7 @@ module RuboCop
       def block_method_called_in_block?(node, method_name)
         node.body.each_child_node do |call_node|
           next if !call_node.block_type? && !call_node.send_type?
-          next unless call_node.method_name == method_name
+          next if call_node.method_name != method_name
 
           @offensive_node = call_node
           return true
@@ -306,7 +306,7 @@ module RuboCop
           return true
         end
         node.each_child_node(:send) do |call_node|
-          next unless call_node.method_name == method_name
+          next if call_node.method_name != method_name
 
           offending_node(call_node)
           return true
@@ -317,7 +317,7 @@ module RuboCop
       # Check if method_name is called among every descendant node of given node.
       def method_called_ever?(node, method_name)
         node.each_descendant(:send) do |call_node|
-          next unless call_node.method_name == method_name
+          next if call_node.method_name != method_name
 
           @offensive_node = call_node
           return true

--- a/Library/Homebrew/rubocops/shell_commands.rb
+++ b/Library/Homebrew/rubocops/shell_commands.rb
@@ -66,7 +66,7 @@ module RuboCop
 
         def on_send(node)
           TARGET_METHODS.each do |target_class, target_method|
-            next unless node.method_name == target_method
+            next if node.method_name != target_method
 
             target_receivers = if target_class.nil?
               [nil, s(:const, nil, :Kernel), s(:const, nil, :Homebrew)]

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -128,7 +128,7 @@ module RuboCop
             problem "Use `\#{pkgshare}` instead of `\#{share}/#{@formula_name}`"
           end
 
-          return unless formula_tap == "homebrew-core"
+          return if formula_tap != "homebrew-core"
 
           find_method_with_args(body_node, :env, :std) do
             problem "`env :std` in homebrew/core formulae is deprecated"

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -295,7 +295,7 @@ module RuboCop
       class GitUrls < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           return if body_node.nil?
-          return unless formula_tap == "homebrew-core"
+          return if formula_tap != "homebrew-core"
 
           find_method_calls_by_name(body_node, :url).each do |url|
             next unless string_content(parameters(url).first).match?(/\.git$/)
@@ -319,7 +319,7 @@ module RuboCop
       class GitUrls < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           return if body_node.nil?
-          return unless formula_tap == "homebrew-core"
+          return if formula_tap != "homebrew-core"
 
           find_method_calls_by_name(body_node, :url).each do |url|
             next unless string_content(parameters(url).first).match?(/\.git$/)

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -158,7 +158,7 @@ class SoftwareSpec
         raise ArgumentError, "option name must be string or symbol; got a #{name.class}: #{name}"
       end
       raise ArgumentError, "option name is required" if name.empty?
-      raise ArgumentError, "option name must be longer than one character: #{name}" unless name.length > 1
+      raise ArgumentError, "option name must be longer than one character: #{name}" if name.length <= 1
       raise ArgumentError, "option name must not start with dashes: #{name}" if name.start_with?("-")
 
       Option.new(name, description)

--- a/Library/Homebrew/sorbet/custom_generators/env_config.rb
+++ b/Library/Homebrew/sorbet/custom_generators/env_config.rb
@@ -35,7 +35,7 @@ File.open("#{__dir__}/../../env_config.rbi", "w") do |file|
   def self.#{method}; end
     RUBY
 
-    file.write("\n") unless method == methods.last
+    file.write("\n") if method != methods.last
   end
 
   file.puts "end"

--- a/Library/Homebrew/sorbet/custom_generators/tty.rb
+++ b/Library/Homebrew/sorbet/custom_generators/tty.rb
@@ -24,7 +24,7 @@ File.open("#{File.dirname(__FILE__)}/../../utils/tty.rbi", "w") do |file|
   def self.#{method}; end
     RUBY
 
-    file.write("\n") unless methods.last == method
+    file.write("\n") if methods.last != method
   end
 
   file.write("end\n")

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -279,7 +279,7 @@ class Tab
   def runtime_dependencies
     # Homebrew versions prior to 1.1.6 generated incorrect runtime dependency
     # lists.
-    @runtime_dependencies unless parsed_homebrew_version < "1.1.6"
+    @runtime_dependencies if parsed_homebrew_version >= "1.1.6"
   end
 
   def cxxstdlib

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -48,7 +48,7 @@ describe "Bash" do
         next if path.symlink?
         next unless path.executable?
         next if path.basename.to_s == "cc" # `bash -n` tries to parse the Ruby part
-        next unless path.read(12) == "#!/bin/bash\n"
+        next if path.read(12) != "#!/bin/bash\n"
 
         expect(path).to have_valid_bash_syntax
       end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
@@ -9,6 +9,6 @@ cask "with-conditional-caveats" do
 
   # a do block may print and use a DSL
   caveats do
-    puts "This caveat is conditional" unless String("Caffeine") == "Caffeine"
+    puts "This caveat is conditional" if String("Caffeine") != "Caffeine"
   end
 end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -471,7 +471,7 @@ options: options)
                "#{formatted_count} | #{formatted_percent}%"
           next if index > 10
         end
-        return unless results.length > 1
+        return if results.length <= 1
 
         formatted_total_footer =
           format "%-#{index_width}s", total_index_footer

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -93,7 +93,7 @@ module Utils
 
       args << "--header" << "Accept-Language: en"
 
-      unless show_output == true
+      if show_output != true
         args << "--fail"
         args << "--progress-bar" unless Context.current.verbose?
         args << "--verbose" if Homebrew::EnvConfig.curl_verbose?
@@ -400,7 +400,7 @@ module Utils
         next [] if argument == false # No flag.
 
         args = ["--#{option.to_s.tr("_", "-")}"]
-        args << argument unless argument == true # It's a flag.
+        args << argument if argument != true # It's a flag.
         args
       end
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -192,7 +192,7 @@ module GitHub
       # rubocop:enable Style/FormatStringToken
 
       token = credentials
-      args += ["--header", "Authorization: token #{token}"] unless credentials_type == :none
+      args += ["--header", "Authorization: token #{token}"] if credentials_type != :none
       args += ["--header", "X-GitHub-Api-Version:2022-11-28"]
 
       data_tmpfile = nil

--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -54,10 +54,10 @@ module Utils
         begin
           exec(*args, options)
         rescue Errno::ENOENT
-          $stderr.puts "brew: command not found: #{args[0]}" unless options[:err] == :close
+          $stderr.puts "brew: command not found: #{args[0]}" if options[:err] != :close
           exit! 127
         rescue SystemCallError
-          $stderr.puts "brew: exec failed: #{args[0]}" unless options[:err] == :close
+          $stderr.puts "brew: exec failed: #{args[0]}" if options[:err] != :close
           exit! 1
         end
       end

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -201,7 +201,7 @@ module SPDX
 
     forbidden_licenses.each do |_, license_info|
       forbidden_name, forbidden_version, forbidden_or_later = *license_info
-      next unless forbidden_name == name
+      next if forbidden_name != name
 
       return true if forbidden_or_later && forbidden_version <= version
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is a new cop [introduced](https://github.com/rubocop/rubocop/pull/11432) in rubocop v1.44.0. It's disabled by default but i think it's enough of a readability improvement to enable. (I also added a rule to favor `if a != b` over `unless a == b`.)

It is [invalid](https://github.com/rubocop/rubocop/issues/11800) in at least one case – when comparing class hierarchies that do not share inheritance (see the disable below).

cc @issyl0 