### PR TITLE
github_runner_matrix: align Intel and ARM timeouts

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -158,8 +158,7 @@ class GitHubRunnerMatrix
       runner.freeze
 
       # The ARM runners are typically over twice as fast as the Intel runners.
-      runner_timeout = timeout
-      runner_timeout /= 2 if timeout < GITHUB_ACTIONS_LONG_TIMEOUT
+      runner_timeout /= 2 if runner_timeout < GITHUB_ACTIONS_LONG_TIMEOUT
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-arm64",
         runner:  runner,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This prevents situations where the Intel runners have a 360 minute
timeout but the ARM runners only have 45 minutes.

See Homebrew/homebrew-core#130284.
