### PR TITLE
Enable `GitHub.issues_for_formula` to show only issues, only PRs, or both

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -489,7 +489,7 @@ class BuildError < RuntimeError
 
   sig { returns(T::Array[T.untyped]) }
   def fetch_issues
-    GitHub.issues_for_formula(formula.name, tap: formula.tap, state: "open")
+    GitHub.issues_for_formula(formula.name, tap: formula.tap, state: "open", type: "issue")
   rescue GitHub::API::RateLimitExceededError => e
     opoo e.message
     []

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -56,10 +56,10 @@ module GitHub
     API.open_rest(url_to("repos", user, repo))
   end
 
-  def self.issues_for_formula(name, tap: CoreTap.instance, tap_remote_repo: tap&.full_name, state: nil)
+  def self.issues_for_formula(name, tap: CoreTap.instance, tap_remote_repo: tap&.full_name, state: nil, type: nil)
     return [] unless tap_remote_repo
 
-    search_issues(name, repo: tap_remote_repo, state: state, in: "title")
+    search_issues(name, repo: tap_remote_repo, state: state, type: type, in: "title")
   end
 
   def self.user


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This change is useful for the "these issues are also open for this build failure" exception. Hopefully there'll be less noise on PRs with people encouraging us to fix things faster if we don't link them to WIP PRs (or any PRs at all).
- Fixes https://github.com/Homebrew/brew/issues/15608.