### PR TITLE
Significantly improve install speeds with smarter postinstall detection

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -24,8 +24,11 @@ module Homebrew
 
     args.named.to_resolved_formulae.each do |f|
       ohai "Postinstalling #{f}"
-      fi = FormulaInstaller.new(f, **{ debug: args.debug?, quiet: args.quiet?, verbose: args.verbose? }.compact)
-      fi.post_install
+      f.install_etc_var
+      if f.post_install_defined?
+        fi = FormulaInstaller.new(f, **{ debug: args.debug?, quiet: args.quiet?, verbose: args.verbose? }.compact)
+        fi.post_install
+      end
     end
   end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -796,7 +796,8 @@ on_request: installed_on_request?, options: options)
       puts "You can run it manually using:"
       puts "  brew postinstall #{formula.full_name}"
     else
-      post_install
+      formula.install_etc_var
+      post_install if formula.post_install_defined?
     end
 
     keg.prepare_debug_symbols if debug_symbols?

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -268,6 +268,12 @@ module Formulary
         raise "Cannot build from source from abstract formula."
       end
 
+      @post_install_defined_boolean = json_formula["post_install_defined"]
+      @post_install_defined_boolean = true if @post_install_defined_boolean.nil? # Backwards compatibility
+      def post_install_defined?
+        self.class.instance_variable_get(:@post_install_defined_boolean)
+      end
+
       if (service_hash = json_formula["service"].presence)
         service_hash = Homebrew::Service.deserialize(service_hash)
         service do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -13,6 +13,7 @@ describe Formula do
   alias_matcher :have_changed_alias, :be_alias_changed
 
   alias_matcher :have_option_defined, :be_option_defined
+  alias_matcher :have_post_install_defined, :be_post_install_defined
   alias_matcher :have_test_defined, :be_test_defined
   alias_matcher :pour_bottle, :be_pour_bottle
 
@@ -634,6 +635,23 @@ describe Formula do
     end
 
     expect(f.desc).to eq("a formula")
+  end
+
+  specify "#post_install_defined?" do
+    f1 = formula do
+      url "foo-1.0"
+
+      def post_install
+        # do nothing
+      end
+    end
+
+    f2 = formula do
+      url "foo-1.0"
+    end
+
+    expect(f1).to have_post_install_defined
+    expect(f2).not_to have_post_install_defined
   end
 
   specify "test fixtures" do


### PR DESCRIPTION
The process of forking to run postinstall is fairly slow. There's probably things we could do to improve that, but it's a little complex given it's a compound of causes.

However, forking isn't always strictly necessary. By moving responsibility of etc/var file installs away from the forked process, and making that forked process scoped to only running `Formula#post_install` and the paraphernalia around it, we can check ahead of time whether a process fork is even necessary. That is, whether a `post_install` is even defined in the formula in question.

The "pouring" stage of `brew install hello` took about 2 seconds for me before this change. After this change, it's effectively instant. (If testing locally prior to merging, you will need `HOMEBREW_NO_INSTALL_FROM_API=1` until the changes propagate to the remote JSON - for safety reasons I assume no information means that a postinstall is needed)

The 2 second speedup effect is espcially noticable when installing a large amount of dependencies.

Fetching is the same as before. Maybe will look at some point to see if there's anything that can be done there or if it's all network overhead.