### PR TITLE
Python: always use --no-build-isolation

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -264,14 +264,14 @@ module Language
         #   Multiline strings are allowed and treated as though they represent
         #   the contents of a `requirements.txt`.
         # @return [void]
-        def pip_install(targets, build_isolation: true)
+        def pip_install(targets)
           targets = Array(targets)
           targets.each do |t|
             if t.respond_to? :stage
-              t.stage { do_install(Pathname.pwd, build_isolation: build_isolation) }
+              t.stage { do_install Pathname.pwd }
             else
               t = t.lines.map(&:strip) if t.respond_to?(:lines) && t.include?("\n")
-              do_install(t, build_isolation: build_isolation)
+              do_install t
             end
           end
         end
@@ -281,11 +281,11 @@ module Language
         #
         # @param (see #pip_install)
         # @return (see #pip_install)
-        def pip_install_and_link(targets, link_manpages: false, build_isolation: true)
+        def pip_install_and_link(targets, link_manpages: false)
           bin_before = Dir[@venv_root/"bin/*"].to_set
           man_before = Dir[@venv_root/"share/man/man*/*"].to_set if link_manpages
 
-          pip_install(targets, build_isolation: build_isolation)
+          pip_install(targets)
 
           bin_after = Dir[@venv_root/"bin/*"].to_set
           bin_to_link = (bin_after - bin_before).to_a
@@ -301,14 +301,13 @@ module Language
 
         private
 
-        def do_install(targets, build_isolation: true)
+        def do_install(targets)
           targets = Array(targets)
           args = [
             "-v", "--no-deps", "--no-binary", ":all:",
             "--use-feature=no-binary-enable-wheel-cache",
-            "--ignore-installed"
+            "--ignore-installed", "--no-build-isolation"
           ]
-          args << "--no-build-isolation" unless build_isolation
           @formula.system @venv_root/"bin/pip", "install", *args, *targets
         end
       end

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -24,7 +24,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts a string" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "--no-build-isolation", "foo")
         .and_return(true)
       virtualenv.pip_install "foo"
     end
@@ -32,7 +32,8 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts a multi-line strings" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo", "bar")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed",
+              "--no-build-isolation", "foo", "bar")
         .and_return(true)
 
       virtualenv.pip_install <<~EOS
@@ -44,12 +45,14 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts an array" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed",
+              "--no-build-isolation", "foo")
         .and_return(true)
 
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "bar")
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed",
+              "--no-build-isolation", "bar")
         .and_return(true)
 
       virtualenv.pip_install ["foo", "bar"]
@@ -61,18 +64,11 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(res).to receive(:stage).and_yield
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", Pathname.pwd)
+              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed",
+              "--no-build-isolation", Pathname.pwd)
         .and_return(true)
 
       virtualenv.pip_install res
-    end
-
-    it "works without build isolation" do
-      expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "--no-build-isolation", "foo")
-        .and_return(true)
-      virtualenv.pip_install("foo", build_isolation: false)
     end
   end
 
@@ -93,7 +89,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       FileUtils.touch src_bin/"kilroy"
       bin_after = Dir.glob(src_bin/"*")
 
-      expect(virtualenv).to receive(:pip_install).with("foo", { build_isolation: true })
+      expect(virtualenv).to receive(:pip_install).with("foo")
       expect(Dir).to receive(:[]).with(src_bin/"*").twice.and_return(bin_before, bin_after)
 
       virtualenv.pip_install_and_link "foo"
@@ -122,7 +118,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       FileUtils.touch src_man/"man5/kilroy.5"
       man_after = Dir.glob(src_man/"**/*")
 
-      expect(virtualenv).to receive(:pip_install).with("foo", { build_isolation: true })
+      expect(virtualenv).to receive(:pip_install).with("foo")
       expect(Dir).to receive(:[]).with(src_bin/"*").and_return([])
       expect(Dir).to receive(:[]).with(src_man/"man*/*").and_return(man_before)
       expect(Dir).to receive(:[]).with(src_bin/"*").and_return([])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to #15121. Now that https://github.com/Homebrew/homebrew-core/pull/125779 is merged, validating the need for this `--no-build-isolation` flag, we can consider passing this flag all the time. I think it's probably a good idea, but I'm certainly open to discussion!

Once this pull request merges, I'll make a PR to `homebrew-core` to remove the usage of the `build_isolation: false` param from the `pytorch` and `torchvision` formulae.