### PR TITLE
rubocops/lines: disallow `quictls` dependencies in homebrew/core

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -219,6 +219,27 @@ module RuboCop
         end
       end
 
+      # This cop makes sure that formulae depend on `openssl` instead of `quictls`.
+      #
+      # @api private
+      class QuicTLSCheck < FormulaCop
+        extend AutoCorrector
+
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          return if body_node.nil?
+
+          # Enforce use of OpenSSL for TLS dependency in core
+          return if formula_tap != "homebrew-core"
+
+          find_method_with_args(body_node, :depends_on, "quictls") do
+            problem "Formulae in homebrew/core should use 'depends_on \"openssl@3\"' " \
+                    "instead of '#{@offensive_node.source}'." do |corrector|
+              corrector.replace(@offensive_node.source_range, "depends_on \"openssl@3\"")
+            end
+          end
+        end
+      end
+
       # This cop makes sure that formulae do not depend on `pyoxidizer` at build-time
       # or run-time.
       #

--- a/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rubocops/lines"
+
+describe RuboCop::Cop::FormulaAudit::QuicTLSCheck do
+  subject(:cop) { described_class.new }
+
+  context "when auditing formula dependencies" do
+    it "reports an offense when a formula depends on `quictls`" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          depends_on "quictls"
+          ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/QuicTLSCheck: Formulae in homebrew/core should use 'depends_on "openssl@3"' instead of 'depends_on "quictls"'.
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

QuicTLS is a fork of OpenSSL that adds support for QUIC. We'll probably
end up adding it to homebrew/core at some point (see
Homebrew/homebrew-core#134975), but I don't think we want to actually
use it as a dependency of any formulae in place of OpenSSL.

We ought to only allow it for software that actually require QuicTLS in
place of OpenSSL, but I'm not aware of any existing formulae that have
this requirement.
