### PR TITLE
tap: disable fsmonitor for third-party taps

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -309,6 +309,8 @@ class Tap
 
     # Override user-set default template
     args << "--template="
+    # prevent fsmonitor from watching this repo
+    args << "--config" << "core.fsmonitor=false"
 
     begin
       safe_system "git", *args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I was getting the following error until I disabled fsmonitor for taps as well:

```
% brew upgrade
Error: Another active Homebrew update process is already in progress.
Please wait for it to finish or terminate it to continue.
==> Downloading https://formulae.brew.sh/api/formula.jws.json
############################################################################################################################################################### 100.0%
==> Downloading https://formulae.brew.sh/api/cask.jws.json
############################################################################################################################################################### 100.0%
```

Git's fsmonitor is already disabled 
- for `HOMEBREW_PREFIX` in https://github.com/Homebrew/brew/pull/13586
- for git downloads in https://github.com/Homebrew/brew/pull/15293