### PR TITLE
formula_creator: require version before creating

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -60,8 +60,7 @@ module Homebrew
       raise "#{path} already exists" if path.exist?
 
       if version.nil? || version.null?
-        opoo "Version cannot be determined from URL."
-        puts "You'll need to add an explicit 'version' to the formula."
+        odie "Version cannot be determined from URL. Explicity set the version with `--set-version` instead."
       elsif fetch?
         unless head?
           r = Resource.new
@@ -108,7 +107,7 @@ module Homebrew
           homepage "#{homepage}"
         <% unless head? %>
           url "#{url}"
-        <% unless version.nil? or version.detected_from_url? %>
+        <% unless version.detected_from_url? %>
           version "#{version}"
         <% end %>
           sha256 "#{sha256}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Always require a version when creating a formula, either via URL detection or with `--set-version`. Otherwise, `brew create` would create the file without a version and then fail when validating.

```
$ brew create --set-name testformula --tap ericfromcanada/test http://example.com/test.xz --no-fetch
Warning: Version cannot be determined from URL.
You'll need to add an explicit 'version' to the formula.
Error: invalid attribute for formula 'ericfromcanada/test/testformula': version (nil)
/usr/local/Homebrew/Library/Homebrew/formula.rb:298:in `validate_attributes!'
/usr/local/Homebrew/Library/Homebrew/formula.rb:223:in `initialize'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:484:in `new'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:484:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:763:in `factory'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet
...
```