### PR TITLE
Fix `inreplace` sig

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2472,6 +2472,14 @@ class Formula
   #
   # @see Utils::Inreplace.inreplace
   # @api public
+  sig {
+    params(
+      paths:        T.any(T::Array[T.untyped], String, Pathname),
+      before:       T.nilable(T.any(Regexp, String)),
+      after:        T.nilable(T.any(Pathname, String, Symbol)),
+      audit_result: T::Boolean,
+    ).void
+  }
   def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
     super(paths, before, after, audit_result)
   rescue Utils::Inreplace::Error => e

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2484,7 +2484,8 @@ class Formula
     super(paths, before, after, audit_result)
   rescue Utils::Inreplace::Error => e
     onoe e.to_s
-    raise BuildError.new(self, "inreplace", paths, {})
+    args = paths.is_a?(Array) ? paths : [paths]
+    raise BuildError.new(self, "inreplace", args, {})
   end
 
   protected

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -41,12 +41,12 @@ module Utils
       params(
         paths:        T.any(T::Array[T.untyped], String, Pathname),
         before:       T.nilable(T.any(Regexp, String)),
-        after:        T.nilable(T.any(String, Symbol)),
+        after:        T.nilable(T.any(Pathname, String, Symbol)),
         audit_result: T::Boolean,
       ).void
     }
     def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
-      after = after.to_s if after.is_a? Symbol
+      after &&= after.to_s
 
       errors = {}
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Implicit `Pathname` strings strike again:

Resolves https://github.com/Homebrew/homebrew-core/actions/runs/5628176140/job/15251794429

```
 ==> go build -trimpath -o=/opt/homebrew/Cellar/loki/2.8.3/bin/loki -ldflags=-s -w
Error: An exception occurred within a child process:
  TypeError: Parameter 'after': Expected type T.nilable(T.any(String, Symbol)), got type Pathname with value #<Pathname:/opt/homebrew/var>
Caller: /opt/homebrew/Library/Homebrew/formula.rb:2476
Definition: /opt/homebrew/Library/Homebrew/utils/inreplace.rb:48
```

Also adds a `sig` to `Formula#inreplace` and fixes an accompanying type error.