### PR TITLE
Support multiple oldnames for formulae & support formula renames in API

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -25,9 +25,13 @@ module Homebrew
                                                                      target: HOMEBREW_CACHE_API/"formula.jws.json"
 
           cache["aliases"] = {}
+          cache["renames"] = {}
           cache["formulae"] = json_formulae.to_h do |json_formula|
             json_formula["aliases"].each do |alias_name|
               cache["aliases"][alias_name] = json_formula["name"]
+            end
+            (json_formula["oldnames"] || [json_formula["oldname"]].compact).each do |oldname|
+              cache["renames"][oldname] = json_formula["name"]
             end
 
             [json_formula["name"], json_formula.except("name")]
@@ -55,6 +59,16 @@ module Homebrew
           end
 
           cache["aliases"]
+        end
+
+        sig { returns(Hash) }
+        def all_renames
+          unless cache.key?("renames")
+            json_updated = download_and_cache_data!
+            write_names_and_aliases(regenerate: json_updated)
+          end
+
+          cache["renames"]
         end
 
         sig { params(regenerate: T::Boolean).void }

--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -29,14 +29,6 @@ module Homebrew
 
     args.named.to_kegs.each do |keg|
       f = Formulary.from_keg(keg)
-
-      if f.oldname
-        rack = HOMEBREW_CELLAR/f.oldname
-        raise NoSuchKegError, f.oldname if !rack.exist? || rack.subdirs.empty?
-
-        odie "#{rack} is a symlink" if rack.symlink?
-      end
-
       Migrator.migrate_if_needed(f, force: args.force?, dry_run: args.dry_run?)
     end
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -222,7 +222,7 @@ class Formula
     @pin = FormulaPin.new(self)
     @follow_installed_alias = true
     @prefix_returns_versioned_prefix = false
-    @oldname_lock = nil
+    @oldname_locks = []
   end
 
   # @private
@@ -491,10 +491,18 @@ class Formula
   delegate resource: :active_spec
 
   # An old name for the formula.
+  # @deprecated Use #{#oldnames} instead.
   def oldname
-    @oldname ||= if tap
-      formula_renames = tap.formula_renames
-      formula_renames.to_a.rassoc(name).first if formula_renames.value?(name)
+    # odeprecated "Formula#oldname", "Formula#oldnames"
+    @oldname ||= oldnames.first
+  end
+
+  # Old names for the formula.
+  def oldnames
+    @oldnames ||= if tap
+      tap.formula_renames.select { |_, oldname| oldname == name }.keys
+    else
+      []
     end
   end
 
@@ -1350,34 +1358,41 @@ class Formula
   def lock
     @lock = FormulaLock.new(name)
     @lock.lock
-    return unless oldname
-    return unless (oldname_rack = HOMEBREW_CELLAR/oldname).exist?
-    return if oldname_rack.resolved_path != rack
 
-    @oldname_lock = FormulaLock.new(oldname)
-    @oldname_lock.lock
+    oldnames.each do |oldname|
+      next unless (oldname_rack = HOMEBREW_CELLAR/oldname).exist?
+      next if oldname_rack.resolved_path != rack
+
+      oldname_lock = FormulaLock.new(oldname)
+      oldname_lock.lock
+      @oldname_locks << oldname_lock
+    end
   end
 
   # @private
   def unlock
     @lock&.unlock
-    @oldname_lock&.unlock
+    @oldname_locks.each(&:unlock)
+  end
+
+  # @private
+  def oldnames_to_migrate
+    oldnames.select do |oldname|
+      old_rack = HOMEBREW_CELLAR/oldname
+      next false unless old_rack.directory?
+      next false if old_rack.subdirs.empty?
+
+      tap == Tab.for_keg(old_rack.subdirs.min).tap
+    end
   end
 
   def migration_needed?
-    return false unless oldname
-    return false if rack.exist?
-
-    old_rack = HOMEBREW_CELLAR/oldname
-    return false unless old_rack.directory?
-    return false if old_rack.subdirs.empty?
-
-    tap == Tab.for_keg(old_rack.subdirs.min).tap
+    !oldnames_to_migrate.empty? && !rack.exist?
   end
 
   # @private
   def outdated_kegs(fetch_head: false)
-    raise Migrator::MigrationNeededError, self if migration_needed?
+    raise Migrator::MigrationNeededError.new(oldnames_to_migrate.first, name) if migration_needed?
 
     cache_key = "#{full_name}-#{fetch_head}"
     Formula.cache[:outdated_kegs] ||= {}
