### PR TITLE
README.md: Normalise BuildPulse icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Secure password storage and syncing is provided by [1Password for Teams](https:/
 
 Flaky test detection and tracking is provided by [BuildPulse](https://buildpulse.io/).
 
-[![BuildPulse](https://user-images.githubusercontent.com/2988/130445500-96f44c87-e7dd-4da0-9877-7e5b1618e144.png)](https://buildpulse.io)
+[![BuildPulse](https://github.com/Homebrew/brew/assets/1699443/87385e9a-6c47-4e59-b17e-fe083e945709)](https://buildpulse.io)
 
 <https://brew.sh>'s DNS is [resolving with DNSimple](https://dnsimple.com/resolving/homebrew).
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

BuildPulse’s icon size was slightly smaller than the others. It also had a circular background but on the website they use a rounded rectangle, so updated to that. Companion to #15713.

Before:

<img width="465" alt="image" src="https://github.com/Homebrew/brew/assets/1699443/d8c20056-4998-4fd2-bb04-335d4743911c">

After:

<img width="466" alt="image" src="https://github.com/Homebrew/brew/assets/1699443/5331cbce-d854-42c5-8eb4-8ac059d6e080">
