### PR TITLE
formula: fix variations not being generated for instance on_os usage

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2253,7 +2253,7 @@ class Formula
 
     os_versions = [*MacOSVersion::SYMBOLS.keys, :linux]
 
-    if path.exist? && self.class.on_system_blocks_exist?
+    if path.exist? && (self.class.on_system_blocks_exist? || @on_system_blocks_exist)
       formula_contents = path.read
       os_versions.product(OnSystem::ARCH_OPTIONS).each do |os, arch|
         bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)


### PR DESCRIPTION
We check if `on_os` is used on class level, but it might be used on instance-level like in caveats.

Fixes #15014.