### PR TITLE
docs: Requirements: add Arch Linux

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -67,6 +67,12 @@ To install build tools, paste at a terminal prompt:
   sudo yum install procps-ng curl file git
   ```
 
+- **Arch Linux**
+
+  ```sh
+  sudo pacman -Syu base-devel procps-ng curl file git
+  ```
+
 ### ARM (unsupported)
 
 Homebrew can run on 32-bit ARM (Raspberry Pi and others) and 64-bit ARM (AArch64), but as they lack binary packages (bottles) they are unsupported. Pull requests are welcome to improve the experience on ARM platforms.


### PR DESCRIPTION
Note: I'm not entirely sure if these are sufficient. I mimicked what's [in `install.sh`](https://github.com/Homebrew/install/blob/master/install.sh#L1052) and what's already listed for the remaining distros.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

<details>
<summary>
brew tests
</summary>
<pre>
Randomized with seed 28976
8 processes for 353 specs, ~ 44 specs per process
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................F...............................................F...................................................F........................................................F...........................F................................F...........................F.......F.................................................................................F....F.....F...................................F........................................F....................................................................F......F..................................................F..............................................F..............................F.................................................................................................F.................F.......................................F..........................................F................................................................................................
...............F..F............................F......................F.............................................................................................F....F.........................................................F............
F.............................................................F..........................F................................................................................................F.........F................................F..
.....F.........................................................................................F..................F...............................................................................................................F..................................
F............................................................F.F.........................................................................................................................F...F.............................................................F....F...................................................................................................F...
.
FF.......F.........F......FFFFF.............................................................F......F...................F.....................................................................................................................................................

Failures:

  1) RuboCop::Cop::FormulaAudit::UsesFromMacos cpio formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  2) RuboCop::Cop::FormulaAudit::UsesFromMacos less formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  3) RuboCop::Cop::FormulaAudit::UsesFromMacos gzip formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  4) RuboCop::Cop::FormulaAudit::UsesFromMacos vim formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  5) RuboCop::Cop::FormulaAudit::UsesFromMacos expect formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  6) RuboCop::Cop::FormulaAudit::UsesFromMacos php formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  7) RuboCop::Cop::FormulaAudit::UsesFromMacos zsh formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  8) RuboCop::Cop::FormulaAudit::UsesFromMacos groff formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  9) RuboCop::Cop::FormulaAudit::UsesFromMacos openssl formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  10) RuboCop::Cop::FormulaAudit::UsesFromMacos python formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  11) RuboCop::Cop::FormulaAudit::UsesFromMacos git formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  12) RuboCop::Cop::FormulaAudit::UsesFromMacos mandoc formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  13) RuboCop::Cop::FormulaAudit::UsesFromMacos rsync formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  14) RuboCop::Cop::FormulaAudit::UsesFromMacos bash formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  15) RuboCop::Cop::FormulaAudit::UsesFromMacos xz formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  16) RuboCop::Cop::FormulaAudit::UsesFromMacos perl formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'
FFFFFF.....................................................................................................F............................................................................................................................................................................

Failures:

  1) RuboCop::Cop::FormulaAudit::ProvidedByMacos bc formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  2) RuboCop::Cop::FormulaAudit::ProvidedByMacos flex formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  3) RuboCop::Cop::FormulaAudit::ProvidedByMacos libxml2 formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  4) RuboCop::Cop::FormulaAudit::ProvidedByMacos icu4c formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  5) RuboCop::Cop::FormulaAudit::ProvidedByMacos m4 formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  6) RuboCop::Cop::FormulaAudit::ProvidedByMacos sqlite formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  7) RuboCop::Cop::FormulaAudit::ProvidedByMacos gperf formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  8) RuboCop::Cop::FormulaAudit::ProvidedByMacos ncurses formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  9) RuboCop::Cop::FormulaAudit::ProvidedByMacos libarchive formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  10) RuboCop::Cop::FormulaAudit::ProvidedByMacos whois formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  11) RuboCop::Cop::FormulaAudit::ProvidedByMacos curl formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  12) RuboCop::Cop::FormulaAudit::ProvidedByMacos libxslt formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  13) RuboCop::Cop::FormulaAudit::ProvidedByMacos bison formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  14) RuboCop::Cop::FormulaAudit::ProvidedByMacos ruby formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  15) RuboCop::Cop::FormulaAudit::ProvidedByMacos cups formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  16) RuboCop::Cop::FormulaAudit::ProvidedByMacos tcl-tk formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  17) RuboCop::Cop::FormulaAudit::ProvidedByMacos file-formula formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  18) RuboCop::Cop::FormulaAudit::ProvidedByMacos swift formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  19) RuboCop::Cop::FormulaAudit::ProvidedByMacos libffi formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  20) RuboCop::Cop::FormulaAudit::ProvidedByMacos unifdef formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  21) RuboCop::Cop::FormulaAudit::ProvidedByMacos berkeley-db formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  22) RuboCop::Cop::FormulaAudit::ProvidedByMacos libressl formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  23) RuboCop::Cop::FormulaAudit::ProvidedByMacos ssh-copy-id formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  24) RuboCop::Cop::FormulaAudit::ProvidedByMacos libiconv formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  25) RuboCop::Cop::FormulaAudit::ProvidedByMacos unzip formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  26) RuboCop::Cop::FormulaAudit::ProvidedByMacos netcat formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  27) RuboCop::Cop::FormulaAudit::ProvidedByMacos rpcgen formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  28) RuboCop::Cop::FormulaAudit::ProvidedByMacos pax formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  29) RuboCop::Cop::FormulaAudit::ProvidedByMacos openldap formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  30) RuboCop::Cop::FormulaAudit::ProvidedByMacos libedit formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  31) RuboCop::Cop::FormulaAudit::ProvidedByMacos llvm formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  32) RuboCop::Cop::FormulaAudit::ProvidedByMacos expat formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  33) RuboCop::Cop::FormulaAudit::ProvidedByMacos bzip2 formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  34) RuboCop::Cop::FormulaAudit::ProvidedByMacos lsof formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  35) RuboCop::Cop::FormulaAudit::ProvidedByMacos dyld-headers formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  36) RuboCop::Cop::FormulaAudit::ProvidedByMacos cyrus-sasl formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  37) RuboCop::Cop::FormulaAudit::ProvidedByMacos ed formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  38) RuboCop::Cop::FormulaAudit::ProvidedByMacos zlib formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  39) RuboCop::Cop::FormulaAudit::ProvidedByMacos pcsc-lite formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  40) RuboCop::Cop::FormulaAudit::ProvidedByMacos apr formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  41) RuboCop::Cop::FormulaAudit::ProvidedByMacos net-snmp formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  42) RuboCop::Cop::FormulaAudit::ProvidedByMacos ncompress formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  43) RuboCop::Cop::FormulaAudit::ProvidedByMacos pod2man formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  44) RuboCop::Cop::FormulaAudit::ProvidedByMacos texinfo formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  45) RuboCop::Cop::FormulaAudit::ProvidedByMacos krb5 formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  46) RuboCop::Cop::FormulaAudit::ProvidedByMacos libpcap formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  47) RuboCop::Cop::FormulaAudit::ProvidedByMacos gnu-getopt formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  48) RuboCop::Cop::FormulaAudit::ProvidedByMacos libxcrypt formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  49) RuboCop::Cop::FormulaAudit::ProvidedByMacos zip formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  50) brew --prefix prints the prefix for a Formula
      Failure/Error:
        expect { brew_sh "--prefix", "wget" }
          .to output("#{ENV.fetch("HOMEBREW_PREFIX")}/opt/wget\n").to_stdout
          .and not_to_output.to_stderr
          .and be_a_success
      
           expected block to output "/home/linuxbrew/.linuxbrew/opt/wget\n" to stdout, but output nothing
      
        ...and:
      
              expected block to not output to stderr, but output "Error: No available formula with the name \"wget\".\n"
      
           ...and:
      
              expected #<Proc:0x000055fd3dcd2c98@/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test/cmd/--prefix_spec.rb:16> to be a success
      # ./test/cmd/--prefix_spec.rb:16:in `block (2 levels) in <top (required)>'
      # ./test/support/helper/spec/shared_context/integration_test.rb:49:in `block (2 levels) in <top (required)>'



