### PR TITLE
mac/keg_relocate: use relative install names

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -103,7 +103,7 @@ class Keg
 
   def each_linkage_for(file, linkage_type, &block)
     links = file.method(linkage_type)
-                .call
+                .call(resolve_variable_references: false)
                 .grep_v(/^@(loader_|executable_|r)path/)
     links.each(&block)
   end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Adds to the logic for how `install_name`s and `rpath`s are fixed (after a build) and relocated (from bottles) on macOS, so that the installed binaries will load other Homebrew-installed dynamic libraries using relative paths instead of absolute paths. 

For example, a reference to a library with an `install_name` currently set in an executable as:

 `/opt/homebrew/Cellar/<same_formula>/<same_version>/lib/lib<some_lib>.dylib` 

will be changed to something like:

 `@loader_path/../lib/lib<some_lib>.dylib` 

instead, and references to libraries from dependencies are changed to:

`@loader_path/../../../../opt/<other_formula>/lib/lib<other_lib>.dylib`.

It should cover both bottled installs as well as builds from source. I've tried both—with default and custom Homebrew prefixes—and didn't run into any issues.

**Note**: there are also other ways to accomplish this same behavior (e.g., by adding a relative `rpath` entry to the binaries pointing to some known anchor point—such as the Homebrew prefix—, and then rewriting all install names to be prefixed with `@rpath`), but this ways keeps the code changes small. Also, Homebrew will already add a `@loader_path`-relative path to fix some unqualified library entries, while some formulae already set `rpath`s for their own purposes (which we shouldn't interfere with).

### Rationale

The point of this is proposed change is to have a Homebrew install be able to survive a filesystem move of the entire prefix, as long as the internal directory structure is preserved (not all formulae can gracefully handle being moved right now, but future PRs at Homebrew/core could help with that). It is a small step towards the Homebrew installation itself eventually being fully relocatable/"portable", which for instance would help with some currently non-standard uses of Homebrew, such as project-specific installs or as a bundler for application dependencies.

I understand that anything other than installing at the default prefix is outside the scope of official support, which is why I went for a PR instead of opening an issue; and why I've intentionally kept it as simple as I could. I hope this change can be considered for review.

EDIT: fix example path