### PR TITLE
Allow `mirror`s to be as capable as `url`s

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -58,7 +58,7 @@ class AbstractDownloadStrategy
   private :meta, :name, :version
 
   def initialize(url, name, version, **meta)
-    @url = url
+    @url = url.to_s
     @name = name
     @version = version
     @cache = meta.fetch(:cache, HOMEBREW_CACHE)
@@ -380,12 +380,13 @@ end
 class CurlDownloadStrategy < AbstractFileDownloadStrategy
   include Utils::Curl
 
+  sig { returns(T::Array[String]) }
   attr_reader :mirrors
 
   def initialize(url, name, version, **meta)
     super
     @try_partial = true
-    @mirrors = meta.fetch(:mirrors, [])
+    @mirrors = meta.fetch(:mirrors, []).map(&:to_s)
   end
 
   # Download and cache the file at {#cached_location}.
@@ -473,7 +474,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       url = url.sub(%r{^https?://#{GitHubPackages::URL_DOMAIN}/}o, "#{domain.chomp("/")}/")
     end
 
-    parsed_output = curl_head(url.to_s, timeout: timeout)
+    parsed_output = curl_head(url, timeout: timeout)
     parsed_headers = parsed_output.fetch(:responses).map { |r| r.fetch(:headers) }
 
     final_url = curl_response_follow_redirections(parsed_output.fetch(:responses), url)

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -17,12 +17,12 @@ class Downloadable
   sig { returns(T.nilable(Checksum)) }
   attr_reader :checksum
 
-  sig { returns(T::Array[String]) }
+  sig { returns(T::Array[URL]) }
   attr_reader :mirrors
 
   sig { void }
   def initialize
-    @mirrors = T.let([], T::Array[String])
+    @mirrors = T.let([], T::Array[URL])
   end
 
   def initialize_dup(other)
@@ -121,9 +121,9 @@ class Downloadable
     @url
   end
 
-  sig { overridable.returns(T::Array[String]) }
+  sig { overridable.returns(T::Array[URL]) }
   def determine_url_mirrors
-    [determine_url.to_s, *mirrors].uniq
+    [*([determine_url] unless determine_url.nil?), *mirrors].uniq
   end
 
   sig { overridable.returns(Pathname) }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2958,8 +2958,8 @@ class Formula
     #
     # <pre>mirror "https://in.case.the.host.is.down.example.com"
     # mirror "https://in.case.the.mirror.is.down.example.com</pre>
-    def mirror(val)
-      stable.mirror(val)
+    def mirror(val, specs = {})
+      stable.mirror(val, specs)
     end
 
     # @!attribute [w] sha256

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -202,8 +202,8 @@ class Resource < Downloadable
     end
   end
 
-  def mirror(val)
-    mirrors << val
+  def mirror(val, **specs)
+    mirrors << URL.new(val, specs)
   end
 
   def patch(strip = :p1, src = nil, &block)

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -28,8 +28,7 @@ class SoftwareSpec
               :uses_from_macos_elements
 
   def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time, :download_name,
-                 :cached_download, :clear_cache, :checksum, :mirrors, :specs, :using, :version, :mirror,
-                 :downloader
+                 :cached_download, :clear_cache, :checksum, :mirrors, :specs, :using, :version, :downloader
 
   def_delegators :@resource, :sha256
 
@@ -103,6 +102,10 @@ class SoftwareSpec
 
     @resource.url(val, **specs)
     dependency_collector.add(@resource)
+  end
+
+  def mirror(val, specs = {})
+    @resource.mirror(val, **specs)
   end
 
   def bottle_defined?

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "resource"
+require "url"
 require "livecheck"
 
 describe Resource do
@@ -126,7 +127,8 @@ describe Resource do
     it "returns an array of mirrors added with #mirror" do
       resource.mirror("foo")
       resource.mirror("bar")
-      expect(resource.mirrors).to eq(%w[foo bar])
+      resource.mirror("baz", using: "quux")
+      expect(resource.mirrors).to eq([URL.new("foo"), URL.new("bar"), URL.new("baz", { using: "quux" })])
     end
   end
 

--- a/Library/Homebrew/url.rb
+++ b/Library/Homebrew/url.rb
@@ -30,4 +30,17 @@ class URL
   def version
     @version ||= Version.detect(@url, **@specs)
   end
+
+  sig { params(other: T.untyped).returns(T.nilable(Integer)) }
+  def <=>(other)
+    other = URL.new(other) if other.is_a? String
+    return unless other.is_a? URL
+
+    return to_s <=> other.to_s if to_s != other.to_s
+
+    return specs <=> other.specs if specs != other.specs
+
+    using <=> other.using
+  end
+  alias eql? ==
 end

--- a/Library/Homebrew/url.rbi
+++ b/Library/Homebrew/url.rbi
@@ -1,0 +1,10 @@
+# typed: strict
+
+class URL
+  # For `alias eql? ==`
+  # See discussions:
+  #  - https://github.com/sorbet/sorbet/pull/1443
+  #  - https://github.com/sorbet/sorbet/issues/2378
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def ==(other); end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is the first half of the work to unblock Homebrew/homebrew-core#129908; it allows `mirror`s everywhere to be capable of taking various `specs` like `url`s can.  This doesn't resolve the issue of HEAD builds not even consulting the mirrors, though.

Draft because I get strange errors trying to typecheck, style, and test this code that are unrelated to Homebrew; I think my system Ruby may be a little out of whack.  So I'm hopeful others will be able to do those parts for me.