### PR TITLE
formula_auditor: handle `head_info` being `nil`

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -349,7 +349,7 @@ module Homebrew
       # TODO: Remove this when OpenSSL migration is complete.
       ignore_openssl_conflict = if (github_event_path = ENV.fetch("GITHUB_EVENT_PATH", nil)).present?
         event_payload = JSON.parse(File.read(github_event_path))
-        head_info = event_payload.dig("pull_request", "head")
+        head_info = event_payload.dig("pull_request", "head").to_h # handle `nil`
 
         # We need to read the head ref from `GITHUB_EVENT_PATH` because
         # `git branch --show-current` returns `master` on PR branches.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This happens when CI runs on an event that isn't a pull request (e.g.
push, merge_group).
