### PR TITLE
rename Cask::outdated_versions

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -210,43 +210,42 @@ module Cask
     end
 
     def outdated?(greedy: false, greedy_latest: false, greedy_auto_updates: false)
-      !outdated_versions(greedy: greedy, greedy_latest: greedy_latest,
-                         greedy_auto_updates: greedy_auto_updates).empty?
+      !outdated_version(greedy: greedy, greedy_latest: greedy_latest,
+                        greedy_auto_updates: greedy_auto_updates).nil?
     end
 
-    # TODO: Rename to `outdated_version` and only return one version.
-    def outdated_versions(greedy: false, greedy_latest: false, greedy_auto_updates: false)
+    def outdated_version(greedy: false, greedy_latest: false, greedy_auto_updates: false)
       # special case: tap version is not available
-      return [] if version.nil?
+      return if version.nil?
 
       if version.latest?
-        return [installed_version] if (greedy || greedy_latest) && outdated_download_sha?
+        return installed_version if (greedy || greedy_latest) && outdated_download_sha?
 
-        return []
+        return
       elsif auto_updates && !greedy && !greedy_auto_updates
-        return []
+        return
       end
 
       # not outdated unless there is a different version on tap
-      return [] if installed_version == version
+      return if installed_version == version
 
-      [installed_version]
+      installed_version
     end
 
     def outdated_info(greedy, verbose, json, greedy_latest, greedy_auto_updates)
       return token if !verbose && !json
 
-      installed_versions = outdated_versions(greedy: greedy, greedy_latest: greedy_latest,
-                                             greedy_auto_updates: greedy_auto_updates).join(", ")
+      installed_version = outdated_version(greedy: greedy, greedy_latest: greedy_latest,
+                                           greedy_auto_updates: greedy_auto_updates).to_s
 
       if json
         {
           name:               token,
-          installed_versions: installed_versions,
+          installed_versions: [installed_version],
           current_version:    version,
         }
       else
-        "#{token} (#{installed_versions}) != #{version}"
+        "#{token} (#{installed_version}) != #{version}"
       end
     end
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -89,17 +89,17 @@ describe Cask::Cask, :cask do
     it "ignores the Casks that have auto_updates true (without --greedy)" do
       c = Cask::CaskLoader.load("auto-updates")
       expect(c).not_to be_outdated
-      expect(c.outdated_versions).to be_empty
+      expect(c.outdated_version).to be_nil
     end
 
     it "ignores the Casks that have version :latest (without --greedy)" do
       c = Cask::CaskLoader.load("version-latest-string")
       expect(c).not_to be_outdated
-      expect(c.outdated_versions).to be_empty
+      expect(c.outdated_version).to be_nil
     end
 
     describe "versioned casks" do
-      subject { cask.outdated_versions }
+      subject { cask.outdated_version }
 
       let(:cask) { described_class.new("basic-cask") }
 
@@ -109,7 +109,7 @@ describe Cask::Cask, :cask do
             it {
               allow(cask).to receive(:installed_version).and_return(installed_version)
               allow(cask).to receive(:version).and_return(Cask::DSL::Version.new(tap_version))
-              expect(cask).to receive(:outdated_versions).and_call_original
+              expect(cask).to receive(:outdated_version).and_call_original
               expect(subject).to eq expected_output
             }
           end
@@ -118,13 +118,13 @@ describe Cask::Cask, :cask do
 
       describe "installed version is equal to tap version => not outdated" do
         include_examples "versioned casks", "1.2.3",
-                         "1.2.3" => []
+                         "1.2.3" => nil
       end
 
       describe "installed version is different than tap version => outdated" do
         include_examples "versioned casks", "1.2.4",
-                         "1.2.3" => ["1.2.3"],
-                         "1.2.4" => []
+                         "1.2.3" => "1.2.3",
+                         "1.2.4" => nil
       end
     end
 
@@ -136,13 +136,13 @@ describe Cask::Cask, :cask do
           context "when versions #{installed_version} are installed and the " \
                   "tap version is #{tap_version}, #{"not " unless greedy}greedy " \
                   "and sha is #{"not " unless outdated_sha}outdated" do
-            subject { cask.outdated_versions(greedy: greedy) }
+            subject { cask.outdated_version(greedy: greedy) }
 
             it {
               allow(cask).to receive(:installed_version).and_return(installed_version)
               allow(cask).to receive(:version).and_return(Cask::DSL::Version.new(tap_version))
               allow(cask).to receive(:outdated_download_sha?).and_return(outdated_sha)
-              expect(cask).to receive(:outdated_versions).and_call_original
+              expect(cask).to receive(:outdated_version).and_call_original
               expect(subject).to eq expected_output
             }
           end
@@ -151,29 +151,29 @@ describe Cask::Cask, :cask do
 
       describe ":latest version installed, :latest version in tap" do
         include_examples ":latest cask", false, false, "latest",
-                         "latest" => []
+                         "latest" => nil
         include_examples ":latest cask", true, false, "latest",
-                         "latest" => []
+                         "latest" => nil
         include_examples ":latest cask", true, true, "latest",
-                         "latest" => ["latest"]
+                         "latest" => "latest"
       end
 
       describe "numbered version installed, :latest version in tap" do
         include_examples ":latest cask", false, false, "latest",
-                         "1.2.3" => []
+                         "1.2.3" => nil
         include_examples ":latest cask", true, false, "latest",
-                         "1.2.3" => []
+                         "1.2.3" => nil
         include_examples ":latest cask", true, true, "latest",
-                         "1.2.3" => ["1.2.3"]
+                         "1.2.3" => "1.2.3"
       end
 
       describe "latest version installed, numbered version in tap" do
         include_examples ":latest cask", false, false, "1.2.3",
-                         "latest" => ["latest"]
+                         "latest" => "latest"
         include_examples ":latest cask", true, false, "1.2.3",
-                         "latest" => ["latest"]
+                         "latest" => "latest"
         include_examples ":latest cask", true, true, "1.2.3",
-                         "latest" => ["latest"]
+                         "latest" => "latest"
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

rename `Cask::outdated_version` because of `# TODO` https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cask/cask.rb#L217
