### PR TITLE
api_hashable: remove HOMEBREW_CELLAR.

### DIFF
--- a/Library/Homebrew/extend/api_hashable.rb
+++ b/Library/Homebrew/extend/api_hashable.rb
@@ -12,7 +12,6 @@ module APIHashable
     @old_home = Dir.home
     Object.send(:remove_const, :HOMEBREW_PREFIX)
     Object.const_set(:HOMEBREW_PREFIX, Pathname.new(HOMEBREW_PREFIX_PLACEHOLDER))
-    Object.const_set(:HOMEBREW_CELLAR, Pathname.new(HOMEBREW_CELLAR_PLACEHOLDER))
     ENV["HOME"] = HOMEBREW_HOME_PLACEHOLDER
 
     @generating_hash = true
@@ -24,8 +23,6 @@ module APIHashable
     # Revert monkeypatches for API generation
     Object.send(:remove_const, :HOMEBREW_PREFIX)
     Object.const_set(:HOMEBREW_PREFIX, @old_homebrew_prefix)
-    Object.send(:remove_const, :HOMEBREW_CELLAR)
-    Object.const_set(:HOMEBREW_CELLAR, @old_homebrew_cellar)
     ENV["HOME"] = @old_home
 
     @generating_hash = false


### PR DESCRIPTION
This breaks some API generation and isn't actually required.

Feels like running `brew generate-formula-api` in CI here should have caught this but didn't? Weird. Any ideas @Bo98?