### PR TITLE
formula_auditor: check disabled formulae have disabled dependents

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -322,6 +322,13 @@ module Homebrew
             EOS
           end
 
+          if dep_f.disabled? && !formula.disabled?
+            problem <<~EOS
+              Dependency '#{dep.name}' is disabled but has un-disabled dependents. Either
+              un-disable '#{dep.name}' or disable it and all of its dependents.
+            EOS
+          end
+
           # we want to allow uses_from_macos for aliases but not bare dependencies
           if self.class.aliases.include?(dep.name) && !dep.uses_from_macos?
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."


### PR DESCRIPTION
Like what we already have for deprecations.