### PR TITLE
formula: enable unity builds in `std_meson_args`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1615,9 +1615,11 @@ class Formula
   end
 
   # Standard parameters for meson builds.
-  sig { returns(T::Array[String]) }
-  def std_meson_args
-    ["--prefix=#{prefix}", "--libdir=#{lib}", "--buildtype=release", "--wrap-mode=nofallback"]
+  sig { params(unity: T.nilable(String)).returns(T::Array[String]) }
+  def std_meson_args(unity: "on")
+    odebug "Unity build enabled. If your build fails, try using `std_meson_args(unity: \"off\")`." if unity != "off"
+
+    ["--prefix=#{prefix}", "--libdir=#{lib}", "--unity=#{unity}", "--buildtype=release", "--wrap-mode=nofallback"]
   end
 
   # Shared library names according to platform conventions.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Enabling unity builds[^1][^2] can help cut down build times and can
produce faster code.

The downsides of enabling this (e.g. slower incremental rebuilds, larger
memory requirements) aren't as significant for us, so let's enable it by
default.

This can break compilation of some software, so let's add an opt-out.

[^1]: https://en.wikipedia.org/wiki/Unity_build
[^2]: https://mesonbuild.com/Unity-builds.html
