### PR TITLE
Dockerfile: Add `build-essential`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
   uuid-runtime \
   tzdata \
   jq \
+  build-essential \
   && if [ "$(. /etc/lsb-release; echo "${DISTRIB_RELEASE}" | cut -d. -f1)" -ge 22 ]; then apt-get install -y --no-install-recommends skopeo; fi \
   && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
   && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
The Dockerfile explicitly installs `curl`, `file`, and `git` (and `procps` exists in `homebrew/brew`). However, the `build-essential` meta-package is not fully installed. Adding it seems to make `homebrew/brew` more consistent with [Homebrew on Linux](https://docs.brew.sh/Homebrew-on-Linux) i.e. more closely resemble users' environments.

Is this intentional to keep the image a little slimmer/faster?

```console
$ podman run -it homebrew/brew
linuxbrew@2884ab0f332b:~$ sudo apt-get update && sudo apt-get upgrade -y
linuxbrew@2884ab0f332b:~$ sudo apt-get install build-essential
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils gpg-wks-client
  gpg-wks-server gpgsm libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libdpkg-perl libfakeroot libfile-fcntllock-perl
  libksba8 liblocale-gettext-perl lto-disabled-list xz-utils
Suggested packages:
  dbus-user-session libpam-systemd pinentry-gnome3 tor debian-keyring
  parcimonie xloadimage bzr
The following NEW packages will be installed:
  build-essential dirmngr dpkg-dev fakeroot gnupg gnupg-l10n gnupg-utils
  gpg-wks-client gpg-wks-server gpgsm libalgorithm-diff-perl
  libalgorithm-diff-xs-perl libalgorithm-merge-perl libdpkg-perl libfakeroot
  libfile-fcntllock-perl libksba8 liblocale-gettext-perl lto-disabled-list
  xz-utils
0 upgraded, 20 newly installed, 0 to remove and 0 not upgraded.
Need to get 2876 kB of archives.
After this operation, 9752 kB of additional disk space will be used.
Do you want to continue? [Y/n] 
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Note: The output of `brew tests` had the failure below about an unexpected caveat. It also happens if I just `brew upgrade && brew tests` so not sure if I should check the last box.
```console
$ podman run -it homebrew/brew
linuxbrew@70933dedbb4d:~$ sudo apt-get update && sudo apt-get install build-essential procps curl file git -y && brew upgrade && brew tests
...
Failures:

  1) Caveats#caveats when f.keg_only is not nil when joining different caveat types together adds the correct amount of new lines to the output
     Failure/Error: expect(caveats).to include("if you don't want/need a background service")
     
       expected "something else\n\nformula_name is keg-only, which means it was not symlinked into /tmp/homebrew-tests-20230706-2088-1ij5ikv/prefix,\nbecause some reason.\n\nWarning: formula_name provides a service which can only be used on macOS or systemd!\nYou can manually execute the service instead with:\n  /tmp/homebrew-tests-20230706-2088-1ij5ikv/cellar/formula_name/1.0/bin/cmd\n" to include "if you don't want/need a background service"
       Diff:
       @@ -1,8 +1,15 @@
       -if you don't want/need a background service
       +something else
       +
       +formula_name is keg-only, which means it was not symlinked into /tmp/homebrew-tests-20230706-2088-1ij5ikv/prefix,
       +because some reason.
       +
       +Warning: formula_name provides a service which can only be used on macOS or systemd!
       +You can manually execute the service instead with:
       +  /tmp/homebrew-tests-20230706-2088-1ij5ikv/cellar/formula_name/1.0/bin/cmd
       
     # ./test/caveats_spec.rb:289:in `block (5 levels) in <top (required)>'
..................................................................................
..................................................................................................................................................................................................................................................................................................................................................................................................................................
..................................................................................................................................................................................................................................................................



Took 90 seconds (1:30)
Tests Failed
```
Running `brew update` before `brew tests` does not change the output (as expected since `brew upgrade` did the update already). This is the environment of `homebrew/brew` after running only the above commands:
```console
linuxbrew@70933dedbb4d:~$ brew config
HOMEBREW_VERSION: 4.0.27-8-g66fc022
ORIGIN: https://github.com/Homebrew/brew
HEAD: 66fc02210607d7676a8feb7dce3349686604434f
Last commit: 10 hours ago
Core tap origin: https://github.com/Homebrew/homebrew-core
Core tap HEAD: df637581c357678739c0a13c189ee29d1987af8c
Core tap last commit: 12 minutes ago
Core tap branch: master
Core tap JSON: 06 Jul 03:22 UTC
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_MAKE_JOBS: 4
Homebrew Ruby: 2.6.10 => /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.10_1/bin/ruby
CPU: quad-core 64-bit skylake
Clang: N/A
Git: 2.41.0 => /bin/git
Curl: 7.81.0 => /bin/curl
Kernel: Linux 6.3.8-200.fc38.x86_64 x86_64 GNU/Linux
OS: Unknown
Host glibc: 2.35
/usr/bin/gcc: 11.3.0
/usr/bin/ruby: N/A
glibc: N/A
gcc@11: N/A
gcc: N/A
xorg: N/A
linuxbrew@70933dedbb4d:~$ brew doctor
Your system is ready to brew.
```

I don't think this error is related to the PR but I thought I'd note since it's in the checklist. I've noticed it before but it doesn't seem to affect actual functionality.