### PR TITLE
os/mac/keg_relocate: avoid changing to an already existing rpath

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -62,7 +62,15 @@ class Keg
           else
             new_name = opt_name_for(bad_name)
             loader_name = loader_name_for(file, new_name)
-            change_rpath(bad_name, loader_name, file) if loader_name != bad_name
+            next if loader_name == bad_name
+
+            if file.rpaths(resolve_variable_references: false).include?(loader_name)
+              # The wanted loader_name is already an rpath, so the existing bad_name is not needed.
+              # Attempting to change bad_name to an already existing rpath will produce an error.
+              delete_rpath(bad_name, file)
+            else
+              change_rpath(bad_name, loader_name, file)
+            end
           end
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Doing `change_rpath(old, new, file)` will error if `new` is already an
rpath for `file`. When this happens, `old` is no longer needed, so we
can delete it.

Fixes a build failure at shivammathur/homebrew-php#1848.
