### PR TITLE
Livecheck: Fixes for Sorbet runtime

### DIFF
--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -71,15 +71,15 @@ module Homebrew
         sig {
           params(
             url:    String,
-            regex:  T.nilable(Regexp),
+            regex:  Regexp,
             unused: T.nilable(T::Hash[Symbol, T.untyped]),
             block:  T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: DEFAULT_REGEX, **unused, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || DEFAULT_REGEX, **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -190,6 +190,7 @@ module Homebrew
 
           match_data.merge!(Strategy.page_content(url))
           content = match_data.delete(:content)
+          return match_data if content.blank?
 
           versions_from_content(content, regex, &block).each do |version_text|
             match_data[:matches][version_text] = Version.new(version_text)

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "rexml/document"
+
 module Homebrew
   module Livecheck
     module Strategy
@@ -53,8 +55,6 @@ module Homebrew
         # @return [REXML::Document, nil]
         sig { params(content: String).returns(T.nilable(REXML::Document)) }
         def self.parse_xml(content)
-          require "rexml/document"
-
           parsing_tries = 0
           begin
             REXML::Document.new(content)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

#15326 will set `HOMEBREW_SORBET_RUNTIME` by default for dev commands or when `HOMEBREW_DEVELOPER` is set. This PR addresses issues that I encountered while running `brew livecheck` across all of our first-party formulae/casks with the Sorbet runtime enabled. There may be other issues that haven't been surfaced yet but this covers the existing ones, at least.


## Selectively pass args to `#find_versions`

The existing way of passing values to `#find_versions` methods in strategies leads to type issues when the Sorbet runtime is enabled. We've also recently talked about moving away from nilable args when we can specify a default value but this doesn't work if we pass in a `nil` value (like we're currently doing).

These changes aim to address both of those areas by better controlling which arguments we're passing to `#find_versions`. This approach naively handles `cask`/`url` arguments by special-casing `ExtractPlist`.

However, we should be checking the strategy's `#find_versions` method for a `cask` or `url` keyword parameter. The issue is that `strategy.method(:find_versions).parameters` is returning `[[:rest, :args], [:block, :blk]]` instead of the actual parameters like `[[:keyreq, :url], [:key, :regex], [:keyrest, :unused], [:block, :block]]`. I'm not sure why this happens but I wanted to get a fix merged (to unblock the Sorbet runtime PR) before digging into it further.


## `Launchpad`: Use `DEFAULT_REGEX` as default `regex` arg

Using `DEFAULT_REGEX` as the default value of the `#find_versions` `regex` parameter allows us to tighten the type, as discussed in #15260 and #15270.


## `Sparkle`: Account for `nil` `content` value

`content` can be `nil` when a request doesn't succeed but `#versions_from_content` expects a `String` value, so we need to guard against a `nil` value like we do in other strategies.


## `Xml`: Move `require` outside of `#parse_xml`

Since we use `REXML::Document` in the type signature for `#parse_xml`, we can encounter an `uninitialized constant Homebrew::Livecheck::Strategy::Xml::REXML` error in strategies like `Sparkle` that use `Xml#parse_xml` internally when the Sorbet runtime is used. Moving the related require outside of the `#parse_xml` method and into the `Xml` strategy proper resolves this issue.