### PR TITLE
Remove `# typed: false` sigil in tests

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -281,11 +281,7 @@ Sorbet/ConstantsFromStrings:
   Enabled: false
 
 Sorbet/FalseSigil:
-  Exclude:
-    - "Taps/**/*"
-    - "/**/{Formula,Casks}/**/*.rb"
-    - "**/{Formula,Casks}/**/*.rb"
-    - "Homebrew/test/**/Casks/**/*.rb"
+  Enabled: false
 
 Sorbet/StrictSigil:
   inherit_mode:

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/PATH_spec.rb
+++ b/Library/Homebrew/test/PATH_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "PATH"

--- a/Library/Homebrew/test/PATH_spec.rb
+++ b/Library/Homebrew/test/PATH_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "PATH"

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "api"

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "build_environment"

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "build_environment"

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "build_options"

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "build_options"

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "bundle_version"

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "bundle_version"

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cache_store"

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cache_store"

--- a/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::AbstractArtifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::AbstractArtifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::Binary, :cask do

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::Binary, :cask do

--- a/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::Artifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::Artifact, :cask do

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::Installer, :cask do

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::Installer, :cask do

--- a/Library/Homebrew/test/cask/artifact/manpage_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/manpage_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::Manpage, :cask do

--- a/Library/Homebrew/test/cask/artifact/manpage_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/manpage_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::Manpage, :cask do

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::Pkg, :cask do

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::Pkg, :cask do

--- a/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::PostflightBlock, :cask do

--- a/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::PostflightBlock, :cask do

--- a/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::PreflightBlock, :cask do

--- a/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::PreflightBlock, :cask do

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "benchmark"

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "benchmark"

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::Suite, :cask do

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::Suite, :cask do

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::App, :cask do

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Artifact::Zap, :cask do

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Artifact::Zap, :cask do

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples/uninstall_zap"

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples/uninstall_zap"

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples/uninstall_zap"

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples/uninstall_zap"

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/audit"

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/audit"

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromAPILoader, :cask do

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromAPILoader, :cask do

--- a/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromContentLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromContentLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromPathLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromPathLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromTapLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromTapLoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromURILoader do

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::CaskLoader::FromURILoader do

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Cask, :cask do

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Cask, :cask do

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Config, :cask do

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Config, :cask do

--- a/Library/Homebrew/test/cask/conflicts_with_spec.rb
+++ b/Library/Homebrew/test/cask/conflicts_with_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "conflicts_with", :cask do

--- a/Library/Homebrew/test/cask/conflicts_with_spec.rb
+++ b/Library/Homebrew/test/cask/conflicts_with_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "conflicts_with", :cask do

--- a/Library/Homebrew/test/cask/denylist_spec.rb
+++ b/Library/Homebrew/test/cask/denylist_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/denylist"

--- a/Library/Homebrew/test/cask/denylist_spec.rb
+++ b/Library/Homebrew/test/cask/denylist_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/denylist"

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 # TODO: this test should be named after the corresponding class, once

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 # TODO: this test should be named after the corresponding class, once

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Cask

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 module Cask

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/container_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/container_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/container_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/container_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/postflight_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/postflight_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/preflight_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/preflight_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/dsl/base"

--- a/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/dsl/base"

--- a/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/staged"

--- a/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/staged"

--- a/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/cask/dsl/shared_examples/base"

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::DSL::Version, :cask do

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::DSL::Version, :cask do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::DSL, :cask do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::DSL, :cask do

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils"

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils"

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Installer, :cask do

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Installer, :cask do

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/list"

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/list"

--- a/Library/Homebrew/test/cask/macos_spec.rb
+++ b/Library/Homebrew/test/cask/macos_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe MacOS, :cask do

--- a/Library/Homebrew/test/cask/macos_spec.rb
+++ b/Library/Homebrew/test/cask/macos_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe MacOS, :cask do

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Cask::Pkg, :cask do

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Cask::Pkg, :cask do

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/installer"

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/installer"

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/uninstall"

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/uninstall"

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/upgrade"

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/upgrade"

