### PR TITLE
Support `brew cleanup --quiet`

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -53,7 +53,7 @@ module Homebrew
       return
     end
 
-    cleanup.clean!
+    cleanup.clean!(quiet: args.quiet?, periodic: false)
 
     unless cleanup.disk_cleanup_size.zero?
       disk_space = disk_usage_readable(cleanup.disk_cleanup_size)


### PR DESCRIPTION
I was looking for a way to suppress output in `brew cleanup` especially the `Warning: Skipping XXX: most recent version X.Y.Z not installed`. I noticed that `Homebrew::Cleanup#clean` takes a `quiet` argument, but `brew cleanup` doesn't pass one in. This PR updates `brew cleanup` to accept and forward along a `quiet` argument.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? - some asked for a password so I aborted

-----
