### PR TITLE
Custom service name

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1015,13 +1015,13 @@ class Formula
   # The generated launchd {.plist} service name.
   sig { returns(String) }
   def plist_name
-    "homebrew.mxcl.#{name}"
+    service.plist_name
   end
 
   # The generated service name.
   sig { returns(String) }
   def service_name
-    "homebrew.#{name}"
+    service.service_name
   end
 
   # The generated launchd {.plist} file path.
@@ -1051,8 +1051,6 @@ class Formula
 
   # The service specification of the software.
   def service
-    return unless service?
-
     @service ||= Homebrew::Service.new(self, &self.class.service)
   end
 
@@ -2169,7 +2167,7 @@ class Formula
       "disabled"                 => disabled?,
       "disable_date"             => disable_date,
       "disable_reason"           => disable_reason,
-      "service"                  => service&.serialize,
+      "service"                  => (service.serialize if service?),
       "tap_git_head"             => tap_git_head,
       "ruby_source_path"         => ruby_source_path,
       "ruby_source_checksum"     => {},

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -288,7 +288,7 @@ module FormulaCellarChecks
   def check_service_command(formula)
     return unless formula.prefix.directory?
     return unless formula.service?
-    return if formula.service.command.blank?
+    return unless formula.service.command?
 
     "Service command does not exist" unless File.exist?(formula.service.command.first)
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1040,7 +1040,7 @@ on_request: installed_on_request?, options: options)
       return
     end
 
-    if formula.service? && formula.service.command.present?
+    if formula.service? && formula.service.command?
       service_path = formula.systemd_service_path
       service_path.atomic_write(formula.service.to_systemd_unit)
       service_path.chmod 0644
@@ -1052,7 +1052,7 @@ on_request: installed_on_request?, options: options)
       end
     end
 
-    service = if formula.service? && formula.service.command.present?
+    service = if formula.service? && formula.service.command?
       formula.service.to_plist
     elsif formula.plist
       formula.plist

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -261,9 +261,10 @@ module Formulary
         run_params = service_hash.delete(:run)
         service do
           T.bind(self, Homebrew::Service)
-          if run_params.is_a?(Hash)
+          case run_params
+          when Hash
             run(**run_params)
-          else
+          when Array, String
             run run_params
           end
           service_hash.each do |key, arg|

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -258,15 +258,22 @@ module Formulary
 
       if (service_hash = json_formula["service"])
         service_hash = Homebrew::Service.deserialize(service_hash)
-        run_params = service_hash.delete(:run)
         service do
           T.bind(self, Homebrew::Service)
-          case run_params
-          when Hash
-            run(**run_params)
-          when Array, String
-            run run_params
+
+          if (run_params = service_hash.delete(:run))
+            case run_params
+            when Hash
+              run(**run_params)
+            when Array, String
+              run run_params
+            end
           end
+
+          if (name_params = service_hash.delete(:name))
+            name(**name_params)
+          end
+
           service_hash.each do |key, arg|
             public_send(key, arg)
           end

--- a/Library/Homebrew/rubocops/service.rb
+++ b/Library/Homebrew/rubocops/service.rb
@@ -21,11 +21,8 @@ module RuboCop
           share:    :opt_share,
         }.freeze
 
-        # These can be defined without using the `run` command.
-        RENAME_METHOD_CALLS = [:plist_name, :service_name].freeze
-
         # At least one of these methods must be defined in a service block.
-        REQUIRED_METHOD_CALLS = [:run, *RENAME_METHOD_CALLS].freeze
+        REQUIRED_METHOD_CALLS = [:run, :name].freeze
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           service_node = find_block(body_node, :service)
@@ -38,13 +35,12 @@ module RuboCop
           # so we don't show both of them at the same time.
           if (method_calls.keys & REQUIRED_METHOD_CALLS).empty?
             offending_node(service_node)
-            problem "Service blocks require `run`, `plist_name` or `service_name` to be defined."
+            problem "Service blocks require `run` or `name` to be defined."
           elsif !method_calls.key?(:run)
