### PR TITLE
README.md: Normalise 1Password icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Our macOS continuous integration infrastructure is hosted by [MacStadium's Orka]
 
 Secure password storage and syncing is provided by [1Password for Teams](https://1password.com/teams/).
 
-[![1Password](https://i.1password.com/akb/featured/1password-icon.svg)](https://1password.com)
+[<img src="https://i.1password.com/akb/featured/1password-icon.svg" alt="1Password" height="64">](https://1password.com)
 
 Flaky test detection and tracking is provided by [BuildPulse](https://buildpulse.io/).
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

1Password’s icon was twice the height of the others. This makes them all the same size (almost, BuildPulse’s is slightly smaller; will be fixed in another PR).