### PR TITLE
dependencies_helpers: fix pruning of build/test deps

### DIFF
--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -45,13 +45,13 @@ module DependenciesHelpers
         klass.prune if ignores.include?("recommended?") || dependent.build.without?(dep)
       elsif dep.optional?
         klass.prune if includes.exclude?("optional?") && !dependent.build.with?(dep)
-      elsif dep.satisfied?
-        klass.prune if ignores.include?("satisfied?")
       elsif dep.build? || dep.test?
         keep = false
         keep ||= dep.test? && includes.include?("test?") && dependent == root_dependent
         keep ||= dep.build? && includes.include?("build?")
         klass.prune unless keep
+      elsif dep.satisfied?
+        klass.prune if ignores.include?("satisfied?")
       end
 
       # If a tap isn't installed, we can't find the dependencies of one of


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We need to check that a dependency is a build or test dependency before
checking that it is satisfied in order to prune dependencies as
requested correctly.

Before:

```
❯ brew deps esptool
ca-certificates
cmake
mpdecimal
openssl@1.1
openssl@3
pkg-config
python@3.11
readline
rust
six
sqlite
xz
```

After:

```
❯ brew deps esptool
ca-certificates
cffi
mpdecimal
openssl@1.1
pycparser
python@3.11
readline
six
sqlite
xz
```

Note: You will need build dependencies installed to reproduce the
"before" behaviour.

See #15445.
