### PR TITLE
Refactor some dependency handling to fix various API dependency issues

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -57,7 +57,7 @@ class Build
       build = effective_build_options_for(dependent)
       if dep.prune_from_option?(build) ||
          dep.prune_if_build_and_not_dependent?(dependent, formula) ||
-         (dep.test? && !dep.build?)
+         (dep.test? && !dep.build?) || dep.implicit?
         Dependency.prune
       elsif dep.build?
         Dependency.keep_but_prune_recursive_deps

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -191,6 +191,7 @@ module Homebrew
       str = "#{str} [test]" if dep.test?
       str = "#{str} [optional]" if dep.optional?
       str = "#{str} [recommended]" if dep.recommended?
+      str = "#{str} [implicit]" if dep.implicit?
     end
 
     str

--- a/Library/Homebrew/dependable.rb
+++ b/Library/Homebrew/dependable.rb
@@ -9,7 +9,7 @@ require "options"
 module Dependable
   # `:run` and `:linked` are no longer used but keep them here to avoid their
   # misuse in future.
-  RESERVED_TAGS = [:build, :optional, :recommended, :run, :test, :linked].freeze
+  RESERVED_TAGS = [:build, :optional, :recommended, :run, :test, :linked, :implicit].freeze
 
   attr_reader :tags
 
@@ -27,6 +27,10 @@ module Dependable
 
   def test?
     tags.include? :test
+  end
+
+  def implicit?
+    tags.include? :implicit
   end
 
   def required?

--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -33,6 +33,10 @@ class Dependencies < SimpleDelegator
     build + required + recommended
   end
 
+  def dup_without_system_deps
+    self.class.new(*__getobj__.reject { |dep| dep.uses_from_macos? && dep.use_macos_install? })
+  end
+
   sig { returns(String) }
   def inspect
     "#<#{self.class.name}: #{__getobj__}>"

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -56,11 +56,7 @@ module DependenciesHelpers
 
       # If a tap isn't installed, we can't find the dependencies of one of
       # its formulae, and an exception will be thrown if we try.
-      if klass == Dependency &&
-         dep.is_a?(TapDependency) &&
-         !dep.tap.installed?
-        Dependency.keep_but_prune_recursive_deps
-      end
+      Dependency.keep_but_prune_recursive_deps if klass == Dependency && dep.tap && !dep.tap.installed?
     end
   end
 

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -180,7 +180,12 @@ class Dependency
         option_names = deps.flat_map(&:option_names).uniq
         kwargs = {}
         kwargs[:bounds] = dep.bounds if dep.uses_from_macos?
-        dep.class.new(name, tags, dep.env_proc, option_names, **kwargs)
+        # TODO: simpify to just **kwargs when we require Ruby >= 2.7
+        if kwargs.empty?
+          dep.class.new(name, tags, dep.env_proc, option_names)
+        else
+          dep.class.new(name, tags, dep.env_proc, option_names, **kwargs)
+        end
       end
     end
 
@@ -208,10 +213,10 @@ class Dependency
     end
 
     def merge_temporality(deps)
-      # Means both build and runtime dependency.
-      return [] unless deps.all?(&:build?)
-
-      [:build]
+      new_tags = []
+      new_tags << :build if deps.all?(&:build?)
+      new_tags << :implicit if deps.all?(&:implicit?)
+      new_tags
     end
   end
 end

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -84,37 +84,37 @@ class DependencyCollector
   def git_dep_if_needed(tags)
     return if Utils::Git.available?
 
-    Dependency.new("git", tags)
+    Dependency.new("git", [*tags, :implicit])
   end
 
   def curl_dep_if_needed(tags)
-    Dependency.new("curl", tags)
+    Dependency.new("curl", [*tags, :implicit])
   end
 
   def subversion_dep_if_needed(tags)
     return if Utils::Svn.available?
 
-    Dependency.new("subversion", tags)
+    Dependency.new("subversion", [*tags, :implicit])
   end
 
   def cvs_dep_if_needed(tags)
-    Dependency.new("cvs", tags) unless which("cvs")
+    Dependency.new("cvs", [*tags, :implicit]) unless which("cvs")
   end
 
   def xz_dep_if_needed(tags)
-    Dependency.new("xz", tags) unless which("xz")
+    Dependency.new("xz", [*tags, :implicit]) unless which("xz")
   end
 
   def zstd_dep_if_needed(tags)
