### PR TITLE
Remove `Tap#versioned_formula_files`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -465,21 +465,19 @@ class Formula
   # Returns any `@`-versioned formulae names for any formula (including versioned formulae).
   sig { returns(T::Array[String]) }
   def versioned_formulae_names
-    versioned_paths = if tap
-      # Faster path, due to `tap.versioned_formula_files` caching.
+    versioned_names = if tap
       name_prefix = "#{name.gsub(/(@[\d.]+)?$/, "")}@"
-      tap.versioned_formula_files.select do |file|
-        file.basename.to_s.start_with?(name_prefix)
+      tap.formula_names.select do |name|
+        name.start_with?(name_prefix)
       end
-    else
+    elsif path.exist?
       Pathname.glob(path.to_s.gsub(/(@[\d.]+)?\.rb$/, "@*.rb"))
+              .map { |path| path.basename(".rb").to_s }
+    end.sort
+
+    versioned_names.reject do |versioned_name|
+      versioned_name == name
     end
-
-    versioned_paths.map do |versioned_path|
-      next if versioned_path == path
-
-      versioned_path.basename(".rb").to_s
-    end.compact.sort
   end
 
   # Returns any `@`-versioned Formula objects for any Formula (including versioned formulae).

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -530,14 +530,6 @@ class Tap
     end
   end
 
-  # An array of all versioned {Formula} files of this {Tap}.
-  sig { returns(T::Array[Pathname]) }
-  def versioned_formula_files
-    @versioned_formula_files ||= formula_files.select do |file|
-      file.basename(".rb").to_s =~ /@[\d.]+$/
-    end
-  end
-
   # An array of all {Cask} files of this {Tap}.
   sig { returns(T::Array[Pathname]) }
   def cask_files

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -156,7 +156,7 @@ describe Formula do
 
       allow(Formulary).to receive(:load_formula_from_path).with(f2.name, f2.path).and_return(f2)
       allow(Formulary).to receive(:factory).with(f2.name).and_return(f2)
-      allow(f.tap).to receive(:versioned_formula_files).and_return([f2.path])
+      allow(f).to receive(:versioned_formulae_names).and_return([f2.name])
     end
 
     it "returns array with versioned formulae" do


### PR DESCRIPTION
This doesn't work with the API and the single caller can be refactored to not need it instead.

Issue spotted in https://github.com/MikeMcQuaid/strap/actions/runs/5465161353/jobs/9948204604?pr=803