### PR TITLE
cmd/update-report: tweak messages for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,5 @@ RUN mkdir -p \
   && brew cleanup \
   && { git -C .linuxbrew/Homebrew config --unset gc.auto; true; } \
   && { git -C .linuxbrew/Homebrew config --unset homebrew.devcmdrun; true; } \
-  && rm -rf .cache
+  && rm -rf .cache \
+  && touch .linuxbrew/.homebrewdocker

--- a/bin/brew
+++ b/bin/brew
@@ -139,6 +139,11 @@ then
   export CI="1"
 fi
 
+if [[ -n "${GITHUB_ACTIONS:-}" && -n "${ImageOS:-}" && -n "${ImageVersion:-}" ]]
+then
+  export HOMEBREW_GITHUB_HOSTED_RUNNER=1
+fi
+
 # filter the user environment
 PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 


### PR DESCRIPTION
* Don't really need the `brew untap` message for CI as it's either already there in the base image or we are already warning them when they are doing a `brew tap`.
* `HOMEBREW_NO_AUTO_UPDATE` is reasonable on CI when you consider people will only be seeing this message when doing a `brew update` and in CI given you likely want a consistent state for the rest of the CI run.

Should we touch the analytics message for GitHub Actions?
