### PR TITLE
Fix `MacOSVersionError` deprecation.

### DIFF
--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -139,9 +139,23 @@ end
 
 require "lazy_object"
 
-MacOSVersionError = LazyObject.new do # rubocop:disable Style/MutableConstant
-  # odeprecated "MacOSVersionError", "MacOSVersion::Error"
-  MacOSVersion::Error
+# `LazyObject` does not work for exceptions when used in `rescue` statements.
+class Object
+  class << self
+    module MacOSVersionErrorCompat
+      def const_missing(name)
+        if name == :MacOSVersionError
+          # odeprecated "MacOSVersionError", "MacOSVersion::Error"
+          return MacOSVersion::Error
+        end
+
+        super
+      end
+    end
+    private_constant :MacOSVersionErrorCompat
+
+    prepend MacOSVersionErrorCompat
+  end
 end
 
 module MacOSVersions


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The probably last usage of this is fixed by https://github.com/Homebrew/homebrew-core/pull/131773 anyways, but this is how it should be done so the constant works properly when used in `rescue` statements.
