### PR TITLE
docs/cask: replace single-quoted with double-quoted

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -885,9 +885,9 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
   * `must_succeed:` - set to `false` if the script is allowed to fail
   * `sudo:` - set to `true` if the script needs *sudo*
 * [`pkgutil:`](#uninstall-pkgutil) (string, regexp or array of strings and regexps) - strings or regexps matching bundle IDs of packages to uninstall using `pkgutil`
-* [`delete:`](#uninstall-delete) (string or array) - single-quoted, absolute paths of files or directory trees to remove. Should only be used as a last resort; `pkgutil:` is strongly preferred.
-* **`rmdir:`** (string or array) - single-quoted, absolute paths of directories to remove if empty. Works recursively.
-* [`trash:`](#uninstall-trash) (string or array) - single-quoted, absolute paths of files or directory trees to move to Trash
+* [`delete:`](#uninstall-delete) (string or array) - double-quoted, absolute paths of files or directory trees to remove. Should only be used as a last resort; `pkgutil:` is strongly preferred.
+* **`rmdir:`** (string or array) - double-quoted, absolute paths of directories to remove if empty. Works recursively.
+* [`trash:`](#uninstall-trash) (string or array) - double-quoted, absolute paths of files or directory trees to move to Trash
 
 Each `uninstall` technique is applied according to the order above. The order in which `uninstall` keys appear in the cask file is ignored.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Replaces references to "single-quoted" strings with "double-quoted" strings to match our style guide.
