### PR TITLE
github_runner_matrix: remove `GITHUB_RUN_ATTEMPT`

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -18,13 +18,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: "13-arm64-${{github.run_id}}-${{github.run_attempt}}"
-          - runner: "12-arm64-${{github.run_id}}-${{github.run_attempt}}"
-          - runner: "12-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "13-arm64-${{ github.run_id }}"
+          - runner: "13-${{ github.run_id }}"
+          - runner: "12-arm64-${{ github.run_id }}"
+          - runner: "12-${{ github.run_id }}"
           - runner: "11-arm64"
             cleanup: true
-          - runner: "11-${{github.run_id}}-${{github.run_attempt}}"
-          - runner: "10.15-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "11-${{ github.run_id }}"
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     env:

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -112,11 +112,10 @@ class GitHubRunnerMatrix
     @runners << create_runner(:linux, :x86_64, linux_runner_spec)
 
     github_run_id      = ENV.fetch("GITHUB_RUN_ID")
-    github_run_attempt = ENV.fetch("GITHUB_RUN_ATTEMPT")
     timeout            = ENV.fetch("HOMEBREW_MACOS_TIMEOUT").to_i
     use_github_runner  = ENV.fetch("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false") == "true"
 
-    ephemeral_suffix = +"-#{github_run_id}-#{github_run_attempt}"
+    ephemeral_suffix = +"-#{github_run_id}"
     ephemeral_suffix << "-deps" if @dependent_matrix
     ephemeral_suffix.freeze
 

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -11,13 +11,12 @@ describe "brew determine-test-runners" do
   let(:linux_runner) { "ubuntu-22.04" }
   # We need to make sure we write to a different path for each example.
   let(:github_output) { "#{TEST_TMPDIR}/github_output#{DetermineRunnerTestHelper.new.number}" }
-  let(:ephemeral_suffix) { "-12345-1" }
+  let(:ephemeral_suffix) { "-12345" }
   let(:runner_env) do
     {
       "HOMEBREW_LINUX_RUNNER"  => linux_runner,
       "HOMEBREW_MACOS_TIMEOUT" => "90",
       "GITHUB_RUN_ID"          => ephemeral_suffix.split("-").second,
-      "GITHUB_RUN_ATTEMPT"     => ephemeral_suffix.split("-").third,
     }.freeze
   end
   let(:all_runners) do

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -9,7 +9,6 @@ describe GitHubRunnerMatrix do
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_TIMEOUT").and_return("90")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")
-    allow(ENV).to receive(:fetch).with("GITHUB_RUN_ATTEMPT").and_return("1")
   end
 
   let(:newest_supported_macos) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should no longer be needed after Homebrew/ci-orchestrator@845d26ccc03ffebb06c39d0b9ce81134e8a6688b.
