### PR TITLE
Revert "Enable Sorbet by default for Homebrew developers and developer commands."

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -850,9 +850,6 @@ if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/dev-cmd/${HOMEBREW_COMMAND}.sh" ]] ||
 then
   export HOMEBREW_DEVELOPER_COMMAND="1"
 
-  # Always run developer commands with Sorbet.
-  export HOMEBREW_SORBET_RUNTIME="1"
-
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
   then
     NO_INSTALL_FROM_API_COMMANDS=(
@@ -884,14 +881,6 @@ then
 
     unset NO_INSTALL_FROM_API_COMMANDS
   fi
-fi
-
-# brew readall is currently failing with Sorbet for homebrew/core.
-# TODO: fix this and remove this HOMEBREW_COMMAND conditional.
-if [[ -n "${HOMEBREW_DEVELOPER}" && "${HOMEBREW_COMMAND}" != "readall" ]]
-then
-  # Always run with Sorbet for Homebrew developers.
-  export HOMEBREW_SORBET_RUNTIME="1"
 fi
 
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -357,8 +357,7 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_SORBET_RUNTIME:                   {
-        description: "If set, enable runtime typechecking using Sorbet. " \
-                     "Set by default for HOMEBREW_DEVELOPER or when running developer commands.",
+        description: "If set, enable runtime typechecking using Sorbet.",
         boolean:     true,
       },
       HOMEBREW_SSH_CONFIG_PATH:                  {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2275,7 +2275,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions of macOS. This is useful in development on new macOS versions.
 
 - `HOMEBREW_SORBET_RUNTIME`
-  <br>If set, enable runtime typechecking using Sorbet. Set by default for HOMEBREW_DEVELOPER or when running developer commands.
+  <br>If set, enable runtime typechecking using Sorbet.
 
 - `HOMEBREW_SSH_CONFIG_PATH`
   <br>If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching `git` repos over `ssh`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3354,7 +3354,7 @@ If set along with \fBHOMEBREW_DEVELOPER\fR, do not use bottles from older versio
 \fBHOMEBREW_SORBET_RUNTIME\fR
 .
 .br
-If set, enable runtime typechecking using Sorbet\. Set by default for HOMEBREW_DEVELOPER or when running developer commands\.
+If set, enable runtime typechecking using Sorbet\.
 .
 .TP
 \fBHOMEBREW_SSH_CONFIG_PATH\fR


### PR DESCRIPTION
Reverts Homebrew/brew#15326

This is causing some breakage in homebrew-core:
https://github.com/Homebrew/homebrew-core/actions/runs/4892972572/jobs/8735383323?pr=130235
https://github.com/Homebrew/homebrew-core/actions/runs/4892972572/jobs/8735365498?pr=130235

Plus: https://github.com/Homebrew/brew/issues/15366