### PR TITLE
cmd/update: don't fetch core taps on manual brew update

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -580,7 +580,8 @@ EOS
 
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
-    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" && -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
+    if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]] &&
+       [[ -z "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
        [[ ("${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" && -z "${HOMEBREW_UPDATE_CORE_TAP}") ||
           ("${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" && -z "${HOMEBREW_UPDATE_CASK_TAP}") ]]
     then


### PR DESCRIPTION
unless `HOMEBREW_DEVELOPER` is set as per before.

Currently, if you do a manual `brew update` without `HOMEBREW_DEVELOPER` set, it will fetch the repo but not actually fully update it. Which is perhaps a little unusual. It also surprised people getting errors that don't actually impact anything in practice.

This PR aligns the fetch check with [the actual branch update check further down](https://github.com/Homebrew/brew/blob/f252323725b600f50817d1d3e0ad8a24979548d9/Library/Homebrew/cmd/update.sh#L740).

One slight caveat is people who do need a tap later on will have to go through a longer fetch to catch up.