### PR TITLE
github_runner_matrix: cleanup GitHub macOS runner

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -129,19 +129,19 @@ class GitHubRunnerMatrix
       runner_timeout += 30 if macos_version <= :big_sur
 
       # Use GitHub Actions macOS Runner for testing dependents if compatible with timeout.
-      runner = if (@dependent_matrix || use_github_runner) &&
-                  macos_version <= NEWEST_GITHUB_ACTIONS_MACOS_RUNNER &&
-                  runner_timeout <= GITHUB_ACTIONS_RUNNER_TIMEOUT
-        "macos-#{version}"
+      runner, cleanup = if (@dependent_matrix || use_github_runner) &&
+                           macos_version <= NEWEST_GITHUB_ACTIONS_MACOS_RUNNER &&
+                           runner_timeout <= GITHUB_ACTIONS_RUNNER_TIMEOUT
+        ["macos-#{version}", true]
       else
-        "#{version}#{ephemeral_suffix}"
+        ["#{version}#{ephemeral_suffix}", false]
       end
 
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-x86_64",
         runner:  runner,
         timeout: runner_timeout,
-        cleanup: false,
+        cleanup: cleanup,
       )
       @runners << create_runner(:macos, :x86_64, spec, macos_version)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These come with some pre-installed software that we probably want to
clean up first.
