### PR TITLE
Strategy#page_headers: Update for #curl_headers

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -182,16 +182,15 @@ module Homebrew
         headers = []
 
         [:default, :browser].each do |user_agent|
-          output, _, status = curl_headers(
+          parsed_output = curl_headers(
             url,
             wanted_headers:    ["location", "content-disposition"],
             use_homebrew_curl: homebrew_curl,
             user_agent:        user_agent,
             **DEFAULT_CURL_OPTIONS,
           )
-          next unless status.success?
+          next if parsed_output.blank?
 
-          parsed_output = parse_curl_output(output, max_iterations: MAX_PARSE_ITERATIONS)
           parsed_output[:responses].each { |response| headers << response[:headers] }
           break if headers.present?
         end

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -182,14 +182,17 @@ module Homebrew
         headers = []
 
         [:default, :browser].each do |user_agent|
-          parsed_output = curl_headers(
-            url,
-            wanted_headers:    ["location", "content-disposition"],
-            use_homebrew_curl: homebrew_curl,
-            user_agent:        user_agent,
-            **DEFAULT_CURL_OPTIONS,
-          )
-          next if parsed_output.blank?
+          begin
+            parsed_output = curl_headers(
+              url,
+              wanted_headers:    ["location", "content-disposition"],
+              use_homebrew_curl: homebrew_curl,
+              user_agent:        user_agent,
+              **DEFAULT_CURL_OPTIONS,
+            )
+          rescue ErrorDuringExecution
+            next
+          end
 
           parsed_output[:responses].each { |response| headers << response[:headers] }
           break if headers.present?

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -213,18 +213,18 @@ module Utils
         )
 
         # 22 means a non-successful HTTP status code, not a `curl` error, so we still got some headers.
-        if result.success? || result.exit_status == 22
-          parsed_output = parse_curl_output(result.stdout)
+        next if !result.success? && result.exit_status != 22
 
-          # If we didn't get any wanted header yet, retry using `GET`.
-          next if request_args.empty? && wanted_headers.any? &&
-                  parsed_output.fetch(:responses).none? { |r| (r.fetch(:headers).keys & wanted_headers).any? }
+        parsed_output = parse_curl_output(result.stdout)
 
-          return parsed_output if result.success?
-        end
+        # If we didn't get any wanted header yet, retry using `GET`.
+        next if request_args.empty? && wanted_headers.any? &&
+                parsed_output.fetch(:responses).none? { |r| (r.fetch(:headers).keys & wanted_headers).any? }
 
-        result.assert_success!
+        return parsed_output if result.success?
       end
+
+      nil
     end
 
     # Check if a URL is protected by CloudFlare (e.g. badlion.net and jaxx.io).

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -213,18 +213,18 @@ module Utils
         )
 
         # 22 means a non-successful HTTP status code, not a `curl` error, so we still got some headers.
-        next if !result.success? && result.exit_status != 22
+        if result.success? || result.exit_status == 22
+          parsed_output = parse_curl_output(result.stdout)
 
-        parsed_output = parse_curl_output(result.stdout)
+          # If we didn't get any wanted header yet, retry using `GET`.
+          next if request_args.empty? && wanted_headers.any? &&
+                  parsed_output.fetch(:responses).none? { |r| (r.fetch(:headers).keys & wanted_headers).any? }
 
-        # If we didn't get any wanted header yet, retry using `GET`.
-        next if request_args.empty? && wanted_headers.any? &&
-                parsed_output.fetch(:responses).none? { |r| (r.fetch(:headers).keys & wanted_headers).any? }
+          return parsed_output if result.success?
+        end
 
-        return parsed_output if result.success?
+        result.assert_success!
       end
-
-      nil
     end
 
     # Check if a URL is protected by CloudFlare (e.g. badlion.net and jaxx.io).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Strategy#page_headers` was modified to call `#curl_headers` but wasn't updated to work with the new return value, so all `HeaderMatch` checks currently fail with an ```undefined method `success?' for nil:NilClass``` error. This would have been caught if it was tested on any existing `HeaderMatch` check.

I was wrapping up my review of #15351 after testing the changes, identifying issues, and working on potential fixes but it was merged before I was able to submit it. This PR aims to explain the issues and provide fixes.

-----

This updates `Strategy#page_headers` to work with the new return value, which will be a hash from `#parse_curl_output` when the request succeeds.

I've removed the `result.assert_success!` call in `#curl_headers` and added a default `nil` return because the existing setup was preventing a few checks from being retried using `GET` (`firefox-cn`, `krisp`, and `prepros`). When a `HEAD` request is used, those checks redirect to a failing request (e.g., 302 -> 404) , which causes `#assert_success!` to loudly fail. These requests succeed with a `GET` request (i.e., 302 -> 200), so it's appropriate for them to be retried and these changes allow for that.

-----

A limitation of the current `#curl_headers` setup is that we can't control the `max_iterations` value used with `#parse_curl_output`, so it's using the high default (25).

When I originally introduced `#parse_curl_output`, Mike was firm that the `while` loop needed to have a limit, so we settled on a high default (25) and a reasonably low value for livecheck that aligns with its `MAX_REDIRECTIONS` value (5). I still think it's preferable to continue to use the lower max here, so what do we think about adding a `max_iterations` parameter to allow us to use `MAX_PARSE_ITERATIONS` again?

-----

One other shortcoming that I was going to mention in review is that this retry logic won't work as expected for `HeaderMatch` `strategy` blocks that check a header other than `Location` or `Content-Disposition`. If either of those headers isn't present but the header we need is, then `#curl_headers` will needlessly retry the request with `GET`.

For example, `tresorit` checks `x-ms-meta-version` in a `strategy` block, so `#curl_headers` ends up needlessly retrying with `GET` even though the first request is successful and contains the aforementioned header. This is the only check where the retry logic is used despite not being needed but I have some ideas of how to address this in the future in a `livecheck` block (though I have to lay some technical groundwork first). This is fine for now but it's something that I noticed in testing and wanted to flag.