--- a/Library/Homebrew/test/cask_dependent_spec.rb
+++ b/Library/Homebrew/test/cask_dependent_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/cask_dependent_spec.rb
+++ b/Library/Homebrew/test/cask_dependent_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "checksum"

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "checksum"

--- a/Library/Homebrew/test/checksum_verification_spec.rb
+++ b/Library/Homebrew/test/checksum_verification_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/checksum_verification_spec.rb
+++ b/Library/Homebrew/test/checksum_verification_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cleaner"

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cleaner"

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cli/named_args"

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cli/named_args"

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "../../cli/parser"

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "../../cli/parser"

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--caskroom_spec.rb
+++ b/Library/Homebrew/test/cmd/--caskroom_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--caskroom_spec.rb
+++ b/Library/Homebrew/test/cmd/--caskroom_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--cellar_spec.rb
+++ b/Library/Homebrew/test/cmd/--cellar_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--cellar_spec.rb
+++ b/Library/Homebrew/test/cmd/--cellar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--env_spec.rb
+++ b/Library/Homebrew/test/cmd/--env_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--env_spec.rb
+++ b/Library/Homebrew/test/cmd/--env_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--repository_spec.rb
+++ b/Library/Homebrew/test/cmd/--repository_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--repository_spec.rb
+++ b/Library/Homebrew/test/cmd/--repository_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--version_spec.rb
+++ b/Library/Homebrew/test/cmd/--version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/--version_spec.rb
+++ b/Library/Homebrew/test/cmd/--version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/autoremove_spec.rb
+++ b/Library/Homebrew/test/cmd/autoremove_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/autoremove_spec.rb
+++ b/Library/Homebrew/test/cmd/autoremove_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "brew bundle", :integration_test do

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "brew bundle", :integration_test do

--- a/Library/Homebrew/test/cmd/cleanup_spec.rb
+++ b/Library/Homebrew/test/cmd/cleanup_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/cleanup_spec.rb
+++ b/Library/Homebrew/test/cmd/cleanup_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/commands_spec.rb
+++ b/Library/Homebrew/test/cmd/commands_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/commands"

--- a/Library/Homebrew/test/cmd/commands_spec.rb
+++ b/Library/Homebrew/test/cmd/commands_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/commands"

--- a/Library/Homebrew/test/cmd/completions_spec.rb
+++ b/Library/Homebrew/test/cmd/completions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/completions_spec.rb
+++ b/Library/Homebrew/test/cmd/completions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/custom-external-command_spec.rb
+++ b/Library/Homebrew/test/cmd/custom-external-command_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "brew custom-external-command", :integration_test do

--- a/Library/Homebrew/test/cmd/custom-external-command_spec.rb
+++ b/Library/Homebrew/test/cmd/custom-external-command_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "brew custom-external-command", :integration_test do

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/developer_spec.rb
+++ b/Library/Homebrew/test/cmd/developer_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/developer_spec.rb
+++ b/Library/Homebrew/test/cmd/developer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/docs_spec.rb
+++ b/Library/Homebrew/test/cmd/docs_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "brew docs" do

--- a/Library/Homebrew/test/cmd/docs_spec.rb
+++ b/Library/Homebrew/test/cmd/docs_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "brew docs" do

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "brew", :integration_test do

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "brew", :integration_test do

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/info"

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/info"

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/options_spec.rb
+++ b/Library/Homebrew/test/cmd/options_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/options_spec.rb
+++ b/Library/Homebrew/test/cmd/options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/postinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/postinstall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/postinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/postinstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/readall_spec.rb
+++ b/Library/Homebrew/test/cmd/readall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/readall_spec.rb
+++ b/Library/Homebrew/test/cmd/readall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/search"

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/search"

