### PR TITLE
rubocop: Set `EnabledByDefault: true`, disabling cops with offenses

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -235,14 +235,28 @@ Performance/OpenStruct:
   Enabled: false
 
 Rails:
-  # Selectively enable what we want.
-  Enabled: false
   # Do not use ActiveSupport in RuboCops.
   Exclude:
     - "Homebrew/rubocops/**/*"
 
 Rails/Delegate:
   Enabled: false # TODO
+
+# TODO: This group of cops comes from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+Rails/ArelStar:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+Rails/RakeEnvironment:
+  Enabled: false
+Rails/Pluck:
+  Enabled: false
+Rails/SaveBang:
+  Enabled: false
+Rails/SkipsModelValidations:
+  Enabled: false
+Rails/TimeZone:
+  Enabled: false
 
 # Intentionally disabled as it doesn't fit with our code style.
 RSpec/AnyInstance:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -14,6 +14,7 @@ inherit_mode:
 AllCops:
   TargetRubyVersion: 2.6
   ActiveSupportExtensionsEnabled: true
+  EnabledByDefault: true
   NewCops: enable
   Include:
     - "**/*.rbi"
@@ -24,6 +25,12 @@ AllCops:
     - "Homebrew/bin/*"
     - "Homebrew/vendor/**/*"
     - "Taps/*/*/vendor/**/*"
+
+# TODO: This group of cops comes from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+Bundler/GemComment:
+  Enabled: false
+Bundler/GemVersion:
+  Enabled: false
 
 Cask/Desc:
   Description: "Ensure that the desc stanza conforms to various content and style checks."
@@ -68,6 +75,34 @@ Layout/ArgumentAlignment:
 # this is a bit less "floaty"
 Layout/CaseIndentation:
   EnforcedStyle: end
+
+# TODO: This group of cops comes from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+Layout/ClassStructure:
+  Enabled: false
+Layout/EmptyLineAfterMultilineCondition:
+  Enabled: false
+Layout/FirstArrayElementLineBreak:
+  Enabled: false
+Layout/FirstHashElementLineBreak:
+  Enabled: false
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: false
+Layout/FirstMethodParameterLineBreak:
+  Enabled: false
+Layout/MultilineArrayLineBreaks:
+  Enabled: false
+Layout/MultilineAssignmentLayout:
+  Enabled: false
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: false
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: false
+Layout/MultilineMethodParameterLineBreaks:
+  Enabled: false
+Layout/RedundantLineBreak:
+  Enabled: false
+Layout/SingleLineBlockChain:
+  Enabled: false
 
 # significantly less indentation involved; more consistent
 Layout/FirstArrayElementIndentation:
@@ -133,6 +168,12 @@ Layout/SpaceBeforeBrackets:
 
 # favour parens-less DSL-style arguments
 Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+# TODO: This group of cops comes from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+Lint/ConstantResolution:
+  Enabled: false
+Lint/NumberConversion:
   Enabled: false
 
 Lint/DuplicateBranch:
@@ -203,6 +244,14 @@ Performance/Caller:
 Performance/MethodObjectAsBlock:
   Enabled: false
 
+# TODO: This group of cops comes from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+Performance/ChainArrayAllocation:
+  Enabled: false
+Performance/IoReadlines:
+  Enabled: false
+Performance/OpenStruct:
+  Enabled: false
+
 Rails:
   # Selectively enable what we want.
   Enabled: false
@@ -258,6 +307,16 @@ RSpec/StubbedMock:
 RSpec/SubjectStub:
   Enabled: false
 
+# TODO: These cops come from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+RSpec/AlignLeftLetBrace:
+  Enabled: false
+RSpec/AlignRightLetBrace:
+  Enabled: false
+RSpec/MessageExpectation:
+  Enabled: false
+RSpec/Pending:
+  Enabled: false
+
 # We use `allow(:foo).to receive(:bar)` everywhere.
 RSpec/MessageSpies:
   EnforcedStyle: receive
@@ -282,6 +341,20 @@ Sorbet/ConstantsFromStrings:
 
 # This is already the default
 Sorbet/FalseSigil:
