### PR TITLE
livecheck: fix implicit no-api handling

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -113,10 +113,12 @@ module Homebrew
       return [nil, references] if livecheck_formula.blank? && livecheck_cask.blank?
 
       # Load the referenced formula or cask
-      referenced_formula_or_cask = if livecheck_formula
-        Formulary.factory(livecheck_formula)
-      elsif livecheck_cask
-        Cask::CaskLoader.load(livecheck_cask)
+      referenced_formula_or_cask = Homebrew.with_no_api_env do
+        if livecheck_formula
+          Formulary.factory(livecheck_formula)
+        elsif livecheck_cask
+          Cask::CaskLoader.load(livecheck_cask)
+        end
       end
 
       # Error if a `livecheck` block references a formula/cask that was already

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -104,7 +104,7 @@ module Homebrew
 
           unversioned_cask_checker = if url.present? && url != cask.url.to_s
             # Create a copy of the `cask` that uses the `livecheck` block URL
-            cask_copy = Cask::CaskLoader.load(cask.full_name)
+            cask_copy = Cask::CaskLoader.load(cask.sourcefile_path)
             cask_copy.allow_reassignment = true
             cask_copy.url { url }
             UnversionedCaskChecker.new(cask_copy)


### PR DESCRIPTION
Fixes referenced formulae and casks being loaded from the API, which does not contain livecheck information.

https://github.com/Homebrew/homebrew-cask/pull/150664