### PR TITLE
Fix typing on revert_upgrade().

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -214,6 +214,7 @@ on_request: true)
       Quarantine.propagate(from: primary_container.path, to: to)
     end
 
+    sig { params(predecessor: T.nilable(Cask)).void }
     def install_artifacts(predecessor: nil)
       artifacts = @cask.artifacts
       already_installed_artifacts = []
@@ -390,6 +391,7 @@ on_request: true)
       @cask.download_sha_path.atomic_write(@cask.new_download_sha) if @cask.checksumable?
     end
 
+    sig { params(successor: T.nilable(Cask)).void }
     def uninstall(successor: nil)
       load_installed_caskfile!
       oh1 "Uninstalling Cask #{Formatter.identifier(@cask)}"
@@ -411,6 +413,7 @@ on_request: true)
       FileUtils.rm_f @cask.download_sha_path if @cask.download_sha_path.exist?
     end
 
+    sig { params(successor: T.nilable(Cask)).void }
     def start_upgrade(successor:)
       uninstall_artifacts(successor: successor)
       backup
@@ -431,7 +434,8 @@ on_request: true)
       backup_metadata_path.rename @cask.metadata_versioned_path
     end
 
-    def revert_upgrade(predecessor)
+    sig { params(predecessor: Cask).void }
+    def revert_upgrade(predecessor:)
       opoo "Reverting upgrade for Cask #{@cask}"
       restore_backup
       install_artifacts(predecessor: predecessor)
@@ -445,6 +449,7 @@ on_request: true)
       puts summary
     end
 
+    sig { params(clear: T::Boolean, successor: T.nilable(Cask)).void }
     def uninstall_artifacts(clear: false, successor: nil)
       artifacts = @cask.artifacts
 

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -174,6 +174,7 @@ module Cask
       raise CaskQuarantinePropagationError.new(to, quarantiner.stderr)
     end
 
+    sig { params(from: Pathname, to: Pathname).void }
     def self.copy_xattrs(from, to)
       odebug "Copying xattrs from #{from} to #{to}"
 

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -131,6 +131,18 @@ module Cask
       false
     end
 
+    sig {
+      params(
+        old_cask:       Cask,
+        new_cask:       Cask,
+        binaries:       T.nilable(T::Boolean),
+        force:          T.nilable(T::Boolean),
+        quarantine:     T.nilable(T::Boolean),
+        require_sha:    T.nilable(T::Boolean),
+        skip_cask_deps: T.nilable(T::Boolean),
+        verbose:        T.nilable(T::Boolean),
+      ).void
+    }
     def self.upgrade_cask(
       old_cask, new_cask,
       binaries:, force:, quarantine:, require_sha:, skip_cask_deps:, verbose:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In #15138, `revert_upgrade()` was declared with a positional parameter for `predecessor`, but it's called with a named parameter. This fixes that inconsistency, and adds some explicit type declarations to all other function signatures I added or changed in #15138 to rule out similar errors.

Fixes the immediate errors in #15406 and https://github.com/orgs/Homebrew/discussions/4498. However, this code is only triggered when an upgrade is reverted, so the root cause of both is probably some other error.