### PR TITLE
fix: allow generate-formula-api to support renamed formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -27,11 +27,16 @@ module Homebrew
     {{ content }}
   EOS
 
-  def html_template(title)
+  def html_template(title, aliases)
+    redirect_list = aliases.present? ? "redirect_from:\n" : ""
+    aliases.each do |item|
+      redirect_list += "  - /formula/#{item}\n"
+    end
     <<~EOS
       ---
       title: #{title}
       layout: cask
+      #{redirect_list}
       ---
       {{ content }}
     EOS
@@ -56,7 +61,7 @@ module Homebrew
       File.write("_data/cask/#{name}.json", "#{json}\n")
       File.write("api/cask/#{name}.json", CASK_JSON_TEMPLATE)
       File.write("api/cask-source/#{name}.rb", path.read)
-      File.write("cask/#{name}.html", html_template(name))
+      File.write("cask/#{name}.html", html_template(name, []))
     rescue
       onoe "Error while generating data for cask '#{path.stem}'."
       raise


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
It feels incredibly naive, but I think this should support formula renames in the API.