### PR TITLE
`zap`: run with uninstall

### DIFF
--- a/Library/Homebrew/cask/artifact/zap.rb
+++ b/Library/Homebrew/cask/artifact/zap.rb
@@ -9,8 +9,20 @@ module Cask
     #
     # @api private
     class Zap < AbstractUninstall
+      def uninstall_phase(**options)
+        ORDERED_DIRECTIVES.reject { |directive_sym| directive_sym == :rmdir }
+                          .each do |directive_sym|
+          dispatch_uninstall_directive(directive_sym, **options)
+        end
+      end
+
+      def post_uninstall_phase(**options)
+        dispatch_uninstall_directive(:rmdir, **options)
+      end
+
       def zap_phase(**options)
-        dispatch_uninstall_directives(**options)
+        uninstall_phase(**options)
+        post_uninstall_phase(**options)
       end
     end
   end

--- a/Library/Homebrew/cask/uninstall.rb
+++ b/Library/Homebrew/cask/uninstall.rb
@@ -4,7 +4,7 @@
 module Cask
   # @api private
   class Uninstall
-    def self.uninstall_casks(*casks, binaries: nil, force: false, verbose: false)
+    def self.uninstall_casks(*casks, binaries: nil, force: false, verbose: false, zap: false)
       require "cask/installer"
 
       casks.each do |cask|
@@ -12,7 +12,7 @@ module Cask
 
         raise CaskNotInstalledError, cask if !cask.installed? && !force
 
-        Installer.new(cask, binaries: binaries, force: force, verbose: verbose).uninstall
+        Installer.new(cask, binaries: binaries, force: force, verbose: verbose, zap: zap).uninstall
       end
     end
   end

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -65,21 +65,12 @@ module Homebrew
       named_args:          args.named,
     )
 
-    if args.zap?
-      casks.each do |cask|
-        odebug "Zapping Cask #{cask}"
-
-        raise Cask::CaskNotInstalledError, cask if !cask.installed? && !args.force?
-
-        Cask::Installer.new(cask, verbose: args.verbose?, force: args.force?).zap
-      end
-    else
-      Cask::Uninstall.uninstall_casks(
-        *casks,
-        verbose: args.verbose?,
-        force:   args.force?,
-      )
-    end
+    Cask::Uninstall.uninstall_casks(
+      *casks,
+      verbose: args.verbose?,
+      force:   args.force?,
+      zap:     args.zap?,
+    )
 
     Cleanup.autoremove if Homebrew::EnvConfig.autoremove?
   end

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -257,7 +257,7 @@ describe Cask::Installer, :cask do
 
       expect(caffeine).to be_installed
 
-      described_class.new(caffeine).zap
+      described_class.new(caffeine, zap: true).uninstall
 
       expect(caffeine).not_to be_installed
       expect(caffeine.config.appdir.join("Caffeine.app")).not_to be_a_symlink


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

WIP! This PR adjusts uninstall behavior. Now, uninstall is aware of zap artifacts when it determines the artifacts that should be removed. If zap is present, uninstall and zap artifacts are merged and removed together. This will allow the behavior in #15070.

Note: I've tried to make this change as transparent as possible, which is why `Artifact::Zap` has the redundant `zap_phase`

Closes #15070.