### PR TITLE
keg_relocate: add `HOMEBREW_PREFIX/lib` to rpaths

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -73,6 +73,12 @@ class Keg
             end
           end
         end
+
+        next if HOMEBREW_PREFIX.to_s == "/usr/local"
+        next if file.rpaths.include?("#{HOMEBREW_PREFIX}/lib")
+
+        loader_name = loader_name_for(file, "#{HOMEBREW_PREFIX}/lib")
+        add_rpath(loader_name, file)
       end
     end
 

--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -50,6 +50,18 @@ class Keg
     raise
   end
 
+  def add_rpath(rpath, file)
+    @require_relocation = rpath.start_with?(HOMEBREW_PREFIX.to_s)
+    odebug "Adding rpath #{rpath} in #{file}"
+    file.add_rpath(rpath, strict: false)
+    codesign_patched_binary(file)
+  rescue MachO::MachOError
+    onoe <<~EOS
+      Failed adding rpath #{rpath} in #{file}
+    EOS
+    raise
+  end
+
   def delete_rpath(rpath, file)
     odebug "Deleting rpath #{rpath} in #{file}"
     file.delete_rpath(rpath, strict: false)

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -59,6 +59,11 @@ module MachOShim
 
   # TODO: See if the `#write!` call can be delayed until
   # we know we're not making any changes to the rpaths.
+  def add_rpath(rpath, **options)
+    macho.add_rpath(rpath, options)
+    macho.write!
+  end
+
   def delete_rpath(rpath, **options)
     macho.delete_rpath(rpath, options)
     macho.write!


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

...on non-`/usr/local` prefixes.

This allows `dlopen` to just work on Homebrew-installed (and linked)
libraries. We don't need to do this for `/usr/local/lib` because this is
already in dyld's default search path.

We already do this manually via setting `LDFLAGS` for some formulae
(e.g. Python, LuaJIT, etc).

I'll likely wait until we've removed `HOMEBREW_RELOCATABLE_INSTALL_NAMES` gating before merging this.
