### PR TITLE
extend/pathname: fix `text_executable?` regex

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -271,7 +271,7 @@ class Pathname
   # @private
   sig { returns(T::Boolean) }
   def text_executable?
-    /^#!\s*\S+/.match?(open("r") { |f| f.read(1024) })
+    /\A#!\s*\S+/.match?(open("r") { |f| f.read(1024) })
   end
 
   sig { returns(String) }


### PR DESCRIPTION
Otherwise we might match binary sequences that happen to be `0A 23 21 <regular non-space character>`.