### PR TITLE
Use `serialize` to hashify `T::Struct`s

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -13,17 +13,24 @@ class GitHubRunnerMatrix
   RunnerSpec = T.type_alias { T.any(LinuxRunnerSpec, MacOSRunnerSpec) }
   private_constant :RunnerSpec
 
-  MacOSRunnerSpecHash = T.type_alias { { name: String, runner: String, timeout: Integer, cleanup: T::Boolean } }
+  MacOSRunnerSpecHash = T.type_alias do
+    {
+      "name"    => String,
+      "runner"  => String,
+      "timeout" => Integer,
+      "cleanup" => T::Boolean,
+    }
+  end
   private_constant :MacOSRunnerSpecHash
 
   LinuxRunnerSpecHash = T.type_alias do
     {
-      name:      String,
-      runner:    String,
-      container: T::Hash[Symbol, String],
-      workdir:   String,
-      timeout:   Integer,
-      cleanup:   T::Boolean,
+      "name"      => String,
+      "runner"    => String,
+      "container" => T::Hash[Symbol, String],
+      "workdir"   => String,
+      "timeout"   => Integer,
+      "cleanup"   => T::Boolean,
     }
   end
   private_constant :LinuxRunnerSpecHash
@@ -57,7 +64,7 @@ class GitHubRunnerMatrix
   def active_runner_specs_hash
     runners.select(&:active)
            .map(&:spec)
-           .map(&:to_h)
+           .map(&:serialize)
   end
 
   private

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -12,31 +12,6 @@ class GitHubRunnerMatrix
 
   RunnerSpec = T.type_alias { T.any(LinuxRunnerSpec, MacOSRunnerSpec) }
   private_constant :RunnerSpec
-
-  MacOSRunnerSpecHash = T.type_alias do
-    {
-      "name"    => String,
-      "runner"  => String,
-      "timeout" => Integer,
-      "cleanup" => T::Boolean,
-    }
-  end
-  private_constant :MacOSRunnerSpecHash
-
-  LinuxRunnerSpecHash = T.type_alias do
-    {
-      "name"      => String,
-      "runner"    => String,
-      "container" => T::Hash[Symbol, String],
-      "workdir"   => String,
-      "timeout"   => Integer,
-      "cleanup"   => T::Boolean,
-    }
-  end
-  private_constant :LinuxRunnerSpecHash
-
-  RunnerSpecHash = T.type_alias { T.any(LinuxRunnerSpecHash, MacOSRunnerSpecHash) }
-  private_constant :RunnerSpecHash
   # rubocop:enable Style/MutableConstant
 
   sig { returns(T::Array[GitHubRunner]) }
@@ -60,7 +35,7 @@ class GitHubRunnerMatrix
     freeze
   end
 
-  sig { returns(T::Array[RunnerSpecHash]) }
+  sig { returns(T::Array[T::Hash[String, T.untyped]]) }
   def active_runner_specs_hash
     runners.select(&:active)
            .map(&:spec)

--- a/Library/Homebrew/linux_runner_spec.rb
+++ b/Library/Homebrew/linux_runner_spec.rb
@@ -8,25 +8,4 @@ class LinuxRunnerSpec < T::Struct
   const :workdir, String
   const :timeout, Integer
   const :cleanup, T::Boolean
-
-  sig {
-    returns({
-      name:      String,
-      runner:    String,
-      container: T::Hash[Symbol, String],
-      workdir:   String,
-      timeout:   Integer,
-      cleanup:   T::Boolean,
-    })
-  }
-  def to_h
-    {
-      name:      name,
-      runner:    runner,
-      container: container,
-      workdir:   workdir,
-      timeout:   timeout,
-      cleanup:   cleanup,
-    }
-  end
 end

--- a/Library/Homebrew/macos_runner_spec.rb
+++ b/Library/Homebrew/macos_runner_spec.rb
@@ -6,14 +6,4 @@ class MacOSRunnerSpec < T::Struct
   const :runner, String
   const :timeout, Integer
   const :cleanup, T::Boolean
-
-  sig { returns({ name: String, runner: String, timeout: Integer, cleanup: T::Boolean }) }
-  def to_h
-    {
-      name:    name,
-      runner:  runner,
-      timeout: timeout,
-      cleanup: cleanup,
-    }
-  end
 end

--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -19,10 +19,4 @@ describe LinuxRunnerSpec do
       expect(spec.respond_to?("#{attribute}=")).to be(false)
     end
   end
-
-  describe "#to_h" do
-    it "returns an object that responds to `#to_json`" do
-      expect(spec.to_h.respond_to?(:to_json)).to be(true)
-    end
-  end
 end

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -10,10 +10,4 @@ describe MacOSRunnerSpec do
       expect(spec.respond_to?("#{attribute}=")).to be(false)
     end
   end
-
-  describe "#to_h" do
-    it "returns an object that responds to `#to_json`" do
-      expect(spec.to_h.respond_to?(:to_json)).to be(true)
-    end
-  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I was looking into if/how we use T::Struct as part of https://github.com/Homebrew/brew/pull/15329#pullrequestreview-1407020659 and thought I would try to get in front of this pattern.

I suggest using `serialize` rather than explicitly mapping each field here. The only difference is the stringified keys (backcompat is possible via `symbolize_keys`, if necessary), but that's generally what you want, because it's typically being converted to a non-ruby format, e.g. JSON.
