### PR TITLE
Fix bump-cask-pr handling of sha256 :no_check

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -136,7 +136,7 @@ module Homebrew
         opoo "Ignoring specified `--sha256=` argument." if new_hash.is_a?(String)
         replacement_pairs << [/"#{old_hash}"/, ":no_check"] if old_hash != :no_check
       elsif old_hash == :no_check && new_hash != :no_check
-        replacement_pairs << [":no_check", "\"#{new_hash}\""]
+        replacement_pairs << [":no_check", "\"#{new_hash}\""] if new_hash.is_a?(String)
       elsif old_hash != :no_check
         if new_hash.nil? || cask.languages.present?
           if new_hash && cask.languages.present?

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -135,6 +135,8 @@ module Homebrew
       if new_version.latest? || new_hash == :no_check
         opoo "Ignoring specified `--sha256=` argument." if new_hash.is_a?(String)
         replacement_pairs << [/"#{old_hash}"/, ":no_check"] if old_hash != :no_check
+      elsif old_hash == :no_check && new_hash != :no_check
+        replacement_pairs << [":no_check", "\"#{new_hash}\""]
       elsif old_hash != :no_check
         if new_hash.nil? || cask.languages.present?
           if new_hash && cask.languages.present?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, if a cask has `sha256` set to `:no_check` attempting to run `brew bump-cask-pr --sha256 [new_sha]` will be unsuccessful as `bump-cask-pr` will try to replace `no_check` rather than `:no_check`. 

This PR adds an additional case to `bump_cask_pr` that handles the situation where `sha256 :no_check` is replaced by an actual checksum. Fixes https://github.com/Homebrew/homebrew-cask/issues/145362.