### PR TITLE
unpack_strategy/zip: avoid loading formulae unnecessarily

### DIFF
--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -23,10 +23,12 @@ module UnpackStrategy
               .returns(SystemCommand::Result)
     }
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      unzip = begin
-        Formula["unzip"]
-      rescue FormulaUnavailableError
-        nil
+      unzip = if which("unzip").blank?
+        begin
+          Formula["unzip"]
+        rescue FormulaUnavailableError
+          nil
+        end
       end
 
       with_env(TZ: "UTC") do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If we already have `unzip` in `PATH`, let's skip trying to load the
`unzip` formula.
