### PR TITLE
utils/gems: fix bundler sometimes unnecessarily reinstalling

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -134,13 +134,19 @@ module Homebrew
   end
 
   def install_bundler!
+    old_bundler_version = ENV.fetch("BUNDLER_VERSION", nil)
+
     setup_gem_environment!
+
+    ENV["BUNDLER_VERSION"] = HOMEBREW_BUNDLER_VERSION # Set so it correctly finds existing installs
     install_gem_setup_path!(
       "bundler",
       version:               HOMEBREW_BUNDLER_VERSION,
       executable:            "bundle",
       setup_gem_environment: false,
     )
+  ensure
+    ENV["BUNDLER_VERSION"] = old_bundler_version
   end
 
   def install_bundler_gems!(only_warn_on_failure: false, setup_path: true, groups: [])


### PR DESCRIPTION
We use `Gem::Specification.find_all_by_name("bundler", "2.3.26")` to check if Bundler is already installed, so we aren't reinstalling it unnecessarily.

However it turns out Rubygems has some feature that to be smart and ignores the version you provide and instead reads what `Gemfile.lock` in your working directory uses.

We don't want this behaviour, so override that behaviour by setting `BUNDLER_VERSION` before invoking the install procedure.