### PR TITLE
Introduce CoreCaskTap class and fix cases of core taps were being unnecessarily installed

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -438,7 +438,7 @@ module Cask
     end
 
     def self.default_path(token)
-      Tap.default_cask_tap.cask_dir/"#{token.to_s.downcase}.rb"
+      CoreCaskTap.instance.cask_dir/"#{token.to_s.downcase}.rb"
     end
 
     def self.tap_paths(token, warn: true)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -197,7 +197,11 @@ module Homebrew
       formulae, casks = args.named.to_formulae_and_casks
                             .partition { |formula_or_cask| formula_or_cask.is_a?(Formula) }
     rescue FormulaOrCaskUnavailableError, Cask::CaskUnavailableError
-      retry if Tap.install_default_cask_tap_if_necessary(force: args.cask?)
+      cask_tap = CoreCaskTap.instance
+      if !cask_tap.installed? && (args.cask? || Tap.untapped_official_taps.exclude?(cask_tap.name))
+        cask_tap.ensure_installed!
+        retry if cask_tap.installed?
+      end
 
       raise
     end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -179,9 +179,7 @@ module Homebrew
       next unless name =~ HOMEBREW_TAP_FORMULA_REGEX
 
       tap = Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))
-      next if (tap.core_tap? || tap == "homebrew/cask") && !EnvConfig.no_install_from_api?
-
-      tap.install unless tap.installed?
+      tap.ensure_installed!
     end
 
     if args.ignore_dependencies?

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -149,7 +149,7 @@ module Homebrew
     updated_taps = []
     Tap.each do |tap|
       next if !tap.git? || tap.git_repo.origin_url.nil?
-      next if (tap.core_tap? || tap == "homebrew/cask") && !Homebrew::EnvConfig.no_install_from_api?
+      next if (tap.core_tap? || tap.core_cask_tap?) && !Homebrew::EnvConfig.no_install_from_api?
 
       if ENV["HOMEBREW_MIGRATE_LINUXBREW_FORMULAE"].present? && tap.core_tap? &&
          Settings.read("linuxbrewmigrated") != "true"
@@ -193,7 +193,7 @@ module Homebrew
     unless Homebrew::EnvConfig.no_install_from_api?
       api_cache = Homebrew::API::HOMEBREW_CACHE_API
       core_tap = CoreTap.instance
