### PR TITLE
extend/ENV/super: correct `deparallelize` signature

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -304,7 +304,7 @@ module Superenv
   # Removes the MAKEFLAGS environment variable, causing make to use a single job.
   # This is useful for makefiles with race conditions.
   # When passed a block, MAKEFLAGS is removed only for the duration of the block and is restored after its completion.
-  sig { params(block: T.proc.returns(T.untyped)).returns(T.untyped) }
+  sig { params(block: T.nilable(T.proc.returns(T.untyped))).returns(T.untyped) }
   def deparallelize(&block)
     old = delete("MAKEFLAGS")
     if block


### PR DESCRIPTION
The block is optional, so it should be marked `T.nilable`

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I observed the following failure on PR [#137236](https://github.com/Homebrew/homebrew-core/pull/137236) today and thought it might be caused by this. The highlighted line in the error is an `ENV.deparallelize` with no block

```
Error: An exception occurred within a child process:
  TypeError: Block parameter 'block': Expected type T.proc.params().returns(T.untyped), got type NilClass
```