### PR TITLE
cmd/--cache: undeprecate `--bottle-tag`

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -27,8 +27,7 @@ module Homebrew
       switch "--force-bottle",
              description: "Show the cache file used when pouring a bottle."
       flag "--bottle-tag=",
-           description: "Show the cache file used when pouring a bottle for the given tag.",
-           hidden:      true
+           description: "Show the cache file used when pouring a bottle for the given tag."
       switch "--HEAD",
              description: "Show the cache file used when building from HEAD."
       switch "--formula", "--formulae",
@@ -97,7 +96,6 @@ module Homebrew
       arch:                       args.arch&.to_sym,
     )
       bottle_tag = if (bottle_tag = args.bottle_tag&.to_sym)
-        odeprecated "brew --cache --bottle-tag", "brew --cache --os --arch"
         Utils::Bottles::Tag.from_symbol(bottle_tag)
       else
         Utils::Bottles::Tag.new(system: os, arch: arch)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is useful for quickly examining bottles with something like

    brew fetch --bottle-tag=$tag $formula && \
      tar xf "$(brew --cache --bottle-tag=$tag $formula)"

See discussion at #15632.