@@ -1499,7 +1514,7 @@ class Formula
 
   # @private
   def possible_names
-    [name, oldname, *aliases].compact
+    [name, *oldnames, *aliases].compact
   end
 
   def to_s
@@ -2087,7 +2102,8 @@ class Formula
       "name"                     => name,
       "full_name"                => full_name,
       "tap"                      => tap&.name,
-      "oldname"                  => oldname,
+      "oldname"                  => oldnames.first, # deprecated
+      "oldnames"                 => oldnames,
       "aliases"                  => aliases.sort,
       "versioned_formulae"       => versioned_formulae.map(&:name),
       "desc"                     => desc,

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -293,9 +293,9 @@ module Formulary
         self.class.instance_variable_get(:@tap_git_head_string)
       end
 
-      @oldname_string = json_formula["oldname"]
-      def oldname
-        self.class.instance_variable_get(:@oldname_string)
+      @oldnames_array = json_formula["oldnames"] || [json_formula["oldname"]].compact
+      def oldnames
+        self.class.instance_variable_get(:@oldnames_array)
       end
 
       @aliases_array = json_formula["aliases"]

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -173,7 +173,7 @@ module Homebrew
           # Check if the formula we try to install is the same as installed
           # but not migrated one. If --force is passed then install anyway.
           opoo <<~EOS
-            #{formula.oldname} is already installed, it's just not migrated.
+            #{formula.oldnames_to_migrate.first} is already installed, it's just not migrated.
             To migrate this formula, run:
               brew migrate #{formula}
             Or to force-install it, run:

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -167,6 +167,7 @@ class Keg
     @name = path.parent.basename.to_s
     @linked_keg_record = HOMEBREW_LINKED_KEGS/name
     @opt_record = HOMEBREW_PREFIX/"opt/#{name}"
+    @oldname_opt_records = []
     @require_relocation = false
   end
 
@@ -270,7 +271,7 @@ class Keg
     remove_opt_record if optlinked?
     remove_linked_keg_record if linked?
     remove_old_aliases
-    remove_oldname_opt_record
+    remove_oldname_opt_records
   rescue Errno::EACCES, Errno::ENOTEMPTY
     raise if raise_failures
 
@@ -319,13 +320,15 @@ class Keg
     ObserverPathnameExtension.n
   end
 
-  def lock(&block)
+  def lock
     FormulaLock.new(name).with_lock do
-      if oldname_opt_record
-        FormulaLock.new(oldname_opt_record.basename.to_s).with_lock(&block)
-      else
-        yield
+      oldname_locks = oldname_opt_records.map do |record|
+        FormulaLock.new(record.basename.to_s)
       end
+      oldname_locks.each(&:lock)
+      yield
+    ensure
+      oldname_locks&.each(&:unlock)
     end
   end
 
@@ -388,11 +391,15 @@ class Keg
     Formulary.from_keg(self)
   end
 
-  def oldname_opt_record
-    @oldname_opt_record ||= if (opt_dir = HOMEBREW_PREFIX/"opt").directory?
-      opt_dir.subdirs.find do |dir|
+  def oldname_opt_records
+    return @oldname_opt_records unless @oldname_opt_records.empty?
+
+    @oldname_opt_records = if (opt_dir = HOMEBREW_PREFIX/"opt").directory?
+      opt_dir.subdirs.select do |dir|
         dir.symlink? && dir != opt_record && path.parent == dir.resolved_path.parent
       end
+    else
+      []
     end
   end
 
@@ -480,13 +487,14 @@ class Keg
 
   def consistent_reproducible_symlink_permissions!; end
 
-  def remove_oldname_opt_record
-    return unless oldname_opt_record
-    return if oldname_opt_record.resolved_path != path
+  def remove_oldname_opt_records
+    oldname_opt_records.reject! do |record|
+      return false if record.resolved_path != path
 
-    @oldname_opt_record.unlink
-    @oldname_opt_record.parent.rmdir_if_possible
-    @oldname_opt_record = nil
+      record.unlink
+      record.parent.rmdir_if_possible
+      true
+    end
   end
 
   def tab
