### PR TITLE
diagnostic: Check for unnecessary Core and Cask taps

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -843,8 +843,9 @@ module Homebrew
       end
 
       def check_for_unnecessary_core_tap
-        return if ENV["HOMEBREW_DEVELOPER"]
-        return if ENV["HOMEBREW_NO_INSTALL_FROM_API"]
+        return if Homebrew::EnvConfig.developer?
+        return if Homebrew::EnvConfig.no_install_from_api?
+        return if Homebrew::Settings.read("devcmdrun") == "true"
         return unless CoreTap.instance.installed?
 
         <<~EOS
@@ -856,9 +857,11 @@ module Homebrew
       end
 
       def check_for_unnecessary_cask_tap
-        return if ENV["HOMEBREW_DEVELOPER"]
-        return if ENV["HOMEBREW_NO_INSTALL_FROM_API"]
-        return unless (cask_tap = Tap.fetch("homebrew", "cask")).installed?
+        return if Homebrew::EnvConfig.developer?
+        return if Homebrew::EnvConfig.no_install_from_api?
+        return if Homebrew::Settings.read("devcmdrun") == "true"
+        cask_tap = Tap.fetch("homebrew", "cask")
+        return unless cask_tap.installed?
 
         <<~EOS
           You have an unnecessary local Cask tap.

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -860,6 +860,7 @@ module Homebrew
         return if Homebrew::EnvConfig.developer?
         return if Homebrew::EnvConfig.no_install_from_api?
         return if Homebrew::Settings.read("devcmdrun") == "true"
+
         cask_tap = Tap.fetch("homebrew", "cask")
         return unless cask_tap.installed?
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -842,6 +842,32 @@ module Homebrew
         EOS
       end
 
+      def check_for_unnecessary_core_tap
+        return if ENV["HOMEBREW_DEVELOPER"]
+        return if ENV["HOMEBREW_NO_INSTALL_FROM_API"]
+        return unless CoreTap.instance.installed?
+
+        <<~EOS
+          You have an unnecessary local Core tap!
+          This can cause problems installing up-to-date formulae.
+          Please remove it by running:
+           brew untap #{CoreTap.instance.name}
+        EOS
+      end
+
+      def check_for_unnecessary_cask_tap
+        return if ENV["HOMEBREW_DEVELOPER"]
+        return if ENV["HOMEBREW_NO_INSTALL_FROM_API"]
+        return unless (cask_tap = Tap.fetch("homebrew", "cask")).installed?
+
+        <<~EOS
+          You have an unnecessary local Cask tap.
+          This can cause problems installing up-to-date casks.
+          Please remove it by running:
+            brew untap #{cask_tap.name}
+        EOS
+      end
+
       def check_cask_software_versions
         add_info "Homebrew Version", HOMEBREW_VERSION
         add_info "macOS", MacOS.full_version

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -114,4 +114,24 @@ describe Homebrew::Diagnostic::Checks do
     expect(checks.check_homebrew_prefix)
       .to match("Your Homebrew's prefix is not #{Homebrew::DEFAULT_PREFIX}")
   end
+
+  specify "#check_for_unnecessary_core_tap" do
+    ENV.delete("HOMEBREW_DEVELOPER")
+    ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
+
+    allow(CoreTap).to receive(:installed?).and_return(true)
+
+    expect(checks.check_for_unnecessary_core_tap).to match("You have an unnecessary local Core tap")
+  end
+
+  specify "#check_for_unnecessary_cask_tap" do
+    ENV.delete("HOMEBREW_DEVELOPER")
+    ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
+
+    cask_tap = Tap.new("homebrew", "cask")
+    allow(Tap).to receive(:fetch).with("homebrew", "cask").and_return(cask_tap)
+    allow(cask_tap).to receive(:installed?).and_return(true)
+
+    expect(checks.check_for_unnecessary_cask_tap).to match("unnecessary local Cask tap")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/15339.
- If the user doesn't have `HOMEBREW_DEVELOPER` or `HOMEBREW_NO_INSTALL_FROM_API` set but does have `homebrew/core` or `homebrew/cask` taps installed this can cause problems with installing outdated software.
- Hence, warn them in `brew doctor` if they have one or both of these taps installed, with an instruction for how to remove them.

This looks like:

```
Warning: You have an unnecessary local Cask tap.
This can cause problems installing up-to-date casks.
Please remove it by running:
  brew untap homebrew/cask

Warning: You have an unnecessary local Core tap!
This can cause problems installing up-to-date formulae.
Please remove it by running:
 brew untap homebrew/core
```
