### PR TITLE
cmd/pyenv-sync: add new command.

### DIFF
--- a/Library/Homebrew/cmd/nodenv-sync.rb
+++ b/Library/Homebrew/cmd/nodenv-sync.rb
@@ -29,22 +29,24 @@ module Homebrew
     nodenv_sync_running = dot_nodenv/".nodenv_sync_running"
     return if nodenv_sync_running.exist?
 
-    nodenv_versions = dot_nodenv/"versions"
-    nodenv_versions.mkpath
-    FileUtils.touch nodenv_sync_running
+    begin
+      nodenv_versions = dot_nodenv/"versions"
+      nodenv_versions.mkpath
+      FileUtils.touch nodenv_sync_running
 
-    nodenv_sync_args.parse
+      nodenv_sync_args.parse
 
-    HOMEBREW_CELLAR.glob("node{,@*}")
-                   .flat_map(&:children)
-                   .each { |path| link_nodenv_versions(path, nodenv_versions) }
+      HOMEBREW_CELLAR.glob("node{,@*}")
+                     .flat_map(&:children)
+                     .each { |path| link_nodenv_versions(path, nodenv_versions) }
 
-    nodenv_versions.children
-                   .select(&:symlink?)
-                   .reject(&:exist?)
-                   .each { |path| FileUtils.rm_f path }
-  ensure
-    nodenv_sync_running.unlink if nodenv_sync_running.exist?
+      nodenv_versions.children
+                     .select(&:symlink?)
+                     .reject(&:exist?)
+                     .each { |path| FileUtils.rm_f path }
+    ensure
+      nodenv_sync_running.unlink if nodenv_sync_running.exist?
+    end
   end
 
   sig { params(path: Pathname, nodenv_versions: Pathname).void }

--- a/Library/Homebrew/cmd/pyenv-sync.rb
+++ b/Library/Homebrew/cmd/pyenv-sync.rb
@@ -1,0 +1,68 @@
+# typed: true
+# frozen_string_literal: true
+
+require "cli/parser"
+require "formula"
+
+module Homebrew
+  module_function
+
+  sig { returns(CLI::Parser) }
+  def pyenv_sync_args
+    Homebrew::CLI::Parser.new do
+      description <<~EOS
+        Create symlinks for Homebrew's installed Python versions in ~/.pyenv/versions.
+
+        Note that older patch version symlinks will be created and linked to the minor
+        version so e.g. Python 3.11.0 will also be symlinked to 3.11.3.
+      EOS
+
+      named_args :none
+    end
+  end
+
+  sig { void }
+  def pyenv_sync
+    dot_pyenv = Pathname(Dir.home)/".pyenv"
+
+    # Don't run multiple times at once.
+    pyenv_sync_running = dot_pyenv/".pyenv_sync_running"
+    return if pyenv_sync_running.exist?
+
+    begin
+      pyenv_versions = dot_pyenv/"versions"
+      pyenv_versions.mkpath
+      FileUtils.touch pyenv_sync_running
+
+      pyenv_sync_args.parse
+
+      HOMEBREW_CELLAR.glob("python{,@*}")
+                     .flat_map(&:children)
+                     .each { |path| link_pyenv_versions(path, pyenv_versions) }
+
+      pyenv_versions.children
+                    .select(&:symlink?)
+                    .reject(&:exist?)
+                    .each { |path| FileUtils.rm_f path }
+    ensure
+      pyenv_sync_running.unlink if pyenv_sync_running.exist?
+    end
+  end
+
+  sig { params(path: Pathname, pyenv_versions: Pathname).void }
+  def link_pyenv_versions(path, pyenv_versions)
+    pyenv_versions.mkpath
+
+    version = Keg.new(path).version
+    major_version = version.major.to_i
+    minor_version = version.minor.to_i
+    patch_version = version.patch.to_i
+
+    (0..patch_version).each do |patch|
+      link_path = pyenv_versions/"#{major_version}.#{minor_version}.#{patch}"
+
+      FileUtils.rm_f link_path
+      FileUtils.ln_sf path, link_path
+    end
+  end
+end

--- a/Library/Homebrew/cmd/rbenv-sync.rb
+++ b/Library/Homebrew/cmd/rbenv-sync.rb
@@ -29,22 +29,24 @@ module Homebrew
     rbenv_sync_running = dot_rbenv/".rbenv_sync_running"
     return if rbenv_sync_running.exist?
 
-    rbenv_versions = dot_rbenv/"versions"
-    rbenv_versions.mkpath
-    FileUtils.touch rbenv_sync_running
+    begin
+      rbenv_versions = dot_rbenv/"versions"
+      rbenv_versions.mkpath
+      FileUtils.touch rbenv_sync_running
 
-    rbenv_sync_args.parse
+      rbenv_sync_args.parse
 
-    HOMEBREW_CELLAR.glob("ruby{,@*}")
-                   .flat_map(&:children)
-                   .each { |path| link_rbenv_versions(path, rbenv_versions) }
+      HOMEBREW_CELLAR.glob("ruby{,@*}")
+                     .flat_map(&:children)
+                     .each { |path| link_rbenv_versions(path, rbenv_versions) }
 
-    rbenv_versions.children
-                  .select(&:symlink?)
-                  .reject(&:exist?)
-                  .each { |path| FileUtils.rm_f path }
-  ensure
-    rbenv_sync_running.unlink if rbenv_sync_running.exist?
+      rbenv_versions.children
+                    .select(&:symlink?)
+                    .reject(&:exist?)
+                    .each { |path| FileUtils.rm_f path }
+    ensure
+      rbenv_sync_running.unlink if rbenv_sync_running.exist?
+    end
   end
 
   sig { params(path: Pathname, rbenv_versions: Pathname).void }


### PR DESCRIPTION
Similar to `rbenv-sync` and `nodenv-sync`, but for use with `pyenv`.

Python has separate formulae for minor Python versions, as such this will symlink all patch versions to the latest minor version.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).

Following the style in https://github.com/Homebrew/brew/pull/14972, didn't see any example tests.

- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