Took 81 seconds (1:21)
Tests Failed
</pre>
</details>

System info:
```console
$ brew doctor
Your system is ready to brew.
$ brew config
HOMEBREW_VERSION: 4.0.28-88-g076cc09
ORIGIN: https://github.com/Homebrew/brew
HEAD: 076cc091209a69e5ed06363df47605a752bee63d
Last commit: 7 minutes ago
Core tap JSON: 17 Jul 18:54 UTC
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_DISPLAY: :0
HOMEBREW_MAKE_JOBS: 8
Homebrew Ruby: 2.6.10 => /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.10_1/bin/ruby
CPU: octa-core 64-bit skylake
Clang: 15.0.7
Git: 2.41.0 => /bin/git
Curl: 8.1.2 => /bin/curl
Kernel: Linux 6.4.3-arch1-2 x86_64 GNU/Linux
OS: Unknown
Host glibc: 2.37
/usr/bin/gcc: 13.1.1
/usr/bin/ruby: N/A
glibc: N/A
gcc@11: N/A
gcc: N/A
xorg: N/A
```

-----

Side note: I think "OS: Unkown" in `brew config` is because I don't have `lsb_release`. I'm not sure if it's intended that [`linux.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/os/linux.rb#L23) doesn't use [`HOMEBREW_OS_VERSION`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/brew.sh#L604).

```console
$ lsb_release
bash: lsb_release: command not found
$ echo "$(source /etc/os-release && echo "${PRETTY_NAME}")"
Arch Linux
$ cat /etc/os-release 
NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://bugs.archlinux.org/"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo
```