### PR TITLE
Replace wildcard copy in cask updates with a loop over children.

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -94,8 +94,10 @@ module Cask
           if target.writable?
             source.children.each { |child| FileUtils.move(child, target + child.basename) }
           else
-            command.run!("/bin/cp", args: ["-pR", "#{source}/*", "#{source}/.*", "#{target}/"],
-                                    sudo: true)
+            source.children.each do |child|
+              command.run!("/bin/cp", args: ["-pR", child, target + child.basename],
+                                      sudo: true)
+            end
           end
           Quarantine.copy_xattrs(source, target)
           source.rmtree


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a regression in #15138 where the copying step may fail with a "cp: [...].app/*: No such file or directory" error. (This is one of the errors documented in https://github.com/orgs/Homebrew/discussions/4498.) This PR also adds a unit test to cover the relevant portion of the code.