### PR TITLE
Simplify CloudFlare header check.

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -242,17 +242,7 @@ module Utils
       return false if response[:headers].blank?
       return false unless [403, 503].include?(response[:status_code].to_i)
 
-      set_cookie_header = Array(response[:headers]["set-cookie"])
-      has_cloudflare_cookie_header = set_cookie_header.compact.any? do |cookie|
-        cookie.match?(/^(__cfduid|__cf_bm)=/i)
-      end
-
-      server_header = Array(response[:headers]["server"])
-      has_cloudflare_server = server_header.compact.any? do |server|
-        server.match?(/^cloudflare/i)
-      end
-
-      has_cloudflare_cookie_header && has_cloudflare_server
+      [*response[:headers]["server"]].any? { |server| server.match?(/^cloudflare/i) }
     end
 
     # Check if a URL is protected by Incapsula (e.g. corsair.com).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Not all websites protected by CloudFlare have a `set-cookie` header, but at the very least, every one has a `server: cloudflare` header.

Fixes CI failure in https://github.com/Homebrew/homebrew-cask/pull/149788.