### PR TITLE
rubocops/service: check for more cellar paths

### DIFF
--- a/Library/Homebrew/rubocops/service.rb
+++ b/Library/Homebrew/rubocops/service.rb
@@ -12,16 +12,28 @@ module RuboCop
       class Service < FormulaCop
         extend AutoCorrector
 
+        CELLAR_PATH_AUDIT_CORRECTIONS = {
+          bin:      :opt_bin,
+          libexec:  :opt_libexec,
+          pkgshare: :opt_pkgshare,
+          prefix:   :opt_prefix,
+          sbin:     :opt_sbin,
+          share:    :opt_share,
+        }.freeze
+
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           service_node = find_block(body_node, :service)
           return if service_node.blank?
 
-          # This check ensures that `bin` is not referenced because
-          # `opt_bin` is more portable and works with the API.
-          find_every_method_call_by_name(service_node, :bin).each do |bin_node|
-            offending_node(bin_node)
-            problem "Use `opt_bin` instead of `bin` in service blocks." do |corrector|
-              corrector.replace(bin_node.source_range, "opt_bin")
+          # This check ensures that cellar paths like `bin` are not referenced
+          # because their `opt_` variants are more portable and work with the
+          # API.
+          CELLAR_PATH_AUDIT_CORRECTIONS.each do |path, opt_path|
+            find_every_method_call_by_name(service_node, path).each do |node|
+              offending_node(node)
+              problem "Use `#{opt_path}` instead of `#{path}` in service blocks." do |corrector|
+                corrector.replace(node.source_range, opt_path)
+              end
             end
           end
         end

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -5,7 +5,7 @@ require "rubocops/service"
 describe RuboCop::Cop::FormulaAudit::Service do
   subject(:cop) { described_class.new }
 
-  it "reports an offense when a formula's service block uses `bin`" do
+  it "reports offenses when a formula's service block uses cellar paths" do
     expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
@@ -13,6 +13,8 @@ describe RuboCop::Cop::FormulaAudit::Service do
         service do
           run [bin/"foo", "run", "-config", etc/"foo/config.json"]
                ^^^ FormulaAudit/Service: Use `opt_bin` instead of `bin` in service blocks.
+          working_dir libexec
+                      ^^^^^^^ FormulaAudit/Service: Use `opt_libexec` instead of `libexec` in service blocks.
         end
       end
     RUBY
@@ -23,18 +25,20 @@ describe RuboCop::Cop::FormulaAudit::Service do
 
         service do
           run [opt_bin/"foo", "run", "-config", etc/"foo/config.json"]
+          working_dir opt_libexec
         end
       end
     RUBY
   end
 
-  it "reports no offenses when a formula's service block uses `opt_bin`" do
+  it "reports no offenses when a formula's service block only uses opt paths" do
     expect_no_offenses(<<~RUBY)
       class Bin < Formula
         url "https://brew.sh/foo-1.0.tgz"
 
         service do
           run [opt_bin/"bin", "run", "-config", etc/"bin/config.json"]
+          working_dir opt_libexec
         end
       end
     RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to #15154. In addition to `bin`, the `service` block can also reference other cellar paths like `libexec`. They don't work with the API either, as reported in https://github.com/orgs/Homebrew/discussions/4459.

Violations are already corrected in Homebrew/homebrew-core#129736 and Homebrew/homebrew-core#129737.
