### PR TITLE
Throttle version bumps based on recently merged PRs.

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -662,12 +662,6 @@ module Homebrew
       stable_url_version = Version.parse(stable.url)
       stable_url_minor_version = stable_url_version.minor.to_i
 
-      formula_suffix = stable.version.patch.to_i
-      throttled_rate = formula.tap&.audit_exception(:throttled_formulae, formula.name)
-      if throttled_rate && formula_suffix.modulo(throttled_rate).nonzero?
-        problem "should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
-      end
-
       case (url = stable.url)
       when /[\d._-](alpha|beta|rc\d)/
         matched = Regexp.last_match(1)

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -657,7 +657,6 @@ module Homebrew
     end
 
     describe "#audit_specs" do
-      let(:throttle_list) { { throttled_formulae: { "foo" => 10 } } }
       let(:versioned_head_spec_list) { { versioned_head_spec_allowlist: ["foo"] } }
 
       it "doesn't allow to miss a checksum" do
@@ -693,54 +692,6 @@ module Homebrew
 
         fa.audit_specs
         expect(fa.problems).to be_empty
-      end
-
-      it "allows versions with no throttle rate" do
-        fa = formula_auditor "bar", <<~RUBY, core_tap: true, tap_audit_exceptions: throttle_list
-          class Bar < Formula
-            url "https://brew.sh/foo-1.0.1.tgz"
-            sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
-          end
-        RUBY
-
-        fa.audit_specs
-        expect(fa.problems).to be_empty
-      end
-
-      it "allows major/minor versions with throttle rate" do
-        fa = formula_auditor "foo", <<~RUBY, core_tap: true, tap_audit_exceptions: throttle_list
-          class Foo < Formula
-            url "https://brew.sh/foo-1.0.0.tgz"
-            sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
-          end
-        RUBY
-
-        fa.audit_specs
-        expect(fa.problems).to be_empty
-      end
-
-      it "allows patch versions to be multiples of the throttle rate" do
-        fa = formula_auditor "foo", <<~RUBY, core_tap: true, tap_audit_exceptions: throttle_list
-          class Foo < Formula
-            url "https://brew.sh/foo-1.0.10.tgz"
-            sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
-          end
-        RUBY
-
-        fa.audit_specs
-        expect(fa.problems).to be_empty
-      end
-
-      it "doesn't allow patch versions that aren't multiples of the throttle rate" do
-        fa = formula_auditor "foo", <<~RUBY, core_tap: true, tap_audit_exceptions: throttle_list
-          class Foo < Formula
-            url "https://brew.sh/foo-1.0.1.tgz"
-            sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
-          end
-        RUBY
-
-        fa.audit_specs
-        expect(fa.problems.first[:message]).to match "should only be updated every 10 releases on multiples of 10"
       end
 
       it "allows non-versioned formulae to have a `HEAD` spec" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The existing throttling method (patch version must be a multiple of *n*) does not work for most casks. This changes throttling to instead check if a PR was merged for a given cask/formula in the last *n* days instead.