--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "brew services", :integration_test, :needs_network do

--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "brew services", :integration_test, :needs_network do

--- a/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 shared_examples "parseable arguments" do

--- a/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 shared_examples "parseable arguments" do

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/tap_spec.rb
+++ b/Library/Homebrew/test/cmd/tap_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/tap_spec.rb
+++ b/Library/Homebrew/test/cmd/tap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/uninstall"

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/uninstall"

--- a/Library/Homebrew/test/cmd/unlink_spec.rb
+++ b/Library/Homebrew/test/cmd/unlink_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/unlink_spec.rb
+++ b/Library/Homebrew/test/cmd/unlink_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/unpin_spec.rb
+++ b/Library/Homebrew/test/cmd/unpin_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/unpin_spec.rb
+++ b/Library/Homebrew/test/cmd/unpin_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/update-report"

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/update-report"

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "commands"

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "commands"

--- a/Library/Homebrew/test/compiler_failure_spec.rb
+++ b/Library/Homebrew/test/compiler_failure_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "compilers"

--- a/Library/Homebrew/test/compiler_failure_spec.rb
+++ b/Library/Homebrew/test/compiler_failure_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "compilers"

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "compilers"

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "compilers"

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "completions"

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "completions"

--- a/Library/Homebrew/test/cxxstdlib_spec.rb
+++ b/Library/Homebrew/test/cxxstdlib_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/cxxstdlib_spec.rb
+++ b/Library/Homebrew/test/cxxstdlib_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependable"

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependable"

--- a/Library/Homebrew/test/dependencies_helpers_spec.rb
+++ b/Library/Homebrew/test/dependencies_helpers_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependencies_helpers"

--- a/Library/Homebrew/test/dependencies_helpers_spec.rb
+++ b/Library/Homebrew/test/dependencies_helpers_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependencies_helpers"

--- a/Library/Homebrew/test/dependencies_spec.rb
+++ b/Library/Homebrew/test/dependencies_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependencies"

--- a/Library/Homebrew/test/dependencies_spec.rb
+++ b/Library/Homebrew/test/dependencies_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependencies"

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependency"

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/update-report"

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/update-report"

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "descriptions"

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "descriptions"

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dev-cmd/audit"

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dev-cmd/audit"

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/command_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/command_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/command_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/command_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dev-cmd/determine-test-runners"

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dev-cmd/determine-test-runners"

--- a/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/formula_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/formula_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/linkage_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/linkage_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/linkage_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/linkage_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dev-cmd/pr-pull"

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dev-cmd/pr-pull"

--- a/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/sh_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/sh_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/sh_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/sh_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/style_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/style_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/style_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/style_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/unpack_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unpack_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/unpack_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unpack_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/download_strategies/abstract_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/abstract_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/github_git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/github_git_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/github_git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/github_git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/subversion_spec.rb
+++ b/Library/Homebrew/test/download_strategies/subversion_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/subversion_spec.rb
+++ b/Library/Homebrew/test/download_strategies/subversion_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/vcs_spec.rb
+++ b/Library/Homebrew/test/download_strategies/vcs_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/download_strategies/vcs_spec.rb
+++ b/Library/Homebrew/test/download_strategies/vcs_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "download_strategy"

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe ErrorDuringExecution do

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe ErrorDuringExecution do

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "exceptions"

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "exceptions"

--- a/Library/Homebrew/test/extend/array_spec.rb
+++ b/Library/Homebrew/test/extend/array_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "extend/array"

--- a/Library/Homebrew/test/extend/array_spec.rb
+++ b/Library/Homebrew/test/extend/array_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "extend/array"

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "globally-scoped helper methods" do

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "globally-scoped helper methods" do

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/formatter"

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/formatter"

--- a/Library/Homebrew/test/formula_free_port_spec.rb
+++ b/Library/Homebrew/test/formula_free_port_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "socket"

