### PR TITLE
Fix missing require in update-report.rb

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -4,6 +4,7 @@
 require "migrator"
 require "formulary"
 require "cask/cask_loader"
+require "cask/migrator"
 require "descriptions"
 require "cleanup"
 require "description_cache_store"


### PR DESCRIPTION
```
Error: uninitialized constant Cask::Migrator
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:591:in `block in migrate_cask_rename'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:590:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:590:in `migrate_cask_rename'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:250:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:250:in `output_update_report'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:41:in `update_report'
/usr/local/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
