### PR TITLE
formula: add `std_pip_args`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1622,6 +1622,19 @@ class Formula
     ["--prefix=#{prefix}", "--libdir=#{lib}", "--buildtype=release", "--wrap-mode=nofallback"]
   end
 
+  # Standard parameters for pip builds.
+  sig {
+    params(prefix:          T.any(String, Pathname, FalseClass),
+           build_isolation: T::Boolean).returns(T::Array[String])
+  }
+  def std_pip_args(prefix: self.prefix, build_isolation: false)
+    args = ["--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed",
+            "--use-feature=no-binary-enable-wheel-cache"]
+    args << "--prefix=#{prefix}" if prefix.present?
+    args << "--no-build-isolation" unless build_isolation
+    args
+  end
+
   # Shared library names according to platform conventions.
   #
   # Optionally specify a `version` to restrict the shared library to a specific

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -301,12 +301,7 @@ module Language
 
         def do_install(targets, build_isolation: true)
           targets = Array(targets)
-          args = [
-            "-v", "--no-deps", "--no-binary", ":all:",
-            "--use-feature=no-binary-enable-wheel-cache",
-            "--ignore-installed"
-          ]
-          args << "--no-build-isolation" unless build_isolation
+          args = @formula.std_pip_args(prefix: false, build_isolation: build_isolation)
           @formula.system @venv_root/"bin/pip", "install", *args, *targets
         end
       end

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -22,17 +22,19 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
   describe "#pip_install" do
     it "accepts a string" do
+      expect(formula).to receive(:std_pip_args).with(prefix:          false,
+                                                     build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
+        .with(dir/"bin/pip", "install", "--std-pip-args", "foo")
         .and_return(true)
       virtualenv.pip_install "foo"
     end
 
     it "accepts a multi-line strings" do
+      expect(formula).to receive(:std_pip_args).with(prefix:          false,
+                                                     build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo", "bar")
+        .with(dir/"bin/pip", "install", "--std-pip-args", "foo", "bar")
         .and_return(true)
 
       virtualenv.pip_install <<~EOS
@@ -42,14 +44,16 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     end
 
     it "accepts an array" do
+      expect(formula).to receive(:std_pip_args).with(prefix:          false,
+                                                     build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "foo")
+        .with(dir/"bin/pip", "install", "--std-pip-args", "foo")
         .and_return(true)
 
+      expect(formula).to receive(:std_pip_args).with(prefix:          false,
+                                                     build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "bar")
+        .with(dir/"bin/pip", "install", "--std-pip-args", "bar")
         .and_return(true)
 
       virtualenv.pip_install ["foo", "bar"]
@@ -59,18 +63,20 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       res = Resource.new("test")
 
       expect(res).to receive(:stage).and_yield
+      expect(formula).to receive(:std_pip_args).with(prefix:          false,
+                                                     build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", Pathname.pwd)
+        .with(dir/"bin/pip", "install", "--std-pip-args", Pathname.pwd)
         .and_return(true)
 
       virtualenv.pip_install res
     end
 
     it "works without build isolation" do
+      expect(formula).to receive(:std_pip_args).with(prefix:          false,
+                                                     build_isolation: false).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-binary", ":all:",
-              "--use-feature=no-binary-enable-wheel-cache", "--ignore-installed", "--no-build-isolation", "foo")
+        .with(dir/"bin/pip", "install", "--std-pip-args", "foo")
         .and_return(true)
       virtualenv.pip_install("foo", build_isolation: false)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

This introduces a `std_pip_args` for use in homebrew-core, matching other languages. We currently have two Python-related installation methods:

1. `Language::Python.setup_install_args`, our `setup.py` shim
1. `Language::Python::Virtualenv.pip_install` for venv-based packages

The former (direct `setup.py` execution) has been deprecated for almost two years now (see [1](https://github.com/pypa/setuptools/pull/2824) and [2](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)). One replacement is to use `pip install` instead, so as we update formulae it'd be useful to easily share common pip args.
