### PR TITLE
os/mac/keg_relocate: avoid rpath re-ordering

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -57,7 +57,13 @@ class Keg
 
         each_linkage_for(file, :rpaths) do |bad_name|
           # Strip duplicate rpaths and rpaths rooted in the build directory.
-          if rooted_in_build_directory?(bad_name) || (file.rpaths.count(bad_name) > 1)
+          if rooted_in_build_directory?(bad_name) ||
+             (file.rpaths(resolve_variable_references: false).count(bad_name) > 1)
+            # TODO: Drop the `resolve_variable_references` argument above (defaults to `true`)
+            #       and fix `delete_rpath` so that it deletes the *last* LC_RPATH command
+            #       (instead of the first one) to avoid changing LC_RPATH command ordering.
+            # NOTE: `delete_rpath` will also need to be able to handle rpaths that are different
+            #       strings but resolve to the same location.
             delete_rpath(bad_name, file)
           else
             new_name = opt_name_for(bad_name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should fix the failures seen for `julia` in Homebrew/core.[^1]

I've detailed a better/more comprehensive fix as a `TODO` in a comments.
However, the problems that the better fix would avoid are comparatively
unlikely, so I think we can try this one out for now while I work on
implementing the said fix.

[^1]: https://github.com/Homebrew/homebrew-core/pull/135398#issuecomment-1643041541
