### PR TITLE
add uninstall_system_extension stanza

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -18,6 +18,7 @@ module Cask
         :launchctl,
         :quit,
         :signal,
+        :system_extension,
         :login_item,
         :kext,
         :script,
@@ -309,6 +310,31 @@ module Cask
           )
 
           opoo "Removal of login item #{id} failed. #{automation_access_instructions}" unless result.success?
+
+          sleep 1
+        end
+      end
+
+      def uninstall_system_extension(*apps, command: nil, **_)
+        apps = cask.artifacts.select { |a| a.class.dsl_key == :app } if apps.empty?
+
+        apps.each do |item|
+          unless T.must(User.current).gui?
+            opoo "Not logged into a GUI; skipping removing '#{item}'."
+            next
+          end
+          ohai "Removing '#{item}'."
+
+          result = system_command(
+            "osascript",
+            args: [
+              "-e",
+              %Q(tell application "Finder" to move application file "#{item}" \
+              of folder "Applications" of startup disk to trash),
+            ],
+          )
+
+          opoo "Removal of '#{item}' failed. Move #{item} to trash manually." unless result.success?
 
           sleep 1
         end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR is in response to https://github.com/Homebrew/homebrew-cask/pull/146071#issuecomment-1528756578. In essence, the current implementation of System Extensions limits the methods available for removing system extensions. System Extensions can be removed either by using Finder to move the linked Application to trash, or by an API call to System Extensions (this is limited to the binary that initially installed the extension). If apps are uninstalled and system extensions are not removed through the above methods they become orphaned and can only be removed by disabling SIP.

Still a draft, but opening to get some more thoughts on the best way to implement this. It's currently in the uninstall set of stanzas. Ideally, it should be called before `Installer.new().uninstall`.