### PR TITLE
Enable Sorbet by default for Homebrew developers and developer commands.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -850,6 +850,9 @@ if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/dev-cmd/${HOMEBREW_COMMAND}.sh" ]] ||
 then
   export HOMEBREW_DEVELOPER_COMMAND="1"
 
+  # Always run developer commands with Sorbet.
+  export HOMEBREW_SORBET_RUNTIME="1"
+
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
     NO_INSTALL_FROM_API_COMMANDS=(
@@ -881,6 +884,14 @@ then
 
     unset NO_INSTALL_FROM_API_COMMANDS
   fi
+fi
+
+# brew readall is currently failing with Sorbet for homebrew/core.
+# TODO: fix this and remove this HOMEBREW_COMMAND conditional.
+if [[ -n "${HOMEBREW_DEVELOPER}" && "${HOMEBREW_COMMAND}" != "readall" ]]
+then
+  # Always run with Sorbet for Homebrew developers.
+  export HOMEBREW_SORBET_RUNTIME="1"
 fi
 
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -357,7 +357,8 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_SORBET_RUNTIME:                   {
-        description: "If set, enable runtime typechecking using Sorbet.",
+        description: "If set, enable runtime typechecking using Sorbet. " \
+                     "Set by default for HOMEBREW_DEVELOPER or when running developer commands.",
         boolean:     true,
       },
       HOMEBREW_SSH_CONFIG_PATH:                  {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2275,7 +2275,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions of macOS. This is useful in development on new macOS versions.
 
 - `HOMEBREW_SORBET_RUNTIME`
-  <br>If set, enable runtime typechecking using Sorbet.
+  <br>If set, enable runtime typechecking using Sorbet. Set by default for HOMEBREW_DEVELOPER or when running developer commands.
 
 - `HOMEBREW_SSH_CONFIG_PATH`
   <br>If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching `git` repos over `ssh`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3354,7 +3354,7 @@ If set along with \fBHOMEBREW_DEVELOPER\fR, do not use bottles from older versio
 \fBHOMEBREW_SORBET_RUNTIME\fR
 .
 .br
-If set, enable runtime typechecking using Sorbet\.
+If set, enable runtime typechecking using Sorbet\. Set by default for HOMEBREW_DEVELOPER or when running developer commands\.
 .
 .TP
 \fBHOMEBREW_SSH_CONFIG_PATH\fR


### PR DESCRIPTION
I've been doing this personally for a few months and not hit any bugs. We already do this for `brew tests`.

It will allow us to:

- remove manual type checks from all developer commands (Sorbet does a better job with these)
- better surface bugs
- better surface type signatures
- get closer to being able to enable this by default for everyone