### PR TITLE
cmd/install: warn on cask install when already installed

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -197,10 +197,10 @@ module Homebrew
     begin
       formulae, casks = args.named.to_formulae_and_casks
                             .partition { |formula_or_cask| formula_or_cask.is_a?(Formula) }
-    rescue FormulaOrCaskUnavailableError, Cask::CaskUnavailableError => e
+    rescue FormulaOrCaskUnavailableError, Cask::CaskUnavailableError
       retry if Tap.install_default_cask_tap_if_necessary(force: args.cask?)
 
-      raise e
+      raise
     end
 
     if casks.any?
@@ -237,6 +237,8 @@ module Homebrew
                             skip_cask_deps: args.skip_cask_deps?,
                             quarantine:     args.quarantine?,
                             quiet:          args.quiet?).install
+      rescue Cask::CaskAlreadyInstalledError => e
+        opoo e.message
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Mentioned in #15295.

Basically we want to warn here instead of erroring out to avoid breaking people's scripts. This was the default behavior before #15273 got merged in to refactor the `cask/cmd/install` logic into `cmd/install`. 