### PR TITLE
Migrate remaining no-api commands to new scoped system

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -862,6 +862,7 @@ fi
 AUTO_UPDATE_CASK_TAP_COMMANDS=(
   bump
   bump-cask-pr
+  bump-unversioned-casks
 )
 if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_CASK_TAP_COMMANDS[@]}"
 then
@@ -896,37 +897,6 @@ if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/dev-cmd/${HOMEBREW_COMMAND}.sh" ]] ||
    [[ -f "${HOMEBREW_LIBRARY}/Homebrew/dev-cmd/${HOMEBREW_COMMAND}.rb" ]]
 then
   export HOMEBREW_DEVELOPER_COMMAND="1"
-
-  if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]]
-  then
-    NO_INSTALL_FROM_API_COMMANDS=(
-      bottle
-      bump-cask-pr
-      bump-formula-pr
-      bump-revision
-      bump-unversioned-casks
-      bump
-      cat
-      create
-      edit
-      extract
-      formula
-      generate-cask-api
-      generate-formula-api
-      livecheck
-      pr-pull
-      pr-upload
-      update-python-resources
-    )
-
-    if check-array-membership "${HOMEBREW_COMMAND}" "${NO_INSTALL_FROM_API_COMMANDS[@]}"
-    then
-      export HOMEBREW_NO_INSTALL_FROM_API=1
-      export HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API=1
-    fi
-
-    unset NO_INSTALL_FROM_API_COMMANDS
-  fi
 fi
 
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -98,7 +98,7 @@ module Homebrew
       conflicts "--formula", "--cask"
       conflicts "--installed", "--all"
 
-      named_args [:formula, :cask]
+      named_args [:formula, :cask], without_api: true
     end
   end
 
@@ -123,7 +123,7 @@ module Homebrew
     ENV.activate_extensions!
     ENV.setup_build_environment
 
