### PR TITLE
bump-cask-pr: convert URL back to string

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -190,7 +190,7 @@ module Homebrew
 
       replacement_pairs << [
         /#{Regexp.escape(old_base_url)}/,
-        new_base_url,
+        new_base_url.to_s,
       ]
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Convert the URL parameter back to a string after checking it for validity. Otherwise, attempting to update the URL errors out with "no implicit conversion of URI::HTTPS into String". (introduced in #15088)