### PR TITLE
simulate_system: fix `tap_syntax` job errors

### DIFF
--- a/Library/Homebrew/simulate_system.rb
+++ b/Library/Homebrew/simulate_system.rb
@@ -19,10 +19,8 @@ module Homebrew
       def with(os: T.unsafe(nil), arch: T.unsafe(nil), &_block)
         raise ArgumentError, "At least one of `os` or `arch` must be specified." if !os && !arch
 
-        if self.os || self.arch
-          raise "Cannot simulate#{os&.inspect&.prepend(" ")}#{arch&.inspect&.prepend(" ")} while already " \
-                "simulating#{self.os&.inspect&.prepend(" ")}#{self.arch&.inspect&.prepend(" ")}."
-        end
+        old_os = self.os
+        old_arch = self.arch
 
         begin
           self.os = os if os
@@ -30,7 +28,8 @@ module Homebrew
 
           yield
         ensure
-          clear
+          @os = old_os
+          @arch = old_arch
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes

    Error: Cannot simulate :ventura :intel while already simulating :macos.

See https://github.com/Homebrew/homebrew-core/actions/runs/4974116510/jobs/8900390980#step:4:24.
