### PR TITLE
Include T::Sig in Module

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -280,8 +280,13 @@ RSpec/Focus:
 Sorbet/ConstantsFromStrings:
   Enabled: false
 
+# This is already the default
 Sorbet/FalseSigil:
   Enabled: false
+
+# T::Sig is monkey-patched into Module
+Sorbet/RedundantExtendTSig:
+  Enabled: true
 
 Sorbet/StrictSigil:
   inherit_mode:

--- a/Library/Homebrew/PATH.rb
+++ b/Library/Homebrew/PATH.rb
@@ -5,8 +5,6 @@
 #
 # @api private
 class PATH
-  extend T::Sig
-
   include Enumerable
   extend Forwardable
 

--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -11,8 +11,6 @@ module Homebrew
   #
   # @api private
   module API
-    extend T::Sig
-
     extend Cachable
 
     HOMEBREW_CACHE_API = (HOMEBREW_CACHE/"api").freeze

--- a/Library/Homebrew/api/analytics.rb
+++ b/Library/Homebrew/api/analytics.rb
@@ -8,8 +8,6 @@ module Homebrew
     # @api private
     module Analytics
       class << self
-        extend T::Sig
-
         sig { returns(String) }
         def analytics_api_path
           "analytics"

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -11,7 +11,6 @@ module Homebrew
     module Cask
       class << self
         include Cachable
-        extend T::Sig
 
         private :cache
 

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -11,7 +11,6 @@ module Homebrew
     module Formula
       class << self
         include Cachable
-        extend T::Sig
 
         private :cache
 

--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -5,8 +5,6 @@
 #
 # @api private
 class BuildEnvironment
-  extend T::Sig
-
   sig { params(settings: Symbol).void }
   def initialize(*settings)
     @settings = Set.new(settings)
@@ -31,8 +29,6 @@ class BuildEnvironment
 
   # DSL for specifying build environment settings.
   module DSL
-    extend T::Sig
-
     # Initialise @env for each class which may use this DSL (e.g. each formula subclass).
     # `env` may never be called, and it needs to be initialised before the class is frozen.
     def inherited(child)

--- a/Library/Homebrew/bundle_version.rb
+++ b/Library/Homebrew/bundle_version.rb
@@ -8,8 +8,6 @@ module Homebrew
   #
   # @api private
   class BundleVersion
-    extend T::Sig
-
     include Comparable
 
     extend SystemCommand::Mixin

--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -9,7 +9,6 @@ module Cask
     #
     # @api private
     class AbstractArtifact
-      extend T::Sig
       extend T::Helpers
       abstract!
 

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -13,8 +13,6 @@ module Cask
     #
     # @api private
     class AbstractUninstall < AbstractArtifact
