### PR TITLE
Feature: support symlinked /home

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -44,6 +44,26 @@ else
   HOMEBREW_DEFAULT_TEMP="/tmp"
 fi
 
+realpath() {
+  (cd "$1" &>/dev/null && pwd -P)
+}
+
+# Support systems where HOMEBREW_PREFIX is the default,
+# but a parent directory is a symlink.
+# Example: Fedora Silverblue symlinks /home -> var/home
+if [[ "${HOMEBREW_PREFIX}" != "${HOMEBREW_DEFAULT_PREFIX}" && "$(realpath "${HOMEBREW_DEFAULT_PREFIX}")" == "${HOMEBREW_PREFIX}" ]]
+then
+  HOMEBREW_PREFIX="${HOMEBREW_DEFAULT_PREFIX}"
+fi
+
+# Support systems where HOMEBREW_REPOSITORY is the default,
+# but a parent directory is a symlink.
+# Example: Fedora Silverblue symlinks /home -> var/home
+if [[ "${HOMEBREW_REPOSITORY}" != "${HOMEBREW_DEFAULT_REPOSITORY}" && "$(realpath "${HOMEBREW_DEFAULT_REPOSITORY}")" == "${HOMEBREW_REPOSITORY}" ]]
+then
+  HOMEBREW_REPOSITORY="${HOMEBREW_DEFAULT_REPOSITORY}"
+fi
+
 # Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
 # for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.
 # These variables are set by bin/brew

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -13,17 +13,6 @@ case "${HOMEBREW_SYSTEM}" in
   Linux) HOMEBREW_LINUX="1" ;;
 esac
 
-# Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
-# for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.
-# These variables are set by bin/brew
-# shellcheck disable=SC2154
-if [[ -d "${HOMEBREW_REPOSITORY}/Cellar" ]]
-then
-  HOMEBREW_CELLAR="${HOMEBREW_REPOSITORY}/Cellar"
-else
-  HOMEBREW_CELLAR="${HOMEBREW_PREFIX}/Cellar"
-fi
-
 HOMEBREW_MACOS_ARM_DEFAULT_PREFIX="/opt/homebrew"
 HOMEBREW_MACOS_ARM_DEFAULT_REPOSITORY="${HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}"
 HOMEBREW_LINUX_DEFAULT_PREFIX="/home/linuxbrew/.linuxbrew"
@@ -53,6 +42,17 @@ else
   HOMEBREW_DEFAULT_CACHE="${CACHE_HOME}/Homebrew"
   HOMEBREW_DEFAULT_LOGS="${CACHE_HOME}/Homebrew/Logs"
   HOMEBREW_DEFAULT_TEMP="/tmp"
+fi
+
+# Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
+# for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.
+# These variables are set by bin/brew
+# shellcheck disable=SC2154
+if [[ -d "${HOMEBREW_REPOSITORY}/Cellar" ]]
+then
+  HOMEBREW_CELLAR="${HOMEBREW_REPOSITORY}/Cellar"
+else
+  HOMEBREW_CELLAR="${HOMEBREW_PREFIX}/Cellar"
 fi
 
 HOMEBREW_CACHE="${HOMEBREW_CACHE:-${HOMEBREW_DEFAULT_CACHE}}"

--- a/bin/brew
+++ b/bin/brew
@@ -40,7 +40,7 @@ do
 done
 unset cmd
 
-BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
+BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
 

--- a/bin/brew
+++ b/bin/brew
@@ -40,7 +40,7 @@ do
 done
 unset cmd
 
-BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd)"
+BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
 


### PR DESCRIPTION
Fixes #14557

