### PR TITLE
formula_auditor: skip dependency conflict audit for OpenSSL migration

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -345,12 +345,28 @@ module Homebrew
       # TODO: remove this and check these there too.
       return if Homebrew::SimulateSystem.simulating_or_running_on_linux?
 
+      # Skip the versioned dependencies conflict audit on the OpenSSL migration branch.
+      # TODO: Remove this when OpenSSL migration is complete.
+      ignore_openssl_conflict = if (github_event_path = ENV.fetch("GITHUB_EVENT_PATH", nil)).present?
+        event_payload = JSON.parse(File.read(github_event_path))
+        head_info = event_payload.dig("pull_request", "head")
+
+        # We need to read the head ref from `GITHUB_EVENT_PATH` because
+        # `git branch --show-current` returns `master` on PR branches.
+        openssl_migration_branch = head_info["ref"] == "openssl-migration"
+        homebrew_owned_repo = head_info.dig("repo", "owner", "login") == "Homebrew"
+        homebrew_core_pr = head_info.dig("repo", "name") == "homebrew-core"
+
+        openssl_migration_branch && homebrew_owned_repo && homebrew_core_pr
+      end
+
       recursive_runtime_formulae = formula.runtime_formula_dependencies(undeclared: false)
       version_hash = {}
       version_conflicts = Set.new
       recursive_runtime_formulae.each do |f|
         name = f.name
         unversioned_name, = name.split("@")
+        next if unversioned_name == "openssl" && ignore_openssl_conflict
         # Allow use of the full versioned name (e.g. `python@3.99`) or an unversioned alias (`python`).
         next if formula.tap&.audit_exception :versioned_formula_dependent_conflicts_allowlist, name
         next if formula.tap&.audit_exception :versioned_formula_dependent_conflicts_allowlist, unversioned_name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We can't migrate the entire OpenSSL dependency tree in one go, so we'll
have to skip this audit in the interim.

See Homebrew/homebrew-core#133144.
