### PR TITLE
Always remove build from `short_version`.

### DIFF
--- a/Library/Homebrew/bundle_version.rb
+++ b/Library/Homebrew/bundle_version.rb
@@ -50,6 +50,9 @@ module Homebrew
 
     sig { params(short_version: T.nilable(String), version: T.nilable(String)).void }
     def initialize(short_version, version)
+      # Remove version from short version, if present.
+      short_version = short_version&.sub(/\s*\(#{Regexp.escape(version)}\)\Z/, "") if version
+
       @short_version = short_version.presence
       @version = version.presence
 
@@ -78,8 +81,6 @@ module Homebrew
     def nice_parts
       short_version = self.short_version
       version = self.version
-
-      short_version = short_version&.delete_suffix("(#{version})") if version
 
       return [T.must(short_version)] if short_version == version
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Makes `item.short_version` in `livecheck`s behave more similar to what it would look like in the default case.
