### PR TITLE
service: fix API compatibility break

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -538,9 +538,7 @@ module Homebrew
         linux: (service_name if service_name != default_service_name),
       }.compact
 
-      unless command?
-        return name_params.blank? ? {} : { name: name_params }
-      end
+      return { name: name_params }.compact_blank if @run_params.blank?
 
       cron_string = if @cron.present?
         [:Minute, :Hour, :Day, :Month, :Weekday]


### PR DESCRIPTION
While #15455 makes future versions of Homebrew ignore the error, the problem still exists that there was a breakage in our JSON API that the error was flagging - the contents of `service` was incorrectly producing different results on different OS versions. This fixes the core issue, without requiring a new release (which takes up to 24 hours to roll out by default).

Fixes Homebrew/homebrew-core#131295.