### PR TITLE
determine-test-runners: add debug output

### DIFF
--- a/Library/Homebrew/dev-cmd/determine-test-runners.rb
+++ b/Library/Homebrew/dev-cmd/determine-test-runners.rb
@@ -42,6 +42,8 @@ module Homebrew
     runner_matrix = GitHubRunnerMatrix.new(testing_formulae, deleted_formulae, dependent_matrix: args.dependents?)
     runners = runner_matrix.active_runner_specs_hash
 
+    ohai "Runners", JSON.pretty_generate(runners)
+
     github_output = ENV.fetch("GITHUB_OUTPUT")
     File.open(github_output, "a") do |f|
       f.puts("runners=#{runners.to_json}")

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -41,8 +41,7 @@ describe "brew determine-test-runners" do
     setup_test_formula "testball"
 
     expect { brew "determine-test-runners", "testball", runner_env.merge({ "GITHUB_OUTPUT" => github_output }) }
-      .to not_to_output.to_stdout
-      .and not_to_output.to_stderr
+      .to not_to_output.to_stderr
       .and be_a_success
 
     expect(File.read(github_output)).not_to be_empty


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The extra timeout on Intel Big Sur doesn't seem to be set, so I'm adding
this so I can have a closer look.
