### PR TITLE
cmd/leaves: add missing cask dependency

### DIFF
--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "formula"
+require "cask_dependent"
 require "cli/parser"
 
 module Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Resolves an issue with `brew leaves` introduced in PR https://github.com/Homebrew/brew/pull/15573:
```
❯ brew leaves
Error: uninitialized constant Homebrew::CaskDependent
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/opt/homebrew/Library/Homebrew/cmd/leaves.rb:40:in `block in leaves'
/opt/homebrew/Library/Homebrew/cmd/leaves.rb:39:in `each'
/opt/homebrew/Library/Homebrew/cmd/leaves.rb:39:in `flat_map'
/opt/homebrew/Library/Homebrew/cmd/leaves.rb:39:in `leaves'
/opt/homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```
