### PR TITLE
dev-cmd/pr-pull: fix branch warning conditions

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -432,7 +432,7 @@ module Homebrew
       odie "Not a GitHub pull request: #{arg}" unless pr
 
       git_repo = tap.git_repo
-      if !git_repo.default_origin_branch? || args.branch_okay? || args.clean?
+      if !git_repo.default_origin_branch? && !args.branch_okay? && !args.no_commit? && !args.no_cherry_pick?
         opoo "Current branch is #{git_repo.branch_name}: do you need to pull inside #{git_repo.origin_branch_name}?"
       end
 


### PR DESCRIPTION
`--branch-okay` is supposed to silence the warning but it actually was making the warning always display.

Also check for `--no-cherry-pick` and `--no-commit` as those are typically passed if you are running this on the PR branch (like we are in homebrew-core).