### PR TITLE
workflows: run on `macos-13`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,9 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - 11-arm64
+    # FIXME: Remove `macos-13` when resolved:
+    #   https://github.com/rhysd/actionlint/issues/296
+    - macos-13
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.

--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       IDENTIFIER: sh.brew.Homebrew
       TMP_PATH: /tmp/brew

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   tapioca:
     if: github.repository == 'Homebrew/brew'
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
     name: cask audit
     needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       HOMEBREW_NO_INSTALL_FROM_API: 1
     steps:
@@ -258,8 +258,8 @@ jobs:
         include:
           - name: update-test (Ubuntu 22.04)
             runs-on: ubuntu-22.04
-          - name: update-test (macOS 12)
-            runs-on: macos-12
+          - name: update-test (macOS 13)
+            runs-on: macos-13
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -300,9 +300,9 @@ jobs:
           - name: tests (Ubuntu 20.04)
             test-flags: --coverage
             runs-on: ubuntu-20.04
-          - name: tests (macOS 12)
+          - name: tests (macOS 13)
             test-flags: --coverage
-            runs-on: macos-12
+            runs-on: macos-13
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -390,8 +390,8 @@ jobs:
             runs-on: ubuntu-22.04
           - name: test default formula (Ubuntu 20.04)
             runs-on: ubuntu-20.04
-          - name: test default formula (macOS 12)
-            runs-on: macos-12
+          - name: test default formula (macOS 13)
+            runs-on: macos-13
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -32,7 +32,7 @@ jobs:
           contains(github.event.pull_request.title, '/Library/Homebrew')
         )
       )
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -72,7 +72,7 @@ module Homebrew
         test-bot:
           strategy:
             matrix:
-              os: [ubuntu-22.04, macos-12]
+              os: [ubuntu-22.04, macos-13]
           runs-on: ${{ matrix.os }}
           steps:
             - name: Set up Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Now that the `macos-13` runner image is available, let's switch to it so that we have the tests run on the latest macOS.

Alternatively, for some of the `tests` workflows, we may consider adding an additional `macos-13` matrix job instead of switching from `macos-12` to it.
