### PR TITLE
Revert "Revert "Enable Sorbet by default for Homebrew developers and developer commands.""

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -883,6 +883,29 @@ then
   fi
 fi
 
+if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEVELOPER_COMMAND}" ]]
+then
+  # Always run with Sorbet for Homebrew developers or Homebrew developer commands.
+  export HOMEBREW_SORBET_RUNTIME="1"
+fi
+
+# brew audit and brew readall is currently failing with Sorbet for homebrew/core.
+# TODO: fix this and remove this if block.
+if [[ -n "${HOMEBREW_SORBET_RUNTIME}" ]]
+then
+  NO_SORBET_RUNTIME_COMMANDS=(
+    audit
+    readall
+  )
+
+  if check-array-membership "${HOMEBREW_COMMAND}" "${NO_SORBET_RUNTIME_COMMANDS[@]}"
+  then
+    unset HOMEBREW_SORBET_RUNTIME
+  fi
+
+  unset NO_SORBET_RUNTIME_COMMANDS
+fi
+
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]
 then
   if [[ -z "${HOMEBREW_DEV_CMD_RUN}" ]]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -357,7 +357,8 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_SORBET_RUNTIME:                   {
-        description: "If set, enable runtime typechecking using Sorbet.",
+        description: "If set, enable runtime typechecking using Sorbet. " \
+                     "Set by default for HOMEBREW_DEVELOPER or when running developer commands.",
         boolean:     true,
       },
       HOMEBREW_SSH_CONFIG_PATH:                  {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2275,7 +2275,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions of macOS. This is useful in development on new macOS versions.
 
 - `HOMEBREW_SORBET_RUNTIME`
-  <br>If set, enable runtime typechecking using Sorbet.
+  <br>If set, enable runtime typechecking using Sorbet. Set by default for HOMEBREW_DEVELOPER or when running developer commands.
 
 - `HOMEBREW_SSH_CONFIG_PATH`
   <br>If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching `git` repos over `ssh`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3354,7 +3354,7 @@ If set along with \fBHOMEBREW_DEVELOPER\fR, do not use bottles from older versio
 \fBHOMEBREW_SORBET_RUNTIME\fR
 .
 .br
-If set, enable runtime typechecking using Sorbet\.
+If set, enable runtime typechecking using Sorbet\. Set by default for HOMEBREW_DEVELOPER or when running developer commands\.
 .
 .TP
 \fBHOMEBREW_SSH_CONFIG_PATH\fR


### PR DESCRIPTION
Along with some fixes for failures in Homebrew/core. See discussion at #15368.

This reverts commit e49cd331dba71b1ced341f1838c7651ecff46a38.
