### PR TITLE
Enable HOMEBREW_SORBET_RUNTIME (sometimes)

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -930,9 +930,6 @@ fi
 if [[ -n "${HOMEBREW_SORBET_RUNTIME}" ]]
 then
   NO_SORBET_RUNTIME_COMMANDS=(
-    generate-cask-api
-    generate-formula-api
-    release
   )
 
   if check-array-membership "${HOMEBREW_COMMAND}" "${NO_SORBET_RUNTIME_COMMANDS[@]}"

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -919,6 +919,37 @@ then
   export HOMEBREW_DEVELOPER_COMMAND="1"
 fi
 
+if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEVELOPER_COMMAND}" ]]
+then
+  # Always run with Sorbet for Homebrew developers or Homebrew developer commands.
+  export HOMEBREW_SORBET_RUNTIME="1"
+fi
+
+# NO_SORBET_RUNTIME_COMMANDS are currently failing with Sorbet for homebrew/core.
+# TODO: fix this and remove this if block.
+if [[ -n "${HOMEBREW_SORBET_RUNTIME}" ]]
+then
+  NO_SORBET_RUNTIME_COMMANDS=(
+    generate-cask-api
+    generate-formula-api
+    release
+  )
+
+  if check-array-membership "${HOMEBREW_COMMAND}" "${NO_SORBET_RUNTIME_COMMANDS[@]}"
+  then
+    unset HOMEBREW_SORBET_RUNTIME
+  fi
+
+  unset NO_SORBET_RUNTIME_COMMANDS
+fi
+
+# Provide a (temporary, undocumented) way to disable Sorbet globally if needed
+# to avoid reverting the above.
+if [[ -n "${HOMEBREW_NO_SORBET_RUNTIME}" ]]
+then
+  unset HOMEBREW_SORBET_RUNTIME
+fi
+
 if [[ -n "${HOMEBREW_DEVELOPER_COMMAND}" && -z "${HOMEBREW_DEVELOPER}" ]]
 then
   if [[ -z "${HOMEBREW_DEV_CMD_RUN}" ]]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -349,7 +349,8 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_SORBET_RUNTIME:                   {
-        description: "If set, enable runtime typechecking using Sorbet.",
+        description: "If set, enable runtime typechecking using Sorbet. " \
+                     "Set by default for HOMEBREW_DEVELOPER or when running some developer commands.",
         boolean:     true,
       },
       HOMEBREW_SSH_CONFIG_PATH:                  {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2312,7 +2312,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions of macOS. This is useful in development on new macOS versions.
 
 - `HOMEBREW_SORBET_RUNTIME`
-  <br>If set, enable runtime typechecking using Sorbet.
+  <br>If set, enable runtime typechecking using Sorbet. Set by default for HOMEBREW_DEVELOPER or when running some developer commands.
 
 - `HOMEBREW_SSH_CONFIG_PATH`
   <br>If set, Homebrew will use the given config file instead of `~/.ssh/config` when fetching `git` repos over `ssh`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3414,7 +3414,7 @@ If set along with \fBHOMEBREW_DEVELOPER\fR, do not use bottles from older versio
 \fBHOMEBREW_SORBET_RUNTIME\fR
 .
 .br
-If set, enable runtime typechecking using Sorbet\.
+If set, enable runtime typechecking using Sorbet\. Set by default for HOMEBREW_DEVELOPER or when running some developer commands\.
 .
 .TP
 \fBHOMEBREW_SSH_CONFIG_PATH\fR


### PR DESCRIPTION
Reverts #15385 with some tweaks:
- remove the commands that are now passing (on my machine)
- add some commands that are definitely failing (on my machine)
- provide the (temporary, undocumented) `HOMEBREW_NO_SORBET_RUNTIME` to disable Sorbet globally if needed more easily from e.g. specific GitHub Actions workflows 

# Please do not revert this PR! Instead: add the relevant commands to `NO_SORBET_RUNTIME_COMMANDS` or set `HOMEBREW_NO_SORBET_RUNTIME`.

Won't be merged until after 4.1.0 is out.