### PR TITLE
Fix small errors in `brew shellenv`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -81,6 +81,7 @@ case "$*" in
     ;;
   shellenv)
     source "${HOMEBREW_LIBRARY}/Homebrew/cmd/shellenv.sh"
+    shift
     homebrew-shellenv "$1"
     exit 0
     ;;

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -24,7 +24,7 @@ homebrew-shellenv() {
   then
     HOMEBREW_SHELL_NAME="$1"
   else
-    HOMEBREW_SHELL_NAME="$(/bin/ps -p "${PPID}" -c -o comm=)}"
+    HOMEBREW_SHELL_NAME="$(/bin/ps -p "${PPID}" -c -o comm=)"
   fi
 
   case "${HOMEBREW_SHELL_NAME}" in


### PR DESCRIPTION
These were introduced by typos and an incorrect assumption on the last update of #15358. The last commit had been tested with a parameter, but had not been re-tested *without* parameter.

A stray `}` had crept into the parameterless version of `HOMEBREW_SHELL_NAME` and because we had not `shift`ed the arguments, `$1` was `shellenv`, resulting in always outputting the POSIX-style configuration.

Apologies for the error.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?