### PR TITLE
Guard `GITHUB_*` variables by `GITHUB_ACTIONS`.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -165,7 +165,7 @@ do
   FILTERED_ENV+=("${VAR}=${!VAR}")
 done
 
-if [[ -n "${CI:-}" ]]
+if [[ -n "${GITHUB_ACTIONS:-}" ]]
 then
   for VAR in "${!GITHUB_@}"
   do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

~~It seems https://github.com/Homebrew/brew/pull/15447 broke actually passing through those variables on `GITHUB_ACTIONS`, since `CI` is not set by default.~~

Nevermind, `CI` is actually set. Still, I think it makes more sense to guard the `GITHUB_*` variables by `GITHUB_ACTIONS` rather than `CI`.
