### PR TITLE
dev-cmd/audit: don't audit every tap when given named packages

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -174,8 +174,10 @@ module Homebrew
     end
 
     # Run tap audits first
+    named_arg_taps = [*audit_formulae, *audit_casks].map(&:tap).uniq if !args.tap && !no_named_args
     tap_problems = Tap.each_with_object({}) do |tap, problems|
       next if args.tap && tap != args.tap
+      next if named_arg_taps&.exclude?(tap)
 
       ta = TapAuditor.new(tap, strict: args.strict?)
       ta.audit

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -227,9 +227,9 @@ module Homebrew
       if args.no_audit?
         ohai "Skipping `brew audit`"
       elsif args.online?
-        ohai "brew audit --cask --online #{cask.sourcefile_path.basename}"
+        ohai "brew audit --cask --online #{cask.full_name}"
       else
-        ohai "brew audit --cask #{cask.sourcefile_path.basename}"
+        ohai "brew audit --cask #{cask.full_name}"
       end
       return
     end


### PR DESCRIPTION
If we run `brew audit --cask something` we probably only want to audit homebrew/cask and not every tap.

Related to https://github.com/orgs/Homebrew/discussions/4620.