### PR TITLE
cmd/update-report: do not fail when tap has no origin

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -158,7 +158,7 @@ module Homebrew
 
     updated_taps = []
     Tap.each do |tap|
-      next unless tap.git?
+      next if !tap.git? || tap.git_repo.origin_url.nil?
       next if (tap.core_tap? || tap == "homebrew/cask") && !Homebrew::EnvConfig.no_install_from_api?
 
       if ENV["HOMEBREW_MIGRATE_LINUXBREW_FORMULAE"].present? && tap.core_tap? &&


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the following error:

```console
$ brew update
Warning: No remote 'origin' in /usr/local/Homebrew/Library/Taps/foo/homebrew-bar, skipping update!
Error: HOMEBREW_UPDATE_BEFORE_FOO_HOMEBREW_BAR is unset!
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:361:in `initialize'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:187:in `new'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:187:in `block in output_update_report'
/usr/local/Homebrew/Library/Homebrew/tap.rb:748:in `block (2 levels) in each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:747:in `each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:747:in `block in each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:746:in `each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:746:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:160:in `output_update_report'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:40:in `update_report'
/usr/local/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
Already up-to-date.
```
