### PR TITLE
dev-cmd/pr-automerge: skip PRs with `pre-release` label

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -23,7 +23,8 @@ module Homebrew
              description: "Pull requests must have this label."
       comma_array "--without-labels",
                   description: "Pull requests must not have these labels (default: " \
-                               "`do not merge`, `new formula`, `automerge-skip`, `CI-published-bottle-commits`)."
+                               "`do not merge`, `new formula`, `automerge-skip`, " \
+                               "`pre-release`, `CI-published-bottle-commits`)."
       switch "--without-approval",
              description: "Pull requests do not require approval to be merged."
       switch "--publish",
@@ -50,6 +51,7 @@ module Homebrew
       "do not merge",
       "new formula",
       "automerge-skip",
+      "pre-release",
       "CI-published-bottle-commits",
     ]
     tap = Tap.fetch(args.tap || CoreTap.instance.name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

PRs with the `pre-release` label are always not ready for merge, so let's skip them by default.

See also: Homebrew/homebrew-core#128906.