--- a/Library/Homebrew/test/formula_free_port_spec.rb
+++ b/Library/Homebrew/test/formula_free_port_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "socket"

--- a/Library/Homebrew/test/formula_info_spec.rb
+++ b/Library/Homebrew/test/formula_info_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula_info"

--- a/Library/Homebrew/test/formula_info_spec.rb
+++ b/Library/Homebrew/test/formula_info_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula_info"

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_pin_spec.rb
+++ b/Library/Homebrew/test/formula_pin_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula_pin"

--- a/Library/Homebrew/test/formula_pin_spec.rb
+++ b/Library/Homebrew/test/formula_pin_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula_pin"

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/formula_spec_selection_spec.rb
+++ b/Library/Homebrew/test/formula_spec_selection_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_spec_selection_spec.rb
+++ b/Library/Homebrew/test/formula_spec_selection_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_support/keg_only_reason_spec.rb
+++ b/Library/Homebrew/test/formula_support/keg_only_reason_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula_support"

--- a/Library/Homebrew/test/formula_support/keg_only_reason_spec.rb
+++ b/Library/Homebrew/test/formula_support/keg_only_reason_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula_support"

--- a/Library/Homebrew/test/formula_validation_spec.rb
+++ b/Library/Homebrew/test/formula_validation_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formula_validation_spec.rb
+++ b/Library/Homebrew/test/formula_validation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "github_runner_matrix"

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "github_runner_matrix"

--- a/Library/Homebrew/test/github_runner_spec.rb
+++ b/Library/Homebrew/test/github_runner_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "github_runner"

--- a/Library/Homebrew/test/github_runner_spec.rb
+++ b/Library/Homebrew/test/github_runner_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "github_runner"

--- a/Library/Homebrew/test/global_spec.rb
+++ b/Library/Homebrew/test/global_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "brew", :integration_test do

--- a/Library/Homebrew/test/global_spec.rb
+++ b/Library/Homebrew/test/global_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "brew", :integration_test do

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "hardware"

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "hardware"

--- a/Library/Homebrew/test/installed_dependents_spec.rb
+++ b/Library/Homebrew/test/installed_dependents_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "installed_dependents"

--- a/Library/Homebrew/test/installed_dependents_spec.rb
+++ b/Library/Homebrew/test/installed_dependents_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "installed_dependents"

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/grep_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/grep_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/grep_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/grep_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/relocation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/relocation_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "keg_relocate"

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "keg"

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "keg"

--- a/Library/Homebrew/test/language/go_spec.rb
+++ b/Library/Homebrew/test/language/go_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "language/go"

--- a/Library/Homebrew/test/language/go_spec.rb
+++ b/Library/Homebrew/test/language/go_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "language/go"

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "language/java"

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "language/java"

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "language/node"

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "language/node"

--- a/Library/Homebrew/test/language/perl/shebang_spec.rb
+++ b/Library/Homebrew/test/language/perl/shebang_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "language/perl"

--- a/Library/Homebrew/test/language/perl/shebang_spec.rb
+++ b/Library/Homebrew/test/language/perl/shebang_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "language/perl"

--- a/Library/Homebrew/test/language/python/shebang_spec.rb
+++ b/Library/Homebrew/test/language/python/shebang_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/language/python/shebang_spec.rb
+++ b/Library/Homebrew/test/language/python/shebang_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "language/python"

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "lazy_object"

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "lazy_object"

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "linkage_cache_store"

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "linkage_cache_store"

--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "linux_runner_spec"

--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "linux_runner_spec"

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/livecheck"

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/livecheck"

--- a/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/livecheck_version"

--- a/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/livecheck_version"

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/skip_conditions"

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/skip_conditions"

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/git_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/git_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/git_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/github_latest"

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/github_latest"

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/gnome"

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/gnome"

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/gnu"

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/gnu"

--- a/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/hackage"

--- a/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/hackage"

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/launchpad"

--- a/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/launchpad"

