### PR TITLE
PyPI: Handle non-`pythonhosted` formula URLs

### DIFF
--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -176,8 +176,12 @@ describe PyPI do
       expect(described_class.update_pypi_url(old_package_url, "0.0.0")).to be_nil
     end
 
-    it "returns nil for non-pypi urls" do
+    it "returns nil for nonexistent urls" do
       expect(described_class.update_pypi_url("https://brew.sh/foo-1.0.tgz", "1.1")).to be_nil
+    end
+
+    it "returns nil for non-pypi urls" do
+      expect(described_class.update_pypi_url("https://github.com/pypa/pip-audit/releases/download/v2.5.6/v2.5.6.tar.gz", "1.1")).to be_nil
     end
   end
 end

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -99,7 +99,7 @@ describe PyPI do
       it "fails for non-PYPI package URLs" do
         package = described_class.new(non_pypi_package_url, is_url: true)
 
-        expect {package.version = "1.2.3" }.to raise_error(ArgumentError)
+        expect { package.version = "1.2.3" }.to raise_error(ArgumentError)
       end
     end
 

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -3,13 +3,16 @@
 require "utils/pypi"
 
 describe PyPI do
-  let(:package_url) do
+  let(:pypi_package_url) do
     "https://files.pythonhosted.org/packages/b0/3f/2e1dad67eb172b6443b5eb37eb885a054a55cfd733393071499514140282/" \
       "snakemake-5.29.0.tar.gz"
   end
-  let(:old_package_url) do
+  let(:old_pypi_package_url) do
     "https://files.pythonhosted.org/packages/6f/c4/da52bfdd6168ea46a0fe2b7c983b6c34c377a8733ec177cc00b197a96a9f/" \
       "snakemake-5.28.0.tar.gz"
+  end
+  let(:non_pypi_package_url) do
+    "https://github.com/pypa/pip-audit/releases/download/v2.5.6/v2.5.6.tar.gz"
   end
 
   describe PyPI::Package do
@@ -22,7 +25,8 @@ describe PyPI do
     let(:package_with_extra) { described_class.new("snakemake[foo]") }
     let(:package_with_extra_and_version) { described_class.new("snakemake[foo]==5.28.0") }
     let(:package_with_different_capitalization) { described_class.new("SNAKEMAKE") }
-    let(:package_from_url) { described_class.new(package_url, is_url: true) }
+    let(:package_from_pypi_url) { described_class.new(pypi_package_url, is_url: true) }
+    let(:package_from_non_pypi_url) { described_class.new(non_pypi_package_url, is_url: true) }
     let(:other_package) { described_class.new("virtualenv==20.2.0") }
 
     describe "initialize" do
@@ -66,12 +70,50 @@ describe PyPI do
         expect(described_class.new("foo[bar,baz]==1.2.3").version).to eq "1.2.3"
       end
 
-      it "initializes name from url" do
-        expect(described_class.new(package_url, is_url: true).name).to eq "snakemake"
+      it "initializes name from PyPI url" do
+        expect(described_class.new(pypi_package_url, is_url: true).name).to eq "snakemake"
       end
 
-      it "initializes version from url" do
-        expect(described_class.new(package_url, is_url: true).version).to eq "5.29.0"
+      it "initializes version from PyPI url" do
+        expect(described_class.new(pypi_package_url, is_url: true).version).to eq "5.29.0"
+      end
+    end
+
+    describe ".version=" do
+      it "sets for package names" do
+        package = described_class.new("snakemake==5.28.0")
+        expect(package.version).to eq "5.28.0"
+
+        package.version = "5.29.0"
+        expect(package.version).to eq "5.29.0"
+      end
+
+      it "sets for PyPI package URLs" do
+        package = described_class.new(old_pypi_package_url, is_url: true)
+        expect(package.version).to eq "5.28.0"
+
+        package.version = "5.29.0"
+        expect(package.version).to eq "5.29.0"
+      end
+
+      it "fails for non-PYPI package URLs" do
+        package = described_class.new(non_pypi_package_url, is_url: true)
+
+        expect {package.version = "1.2.3" }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe ".valid_pypi_package?" do
+      it "is true for package names" do
+        expect(package.valid_pypi_package?).to be true
+      end
+
+      it "is true for PyPI URLs" do
+        expect(package_from_pypi_url.valid_pypi_package?).to be true
+      end
+
+      it "is false for non-PyPI URLs" do
+        expect(package_from_non_pypi_url.valid_pypi_package?).to be false
       end
     end
 
