### PR TITLE
Do not insist on using macOS texinfo

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -52,7 +52,6 @@ module RuboCop
           ssh-copy-id
           swift
           tcl-tk
-          texinfo
           unifdef
           unzip
           whois


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

macOS `texinfo` is left at an old version, and is not present on newer version (Ventura and later). We have migrated all of homebrew-core versions to using Homebrew's texinfo when necessary (like in https://github.com/Homebrew/homebrew-core/pull/114068 and friends), but the audit still triggers in some cases: https://github.com/Homebrew/homebrew-core/pull/135322

It's high time we stop insisting on using macOS texinfo. I actually thought I had done that already a couple of months ago :)