+  Enabled: false
+
+# TODO: These cops come from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+Sorbet/EnforceSignatures:
+  Enabled: false
+Sorbet/ForbidTUnsafe:
+  Enabled: false
+Sorbet/ForbidTUntyped:
+  Enabled: false
+Sorbet/HasSigil:
+  Enabled: false
+Sorbet/IgnoreSigil:
+  Enabled: false
+Sorbet/StrongSigil:
   Enabled: false
 
 # T::Sig is monkey-patched into Module
@@ -323,6 +396,54 @@ Style/BlockDelimiters:
 # Use consistent style for better readability.
 Style/CollectionMethods:
   Enabled: true
+
+# TODO: This group of cops comes from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
+Style/ArrayCoercion:
+  Enabled: false
+Style/AsciiComments:
+  Enabled: false
+Style/ClassMethodsDefinitions:
+  Enabled: false
+Style/ConstantVisibility:
+  Enabled: false
+Style/Copyright:
+  Enabled: false
+Style/DateTime:
+  Enabled: false
+Style/DocumentationMethod:
+  Enabled: false
+Style/ImplicitRuntimeError:
+  Enabled: false
+Style/InlineComment:
+  Enabled: false
+Style/IpAddresses:
+  Enabled: false
+Style/MethodCallWithArgsParentheses:
+  Enabled: false
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+Style/MissingElse:
+  Enabled: false
+Style/MultilineMethodSignature:
+  Enabled: false
+Style/OptionHash:
+  Enabled: false
+Style/RequireOrder:
+  Enabled: false
+Style/Send:
+  Enabled: false
+Style/SingleLineBlockParams:
+  Enabled: false
+Style/StaticClass:
+  Enabled: false
+Style/StringHashKeys:
+  Enabled: false
+Style/TopLevelMethodDefinition:
+  Enabled: false
+Style/TrailingCommaInBlockArgs:
+  Enabled: false
+Style/YodaExpression:
+  Enabled: false
 
 # Don't allow cops to be disabled in casks and formulae.
 Style/DisableCopsWithinSourceCodeDirective:
@@ -374,7 +495,6 @@ Style/HashAsLastArrayItem:
     - "**/Formula/**/*.rb"
 
 Style/InvertibleUnlessCondition:
-  Enabled: true
   InverseMethods:
     # Favor `if a != b` over `unless a == b`
     :==: :!=

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -34,32 +34,18 @@ Bundler/GemVersion:
 
 Cask/Desc:
   Description: "Ensure that the desc stanza conforms to various content and style checks."
-  Enabled: true
 
 Cask/HomepageUrlTrailingSlash:
   Description: "Ensure that the homepage url has a slash after the domain name."
-  Enabled: true
 
 Cask/NoDslVersion:
   Description: "Do not use the deprecated DSL version syntax in your cask header."
-  Enabled: true
 
 Cask/StanzaGrouping:
   Description: "Ensure that cask stanzas are grouped correctly. More info at https://docs.brew.sh/Cask-Cookbook#stanza-order"
-  Enabled: true
 
 Cask/StanzaOrder:
   Description: "Ensure that cask stanzas are sorted correctly. More info at https://docs.brew.sh/Cask-Cookbook#stanza-order"
-  Enabled: true
-
-FormulaAudit:
-  Enabled: true
-
-FormulaAuditStrict:
-  Enabled: true
-
-Homebrew:
-  Enabled: true
 
 # only used internally
 Homebrew/MoveToExtendOS:
@@ -232,10 +218,6 @@ Naming/MethodParameterName:
 Naming/VariableNumber:
   Enabled: false
 
-# Does not hinder readability, so might as well enable it.
-Performance/CaseWhenSplat:
-  Enabled: true
-
 # Makes code less readable for minor performance increases.
 Performance/Caller:
   Enabled: false
@@ -259,41 +241,8 @@ Rails:
   Exclude:
     - "Homebrew/rubocops/**/*"
 
-# These relate to ActiveSupport and not other parts of Rails.
-Rails/ActiveSupportAliases:
-  Enabled: true
-Rails/Blank:
-  Enabled: true
-Rails/CompactBlank:
-  Enabled: true
 Rails/Delegate:
   Enabled: false # TODO
