### PR TITLE
Bitbucket: Fix tag match

### DIFF
--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -61,24 +61,29 @@ module Homebrew
           match = url.match(URL_MATCH_REGEX)
           return values if match.blank?
 
-          # `/get/` archives are Git tag snapshots, so we need to check that tab
-          # instead of the main `/downloads/` page
-          values[:url] = if match[:dl_type] == "get"
-            "https://bitbucket.org/#{match[:path]}/downloads/?tab=tags"
-          else
-            "https://bitbucket.org/#{match[:path]}/downloads/"
-          end
-
           regex_prefix = Regexp.escape(T.must(match[:prefix])).gsub("\\-", "-")
 
-          # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
-          suffix = T.must(match[:suffix]).sub(Strategy::TARBALL_EXTENSION_REGEX, ".t")
-          regex_suffix = Regexp.escape(suffix).gsub("\\-", "-")
+          # `/get/` archives are Git tag snapshots, so we need to check that tab
+          # instead of the main `/downloads/` page
+          if match[:dl_type] == "get"
+            values[:url] = "https://bitbucket.org/#{match[:path]}/downloads/?tab=tags"
 
-          # Example regexes:
-          # * `/href=.*?v?(\d+(?:\.\d+)+)\.t/i`
-          # * `/href=.*?example-v?(\d+(?:\.\d+)+)\.t/i`
-          values[:regex] = /href=.*?#{regex_prefix}v?(\d+(?:\.\d+)+)#{regex_suffix}/i
+            # Example tag regexes:
+            # * `/<td[^>]*?class="name"[^>]*?>\s*v?(\d+(?:\.\d+)+)\s*?</im`
+            # * `/<td[^>]*?class="name"[^>]*?>\s*abc-v?(\d+(?:\.\d+)+)\s*?</im`
+            values[:regex] = /<td[^>]*?class="name"[^>]*?>\s*#{regex_prefix}v?(\d+(?:\.\d+)+)\s*?</im
+          else
+            values[:url] = "https://bitbucket.org/#{match[:path]}/downloads/"
+
+            # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
+            suffix = T.must(match[:suffix]).sub(Strategy::TARBALL_EXTENSION_REGEX, ".t")
+            regex_suffix = Regexp.escape(suffix).gsub("\\-", "-")
+
+            # Example file regexes:
+            # * `/href=.*?v?(\d+(?:\.\d+)+)\.t/i`
+            # * `/href=.*?abc-v?(\d+(?:\.\d+)+)\.t/i`
+            values[:regex] = /href=.*?#{regex_prefix}v?(\d+(?:\.\d+)+)#{regex_suffix}/i
+          end
 
           values
         end

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -17,7 +17,7 @@ describe Homebrew::Livecheck::Strategy::Bitbucket do
     {
       get:       {
         url:   "https://bitbucket.org/abc/def/downloads/?tab=tags",
-        regex: /href=.*?v?(\d+(?:\.\d+)+)\.t/i,
+        regex: /<td[^>]*?class="name"[^>]*?>\s*v?(\d+(?:\.\d+)+)\s*?</im,
       },
       downloads: {
         url:   "https://bitbucket.org/abc/def/downloads/",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In some cases, the `Bitbucket` strategy currently matches versions from tag tarball links on a project's `downloads/?tab=tags` page. It appears that Bitbucket now uses a hash as the filename on this page instead of the tag name, so the existing regex no longer matches.

This adds an alternative regex to match versions from the tag name element (e.g., `<td class="name">example-1.2.3</td>`), which will fix version matching in this scenario.

Affected formulae are `mvnvm`, `uru`, `when`, and `x265`. All but `uru` are currently falling back to checking the Git tags from their `head` URL. With this change, the `uru` check works again and the others return to using the `Bitbucket` strategy (since it returns a version).

For what it's worth, now that Bitbucket has dropped Mercurial support, it should be technically possible to have `Bitbucket` use the `Git` strategy internally to check tags in this scenario. That may be preferable but I wanted to merge a fix in the interim time.