@@ -511,10 +519,10 @@ class Keg
       make_relative_symlink(alias_opt_record, path, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
     end
 
-    return unless oldname_opt_record
-
-    oldname_opt_record.delete
-    make_relative_symlink(oldname_opt_record, path, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
+    oldname_opt_records.each do |record|
+      record.delete
+      make_relative_symlink(record, path, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
+    end
   end
 
   def delete_pyc_files!

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -933,9 +933,11 @@ class CoreTap < Tap
   # @private
   sig { returns(Hash) }
   def formula_renames
-    @formula_renames ||= begin
+    @formula_renames ||= if Homebrew::EnvConfig.no_install_from_api?
       self.class.ensure_installed!
       super
+    else
+      Homebrew::API::Formula.all_renames
     end
   end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -269,7 +269,7 @@ describe Formula do
 
   specify "#migration_needed" do
     f = Testball.new("newname")
-    f.instance_variable_set(:@oldname, "oldname")
+    f.instance_variable_set(:@oldnames, ["oldname"])
     f.instance_variable_set(:@tap, CoreTap.instance)
 
     oldname_prefix = (HOMEBREW_CELLAR/"oldname/2.20")

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -53,21 +53,21 @@ describe Keg do
     expect(keg).not_to be_an_empty_installation
   end
 
-  specify "#oldname_opt_record" do
-    expect(keg.oldname_opt_record).to be_nil
+  specify "#oldname_opt_records" do
+    expect(keg.oldname_opt_records).to be_empty
     oldname_opt_record = HOMEBREW_PREFIX/"opt/oldfoo"
     oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
-    expect(keg.oldname_opt_record).to eq(oldname_opt_record)
+    expect(keg.oldname_opt_records).to eq([oldname_opt_record])
   end
 
-  specify "#remove_oldname_opt_record" do
+  specify "#remove_oldname_opt_records" do
     oldname_opt_record = HOMEBREW_PREFIX/"opt/oldfoo"
     oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/2.0")
-    keg.remove_oldname_opt_record
+    keg.remove_oldname_opt_records
     expect(oldname_opt_record).to be_a_symlink
     oldname_opt_record.unlink
     oldname_opt_record.make_relative_symlink(HOMEBREW_CELLAR/"foo/1.0")
-    keg.remove_oldname_opt_record
+    keg.remove_oldname_opt_records
     expect(oldname_opt_record).not_to be_a_symlink
   end
 

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -6,7 +6,7 @@ require "tab"
 require "keg"
 
 describe Migrator do
-  subject(:migrator) { described_class.new(new_formula) }
+  subject(:migrator) { described_class.new(new_formula, old_formula.name) }
 
   let(:new_formula) { Testball.new("newname") }
   let(:old_formula) { Testball.new("oldname") }
@@ -55,15 +55,9 @@ describe Migrator do
   end
 
   describe "::new" do
-    it "raises an error if there is no old name" do
-      expect do
-        described_class.new(old_formula)
-      end.to raise_error(Migrator::MigratorNoOldnameError)
-    end
-
     it "raises an error if there is no old path" do
       expect do
-        described_class.new(new_formula)
+        described_class.new(new_formula, "oldname")
       end.to raise_error(Migrator::MigratorNoOldpathError)
     end
 
@@ -76,7 +70,7 @@ describe Migrator do
       tab.write
 
       expect do
-        described_class.new(new_formula)
+        described_class.new(new_formula, "oldname")
       end.to raise_error(Migrator::MigratorDifferentTapsError)
     end
   end
@@ -212,7 +206,7 @@ describe Migrator do
     tab.tabfile = HOMEBREW_CELLAR/"oldname/0.1/INSTALL_RECEIPT.json"
     tab.source["path"] = "/should/be/the/same"
     tab.write
-    migrator = described_class.new(new_formula)
+    migrator = described_class.new(new_formula, "oldname")
     tab.tabfile.delete
     migrator.backup_old_tabs
     expect(Tab.for_keg(old_keg_record).source["path"]).to eq("/should/be/the/same")


### PR DESCRIPTION
Supporting formula renames in the API is fairly trivial. We have `oldname` data already  so we can create a `formula_renames` structure from that information.

There was one catch however: the API only supports one oldname. But in homebrew/core we have formulae which have multiple renames, typically from merging multiple formulae into one. Since the API only supported a single oldname, we  would only have a partial set of data and thus not fully fix the issue.

So I tried to add support for multiple oldnames properly here too. It's not a huge redo - mostly just making things use arrays instead. I've also adjusted the migrator to handle it better - it now actually merges rather than just pick a random one, but otherwise functions the same way.