-Rails/DelegateAllowBlank:
-  Enabled: true
-Rails/DurationArithmetic:
-  Enabled: true
-Rails/ExpandedDateRange:
-  Enabled: true
-Rails/Inquiry:
-  Enabled: true
-Rails/NegateInclude:
-  Enabled: true
-Rails/PluralizationGrammar:
-  Enabled: true
-Rails/Presence:
-  Enabled: true
-Rails/Present:
-  Enabled: true
-Rails/RelativeDateConstant:
-  Enabled: true
-Rails/SafeNavigation:
-  Enabled: true
-Rails/SafeNavigationWithBlank:
-  Enabled: true
-Rails/StripHeredoc:
-  Enabled: true
-Rails/ToFormattedS:
-  Enabled: true
 
 # Intentionally disabled as it doesn't fit with our code style.
 RSpec/AnyInstance:
@@ -357,20 +306,14 @@ Sorbet/IgnoreSigil:
 Sorbet/StrongSigil:
   Enabled: false
 
-# T::Sig is monkey-patched into Module
-Sorbet/RedundantExtendTSig:
-  Enabled: true
-
 Sorbet/StrictSigil:
   inherit_mode:
     override:
       - Include
-  Enabled: true
   Include:
     - "**/*.rbi"
 
 Sorbet/TrueSigil:
-  Enabled: true
   Exclude:
     - "Taps/**/*"
     - "/**/{Formula,Casks}/**/*.rb"
@@ -381,10 +324,6 @@ Sorbet/TrueSigil:
 Style/AndOr:
   EnforcedStyle: always
 
-# Avoid leaking resources.
-Style/AutoResourceCleanup:
-  Enabled: true
-
 # This makes these a little more obvious.
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
@@ -392,10 +331,6 @@ Style/BarePercentLiterals:
 Style/BlockDelimiters:
   BracesRequiredMethods:
     - "sig"
-
-# Use consistent style for better readability.
-Style/CollectionMethods:
-  Enabled: true
 
 # TODO: This group of cops comes from `EnabledByDefault: true`. We should maybe enable the ones with < 100 offenses.
 Style/ArrayCoercion:
@@ -447,7 +382,6 @@ Style/YodaExpression:
 
 # Don't allow cops to be disabled in casks and formulae.
 Style/DisableCopsWithinSourceCodeDirective:
-  Enabled: true
   Include:
     - "Taps/*/*/*.rb"
     - "/**/{Formula,Casks}/**/*.rb"
@@ -527,10 +461,6 @@ Style/OpenStructUse:
 Style/RescueStandardError:
   EnforcedStyle: implicit
 
-# Returning `nil` is unnecessary.
-Style/ReturnNil:
-  Enabled: true
-
 # We have no use for using `warn` because we
 # are calling Ruby with warnings disabled.
 Style/StderrPuts:
@@ -551,10 +481,6 @@ Style/StringLiterals:
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
-# Use consistent method names.
-Style/StringMethods:
-  Enabled: true
-
 # An array of symbols is more readable than a symbol array
 # and also allows for easier grepping.
 Style/SymbolArray:
@@ -574,7 +500,6 @@ Style/TrailingCommaInHashLiteral:
 
 # `unless ... ||` and `unless ... &&` are hard to mentally parse
 Style/UnlessLogicalOperators:
-  Enabled: true
   EnforcedStyle: forbid_logical_operators
 
 # a bit confusing to non-Rubyists but useful for longer arrays


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of #15297. Specifically, [bullet point three of Mike's suggestion](https://github.com/Homebrew/brew/issues/15297#issuecomment-1519579881). After this, I'll start chipping away at switching cops on.
- `EnabledByDefault` is a feature of RuboCop that enables all cops even those marked `Enabled: false` in core RuboCop.
- I went through and disabled all the cops with offenses from this config change. This way we can do a piecemeal approach to enabling cops with offenses, while getting the benefits of the new cops with no offenses.
- It is intentional that `brew style` comes back green here and there are no code style fixes.

-----

- I was going to put these in alphabetical order, but it's probably not worth it. Once we've moved sufficiently many of these to `Enabled: true`, if we're doing that, or if we decide we're not, _then_ we can do that. But batching them into sections with TODOs for "these need looking at" seemed more sensible to me.