### PR TITLE
docs/FAQ: tap homebrew/core before editing formula

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -140,7 +140,7 @@ If all maintainer feedback has been addressed and all tests are passing, bump it
 
 ## Can I edit formulae myself?
 
-Yes! It’s easy! Just `brew edit <formula>`. You don’t have to submit modifications back to `homebrew/core`, just edit the formula to what you personally need and `brew install <formula>`. As a bonus, `brew update` will merge your changes with upstream so you can still keep the formula up-to-date **with** your personal modifications!
+Yes! It’s easy! If `brew tap` doesn't show `homebrew/core`, run `brew tap homebrew/core` first. Then just `brew edit <formula>`. You don’t have to submit modifications back to `homebrew/core`, just edit the formula to what you personally need and `brew install <formula>`. As a bonus, `brew update` will merge your changes with upstream so you can still keep the formula up-to-date **with** your personal modifications!
 
 Note that if you are editing a core formula or cask you must set `HOMEBREW_NO_INSTALL_FROM_API=1` before using `brew install` or `brew update` otherwise they will ignore your local changes and default to the API.
 


### PR DESCRIPTION
New installs don't tap `homebrew/core` and default to the API instead, so `brew edit foo` fails with `Error: Invalid usage: foo doesn't exist on disk.` for any formula `foo`. Add an instruction in the FAQs to run `brew tap homebrew/core` first, which fixes this issue. (See more notes below checklist.)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

#15693 also addresses changes to docs now that the core repos are untapped by default, but seems to focus more on those developing and contributing new formulae rather than those making quick edits to core formulae.

#15693 uses `brew tap --force homebrew/core`, while my change omits `--force`. Running without `--force` results in a warning but the command still completes successfully. I can add `--force` into the docs if desired.

Ignoring failures in `brew style` and `brew tests`, as they seem to be unrelated to the doc change.

Relevant `brew style` output:

```
==> Running `brew cleanup shellcheck`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

In /opt/homebrew/Library/Homebrew/brew.sh line 604:
  [[ -n "${HOMEBREW_LINUX}" ]] && HOMEBREW_OS_VERSION="$(source /etc/os-release && echo "${PRETTY_NAME}")"
                                                                ^-------------^ SC1091 (info): Not following: /etc/os-release: openBinaryFile: does not exist (No such file or directory)
                                                                                         ^------------^ SC2154 (warning): PRETTY_NAME is referenced but not assigned.

For more information:
  https://www.shellcheck.net/wiki/SC2154 -- PRETTY_NAME is referenced but not...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: /etc/os-release: o...
```

Relevant `brew tests` output:

```
Randomized with seed 44625
12 processes for 402 specs, ~ 33 specs per process
............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
.........................................................................................................................................................................................................
...........................................................................................................................................................................................................................................................................................
................................................................................................................................
...........................................................................................................................................................
...............................................................................................................................................................................................................................................................................................................................................................................................................................
.......................
..............................................................................................................................................................................................................................................................................................................Password:......................................................................................................................
.............................................................................................................................................................................................................................................................................................
.................................................................................................................................................................................................................................................................................................................................................................
.......................................................................................................................................................................................................................................................................
F..................................................................................

Failures:

  1) Cask::Artifact::App upgrade when the directory is owned by root reuses the same directory
     Failure/Error: app.install_phase(command: command, adopt: adopt, force: force, predecessor: cask)

     Timeout::Error:
       execution expired
     # ./system_command.rb:229:in `join'
     # ./system_command.rb:229:in `each_output_line'
     # ./system_command.rb:47:in `run!'
     # ./system_command.rb:34:in `run'
     # ./system_command.rb:38:in `run!'
     # ./system_command.rb:26:in `system_command!'
     # ./cask/quarantine.rb:181:in `copy_xattrs'
     # ./cask/artifact/moved.rb:94:in `move'
     # ./cask/artifact/moved.rb:19:in `install_phase'
     # ./test/cask/artifact/app_spec.rb:369:in `block (4 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/homebrew_cask.rb:51:in `block (2 levels) in <top (required)>'



Took 159 seconds (2:39)
Tests Failed

Password:
```