### PR TITLE
utils/github/api: fix credentials_type

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -167,10 +167,10 @@ module GitHub
     def self.credentials_type
       if Homebrew::EnvConfig.github_api_token.present?
         :env_token
-      elsif keychain_username_password.present?
-        :keychain_username_password
       elsif github_cli_token.present?
         :github_cli_token
+      elsif keychain_username_password.present?
+        :keychain_username_password
       else
         :none
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The order is shared with self.credentials, but during the deprecation cycle the need to adjust self.credentials_type to match was overlooked.