-            other_method_calls = method_calls.keys - RENAME_METHOD_CALLS
+            other_method_calls = method_calls.keys - [:name]
             if other_method_calls.any?
               offending_node(service_node)
-              problem "`run` must be defined to use methods other than " \
-                      "`service_name` and `plist_name` like #{other_method_calls}."
+              problem "`run` must be defined to use methods other than `name` like #{other_method_calls}."
             end
           end
 

--- a/Library/Homebrew/rubocops/service.rb
+++ b/Library/Homebrew/rubocops/service.rb
@@ -21,15 +21,39 @@ module RuboCop
           share:    :opt_share,
         }.freeze
 
+        # These can be defined without using the `run` command.
+        RENAME_METHOD_CALLS = [:plist_name, :service_name].freeze
+
+        # At least one of these methods must be defined in a service block.
+        REQUIRED_METHOD_CALLS = [:run, *RENAME_METHOD_CALLS].freeze
+
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           service_node = find_block(body_node, :service)
           return if service_node.blank?
 
+          method_calls = service_node.each_descendant(:send).group_by(&:method_name)
+          method_calls.delete(:service)
+
+          # NOTE: Solving the first problem here might solve the second one too
+          # so we don't show both of them at the same time.
+          if (method_calls.keys & REQUIRED_METHOD_CALLS).empty?
+            offending_node(service_node)
+            problem "Service blocks require `run`, `plist_name` or `service_name` to be defined."
+          elsif !method_calls.key?(:run)
+            other_method_calls = method_calls.keys - RENAME_METHOD_CALLS
+            if other_method_calls.any?
+              offending_node(service_node)
+              problem "`run` must be defined to use methods other than " \
+                      "`service_name` and `plist_name` like #{other_method_calls}."
+            end
+          end
+
           # This check ensures that cellar paths like `bin` are not referenced
-          # because their `opt_` variants are more portable and work with the
-          # API.
+          # because their `opt_` variants are more portable and work with the API.
           CELLAR_PATH_AUDIT_CORRECTIONS.each do |path, opt_path|
-            find_every_method_call_by_name(service_node, path).each do |node|
+            next unless method_calls.key?(path)
+
+            method_calls.fetch(path).each do |node|
               offending_node(node)
               problem "Use `#{opt_path}` instead of `#{path}` in service blocks." do |corrector|
                 corrector.replace(node.source_range, opt_path)

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -41,16 +41,9 @@ module Homebrew
       "homebrew.mxcl.#{@formula.name}"
     end
 
-    sig { params(name: T.nilable(String)).returns(String) }
-    def plist_name(name = nil)
-      case T.unsafe(name)
-      when nil
-        @plist_name ||= default_plist_name
-      when String
-        @plist_name = name
-      else
-        raise TypeError, "Service#plist_name expects a String"
-      end
+    sig { returns(String) }
+    def plist_name
+      @plist_name ||= default_plist_name
     end
 
     sig { returns(String) }
@@ -58,16 +51,17 @@ module Homebrew
       "homebrew.#{@formula.name}"
     end
 
