### PR TITLE
BazaarDownloadStrategy: Replace in-place sub

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1277,7 +1277,7 @@ end
 class BazaarDownloadStrategy < VCSDownloadStrategy
   def initialize(url, name, version, **meta)
     super
-    @url.sub!(%r{^bzr://}, "")
+    @url = @url.sub(%r{^bzr://}, "")
   end
 
   # @see AbstractDownloadStrategy#source_modified_time


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

livecheck's `Git` strategy uses `DownloadStrategyDetector#detect` in its `#match?` method to check if a URL is a Git repository. This has historically worked fine but I've recently seen a `can't modify frozen String` error for a few formulae (percona-toolkit, schroedinger, squid) in relation to the in-place `sub` call in `BazaarDownloadStrategy`'s initializer.

Other download strategies use a `@url = @url.sub(...)` pattern to avoid this issue, so this PR resolves the issue by using the same approach in `BazaarDownloadStrategy`.