### PR TITLE
docs/config: remove jekyll-feed.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,6 @@ exclude:
   - vendor
 
 plugins:
-  - jekyll-feed
   - jekyll-redirect-from
   - jekyll-remote-theme
   - jekyll-seo-tag


### PR DESCRIPTION
This slightly speeds up generation and it's no longer needed as of https://github.com/Homebrew/brew.sh/pull/957.