### PR TITLE
bump-formula-pr: fix method argument type

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -325,7 +325,7 @@ module Homebrew
 
     unless args.dry_run?
       resources_checked = PyPI.update_python_resources! formula,
-                                                        version:                  new_formula_version,
+                                                        version:                  new_formula_version.to_s,
                                                         package_name:             args.python_package_name,
                                                         extra_packages:           args.python_extra_packages,
                                                         exclude_packages:         args.python_exclude_packages,


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes: https://github.com/Homebrew/brew/issues/15366

Before:
```
homebrew-core on  master ➜  brew bump-formula-pr --write-only node-build --version=4.9.115 --force
Warning: These open pull requests may be duplicates:
node-build 4.9.115 https://github.com/Homebrew/homebrew-core/pull/130235
==> Downloading https://github.com/nodenv/node-build/archive/v4.9.115.tar.gz
Already downloaded: /home/dawid/.cache/Homebrew/downloads/a329b85d12ba92867ed95de997b0ff825f21fa6c3e41dd3d18078dbb8a66873c--node-build-4.9.115.tar.gz
Warning: Cannot verify integrity of 'a329b85d12ba92867ed95de997b0ff825f21fa6c3e41dd3d18078dbb8a66873c--node-build-4.9.115.tar.gz'.
No checksum was provided.
For your reference, the checksum is:
  sha256 "5082191984141b193a6a2fef85ec0c78de9cb23ecd45c0638821410afd1b2108"
==> replace /https:\/\/github\.com\/nodenv\/node\-build\/archive\/v4\.9\.114\.tar\.gz/ with "https://github.com/nodenv/node-build/archive/v4
==> replace "598c90665c862aadc4e0410d439afe30d6640678fe68889b48366bb985f8cbed" with "5082191984141b193a6a2fef85ec0c78de9cb23ecd45c0638821410
Error: Parameter 'version': Expected type T.nilable(String), got type Version with hash -1768358259431250442
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:113
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/pypi.rb:136
Do not report this issue until you've run `brew update` and tried again.
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/configuration.rb:296:in `call_validation_error_handler_default'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/configuration.rb:303:in `call_validation_error_handler'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:187:in `report_error'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:116:in `block in validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/signature.rb:211:in `block in each_args_value_type'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/signature.rb:206:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/signature.rb:206:in `each_args_value_type'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:113:in `validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/_methods.rb:270:in `block in _on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:327:in `bump_formula_pr'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```

After:
```
homebrew-core on  master ➜  brew bump-formula-pr --write-only node-build --version=4.9.115 --force
Warning: These open pull requests may be duplicates:
node-build 4.9.115 https://github.com/Homebrew/homebrew-core/pull/130235
==> Downloading https://github.com/nodenv/node-build/archive/v4.9.115.tar.gz
Already downloaded: /home/dawid/.cache/Homebrew/downloads/a329b85d12ba92867ed95de997b0ff825f21fa6c3e41dd3d18078dbb8a66873c--node-build-4.9.115.tar.gz
Warning: Cannot verify integrity of 'a329b85d12ba92867ed95de997b0ff825f21fa6c3e41dd3d18078dbb8a66873c--node-build-4.9.115.tar.gz'.
No checksum was provided.
For your reference, the checksum is:
  sha256 "5082191984141b193a6a2fef85ec0c78de9cb23ecd45c0638821410afd1b2108"
==> replace /https:\/\/github\.com\/nodenv\/node\-build\/archive\/v4\.9\.114\.tar\.gz/ with "https://github.com/nodenv/node-build/archive/v4
==> replace "598c90665c862aadc4e0410d439afe30d6640678fe68889b48366bb985f8cbed" with "5082191984141b193a6a2fef85ec0c78de9cb23ecd45c0638821410
==> try to fork repository with GitHub API
==> git add /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/node-build.rb
==> git checkout --no-track -b bump-node-build-4.9.115 origin/master
==> git commit --no-edit --verbose --message='node-build 4.9.115' -- /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
==> git push --set-upstream FORK_URL bump-node-build-4.9.115:bump-node-build-4.9.115
==> git checkout --quiet -
==> create pull request with GitHub API (base branch: master)
```