### PR TITLE
`brew bump`: modify versioning logic

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -242,7 +242,10 @@ module Homebrew
 
     new_version = if livecheck_latest.is_a?(Version) && livecheck_latest > current_version
       livecheck_latest
-    elsif repology_latest.is_a?(Version) && repology_latest > current_version && !formula_or_cask.livecheckable?
+    elsif repology_latest.is_a?(Version) &&
+          repology_latest > current_version &&
+          !formula_or_cask.livecheckable? &&
+          current_version != "latest"
       repology_latest
     end.presence
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If a cask has `version :latest` is not livecheckable and repology returns a version, `brew bump` will replace `version :latest` with the repology version. This is not desired as it will reversion casks that were unversioned on purpose. 

e.g. 
```
==> autodesk-fusion360
Current cask version   :  latest
Latest livecheck version: latest
Latest Repology version:  2.0.15509
Open pull requests:       none
Closed pull requests:     none
```