--- a/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/npm"

--- a/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/npm"

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/sourceforge"

--- a/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/sourceforge"

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy/xorg"

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy/xorg"

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "livecheck/strategy"

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "lock_file"

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "lock_file"

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "macos_runner_spec"

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "macos_runner_spec"

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "messages"

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "messages"

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "migrator"

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "migrator"

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "missing_formula"

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "missing_formula"

--- a/Library/Homebrew/test/options/deprecated_option_spec.rb
+++ b/Library/Homebrew/test/options/deprecated_option_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options/deprecated_option_spec.rb
+++ b/Library/Homebrew/test/options/deprecated_option_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options/option_spec.rb
+++ b/Library/Homebrew/test/options/option_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options/option_spec.rb
+++ b/Library/Homebrew/test/options/option_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "options"

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "extend/pathname"

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "extend/pathname"

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "dependency_collector"

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "diagnostic"

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test/support/fixtures/testball"

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "keg"

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "keg"

--- a/Library/Homebrew/test/os/mac/mach_spec.rb
+++ b/Library/Homebrew/test/os/mac/mach_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe "Mach-O" do

--- a/Library/Homebrew/test/os/mac/mach_spec.rb
+++ b/Library/Homebrew/test/os/mac/mach_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe "Mach-O" do

--- a/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
+++ b/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 # These tests assume the needed SDKs are correctly installed, i.e. `brew doctor` passes.

--- a/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
+++ b/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 # These tests assume the needed SDKs are correctly installed, i.e. `brew doctor` passes.

--- a/Library/Homebrew/test/os/mac/sdk_spec.rb
+++ b/Library/Homebrew/test/os/mac/sdk_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe OS::Mac::CLTSDKLocator do

--- a/Library/Homebrew/test/os/mac/sdk_spec.rb
+++ b/Library/Homebrew/test/os/mac/sdk_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe OS::Mac::CLTSDKLocator do

--- a/Library/Homebrew/test/os/mac/version_spec.rb
+++ b/Library/Homebrew/test/os/mac/version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "version"

--- a/Library/Homebrew/test/os/mac/version_spec.rb
+++ b/Library/Homebrew/test/os/mac/version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "version"

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "locale"

--- a/Library/Homebrew/test/os/os_spec.rb
+++ b/Library/Homebrew/test/os/os_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe OS do

--- a/Library/Homebrew/test/os/os_spec.rb
+++ b/Library/Homebrew/test/os/os_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe OS do

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "patch"

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "patch"

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "extend/pathname"

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "extend/pathname"

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "pkg_version"

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "pkg_version"

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "extend/ENV"

--- a/Library/Homebrew/test/requirements/arch_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/arch_requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "requirements/arch_requirement"

--- a/Library/Homebrew/test/requirements/arch_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/arch_requirement_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "requirements/arch_requirement"

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "requirements/codesign_requirement"

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "requirements/codesign_requirement"

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "requirements/linux_requirement"

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "requirements/linux_requirement"

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "requirements/macos_requirement"

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "requirements/macos_requirement"

--- a/Library/Homebrew/test/requirements_spec.rb
+++ b/Library/Homebrew/test/requirements_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "requirements"

--- a/Library/Homebrew/test/requirements_spec.rb
+++ b/Library/Homebrew/test/requirements_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "requirements"

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "resource"

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "resource"

--- a/Library/Homebrew/test/rubocop_spec.rb
+++ b/Library/Homebrew/test/rubocop_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/rubocop_spec.rb
+++ b/Library/Homebrew/test/rubocop_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/bottle"

--- a/Library/Homebrew/test/rubocops/cask/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/desc_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/desc_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_dsl_version_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_dsl_version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_dsl_version_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_dsl_version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
+++ b/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module CaskCop

--- a/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
+++ b/Library/Homebrew/test/rubocops/cask/shared_examples/cask_cop.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 module CaskCop

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/variables_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/cask/variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/variables_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/caveats"

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/caveats"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/checksum"

