### PR TITLE
Download `tap_migrations.json` files from the API

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -43,8 +43,7 @@ module Homebrew
 
         sig { returns(T::Boolean) }
         def download_and_cache_data!
-          json_casks, updated = Homebrew::API.fetch_json_api_file "cask.jws.json",
-                                                                  target: HOMEBREW_CACHE_API/"cask.jws.json"
+          json_casks, updated = Homebrew::API.fetch_json_api_file "cask.jws.json"
 
           cache["renames"] = {}
           cache["casks"] = json_casks.to_h do |json_cask|

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -40,8 +40,7 @@ module Homebrew
 
         sig { returns(T::Boolean) }
         def download_and_cache_data!
-          json_formulae, updated = Homebrew::API.fetch_json_api_file "formula.jws.json",
-                                                                     target: HOMEBREW_CACHE_API/"formula.jws.json"
+          json_formulae, updated = Homebrew::API.fetch_json_api_file "formula.jws.json"
 
           cache["aliases"] = {}
           cache["renames"] = {}


### PR DESCRIPTION
Download the previously stored tap migrations files for homebrew/core and homebrew/cask from the formulae.brew.sh API.

This adds a much longer stale time (24 hours) to decide whether or not the migrations files need downloaded from the API in Ruby land. `brew update` will still update them every time.

While we're here, DRY up some code in `update.sh` too.

Requires https://github.com/Homebrew/brew/pull/15628
Fixes https://github.com/Homebrew/brew/issues/14897