### PR TITLE
formula: consider arbitrary formula source paths

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2199,7 +2199,7 @@ class Formula
         "sha256" => resource("ruby-source").checksum.hexdigest,
       }
     elsif !self.class.loaded_from_api && path.exist?
-      hsh["ruby_source_path"] = path.relative_path_from(tap.path).to_s
+      hsh["ruby_source_path"] = (path.relative_path_from(tap.path).to_s if tap)
       hsh["ruby_source_checksum"] = {
         "sha256" => Digest::SHA256.file(path).hexdigest,
       }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`to_hash` currently assumes that a keg's formula came from a tap. However, if any keg came from an arbitrary formula file (e.g. `~/Desktop/unrar.rb`), it won't have an associated tap and a command like `brew info --installed --json=v2` will return "undefined method 'path' for nil:NilClass". This change causes the above command to generate a value for `ruby_source_path` only if a tap is associated, e.g.:
```
      "ruby_source_checksum": {
        "sha256": "3ea62d262bd704dc416e8df336f1e399e3c7012a5f8b7d55b39ec290f5cd95b4"
      },
      "ruby_source_path": null
```