--- a/Library/Homebrew/test/rubocops/class/class_name_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/class_name_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/class_name_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/class_name_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_present.rb
+++ b/Library/Homebrew/test/rubocops/class/test_present.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_present.rb
+++ b/Library/Homebrew/test/rubocops/class/test_present.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/test_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/class/test_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/test_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/class"

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/components_order"

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/components_order"

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/components_redundancy"

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/components_redundancy"

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/conflicts"

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/conflicts"

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/dependency_order"

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/dependency_order"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/deprecate_disable"

--- a/Library/Homebrew/test/rubocops/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/desc_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/desc"

--- a/Library/Homebrew/test/rubocops/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/desc_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/desc"

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/files"

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/files"

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/homepage"

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/homepage"

--- a/Library/Homebrew/test/rubocops/io_read_spec.rb
+++ b/Library/Homebrew/test/rubocops/io_read_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/io_read"

--- a/Library/Homebrew/test/rubocops/io_read_spec.rb
+++ b/Library/Homebrew/test/rubocops/io_read_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/io_read"

--- a/Library/Homebrew/test/rubocops/keg_only_spec.rb
+++ b/Library/Homebrew/test/rubocops/keg_only_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/keg_only"

--- a/Library/Homebrew/test/rubocops/keg_only_spec.rb
+++ b/Library/Homebrew/test/rubocops/keg_only_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/keg_only"

--- a/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/livecheck"

--- a/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
+++ b/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/move_to_extend_os"

--- a/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
+++ b/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/move_to_extend_os"

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/options"

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/options"

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/patches"

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/patches"

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/service"

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/service"

--- a/Library/Homebrew/test/rubocops/shell_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/shell_commands_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/shell_commands"

--- a/Library/Homebrew/test/rubocops/shell_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/shell_commands_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/shell_commands"

--- a/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/comments_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/comments_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/comments_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/comments_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/licenses_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/licenses_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/licenses_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/licenses_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/make_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/make_check_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/make_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/make_check_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/lines"

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/text"

--- a/Library/Homebrew/test/rubocops/urls/git_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/git_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/urls"

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/uses_from_macos"

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "rubocops/version"

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "rubocops/version"

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "sandbox"

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "sandbox"

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "search"

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "search"

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formula"

--- a/Library/Homebrew/test/settings_spec.rb
+++ b/Library/Homebrew/test/settings_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/settings_spec.rb
+++ b/Library/Homebrew/test/settings_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "settings"

--- a/Library/Homebrew/test/software_spec/bottle_spec.rb
+++ b/Library/Homebrew/test/software_spec/bottle_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "software_spec"

--- a/Library/Homebrew/test/software_spec/bottle_spec.rb
+++ b/Library/Homebrew/test/software_spec/bottle_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "software_spec"

--- a/Library/Homebrew/test/software_spec/head_spec.rb
+++ b/Library/Homebrew/test/software_spec/head_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "software_spec"

--- a/Library/Homebrew/test/software_spec/head_spec.rb
+++ b/Library/Homebrew/test/software_spec/head_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "software_spec"

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "software_spec"

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "software_spec"

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 if ENV["HOMEBREW_TESTS_COVERAGE"]

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 if ENV["HOMEBREW_TESTS_COVERAGE"]

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "style"

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "style"

--- a/Library/Homebrew/test/support/helper/cask.rb
+++ b/Library/Homebrew/test/support/helper/cask.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/support/helper/cask.rb
+++ b/Library/Homebrew/test/support/helper/cask.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/cask_loader"

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "formulary"

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "formulary"

--- a/Library/Homebrew/test/support/helper/mktmpdir.rb
+++ b/Library/Homebrew/test/support/helper/mktmpdir.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module Test

--- a/Library/Homebrew/test/support/helper/mktmpdir.rb
+++ b/Library/Homebrew/test/support/helper/mktmpdir.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 module Test

