### PR TITLE
utils/pypi: don't overwrite name/extras/version from basic_metadata if already set

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -127,9 +127,9 @@ module PyPI
         match = File.basename(@package_string).match(/^(.+)-([a-z\d.]+?)(?:.tar.gz|.zip)$/)
         raise ArgumentError, "Package should be a valid PyPI URL" if match.blank?
 
-        @name = PyPI.normalize_python_package match[1]
-        @extras = []
-        @version = match[2]
+        @name ||= PyPI.normalize_python_package match[1]
+        @extras ||= []
+        @version ||= match[2]
       elsif @is_url
         ensure_formula_installed!("python")
 
@@ -152,9 +152,9 @@ module PyPI
 
         metadata = JSON.parse(pip_output)["install"].first["metadata"]
 
-        @name = PyPI.normalize_python_package metadata["name"]
-        @extras = []
-        @version = metadata["version"]
+        @name ||= PyPI.normalize_python_package metadata["name"]
+        @extras ||= []
+        @version ||= metadata["version"]
       else
         if @package_string.include? "=="
           name, version = @package_string.split("==")
@@ -170,9 +170,9 @@ module PyPI
           extras = []
         end
 
-        @name = PyPI.normalize_python_package name
-        @extras = extras
-        @version = version
+        @name ||= PyPI.normalize_python_package name
+        @extras ||= extras
+        @version ||= version
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
When any of `@name`, `@extras`, or `@version` aren't set, all are attempted to be inferred from the original URL. This change only updates the variables if they weren't already set.


Resolves https://github.com/Homebrew/brew/issues/15653