-      cask_tap = Tap.fetch("homebrew/cask")
+      cask_tap = CoreCaskTap.instance
       [
         [:formula, core_tap, core_tap.formula_dir],
         [:cask,    cask_tap, cask_tap.cask_dir],
@@ -402,7 +402,7 @@ module Homebrew
     return if (HOMEBREW_PREFIX/".homebrewdocker").exist?
 
     core_tap = CoreTap.instance
-    cask_tap = Tap.default_cask_tap
+    cask_tap = CoreCaskTap.instance
     return if !core_tap.installed? && !cask_tap.installed?
 
     puts "Installing from the API is now the default behaviour!"
@@ -504,7 +504,7 @@ class Reporter
       new_name = tap.cask_renames[old_name]
       next unless new_name
 
-      new_full_name = if tap.name == "homebrew/cask"
+      new_full_name = if tap.core_cask_tap?
         new_name
       else
         "#{tap}/#{new_name}"
@@ -518,7 +518,7 @@ class Reporter
       old_name = tap.cask_renames.key(new_name)
       next unless old_name
 
-      old_full_name = if tap.name == "homebrew/cask"
+      old_full_name = if tap.core_cask_tap?
         old_name
       else
         "#{tap}/#{old_name}"

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -600,7 +600,7 @@ class Reporter
         next unless (HOMEBREW_PREFIX/"Caskroom"/new_name).exist?
 
         new_tap = Tap.fetch(new_tap_name)
-        new_tap.install unless new_tap.installed?
+        new_tap.ensure_installed!
         ohai "#{name} has been moved to Homebrew.", <<~EOS
           To uninstall the cask, run:
             brew uninstall --cask --force #{name}
@@ -650,7 +650,7 @@ class Reporter
           EOS
         end
       else
-        new_tap.install unless new_tap.installed?
+        new_tap.ensure_installed!
         # update tap for each Tab
         tabs.each { |tab| tab.tap = new_tap }
         tabs.each(&:write)

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -107,6 +107,7 @@ module Homebrew
     destination_tap = Tap.fetch(args.named.second)
     unless Homebrew::EnvConfig.developer?
       odie "Cannot extract formula to homebrew/core!" if destination_tap.core_tap?
+      odie "Cannot extract formula to homebrew/cask!" if destination_tap.core_cask_tap?
       odie "Cannot extract formula to the same tap!" if destination_tap == source_tap
     end
     destination_tap.install unless destination_tap.installed?

--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -42,7 +42,7 @@ module Homebrew
   def generate_cask_api
     args = generate_cask_api_args.parse
 
-    tap = Tap.default_cask_tap
+    tap = CoreCaskTap.instance
     raise TapUnavailableError, tap.name unless tap.installed?
 
     unless args.dry_run?

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -531,7 +531,7 @@ module Homebrew
       end
 
       def check_casktap_integrity
-        default_cask_tap = Tap.default_cask_tap
+        default_cask_tap = CoreCaskTap.instance
         return unless default_cask_tap.installed?
 
         broken_tap(default_cask_tap) || examine_git_origin(default_cask_tap.git_repo, default_cask_tap.remote)
@@ -861,7 +861,7 @@ module Homebrew
         return if Homebrew::EnvConfig.no_install_from_api?
         return if Homebrew::Settings.read("devcmdrun") == "true"
 
-        cask_tap = Tap.fetch("homebrew", "cask")
+        cask_tap = CoreCaskTap.instance
         return unless cask_tap.installed?
 
         <<~EOS
@@ -921,7 +921,7 @@ module Homebrew
       end
 
       def check_cask_taps
-        default_cask_tap = Tap.default_cask_tap
+        default_cask_tap = CoreCaskTap.instance
         alt_taps = Tap.select { |t| t.cask_dir.exist? && t != default_cask_tap }
 
         error_tap_paths = []

--- a/Library/Homebrew/extend/os/mac/tap.rb
+++ b/Library/Homebrew/extend/os/mac/tap.rb
@@ -3,12 +3,15 @@
 
 class Tap
   def self.install_default_cask_tap_if_necessary(force: false)
-    return false if default_cask_tap.installed?
+    odeprecated "Tap.install_default_cask_tap_if_necessary", "CoreCaskTap.ensure_installed!"
+
+    cask_tap = CoreCaskTap.instance
+    return false if cask_tap.installed?
     return false unless Homebrew::EnvConfig.no_install_from_api?
     return false if Homebrew::EnvConfig.automatically_set_no_install_from_api?
-    return false if !force && Tap.untapped_official_taps.include?(default_cask_tap.name)
+    return false if !force && Tap.untapped_official_taps.include?(cask_tap.name)
 
-    default_cask_tap.install
+    cask_tap.install
     true
   end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -229,8 +229,8 @@ class FormulaInstaller
     rescue TapFormulaUnavailableError => e
       raise if e.tap.installed?
 
-      e.tap.install
-      retry
+      e.tap.ensure_installed!
+      retry if e.tap.installed? # It may have not installed if it's a core tap.
     end
   rescue FormulaUnavailableError => e
     e.dependent = formula.full_name

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -626,7 +626,7 @@ module Formulary
           new_tap_user, new_tap_repo, = new_tap_name.split("/")
           new_tap_name = "#{new_tap_user}/#{new_tap_repo}"
           new_tap = Tap.fetch new_tap_name
-          new_tap.install unless new_tap.installed?
+          new_tap.ensure_installed!
           new_tapped_name = "#{new_tap_name}/#{name}"
           name, path = formula_name_path(new_tapped_name, warn: false)
           old_name = tapped_name

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -3,10 +3,11 @@
 describe Cask::CaskLoader::FromTapLoader do
   let(:cask_name) { "testball" }
   let(:cask_full_name) { "homebrew/cask/#{cask_name}" }
-  let(:cask_path) { Tap.default_cask_tap.cask_dir/"#{cask_name}.rb" }
+  let(:cask_path) { CoreCaskTap.instance.cask_dir/"#{cask_name}.rb" }
 
   describe "#load" do
     before do
+      CoreCaskTap.instance.clear_cache
       cask_path.parent.mkpath
       cask_path.write <<~RUBY
         cask '#{cask_name}' do
@@ -24,7 +25,7 @@ describe Cask::CaskLoader::FromTapLoader do
     end
 
     context "with sharded Cask directory" do
-      let(:cask_path) { Tap.default_cask_tap.cask_dir/cask_name[0]/"#{cask_name}.rb" }
+      let(:cask_path) { CoreCaskTap.instance.cask_dir/cask_name[0]/"#{cask_name}.rb" }
 
       it "returns a Cask" do
         expect(described_class.new(cask_full_name).load(config: nil)).to be_a(Cask::Cask)

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -24,7 +24,7 @@ describe Cask::Cask, :cask do
   end
 
   describe "load" do
-    let(:tap_path) { Tap.default_cask_tap.path }
+    let(:tap_path) { CoreCaskTap.instance.path }
     let(:file_dirname) { Pathname.new(__FILE__).dirname }
     let(:relative_tap_path) { tap_path.relative_path_from(file_dirname) }
 

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -119,7 +119,7 @@ describe Homebrew::Diagnostic::Checks do
     ENV.delete("HOMEBREW_DEVELOPER")
     ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
 
-    allow(CoreTap).to receive(:installed?).and_return(true)
+    expect_any_instance_of(CoreTap).to receive(:installed?).and_return(true)
 
     expect(checks.check_for_unnecessary_core_tap).to match("You have an unnecessary local Core tap")
   end
@@ -128,9 +128,7 @@ describe Homebrew::Diagnostic::Checks do
     ENV.delete("HOMEBREW_DEVELOPER")
     ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
 
-    cask_tap = Tap.new("homebrew", "cask")
-    allow(Tap).to receive(:fetch).with("homebrew", "cask").and_return(cask_tap)
-    allow(cask_tap).to receive(:installed?).and_return(true)
+    expect_any_instance_of(CoreCaskTap).to receive(:installed?).and_return(true)
 
     expect(checks.check_for_unnecessary_cask_tap).to match("unnecessary local Cask tap")
   end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -38,7 +38,7 @@ RSpec.shared_context "Homebrew Cask", :needs_macos do # rubocop:disable RSpec/Co
     begin
       Cask::Config::DEFAULT_DIRS_PATHNAMES.each_value(&:mkpath)
 
-      Tap.default_cask_tap.tap do |tap|
+      CoreCaskTap.instance.tap do |tap|
         FileUtils.mkdir_p tap.path.dirname
         FileUtils.ln_sf TEST_FIXTURE_DIR.join("cask"), tap.path
       end
@@ -52,7 +52,7 @@ RSpec.shared_context "Homebrew Cask", :needs_macos do # rubocop:disable RSpec/Co
     ensure
       FileUtils.rm_rf Cask::Config::DEFAULT_DIRS_PATHNAMES.values
       FileUtils.rm_rf [Cask::Config.new.binarydir, Cask::Caskroom.path, Cask::Cache.path]
-      Tap.default_cask_tap.path.unlink
+      CoreCaskTap.instance.path.unlink
       third_party_tap.path.unlink
       FileUtils.rm_rf third_party_tap.path.parent
     end


### PR DESCRIPTION
* Introduce `CoreCaskTap` (closes #15597)
* Fix various tap methods (e.g. `cask_tokens`) not working on untapped Homebrew/cask under API.
* Deprecate `Tap.default_cask_tap` and `Tap.install_default_cask_tap_if_necessary` in favour of `CoreCaskTap`.
* Add `ensure_installed!` as a tap instance method for all taps. Previously exclusively a `CoreTap` class method, this method will now do the right thing given any arbitrary tap object (i.e. not install anything for core taps under API mode, but do install for other taps).
* Use new `ensure_installed!` instance method to fix various cases where core taps were being unnecessarily installed, in particular around tap migrations (probably fixes #15674)