-    Dependency.new("zstd", tags) unless which("zstd")
+    Dependency.new("zstd", [*tags, :implicit]) unless which("zstd")
   end
 
   def unzip_dep_if_needed(tags)
-    Dependency.new("unzip", tags) unless which("unzip")
+    Dependency.new("unzip", [*tags, :implicit]) unless which("unzip")
   end
 
   def bzip2_dep_if_needed(tags)
-    Dependency.new("bzip2", tags) unless which("bzip2")
+    Dependency.new("bzip2", [*tags, :implicit]) unless which("bzip2")
   end
 
   def self.tar_needs_xz_dependency?
@@ -127,6 +127,8 @@ class DependencyCollector
   def init_global_dep_tree_if_needed!; end
 
   def parse_spec(spec, tags)
+    raise ArgumentError, "Implicit dependencies cannot be manually specified" if tags.include?(:implicit)
+
     case spec
     when String
       parse_string_spec(spec, tags)
@@ -184,11 +186,11 @@ class DependencyCollector
     elsif strategy <= SubversionDownloadStrategy
       subversion_dep_if_needed(tags)
     elsif strategy <= MercurialDownloadStrategy
-      Dependency.new("mercurial", tags)
+      Dependency.new("mercurial", [*tags, :implicit])
     elsif strategy <= FossilDownloadStrategy
-      Dependency.new("fossil", tags)
+      Dependency.new("fossil", [*tags, :implicit])
     elsif strategy <= BazaarDownloadStrategy
-      Dependency.new("breezy", tags)
+      Dependency.new("breezy", [*tags, :implicit])
     elsif strategy <= CVSDownloadStrategy
       cvs_dep_if_needed(tags)
     elsif strategy < AbstractDownloadStrategy
@@ -204,10 +206,10 @@ class DependencyCollector
     when ".zst"         then zstd_dep_if_needed(tags)
     when ".zip"         then unzip_dep_if_needed(tags)
     when ".bz2"         then bzip2_dep_if_needed(tags)
-    when ".lha", ".lzh" then Dependency.new("lha", tags)
-    when ".lz"          then Dependency.new("lzip", tags)
-    when ".rar"         then Dependency.new("libarchive", tags)
-    when ".7z"          then Dependency.new("p7zip", tags)
+    when ".lha", ".lzh" then Dependency.new("lha", [*tags, :implicit])
+    when ".lz"          then Dependency.new("lzip", [*tags, :implicit])
+    when ".rar"         then Dependency.new("libarchive", [*tags, :implicit])
+    when ".7z"          then Dependency.new("p7zip", [*tags, :implicit])
     end
   end
 end

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -144,11 +144,7 @@ class DependencyCollector
   end
 
   def parse_string_spec(spec, tags)
-    if spec.match?(HOMEBREW_TAP_FORMULA_REGEX)
-      TapDependency.new(spec, tags)
-    else
-      Dependency.new(spec, tags)
-    end
+    Dependency.new(spec, tags)
   end
 
   def parse_symbol_spec(spec, tags)

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -17,7 +17,7 @@ class DependencyCollector
     return if global_dep_tree[GCC]&.intersect?(related_formula_names)
     return unless formula_for(GCC)
 
-    Dependency.new(GCC)
+    Dependency.new(GCC, [:implicit])
   end
 
   sig { params(related_formula_names: T::Set[String]).returns(T.nilable(Dependency)) }
@@ -28,7 +28,7 @@ class DependencyCollector
     return if global_dep_tree[GLIBC]&.intersect?(related_formula_names)
     return unless formula_for(GLIBC)
 
-    Dependency.new(GLIBC)
+    Dependency.new(GLIBC, [:implicit])
   end
 
   private

--- a/Library/Homebrew/extend/os/mac/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/mac/dependency_collector.rb
@@ -8,11 +8,11 @@ class DependencyCollector
   def git_dep_if_needed(tags); end
 
   def subversion_dep_if_needed(tags)
-    Dependency.new("subversion", tags)
+    Dependency.new("subversion", [*tags, :implicit])
   end
 
   def cvs_dep_if_needed(tags)
-    Dependency.new("cvs", tags)
+    Dependency.new("cvs", [*tags, :implicit])
   end
 
   def xz_dep_if_needed(tags); end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -533,6 +533,9 @@ class Formula
   # The {Dependency}s for the currently active {SoftwareSpec}.
   delegate deps: :active_spec
 
