### PR TITLE
test/utils/github_spec: fix artifact URL test

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -57,16 +57,18 @@ describe GitHub do
     it "fails to find artifacts that don't exist" do
       expect do
         described_class.get_artifact_url(
-          described_class.get_workflow_run("Homebrew", "homebrew-core", "79751", artifact_name: "false_bottles"),
+          described_class.get_workflow_run("Homebrew", "homebrew-core", "135608",
+                                           workflow_id: "triage.yml", artifact_name: "false_artifact"),
         )
       end.to raise_error(/No artifact .+ was found/)
     end
 
     it "gets an artifact link" do
       url = described_class.get_artifact_url(
-        described_class.get_workflow_run("Homebrew", "homebrew-core", "79751", artifact_name: "bottles"),
+        described_class.get_workflow_run("Homebrew", "homebrew-core", "135608",
+                                         workflow_id: "triage.yml", artifact_name: "event_payload"),
       )
-      expect(url).to eq("https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/70494047/zip")
+      expect(url).to eq("https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/781984175/zip")
     end
   end
 


### PR DESCRIPTION
GitHub completely wipes the existance of old CI runs after a couple years.

This'll probably break again in a couple years. Maybe should mock the response or something