### PR TITLE
PyPI: Handle non-pythonhosted formula URLs

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -8,49 +8,62 @@ module PyPI
   PYTHONHOSTED_URL_PREFIX = "https://files.pythonhosted.org/packages/"
   private_constant :PYTHONHOSTED_URL_PREFIX
 
-  # PyPI Package
-  #
+  # Represents a Python package.
+  # This package can be a PyPI package (either by name/version or PyPI distribution URL),
+  # or it can be a non-PyPI URL.
   # @api private
   class Package
-    attr_accessor :name, :extras, :version
-
     sig { params(package_string: String, is_url: T::Boolean).void }
     def initialize(package_string, is_url: false)
       @pypi_info = nil
-
-      if is_url
-        match = if package_string.start_with?(PYTHONHOSTED_URL_PREFIX)
-          File.basename(package_string).match(/^(.+)-([a-z\d.]+?)(?:.tar.gz|.zip)$/)
-        end
-        raise ArgumentError, "Package should be a valid PyPI URL" if match.blank?
-
-        @name = PyPI.normalize_python_package(match[1])
-        @version = match[2]
-        return
-      end
-
-      if package_string.include? "=="
-        @name, @version = package_string.split("==")
-      else
-        @name = package_string
-      end
-
-      return unless (match = T.must(@name).match(/^(.*?)\[(.+)\]$/))
-
-      @name = match[1]
-      @extras = T.must(match[2]).split ","
+      @package_string = package_string
+      @is_url = is_url
+      @is_pypi_url = package_string.start_with? PYTHONHOSTED_URL_PREFIX
     end
 
-    # Get name, URL, SHA-256 checksum, and latest version for a given PyPI package.
-    sig { params(version: T.nilable(T.any(String, Version))).returns(T.nilable(T::Array[String])) }
-    def pypi_info(version: nil)
-      return @pypi_info if @pypi_info.present? && version.blank?
+    sig { returns(String) }
+    def name
+      basic_metadata if @name.blank?
+      @name
+    end
 
-      version ||= @version
-      metadata_url = if version.present?
-        "https://pypi.org/pypi/#{@name}/#{version}/json"
+    sig { returns(T::Array[T.nilable(String)]) }
+    def extras
+      basic_metadata if @extras.blank?
+      @extras
+    end
+
+    sig { returns(T.nilable(String)) }
+    def version
+      basic_metadata if @version.blank?
+      @version
+    end
+
+    sig { params(new_version: String).void }
+    def version=(new_version)
+      raise ArgumentError, "can't update version for non-PyPI packages" unless valid_pypi_package?
+
+      @version = new_version
+    end
+
+    sig { returns(T::Boolean) }
+    def valid_pypi_package?
+      @is_pypi_url || !@is_url
+    end
+
+    # Get name, URL, SHA-256 checksum, and latest version for a given package.
+    # This only works for packages from PyPI or from a PyPI URL; packages
+    # derived from non-PyPI URLs will produce `nil` here.
+    sig { params(new_version: T.nilable(T.any(String, Version))).returns(T.nilable(T::Array[String])) }
+    def pypi_info(new_version: nil)
+      return unless valid_pypi_package?
+      return @pypi_info if @pypi_info.present? && new_version.blank?
+
+      new_version ||= version
+      metadata_url = if new_version.present?
+        "https://pypi.org/pypi/#{name}/#{new_version}/json"
       else
-        "https://pypi.org/pypi/#{@name}/json"
+        "https://pypi.org/pypi/#{name}/json"
       end
       out, _, status = curl_output metadata_url, "--location", "--fail"
 
@@ -71,23 +84,22 @@ module PyPI
       ]
     end
 
-    sig { returns(T::Boolean) }
-    def valid_pypi_package?
-      info = pypi_info
-      info.present? && info.is_a?(Array)
-    end
-
     sig { returns(String) }
     def to_s
-      out = @name
-      out += "[#{@extras.join(",")}]" if @extras.present?
-      out += "==#{@version}" if @version.present?
-      out
+      if valid_pypi_package?
+        out = name
+        out += "[#{extras.join(",")}]" if extras.present?
+        out += "==#{version}" if version.present?
+        out
+      else
+        @package_string
+      end
     end
 
     sig { params(other: Package).returns(T::Boolean) }
     def same_package?(other)
-      T.must(@name.tr("_", "-").casecmp(other.name.tr("_", "-"))).zero?
+      # These names are pre-normalized, so we can compare them directly.
+      name == other.name
     end
 
     # Compare only names so we can use .include? and .uniq on a Package array
@@ -99,12 +111,69 @@ module PyPI
 
     sig { returns(Integer) }
     def hash
-      @name.tr("_", "-").downcase.hash
+      name.hash
     end
 
     sig { params(other: Package).returns(T.nilable(Integer)) }
     def <=>(other)