+  # The declared {Dependency}s for the currently active {SoftwareSpec} (i.e. including those provided by macOS)
+  delegate declared_deps: :active_spec
+
   # Dependencies provided by macOS for the currently active {SoftwareSpec}.
   delegate uses_from_macos_elements: :active_spec
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -254,7 +254,7 @@ module Homebrew
       @specs.each do |spec|
         # Check for things we don't like to depend on.
         # We allow non-Homebrew installs whenever possible.
-        spec.deps.each do |dep|
+        spec.declared_deps.each do |dep|
           begin
             dep_f = dep.to_formula
           rescue TapFormulaUnavailableError
@@ -323,7 +323,7 @@ module Homebrew
           end
 
           # we want to allow uses_from_macos for aliases but not bare dependencies
-          if self.class.aliases.include?(dep.name) && spec.uses_from_macos_names.exclude?(dep.name)
+          if self.class.aliases.include?(dep.name) && !dep.uses_from_macos?
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 

--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -11,10 +11,13 @@ module Language
       module_function
 
       def detected_perl_shebang(formula = self)
-        perl_path = if formula.deps.map(&:name).include? "perl"
-          Formula["perl"].opt_bin/"perl"
-        elsif formula.uses_from_macos_names.include? "perl"
-          "/usr/bin/perl#{MacOS.preferred_perl_version}"
+        perl_deps = formula.declared_deps.select { |dep| dep.name == "perl" }
+        perl_path = if perl_deps.present?
+          if perl_deps.any? { |dep| !dep.uses_from_macos? || !dep.use_macos_install? }
+            Formula["perl"].opt_bin/"perl"
+          else
+            "/usr/bin/perl#{MacOS.preferred_perl_version}"
+          end
         else
           raise ShebangDetectionError.new("Perl", "formula does not depend on Perl")
         end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -24,8 +24,7 @@ class SoftwareSpec
   }.freeze
 
   attr_reader :name, :full_name, :owner, :build, :resources, :patches, :options, :deprecated_flags,
-              :deprecated_options, :dependency_collector, :bottle_specification, :compiler_failures,
-              :uses_from_macos_elements
+              :deprecated_options, :dependency_collector, :bottle_specification, :compiler_failures
 
   def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time, :download_name,
                  :cached_download, :clear_cache, :checksum, :mirrors, :specs, :using, :version, :mirror,
@@ -195,28 +194,34 @@ class SoftwareSpec
       deps = [bounds.shift].to_h
     end
 
+    spec, tags = deps.is_a?(Hash) ? deps.first : deps
+    raise TypeError, "Dependency name must be a string!" unless spec.is_a?(String)
+
     @uses_from_macos_elements << deps
 
-    # Check whether macOS is new enough for dependency to not be required.
-    if Homebrew::SimulateSystem.simulating_or_running_on_macos?
-      # Assume the oldest macOS version when simulating a generic macOS version
-      return if Homebrew::SimulateSystem.current_os == :macos && !bounds.key?(:since)
-
-      if Homebrew::SimulateSystem.current_os != :macos
-        current_os = MacOSVersion.from_symbol(Homebrew::SimulateSystem.current_os)
-        since_os = MacOSVersion.from_symbol(bounds[:since]) if bounds.key?(:since)
-        return if current_os >= since_os
-      end
-    end
-
-    depends_on deps
+    depends_on UsesFromMacOSDependency.new(spec, Array(tags), bounds: bounds)
   end
 
+  # @deprecated
+  # rubocop:disable Style/TrivialAccessors
+  def uses_from_macos_elements
+    # TODO: remove all @uses_from_macos_elements when disabling or removing this method
+    # odeprecated "#uses_from_macos_elements", "#declared_deps"
+    @uses_from_macos_elements
+  end
+  # rubocop:enable Style/TrivialAccessors
+
+  # @deprecated
   def uses_from_macos_names
+    # odeprecated "#uses_from_macos_names", "#declared_deps"
     uses_from_macos_elements.flat_map { |e| e.is_a?(Hash) ? e.keys : e }
   end
 
   def deps
+    dependency_collector.deps.dup_without_system_deps
+  end
+
+  def declared_deps
     dependency_collector.deps
   end
 

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -52,13 +52,13 @@ describe DependencyCollector do
     it "creates a resource dependency from a CVS URL" do
       resource = Resource.new
       resource.url(":pserver:anonymous:@brew.sh:/cvsroot/foo/bar", using: :cvs)
