### PR TITLE
git_repository: implement `#to_s`

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -161,10 +161,10 @@ module Homebrew
     package_name = package_file.basename.to_s.chomp(".rb")
 
     odebug "Cherry-picking #{package_file}: #{commit}"
-    Utils::Git.cherry_pick!(git_repo, commit, verbose: verbose, resolve: resolve)
+    Utils::Git.cherry_pick!(git_repo.to_s, commit, verbose: verbose, resolve: resolve)
 
-    old_package = Utils::Git.file_at_commit(git_repo, file, "HEAD^")
-    new_package = Utils::Git.file_at_commit(git_repo, file, "HEAD")
+    old_package = Utils::Git.file_at_commit(git_repo.to_s, file, "HEAD^")
+    new_package = Utils::Git.file_at_commit(git_repo.to_s, file, "HEAD")
 
     bump_subject = determine_bump_subject(old_package, new_package, package_file, reason: reason).strip
     subject, body, trailers = separate_commit_message(git_repo.commit_message)

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -109,6 +109,12 @@ class GitRepository
     popen_git("log", "-1", "--pretty=%B", commit, "--", safe: safe, err: :out)&.strip
   end
 
+  sig { returns(String) }
+  def to_str
+    pathname.to_str
+  end
+  alias to_s to_str
+
   private
 
   sig { params(args: T.untyped, safe: T::Boolean, err: T.nilable(Symbol)).returns(T.nilable(String)) }

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -110,10 +110,9 @@ class GitRepository
   end
 
   sig { returns(String) }
-  def to_str
-    pathname.to_str
+  def to_s
+    pathname.to_s
   end
-  alias to_s to_str
 
   private
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes:

    Error: no implicit conversion of GitRepository into String

when doing `brew pr-pull --autosquash`. See [1].

I contemplated implementing only `#to_s`, but we've historically used
these as `Pathname`s, and `Pathname` defines `#to_str`.

[1] https://github.com/Homebrew/homebrew-core/actions/runs/4784638305/jobs/8506369135#step:10:54

