### PR TITLE
Fix `brew formulae` and `brew casks` when the API is used

### DIFF
--- a/Library/Homebrew/cmd/casks.sh
+++ b/Library/Homebrew/cmd/casks.sh
@@ -13,9 +13,12 @@ homebrew-casks() {
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
         -f "${HOMEBREW_CACHE}/api/cask_names.txt" ]]
   then
-    cat "${HOMEBREW_CACHE}/api/cask_names.txt"
-    echo
+    {
+      cat "${HOMEBREW_CACHE}/api/cask_names.txt"
+      echo
+      homebrew-items '*/Casks/*\.rb' '.*/homebrew/homebrew-cask/.*' 's|/Casks/|/|' '^homebrew/cask'
+    } | sort -uf
   else
-    homebrew-items '*/Casks/*\.rb' '' 's|/Casks/|/|' '^homebrew/cask'
+    homebrew-items '*/Casks/*\.rb' '^\b$' 's|/Casks/|/|' '^homebrew/cask'
   fi
 }

--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -13,9 +13,12 @@ homebrew-formulae() {
   if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" &&
         -f "${HOMEBREW_CACHE}/api/formula_names.txt" ]]
   then
-    cat "${HOMEBREW_CACHE}/api/formula_names.txt"
-    echo
+    {
+      cat "${HOMEBREW_CACHE}/api/formula_names.txt"
+      echo
+      homebrew-items '*\.rb' '.*Casks(/.*|$)|.*/homebrew/homebrew-core/.*' 's|/Formula/|/|' '^homebrew/core'
+    } | sort -uf
   else
-    homebrew-items '*\.rb' 'Casks' 's|/Formula/|/|' '^homebrew/core'
+    homebrew-items '*\.rb' '.*Casks(/.*|$)' 's|/Formula/|/|' '^homebrew/core'
   fi
 }

--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -1,6 +1,7 @@
 homebrew-items() {
   local items
   local sed_extended_regex_flag
+  local find_args
   local find_include_filter="$1"
   local find_exclude_filter="$2"
   local sed_filter="$3"
@@ -11,17 +12,19 @@ homebrew-items() {
   if [[ -n "${HOMEBREW_MACOS}" ]]
   then
     sed_extended_regex_flag="-E"
+    find_args=("-E" "${HOMEBREW_REPOSITORY}/Library/Taps")
   else
     sed_extended_regex_flag="-r"
+    find_args=("${HOMEBREW_REPOSITORY}/Library/Taps" "-regextype" "posix-extended")
   fi
 
   # HOMEBREW_REPOSITORY is set by brew.sh
   # shellcheck disable=SC2154
   [[ -d "${HOMEBREW_REPOSITORY}/Library/Taps" ]] || return
   items="$(
-    find "${HOMEBREW_REPOSITORY}/Library/Taps" \
+    find "${find_args[@]}" \
       -type d \( \
-      -name "${find_exclude_filter}" -o \
+      -regex "${find_exclude_filter}" -o \
       -name cmd -o \
       -name .github -o \
       -name lib -o \


### PR DESCRIPTION
I'm not sure if this is an elegant solution but it gives an identical output to when `HOMEBREW_NO_INSTALL_FROM_API` is set, regardless of whether `homebrew/core` or `homebrew/cask` are tapped. Feel free to make any improvements.

Closes #15229

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
