### PR TITLE
caveats: suggest command that preserves existing `PKG_CONFIG_PATH`

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -87,11 +87,11 @@ class Caveats
         EOS
 
         if (formula.lib/"pkgconfig").directory?
-          s << "  #{Utils::Shell.export_value("PKG_CONFIG_PATH", "#{formula.opt_lib}/pkgconfig")}\n"
+          s << "  #{Utils::Shell.export_value("PKG_CONFIG_PATH", "#{formula.opt_lib}/pkgconfig", clobber: false)}\n"
         end
 
         if (formula.share/"pkgconfig").directory?
-          s << "  #{Utils::Shell.export_value("PKG_CONFIG_PATH", "#{formula.opt_share}/pkgconfig")}\n"
+          s << "  #{Utils::Shell.export_value("PKG_CONFIG_PATH", "#{formula.opt_share}/pkgconfig", clobber: false)}\n"
         end
       end
     end

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -32,11 +32,23 @@ module Utils
     end
 
     # Quote values. Quoting keys is overkill.
-    sig { params(key: String, value: String, shell: T.nilable(Symbol)).returns(T.nilable(String)) }
-    def export_value(key, value, shell = preferred)
+    sig {
+      params(
+        key:       String,
+        value:     String,
+        shell:     T.nilable(Symbol),
+        clobber:   T.nilable(T::Boolean),
+        separator: T.nilable(String),
+      ).returns(T.nilable(String))
+    }
+    def export_value(key, value, shell = preferred, clobber: true, separator: ":")
       case shell
       when :bash, :ksh, :mksh, :sh, :zsh
-        "export #{key}=\"#{sh_quote(value)}\""
+        s = +"export #{key}=\"#{sh_quote(value)}"
+        s << "${#{key}:+#{separator}${#{key}}}" unless clobber
+        s << '"'
+
+        s.freeze
       when :fish
         # fish quoting is mostly Bourne compatible except that
         # a single quote can be included in a single-quoted string via \'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before:

    ❯ brew info curl
    [snip]
    For pkg-config to find curl you may need to set:
      export PKG_CONFIG_PATH="/usr/local/opt/curl/lib/pkgconfig"
    [snip]

After:

    ❯ brew info curl
    [snip]
    For pkg-config to find curl you may need to set:
      export PKG_CONFIG_PATH="/usr/local/opt/curl/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
    [snip]

This means that the suggested command will prepend the suggested path to
`PKG_CONFIG_PATH` if it's already set, or set `PKG_CONFIG_PATH` to the
suggested path if it is not set or is null.

I've only implemented this for Bash-like shells, because I don't know
what the syntax is for other shells.

Closes #15546.
