### PR TITLE
generate-*-api: fix on-disk tap migrations not being used

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -49,11 +49,11 @@ module Homebrew
       directories = ["_data/cask", "api/cask", "api/cask-source", "cask"].freeze
       FileUtils.rm_rf directories
       FileUtils.mkdir_p directories
-
-      File.write("api/cask_tap_migrations.json", JSON.dump(tap.tap_migrations))
     end
 
     Homebrew.with_no_api_env do
+      File.write("api/cask_tap_migrations.json", JSON.dump(tap.tap_migrations)) unless args.dry_run?
+
       Cask::Cask.generating_hash!
 
       tap.cask_files.each do |path|

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -50,11 +50,11 @@ module Homebrew
       directories = ["_data/formula", "api/formula", "formula"]
       FileUtils.rm_rf directories + ["_data/formula_canonical.json"]
       FileUtils.mkdir_p directories
-
-      File.write("api/formula_tap_migrations.json", JSON.dump(tap.tap_migrations))
     end
 
     Homebrew.with_no_api_env do
+      File.write("api/formula_tap_migrations.json", JSON.dump(tap.tap_migrations)) unless args.dry_run?
+
       Formulary.enable_factory_cache!
       Formula.generating_hash!
 


### PR DESCRIPTION
This needs to be in the no-API block, otherwise we're just taking in API data to generate API data.