### PR TITLE
cask/quarantine: fix exception not being caught

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -217,7 +217,7 @@ module Cask
           File.write(test_file, "")
           test_file.delete
           return true
-        rescue Errno::EACCES
+        rescue Errno::EACCES, Errno::EPERM
           # Using error handler below
         end
       else


### PR DESCRIPTION
The problem is that the branch attempts a write which throws but also returns right after, which causes the calling code to miss executing the branch to acquire permissions [1]. This change makes it so that the write is attempted, and if it fails, `app_management_permissions_granted` will return false to the caller, which will end up executing `Utils.gain_permissions_remove(target, command: command)`.

This fixes the issue of cask upgrades/reinstalls to failing due to permissions [2]. It's worth noting though, the prompt for allowing App Management permissions does not seem to occur, so that's something else to be investigated.

1. https://github.com/Homebrew/brew/blob/f7d86ff9bc166cf59a4cdec3520d45eec9a49e75/Library/Homebrew/cask/artifact/moved.rb#L170-L172
2. https://github.com/Homebrew/homebrew-cask/issues/148253

Fixes https://github.com/Homebrew/homebrew-cask/issues/148253
Fixes #15517

Signed-off-by: Ismayil Mirzali <ismayilmirzeli@gmail.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