-      extend T::Sig
-
       ORDERED_DIRECTIVES = [
         :early_script,
         :launchctl,

--- a/Library/Homebrew/cask/artifact/artifact.rb
+++ b/Library/Homebrew/cask/artifact/artifact.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Artifact < Moved
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_name
         "Generic Artifact"

--- a/Library/Homebrew/cask/artifact/keyboard_layout.rb
+++ b/Library/Homebrew/cask/artifact/keyboard_layout.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class KeyboardLayout < Moved
-      extend T::Sig
-
       def install_phase(**options)
         super(**options)
         delete_keyboard_layout_cache(**options)

--- a/Library/Homebrew/cask/artifact/mdimporter.rb
+++ b/Library/Homebrew/cask/artifact/mdimporter.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Mdimporter < Moved
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_name
         "Spotlight metadata importer"

--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Moved < Relocated
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_description
         "#{english_name}s"

--- a/Library/Homebrew/cask/artifact/prefpane.rb
+++ b/Library/Homebrew/cask/artifact/prefpane.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Prefpane < Moved
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_name
         "Preference Pane"

--- a/Library/Homebrew/cask/artifact/qlplugin.rb
+++ b/Library/Homebrew/cask/artifact/qlplugin.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Qlplugin < Moved
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_name
         "QuickLook Plugin"

--- a/Library/Homebrew/cask/artifact/relocated.rb
+++ b/Library/Homebrew/cask/artifact/relocated.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Relocated < AbstractArtifact
-      extend T::Sig
-
       def self.from_args(cask, *args)
         source_string, target_hash = args
 

--- a/Library/Homebrew/cask/artifact/stage_only.rb
+++ b/Library/Homebrew/cask/artifact/stage_only.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class StageOnly < AbstractArtifact
-      extend T::Sig
-
       def self.from_args(cask, *args, **kwargs)
         if (args != [true] && args != ["true"]) || kwargs.present?
           raise CaskInvalidError.new(cask.token, "'stage_only' takes only a single argument: true")

--- a/Library/Homebrew/cask/artifact/suite.rb
+++ b/Library/Homebrew/cask/artifact/suite.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Suite < Moved
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_name
         "App Suite"

--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Symlinked < Relocated
-      extend T::Sig
-
       sig { returns(String) }
       def self.link_type_english_name
         "Symlink"

--- a/Library/Homebrew/cask/artifact/vst3_plugin.rb
+++ b/Library/Homebrew/cask/artifact/vst3_plugin.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class Vst3Plugin < Moved
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_name
         "VST3 Plugin"

--- a/Library/Homebrew/cask/artifact/vst_plugin.rb
+++ b/Library/Homebrew/cask/artifact/vst_plugin.rb
@@ -9,8 +9,6 @@ module Cask
     #
     # @api private
     class VstPlugin < Moved
-      extend T::Sig
-
       sig { returns(String) }
       def self.english_name
         "VST Plugin"

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -14,8 +14,6 @@ module Cask
   #
   # @api private
   class Audit
-    extend T::Sig
-
     extend Predicable
 
     attr_reader :cask, :download

--- a/Library/Homebrew/cask/cache.rb
+++ b/Library/Homebrew/cask/cache.rb
@@ -6,8 +6,6 @@ module Cask
   #
   # @api private
   module Cache
-    extend T::Sig
-
     sig { returns(Pathname) }
     def self.path
       @path ||= HOMEBREW_CACHE/"Cask"

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -13,8 +13,6 @@ module Cask
   #
   # @api private
   class Cask
-    extend T::Sig
-
     extend Forwardable
     extend Predicable
     extend APIHashable

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -13,7 +13,6 @@ module Cask
     extend Context
 
     module ILoader
-      extend T::Sig
       extend T::Helpers
       interface!
 
@@ -110,8 +109,6 @@ module Cask
 
     # Loads a cask from a URI.
     class FromURILoader < FromPathLoader
-      extend T::Sig
-
       def self.can_load?(ref)
         # Cache compiled regex
         @uri_regex ||= begin
@@ -362,8 +359,6 @@ module Cask
 
     # Pseudo-loader which raises an error when trying to load the corresponding cask.
     class NullLoader < FromPathLoader
-      extend T::Sig
-
       def self.can_load?(*)
         true
       end

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -8,8 +8,6 @@ module Cask
   #
   # @api private
   module Caskroom
-    extend T::Sig
-
     sig { returns(Pathname) }
     def self.path
       @path ||= HOMEBREW_PREFIX/"Caskroom"

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -11,8 +11,6 @@ module Cask
   #
   # @api private
   class Config
-    extend T::Sig
-
     DEFAULT_DIRS = {
       appdir:               "/Applications",
       keyboard_layoutdir:   "/Library/Keyboard Layouts",

--- a/Library/Homebrew/cask/denylist.rb
+++ b/Library/Homebrew/cask/denylist.rb
@@ -6,8 +6,6 @@ module Cask
   #
   # @api private
   module Denylist
-    extend T::Sig
-
     sig { params(name: String).returns(T.nilable(String)) }
     def self.reason(name)
       case name

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -11,7 +11,6 @@ module Cask
     #
     # @api private
     class DependsOn < SimpleDelegator
-      extend T::Sig
       VALID_KEYS = Set.new([
         :formula,
         :cask,

--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -7,8 +7,6 @@ module Cask
     #
     # @api private
     class Version < ::String
-      extend T::Sig
-
       DIVIDERS = {
         "." => :dots,
         "-" => :hyphens,

--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -11,8 +11,6 @@ module Cask
   #
   # @api private
   class MultipleCaskErrors < CaskError
-    extend T::Sig
-
     def initialize(errors)
       super()
 
@@ -32,8 +30,6 @@ module Cask
   #
   # @api private
   class AbstractCaskErrorWithToken < CaskError
-    extend T::Sig
-
     sig { returns(String) }
     attr_reader :token
 
@@ -52,8 +48,6 @@ module Cask
   #
   # @api private
   class CaskNotInstalledError < AbstractCaskErrorWithToken
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       "Cask '#{token}' is not installed."
@@ -64,8 +58,6 @@ module Cask
   #
   # @api private
   class CaskConflictError < AbstractCaskErrorWithToken
-    extend T::Sig
-
     attr_reader :conflicting_cask
 
     def initialize(token, conflicting_cask)
@@ -83,8 +75,6 @@ module Cask
   #
   # @api private
   class CaskUnavailableError < AbstractCaskErrorWithToken
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       "Cask '#{token}' is unavailable#{reason.empty? ? "." : ": #{reason}"}"
@@ -95,8 +85,6 @@ module Cask
   #
   # @api private
   class CaskUnreadableError < CaskUnavailableError
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       "Cask '#{token}' is unreadable#{reason.empty? ? "." : ": #{reason}"}"
@@ -107,8 +95,6 @@ module Cask
   #
   # @api private
   class TapCaskUnavailableError < CaskUnavailableError
-    extend T::Sig
-
     attr_reader :tap
 
     def initialize(tap, token)
@@ -128,8 +114,6 @@ module Cask
   #
   # @api private
   class TapCaskAmbiguityError < CaskError
-    extend T::Sig
-
     def initialize(ref, loaders)
       super <<~EOS
         Cask #{ref} exists in multiple taps:
@@ -142,8 +126,6 @@ module Cask
   #
   # @api private
   class CaskAlreadyCreatedError < AbstractCaskErrorWithToken
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       %Q(Cask '#{token}' already exists. Run #{Formatter.identifier("brew edit --cask #{token}")} to edit it.)
@@ -154,8 +136,6 @@ module Cask
   #
   # @api private
   class CaskAlreadyInstalledError < AbstractCaskErrorWithToken
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       <<~EOS
@@ -171,8 +151,6 @@ module Cask
   #
   # @api private
   class CaskCyclicDependencyError < AbstractCaskErrorWithToken
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       "Cask '#{token}' includes cyclic dependencies on other Casks#{reason.empty? ? "." : ": #{reason}"}"
@@ -183,8 +161,6 @@ module Cask
   #
   # @api private
   class CaskSelfReferencingDependencyError < CaskCyclicDependencyError
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       "Cask '#{token}' depends on itself."
@@ -195,8 +171,6 @@ module Cask
   #
   # @api private
   class CaskUnspecifiedError < CaskError
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       "This command requires a Cask token."
@@ -207,8 +181,6 @@ module Cask
   #
   # @api private
   class CaskInvalidError < AbstractCaskErrorWithToken
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       "Cask '#{token}' definition is invalid#{reason.empty? ? "." : ": #{reason}"}"
@@ -228,8 +200,6 @@ module Cask
   #
   # @api private
   class CaskQuarantineError < CaskError
-    extend T::Sig
-
     attr_reader :path, :reason
 
     def initialize(path, reason)
@@ -257,8 +227,6 @@ module Cask
   #
   # @api private
   class CaskQuarantinePropagationError < CaskQuarantineError
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       s = +"Failed to quarantine one or more files within #{path}."
@@ -277,8 +245,6 @@ module Cask
   #
   # @api private
   class CaskQuarantineReleaseError < CaskQuarantineError
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       s = +"Failed to release #{path} from quarantine."

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -16,8 +16,6 @@ module Cask
   #
   # @api private
   class Installer
-    extend T::Sig
-
     extend Predicable
 
     def initialize(cask, command: SystemCommand, force: false, adopt: false,

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -8,8 +8,6 @@ module Cask
   #
   # @api private
   class Pkg
-    extend T::Sig
-
     sig { params(regexp: String, command: T.class_of(SystemCommand)).returns(T::Array[Pkg]) }
     def self.all_matching(regexp, command)
       command.run("/usr/sbin/pkgutil", args: ["--pkgs=#{regexp}"]).stdout.split("\n").map do |package_id|

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -9,8 +9,6 @@ module Cask
   #
   # @api private
   module Quarantine
-    extend T::Sig
-
     QUARANTINE_ATTRIBUTE = "com.apple.quarantine"
 
     QUARANTINE_SCRIPT = (HOMEBREW_LIBRARY_PATH/"cask/utils/quarantine.swift").freeze

--- a/Library/Homebrew/cask/staged.rb
+++ b/Library/Homebrew/cask/staged.rb
@@ -8,8 +8,6 @@ module Cask
   #
   # @api private
   module Staged
-    extend T::Sig
-
     # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
     # rubocop:disable Style/MutableConstant
     Paths = T.type_alias { T.any(String, Pathname, T::Array[T.any(String, Pathname)]) }

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -7,8 +7,6 @@ require "cask/config"
 module Cask
   # @api private
   class Upgrade
-    extend T::Sig
-
     sig {
       params(
         casks:               Cask,

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -5,12 +5,8 @@
 #
 # @api private
 class URL < Delegator
-  extend T::Sig
-
   # @api private
   class DSL
-    extend T::Sig
-
     attr_reader :uri, :specs,
                 :verified, :using,
                 :tag, :branch, :revisions, :revision,
@@ -79,12 +75,8 @@ class URL < Delegator
 
   # @api private
   class BlockDSL
-    extend T::Sig
-
     # To access URL associated with page contents.
     module PageWithURL
-      extend T::Sig
-
       # @api public
       sig { returns(URI::Generic) }
       attr_accessor :url

--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -11,8 +11,6 @@ module Cask
   #
   # @api private
   module Utils
-    extend T::Sig
-
     def self.gain_permissions_remove(path, command: SystemCommand)
       if path.respond_to?(:rmtree) && path.exist?
         gain_permissions(path, ["-R"], command) do |p|

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -16,8 +16,6 @@ module Homebrew
     private_constant :CLEANUP_DEFAULT_DAYS
 
     class << self
-      extend T::Sig
-
       sig { params(pathname: Pathname).returns(T::Boolean) }
       def incomplete?(pathname)
         pathname.extname.end_with?(".incomplete")

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -6,8 +6,6 @@ require "ostruct"
 module Homebrew
   module CLI
     class Args < OpenStruct
-      extend T::Sig
-
       attr_reader :options_only, :flags_only
 
       # undefine tap to allow --tap argument

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -11,8 +11,6 @@ module Homebrew
     #
     # @api private
     class NamedArgs < Array
-      extend T::Sig
-
       def initialize(*args, parent: Args.new, override_spec: nil, force_bottle: false, flags: [], cask_options: false)
         require "cask/cask"
         require "cask/cask_loader"

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -15,8 +15,6 @@ HIDDEN_DESC_PLACEHOLDER = "@@HIDDEN@@"
 module Homebrew
   module CLI
     class Parser
-      extend T::Sig
-
       attr_reader :processed_options, :hide_from_man_page, :named_args_type
 
       def self.from_cmd_path(cmd_path)
@@ -680,8 +678,6 @@ module Homebrew
     end
 
     class MaxNamedArgumentsError < UsageError
-      extend T::Sig
-
       sig { params(maximum: Integer, types: T::Array[Symbol]).void }
       def initialize(maximum, types: [])
         super case maximum
@@ -698,8 +694,6 @@ module Homebrew
     end
 
     class MinNamedArgumentsError < UsageError
-      extend T::Sig
-
       sig { params(minimum: Integer, types: T::Array[Symbol]).void }
       def initialize(minimum, types: [])
         types << :named if types.empty?
@@ -711,8 +705,6 @@ module Homebrew
     end
 
     class NumberOfNamedArgumentsError < UsageError
-      extend T::Sig
-
       sig { params(minimum: Integer, types: T::Array[Symbol]).void }
       def initialize(minimum, types: [])
         types << :named if types.empty?

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -6,8 +6,6 @@ require "cli/parser"
 require "cask/download"
 
 module Homebrew
-  extend T::Sig
-
   extend Fetch
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/--caskroom.rb
+++ b/Library/Homebrew/cmd/--caskroom.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -7,8 +7,6 @@ require "utils/shell"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.__prefix_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/cmd/--repository.rb
+++ b/Library/Homebrew/cmd/--repository.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/analytics.rb
+++ b/Library/Homebrew/cmd/analytics.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -5,8 +5,6 @@ require "cleanup"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/completions.rb
+++ b/Library/Homebrew/cmd/completions.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "completions"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -5,8 +5,6 @@ require "system_config"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -7,8 +7,6 @@ require "cask/caskroom"
 require "dependencies_helpers"
 
 module Homebrew
-  extend T::Sig
-
   extend DependenciesHelpers
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -7,8 +7,6 @@ require "description_cache_store"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/developer.rb
+++ b/Library/Homebrew/cmd/developer.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/docs.rb
+++ b/Library/Homebrew/cmd/docs.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -6,8 +6,6 @@ require "cli/parser"
 require "cask/caskroom"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.doctor_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -7,8 +7,6 @@ require "cli/parser"
 require "cask/download"
 
 module Homebrew
-  extend T::Sig
-
   extend Fetch
 
   FETCH_MAX_TRIES = 5

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -9,8 +9,6 @@ require "socket"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   extend Install
 
   module_function

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "formula"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -14,8 +14,6 @@ require "deprecate_disable"
 require "api"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   VALID_DAYS = %w[30 90 365].freeze

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -13,8 +13,6 @@ require "cli/parser"
 require "upgrade"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.install_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -5,8 +5,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -6,8 +6,6 @@ require "cli/parser"
 require "unlink"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -7,8 +7,6 @@ require "cli/parser"
 require "cask/list"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.log_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -5,8 +5,6 @@ require "migrator"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -7,8 +7,6 @@ require "diagnostic"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -5,8 +5,6 @@ require "formula"
 require "options"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -8,8 +8,6 @@ require "cask/caskroom"
 require "api"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.outdated_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -5,8 +5,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -6,8 +6,6 @@ require "formula_installer"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -6,8 +6,6 @@ require "cli/parser"
 require "env_config"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -15,8 +15,6 @@ require "upgrade"
 require "api"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.reinstall_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -8,8 +8,6 @@ require "cli/parser"
 require "search"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   PACKAGE_MANAGERS = {

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -13,8 +13,6 @@ require "cask/uninstall"
 require "uninstall"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/unlink.rb
+++ b/Library/Homebrew/cmd/unlink.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "unlink"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/unpin.rb
+++ b/Library/Homebrew/cmd/unpin.rb
@@ -5,8 +5,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -11,8 +11,6 @@ require "settings"
 require "linuxbrew-core-migration"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   def auto_update_header(args:)
@@ -607,8 +605,6 @@ class Reporter
 end
 
 class ReporterHub
-  extend T::Sig
-
   extend Forwardable
 
   attr_reader :reporters

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -11,8 +11,6 @@ require "cask/macos"
 require "api"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -12,8 +12,6 @@ require "dependencies_helpers"
 require "ostruct"
 
 module Homebrew
-  extend T::Sig
-
   extend DependenciesHelpers
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -100,7 +100,6 @@ end
 #
 # @api private
 class CompilerSelector
-  extend T::Sig
   include CompilerConstants
 
   Compiler = Struct.new(:type, :name, :version)

--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -10,8 +10,6 @@ module Homebrew
   #
   # @api private
   module Completions
-    extend T::Sig
-
     Variables = Struct.new(
       :aliases,
       :builtin_command_descriptions,

--- a/Library/Homebrew/cxxstdlib.rb
+++ b/Library/Homebrew/cxxstdlib.rb
@@ -5,8 +5,6 @@ require "compilers"
 
 # Combination of C++ standard library and compiler.
 class CxxStdlib
-  extend T::Sig
-
   def self.create(type, compiler)
     raise ArgumentError, "Invalid C++ stdlib type: #{type}" if type && [:libstdcxx, :libcxx].exclude?(type)
 

--- a/Library/Homebrew/debrew.rb
+++ b/Library/Homebrew/debrew.rb
@@ -28,8 +28,6 @@ module Debrew
 
   # Module for displaying a debugging menu.
   class Menu
-    extend T::Sig
-
     Entry = Struct.new(:name, :action)
 
     attr_accessor :prompt, :entries

--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -7,8 +7,6 @@ require "delegate"
 #
 # @api private
 class Dependencies < SimpleDelegator
-  extend T::Sig
-
   def initialize(*args)
     super(args)
   end
@@ -45,8 +43,6 @@ end
 #
 # @api private
 class Requirements < SimpleDelegator
-  extend T::Sig
-
   def initialize(*args)
     super(Set.new(args))
   end

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -7,8 +7,6 @@ require "dependable"
 #
 # @api private
 class Dependency
-  extend T::Sig
-
   extend Forwardable
   include Dependable
   extend Cachable
@@ -82,8 +80,6 @@ class Dependency
   end
 
   class << self
-    extend T::Sig
-
     # Expand the dependencies of each dependent recursively, optionally yielding
     # `[dependent, dep]` pairs to allow callers to apply arbitrary filters to
     # the list.

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -18,8 +18,6 @@ require "extend/cachable"
 # This class is used by `depends_on` in the formula DSL to turn dependency
 # specifications into the proper kinds of dependencies and requirements.
 class DependencyCollector
-  extend T::Sig
-
   extend Cachable
 
   attr_reader :deps, :requirements

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -20,8 +20,6 @@ require "formula_auditor"
 require "tap_auditor"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.audit_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -36,8 +36,6 @@ ALLOWABLE_HOMEBREW_REPOSITORY_LINKS = [
 ].freeze
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.bottle_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -7,8 +7,6 @@ require "cli/parser"
 require "utils/tar"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -7,8 +7,6 @@ require "utils/pypi"
 require "utils/tar"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -5,8 +5,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -10,8 +10,6 @@ require "tap"
 require "unversioned_cask_checker"
 
 module Homebrew
-  extend T::Sig
-
   extend SystemCommand::Mixin
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "livecheck/livecheck"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.cat_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/command.rb
+++ b/Library/Homebrew/dev-cmd/command.rb
@@ -5,8 +5,6 @@ require "commands"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "csv"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   PRIMARY_REPOS = %w[brew core cask].freeze

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -9,8 +9,6 @@ require "utils/pypi"
 require "cask/cask_loader"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/determine-test-runners.rb
+++ b/Library/Homebrew/dev-cmd/determine-test-runners.rb
@@ -6,8 +6,6 @@ require "test_runner_formula"
 require "github_runner_matrix"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(Homebrew::CLI::Parser) }
   def self.determine_test_runners_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "utils/github"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -5,8 +5,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -69,8 +69,6 @@ ensure
 end
 
 module Homebrew
-  extend T::Sig
-
   BOTTLE_BLOCK_REGEX = /  bottle (?:do.+?end|:[a-z]+)\n\n/m.freeze
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/formula.rb
+++ b/Library/Homebrew/dev-cmd/formula.rb
@@ -5,8 +5,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "cask/cask"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "formula"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/generate-man-completions.rb
+++ b/Library/Homebrew/dev-cmd/generate-man-completions.rb
@@ -6,8 +6,6 @@ require "completions"
 require "manpages"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -26,8 +26,6 @@ class Symbol
 end
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -6,8 +6,6 @@ require "linkage_checker"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -7,8 +7,6 @@ require "livecheck/livecheck"
 require "livecheck/strategy"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   WATCHLIST_PATH = File.expand_path(Homebrew::EnvConfig.livecheck_watchlist).freeze

--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "utils/github"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "utils/github"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -8,8 +8,6 @@ require "tmpdir"
 require "formula"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.pr_pull_args
     Homebrew::CLI::Parser.new do
@@ -530,8 +528,6 @@ module Homebrew
 end
 
 class GitHubArtifactDownloadStrategy < AbstractFileDownloadStrategy
-  extend T::Sig
-
   def fetch(timeout: nil)
     ohai "Downloading #{url}"
     if cached_location.exist?

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -6,8 +6,6 @@ require "github_packages"
 require "github_releases"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/release.rb
+++ b/Library/Homebrew/dev-cmd/release.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -6,8 +6,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/style.rb
+++ b/Library/Homebrew/dev-cmd/style.rb
@@ -7,8 +7,6 @@ require "style"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -5,8 +5,6 @@ require "tap"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.tap_new_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -7,8 +7,6 @@ require "timeout"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "fileutils"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.typecheck_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -7,8 +7,6 @@ require "api"
 require "os/mac/xcode"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/unpack.rb
+++ b/Library/Homebrew/dev-cmd/unpack.rb
@@ -6,8 +6,6 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.unpack_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/update-license-data.rb
+++ b/Library/Homebrew/dev-cmd/update-license-data.rb
@@ -6,7 +6,6 @@ require "utils/spdx"
 require "system_command"
 
 module Homebrew
-  extend T::Sig
   include SystemCommand::Mixin
 
   module_function

--- a/Library/Homebrew/dev-cmd/update-maintainers.rb
+++ b/Library/Homebrew/dev-cmd/update-maintainers.rb
@@ -8,8 +8,6 @@ require "manpages"
 require "active_support/core_ext/hash/slice"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "utils/pypi"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/dev-cmd/update-sponsors.rb
+++ b/Library/Homebrew/dev-cmd/update-sponsors.rb
@@ -5,8 +5,6 @@ require "cli/parser"
 require "utils/github"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   NAMED_MONTHLY_AMOUNT = 100

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -3,8 +3,6 @@
 
 require "cli/parser"
 module Homebrew
-  extend T::Sig
-
   sig { returns(CLI::Parser) }
   def self.update_test_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -4,8 +4,6 @@
 require "cli/parser"
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   sig { returns(CLI::Parser) }

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -6,8 +6,6 @@ require "version"
 # @private
 class DevelopmentTools
   class << self
-    extend T::Sig
-
     sig { params(tool: String).returns(T.nilable(Pathname)) }
     def locate(tool)
       # Don't call tools (cc, make, strip, etc.) directly!

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -48,8 +48,6 @@ module Homebrew
 
     # Diagnostic checks.
     class Checks
-      extend T::Sig
-
       def initialize(verbose: true)
         @verbose = verbose
       end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -27,8 +27,6 @@ using TimeRemaining
 #
 # @api private
 class AbstractDownloadStrategy
-  extend T::Sig
-
   extend Forwardable
   include FileUtils
   include Context
@@ -709,8 +707,6 @@ end
 #
 # @api public
 class SubversionDownloadStrategy < VCSDownloadStrategy
-  extend T::Sig
-
   def initialize(url, name, version, **meta)
     super
     @url = @url.sub("svn+http://", "")
@@ -1135,8 +1131,6 @@ end
 #
 # @api public
 class CVSDownloadStrategy < VCSDownloadStrategy
-  extend T::Sig
-
   def initialize(url, name, version, **meta)
     super
     @url = @url.sub(%r{^cvs://}, "")
@@ -1217,8 +1211,6 @@ end
 #
 # @api public
 class MercurialDownloadStrategy < VCSDownloadStrategy
-  extend T::Sig
-
   def initialize(url, name, version, **meta)
     super
     @url = @url.sub(%r{^hg://}, "")
@@ -1281,8 +1273,6 @@ end
 #
 # @api public
 class BazaarDownloadStrategy < VCSDownloadStrategy
-  extend T::Sig
-
   def initialize(url, name, version, **meta)
     super
     @url.sub!(%r{^bzr://}, "")
@@ -1346,8 +1336,6 @@ end
 #
 # @api public
 class FossilDownloadStrategy < VCSDownloadStrategy
-  extend T::Sig
-
   def initialize(url, name, version, **meta)
     super
     @url = @url.sub(%r{^fossil://}, "")

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -8,8 +8,6 @@ module Homebrew
   #
   # @api private
   module EnvConfig
-    extend T::Sig
-
     module_function
 
     ENVS = {

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -6,8 +6,6 @@ require "utils"
 
 # Raised when a command is used wrong.
 class UsageError < RuntimeError
-  extend T::Sig
-
   attr_reader :reason
 
   def initialize(reason = nil)
@@ -83,8 +81,6 @@ end
 
 # Raised when neither a formula nor a cask with the given name is available.
 class FormulaOrCaskUnavailableError < RuntimeError
-  extend T::Sig
-
   attr_reader :name
 
   def initialize(name)
@@ -111,8 +107,6 @@ end
 
 # Raised when a formula or cask in a specific tap is not available.
 class TapFormulaOrCaskUnavailableError < FormulaOrCaskUnavailableError
-  extend T::Sig
-
   attr_reader :tap
 
   def initialize(tap, name)
@@ -130,8 +124,6 @@ end
 
 # Raised when a formula is not available.
 class FormulaUnavailableError < FormulaOrCaskUnavailableError
-  extend T::Sig
-
   attr_accessor :dependent
 
   sig { returns(T.nilable(String)) }
@@ -149,8 +141,6 @@ end
 #
 # @api private
 module FormulaClassUnavailableErrorModule
-  extend T::Sig
-
   attr_reader :path, :class_name, :class_list
 
   def to_s
@@ -195,8 +185,6 @@ end
 #
 # @api private
 module FormulaUnreadableErrorModule
-  extend T::Sig
-
   attr_reader :formula_error
 
   sig { returns(String) }
@@ -404,8 +392,6 @@ end
 
 # Raised when a formula conflicts with another one.
 class FormulaConflictError < RuntimeError
-  extend T::Sig
-
   attr_reader :formula, :conflicts
 
   def initialize(formula, conflicts)
@@ -466,8 +452,6 @@ end
 
 # Raised when an error occurs during a formula build.
 class BuildError < RuntimeError
-  extend T::Sig
-
   attr_reader :cmd, :args, :env
   attr_accessor :formula, :options
 
@@ -651,8 +635,6 @@ end
 
 # Raised by {Kernel#safe_system} in `utils.rb`.
 class ErrorDuringExecution < RuntimeError
-  extend T::Sig
-
   attr_reader :cmd, :status, :output
 
   def initialize(cmd, status:, output: nil, secrets: [])

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -8,8 +8,6 @@ require "extend/ENV/std"
 require "extend/ENV/super"
 
 module Kernel
-  extend T::Sig
-
   sig { params(env: T.nilable(String)).returns(T::Boolean) }
   def superenv?(env)
     return false if env == "std"
@@ -24,8 +22,6 @@ end
 #  # @see https://rubydoc.info/stdlib/core/ENV ENV core documentation
 #  class ENV; end
 module EnvActivation
-  extend T::Sig
-
   sig { params(env: T.nilable(String)).void }
   def activate_extensions!(env: nil)
     if superenv?(env)

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -11,8 +11,6 @@ require "development_tools"
 # @see Stdenv
 # @see https://www.rubydoc.info/stdlib/Env Ruby's ENV API
 module SharedEnvExtension
-  extend T::Sig
-
   include CompilerConstants
 
   CC_FLAG_VARS = %w[CFLAGS CXXFLAGS OBJCFLAGS OBJCXXFLAGS].freeze

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -6,8 +6,6 @@ require "extend/ENV/shared"
 
 # @api private
 module Stdenv
-  extend T::Sig
-
   include SharedEnvExtension
 
   # @private

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -15,8 +15,6 @@ require "development_tools"
 # 7. Simpler formulae that *just work*
 # 8. Build-system agnostic configuration of the toolchain
 module Superenv
-  extend T::Sig
-
   include SharedEnvExtension
 
   # @private

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -4,8 +4,6 @@
 # Contains shorthand Homebrew utility methods like `ohai`, `opoo`, `odisabled`.
 # TODO: move these out of `Kernel`.
 module Kernel
-  extend T::Sig
-
   def require?(path)
     return false if path.nil?
 

--- a/Library/Homebrew/extend/module.rb
+++ b/Library/Homebrew/extend/module.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 class Module
+  include T::Sig
+
   def attr_rw(*attrs)
     attrs.each do |attr|
       module_eval <<-EOS, __FILE__, __LINE__+1

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -4,8 +4,6 @@
 require "simulate_system"
 
 module OnSystem
-  extend T::Sig
-
   ARCH_OPTIONS = [:intel, :arm].freeze
   BASE_OS_OPTIONS = [:macos, :linux].freeze
 
@@ -139,8 +137,6 @@ module OnSystem
   end
 
   module MacOSAndLinux
-    extend T::Sig
-
     sig { params(base: Class).void }
     def self.included(base)
       OnSystem.setup_arch_methods(base)
@@ -150,8 +146,6 @@ module OnSystem
   end
 
   module MacOSOnly
-    extend T::Sig
-
     sig { params(base: Class).void }
     def self.included(base)
       OnSystem.setup_arch_methods(base)

--- a/Library/Homebrew/extend/os/linux/cleaner.rb
+++ b/Library/Homebrew/extend/os/linux/cleaner.rb
@@ -4,7 +4,6 @@
 class Cleaner
   private
 
-  extend T::Sig
   sig { params(path: Pathname).returns(T.nilable(T::Boolean)) }
   def executable_path?(path)
     path.elf? || path.text_executable?

--- a/Library/Homebrew/extend/os/linux/cmd/update-report.rb
+++ b/Library/Homebrew/extend/os/linux/cmd/update-report.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 module Homebrew
-  extend T::Sig
-
   module_function
 
   def no_changes_message

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -4,8 +4,6 @@
 require "os/linux/glibc"
 
 class DependencyCollector
-  extend T::Sig
-
   undef gcc_dep_if_needed
   undef glibc_dep_if_needed
   undef init_global_dep_tree_if_needed!

--- a/Library/Homebrew/extend/os/linux/dev-cmd/update-test.rb
+++ b/Library/Homebrew/extend/os/linux/dev-cmd/update-test.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 module Homebrew
-  extend T::Sig
-
   class << self
     alias generic_git_tags git_tags
 

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -3,8 +3,6 @@
 
 class DevelopmentTools
   class << self
-    extend T::Sig
-
     sig { params(tool: String).returns(T.nilable(Pathname)) }
     def locate(tool)
       (@locate ||= {}).fetch(tool) do |key|

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 module Superenv
-  extend T::Sig
-
   # The location of Homebrew's shims on Linux.
   def self.shims_path
     HOMEBREW_SHIMS_PATH/"linux/super"

--- a/Library/Homebrew/extend/os/linux/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/linux/formula_cellar_checks.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 module FormulaCellarChecks
-  extend T::Sig
   sig { params(filename: Pathname).returns(T::Boolean) }
   def valid_library_extension?(filename)
     generic_valid_library_extension?(filename) || filename.basename.to_s.include?(".so.")

--- a/Library/Homebrew/extend/os/linux/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/extend/os/linux/requirements/xcode_requirement.rb
@@ -4,8 +4,6 @@
 require "requirement"
 
 class XcodeRequirement < Requirement
-  extend T::Sig
-
   sig { returns(T::Boolean) }
   def xcode_installed_version
     true

--- a/Library/Homebrew/extend/os/linux/software_spec.rb
+++ b/Library/Homebrew/extend/os/linux/software_spec.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 class BottleSpecification
-  extend T::Sig
-
   sig { params(tag: Utils::Bottles::Tag).returns(T::Boolean) }
   def skip_relocation?(tag: Utils::Bottles.tag)
     false

--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -6,8 +6,6 @@ require "os/mac/xcode"
 # @private
 class DevelopmentTools
   class << self
-    extend T::Sig
-
     alias generic_locate locate
     undef installed?, default_compiler, curl_handles_most_https_certificates?,
           subversion_handles_most_https_certificates?

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 module SharedEnvExtension
-  extend T::Sig
-
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false,
                               debug_symbols: false)
     generic_shared_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle,

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 module Superenv
-  extend T::Sig
-
   class << self
     # The location of Homebrew's shims on macOS.
     def shims_path

--- a/Library/Homebrew/extend/os/mac/formula_support.rb
+++ b/Library/Homebrew/extend/os/mac/formula_support.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 class KegOnlyReason
-  extend T::Sig
   sig { returns(T::Boolean) }
   def applicable?
     true

--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 module Hardware
-  extend T::Sig
   sig { params(version: T.nilable(Version)).returns(Symbol) }
   def self.oldest_cpu(version = nil)
     version = if version

--- a/Library/Homebrew/extend/os/mac/missing_formula.rb
+++ b/Library/Homebrew/extend/os/mac/missing_formula.rb
@@ -7,9 +7,7 @@ require "cask/caskroom"
 
 module Homebrew
   module MissingFormula
-    extend T::Sig
     class << self
-      extend T::Sig
       sig { params(name: String).returns(T.nilable(String)) }
       def disallowed_reason(name)
         case name.downcase

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -6,8 +6,6 @@ require "system_command"
 module UnpackStrategy
   class Zip
     module MacOSZipExtension
-      extend T::Sig
-
       include UnpackStrategy
       include SystemCommand::Mixin
 

--- a/Library/Homebrew/extend/os/mac/utils/analytics.rb
+++ b/Library/Homebrew/extend/os/mac/utils/analytics.rb
@@ -4,8 +4,6 @@
 module Utils
   module Analytics
     class << self
-      extend T::Sig
-
       sig { returns(String) }
       def custom_prefix_label_google
         return generic_custom_prefix_label_google if Hardware::CPU.arm?

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -6,8 +6,6 @@ require "resource"
 require "metafiles"
 
 module DiskUsageExtension
-  extend T::Sig
-
   sig { returns(Integer) }
   def disk_usage
     return @disk_usage if defined?(@disk_usage)
@@ -78,8 +76,6 @@ end
 # Homebrew extends Ruby's `Pathname` to make our code more readable.
 # @see https://ruby-doc.org/stdlib-2.6.3/libdoc/pathname/rdoc/Pathname.html Ruby's Pathname API
 class Pathname
-  extend T::Sig
-
   include DiskUsageExtension
 
   # Moves a file from the original location to the {Pathname}'s.
@@ -498,11 +494,7 @@ require "extend/os/pathname"
 
 # @private
 module ObserverPathnameExtension
-  extend T::Sig
-
   class << self
-    extend T::Sig
-
     include Context
 
     sig { returns(Integer) }

--- a/Library/Homebrew/fetch.rb
+++ b/Library/Homebrew/fetch.rb
@@ -4,8 +4,6 @@
 module Homebrew
   # @api private
   module Fetch
-    extend T::Sig
-
     sig { params(formula: Formula, args: CLI::Args).returns(T::Boolean) }
     def fetch_bottle?(formula, args:)
       bottle = formula.bottle

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -58,8 +58,6 @@ require "extend/api_hashable"
 #   end
 # end</pre>
 class Formula
-  extend T::Sig
-
   include FileUtils
   include Utils::Inreplace
   include Utils::Shebang
@@ -2726,7 +2724,7 @@ class Formula
   # The methods below define the formula DSL.
   class << self
     extend Predicable
-    extend T::Sig
+
     include BuildEnvironment::DSL
     include OnSystem::MacOSAndLinux
 

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -7,7 +7,6 @@ require "utils/shell"
 #
 # @api private
 module FormulaCellarChecks
-  extend T::Sig
   extend T::Helpers
 
   abstract!

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -9,8 +9,6 @@ module Homebrew
   #
   # @api private
   class FormulaCreator
-    extend T::Sig
-
     attr_reader :args, :url, :sha256, :desc, :homepage
     attr_accessor :name, :version, :tap, :path, :mode, :license
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -27,8 +27,6 @@ require "service"
 #
 # @api private
 class FormulaInstaller
-  extend T::Sig
-
   include FormulaCellarChecks
   extend Predicable
 

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -7,8 +7,6 @@ FormulaConflict = Struct.new(:name, :reason)
 # Used to annotate formulae that duplicate macOS-provided software
 # or cause conflicts when linked in.
 class KegOnlyReason
-  extend T::Sig
-
   attr_reader :reason
 
   def initialize(reason, explanation)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -14,8 +14,6 @@ require "active_support/core_ext/hash/deep_transform_values"
 #
 # @api private
 module Formulary
-  extend T::Sig
-
   extend Cachable
 
   URL_START_REGEX = %r{(https?|ftp|file)://}.freeze
@@ -486,8 +484,6 @@ module Formulary
 
   # Loads formulae from URLs.
   class FromUrlLoader < FormulaLoader
-    extend T::Sig
-
     attr_reader :url
 
     sig { params(url: T.any(URI::Generic, String), from: T.nilable(Symbol)).void }

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -8,8 +8,6 @@ require "utils/popen"
 # @see Utils::Git
 # @api private
 class GitRepository
-  extend T::Sig
-
   sig { returns(Pathname) }
   attr_reader :pathname
 

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -9,8 +9,6 @@ require "zlib"
 #
 # @api private
 class GitHubPackages
-  extend T::Sig
-
   include Context
 
   URL_DOMAIN = "ghcr.io"

--- a/Library/Homebrew/github_releases.rb
+++ b/Library/Homebrew/github_releases.rb
@@ -8,8 +8,6 @@ require "json"
 #
 # @api private
 class GitHubReleases
-  extend T::Sig
-
   include Context
   include Utils::Curl
 

--- a/Library/Homebrew/github_runner.rb
+++ b/Library/Homebrew/github_runner.rb
@@ -5,8 +5,6 @@ require "linux_runner_spec"
 require "macos_runner_spec"
 
 class GitHubRunner < T::Struct
-  extend T::Sig
-
   const :platform, Symbol
   const :arch, Symbol
   const :spec, T.any(LinuxRunnerSpec, MacOSRunnerSpec)

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -5,8 +5,6 @@ require "test_runner_formula"
 require "github_runner"
 
 class GitHubRunnerMatrix
-  extend T::Sig
-
   # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
   # rubocop:disable Style/MutableConstant
   MaybeStringArray = T.type_alias { T.nilable(T::Array[String]) }

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -72,6 +72,7 @@ HOMEBREW_PULL_OR_COMMIT_URL_REGEX =
   %r[https://github\.com/([\w-]+)/([\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})].freeze
 HOMEBREW_BOTTLES_EXTNAME_REGEX = /\.([a-z0-9_]+)\.bottle\.(?:(\d+)\.)?tar\.gz$/.freeze
 
+require "extend/module"
 require "env_config"
 require "macos_versions"
 require "os"
@@ -134,7 +135,6 @@ require "extend/array"
 require "git_repository"
 require "extend/pathname"
 require "extend/predicable"
-require "extend/module"
 require "cli/args"
 
 require "PATH"

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -24,8 +24,6 @@ module Hardware
     INTEL_64BIT_OLDEST_CPU = :core2
 
     class << self
-      extend T::Sig
-
       def optimization_flags
         @optimization_flags ||= {
           native:             arch_flag("native"),

--- a/Library/Homebrew/installed_dependents.rb
+++ b/Library/Homebrew/installed_dependents.rb
@@ -7,8 +7,6 @@ require "cask_dependent"
 #
 # @api private
 module InstalledDependents
-  extend T::Sig
-
   module_function
 
   # Given an array of kegs, this method will try to find some other kegs

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -10,8 +10,6 @@ require "extend/cachable"
 #
 # @api private
 class Keg
-  extend T::Sig
-
   extend Cachable
 
   # Error for when a keg is already linked.
@@ -40,8 +38,6 @@ class Keg
 
   # Error for when a file already exists or belongs to another keg.
   class ConflictError < LinkError
-    extend T::Sig
-
     sig { returns(String) }
     def suggestion
       conflict = Keg.for(dst)
@@ -72,8 +68,6 @@ class Keg
 
   # Error for when a directory is not writable.
   class DirectoryNotWritableError < LinkError
-    extend T::Sig
-
     sig { returns(String) }
     def to_s
       <<~EOS

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -12,8 +12,6 @@ class Keg
   NULL_BYTE_STRING = "\\x00"
 
   class Relocation
-    extend T::Sig
-
     RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))/.freeze
 
     def initialize

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -6,8 +6,6 @@ module Language
   #
   # @api public
   module Java
-    extend T::Sig
-
     sig { params(version: T.nilable(String)).returns(T.nilable(Formula)) }
     def self.find_openjdk_formula(version = nil)
       can_be_newer = version&.end_with?("+")

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -6,8 +6,6 @@ module Language
   #
   # @api public
   module Node
-    extend T::Sig
-
     sig { returns(String) }
     def self.npm_cache_config
       "cache=#{HOMEBREW_CACHE}/npm_cache"

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -124,8 +124,6 @@ module Language
 
     # Mixin module for {Formula} adding virtualenv support features.
     module Virtualenv
-      extend T::Sig
-
       # Instantiates, creates, and yields a {Virtualenv} object for use from
       # {Formula#install}, which provides helper methods for instantiating and
       # installing packages into a Python virtualenv.

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -10,8 +10,6 @@ require "fiddle"
 #
 # @api private
 class LinkageChecker
-  extend T::Sig
-
   attr_reader :undeclared_deps, :keg, :formula, :store
 
   def initialize(keg, formula = nil, cache_db:, rebuild_cache: false)

--- a/Library/Homebrew/linux_runner_spec.rb
+++ b/Library/Homebrew/linux_runner_spec.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 class LinuxRunnerSpec < T::Struct
-  extend T::Sig
-
   const :name, String
   const :runner, String
   const :container, T::Hash[Symbol, String]

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -17,8 +17,6 @@ module Homebrew
   #
   # @api private
   module Livecheck
-    extend T::Sig
-
     module_function
 
     GITEA_INSTANCES = %w[

--- a/Library/Homebrew/livecheck/livecheck_version.rb
+++ b/Library/Homebrew/livecheck/livecheck_version.rb
@@ -7,8 +7,6 @@ module Homebrew
     #
     # @api private
     class LivecheckVersion
-      extend T::Sig
-
       include Comparable
 
       sig {

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -10,8 +10,6 @@ module Homebrew
     #
     # @api private
     module SkipConditions
-      extend T::Sig
-
       module_function
 
       sig {

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -10,8 +10,6 @@ module Homebrew
     #
     # @api private
     module Strategy
-      extend T::Sig
-
       module_function
 
       # {Strategy} priorities informally range from 1 to 10, where 10 is the

--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -26,8 +26,6 @@ module Homebrew
       #
       # @api public
       class Apache
-        extend T::Sig
-
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
           ^https?://

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -28,8 +28,6 @@ module Homebrew
       #
       # @api public
       class Bitbucket
-        extend T::Sig
-
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
           ^https?://bitbucket\.org

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -18,8 +18,6 @@ module Homebrew
       #
       # @api public
       class Cpan
-        extend T::Sig
-
         NICE_NAME = "CPAN"
 
         # The `Regexp` used to determine if the strategy applies to the URL.

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -12,8 +12,6 @@ module Homebrew
       #
       # @api private
       class ElectronBuilder
-        extend T::Sig
-
         NICE_NAME = "electron-builder"
 
         # A priority of zero causes livecheck to skip the strategy. We do this

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -19,8 +19,6 @@ module Homebrew
       #
       # @api private
       class ExtractPlist
-        extend T::Sig
-
         # A priority of zero causes livecheck to skip the strategy. We do this
         # for {ExtractPlist} so we can selectively apply it when appropriate.
         PRIORITY = 0
@@ -43,8 +41,6 @@ module Homebrew
           :bundle_version,
           keyword_init: true,
         ) do
-          extend T::Sig
-
           extend Forwardable
 
           # @api public

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -24,8 +24,6 @@ module Homebrew
       #
       # @api public
       class Git
-        extend T::Sig
-
         # The priority of the strategy on an informal scale of 1 to 10 (from
         # lowest to highest).
         PRIORITY = 8

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -32,8 +32,6 @@ module Homebrew
       #
       # @api public
       class GithubLatest
-        extend T::Sig
-
         NICE_NAME = "GitHub - Latest"
 
         # A priority of zero causes livecheck to skip the strategy. We do this

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -25,8 +25,6 @@ module Homebrew
       #
       # @api public
       class Gnome
-        extend T::Sig
-
         NICE_NAME = "GNOME"
 
         # The `Regexp` used to determine if the strategy applies to the URL.

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -29,8 +29,6 @@ module Homebrew
       #
       # @api public
       class Gnu
-        extend T::Sig
-
         NICE_NAME = "GNU"
 
         # The `Regexp` used to determine if the strategy applies to the URL.

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -17,8 +17,6 @@ module Homebrew
       #
       # @api public
       class Hackage
-        extend T::Sig
-
         # A `Regexp` used in determining if the strategy applies to the URL and
         # also as part of extracting the package name from the URL basename.
         PACKAGE_NAME_REGEX = /(?<package_name>.+?)-\d+/i.freeze

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -12,8 +12,6 @@ module Homebrew
       #
       # @api private
       class HeaderMatch
-        extend T::Sig
-
         NICE_NAME = "Header match"
 
         # A priority of zero causes livecheck to skip the strategy. We do this

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -23,8 +23,6 @@ module Homebrew
       #
       # @api public
       class Json
-        extend T::Sig
-
         NICE_NAME = "JSON"
 
         # A priority of zero causes livecheck to skip the strategy. We do this

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -23,8 +23,6 @@ module Homebrew
       #
       # @api public
       class Launchpad
-        extend T::Sig
-
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
           ^https?://(?:[^/]+?\.)*launchpad\.net

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -17,8 +17,6 @@ module Homebrew
       #
       # @api public
       class Npm
-        extend T::Sig
-
         NICE_NAME = "npm"
 
         # The `Regexp` used to determine if the strategy applies to the URL.

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -16,8 +16,6 @@ module Homebrew
       #
       # @api public
       class PageMatch
-        extend T::Sig
-
         NICE_NAME = "Page match"
 
         # A priority of zero causes livecheck to skip the strategy. We do this

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -17,8 +17,6 @@ module Homebrew
       #
       # @api public
       class Pypi
-        extend T::Sig
-
         NICE_NAME = "PyPI"
 
         # The `Regexp` used to extract the package name and suffix (e.g., file

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -31,8 +31,6 @@ module Homebrew
       #
       # @api public
       class Sourceforge
-        extend T::Sig
-
         NICE_NAME = "SourceForge"
 
         # The `Regexp` used to determine if the strategy applies to the URL.

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -14,8 +14,6 @@ module Homebrew
       #
       # @api private
       class Sparkle
-        extend T::Sig
-
         # A priority of zero causes livecheck to skip the strategy. We do this
         # for {Sparkle} so we can selectively apply it when appropriate.
         PRIORITY = 0
@@ -46,8 +44,6 @@ module Homebrew
           :bundle_version,
           keyword_init: true,
         ) do
-          extend T::Sig
-
           extend Forwardable
 
           # @api public

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -27,8 +27,6 @@ module Homebrew
       #
       # @api public
       class Xml
-        extend T::Sig
-
         NICE_NAME = "XML"
 
         # A priority of zero causes livecheck to skip the strategy. We do this

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -38,8 +38,6 @@ module Homebrew
       #
       # @api public
       class Xorg
-        extend T::Sig
-
         NICE_NAME = "X.Org"
 
         # A `Regexp` used in determining if the strategy applies to the URL and

--- a/Library/Homebrew/livecheck/strategy/yaml.rb
+++ b/Library/Homebrew/livecheck/strategy/yaml.rb
@@ -23,8 +23,6 @@ module Homebrew
       #
       # @api public
       class Yaml
-        extend T::Sig
-
         NICE_NAME = "YAML"
 
         # A priority of zero causes livecheck to skip the strategy. We do this

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -7,8 +7,6 @@
 #
 # @api private
 class Locale
-  extend T::Sig
-
   # Error when a string cannot be parsed to a `Locale`.
   class ParserError < StandardError
   end

--- a/Library/Homebrew/macos_runner_spec.rb
+++ b/Library/Homebrew/macos_runner_spec.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 class MacOSRunnerSpec < T::Struct
-  extend T::Sig
-
   const :name, String
   const :runner, String
   const :cleanup, T::Boolean

--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -12,8 +12,6 @@ module Homebrew
   #
   # @api private
   module Manpages
-    extend T::Sig
-
     Variables = Struct.new(
       :alumni,
       :commands,

--- a/Library/Homebrew/messages.rb
+++ b/Library/Homebrew/messages.rb
@@ -4,8 +4,6 @@
 # A {Messages} object collects messages that may need to be displayed together
 # at the end of a multi-step `brew` command run.
 class Messages
-  extend T::Sig
-
   attr_reader :caveats, :package_count, :install_times
 
   sig { void }

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -9,8 +9,6 @@ require "tab"
 #
 # @api private
 class Migrator
-  extend T::Sig
-
   include Context
 
   # Error for when a migration is necessary.

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -4,8 +4,6 @@
 # Performs {Formula#mktemp}'s functionality, and tracks the results.
 # Each instance is only intended to be used once.
 class Mktemp
-  extend T::Sig
-
   include FileUtils
 
   # Path to the tmpdir used in this run, as a {Pathname}.

--- a/Library/Homebrew/options.rb
+++ b/Library/Homebrew/options.rb
@@ -5,8 +5,6 @@
 #
 # @api private
 class Option
-  extend T::Sig
-
   attr_reader :name, :description, :flag
 
   def initialize(name, description = "")
@@ -44,8 +42,6 @@ end
 #
 # @api private
 class DeprecatedOption
-  extend T::Sig
-
   attr_reader :old, :current
 
   def initialize(old, current)
@@ -73,8 +69,6 @@ end
 #
 # @api private
 class Options
-  extend T::Sig
-
   include Enumerable
 
   def self.create(array)

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -7,8 +7,6 @@ require "version"
 #
 # @api private
 module OS
-  extend T::Sig
-
   # Check if the operating system is macOS.
   #
   # @api public

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -6,8 +6,6 @@ require "utils"
 module OS
   # Helper module for querying system information on Linux.
   module Linux
-    extend T::Sig
-
     sig { returns(String) }
     def self.os_version
       if which("lsb_release")

--- a/Library/Homebrew/os/linux/glibc.rb
+++ b/Library/Homebrew/os/linux/glibc.rb
@@ -7,8 +7,6 @@ module OS
     #
     # @api private
     module Glibc
-      extend T::Sig
-
       module_function
 
       sig { returns(Version) }

--- a/Library/Homebrew/os/linux/kernel.rb
+++ b/Library/Homebrew/os/linux/kernel.rb
@@ -7,8 +7,6 @@ module OS
     #
     # @api private
     module Kernel
-      extend T::Sig
-
       module_function
 
       sig { returns(Version) }

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -9,8 +9,6 @@ require "os/mac/keg"
 module OS
   # Helper module for querying system information on macOS.
   module Mac
-    extend T::Sig
-
     ::MacOS = OS::Mac
 
     raise "Loaded OS::Mac on generic OS!" if ENV["HOMEBREW_TEST_GENERIC_OS"]

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -9,8 +9,6 @@ module OS
     #
     # @api private
     class SDK
-      extend T::Sig
-
       # 11.x SDKs are explicitly excluded - we want the MacOSX11.sdk symlink instead.
       VERSIONED_SDK_REGEX = /MacOSX(10\.\d+|\d+)\.sdk$/.freeze
 
@@ -35,7 +33,6 @@ module OS
     #
     # @api private
     class BaseSDKLocator
-      extend T::Sig
       extend T::Helpers
 
       abstract!
@@ -146,8 +143,6 @@ module OS
     #
     # @api private
     class XcodeSDKLocator < BaseSDKLocator
-      extend T::Sig
-
       sig { override.returns(Symbol) }
       def source
         :xcode
@@ -173,8 +168,6 @@ module OS
     #
     # @api private
     class CLTSDKLocator < BaseSDKLocator
-      extend T::Sig
-
       sig { override.returns(Symbol) }
       def source
         :clt

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -11,8 +11,6 @@ module OS
     #
     # @api private
     class Version < ::Version
-      extend T::Sig
-
       sig { params(version: Symbol).returns(T.attached_class) }
       def self.from_symbol(version)
         str = MacOSVersions::SYMBOLS.fetch(version) { raise MacOSVersionError, version }

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -7,8 +7,6 @@ module OS
     #
     # @api private
     module Xcode
-      extend T::Sig
-
       DEFAULT_BUNDLE_PATH = Pathname("/Applications/Xcode.app").freeze
       BUNDLE_ID = "com.apple.dt.Xcode"
       OLD_BUNDLE_ID = "com.apple.Xcode"
@@ -259,8 +257,6 @@ module OS
     #
     # @api private
     module CLT
-      extend T::Sig
-
       # The original Mavericks CLT package ID
       EXECUTABLE_PKG_ID = "com.apple.pkg.CLTools_Executables"
       MAVERICKS_NEW_PKG_ID = "com.apple.pkg.CLTools_Base" # obsolete

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -35,8 +35,6 @@ end
 #
 # @api private
 class EmbeddedPatch
-  extend T::Sig
-
   attr_writer :owner
   attr_reader :strip
 
@@ -67,8 +65,6 @@ end
 #
 # @api private
 class DATAPatch < EmbeddedPatch
-  extend T::Sig
-
   attr_accessor :path
 
   def initialize(strip)
@@ -110,8 +106,6 @@ end
 #
 # @api private
 class ExternalPatch
-  extend T::Sig
-
   extend Forwardable
 
   attr_reader :resource, :strip

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -12,8 +12,6 @@ require "build_environment"
 #
 # @api private
 class Requirement
-  extend T::Sig
-
   include Dependable
   extend Cachable
 
@@ -164,8 +162,6 @@ class Requirement
   end
 
   class << self
-    extend T::Sig
-
     include BuildEnvironment::DSL
 
     attr_reader :env_proc, :build

--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -7,8 +7,6 @@ require "requirement"
 #
 # @api private
 class ArchRequirement < Requirement
-  extend T::Sig
-
   fatal true
 
   attr_reader :arch

--- a/Library/Homebrew/requirements/codesign_requirement.rb
+++ b/Library/Homebrew/requirements/codesign_requirement.rb
@@ -5,8 +5,6 @@
 #
 # @api private
 class CodesignRequirement < Requirement
-  extend T::Sig
-
   fatal true
 
   def initialize(tags)

--- a/Library/Homebrew/requirements/linux_requirement.rb
+++ b/Library/Homebrew/requirements/linux_requirement.rb
@@ -5,8 +5,6 @@
 #
 # @api private
 class LinuxRequirement < Requirement
-  extend T::Sig
-
   fatal true
 
   satisfy(build_env: false) { OS.linux? }

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -7,8 +7,6 @@ require "requirement"
 #
 # @api private
 class MacOSRequirement < Requirement
-  extend T::Sig
-
   fatal true
 
   attr_reader :comparator, :version

--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -7,8 +7,6 @@ require "requirement"
 #
 # @api private
 class XcodeRequirement < Requirement
-  extend T::Sig
-
   fatal true
 
   attr_reader :version

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -14,8 +14,6 @@ require "extend/on_system"
 #
 # @api private
 class Resource
-  extend T::Sig
-
   include Context
   include FileUtils
   include OnSystem::MacOSAndLinux
@@ -343,8 +341,6 @@ end
 #
 # @api private
 class ResourceStageContext
-  extend T::Sig
-
   extend Forwardable
 
   # The {Resource} that is being staged.

--- a/Library/Homebrew/rubocops.rb
+++ b/Library/Homebrew/rubocops.rb
@@ -2,5 +2,6 @@
 # frozen_string_literal: true
 
 require_relative "standalone"
+require_relative "extend/module"
 
 require "rubocops/all"

--- a/Library/Homebrew/rubocops/cask/ast/cask_header.rb
+++ b/Library/Homebrew/rubocops/cask/ast/cask_header.rb
@@ -7,8 +7,6 @@ module RuboCop
       # This class wraps the AST method node that represents the cask header. It
       # includes various helper methods to aid cops in their analysis.
       class CaskHeader
-        extend T::Sig
-
         def initialize(method_node)
           @method_node = method_node
         end

--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
@@ -7,7 +7,7 @@ module RuboCop
       # Common functionality for cops checking casks.
       module CaskHelp
         extend T::Helpers
-        extend T::Sig
+
         abstract!
 
         sig { abstract.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }

--- a/Library/Homebrew/rubocops/cask/no_dsl_version.rb
+++ b/Library/Homebrew/rubocops/cask/no_dsl_version.rb
@@ -19,8 +19,6 @@ module RuboCop
       #     ...
       #   end
       class NoDslVersion < Base
-        extend T::Sig
-
         extend Forwardable
         extend AutoCorrector
         include CaskHelp

--- a/Library/Homebrew/rubocops/cask/no_overrides.rb
+++ b/Library/Homebrew/rubocops/cask/no_overrides.rb
@@ -5,7 +5,6 @@ module RuboCop
   module Cop
     module Cask
       class NoOverrides < Base
-        extend T::Sig
         include CaskHelp
 
         ON_SYSTEM_METHODS = RuboCop::Cask::Constants::ON_SYSTEM_METHODS

--- a/Library/Homebrew/rubocops/dependency_order.rb
+++ b/Library/Homebrew/rubocops/dependency_order.rb
@@ -11,7 +11,6 @@ module RuboCop
       # precedence order:
       # build-time > test > normal > recommended > optional
       class DependencyOrder < FormulaCop
-        extend T::Sig
         extend AutoCorrector
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)

--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -9,7 +9,6 @@ module RuboCop
     #
     # @api private
     class FormulaCop < Base
-      extend T::Sig
       extend T::Helpers
       include RangeHelp
       include HelperFunctions

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -9,7 +9,6 @@ module RuboCop
       # This cop audits `patch`es in formulae.
       # TODO: Many of these could be auto-corrected.
       class Patches < FormulaCop
-        extend T::Sig
         extend AutoCorrector
 
         def audit_formula(node, _class_node, _parent_class_node, body)

--- a/Library/Homebrew/rubocops/shared/helper_functions.rb
+++ b/Library/Homebrew/rubocops/shared/helper_functions.rb
@@ -14,7 +14,6 @@ module RuboCop
     #
     # @api private
     module HelperFunctions
-      extend T::Sig
       include RangeHelp
 
       # Checks for regex match of pattern in the node and

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -261,8 +261,6 @@ module RuboCop
       #
       # @api private
       class PyPiUrls < FormulaCop
-        extend T::Sig
-
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           return if body_node.nil?
 

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -10,8 +10,6 @@ require "tempfile"
 #
 # @api private
 class Sandbox
-  extend T::Sig
-
   SANDBOX_EXEC = "/usr/bin/sandbox-exec"
   private_constant :SANDBOX_EXEC
 
@@ -210,8 +208,6 @@ class Sandbox
 
   # Configuration profile for a sandbox.
   class SandboxProfile
-    extend T::Sig
-
     SEATBELT_ERB = <<~ERB
       (version 1)
       (debug deny) ; log all denied operations to /var/log/system.log

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -8,7 +8,6 @@ module Homebrew
   # `service` block and stores related instance variables. Most of these methods
   # also return the related instance variable when no argument is provided.
   class Service
-    extend T::Sig
     extend Forwardable
     include OnSystem::MacOSAndLinux
 

--- a/Library/Homebrew/simulate_system.rb
+++ b/Library/Homebrew/simulate_system.rb
@@ -7,8 +7,6 @@ module Homebrew
   # @api private
   class SimulateSystem
     class << self
-      extend T::Sig
-
       attr_reader :arch, :os
 
       sig { params(new_os: Symbol).void }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -15,8 +15,6 @@ require "os/mac/version"
 require "extend/on_system"
 
 class SoftwareSpec
-  extend T::Sig
-
   extend Forwardable
   include OnSystem::MacOSAndLinux
 
@@ -293,8 +291,6 @@ end
 
 class Bottle
   class Filename
-    extend T::Sig
-
     attr_reader :name, :version, :tag, :rebuild
 
     def self.create(formula, tag, rebuild)
@@ -509,8 +505,6 @@ end
 
 class BottleSpecification
   RELOCATABLE_CELLARS = [:any, :any_skip_relocation].freeze
-
-  extend T::Sig
 
   attr_rw :rebuild
   attr_accessor :tap

--- a/Library/Homebrew/sorbet/parlour.rb
+++ b/Library/Homebrew/sorbet/parlour.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require_relative "../extend/module"
 require_relative "../warnings"
 Warnings.ignore :parser_syntax do
   require "parser/current"

--- a/Library/Homebrew/sorbet/parlour.rb
+++ b/Library/Homebrew/sorbet/parlour.rb
@@ -10,8 +10,6 @@ end
 module Homebrew
   # Parlour type signature generator helper class for Homebrew.
   module Parlour
-    extend T::Sig
-
     ROOT_DIR = T.let(Pathname(__dir__).parent.realpath.freeze, Pathname).freeze
 
     sig { returns(T::Array[Parser::AST::Node]) }

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -325,8 +325,6 @@ module Homebrew
 
     # Source location of a style offense.
     class LineLocation
-      extend T::Sig
-
       attr_reader :line, :column
 
       def initialize(json)

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -14,14 +14,10 @@ require "extend/time"
 #
 # @api private
 class SystemCommand
-  extend T::Sig
-
   using TimeRemaining
 
   # Helper functions for calling {SystemCommand.run}.
   module Mixin
-    extend T::Sig
-
     def system_command(executable, **options)
       SystemCommand.run(executable, **options)
     end
@@ -282,8 +278,6 @@ class SystemCommand
 
   # Result containing the output and exit status of a finished sub-process.
   class Result
-    extend T::Sig
-
     include Context
 
     attr_accessor :command, :status, :exit_status

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -12,8 +12,6 @@ require "system_command"
 # @api private
 module SystemConfig
   class << self
-    extend T::Sig
-
     include SystemCommand::Mixin
 
     def clang

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -9,8 +9,6 @@ require "extend/cachable"
 
 # Rather than calling `new` directly, use one of the class methods like {Tab.create}.
 class Tab
-  extend T::Sig
-
   extend Cachable
 
   FILENAME = "INSTALL_RECEIPT.json"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -14,8 +14,6 @@ require "settings"
 # {#user} represents the GitHub username and {#repo} represents the repository
 # name without the leading `homebrew-`.
 class Tap
-  extend T::Sig
-
   extend Cachable
 
   TAP_DIRECTORY = (HOMEBREW_LIBRARY/"Taps").freeze
@@ -849,8 +847,6 @@ end
 
 # A specialized {Tap} class for the core formulae.
 class CoreTap < Tap
-  extend T::Sig
-
   # @private
   sig { void }
   def initialize
@@ -1010,8 +1006,6 @@ end
 
 # Permanent configuration per {Tap} using `git-config(1)`.
 class TapConfig
-  extend T::Sig
-
   attr_reader :tap
 
   sig { params(tap: Tap).void }

--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -6,8 +6,6 @@ module Homebrew
   #
   # @api private
   class TapAuditor
-    extend T::Sig
-
     attr_reader :name, :path, :formula_names, :formula_aliases, :cask_tokens,
                 :tap_audit_exceptions, :tap_style_exceptions, :tap_pypi_formula_mappings, :problems
 

--- a/Library/Homebrew/test_runner_formula.rb
+++ b/Library/Homebrew/test_runner_formula.rb
@@ -4,8 +4,6 @@
 require "formula"
 
 class TestRunnerFormula
-  extend T::Sig
-
   sig { returns(String) }
   attr_reader :name
 

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -7,7 +7,6 @@ require "system_command"
 #
 # @api private
 module UnpackStrategy
-  extend T::Sig
   extend T::Helpers
 
   include SystemCommand::Mixin

--- a/Library/Homebrew/unpack_strategy/air.rb
+++ b/Library/Homebrew/unpack_strategy/air.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking Adobe Air archives.
   class Air
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/bazaar.rb
+++ b/Library/Homebrew/unpack_strategy/bazaar.rb
@@ -6,8 +6,6 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Bazaar archives.
   class Bazaar < Directory
-    extend T::Sig
-
     def self.can_extract?(path)
       super && (path/".bzr").directory?
     end

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking bzip2 archives.
   class Bzip2
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking Cabinet archives.
   class Cab
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/compress.rb
+++ b/Library/Homebrew/unpack_strategy/compress.rb
@@ -6,8 +6,6 @@ require_relative "tar"
 module UnpackStrategy
   # Strategy for unpacking compress archives.
   class Compress < Tar
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".Z"]

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking directories.
   class Directory
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -6,14 +6,10 @@ require "tempfile"
 module UnpackStrategy
   # Strategy for unpacking disk images.
   class Dmg
-    extend T::Sig
-
     include UnpackStrategy
 
     # Helper module for listing the contents of a volume mounted from a disk image.
     module Bom
-      extend T::Sig
-
       DMG_METADATA = Set.new(%w[
         .background
         .com.apple.timemachine.donotpresent
@@ -79,8 +75,6 @@ module UnpackStrategy
 
     # Strategy for unpacking a volume mounted from a disk image.
     class Mount
-      extend T::Sig
-
       include UnpackStrategy
 
       def eject(verbose: false)

--- a/Library/Homebrew/unpack_strategy/executable.rb
+++ b/Library/Homebrew/unpack_strategy/executable.rb
@@ -6,8 +6,6 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking executables.
   class Executable < Uncompressed
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".sh", ".bash"]

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -6,8 +6,6 @@ require "system_command"
 module UnpackStrategy
   # Strategy for unpacking Fossil repositories.
   class Fossil
-    extend T::Sig
-
     include UnpackStrategy
     extend SystemCommand::Mixin
 

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking archives with `unar`.
   class GenericUnar
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/gzip.rb
+++ b/Library/Homebrew/unpack_strategy/gzip.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking gzip archives.
   class Gzip
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/jar.rb
+++ b/Library/Homebrew/unpack_strategy/jar.rb
@@ -6,8 +6,6 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking Java archives.
   class Jar < Uncompressed
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".apk", ".jar"]

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking LHa archives.
   class Lha
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/lua_rock.rb
+++ b/Library/Homebrew/unpack_strategy/lua_rock.rb
@@ -6,8 +6,6 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking LuaRock archives.
   class LuaRock < Uncompressed
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".rock"]

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking lzip archives.
   class Lzip
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking LZMA archives.
   class Lzma
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
+++ b/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
@@ -6,8 +6,6 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking Microsoft Office documents.
   class MicrosoftOfficeXml < Uncompressed
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [

--- a/Library/Homebrew/unpack_strategy/otf.rb
+++ b/Library/Homebrew/unpack_strategy/otf.rb
@@ -6,8 +6,6 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking OpenType fonts.
   class Otf < Uncompressed
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".otf"]

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking P7ZIP archives.
   class P7Zip
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/pax.rb
+++ b/Library/Homebrew/unpack_strategy/pax.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking pax archives.
   class Pax
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/pkg.rb
+++ b/Library/Homebrew/unpack_strategy/pkg.rb
@@ -6,8 +6,6 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking macOS package installers.
   class Pkg < Uncompressed
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".pkg", ".mkpg"]

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking RAR archives.
   class Rar
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
+++ b/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
@@ -6,8 +6,6 @@ require_relative "generic_unar"
 module UnpackStrategy
   # Strategy for unpacking self-extracting executables.
   class SelfExtractingExecutable < GenericUnar
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       []

--- a/Library/Homebrew/unpack_strategy/sit.rb
+++ b/Library/Homebrew/unpack_strategy/sit.rb
@@ -6,8 +6,6 @@ require_relative "generic_unar"
 module UnpackStrategy
   # Strategy for unpacking Stuffit archives.
   class Sit < GenericUnar
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".sit"]

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -6,8 +6,6 @@ require "system_command"
 module UnpackStrategy
   # Strategy for unpacking tar archives.
   class Tar
-    extend T::Sig
-
     include UnpackStrategy
     extend SystemCommand::Mixin
 

--- a/Library/Homebrew/unpack_strategy/ttf.rb
+++ b/Library/Homebrew/unpack_strategy/ttf.rb
@@ -6,8 +6,6 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking TrueType fonts.
   class Ttf < Uncompressed
-    extend T::Sig
-
     sig { returns(T::Array[String]) }
     def self.extensions
       [".ttc", ".ttf"]

--- a/Library/Homebrew/unpack_strategy/uncompressed.rb
+++ b/Library/Homebrew/unpack_strategy/uncompressed.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking uncompressed files.
   class Uncompressed
-    extend T::Sig
-
     include UnpackStrategy
 
     sig {

--- a/Library/Homebrew/unpack_strategy/xar.rb
+++ b/Library/Homebrew/unpack_strategy/xar.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking xar archives.
   class Xar
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking xz archives.
   class Xz
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking ZIP archives.
   class Zip
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -4,8 +4,6 @@
 module UnpackStrategy
   # Strategy for unpacking zstd archives.
   class Zstd
-    extend T::Sig
-
     include UnpackStrategy
 
     sig { returns(T::Array[String]) }

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -11,9 +11,7 @@ module Homebrew
   #
   # @api private
   class UnversionedCaskChecker
-    extend T::Sig
-
-    sig {  returns(Cask::Cask) }
+    sig { returns(Cask::Cask) }
     attr_reader :cask
 
     sig { params(cask: Cask::Cask).void }

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -24,7 +24,6 @@ require "extend/kernel"
 
 module Homebrew
   extend Context
-  extend T::Sig
 
   def self._system(cmd, *args, **options)
     pid = fork do
@@ -87,8 +86,6 @@ module Homebrew
 end
 
 module Utils
-  extend T::Sig
-
   # Removes the rightmost segment from the constant expression in the string.
   #
   #   deconstantize('Net::HTTP')   # => "Net"

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -17,8 +17,6 @@ module Utils
     INFLUX_ORG = "9a707721bb47fc02"
 
     class << self
-      extend T::Sig
-
       include Context
 
       sig { params(type: Symbol, metadata: T::Hash[Symbol, T.untyped]).void }

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -9,8 +9,6 @@ module Utils
   #
   # @api private
   module AST
-    extend T::Sig
-
     Node = RuboCop::AST::Node
     SendNode = RuboCop::AST::SendNode
     BlockNode = RuboCop::AST::BlockNode
@@ -79,7 +77,6 @@ module Utils
     #
     # @api private
     class FormulaAST
-      extend T::Sig
       extend Forwardable
       include AST
 

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -9,8 +9,6 @@ module Utils
   # @api private
   module Bottles
     class << self
-      extend T::Sig
-
       # Gets the tag for the running OS.
       def tag(symbol = nil)
         return Tag.from_symbol(symbol) if symbol.present?
@@ -124,8 +122,6 @@ module Utils
 
     # Denotes the arch and OS of a bottle.
     class Tag
-      extend T::Sig
-
       attr_reader :system, :arch
 
       sig { params(value: Symbol).returns(T.attached_class) }
@@ -245,8 +241,6 @@ module Utils
 
     # The specification for a specific tag
     class TagSpecification
-      extend T::Sig
-
       sig { returns(Utils::Bottles::Tag) }
       attr_reader :tag
 
@@ -265,8 +259,6 @@ module Utils
 
     # Collector for bottle specifications.
     class Collector
-      extend T::Sig
-
       sig { void }
       def initialize
         @tag_specs = T.let({}, T::Hash[Utils::Bottles::Tag, Utils::Bottles::TagSpecification])

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -10,8 +10,6 @@ module Utils
   #
   # @api private
   module Curl
-    extend T::Sig
-
     using TimeRemaining
 
     # This regex is used to extract the part of an ETag within quotation marks,

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -7,8 +7,6 @@ module Utils
   # @see GitRepository
   # @api private
   module Git
-    extend T::Sig
-
     def self.available?
       version.present?
     end

--- a/Library/Homebrew/utils/git_repository.rb
+++ b/Library/Homebrew/utils/git_repository.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 module Utils
-  extend T::Sig
-
   # Gets the full commit hash of the HEAD commit.
   sig {
     params(

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -11,8 +11,6 @@ require "system_command"
 #
 # @api private
 module GitHub
-  extend T::Sig
-
   include SystemCommand::Mixin
 
   def self.check_runs(repo: nil, commit: nil, pull_request: nil)

--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -9,8 +9,6 @@ module GitHub
   #
   # @api private
   module Actions
-    extend T::Sig
-
     sig { params(string: String).returns(String) }
     def self.escape(string)
       # See https://github.community/t/set-output-truncates-multiline-strings/16852/3.
@@ -39,8 +37,6 @@ module GitHub
 
     # Helper class for formatting annotations on GitHub Actions.
     class Annotation
-      extend T::Sig
-
       ANNOTATION_TYPES = [:notice, :warning, :error].freeze
 
       sig { params(path: T.any(String, Pathname)).returns(T.nilable(Pathname)) }

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -31,8 +31,6 @@ module GitHub
   #
   # @api private
   module API
-    extend T::Sig
-
     # Generic API error.
     class Error < RuntimeError
       attr_reader :github_message

--- a/Library/Homebrew/utils/gzip.rb
+++ b/Library/Homebrew/utils/gzip.rb
@@ -8,8 +8,6 @@ GZIP_BUFFER_SIZE = 64 * 1024
 module Utils
   # Helper functions for creating gzip files.
   module Gzip
-    extend T::Sig
-
     sig {
       params(
         path:      T.any(String, Pathname),

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -8,8 +8,6 @@ module Utils
   #
   # @api private
   module Inreplace
-    extend T::Sig
-
     # Error during text replacement.
     class Error < RuntimeError
       def initialize(errors)

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -5,8 +5,6 @@
 #
 # @api private
 module PyPI
-  extend T::Sig
-
   PYTHONHOSTED_URL_PREFIX = "https://files.pythonhosted.org/packages/"
   private_constant :PYTHONHOSTED_URL_PREFIX
 
@@ -14,8 +12,6 @@ module PyPI
   #
   # @api private
   class Package
-    extend T::Sig
-
     attr_accessor :name, :extras, :version
 
     sig { params(package_string: String, is_url: T::Boolean).void }

--- a/Library/Homebrew/utils/shebang.rb
+++ b/Library/Homebrew/utils/shebang.rb
@@ -6,16 +6,12 @@ module Utils
   #
   # @api private
   module Shebang
-    extend T::Sig
-
     module_function
 
     # Specification on how to rewrite a given shebang.
     #
     # @api private
     class RewriteInfo
-      extend T::Sig
-
       attr_reader :regex, :max_length, :replacement
 
       sig { params(regex: Regexp, max_length: Integer, replacement: T.any(String, Pathname)).void }

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -3,8 +3,6 @@
 
 module Utils
   module Shell
-    extend T::Sig
-
     module_function
 
     # Take a path and heuristically convert it to a shell name,

--- a/Library/Homebrew/utils/string_inreplace_extension.rb
+++ b/Library/Homebrew/utils/string_inreplace_extension.rb
@@ -5,8 +5,6 @@
 #
 # @api private
 class StringInreplaceExtension
-  extend T::Sig
-
   attr_accessor :errors, :inreplace_string
 
   sig { params(string: String).void }

--- a/Library/Homebrew/utils/svn.rb
+++ b/Library/Homebrew/utils/svn.rb
@@ -9,8 +9,6 @@ module Utils
   # @api private
   module Svn
     class << self
-      extend T::Sig
-
       include SystemCommand::Mixin
 
       sig { returns(T::Boolean) }

--- a/Library/Homebrew/utils/topological_hash.rb
+++ b/Library/Homebrew/utils/topological_hash.rb
@@ -6,8 +6,6 @@ require "tsort"
 module Utils
   # Topologically sortable hash map.
   class TopologicalHash < Hash
-    extend T::Sig
-
     include TSort
 
     sig {

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -40,8 +40,6 @@ module Tty
   CODES = COLOR_CODES.merge(STYLE_CODES).freeze
 
   class << self
-    extend T::Sig
-
     sig { params(stream: T.any(IO, StringIO), _block: T.proc.params(arg0: T.any(IO, StringIO)).void).void }
     def with(stream, &_block)
       previous_stream = @stream

--- a/Library/Homebrew/utils/user.rb
+++ b/Library/Homebrew/utils/user.rb
@@ -10,8 +10,6 @@ require "system_command"
 #
 # @api private
 class User < SimpleDelegator
-  extend T::Sig
-
   include SystemCommand::Mixin
 
   # Return whether the user has an active GUI session.

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -10,8 +10,6 @@ require "version/parser"
 #
 # @api private
 class Version
-  extend T::Sig
-
   include Comparable
 
   sig { params(name: T.any(String, Symbol), full: T::Boolean).returns(Regexp) }
@@ -21,7 +19,6 @@ class Version
 
   # A part of a {Version}.
   class Token
-    extend T::Sig
     extend T::Helpers
     abstract!
 
@@ -105,8 +102,6 @@ class Version
 
   # A pseudo-token representing the absence of a token.
   class NullToken < Token
-    extend T::Sig
-
     sig { override.returns(NilClass) }
     attr_reader :value
 
@@ -174,7 +169,6 @@ class Version
   # A token consisting of only numbers.
   class NumericToken < Token
     PATTERN = /[0-9]+/i.freeze
-    extend T::Sig
 
     sig { override.returns(Integer) }
     attr_reader :value

--- a/Library/Homebrew/version/head.rb
+++ b/Library/Homebrew/version/head.rb
@@ -7,8 +7,6 @@ class Version
   #
   # @api private
   class HeadVersion < Version
-    extend T::Sig
-
     sig { returns(T.nilable(String)) }
     attr_reader :commit
 

--- a/Library/Homebrew/version/null.rb
+++ b/Library/Homebrew/version/null.rb
@@ -8,8 +8,6 @@ class Version
   #
   # @api private
   class NullVersion < Version
-    extend T::Sig
-
     include Comparable
     include Singleton
 

--- a/Library/Homebrew/version/parser.rb
+++ b/Library/Homebrew/version/parser.rb
@@ -4,7 +4,6 @@
 class Version
   # @api private
   class Parser
-    extend T::Sig
     extend T::Helpers
     abstract!
 
@@ -14,7 +13,6 @@ class Version
 
   # @api private
   class RegexParser < Parser
-    extend T::Sig
     extend T::Helpers
     abstract!
 
@@ -43,8 +41,6 @@ class Version
 
   # @api private
   class UrlParser < RegexParser
-    extend T::Sig
-
     sig { override.params(spec: Pathname).returns(String) }
     def self.process_spec(spec)
       spec.to_s
@@ -53,8 +49,6 @@ class Version
 
   # @api private
   class StemParser < RegexParser
-    extend T::Sig
-
     SOURCEFORGE_DOWNLOAD_REGEX = %r{(?:sourceforge\.net|sf\.net)/.*/download$}.freeze
     NO_FILE_EXTENSION_REGEX = /\.[^a-zA-Z]+$/.freeze
 

--- a/docs/Typechecking.md
+++ b/docs/Typechecking.md
@@ -8,7 +8,7 @@ The [Sorbet Documentation] is a good place to get started if you want to dive de
 
 ### Inline Type Annotations
 
-To add type annotations to a class or module, we extend it with the `T::Sig` module (read this as `Type::Signature`). This adds the `sig` method which is used to annotate method signatures. Here's a simple example:
+The `sig` method is used to annotate method signatures. Here's a simple example:
 
 ```ruby
 class MyClass


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`extend T::Sig` is used over 400 times, we can just monkey-patch it into `Module` at this point.

`rubocop-sorbet` even has a [cop](https://github.com/Shopify/rubocop-sorbet/blob/main/manual/cops_sorbet.md#sorbetredundantextendtsig) to help with this

(though I'm a bit confused why it's `include` in `Module` to subsume the use of `extend` everywhere else 🤕)