### PR TITLE
Fix error messages for brew edit and brew create

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -94,7 +94,7 @@ module Homebrew
     token = Cask::Utils.token_from(name)
 
     cask_tap = Tap.fetch(args.tap || "homebrew/cask")
-    raise TapUnavailableError, args.tap unless cask_tap.installed?
+    raise TapUnavailableError, cask_tap unless cask_tap.installed?
 
     cask_path = Cask::CaskLoader.path("#{cask_tap}/#{token}")
     cask_path.dirname.mkpath unless cask_path.dirname.exist?
@@ -151,7 +151,7 @@ module Homebrew
     fc.version = args.set_version
     fc.license = args.set_license
     fc.tap = Tap.fetch(args.tap || "homebrew/core")
-    raise TapUnavailableError, args.tap unless fc.tap.installed?
+    raise TapUnavailableError, fc.tap unless fc.tap.installed?
 
     fc.url = args.named.first
 

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -94,7 +94,7 @@ module Homebrew
     token = Cask::Utils.token_from(name)
 
     cask_tap = Tap.fetch(args.tap || "homebrew/cask")
-    raise TapUnavailableError, cask_tap unless cask_tap.installed?
+    raise TapUnavailableError, cask_tap.name unless cask_tap.installed?
 
     cask_path = Cask::CaskLoader.path("#{cask_tap}/#{token}")
     cask_path.dirname.mkpath unless cask_path.dirname.exist?
@@ -151,7 +151,7 @@ module Homebrew
     fc.version = args.set_version
     fc.license = args.set_license
     fc.tap = Tap.fetch(args.tap || "homebrew/core")
-    raise TapUnavailableError, fc.tap unless fc.tap.installed?
+    raise TapUnavailableError, fc.tap.name unless fc.tap.installed?
 
     fc.url = args.named.first
 

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -68,7 +68,7 @@ module Homebrew
         else
           <<~EOS
             #{not_exist_message}
-            Run #{Formatter.identifier("brew create --formula --set-name #{path.basename} $URL")} \
+            Run #{Formatter.identifier("brew create --set-name #{path.basename} $URL")} \
             to create a new formula!
           EOS
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fix `brew edit` error message if the formula doesn't exist (`brew create` doesn't have `--formula` argument)
- Fix `brew create` error message  if run without `--tap` argument and the default tap/cask is untapped
