### PR TITLE
formula_installer: fix postinstall using incorrect formula file

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1115,7 +1115,7 @@ on_request: installed_on_request?, options: options)
     # the formula from the tap.
     formula_path = begin
       keg_formula_path = formula.opt_prefix/".brew/#{formula.name}.rb"
-      tap_formula_path = formula.path
+      tap_formula_path = formula.specified_path
       keg_formula = Formulary.factory(keg_formula_path)
       tap_formula = Formulary.factory(tap_formula_path) if tap_formula_path.exist?
       other_version_installed = (keg_formula.pkg_version != tap_formula&.pkg_version)


### PR DESCRIPTION
In certain cases the wrong, resolved file path is used in the postinstall stage. Confusingly, when this happened postinstall would actually just be skipped silently without any warnings unless you had `--debug` so the issue was easy to miss and could have been an issue for some time.

The build stage uses `specified_path` so the fix here is to be consistent with the rest of FormulaInstaller and do the same with postinstall.

Fixes https://github.com/Homebrew/homebrew-core/issues/130672.