-    sig { params(name: T.nilable(String)).returns(String) }
-    def service_name(name = nil)
-      case T.unsafe(name)
-      when nil
-        @service_name ||= default_service_name
-      when String
-        @service_name = name
-      else
-        raise TypeError, "Service#service_name expects a String"
-      end
+    sig { returns(String) }
+    def service_name
+      @service_name ||= default_service_name
+    end
+
+    sig { params(macos: T.nilable(String), linux: T.nilable(String)).void }
+    def name(macos: nil, linux: nil)
+      raise TypeError, "Service#name expects at least one String" if [macos, linux].none?(String)
+
+      @plist_name = macos if macos
+      @service_name = linux if linux
     end
 
     sig {
@@ -539,14 +533,13 @@ module Homebrew
     # Prepare the service hash for inclusion in the formula API JSON.
     sig { returns(Hash) }
     def serialize
-      custom_plist_name = plist_name if plist_name != default_plist_name
-      custom_service_name = service_name if service_name != default_service_name
+      name_params = {
+        macos: (plist_name if plist_name != default_plist_name),
+        linux: (service_name if service_name != default_service_name),
+      }.compact
 
       unless command?
-        return {
-          plist_name:   custom_plist_name,
-          service_name: custom_service_name,
-        }.compact
+        return name_params.blank? ? {} : { name: name_params }
       end
 
       cron_string = if @cron.present?
@@ -558,8 +551,7 @@ module Homebrew
       sockets_string = "#{@sockets[:type]}://#{@sockets[:host]}:#{@sockets[:port]}" if @sockets.present?
 
       {
-        plist_name:            custom_plist_name,
-        service_name:          custom_service_name,
+        name:                  name_params.presence,
         run:                   @run_params,
         run_type:              @run_type,
         interval:              @interval,
@@ -584,15 +576,10 @@ module Homebrew
     sig { params(api_hash: Hash).returns(Hash) }
     def self.deserialize(api_hash)
       hash = {}
-
-      %w[plist_name service_name].each do |key|
-        next if (value = api_hash[key]).nil?
-
-        hash[key.to_sym] = value
-      end
+      hash[:name] = api_hash["name"].transform_keys(&:to_sym) if api_hash.key?("name")
 
       # The service hash might not have a "run" command if it only documents
-      # an existing service file with "plist_name" or "service_name".
+      # an existing service file with the "name" command.
       return hash unless api_hash.key?("run")
 
       hash[:run] =

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -211,8 +211,7 @@ describe Caveats do
         f = formula do
           url "foo-1.0"
           service do
-            plist_name "custom.mxcl.foo"
-            service_name "custom.foo"
+            name macos: "custom.mxcl.foo", linux: "custom.foo"
           end
         end
         expect(Utils::Service).to receive(:installed?).with(f).once.and_return(true)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -218,21 +218,21 @@ describe FormulaInstaller do
 
     it "works if service is set" do
       formula = Testball.new
+      service = Homebrew::Service.new(formula)
       launchd_service_path = formula.launchd_service_path
       service_path = formula.systemd_service_path
-      service = Homebrew::Service.new(formula)
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(true)
-      expect(formula).to receive(:service).exactly(5).and_return(service)
+      expect(formula).to receive(:service).exactly(7).and_return(service)
       expect(formula).to receive(:launchd_service_path).and_call_original
       expect(formula).to receive(:systemd_service_path).and_call_original
 
       expect(service).to receive(:timed?).and_return(false)
+      expect(service).to receive(:command?).exactly(2).and_return(true)
       expect(service).to receive(:to_plist).and_return("plist")
       expect(service).to receive(:to_systemd_unit).and_return("unit")
-      expect(service).to receive(:command).exactly(2).and_return("/bin/sh")
 
       installer = described_class.new(formula)
       expect do
@@ -245,24 +245,24 @@ describe FormulaInstaller do
 
     it "works if timed service is set" do
       formula = Testball.new
+      service = Homebrew::Service.new(formula)
       launchd_service_path = formula.launchd_service_path
       service_path = formula.systemd_service_path
       timer_path = formula.systemd_timer_path
-      service = Homebrew::Service.new(formula)
       formula.opt_prefix.mkpath
 
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(true)
-      expect(formula).to receive(:service).exactly(6).and_return(service)
+      expect(formula).to receive(:service).exactly(9).and_return(service)
       expect(formula).to receive(:launchd_service_path).and_call_original
       expect(formula).to receive(:systemd_service_path).and_call_original
       expect(formula).to receive(:systemd_timer_path).and_call_original
 
-      expect(service).to receive(:to_plist).and_return("plist")
       expect(service).to receive(:timed?).and_return(true)
+      expect(service).to receive(:command?).exactly(2).and_return(true)
+      expect(service).to receive(:to_plist).and_return("plist")
       expect(service).to receive(:to_systemd_unit).and_return("unit")
       expect(service).to receive(:to_systemd_timer).and_return("timer")
-      expect(service).to receive(:command).exactly(2).and_return("/bin/sh")
 
       installer = described_class.new(formula)
       expect do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -736,14 +736,13 @@ describe Formula do
       f = formula do
         url "https://brew.sh/test-1.0.tbz"
         service do
-          plist_name "custom.macos.beanstalkd"
-          service_name "custom.linux.beanstalkd"
+          name macos: "custom.macos.beanstalkd", linux: "custom.linux.beanstalkd"
         end
       end
 
       expect(f.plist_name).to eq("custom.macos.beanstalkd")
       expect(f.service_name).to eq("custom.linux.beanstalkd")
-      expect(f.service.serialize.keys).to contain_exactly(:plist_name, :service_name)
+      expect(f.service.serialize.keys).to contain_exactly(:name)
     end
 
     specify "service helpers return data" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -701,7 +701,7 @@ describe Formula do
         url "https://brew.sh/test-1.0.tbz"
       end
 
-      expect(f.service).to be_nil
+      expect(f.service.serialize).to eq({})
     end
 
     specify "service complicated" do
@@ -717,7 +717,8 @@ describe Formula do
           keep_alive true
         end
       end
-      expect(f.service).not_to be_nil
+      expect(f.service.serialize.keys)
+        .to contain_exactly(:run, :run_type, :error_log_path, :log_path, :working_dir, :keep_alive)
     end
 
     specify "service uses simple run" do
@@ -728,7 +729,21 @@ describe Formula do
         end
       end
 
-      expect(f.service).not_to be_nil
+      expect(f.service.serialize.keys).to contain_exactly(:run, :run_type)
+    end
+
+    specify "service with only custom names" do
+      f = formula do
+        url "https://brew.sh/test-1.0.tbz"
+        service do
+          plist_name "custom.macos.beanstalkd"
+          service_name "custom.linux.beanstalkd"
+        end
+      end
+
+      expect(f.plist_name).to eq("custom.macos.beanstalkd")
+      expect(f.service_name).to eq("custom.linux.beanstalkd")
+      expect(f.service.serialize.keys).to contain_exactly(:plist_name, :service_name)
     end
 
     specify "service helpers return data" do

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -272,6 +272,7 @@ describe Formulary do
             "link_overwrite"           => ["bin/abc"],
             "caveats"                  => "example caveat string\n/$HOME\n$HOMEBREW_PREFIX",
             "service"                  => {
+              "name"        => { macos: "custom.launchd.name", linux: "custom.systemd.name" },
               "run"         => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "test"],
               "run_type"    => "immediate",
               "working_dir" => "/$HOME",
@@ -362,6 +363,8 @@ describe Formulary do
         expect(formula.service.command).to eq(["#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd", "test"])
         expect(formula.service.run_type).to eq(:immediate)
         expect(formula.service.working_dir).to eq(Dir.home)
+        expect(formula.plist_name).to eq("custom.launchd.name")
+        expect(formula.service_name).to eq("custom.systemd.name")
 
         expect do
           formula.install

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -5,6 +5,48 @@ require "rubocops/service"
 describe RuboCop::Cop::FormulaAudit::Service do
   subject(:cop) { described_class.new }
 
+  it "reports offenses when a service block is missing a required command" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        service do
+        ^^^^^^^^^^ FormulaAudit/Service: Service blocks require `run`, `plist_name` or `service_name` to be defined.
+          run_type :cron
+          working_dir "/tmp/example"
+        end
+      end
+    RUBY
+  end
+
+  it "reports no offenses when a service block only includes custom names" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        service do
+          plist_name "custom.mcxl.foo"
+          service_name "custom.foo"
+        end
+      end
+    RUBY
+  end
+
+  it "reports offenses when a service block includes more than custom names and no run command" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        service do
+        ^^^^^^^^^^ FormulaAudit/Service: `run` must be defined to use methods other than `service_name` and `plist_name` like [:working_dir].
+          plist_name "custom.mcxl.foo"
+          service_name "custom.foo"
+          working_dir "/tmp/example"
+        end
+      end
+    RUBY
+  end
+
   it "reports offenses when a formula's service block uses cellar paths" do
     expect_offense(<<~RUBY)
       class Foo < Formula
@@ -31,7 +73,7 @@ describe RuboCop::Cop::FormulaAudit::Service do
     RUBY
   end
 
-  it "reports no offenses when a formula's service block only uses opt paths" do
+  it "reports no offenses when a service block only uses opt paths" do
     expect_no_offenses(<<~RUBY)
       class Bin < Formula
         url "https://brew.sh/foo-1.0.tgz"

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::FormulaAudit::Service do
         url "https://brew.sh/foo-1.0.tgz"
 
         service do
-        ^^^^^^^^^^ FormulaAudit/Service: Service blocks require `run`, `plist_name` or `service_name` to be defined.
+        ^^^^^^^^^^ FormulaAudit/Service: Service blocks require `run` or `name` to be defined.
           run_type :cron
           working_dir "/tmp/example"
         end
@@ -25,8 +25,7 @@ describe RuboCop::Cop::FormulaAudit::Service do
         url "https://brew.sh/foo-1.0.tgz"
 
         service do
-          plist_name "custom.mcxl.foo"
-          service_name "custom.foo"
+          name macos: "custom.mcxl.foo", linux: "custom.foo"
         end
       end
     RUBY
@@ -38,9 +37,8 @@ describe RuboCop::Cop::FormulaAudit::Service do
         url "https://brew.sh/foo-1.0.tgz"
 
         service do
-        ^^^^^^^^^^ FormulaAudit/Service: `run` must be defined to use methods other than `service_name` and `plist_name` like [:working_dir].
-          plist_name "custom.mcxl.foo"
-          service_name "custom.foo"
+        ^^^^^^^^^^ FormulaAudit/Service: `run` must be defined to use methods other than `name` like [:working_dir].
+          name macos: "custom.mcxl.foo", linux: "custom.foo"
           working_dir "/tmp/example"
         end
       end

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -949,6 +949,10 @@ describe Homebrew::Service do
   describe ".deserialize" do
     let(:serialized_hash) do
       {
+        "name"                  => {
+          "linux" => "custom.systemd.name",
+          "macos" => "custom.launchd.name",
+        },
         "environment_variables" => {
           "PATH" => "$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:/usr/bin:/bin:/usr/sbin:/sbin",
         },
@@ -961,6 +965,10 @@ describe Homebrew::Service do
 
     let(:deserialized_hash) do
       {
+        name:                  {
+          linux: "custom.systemd.name",
+          macos: "custom.launchd.name",
+        },
         environment_variables: {
           PATH: "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:/usr/sbin:/sbin",
         },

--- a/Library/Homebrew/utils/service.rb
+++ b/Library/Homebrew/utils/service.rb
@@ -1,0 +1,50 @@
+# typed: true
+# frozen_string_literal: true
+
+module Utils
+  # Helpers for `brew services` related code.
+  module Service
+    # Check if a service is running for a specified formula.
+    sig { params(formula: Formula).returns(T::Boolean) }
+    def self.running?(formula)
+      if launchctl?
+        quiet_system(launchctl, "list", formula.plist_name)
+      elsif systemctl?
+        quiet_system(systemctl, "is-active", "--quiet", formula.service_name)
+      end
+    end
+
+    # Check if a service file is installed in the expected location.
+    sig { params(formula: Formula).returns(T::Boolean) }
+    def self.installed?(formula)
+      (launchctl? && formula.launchd_service_path.exist?) ||
+        (systemctl? && formula.systemd_service_path.exist?)
+    end
+
+    # Path to launchctl binary.
+    sig { returns(T.nilable(Pathname)) }
+    def self.launchctl
+      return @launchctl if defined? @launchctl
+
+      @launchctl = which("launchctl")
+    end
+
+    # Path to systemctl binary.
+    sig { returns(T.nilable(Pathname)) }
+    def self.systemctl
+      return @systemctl if defined? @systemctl
+
+      @systemctl = which("systemctl")
+    end
+
+    sig { returns(T::Boolean) }
+    def self.launchctl?
+      !launchctl.nil?
+    end
+
+    sig { returns(T::Boolean) }
+    def self.systemctl?
+      !systemctl.nil?
+    end
+  end
+end

--- a/Library/Homebrew/utils/service.rbi
+++ b/Library/Homebrew/utils/service.rbi
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Utils
+  module Service
+    include Kernel
+  end
+end

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -871,11 +871,16 @@ Another example would be configuration files that should not be overwritten on p
 
 There are two ways to add `launchd` plists and `systemd` services to a formula, so that [`brew services`](https://github.com/Homebrew/homebrew-services) can pick them up:
 
-1. If the package already provides a service file the formula can install it into the prefix:
+1. If the package already provides a service file the formula can reference it by name:
 
    ```ruby
-   prefix.install_symlink "file.plist" => "#{plist_name}.plist"
-   prefix.install_symlink "file.service" => "#{service_name}.service"
+   service do
+     # Corresponds to the launchd script at "#{plist_name}.plist".
+     plist_name "custom.plist.name"
+
+     # Corresponds to the systemd script at "#{service_name}.service".
+     service_name "custom.service.name"
+   end
    ```
 
 2. If the formula does not provide a service file you can generate one using the following stanza:
@@ -888,7 +893,7 @@ There are two ways to add `launchd` plists and `systemd` services to a formula, 
 
 #### Service block methods
 
-This table lists the options you can set within a `service` block. Only the `run` field is required which indicates what to run.
+This table lists the options you can set within a `service` block. One of the `run`, `plist_name` or `service_name` fields is required inside the service block. The `run` field indicates what command to run and is required before using fields other than `plist_name` and `service_name`.
 
 | method                  | default      | macOS | Linux | description |
 | ----------------------- | ------------ | :---: | :---: | ----------- |
@@ -909,6 +914,8 @@ This table lists the options you can set within a `service` block. Only the `run
 | `process_type`          | -            |  yes  | no-op | type of process to manage: `:background`, `:standard`, `:interactive` or `:adaptive`
 | `macos_legacy_timers`   | -            |  yes  | no-op | timers created by `launchd` jobs are coalesced unless this is set
 | `sockets`               | -            |  yes  | no-op | socket that is created as an accesspoint to the service
+| `plist_name`            | `"homebrew.mxcl.#{formula.name}"` | yes | no | name of the `launchd` job
+| `service_name`          | `"homebrew.#{formula.name}"` | no | yes | name of the `systemd` job
 
 For services that are kept alive after starting you can use the default `run_type`:
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -875,13 +875,12 @@ There are two ways to add `launchd` plists and `systemd` services to a formula, 
 
    ```ruby
    service do
-     # Corresponds to the launchd script at "#{plist_name}.plist".
-     plist_name "custom.plist.name"
-
-     # Corresponds to the systemd script at "#{service_name}.service".
-     service_name "custom.service.name"
+     name macos: "custom.launchd.name",
+          linux: "custom.systemd.name"
    end
    ```
+
+   To find the file we append `.plist` to the `launchd` service name and `.service` to the `systemd` service name internally.
 
 2. If the formula does not provide a service file you can generate one using the following stanza:
 
@@ -893,7 +892,7 @@ There are two ways to add `launchd` plists and `systemd` services to a formula, 
 
 #### Service block methods
 
-This table lists the options you can set within a `service` block. One of the `run`, `plist_name` or `service_name` fields is required inside the service block. The `run` field indicates what command to run and is required before using fields other than `plist_name` and `service_name`.
+This table lists the options you can set within a `service` block. The `run` or `name` field must be defined inside the service block. The `run` field indicates what command to run and is required before using fields other than `name`.
 
 | method                  | default      | macOS | Linux | description |
 | ----------------------- | ------------ | :---: | :---: | ----------- |
@@ -914,8 +913,7 @@ This table lists the options you can set within a `service` block. One of the `r
 | `process_type`          | -            |  yes  | no-op | type of process to manage: `:background`, `:standard`, `:interactive` or `:adaptive`
 | `macos_legacy_timers`   | -            |  yes  | no-op | timers created by `launchd` jobs are coalesced unless this is set
 | `sockets`               | -            |  yes  | no-op | socket that is created as an accesspoint to the service
-| `plist_name`            | `"homebrew.mxcl.#{formula.name}"` | yes | no | name of the `launchd` job
-| `service_name`          | `"homebrew.#{formula.name}"` | no | yes | name of the `systemd` job
+| `name`                  | -            |  yes  |  yes  | a hash with the `launchd` service name on macOS and/or the `systemd` service name on Linux
 
 For services that are kept alive after starting you can use the default `run_type`:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #15175.

Basically, this adds the following DSL to the service block to support service files with custom names.

```rb
service do
  plist_name "name"
  service_name "name"
end
```

These two new methods can be used with or without the rest of the normal service block methods. It is also backwards compatible so the previous redefine-the-plist_name-method strategy will still work (but of course that doesn't work with the API which is the whole point here).

For more details allow me to plagiarize the first commit message.

```
The main thing is that this DSL allows us to provide an
interface that can be serialized to the JSON API.

Changes:
- Homebrew::Service
  - Adds `#service_name` and `#plist_name` methods
    - Each is now included in the `#serialize` method as well
  - Eval block on instantiation
    - Before we lazy evaluated this but the cost is not significant
      and it complicated the code a bunch. This only gets called
      during install, when evaluating caveats and in the `brew service`
      command. It skips this evaluation if the service block isn't there.
  - Add `#command?` helper to avoid `#command.blank?` and `#command.present?`
- Formula
  - `#service` now returns a service whenever it's called. This call is
    hidden behind a call to `#service?` most of the time anyway so this
    should be fine.
  - `#plist_name` and `#service_name` now call the methods of the same name
    on the service class. This should have already been in the service object
    to begin with and keeping these methods here helps preserve backwards
    compatibility with people who were overwriting these methods before.
- Caveats
  - Prefer `service#command?`
  - Add helpers for checking on service commands
    - This duplicates some of the work in `brew services`. Maybe we should
      merge that repo in at some point.
  - Check for installed service at `#plist_name` or `#service_name`. I think
    this should be used instead of `Keg#plist_installed?` which checked for any plist file.
    We should think about deprecating `#plist_installed?` in the future.
  - Stop using `ps aux | grep #{formula.plist_name}` to check for service files
    because it was inaccurate (it always returns true on my machine) because the grep
    process is started before the ps process.
  - Note: The behavior is the same as it was before. This means that caveats
    only show up for custom service files on install or if they're already installed.
    Otherwise it won't show up in `brew info`. This is because it has to check
    first if the service file has been installed.
- Utils::Service
  - Add utils for evaluating if a service is installed and running. This duplicates
    some of the work already found in `brew services`. We should seriously consider
    merging `brew services` with the main brew repo in the future since it's already
    tightly coupled to the code in the main repo.
- Update and add tests
```

I also added to the service cops to check that people are using that block as expected.

This still needs a bit more testing and I need to double check that there aren't any other changes that need to be made in [homebrew-services](https://github.com/Homebrew/homebrew-services). Let me know if you're happy with the general approach though.

**Edit:** This was updated to improve DSL naming as discussed in [this thread](https://github.com/Homebrew/brew/pull/15396#discussion_r1189833061).

The new DSL will look like.

```rb
service do
  name macos: "custom.launchd.name", linux: "custom.systemd.name"
end
```