This commit serves as a proof-of-concept that using Homebrew bottles is possible on Fedora Silverblue and other setups where `/home` is symlinked as`/home -> var/home`. The `install.sh` script does install in `/home/linuxbrew/.linuxbrew` it just so happens that its physical location is `/var/home/linuxbrew/.linuxbrew` due to the symlink. So, all programs are actually in the correct prefix. However due to the way `bin/brew` resolves symlinks, Homebrew commands think the prefix is custom. Me and @rohanssrao have tested that this fix also works in `fedora-toolbox` and `ubuntu` containers where we symlinked `/home` ->`var/home`. The script can be found at [`silverbrew-fedora-toolbox.sh`](https://github.com/osalbahr/brew/blob/silverbrew-develop/silverbrew-fedora-toolbox.sh) and you can directly run it in a new container after `podman run -it fedora-toolbox|ubuntu`. I am opening this PR to see if removing one `-P` causes unexpected regression. It seems to work fine on macOS too after this edit. To the best of my understanding, the goal is just to find the Homebrew directory from the `brew` symlink and it seems to achieve that goal without the removed `-P`. This change was originally proposed in Homebrew/discussions#1282 but was not tested to the best of my knowledge.

Before:
```console
[nebula@fedora Homebrew]$ brew install xz
==> Fetching xz
Warning: Building xz from source as the bottle needs:
- HOMEBREW_CELLAR: /home/linuxbrew/.linuxbrew/Cellar (yours is /var/home/linuxbrew/.linuxbrew/Cellar)
- HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew (yours is /var/home/linuxbrew/.linuxbrew)
==> Downloading https://downloads.sourceforge.net/project/lzmautils/xz-5.4.3.tar.gz
==> Downloading from https://netactuate.dl.sourceforge.net/project/lzmautils/xz-5.4.3.tar.gz
####################################################################################################################################################################################################################################### 100.0%
Error: The following formula cannot be installed from bottle and must be
built from source.
  xz
Install Clang or run `brew install gcc`.
```

After:
```console
[nebula@fedora Homebrew]$ git diff
diff --git a/bin/brew b/bin/brew
index afc02e9eb..373294806 100755
--- a/bin/brew
+++ b/bin/brew
@@ -40,7 +40,7 @@ do
 done
 unset cmd

-BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
+BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"

[nebula@fedora Homebrew]$ brew install xz
==> Fetching xz
==> Downloading https://ghcr.io/v2/homebrew/core/xz/manifests/5.4.3
Already downloaded: /var/home/nebula/.cache/Homebrew/downloads/8d9f9cb1c34807246a161f74e3de29be172826599700e583c128fa2340fe177f--xz-5.4.3.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/xz/blobs/sha256:91c390f663972a9249fbbd98546bc2687afab99e5c740065d33cb474ed612bf5
Already downloaded: /var/home/nebula/.cache/Homebrew/downloads/06ce31cc5406b5ea435a2580360a65549816c1b5412f25fdb5dde5b136c90da9--xz--5.4.3.x86_64_linux.bottle.tar.gz
==> Pouring xz--5.4.3.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/xz/5.4.3: 312 files, 3.7MB
==> Running `brew cleanup xz`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```
Usage:
```console
[nebula@fedora test-xz]$ ls
[nebula@fedora test-xz]$ echo "Hello, Silverblue" > old.txt
[nebula@fedora test-xz]$ ls
old.txt
[nebula@fedora test-xz]$ xz old.txt
[nebula@fedora test-xz]$ ls
old.txt.xz
[nebula@fedora test-xz]$ file old.txt.xz
old.txt.xz: XZ compressed data, checksum CRC64
[nebula@fedora test-xz]$ xz -d old.txt.xz
[nebula@fedora test-xz]$ ls
old.txt
[nebula@fedora test-xz]$ cat old.txt
Hello, Silverblue
[nebula@fedora test-xz]$ xz --version
xz (XZ Utils) 5.4.3
liblzma 5.4.3
[nebula@fedora test-xz]$ which xz
/home/linuxbrew/.linuxbrew/bin/xz
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Note: `brew style|typecheck|tests` fail with the following error message:
```console
An error occurred while installing json (2.6.3), and Bundler cannot
continue.

In Gemfile:
  rubocop-rspec was resolved to 2.20.0, which depends on
    rubocop-capybara was resolved to 2.18.0, which depends on
      rubocop was resolved to 1.50.2, which depends on
        json
Error: failed to run `/var/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/bundle install`!
[nebula@fedora ~]$ /var/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/bundle install
/usr/bin/env: ‘ruby’: No such file or directory
[nebula@fedora ~]$ ruby
bash: ruby: command not found
```
But I think this might be unrelated to this commit. Fedora Silverblue 38 (latest) does not have `ruby` installed in the host.

-----
System info:
```console
[nebula@fedora Homebrew]$ brew config
HOMEBREW_VERSION: 4.0.28-17-gc4c79c2
ORIGIN: https://github.com/Homebrew/brew
HEAD: c4c79c25a3dafc9f22f8c05439d7b5ed4f286c6a
Last commit: 7 minutes ago
Core tap origin: https://github.com/Homebrew/homebrew-core
Core tap HEAD: b4f8dec4ac8cde0a20c6db1ca6c6d16df8e4c867
Core tap last commit: 7 hours ago
Core tap branch: master
Core tap JSON: 09 Jul 01:38 UTC
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_REPOSITORY: /var/home/linuxbrew/.linuxbrew/Homebrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_DISPLAY: :0
HOMEBREW_EDITOR: /usr/bin/nano
HOMEBREW_MAKE_JOBS: 8
Homebrew Ruby: 2.6.10 => /var/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.10_1/bin/ruby
CPU: octa-core 64-bit skylake
Clang: N/A
Git: 2.40.0 => /bin/git
Curl: 7.87.0 => /bin/curl
Kernel: Linux 6.2.9-300.fc38.x86_64 x86_64 GNU/Linux
OS: Fedora release 38 (Thirty Eight)
Host glibc: 2.37
/usr/bin/gcc: N/A
/usr/bin/ruby: N/A
glibc: N/A
gcc@11: N/A
gcc: 13.1.0
xorg: N/A
[nebula@fedora Homebrew]$ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: No developer tools installed.
Install Clang or run `brew install gcc`.
```
----
Motivation/alternatives:
Since Fedora Silverblue follows the immutable paradigm (similarly to macOS), using Homebrew on Silverblue has the same added benefits as using Homebrew on macOS. The alternatives to this PR require using Homebrew in a container or a wrapper and I would like to reduce dependency on containers, or disabling selinux to create a permanent mount which is quite invasive.