--- a/Library/Homebrew/test/support/helper/output_as_tty.rb
+++ b/Library/Homebrew/test/support/helper/output_as_tty.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "delegate"

--- a/Library/Homebrew/test/support/helper/output_as_tty.rb
+++ b/Library/Homebrew/test/support/helper/output_as_tty.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "delegate"

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "cask/config"

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "cask/config"

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "open3"

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 shared_examples "formulae exist" do |array|

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 shared_examples "formulae exist" do |array|

--- a/Library/Homebrew/test/system_command_result_spec.rb
+++ b/Library/Homebrew/test/system_command_result_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "system_command"

--- a/Library/Homebrew/test/system_command_result_spec.rb
+++ b/Library/Homebrew/test/system_command_result_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "system_command"

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe SystemCommand do

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe SystemCommand do

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "tab"

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "tab"

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Tap do

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Tap do

--- a/Library/Homebrew/test/test_runner_formula_spec.rb
+++ b/Library/Homebrew/test/test_runner_formula_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "test_runner_formula"

--- a/Library/Homebrew/test/test_runner_formula_spec.rb
+++ b/Library/Homebrew/test/test_runner_formula_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "test_runner_formula"

--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "uninstall"

--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "uninstall"

--- a/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/git_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/git_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/git_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/jar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/jar_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/jar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/jar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/lha_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lha_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/lha_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lha_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/rar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/rar_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/rar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/rar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/shared_examples.rb
+++ b/Library/Homebrew/test/unpack_strategy/shared_examples.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "unpack_strategy"

--- a/Library/Homebrew/test/unpack_strategy/shared_examples.rb
+++ b/Library/Homebrew/test/unpack_strategy/shared_examples.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "unpack_strategy"

--- a/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/xar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xar_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/xar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/xz_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xz_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/xz_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xz_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require_relative "shared_examples"

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe UnpackStrategy do

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe UnpackStrategy do

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/analytics"

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/analytics"

--- a/Library/Homebrew/test/utils/ast/ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/ast_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/ast/ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/ast_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/ast"

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/autoremove"

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/autoremove"

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/bottles"

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/curl"

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/curl"

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/fork"

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/fork"

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/git_repository"

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/git_repository"

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/git"

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/git"

--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/github/actions"

--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/github/actions"

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/github"

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/github"

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/gzip"

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/gzip"

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "tempfile"

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "tempfile"

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/popen"

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/popen"

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/pypi"

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/pypi"

--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Utils do

--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Utils do

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/shell"

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/shell"

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/spdx"

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/spdx"

--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/string_inreplace_extension"

--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/string_inreplace_extension"

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/svn"

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/svn"

--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/tar"

--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/tar"

--- a/Library/Homebrew/test/utils/topological_hash_spec.rb
+++ b/Library/Homebrew/test/utils/topological_hash_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/topological_hash"

--- a/Library/Homebrew/test/utils/topological_hash_spec.rb
+++ b/Library/Homebrew/test/utils/topological_hash_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/topological_hash"

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 describe Tty do

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 describe Tty do

--- a/Library/Homebrew/test/utils/user_spec.rb
+++ b/Library/Homebrew/test/utils/user_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils/user"

--- a/Library/Homebrew/test/utils/user_spec.rb
+++ b/Library/Homebrew/test/utils/user_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils/user"

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "utils"

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "utils"

--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "version/parser"

--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "version/parser"

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require "version"

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -1,4 +1,4 @@
-# typed: false
+
 # frozen_string_literal: true
 
 require "version"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Resolves https://github.com/Homebrew/brew/issues/15281 (but note my [caveat](https://github.com/Homebrew/brew/issues/15281#issuecomment-1518114264) re: `# typed: ignore`)

(Since `# typed: false` is the [default](https://sorbet.org/docs/static#file-level-granularity-strictness-levels), its presence just adds verbosity) 