### PR TITLE
formula_auditor: adjust deps audit for a staging branch

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -116,7 +116,8 @@ module Homebrew
     new_formula = args.new_formula?
     strict = new_formula || args.strict?
     online = new_formula || args.online?
-    skip_style = args.skip_style? || args.no_named? || args.tap
+    tap_audit = args.tap.present?
+    skip_style = args.skip_style? || args.no_named? || tap_audit
     no_named_args = T.let(false, T::Boolean)
 
     ENV.activate_extensions!
@@ -202,6 +203,7 @@ module Homebrew
         spdx_license_data:   spdx_license_data,
         spdx_exception_data: spdx_exception_data,
         style_offenses:      style_offenses&.for_path(f.path),
+        tap_audit:           tap_audit,
       }.compact
 
       errors = os_arch_combinations.flat_map do |os, arch|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

1. Adjust audit so that it ignores conflicts only for `brew audit --tap`.
   This is useful because it prevents us from trying to migrate a formula
   to `openssl@3` before all its dependencies have also been migrated.
2. Exempt only PRs that target a branch called
   `openssl-migration-staging`.
