### PR TITLE
completions/fish: fix cask references for Linux

### DIFF
--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -130,11 +130,11 @@ function __fish_brew_suggest_casks_all -d "Lists locally available casks"
 end
 
 function __fish_brew_suggest_casks_installed -d "Lists installed casks"
-    command ls -1 (brew --caskroom)
+    command ls -1 (brew --caskroom) 2>/dev/null
 end
 
 function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the information about potential upgrade"
-    brew outdated --cask --verbose \
+    brew outdated --cask --verbose 2>/dev/null \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -117,11 +117,11 @@ function __fish_brew_suggest_casks_all -d "Lists locally available casks"
 end
 
 function __fish_brew_suggest_casks_installed -d "Lists installed casks"
-    command ls -1 (brew --caskroom)
+    command ls -1 (brew --caskroom) 2>/dev/null
 end
 
 function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the information about potential upgrade"
-    brew outdated --cask --verbose \
+    brew outdated --cask --verbose 2>/dev/null \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Regression introduced (partly) in https://github.com/Homebrew/brew/pull/15174.

Before:
```
Wed 19 Apr 11:37:15 ➜  .linuxbrew/Homebrew master ✓  brew rm ls: cannot access '/home/linuxbrew/.linuxbrew/Caskroom': No such file or directory

ansible          freetype                   kompose       libuv               mpdecimal        shared-mime-info 
ansible-lint     fribidi                    krb5          libva               msgpack          shellcheck       
```

After:
```
Wed 19 Apr 11:37:56 ➜  .linuxbrew/Homebrew fish-linux-cask ✓  brew rm spice-protocol
ansible          freetype                   kompose       libuv               mpdecimal        shared-mime-info 
```

Plus:
```
Wed 19 Apr 11:37:56 ➜  .linuxbrew/Homebrew fish-linux-cask ✓  brew outdated --cask --verbose 
Error: Invalid `--cask` usage: Casks do not work on Linux
Wed 19 Apr 11:38:25 ➜  .linuxbrew/Homebrew fish-linux-cask ✓  brew outdated --cask --verbose 2>/dev/null
Wed 19 Apr 11:38:35 ➜  .linuxbrew/Homebrew fish-linux-cask ✓  
```