### PR TITLE
Revert "Merge pull request #15369 from carlocab/sorbet-runtime"

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -883,29 +883,6 @@ then
   fi
 fi
 
-if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEVELOPER_COMMAND}" ]]
-then
-  # Always run with Sorbet for Homebrew developers or Homebrew developer commands.
-  export HOMEBREW_SORBET_RUNTIME="1"
-fi
-
-# brew audit and brew readall is currently failing with Sorbet for homebrew/core.
-# TODO: fix this and remove this if block.
-if [[ -n "${HOMEBREW_SORBET_RUNTIME}" ]]
-then
-  NO_SORBET_RUNTIME_COMMANDS=(
-    audit
-    readall
-  )
-
-  if check-array-membership "${HOMEBREW_COMMAND}" "${NO_SORBET_RUNTIME_COMMANDS[@]}"
-  then
-    unset HOMEBREW_SORBET_RUNTIME
-  fi
-
-  unset NO_SORBET_RUNTIME_COMMANDS
-fi
-
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]
 then
   if [[ -z "${HOMEBREW_DEV_CMD_RUN}" ]]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -357,8 +357,7 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_SORBET_RUNTIME:                   {
-        description: "If set, enable runtime typechecking using Sorbet. " \
-                     "Set by default for HOMEBREW_DEVELOPER or when running developer commands.",
+        description: "If set, enable runtime typechecking using Sorbet.",
         boolean:     true,
       },
       HOMEBREW_SSH_CONFIG_PATH:                  {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2275,7 +2275,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions of macOS. This is useful in development on new macOS versions.
 
 - `HOMEBREW_SORBET_RUNTIME`
-  <br>If set, enable runtime typechecking using Sorbet. Set by default for HOMEBREW_DEVELOPER or when running developer commands.
+  <br>If set, enable runtime typechecking using Sorbet.
 
 - `HOMEBREW_SSH_CONFIG_PATH`
   <br>If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching `git` repos over `ssh`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3354,7 +3354,7 @@ If set along with \fBHOMEBREW_DEVELOPER\fR, do not use bottles from older versio
 \fBHOMEBREW_SORBET_RUNTIME\fR
 .
 .br
-If set, enable runtime typechecking using Sorbet\. Set by default for HOMEBREW_DEVELOPER or when running developer commands\.
+If set, enable runtime typechecking using Sorbet\.
 .
 .TP
 \fBHOMEBREW_SSH_CONFIG_PATH\fR


### PR DESCRIPTION
This reverts commit 8c059bba279f4b72b783fca91746d14b6286e6fc, reversing changes made to f71b3d37abcc9cd12b0c8a621bc3712c00db8ec1.

Fixes breakage starting dependent testing:
```
Run brew determine-test-runners --dependents --eval-all "$TESTING_FORMULAE"
Error: Return value: Expected type String, got type NilClass
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/version.rb:627
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/version.rb:655
```
