### PR TITLE
dependency: use formula name.

### DIFF
--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -5,7 +5,8 @@ require "dependency"
 describe Dependency do
   def build_dep(name, tags = [], deps = [])
     dep = described_class.new(name.to_s, tags)
-    allow(dep).to receive(:to_formula).and_return(instance_double(Formula, deps: deps, name: name))
+    allow(dep).to receive(:to_formula).and_return \
+      instance_double(Formula, deps: deps, name: name, full_name: name)
     dep
   end
 
@@ -43,7 +44,8 @@ describe Dependency do
     end
 
     it "preserves dependency order" do
-      allow(foo).to receive(:to_formula).and_return(instance_double(Formula, name: "f", deps: [qux, baz]))
+      allow(foo).to receive(:to_formula).and_return \
+        instance_double(Formula, name: "foo", full_name: "foo", deps: [qux, baz])
       expect(described_class.expand(formula)).to eq([qux, baz, foo, bar])
     end
   end
@@ -74,7 +76,8 @@ describe Dependency do
   it "merges dependencies and preserves env_proc" do
     env_proc = double
     dep = described_class.new("foo", [], env_proc)
-    allow(dep).to receive(:to_formula).and_return(instance_double(Formula, deps: [], name: "foo"))
+    allow(dep).to receive(:to_formula).and_return \
+      instance_double(Formula, deps: [], name: "foo", full_name: "foo")
     deps.replace([dep])
     expect(described_class.expand(formula).first.env_proc).to eq(env_proc)
   end
@@ -124,8 +127,9 @@ describe Dependency do
   it "doesn't raise an error when a dependency is cyclic" do
     foo = build_dep(:foo)
     bar = build_dep(:bar, [], [foo])
-    allow(foo).to receive(:to_formula).and_return(instance_double(Formula, deps: [bar], name: foo.name))
-    f = instance_double(Formula, name: "f", deps: [foo, bar])
+    allow(foo).to receive(:to_formula).and_return \
+      instance_double(Formula, deps: [bar], name: foo.name, full_name: foo.name)
+    f = instance_double(Formula, name: "f", full_name: "f", deps: [foo, bar])
     expect { described_class.expand(f) }.not_to raise_error
   end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -829,7 +829,9 @@ describe Formula do
 
       allow(tap_loader).to receive(:get_formula).and_raise(RuntimeError, "tried resolving tap formula")
       allow(Formulary).to receive(:loader_for).with("foo/bar/f1", from: nil).and_return(tap_loader)
-      stub_formula_loader(formula("f2") { url("f2-1.0") }, "baz/qux/f2")
+
+      f2_path = Tap.new("baz", "qux").path/"Formula/f2.rb"
+      stub_formula_loader(formula("f2", path: f2_path) { url("f2-1.0") }, "baz/qux/f2")
 
       f3 = formula "f3" do
         url "f3-1.0"
@@ -840,7 +842,9 @@ describe Formula do
 
       expect(f3.runtime_dependencies.map(&:name)).to eq(["baz/qux/f2"])
 
-      stub_formula_loader(formula("f1") { url("f1-1.0") }, "foo/bar/f1")
+      f1_path = Tap.new("foo", "bar").path/"Formula/f1.rb"
+      stub_formula_loader(formula("f1", path: f1_path) { url("f1-1.0") }, "foo/bar/f1")
+
       f3.build = BuildOptions.new(Options.create(["--with-f1"]), f3.options)
 
       expect(f3.runtime_dependencies.map(&:name)).to eq(["foo/bar/f1", "baz/qux/f2"])


### PR DESCRIPTION
This allows renamed or aliased formulae dependencies to be resolved to specific formulae correctly and deduplicated.

Fixes https://github.com/Homebrew/brew/issues/15488