-      @name <=> other.name
+      name <=> other.name
+    end
+
+    private
+
+    # Returns [name, [extras], version] for this package.
+    def basic_metadata
+      if @is_pypi_url
+        match = File.basename(@package_string).match(/^(.+)-([a-z\d.]+?)(?:.tar.gz|.zip)$/)
+        raise ArgumentError, "Package should be a valid PyPI URL" if match.blank?
+
+        @name = PyPI.normalize_python_package match[1]
+        @extras = []
+        @version = match[2]
+      elsif @is_url
+        ensure_formula_installed!("python")
+
+        # The URL might be a source distribution hosted somewhere;
+        # try and use `pip install -q --no-deps --dry-run --report ...` to get its
+        # name and version.
+        # Note that this is different from the (similar) `pip install --report` we
+        # do below, in that it uses `--no-deps` because we only care about resolving
+        # this specific URL's project metadata.
+        command =
+          [Formula["python"].bin/"python3", "-m", "pip", "install", "-q", "--no-deps",
+           "--dry-run", "--ignore-installed", "--report", "/dev/stdout", @package_string]
+        pip_output = Utils.popen_read({ "PIP_REQUIRE_VIRTUALENV" => "false" }, *command)
+        unless $CHILD_STATUS.success?
+          raise ArgumentError, <<~EOS
+            Unable to determine metadata for "#{@package_string}" because of a failure when running
+            `#{command.join(" ")}`.
+          EOS
+        end
+
+        metadata = JSON.parse(pip_output)["install"].first["metadata"]
+
+        @name = PyPI.normalize_python_package metadata["name"]
+        @extras = []
+        @version = metadata["version"]
+      else
+        if @package_string.include? "=="
+          name, version = @package_string.split("==")
+        else
+          name = @package_string
+          version = nil
+        end
+
+        if (match = T.must(name).match(/^(.*?)\[(.+)\]$/))
+          name = match[1]
+          extras = T.must(match[2]).split ","
+        else
+          extras = []
+        end
+
+        @name = PyPI.normalize_python_package name
+        @extras = extras
+        @version = version
+      end
     end
   end
 
@@ -114,7 +183,7 @@ module PyPI
 
     return unless package.valid_pypi_package?
 
-    _, url = package.pypi_info(version: version)
+    _, url = package.pypi_info(new_version: version)
     url
   rescue ArgumentError
     nil
@@ -159,29 +228,16 @@ module PyPI
     main_package = if package_name.present?
       Package.new(package_name)
     else
-      begin
-        Package.new(formula.stable.url, is_url: true)
-      rescue ArgumentError
-        nil
+      Package.new(formula.stable.url, is_url: true)
+    end
+
+    if version.present?
+      if main_package.valid_pypi_package?
+        main_package.version = version
+      else
+        odie "The main package is not a PyPI package. Please update its URL manually."
       end
     end
-
-    if main_package.blank?
-      return if ignore_non_pypi_packages
-
-      odie <<~EOS
-        Could not infer PyPI package name from URL:
-          #{Formatter.url(formula.stable.url)}
-      EOS
-    end
-
-    unless main_package.valid_pypi_package?
-      return if ignore_non_pypi_packages
-
-      odie "\"#{main_package}\" is not available on PyPI."
-    end
-
-    main_package.version = version if version.present?
 
     extra_packages = (extra_packages || []).map { |p| Package.new p }
     exclude_packages = (exclude_packages || []).map { |p| Package.new p }

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -237,7 +237,8 @@ module PyPI
       else
         return if ignore_non_pypi_packages
 
-        odie "The main package is not a PyPI package. Please update its URL manually."
+        odie "The main package is not a PyPI package, meaning that version-only updates cannot be \
+          performed. Please update its URL manually."
       end
     end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -236,6 +236,7 @@ module PyPI
         main_package.version = version
       else
         return if ignore_non_pypi_packages
+
         odie "The main package is not a PyPI package. Please update its URL manually."
       end
     end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -235,6 +235,7 @@ module PyPI
       if main_package.valid_pypi_package?
         main_package.version = version
       else
+        return if ignore_non_pypi_packages
         odie "The main package is not a PyPI package. Please update its URL manually."
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is take two on #15511.

From the original:

This is another quality of life improvement to our handling of Python packages, unlocked by the switch to `pip install --report --dry-run` from a few weeks ago: `pip install` can accept arbitrary distribution URLs, meaning that we no longer require the top-level to be a `pythonhosted` URL in order to auto-bump its dependencies using `update-python-resources`.

This should result in automation for a handful of formulae that previously required manual resource updating. More indirectly, it improves `brew-pip-audit`'s ability to bulk audit Python packages present in Homebrew formulae, resulting in more automated vulnerability fix PRs as well.