### PR TITLE
brew.sh: run brew readall with Sorbet.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -886,9 +886,7 @@ then
   fi
 fi
 
-# brew readall is currently failing with Sorbet for homebrew/core.
-# TODO: fix this and remove this HOMEBREW_COMMAND conditional.
-if [[ -n "${HOMEBREW_DEVELOPER}" && "${HOMEBREW_COMMAND}" != "readall" ]]
+if [[ -n "${HOMEBREW_DEVELOPER}" ]]
 then
   # Always run with Sorbet for Homebrew developers.
   export HOMEBREW_SORBET_RUNTIME="1"


### PR DESCRIPTION
This re-adds the `readall` command from the temporary exemption in https://github.com/Homebrew/brew/pull/15326.