### PR TITLE
pypi: normalize name in `pypi_info`

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -65,7 +65,10 @@ module PyPI
       sdist = json["urls"].find { |url| url["packagetype"] == "sdist" }
       return json["info"]["name"] if sdist.nil?
 
-      @pypi_info = [json["info"]["name"], sdist["url"], sdist["digests"]["sha256"], json["info"]["version"]]
+      @pypi_info = [
+        PyPI.normalize_python_package(json["info"]["name"]), sdist["url"],
+        sdist["digests"]["sha256"], json["info"]["version"]
+      ]
     end
 
     sig { returns(T::Boolean) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is just another small QoL improvement to the PyPI helpers: we now normalize the package name that gets returned in `pypi_info`, which means that PyPI resource names are now consistent and a little easier to search for throughout formulae that are updated with `update-python-resources`.