-      expect(collector.add(resource)).to eq(Dependency.new("cvs", [:build, :test]))
+      expect(collector.add(resource)).to eq(Dependency.new("cvs", [:build, :test, :implicit]))
     end
 
     it "creates a resource dependency from a '.7z' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.7z")
-      expect(collector.add(resource)).to eq(Dependency.new("p7zip", [:build, :test]))
+      expect(collector.add(resource)).to eq(Dependency.new("p7zip", [:build, :test, :implicit]))
     end
 
     it "creates a resource dependency from a '.gz' URL" do
@@ -70,25 +70,25 @@ describe DependencyCollector do
     it "creates a resource dependency from a '.lz' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.lz")
-      expect(collector.add(resource)).to eq(Dependency.new("lzip", [:build, :test]))
+      expect(collector.add(resource)).to eq(Dependency.new("lzip", [:build, :test, :implicit]))
     end
 
     it "creates a resource dependency from a '.lha' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.lha")
-      expect(collector.add(resource)).to eq(Dependency.new("lha", [:build, :test]))
+      expect(collector.add(resource)).to eq(Dependency.new("lha", [:build, :test, :implicit]))
     end
 
     it "creates a resource dependency from a '.lzh' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.lzh")
-      expect(collector.add(resource)).to eq(Dependency.new("lha", [:build, :test]))
+      expect(collector.add(resource)).to eq(Dependency.new("lha", [:build, :test, :implicit]))
     end
 
     it "creates a resource dependency from a '.rar' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.rar")
-      expect(collector.add(resource)).to eq(Dependency.new("libarchive", [:build, :test]))
+      expect(collector.add(resource)).to eq(Dependency.new("libarchive", [:build, :test, :implicit]))
     end
 
     it "raises a TypeError for unknown classes" do

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -100,15 +100,20 @@ describe Dependency do
     expect(foo1).not_to eql(foo3)
   end
 
-  describe TapDependency do
-    subject(:dependency) { described_class.new("foo/bar/dog") }
-
-    specify "#tap" do
+  describe "#tap" do
+    it "returns a tap passed a fully-qualified name" do
+      dependency = described_class.new("foo/bar/dog")
       expect(dependency.tap).to eq(Tap.new("foo", "bar"))
     end
 
-    specify "#option_names" do
-      expect(dependency.option_names).to eq(%w[dog])
+    it "returns no tap passed a simple name" do
+      dependency = described_class.new("dog")
+      expect(dependency.tap).to be_nil
     end
+  end
+
+  specify "#option_names" do
+    dependency = described_class.new("foo/bar/dog")
+    expect(dependency.option_names).to eq(%w[dog])
   end
 end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -340,6 +340,7 @@ describe Formulary do
         expect(formula).to be_a(Formula)
 
         expect(formula.keg_only_reason.reason).to eq :provided_by_macos
+        expect(formula.declared_deps.count).to eq 6
         if OS.mac?
           expect(formula.deps.count).to eq 5
         else
@@ -398,6 +399,7 @@ describe Formulary do
 
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
+        expect(formula.declared_deps.count).to eq 7
         expect(formula.deps.count).to eq 6
         expect(formula.deps.map(&:name).include?("variations_dep")).to be true
         expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be false
@@ -409,6 +411,7 @@ describe Formulary do
 
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
+        expect(formula.declared_deps.count).to eq 6
         expect(formula.deps.count).to eq 6
         expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be true
       end
@@ -419,6 +422,7 @@ describe Formulary do
 
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
+        expect(formula.declared_deps.count).to eq 6
         expect(formula.deps.count).to eq 5
         expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be true
       end

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -14,19 +14,19 @@ describe DependencyCollector do
       it "creates a resource dependency from a '.xz' URL" do
         resource.url("https://brew.sh/foo.xz")
         allow_any_instance_of(Object).to receive(:which).with("xz")
-        expect(collector.add(resource)).to eq(Dependency.new("xz", [:build, :test]))
+        expect(collector.add(resource)).to eq(Dependency.new("xz", [:build, :test, :implicit]))
       end
 
       it "creates a resource dependency from a '.zip' URL" do
         resource.url("https://brew.sh/foo.zip")
         allow_any_instance_of(Object).to receive(:which).with("unzip")