-    audit_formulae, audit_casks = with_no_api_env do # audit requires full Ruby source
+    audit_formulae, audit_casks = Homebrew.with_no_api_env do # audit requires full Ruby source
       if args.tap
         Tap.fetch(args.tap).then do |tap|
           [
@@ -217,7 +217,7 @@ module Homebrew
           # Audit requires full Ruby source so disable API.
           # We shouldn't do this for taps however so that we don't unnecessarily require a full Homebrew/core clone.
           fa = if f.core_formula?
-            with_no_api_env(&audit_proc)
+            Homebrew.with_no_api_env(&audit_proc)
           else
             audit_proc.call
           end

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -86,7 +86,7 @@ module Homebrew
 
       conflicts "--no-rebuild", "--keep-old"
 
-      named_args [:installed_formula, :file], min: 1
+      named_args [:installed_formula, :file], min: 1, without_api: true
     end
   end
 
@@ -311,6 +311,7 @@ module Homebrew
 
       tap = CoreTap.instance
     end
+    raise TapUnavailableError, tap.name unless tap.installed?
 
     return ofail "Formula has no stable version: #{formula.full_name}" unless formula.stable
 

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -52,7 +52,7 @@ module Homebrew
       conflicts "--dry-run", "--write"
       conflicts "--no-audit", "--online"
 
-      named_args :cask, number: 1
+      named_args :cask, number: 1, without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -85,7 +85,7 @@ module Homebrew
       conflicts "--no-audit", "--online"
       conflicts "--url", "--tag"
 
-      named_args :formula, max: 1
+      named_args :formula, max: 1, without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -25,7 +25,7 @@ module Homebrew
 
       conflicts "--dry-run", "--write-only"
 
-      named_args :formula, min: 1
+      named_args :formula, min: 1, without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -25,7 +25,7 @@ module Homebrew
       flag   "--state-file=",
              description: "File for caching state."
 
-      named_args [:cask, :tap], min: 1
+      named_args [:cask, :tap], min: 1, without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -33,7 +33,7 @@ module Homebrew
       conflicts "--cask", "--formula"
       conflicts "--no-pull-requests", "--open-pr"
 
-      named_args [:formula, :cask]
+      named_args [:formula, :cask], without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -18,7 +18,7 @@ module Homebrew
 
       conflicts "--formula", "--cask"
 
-      named_args [:formula, :cask], min: 1
+      named_args [:formula, :cask], min: 1, without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -188,19 +188,24 @@ module Homebrew
         EOS
       end
 
-      if Formula.aliases.include? fc.name
-        realname = Formulary.canonical_name(fc.name)
-        odie <<~EOS
-          The formula '#{realname}' is already aliased to '#{fc.name}'.
-          Please check that you are not creating a duplicate.
-          To force creation use `--force`.
-        EOS
+      Homebrew.with_no_api_env do
+        if Formula.aliases.include? fc.name
+          realname = Formulary.canonical_name(fc.name)
+          odie <<~EOS
+            The formula '#{realname}' is already aliased to '#{fc.name}'.
+            Please check that you are not creating a duplicate.
+            To force creation use `--force`.
+          EOS
+        end
       end
     end
 
     fc.generate!
 
-    PyPI.update_python_resources! Formula[fc.name], ignore_non_pypi_packages: true if args.python?
+    formula = Homebrew.with_no_api_env do
+      Formula[fc.name]
+    end
+    PyPI.update_python_resources! formula, ignore_non_pypi_packages: true if args.python?
 
     puts "Please run `brew audit --new #{fc.name}` before submitting, thanks."
     fc.path

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -24,7 +24,7 @@ module Homebrew
 
       conflicts "--formula", "--cask"
 
-      named_args [:formula, :cask]
+      named_args [:formula, :cask], without_api: true
     end
   end
 
@@ -76,10 +76,9 @@ module Homebrew
       end.presence
     end
 
-    if Homebrew::EnvConfig.automatically_set_no_install_from_api? &&
-       !Homebrew::EnvConfig.no_env_hints?
+    if !Homebrew::EnvConfig.no_install_from_api? && !Homebrew::EnvConfig.no_env_hints?
       paths.each do |path|
-        next if !path.fnmatch?("**/homebrew-core/Formula/**/*.rb") && !path.fnmatch?("**/homebrew-cask/Casks/**/*.rb")
+        next if !path.fnmatch?("**/homebrew-core/Formula/*.rb") && !path.fnmatch?("**/homebrew-cask/Casks/*.rb")
 
         opoo <<~EOS
           Unless `HOMEBREW_NO_INSTALL_FROM_API` is set when running

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -88,7 +88,7 @@ module Homebrew
       switch "-f", "--force",
              description: "Overwrite the destination formula if it already exists."
 
-      named_args [:formula, :tap], number: 2
+      named_args [:formula, :tap], number: 2, without_api: true
     end
   end
 
@@ -98,11 +98,11 @@ module Homebrew
     if (match = args.named.first.match(HOMEBREW_TAP_FORMULA_REGEX))
       name = match[3].downcase
       source_tap = Tap.fetch(match[1], match[2])
-      raise TapFormulaUnavailableError.new(source_tap, name) unless source_tap.installed?
     else
       name = args.named.first.downcase
       source_tap = CoreTap.instance
     end
+    raise TapFormulaUnavailableError.new(source_tap, name) unless source_tap.installed?
 
     destination_tap = Tap.fetch(args.named.second)
     unless Homebrew::EnvConfig.developer?

--- a/Library/Homebrew/dev-cmd/formula.rb
+++ b/Library/Homebrew/dev-cmd/formula.rb
@@ -14,7 +14,7 @@ module Homebrew
         Display the path where <formula> is located.
       EOS
 
-      named_args :formula, min: 1
+      named_args :formula, min: 1, without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -44,6 +44,7 @@ module Homebrew
     args = generate_formula_api_args.parse
 
     tap = CoreTap.instance
+    raise TapUnavailableError, tap.name unless tap.installed?
 
     unless args.dry_run?
       directories = ["_data/formula", "api/formula", "formula"]
@@ -51,25 +52,27 @@ module Homebrew
       FileUtils.mkdir_p directories
     end
 
-    Formulary.enable_factory_cache!
-    Formula.generating_hash!
+    Homebrew.with_no_api_env do
+      Formulary.enable_factory_cache!
+      Formula.generating_hash!
 
-    tap.formula_names.each do |name|
-      formula = Formulary.factory(name)
-      name = formula.name
-      json = JSON.pretty_generate(formula.to_hash_with_variations)
+      tap.formula_names.each do |name|
+        formula = Formulary.factory(name)
+        name = formula.name
+        json = JSON.pretty_generate(formula.to_hash_with_variations)
 
-      unless args.dry_run?
-        File.write("_data/formula/#{name.tr("+", "_")}.json", "#{json}\n")
-        File.write("api/formula/#{name}.json", FORMULA_JSON_TEMPLATE)
-        File.write("formula/#{name}.html", html_template(name))
+        unless args.dry_run?
+          File.write("_data/formula/#{name.tr("+", "_")}.json", "#{json}\n")
+          File.write("api/formula/#{name}.json", FORMULA_JSON_TEMPLATE)
+          File.write("formula/#{name}.html", html_template(name))
+        end
+      rescue
+        onoe "Error while generating data for formula '#{name}'."
+        raise
       end
-    rescue
-      onoe "Error while generating data for formula '#{name}'."
-      raise
-    end
 
-    canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
-    File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
+      canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
+      File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
+    end
   end
 end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -414,6 +414,7 @@ module Homebrew
     workflows = args.workflows.presence || ["tests.yml"]
     artifact = args.artifact || "bottles"
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
+    raise TapUnavailableError, tap.name unless tap.installed?
 
     Utils::Git.set_name_email!(committer: args.committer.blank?)
     Utils::Git.setup_gpg!

--- a/Library/Homebrew/dev-cmd/style.rb
+++ b/Library/Homebrew/dev-cmd/style.rb
@@ -40,7 +40,7 @@ module Homebrew
       conflicts "--formula", "--cask"
       conflicts "--only-cops", "--except-cops"
 
-      named_args [:file, :tap, :formula, :cask]
+      named_args [:file, :tap, :formula, :cask], without_api: true
     end
   end
 

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -30,7 +30,7 @@ module Homebrew
       comma_array "--exclude-packages",
                   description: "Exclude these packages when finding resources."
 
-      named_args :formula, min: 1
+      named_args :formula, min: 1, without_api: true
     end
   end
 


### PR DESCRIPTION
I haven't tested absolutely everything here (e.g. `brew bottle`), but the ones I did seemed to work fine.