### PR TITLE
cleanup: fix version error for cache items without a version

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -109,7 +109,7 @@ module Homebrew
         version ||= basename_str[/\A.*(?:--.*?)*--(.*?)#{Regexp.escape(pathname.extname)}\Z/, 1]
         version ||= basename_str[/\A.*--?(.*?)#{Regexp.escape(pathname.extname)}\Z/, 1]
 
-        return false unless version
+        return false if version.blank?
 
         version = Version.new(version)
 


### PR DESCRIPTION
This was technically caused in my case by local work, but `pr-pull` is a real world example of where this will genuinely happen (we perhaps should move that to a separate subdirectory in the cache at some point).