### PR TITLE
github_runner_matrix: remove `HOMEBREW_LINUX_CLEANUP`

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -62,10 +62,11 @@ class GitHubRunnerMatrix
 
   private
 
+  SELF_HOSTED_LINUX_RUNNER = "linux-self-hosted-1"
+
   sig { returns(LinuxRunnerSpec) }
   def linux_runner_spec
-    linux_runner  = ENV.fetch("HOMEBREW_LINUX_RUNNER")
-    linux_cleanup = ENV.fetch("HOMEBREW_LINUX_CLEANUP")
+    linux_runner = ENV.fetch("HOMEBREW_LINUX_RUNNER")
 
     LinuxRunnerSpec.new(
       name:      "Linux",
@@ -76,7 +77,7 @@ class GitHubRunnerMatrix
       },
       workdir:   "/github/home",
       timeout:   4320,
-      cleanup:   linux_cleanup == "true",
+      cleanup:   linux_runner == SELF_HOSTED_LINUX_RUNNER,
     )
   end
 

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -15,7 +15,6 @@ describe "brew determine-test-runners" do
   let(:runner_env) do
     {
       "HOMEBREW_LINUX_RUNNER"  => linux_runner,
-      "HOMEBREW_LINUX_CLEANUP" => "false",
       "HOMEBREW_MACOS_TIMEOUT" => "90",
       "GITHUB_RUN_ID"          => ephemeral_suffix.split("-").second,
       "GITHUB_RUN_ATTEMPT"     => ephemeral_suffix.split("-").third,

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -6,7 +6,6 @@ require "test/support/fixtures/testball"
 describe GitHubRunnerMatrix do
   before do
     allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_RUNNER").and_return("ubuntu-latest")
-    allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_CLEANUP").and_return("false")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_TIMEOUT").and_return("90")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will allow us to remove handling of this in our workflow files in
Homebrew/core.
