### PR TITLE
formula_auditor: disallow non-test `rustup-init` dependencies

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -309,6 +309,10 @@ module Homebrew
 
           next unless @core_tap
 
+          if @strict && dep.name == "rustup-init" && !dep.test?
+            problem "Formulae should use `rust` instead of `rustup-init` to build"
+          end
+
           unless dep_f.tap.core_tap?
             problem <<~EOS
               Dependency '#{dep.name}' is not in homebrew/core. Formulae in homebrew/core

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -309,10 +309,6 @@ module Homebrew
 
           next unless @core_tap
 
-          if @strict && dep.name == "rustup-init" && !dep.test?
-            problem "Formulae should use `rust` instead of `rustup-init` to build"
-          end
-
           unless dep_f.tap.core_tap?
             problem <<~EOS
               Dependency '#{dep.name}' is not in homebrew/core. Formulae in homebrew/core

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -884,6 +884,50 @@ module RuboCop
           problem "Formulae should not depend on :tuntap" if depends_on? :tuntap
         end
       end
+
+      # This cop makes sure that formulae build with `rust` instead of `rustup-init`.
+      #
+      # @api private
+      class RustCheck < FormulaCop
+        extend AutoCorrector
+
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          return if body_node.nil?
+
+          # Enforce use of `rust` for rust dependency in core
+          return if formula_tap != "homebrew-core"
+
+          find_method_with_args(body_node, :depends_on, "rustup-init") do
+            problem "Formulae in homebrew/core should use 'depends_on \"rust\"' " \
+                    "instead of '#{@offensive_node.source}'." do |corrector|
+              corrector.replace(@offensive_node.source_range, "depends_on \"rust\"")
+            end
+          end
+
+          # TODO: Enforce order of dependency types so we don't need to check for
+          #       depends_on "rustup-init" => [:test, :build]
+          [:build, [:build, :test], [:test, :build]].each do |type|
+            find_method_with_args(body_node, :depends_on, "rustup-init" => type) do
+              problem "Formulae in homebrew/core should use 'depends_on \"rust\" => #{type}' " \
+                      "instead of '#{@offensive_node.source}'." do |corrector|
+                corrector.replace(@offensive_node.source_range, "depends_on \"rust\" => #{type}")
+              end
+            end
+          end
+
+          install_node = find_method_def(body_node, :install)
+          return if install_node.blank?
+
+          find_every_method_call_by_name(install_node, :system).each do |method|
+            param = parameters(method).first
+            next if param.blank?
+            # FIXME: Handle Pathname parameters (e.g. `system bin/"rustup-init"`).
+            next if regex_match_group(param, /rustup-init$/).blank?
+
+            problem "Formula in homebrew/core should not use `rustup-init` at build-time."
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We want formulae to build with our `rust` formula instead of a random
toolchain downloaded with `rustup`.

Unfortunately, some formulae already do this, so let's gate the check
behind `--strict`. It should also prevent new formulae that build using
`rustup` from being added.

This should hopefully prevent PRs like Homebrew/homebrew-core#119832
from being merged.
