### PR TITLE
App Management message reflects new System Settings labels

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -248,7 +248,7 @@ module Cask
       opoo <<~EOF
         Your terminal does not have App Management permissions, so Homebrew will delete and reinstall the app.
         This may result in some configurations (like notification settings or location in the Dock/Launchpad) being lost.
-        To fix this, go to Settings > Privacy & Security > App Management and turn on the switch for your terminal.
+        To fix this, go to System Settings > Privacy & Security > App Management and add or enable your terminal.
       EOF
 
       false

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -248,7 +248,7 @@ module Cask
       opoo <<~EOF
         Your terminal does not have App Management permissions, so Homebrew will delete and reinstall the app.
         This may result in some configurations (like notification settings or location in the Dock/Launchpad) being lost.
-        To fix this, go to Settings > Security and Privacy > App Management and turn on the switch for your terminal.
+        To fix this, go to Settings > Privacy & Security > App Management and turn on the switch for your terminal.
       EOF
 
       false


### PR DESCRIPTION
With the update of MacOS from Monterey (12) to Ventura (13) the appearance of the System Settings has changes and the "Security & Privacy" category has been renamed to "Privacy & Security".

I am aware that currently Ventura has a very low adoption rate so this change could be premature.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
