### PR TITLE
GitHub::API: Allow passing options to curl

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -65,10 +65,7 @@ module Homebrew
 
       # Baseline `curl` options used in {Strategy} methods.
       DEFAULT_CURL_OPTIONS = {
-        print_stdout:    false,
-        print_stderr:    false,
         debug:           false,
-        verbose:         false,
         timeout:         CURL_PROCESS_TIMEOUT,
         connect_timeout: CURL_CONNECT_TIMEOUT,
         max_time:        CURL_MAX_TIME,

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -65,10 +65,16 @@ module Homebrew
 
       # Baseline `curl` options used in {Strategy} methods.
       DEFAULT_CURL_OPTIONS = {
+        # By default, `Utils::Curl` methods will print text (e.g. the command)
+        # when `--debug` is set. `debug` is set to `false` to ensure that this
+        # unwanted text doesn't appear in livecheck's debug output.
         debug:           false,
         timeout:         CURL_PROCESS_TIMEOUT,
         connect_timeout: CURL_CONNECT_TIMEOUT,
         max_time:        CURL_MAX_TIME,
+        # `Utils::Curl` uses curl's `--retry` option by default but this isn't
+        # valuable enough in the context of livecheck to justify the additional
+        # effort. A zero value ensures that the `--retry` option is omitted.
         retries:         0,
       }.freeze
 

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -141,7 +141,11 @@ module Homebrew
 
           match_data[:url] = generated[:url]
 
-          release = GitHub.get_latest_release(generated[:username], generated[:repository])
+          release = GitHub.get_latest_release(
+            generated[:username],
+            generated[:repository],
+            **Strategy::DEFAULT_CURL_OPTIONS,
+          )
           versions_from_content(release, regex, &block).each do |match_text|
             match_data[:matches][match_text] = Version.new(match_text)
           end

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -72,7 +72,7 @@ module Homebrew
           match = url.sub(/\.git$/i, "").match(URL_MATCH_REGEX)
           return values if match.blank?
 
-          values[:url] = "https://api.github.com/repos/#{match[:username]}/#{match[:repository]}/releases/latest"
+          values[:url] = "#{GitHub::API_URL}/repos/#{match[:username]}/#{match[:repository]}/releases/latest"
           values[:username] = match[:username]
           values[:repository] = match[:repository]
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -248,9 +248,25 @@ module GitHub
     API.open_rest(url, request_method: :GET)
   end
 
-  def self.get_latest_release(user, repo)
+  def self.get_latest_release(
+    user,
+    repo,
+    debug: nil,
+    timeout: nil,
+    connect_timeout: nil,
+    max_time: nil,
+    retries: nil
+  )
     url = "#{API_URL}/repos/#{user}/#{repo}/releases/latest"
-    API.open_rest(url, request_method: :GET)
+
+    curl_options = {
+      debug:           debug,
+      timeout:         timeout,
+      connect_timeout: connect_timeout,
+      max_time:        max_time,
+      retries:         retries,
+    }.compact
+    API.open_rest(url, request_method: :GET, **curl_options)
   end
 
   def self.generate_release_notes(user, repo, tag, previous_tag: nil)

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -248,6 +248,17 @@ module GitHub
     API.open_rest(url, request_method: :GET)
   end
 
+  sig {
+    params(
+      user:            String,
+      repo:            String,
+      debug:           T.nilable(T::Boolean),
+      timeout:         T.nilable(T.any(Integer, Float)),
+      connect_timeout: T.nilable(T.any(Integer, Float)),
+      max_time:        T.nilable(T.any(Integer, Float)),
+      retries:         T.nilable(Integer),
+    ).returns(T::Hash[String, T.untyped])
+  }
   def self.get_latest_release(
     user,
     repo,

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -181,7 +181,17 @@ module GitHub
     end
 
     def self.open_rest(
-      url, data: nil, data_binary_path: nil, request_method: nil, scopes: [].freeze, parse_json: true
+      url,
+      data: nil,
+      data_binary_path: nil,
+      request_method: nil,
+      scopes: [].freeze,
+      parse_json: true,
+      debug: nil,
+      timeout: nil,
+      connect_timeout: nil,
+      max_time: nil,
+      retries: nil
     )
       # This is a no-op if the user is opting out of using the GitHub API.
       return block_given? ? yield({}) : {} if Homebrew::EnvConfig.no_github_api?
@@ -222,7 +232,15 @@ module GitHub
 
         args += ["--dump-header", T.must(headers_tmpfile.path)]
 
-        output, errors, status = curl_output("--location", url.to_s, *args, secrets: [token])
+        curl_options = {
+          debug:           debug,
+          timeout:         timeout,
+          connect_timeout: connect_timeout,
+          max_time:        max_time,
+          retries:         retries,
+        }.compact
+
+        output, errors, status = curl_output("--location", url.to_s, *args, secrets: [token], **curl_options)
         output, _, http_code = output.rpartition("\n")
         output, _, http_code = output.rpartition("\n") if http_code == "000"
         headers = headers_tmpfile.read

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -180,6 +180,21 @@ module GitHub
       EOS
     end
 
+    sig {
+      params(
+        url:              T.any(String, URI::HTTPS),
+        data:             T.nilable(T::Hash[String, T.untyped]),
+        data_binary_path: T.nilable(String),
+        request_method:   T.nilable(Symbol),
+        scopes:           Array,
+        parse_json:       T::Boolean,
+        debug:            T.nilable(T::Boolean),
+        timeout:          T.nilable(T.any(Integer, Float)),
+        connect_timeout:  T.nilable(T.any(Integer, Float)),
+        max_time:         T.nilable(T.any(Integer, Float)),
+        retries:          T.nilable(Integer),
+      ).returns(T.untyped)
+    }
     def self.open_rest(
       url,
       data: nil,
@@ -280,7 +295,7 @@ module GitHub
 
     def self.open_graphql(query, variables: nil, scopes: [].freeze, raise_errors: true)
       data = { query: query, variables: variables }
-      result = open_rest("#{API_URL}/graphql", scopes: scopes, data: data, request_method: "POST")
+      result = open_rest("#{API_URL}/graphql", scopes: scopes, data: data, request_method: :POST)
 
       if raise_errors
         if result["errors"].present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR makes it possible to pass additional options to `GitHub::API#open_rest`, which are passed on to `#curl_output` (and also to `#curl_args` as a result).

For example, we carefully control debug output in livecheck but sometimes we call methods from other parts of Homebrew that call a `Utils::Curl` method and the curl debug output is printed in the middle of livecheck's debug output. In this scenario, we need to be able to pass `debug: false` to `#curl_options` to prevent its debug output from printing and that's one use case that this supports.

With that in mind, this is primarily intended for use in #15270 and #15260. We'll have to switch to using a direct `#open_rest` call in `GithubLatest` (instead of `GitHub::get_latest_release`) but the strategy already generates the appropriate API URL, so it's a very easy change.

For what it's worth, it's technically possible to add `**options` to some of the `GitHub` methods and pass them through to the `#open_rest` call. However, 10 out of ~30 are already using the double splat for another purpose (e.g., `issues(repo:, **filters)`, `search_issues(query, **qualifiers)`, etc.). Since it's not a change that can be uniformly rolled out to all the `GitHub` methods, I decided to keep this PR simple for now.