### PR TITLE
brew.sh: fix auto-update interval for dev-cmd users

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -276,17 +276,17 @@ auto-update() {
 
     if [[ -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
     then
-      if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
+      if [[ -n "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
       then
-        # 24 hours
-        HOMEBREW_AUTO_UPDATE_SECS="86400"
+        # 5 minutes
+        HOMEBREW_AUTO_UPDATE_SECS="300"
       elif [[ -n "${HOMEBREW_DEV_CMD_RUN}" ]]
       then
         # 1 hour
         HOMEBREW_AUTO_UPDATE_SECS="3600"
       else
-        # 5 minutes
-        HOMEBREW_AUTO_UPDATE_SECS="300"
+        # 24 hours
+        HOMEBREW_AUTO_UPDATE_SECS="86400"
       fi
     fi
 


### PR DESCRIPTION
The intention here was:

* `HOMEBREW_NO_INSTALL_FROM_API` users have 5 minute intervals
* `dev-cmd` users have 1 hour intervals (as they are more "at risk" of brew regressions)
* Regular users have 24 hour intervals

However the order left the `dev-cmd` case not really working as intended:

* `dev-cmd` without `HOMEBREW_NO_INSTALL_FROM_API` would still have the 24 hour interval
* `dev-cmd` with `HOMEBREW_NO_INSTALL_FROM_API` would actually increase the interval from 5 minutes to 1 hour compared to regular users.

So this swaps the order to fix that.