### PR TITLE
Fix `SimulateSystem` when `HOMEBREW_SIMULATE_MACOS_ON_LINUX` is set.

### DIFF
--- a/Library/Homebrew/extend/os/linux/simulate_system.rb
+++ b/Library/Homebrew/extend/os/linux/simulate_system.rb
@@ -4,25 +4,17 @@
 module Homebrew
   class SimulateSystem
     class << self
-      undef os
-      undef simulating_or_running_on_linux?
       undef current_os
-
-      sig { returns(T.nilable(Symbol)) }
-      def os
-        return :macos if @os.blank? && Homebrew::EnvConfig.simulate_macos_on_linux?
-
-        @os
-      end
-
-      sig { returns(T::Boolean) }
-      def simulating_or_running_on_linux?
-        os.blank? || os == :linux
-      end
 
       sig { returns(Symbol) }
       def current_os
-        os || :linux
+        if (os = self.os)
+          return os
+        end
+
+        return :macos if Homebrew::EnvConfig.simulate_macos_on_linux?
+
+        :linux
       end
     end
   end

--- a/Library/Homebrew/extend/os/mac/simulate_system.rb
+++ b/Library/Homebrew/extend/os/mac/simulate_system.rb
@@ -4,13 +4,7 @@
 module Homebrew
   class SimulateSystem
     class << self
-      undef simulating_or_running_on_macos?
       undef current_os
-
-      sig { returns(T::Boolean) }
-      def simulating_or_running_on_macos?
-        os.blank? || [:macos, *MacOSVersion::SYMBOLS.keys].include?(os)
-      end
 
       sig { returns(Symbol) }
       def current_os

--- a/Library/Homebrew/simulate_system.rb
+++ b/Library/Homebrew/simulate_system.rb
@@ -1,12 +1,17 @@
 # typed: true
 # frozen_string_literal: true
 
+require "macos_version"
+
 module Homebrew
   # Helper module for simulating different system condfigurations.
   #
   # @api private
   class SimulateSystem
     class << self
+      MACOS_SYMBOLS = Set.new([:macos, *MacOSVersion::SYMBOLS.keys]).freeze
+      private_constant :MACOS_SYMBOLS
+
       attr_reader :arch, :os
 
       sig {
@@ -36,8 +41,7 @@ module Homebrew
 
       sig { params(new_os: Symbol).void }
       def os=(new_os)
-        os_options = [:macos, :linux, *MacOSVersion::SYMBOLS.keys]
-        raise "Unknown OS: #{new_os}" unless os_options.include?(new_os)
+        raise "Unknown OS: #{new_os}" if MACOS_SYMBOLS.exclude?(new_os) && new_os != :linux
 
         @os = new_os
       end
@@ -56,12 +60,12 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def simulating_or_running_on_macos?
-        [:macos, *MacOSVersion::SYMBOLS.keys].include?(os)
+        MACOS_SYMBOLS.include?(current_os)
       end
 
       sig { returns(T::Boolean) }
       def simulating_or_running_on_linux?
-        os == :linux
+        current_os == :linux
       end
 
       sig { returns(Symbol) }

--- a/Library/Homebrew/simulate_system.rb
+++ b/Library/Homebrew/simulate_system.rb
@@ -19,8 +19,10 @@ module Homebrew
       def with(os: T.unsafe(nil), arch: T.unsafe(nil), &_block)
         raise ArgumentError, "At least one of `os` or `arch` must be specified." if !os && !arch
 
-        old_os = self.os
-        old_arch = self.arch
+        if self.os || self.arch
+          raise "Cannot simulate#{os&.inspect&.prepend(" ")}#{arch&.inspect&.prepend(" ")} while already " \
+                "simulating#{self.os&.inspect&.prepend(" ")}#{self.arch&.inspect&.prepend(" ")}."
+        end
 
         begin
           self.os = os if os
@@ -28,8 +30,7 @@ module Homebrew
 
           yield
         ensure
-          @os = old_os
-          @arch = old_arch
+          clear
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Reverts https://github.com/Homebrew/brew/pull/15428.

This moves the handling of `HOMEBREW_SIMULATE_MACOS_ON_LINUX` into `SimulateSystem::current_os`, so it doesn't interfere with `SimulateSystem::os`.
