### PR TITLE
dev-cmd/generate-*-api: add dry run option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,7 @@ jobs:
         run: brew audit --skip-style --except=version --tap=homebrew/core
 
       - name: Generate formula API
-        run: brew generate-formula-api
+        run: brew generate-formula-api --dry-run
 
   cask-audit:
     name: cask audit
@@ -196,7 +196,7 @@ jobs:
           brew audit --skip-style --except=version --tap=homebrew/cask-versions
 
       - name: Generate cask API
-        run: brew generate-cask-api
+        run: brew generate-cask-api --dry-run
 
   vendored-gems:
     name: vendored gems


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As discussed in https://github.com/Homebrew/brew/pull/15404#issuecomment-1545301705.

There are two reasons for this:
- Makes it easier to run this command as a sanity check without having to create a temporary directory
- Is somewhat faster since you don't have to write thousands of files

This is on my old iMac but I think it illustrates the point either way.

```
~/tmp-test $ hyperfine 'brew generate-cask-api' 'brew generate-cask-api -n'
Benchmark 1: brew generate-cask-api
  Time (mean ± σ):     23.148 s ±  0.702 s    [User: 10.490 s, System: 8.594 s]
  Range (min … max):   21.857 s … 23.968 s    10 runs
 
Benchmark 2: brew generate-cask-api -n
  Time (mean ± σ):     11.704 s ±  0.233 s    [User: 9.186 s, System: 1.844 s]
  Range (min … max):   11.299 s … 12.133 s    10 runs
 
Summary
  'brew generate-cask-api -n' ran
    1.98 ± 0.07 times faster than 'brew generate-cask-api'
```

```
~/tmp-test $ hyperfine 'brew generate-formula-api' 'brew generate-formula-api -n'
Benchmark 1: brew generate-formula-api
  Time (mean ± σ):     74.508 s ±  1.502 s    [User: 55.528 s, System: 14.716 s]
  Range (min … max):   72.554 s … 77.867 s    10 runs
 
Benchmark 2: brew generate-formula-api -n
  Time (mean ± σ):     58.628 s ±  1.017 s    [User: 51.228 s, System: 6.647 s]
  Range (min … max):   57.633 s … 61.213 s    10 runs
 
Summary
  'brew generate-formula-api -n' ran
    1.27 ± 0.03 times faster than 'brew generate-formula-api'
```