### PR TITLE
bottle: some tar flags are not supported on Mojave

### DIFF
--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -4,6 +4,10 @@
 module Homebrew
   sig { returns(T::Array[String]) }
   def self.tar_args
-    ["--no-mac-metadata", "--no-acls", "--no-xattrs"].freeze
+    if MacOS.version >= :catalina
+      ["--no-mac-metadata", "--no-acls", "--no-xattrs"].freeze
+    else
+      [].freeze
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
```
Inspecting 1173 files
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

1173 files inspected, no offenses detected
==> Installing `shellcheck` for shell style checks...
Warning: You are using macOS 10.14.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
Do not create any issues about this on Homebrew's GitHub repositories.
Do not create any issues even if you think this message is unrelated.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.

ghc: This software does not run on macOS versions older than Catalina.
Error: shellcheck: An unsatisfied requirement failed this build.
Error: Failure while executing; `/usr/local/bin/brew install --formula shellcheck` exited with 1.
```
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Pull request for the [discussion](https://github.com/orgs/Homebrew/discussions/4462). I am not sure Catalina is the minimum supported MacOS version. I am not sure this [commit](https://github.com/libarchive/libarchive/commit/6127a37e01bd4ca3cdff310d69b174e82e22b7c7) is the correct commit for the tar flags. It seems that minimum version of libarchive is 3.3. The version of libarchive on my Mojave is 2.8.3. I don't know the build-in version of libarchive on Catalina.
