### PR TITLE
shims/mac: handle usage of Homebrew `make`

### DIFF
--- a/Library/Homebrew/shims/mac/super/bsdmake
+++ b/Library/Homebrew/shims/mac/super/bsdmake
@@ -1,4 +1,1 @@
-#!/bin/bash
-
-export HOMEBREW_CCCFG="O${HOMEBREW_CCCFG}"
-exec xcrun bsdmake "$@"
+make

--- a/Library/Homebrew/shims/mac/super/make
+++ b/Library/Homebrew/shims/mac/super/make
@@ -1,4 +1,12 @@
 #!/bin/bash
 
 export HOMEBREW_CCCFG="O${HOMEBREW_CCCFG}"
-exec xcrun "make" "$@"
+
+SHIM_FILE="${0##*/}"
+
+if xcrun --find "${SHIM_FILE}" &>/dev/null
+then
+  exec xcrun "${SHIM_FILE}" "$@"
+else
+  exec xcrun make "$@"
+fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We have a handful of formulae that use Homebrew `make` to build. Doing
this evades our compiler shims. Let's try to avoid this by allowing our
shims to support usage of Homebrew `make` by calling it as `gmake` in
the formula.
