### PR TITLE
workflows/tests: update homebrew-cask

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Set up Homebrew all cask taps
         run: |
-          brew tap homebrew/cask
+          brew tap homebrew/cask && brew update-reset "$(brew --repo homebrew/cask)"
           brew tap homebrew/cask-drivers
           brew tap homebrew/cask-fonts
           brew tap homebrew/cask-versions


### PR DESCRIPTION
We're not actually testing the latest homebrew-cask at the moment, because homebrew-cask is preinstalled on GitHub Actions macOS images and a simple `brew tap` won't update it.

Maybe `setup-homebrew` should update it. This is a safer fix for now since I need it for #15522, and we had `update-reset` here before so shouldn't be controversial.