### PR TITLE
Explain how to undo brew edit

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -144,6 +144,8 @@ Yes! It’s easy! Just `brew edit <formula>`. You don’t have to submit modific
 
 Note that if you are editing a core formula or cask you must set `HOMEBREW_NO_INSTALL_FROM_API=1` before using `brew install` or `brew update` otherwise they will ignore your local changes and default to the API.
 
+To undo your changes, run `brew update-reset`. It will revert to the upstream state on all Homebrew's repositories.
+
 ## Can I make new formulae?
 
 Yes! It’s easy! Just `brew create URL`. Homebrew will then open the formula in `EDITOR` so you can edit it, but it probably already installs; try it: `brew install <formula>`. If you encounter any issues, run the command with the `--debug` switch like so: `brew install --debug <formula>`, which drops you into a debugging shell.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -144,7 +144,7 @@ Yes! It’s easy! Just `brew edit <formula>`. You don’t have to submit modific
 
 Note that if you are editing a core formula or cask you must set `HOMEBREW_NO_INSTALL_FROM_API=1` before using `brew install` or `brew update` otherwise they will ignore your local changes and default to the API.
 
-To undo your changes, run `brew update-reset`. It will revert to the upstream state on all Homebrew's repositories.
+To undo all changes you have made to any of Homebrew's repositories, run `brew update-reset`. It will revert to the upstream state on all Homebrew's repositories.
 
 ## Can I make new formulae?
 


### PR DESCRIPTION
Add a line in the FAQ explaining how brew update-reset can be used to undo changes users might have made with brew edit.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I fell into [this trap](https://github.com/Homebrew/brew/issues/5108) a couple times in the past month (I just started using Hombrew). Each time i had to google the solution again, so I thought why not suggest to add this trick in the FAQ where I first learned about `brew edit`?

Not sure whether it is possible to use `brew update-reset` on a specific formula. (The man page states : "_Fetch and reset Homebrew and all tap repositories (or any specified repository) using git(1) to their latest origin/HEAD._" would I need to indicate a repository rather than the formula name?) So I kept the documentation clear about how this will revert to upstream for all repositories.

