### PR TITLE
utils/pypi: replace `pipgrip` with `pip`'s built in dependency resolution

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -286,6 +286,8 @@ module PyPI
   end
 
   def self.normalize_python_package(name)
+    # This normalization is defined in the PyPA packaging specifications;
+    # https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
     name.gsub(/[-_.]+/, "-").downcase
   end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -291,13 +291,13 @@ module PyPI
   def self.pip_report_to_packages(report, main_package, exclude_packages)
     return [] if report.blank?
 
-    report["install"].filter_map do |package|
+    report["install"].map do |package|
       name = normalize_python_package(package["metadata"]["name"])
       version = package["metadata"]["version"]
 
       package = "#{name}==#{version}"
 
       package if exclude_packages.exclude? package
-    end
+    end.compact
   end
 end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -295,7 +295,7 @@ module PyPI
       name = normalize_python_package(package["metadata"]["name"])
       version = package["metadata"]["version"]
 
-      package = "#{name}==#{version}"
+      package = Package.new "#{name}==#{version}"
 
       package if exclude_packages.exclude? package
     end.compact

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -28,7 +28,7 @@ module PyPI
         end
         raise ArgumentError, "Package should be a valid PyPI URL" if match.blank?
 
-        @name = normalize_python_package(match[1])
+        @name = PyPI.normalize_python_package(match[1])
         @version = match[2]
         return
       end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -226,7 +226,7 @@ module PyPI
       EOS
     end
 
-    found_packages = pip_report_to_packages(JSON.parse(pip_output), main_package, exclude_packages).uniq
+    found_packages = pip_report_to_packages(JSON.parse(pip_output), exclude_packages).uniq
 
     new_resource_blocks = ""
     found_packages.sort.each do |package|
@@ -288,7 +288,7 @@ module PyPI
     name.gsub(/[-_.]+/, "-").downcase
   end
 
-  def self.pip_report_to_packages(report, main_package, exclude_packages)
+  def self.pip_report_to_packages(report, exclude_packages)
     return [] if report.blank?
 
     report["install"].map do |package|

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -212,11 +212,11 @@ module PyPI
       end
     end
 
-    ensure_formula_installed!("pipgrip")
+    ensure_formula_installed!("python")
 
     ohai "Retrieving PyPI dependencies for \"#{input_packages.join(" ")}\"..." if !print_only && !silent
     command =
-      [Formula["pipgrip"].opt_bin/"pipgrip", "--json", "--tree", "--no-cache-dir", *input_packages.map(&:to_s)]
+      [Formula["python"].bin/"python", "-m", "pip", "install", "-q", "--dry-run", "--ignore-installed", "--report", "/dev/stdout", *input_packages.map(&:to_s)]
     pipgrip_output = Utils.popen_read(*command)
     unless $CHILD_STATUS.success?
       odie <<~EOS
@@ -282,6 +282,10 @@ module PyPI
     end
 
     true
+  end
+
+  def self.normalize_python_package(name)
+    name.gsub(/[-_.]+/, "-").downcase
   end
 
   def self.json_to_packages(json_tree, main_package, exclude_packages)

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -217,7 +217,7 @@ module PyPI
     ohai "Retrieving PyPI dependencies for \"#{input_packages.join(" ")}\"..." if !print_only && !silent
     command =
       [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--dry-run", "--ignore-installed", "--report", "/dev/stdout", *input_packages.map(&:to_s)]
-    pipgrip_output = Utils.popen_read(*command)
+    pipgrip_output = Utils.popen_read(*command, env: { "PIP_REQUIRE_VIRTUALENV" => "false" })
     unless $CHILD_STATUS.success?
       odie <<~EOS
         Unable to determine dependencies for "#{input_packages.join(" ")}" because of a failure when running

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -217,7 +217,7 @@ module PyPI
     ohai "Retrieving PyPI dependencies for \"#{input_packages.join(" ")}\"..." if !print_only && !silent
     command =
       [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--dry-run", "--ignore-installed", "--report", "/dev/stdout", *input_packages.map(&:to_s)]
-    pipgrip_output = Utils.popen_read(*command, env: { "PIP_REQUIRE_VIRTUALENV" => "false" })
+    pip_output = Utils.popen_read({ "PIP_REQUIRE_VIRTUALENV" => "false" }, *command)
     unless $CHILD_STATUS.success?
       odie <<~EOS
         Unable to determine dependencies for "#{input_packages.join(" ")}" because of a failure when running
@@ -226,7 +226,7 @@ module PyPI
       EOS
     end
 
-    found_packages = json_to_packages(JSON.parse(pipgrip_output), main_package, exclude_packages).uniq
+    found_packages = json_to_packages(JSON.parse(pip_output), main_package, exclude_packages).uniq
 
     new_resource_blocks = ""
     found_packages.sort.each do |package|

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -216,7 +216,7 @@ module PyPI
 
     ohai "Retrieving PyPI dependencies for \"#{input_packages.join(" ")}\"..." if !print_only && !silent
     command =
-      [Formula["python"].bin/"python", "-m", "pip", "install", "-q", "--dry-run", "--ignore-installed", "--report", "/dev/stdout", *input_packages.map(&:to_s)]
+      [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--dry-run", "--ignore-installed", "--report", "/dev/stdout", *input_packages.map(&:to_s)]
     pipgrip_output = Utils.popen_read(*command)
     unless $CHILD_STATUS.success?
       odie <<~EOS

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -28,7 +28,7 @@ module PyPI
         end
         raise ArgumentError, "Package should be a valid PyPI URL" if match.blank?
 
-        @name = match[1]
+        @name = normalize_python_package(match[1])
         @version = match[2]
         return
       end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -216,7 +216,8 @@ module PyPI
 
     ohai "Retrieving PyPI dependencies for \"#{input_packages.join(" ")}\"..." if !print_only && !silent
     command =
-      [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--dry-run", "--ignore-installed", "--report", "/dev/stdout", *input_packages.map(&:to_s)]
+      [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--dry-run", "--ignore-installed", "--report",
+       "/dev/stdout", *input_packages.map(&:to_s)]
     pip_output = Utils.popen_read({ "PIP_REQUIRE_VIRTUALENV" => "false" }, *command)
     unless $CHILD_STATUS.success?
       odie <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is both a performance and correctness improvement: it replaces our use of `pipgrip` for Python dependency collection with `pip`'s (new) built-in `--report` and `--dry-run` functionality, which produces a conceptually similar dependency report in JSON.

Performance wise, this results in about a 20% improvement in local testing over the `pipgrip` based implementation. This is probably mostly tied to not using the Poetry resolver (which is what `pipgrip` uses).

Correctness wise, this uses the same resolution logic and library (`resolvelib`) that `pip` uses, meaning that it exactly matches what users will actually see when they `pip install` a package. Poetry (and therefore `pipgrip`) use their own resolution algorithm, which can sometimes produce discrepancies versus the resolutions produced by `pip`. This hasn't surfaced as breakage (to my knowledge) in Homebrew's formulae yet, but unifying on `pip` here will prevent it from being an issue in the future.

There are also some small usability improvements: we now normalize each package name for comparison, meaning that flags like `--extra-packages` and `--exclude-packages` no longer need an exact case match to correctly include/filter packages.

I haven't added unit tests, since this code was already untested and is (still) pretty heavy (in terms of shelling out). That being said, I'm happy to add them if there's a preference for that 🙂 
