### PR TITLE
actionlint.yaml: remove workaround for `macos-13`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,9 +2,6 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
   labels:
     - 11-arm64
-    # FIXME: Remove `macos-13` when resolved:
-    #   https://github.com/rhysd/actionlint/issues/296
-    - macos-13
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - '.github/workflows/*.ya?ml'
+      - '.github/actionlint.yaml'
   pull_request:
     paths:
       - '.github/workflows/*.ya?ml'
+      - '.github/actionlint.yaml'
   merge_group:
 
 env:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is no longer needed after Homebrew/homebrew-core#132722.

This reverts commit f729127fae6a12e173f55a59ef90a72c7cf18141.