@@ -81,7 +123,8 @@ describe PyPI do
       end
 
       it "gets pypi info from a package name and specified version" do
-        expect(package.pypi_info(version: "5.29.0")).to eq ["snakemake", package_url, package_checksum, "5.29.0"]
+        expect(package.pypi_info(new_version: "5.29.0")).to eq ["snakemake", pypi_package_url, package_checksum,
+                                                                "5.29.0"]
       end
 
       it "gets pypi info from a package name with extra" do
@@ -89,26 +132,27 @@ describe PyPI do
       end
 
       it "gets pypi info from a package name and version" do
-        expect(package_with_version.pypi_info).to eq ["snakemake", old_package_url, old_package_checksum, "5.28.0"]
+        expect(package_with_version.pypi_info).to eq ["snakemake", old_pypi_package_url, old_package_checksum,
+                                                      "5.28.0"]
       end
 
       it "gets pypi info from a package name with overridden version" do
-        expected_result = ["snakemake", package_url, package_checksum, "5.29.0"]
-        expect(package_with_version.pypi_info(version: "5.29.0")).to eq expected_result
+        expected_result = ["snakemake", pypi_package_url, package_checksum, "5.29.0"]
+        expect(package_with_version.pypi_info(new_version: "5.29.0")).to eq expected_result
       end
 
       it "gets pypi info from a package name, extras, and version" do
-        expected_result = ["snakemake", old_package_url, old_package_checksum, "5.28.0"]
+        expected_result = ["snakemake", old_pypi_package_url, old_package_checksum, "5.28.0"]
         expect(package_with_extra_and_version.pypi_info).to eq expected_result
       end
 
       it "gets pypi info from a url" do
-        expect(package_from_url.pypi_info).to eq ["snakemake", package_url, package_checksum, "5.29.0"]
+        expect(package_from_pypi_url.pypi_info).to eq ["snakemake", pypi_package_url, package_checksum, "5.29.0"]
       end
 
       it "gets pypi info from a url with overridden version" do
-        expected_result = ["snakemake", old_package_url, old_package_checksum, "5.28.0"]
-        expect(package_from_url.pypi_info(version: "5.28.0")).to eq expected_result
+        expected_result = ["snakemake", old_pypi_package_url, old_package_checksum, "5.28.0"]
+        expect(package_from_pypi_url.pypi_info(new_version: "5.28.0")).to eq expected_result
       end
     end
 
@@ -130,7 +174,7 @@ describe PyPI do
       end
 
       it "returns string representation of package from url" do
-        expect(package_from_url.to_s).to eq "snakemake==5.29.0"
+        expect(package_from_pypi_url.to_s).to eq "snakemake==5.29.0"
       end
     end
 
@@ -169,19 +213,15 @@ describe PyPI do
 
   describe "update_pypi_url", :needs_network do
     it "updates url to new version" do
-      expect(described_class.update_pypi_url(old_package_url, "5.29.0")).to eq package_url
+      expect(described_class.update_pypi_url(old_pypi_package_url, "5.29.0")).to eq pypi_package_url
     end
 
     it "returns nil for invalid versions" do
-      expect(described_class.update_pypi_url(old_package_url, "0.0.0")).to be_nil
-    end
-
-    it "returns nil for nonexistent urls" do
-      expect(described_class.update_pypi_url("https://brew.sh/foo-1.0.tgz", "1.1")).to be_nil
+      expect(described_class.update_pypi_url(old_pypi_package_url, "0.0.0")).to be_nil
     end
 
     it "returns nil for non-pypi urls" do
-      expect(described_class.update_pypi_url("https://github.com/pypa/pip-audit/releases/download/v2.5.6/v2.5.6.tar.gz", "1.1")).to be_nil
+      expect(described_class.update_pypi_url(non_pypi_package_url, "1.1")).to be_nil
     end
   end
 end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -31,8 +31,8 @@ module PyPI
           # try and use `pip install -q --no-deps --dry-run --report ...` to get its
           # name and version.
           command =
