### PR TITLE
Enable Sorbet/TrueSigil cop

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -295,6 +295,14 @@ Sorbet/StrictSigil:
   Include:
     - "**/*.rbi"
 
+Sorbet/TrueSigil:
+  Enabled: true
+  Exclude:
+    - "Taps/**/*"
+    - "/**/{Formula,Casks}/**/*.rb"
+    - "**/{Formula,Casks}/**/*.rb"
+    - "Homebrew/test/**/*.rb"
+
 # Require &&/|| instead of and/or
 Style/AndOr:
   EnforcedStyle: always


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
As the remaining un-typed files were removed in https://github.com/Homebrew/brew/pull/15201 and https://github.com/Homebrew/brew/pull/15273, this PR enables a cop that requires files to be typed. The configuration is taken from `Sorbet/FalseSigil` above it, with the exception of excluding all `Homebrew/test` files.