### PR TITLE
tab: fix typing of versions

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1233,7 +1233,7 @@ on_request: installed_on_request?, options: options)
     tab.time = Time.now.to_i
     tab.aliases = formula.aliases
     tab.arch = Hardware::CPU.arch
-    tab.source["versions"]["stable"] = formula.stable.version.to_s
+    tab.source["versions"]["stable"] = formula.stable.version&.to_s
     tab.source["versions"]["version_scheme"] = formula.version_scheme
     tab.source["path"] = formula.specified_path.to_s
     tab.source["tap_git_head"] = formula.tap&.installed? ? formula.tap&.git_head : nil

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -45,8 +45,8 @@ class Tab
         "tap_git_head" => nil, # Filled in later if possible
         "spec"         => formula.active_spec_sym.to_s,
         "versions"     => {
-          "stable"         => formula.stable&.version.to_s,
-          "head"           => formula.head&.version.to_s,
+          "stable"         => formula.stable&.version&.to_s,
+          "head"           => formula.head&.version&.to_s,
           "version_scheme" => formula.version_scheme,
         },
       },
@@ -106,6 +106,11 @@ class Tab
         "head"           => nil,
         "version_scheme" => 0,
       }
+    end
+
+    # Tabs created with Homebrew 1.5.13 through 4.0.17 inclusive created empty string versions in some cases.
+    ["stable", "head"].each do |spec|
+      attributes["source"]["versions"][spec] = attributes["source"]["versions"][spec].presence
     end
 
     new(attributes)
@@ -171,8 +176,8 @@ class Tab
         "tap"      => formula.tap&.name,
         "spec"     => formula.active_spec_sym.to_s,
         "versions" => {
-          "stable"         => formula.stable&.version.to_s,
-          "head"           => formula.head&.version.to_s,
+          "stable"         => formula.stable&.version&.to_s,
+          "head"           => formula.head&.version&.to_s,
           "version_scheme" => formula.version_scheme,
         },
       }


### PR DESCRIPTION
This is a nearly 5 year old bug that only revealed itself now that we've tightened up typing and validation in `version.rb` (for the better IMO - empty string versions do not make sense, can hide genuine bugs, have indeterminate behaviour in terms of comparisons, and fails to satisfy any `Version#null?` check).

This did _not_ affect bottles installed from GitHub Packages, so most users were unaffected.

Fixes #15401.