### PR TITLE
formulary: sub home placeholder in caveats

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -287,6 +287,7 @@ module Formulary
       def caveats
         self.class.instance_variable_get(:@caveats_string)
             &.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+            &.gsub(HOMEBREW_HOME_PLACEHOLDER, Dir.home)
       end
 
       @tap_git_head_string = json_formula["tap_git_head"]

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -270,7 +270,7 @@ describe Formulary do
             "conflicts_with"           => ["conflicting_formula"],
             "conflicts_with_reasons"   => ["it does"],
             "link_overwrite"           => ["bin/abc"],
-            "caveats"                  => "example caveat string",
+            "caveats"                  => "example caveat string\n/$HOME\n$HOMEBREW_PREFIX",
             "service"                  => {
               "run"         => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "test"],
               "run_type"    => "immediate",
@@ -356,7 +356,7 @@ describe Formulary do
         expect(formula.conflicts.map(&:reason)).to include "it does"
         expect(formula.class.link_overwrite_paths).to include "bin/abc"
 
-        expect(formula.caveats).to eq "example caveat string"
+        expect(formula.caveats).to eq "example caveat string\n#{Dir.home}\n#{HOMEBREW_PREFIX}"
 
         expect(formula).to be_a_service
         expect(formula.service.command).to eq(["#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd", "test"])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We set a placeholder for the home directory when generating API JSON so we should substitute the actual home directory back in when printing caveats locally. This allows people to use `Dir.home` in caveats and have it display correctly no matter the platform or operating system.

```sh
/u/l/H/L/T/h/homebrew-core (master|✔) $ awk '
                                        is_caveats(), is_end()

                                        function is_caveats() {
                                          if ($1 == "def" && $2 == "caveats") {
                                            END_INDENT = get_indent()
                                            return 1
                                          } else {
                                            return 0
                                          }
                                        }

                                        function is_end() {
                                          return NF == 1 && $1 == "end" && get_indent() == END_INDENT
                                        }

                                        function get_indent() {
                                          match($0, /^ */)
                                          return RLENGTH
                                        }' (find . -name '*.rb') |
                                            grep 'Dir.home'
    return unless File.exist?("#{Dir.home}/.emscripten")
      #{Dir.home}/.config/redshift/redshift.conf
```

`Dir.home` is used in two caveats blocks right now, [emscripten](https://github.com/Homebrew/homebrew-core/blob/e98341f86895a255f913a3ece4e426c5f4e69511/Formula/emscripten.rb#L193-L203) and [redshift](https://github.com/Homebrew/homebrew-core/blob/e98341f86895a255f913a3ece4e426c5f4e69511/Formula/redshift.rb#L57-L64), but only one is used in the actual caveat string.