### PR TITLE
Use "cone" mode for sparse checkouts

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -835,9 +835,11 @@ class GitDownloadStrategy < VCSDownloadStrategy
     # constructor calls `cache_tag` and sets the cache path.
     @only_path = meta[:only_path]
 
-    # "Cone" mode of sparse checkout requires patterns to be directories
-    @only_path = "/#{@only_path}" unless @only_path.start_with?("/")
-    @only_path = "#{@only_path}/" unless @only_path.end_with?("/")
+    if @only_path.present?
+      # "Cone" mode of sparse checkout requires patterns to be directories
+      @only_path = "/#{@only_path}" unless @only_path.start_with?("/")
+      @only_path = "#{@only_path}/" unless @only_path.end_with?("/")
+    end
 
     super
     @ref_type ||= :branch

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -835,6 +835,10 @@ class GitDownloadStrategy < VCSDownloadStrategy
     # constructor calls `cache_tag` and sets the cache path.
     @only_path = meta[:only_path]
 
+    # "Cone" mode of sparse checkout requires patterns to be directories
+    @only_path = "/#{@only_path}" unless @only_path.start_with?("/")
+    @only_path = "#{@only_path}/" unless @only_path.end_with?("/")
+
     super
     @ref_type ||= :branch
     @ref ||= "master"
@@ -1080,12 +1084,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
              chdir: cached_location
 
     (git_dir/"info").mkpath
-
-    # "Cone" mode of sparse checkout requires patterns to be directories
-    path = @only_path
-    path = "/#{path}" unless path.start_with?("/")
-    path = "#{path}/" unless path.end_with?("/")
-    (git_dir/"info"/"sparse-checkout").atomic_write("#{path}\n")
+    (git_dir/"info/sparse-checkout").atomic_write("#{@only_path}\n")
   end
 end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1075,9 +1075,17 @@ class GitDownloadStrategy < VCSDownloadStrategy
     command! "git",
              args:  ["config", "core.sparseCheckout", "true"],
              chdir: cached_location
+    command! "git",
+             args:  ["config", "core.sparseCheckoutCone", "true"],
+             chdir: cached_location
 
     (git_dir/"info").mkpath
-    (git_dir/"info"/"sparse-checkout").atomic_write("#{@only_path}\n")
+
+    # "Cone" mode of sparse checkout requires patterns to be directories
+    path = @only_path
+    path = "/#{path}" unless path.start_with?("/")
+    path = "#{path}/" unless path.end_with?("/")
+    (git_dir/"info"/"sparse-checkout").atomic_write("#{path}\n")
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Appears to fix https://github.com/Homebrew/brew/issues/15537. I don't know why that crash started showing up with git 2.41.0, but this does appear to fix it.

While trying to reproduce the bug I noticed that some sparse checkouts did cause a git crash and others didn't. It turned out that the ones that worked were using "cone" mode, whereas homebrew is currently using non-cone mode. Cone mode is a bit less flexible — for instance it doesn't let you exclude top-level files, and it only lets you select directories not individual files. However, the git documentation lists a long series of [problems with non-cone mode](https://git-scm.com/docs/git-sparse-checkout#_internalsnon_cone_problems), and concludes by saying "non-cone mode is deprecated. Please switch to using cone mode."

This is technically a **breaking change**, as `only_path` could be an individual file, whereas with this change it must be a directory. However, I searched GitHub for examples of casks using `only_path`, and all the examples I could find were directories.

