### PR TITLE
cmd/update.sh: fix some flags throwing errors on update report

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -347,9 +347,15 @@ homebrew-update() {
       --verbose) HOMEBREW_VERBOSE=1 ;;
       --debug) HOMEBREW_DEBUG=1 ;;
       --quiet) HOMEBREW_QUIET=1 ;;
-      --merge) HOMEBREW_MERGE=1 ;;
+      --merge)
+        shift
+        HOMEBREW_MERGE=1
+        ;;
       --force) HOMEBREW_UPDATE_FORCE=1 ;;
-      --simulate-from-current-branch) HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH=1 ;;
+      --simulate-from-current-branch)
+        shift
+        HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH=1
+        ;;
       --auto-update) export HOMEBREW_UPDATE_AUTO=1 ;;
       --*) ;;
       -*)


### PR DESCRIPTION
Probably seldomly used but when doing the bump auto-update tweaks I noticed that passing `--merge` and `--simulate-from-current-branch` to `brew update` will error once reaching `brew update-report` becuse update-report doesn't support these flags.