### PR TITLE
github_packages: ensure only OCI format is uploaded

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -429,7 +429,7 @@ class GitHubPackages
                      "org.opencontainers.image.ref.name" => version_rebuild)
 
     puts
-    args = ["copy", "--retry-times=3", "--all", "oci:#{root}", image_uri.to_s]
+    args = ["copy", "--retry-times=3", "--format=oci", "--all", "oci:#{root}", image_uri.to_s]
     if dry_run
       puts "#{skopeo} #{args.join(" ")} --dest-creds=#{user}:$HOMEBREW_GITHUB_PACKAGES_TOKEN"
     else


### PR DESCRIPTION
If the GitHub server returns an error when we are uploading the image index, skopeo could fall back and use a Docker distribution manifest list instead, creating a manifest that brew cannot read.

Let's force OCI format here, which will disable the fallback formats, and mean that upload operation fails if GitHub is having issues rather than letting it go and upload a bad manifest.