-        expect(collector.add(resource)).to eq(Dependency.new("unzip", [:build, :test]))
+        expect(collector.add(resource)).to eq(Dependency.new("unzip", [:build, :test, :implicit]))
       end
 
       it "creates a resource dependency from a '.bz2' URL" do
         resource.url("https://brew.sh/foo.tar.bz2")
         allow_any_instance_of(Object).to receive(:which).with("bzip2")
-        expect(collector.add(resource)).to eq(Dependency.new("bzip2", [:build, :test]))
+        expect(collector.add(resource)).to eq(Dependency.new("bzip2", [:build, :test, :implicit]))
       end
     end
 

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -34,6 +34,6 @@ describe DependencyCollector do
   specify "Resource dependency from a Subversion URL" do
     resource = Resource.new
     resource.url("svn://brew.sh/foo/bar")
-    expect(collector.add(resource)).to eq(Dependency.new("subversion", [:build, :test]))
+    expect(collector.add(resource)).to eq(Dependency.new("subversion", [:build, :test, :implicit]))
   end
 end

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -19,19 +19,27 @@ describe Formula do
 
       expect(f.class.stable.deps).to be_empty
       expect(f.class.head.deps).to be_empty
+      expect(f.class.stable.declared_deps).not_to be_empty
+      expect(f.class.head.declared_deps).not_to be_empty
+      expect(f.class.stable.declared_deps.first.name).to eq("foo")
+      expect(f.class.head.declared_deps.first.name).to eq("foo")
       expect(f.class.stable.uses_from_macos_elements.first).to eq("foo")
       expect(f.class.head.uses_from_macos_elements.first).to eq("foo")
     end
 
-    it "doesn't add a macOS dependency to any spec if the OS version doesn't meet requirements" do
+    it "adds a dependency to any spec if the OS version doesn't meet requirements" do
       f = formula "foo" do
         url "foo-1.0"
 
         uses_from_macos("foo", since: :high_sierra)
       end
 
+      expect(f.class.stable.deps).not_to be_empty
+      expect(f.class.head.deps).not_to be_empty
       expect(f.class.stable.deps.first.name).to eq("foo")
       expect(f.class.head.deps.first.name).to eq("foo")
+      expect(f.class.stable.declared_deps).not_to be_empty
+      expect(f.class.head.declared_deps).not_to be_empty
       expect(f.class.stable.uses_from_macos_elements).to eq(["foo"])
       expect(f.class.head.uses_from_macos_elements).to eq(["foo"])
     end


### PR DESCRIPTION
This PR tries to tackle several of the "harder" issues involving API dependencies. Basically the stuff that required deeper refactoring rather than a hack-on fix.

There were several cases where the dependency list was incorrect. Usually this erred on the side of too many dependencies rather than too little, so hasn't seen widespread bug reports beyond a few comments here and there.

Notably:

* The dependency list had parts that varied depending on the machine that generated the API JSON rather than the consumer.
* Stable-only or HEAD-only dependencies were not correctly considered.
* `uses_from_macos "example", since: ...` did not work correctly.

This changes in this PR are:
* Removed `TapDependency` (this makes the rest of the PR a bit simpler), folding it into `Dependency`
* Refactored `uses_from_macos` handling. Instead of being a conditional `depends_on`, it now consistently adds a `UsesFromMacOSDependency` on _all_ platforms with the checks now taking place in `installed?`. This provides a more consistent behaviour on all platforms, and has a bonus of reducing the bloat of the `variations` part of the JSON.
* Introduced an internal `auto` tag, which is now applied to all dependencies not explicitly added via a `depends_on`. This fixes an issue where some of the "if needed" deps leaked from the machine that generated the API JSON. For example, if a formula uses `xz` and the machine that generated the API JSON did not have `xz`, it will now no longer appear on the API dependency list and instead be determined by the API consumer.
* Changed the API hash and Formulary to support all these changes. Some fields in the hash were deprecated as a result as some changes were unavoidably backwards incompatible given the basic array of strings we had before simply does not have the flexibility to store the additional information added in this PR like a hash/dictionary does. (Requirements already used a hash so the existing field worked there.)

This is draft because rspec tests need adjusting and basic commands are probably very broken as is. But the general implementation as a whole should be done, with just bug/typo fixes needed.