### PR TITLE
cmd/tap: ensure remote exists before repairing

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -419,6 +419,7 @@ class Tap
       end
       $stderr.ohai "#{name}: changed remote from #{remote} to #{requested_remote}" unless quiet
     end
+    return unless remote
 
     current_upstream_head = T.must(git_repo.origin_branch_name)
     return if requested_remote.blank? && git_repo.origin_has_branch?(current_upstream_head)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Avoid an error when attempting to repair a freshly-created tap:

```
$ brew tap-new ericfromcanada/test
Initialized empty Git repository in /usr/local/Homebrew/Library/Taps/ericfromcanada/homebrew-test/.git/
[main (root-commit) 7465854] Create ericfromcanada/test tap
 3 files changed, 90 insertions(+)
 create mode 100644 .github/workflows/publish.yml
 create mode 100644 .github/workflows/tests.yml
 create mode 100644 README.md
==> Created ericfromcanada/test
/usr/local/Homebrew/Library/Taps/ericfromcanada/homebrew-test

When a pull request making changes to a formula (or formulae) becomes green
(all checks passed), then you can publish the built bottles.
To do so, label your PR as `pr-pull` and the workflow will be triggered.

$ brew tap --repair ericfromcanada/test 
Error: undefined method `remote?' for #<Tap:0x00007fb4481cec20>
/usr/local/Homebrew/Library/Homebrew/tap.rb:423:in `fix_remote_configuration'
/usr/local/Homebrew/Library/Homebrew/tap.rb:788:in `block (2 levels) in each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:787:in `each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:787:in `block in each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:786:in `each'
/usr/local/Homebrew/Library/Homebrew/tap.rb:786:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/tap.rb:60:in `tap'
/usr/local/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```