### PR TITLE
shims/mac/super/make: use standard exec routines

### DIFF
--- a/Library/Homebrew/shims/mac/super/make
+++ b/Library/Homebrew/shims/mac/super/make
@@ -1,12 +1,10 @@
 #!/bin/bash
 
+# HOMEBREW_LIBRARY is set by bin/brew
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
+
 export HOMEBREW_CCCFG="O${HOMEBREW_CCCFG}"
 
-SHIM_FILE="${0##*/}"
-
-if xcrun --find "${SHIM_FILE}" &>/dev/null
-then
-  exec xcrun "${SHIM_FILE}" "$@"
-else
-  exec xcrun make "$@"
-fi
+try_exec_non_system "${SHIM_FILE}" "$@"
+safe_exec "/usr/bin/make" "$@"


### PR DESCRIPTION
`xcrun --find` will always succeed here so instead do what we do for most other shims.