-            [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--no-deps", "--dry-run", "--ignore-installed", "--report",
-             "/dev/stdout", package_string]
+            [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--no-deps",
+             "--dry-run", "--ignore-installed", "--report", "/dev/stdout", package_string]
           pip_output = Utils.popen_read({ "PIP_REQUIRE_VIRTUALENV" => "false" }, *command)
           unless $CHILD_STATUS.success?
             raise ArgumentError, <<~EOS

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -30,6 +30,9 @@ module PyPI
           # The URL might be a source distribution hosted somewhere;
           # try and use `pip install -q --no-deps --dry-run --report ...` to get its
           # name and version.
+          # Note that this is different from the (similar) `pip install --report` we
+          # do below, in that it uses `--no-deps` because we only care about resolving
+          # this specific URL's project metadata.
           command =
             [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--no-deps",
              "--dry-run", "--ignore-installed", "--report", "/dev/stdout", package_string]

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -41,7 +41,6 @@ module PyPI
             raise ArgumentError, <<~EOS
               Unable to determine dependencies for "#{package_string}" because of a failure when running
               `#{command.join(" ")}`.
-              Please update the resources for "#{formula.name}" manually.
             EOS
           end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -27,6 +27,8 @@ module PyPI
           @name = PyPI.normalize_python_package(match[1])
           @version = match[2]
         else
+          ensure_formula_installed!("python")
+
           # The URL might be a source distribution hosted somewhere;
           # try and use `pip install -q --no-deps --dry-run --report ...` to get its
           # name and version.
@@ -64,7 +66,9 @@ module PyPI
       @extras = T.must(match[2]).split ","
     end
 
-    # Get name, URL, SHA-256 checksum, and latest version for a given PyPI package.
+    # Get name, URL, SHA-256 checksum, and latest version for a given package.
+    # This only works for packages from PyPI or from a PyPI URL; packages
+    # derived from non-PyPI URLs will produce `nil` here.
     sig { params(version: T.nilable(T.any(String, Version))).returns(T.nilable(T::Array[String])) }
     def pypi_info(version: nil)
       return @pypi_info if @pypi_info.present? && version.blank?

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -8,8 +8,10 @@ module PyPI
   PYTHONHOSTED_URL_PREFIX = "https://files.pythonhosted.org/packages/"
   private_constant :PYTHONHOSTED_URL_PREFIX
 
-  # PyPI Package
-  #
+
+  # Represents a Python package.
+  # This package can be a PyPI package (either by name/version or PyPI distribution URL),
+  # or it can be a non-PyPI URL.
   # @api private
   class Package
     attr_accessor :name, :extras, :version
@@ -49,6 +51,7 @@ module PyPI
           metadata = JSON.parse(pip_output)["install"].first["metadata"]
           @name = PyPI.normalize_python_package metadata["name"]
           @version = metadata["version"]
+          @from_pypi = false
         end
 
         return
@@ -100,6 +103,7 @@ module PyPI
 
     sig { returns(T::Boolean) }
     def valid_pypi_package?
+      return false unless @from_pypi
       info = pypi_info
       info.present? && info.is_a?(Array)
     end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -19,6 +19,7 @@ module PyPI
     sig { params(package_string: String, is_url: T::Boolean).void }
     def initialize(package_string, is_url: false)
       @pypi_info = nil
+      @from_pypi = true
 
       if is_url
         if package_string.start_with?(PYTHONHOSTED_URL_PREFIX)

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -31,7 +31,7 @@ module PyPI
       @extras ||= basic_metadata[1]
     end
 
-    sig { returns(String) }
+    sig { returns(T.nilable(String)) }
     def version
       @version ||= basic_metadata[2]
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is another quality of life improvement to our handling of Python packages, unlocked by the switch to `pip install --report --dry-run` from a few weeks ago: `pip install` can accept arbitrary distribution URLs, meaning that we no longer require the top-level to be a `pythonhosted` URL in order to auto-bump its dependencies using `update-python-resources`.

This should result in automation for a handful of formulae that previously required manual resource updating. More indirectly, it improves `brew-pip-audit`'s ability to bulk audit Python packages present in Homebrew formulae, resulting in more automated vulnerability fix PRs as well.