### PR TITLE
Add `--os` and `--arch` flags to `readall`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,7 +148,7 @@ jobs:
         run: brew tap homebrew/core
 
       - name: Run brew readall on homebrew/core
-        run: brew readall --aliases homebrew/core
+        run: brew readall --os=all --arch=all --aliases homebrew/core
 
       - name: Run brew audit --skip-style on homebrew/core
         run: brew audit --skip-style --except=version --tap=homebrew/core
@@ -186,7 +186,7 @@ jobs:
           brew tap homebrew/cask-versions
 
       - name: Run brew readall on all casks
-        run: brew readall homebrew/cask homebrew/cask-drivers homebrew/cask-fonts homebrew/cask-versions
+        run: brew readall --os=all --arch=all homebrew/cask homebrew/cask-drivers homebrew/cask-fonts homebrew/cask-versions
 
       - name: Run brew audit --skip-style on casks
         run: |

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -17,6 +17,10 @@ module Homebrew
         significant changes to `formula.rb`, testing the performance of loading
         all items or checking if any current formulae/casks have Ruby issues.
       EOS
+      flag   "--os=",
+             description: "Read using the given operating system. (Pass `all` to simulate all operating systems.)"
+      flag   "--arch=",
+             description: "Read using the given CPU architecture. (Pass `all` to simulate all architectures.)"
       switch "--aliases",
              description: "Verify any alias symlinks in each tap."
       switch "--syntax",
@@ -34,6 +38,10 @@ module Homebrew
   def readall
     args = readall_args.parse
 
+    if args.no_simulate?
+      # odeprecated "--no-simulate", "nothing (i.e. not passing `--os` or `--arch`)"
+    end
+
     if args.syntax? && args.no_named?
       scan_files = "#{HOMEBREW_LIBRARY_PATH}/**/*.rb"
       ruby_files = Dir.glob(scan_files).grep_v(%r{/(vendor)/})
@@ -41,7 +49,12 @@ module Homebrew
       Homebrew.failed = true unless Readall.valid_ruby_syntax?(ruby_files)
     end
 
-    options = { aliases: args.aliases?, no_simulate: args.no_simulate? }
+    options = {
+      aliases:     args.aliases?,
+      no_simulate: args.no_simulate?,
+    }
+    # TODO: Always pass this once `--os` and `--arch` are passed explicitly to `brew readall` in CI.
+    options[:os_arch_combinations] = args.os_arch_combinations if args.os || args.arch
     taps = if args.no_named?
       if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
         odisabled "brew readall", "brew readall --eval-all or HOMEBREW_EVAL_ALL"

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -66,19 +66,21 @@ module Readall
       true
     end
 
-    def valid_tap?(tap, options = {})
+    def valid_tap?(tap, aliases: false, no_simulate: false, os_arch_combinations: nil)
       success = true
 
-      if options[:aliases]
+      if aliases
         valid_aliases = valid_aliases?(tap.alias_dir, tap.formula_dir)
         success = false unless valid_aliases
       end
-      if options[:no_simulate]
+      if no_simulate
         success = false unless valid_formulae?(tap.formula_files)
         success = false unless valid_casks?(tap.cask_files)
       else
-        os_names = [*MacOSVersion::SYMBOLS.keys, :linux]
-        os_names.product(OnSystem::ARCH_OPTIONS).each do |os, arch|
+        # TODO: Remove this default case once `--os` and `--arch` are passed explicitly to `brew readall` in CI.
+        os_arch_combinations ||= [*MacOSVersion::SYMBOLS.keys, :linux].product(OnSystem::ARCH_OPTIONS)
+
+        os_arch_combinations.each do |os, arch|
           bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
           next unless bottle_tag.valid_combination?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add `--os` and `--arch` flags to `readall`, so it is consistent with `fetch`, `--cache` and `audit`.

`--no-simulate` will be deprecated, as it will become the default again once we have changed CI to run with `--os=all --arch=all`.
