### PR TITLE
utils/inreplace: fix typechecking error

### DIFF
--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -40,7 +40,7 @@ module Utils
     sig {
       params(
         paths:        T.any(T::Array[T.untyped], String, Pathname),
-        before:       T.nilable(T.any(Regexp, String)),
+        before:       T.nilable(T.any(Pathname, Regexp, String)),
         after:        T.nilable(T.any(Pathname, String, Symbol)),
         audit_result: T::Boolean,
       ).void


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes

        TypeError: Parameter 'before': Expected type T.nilable(T.any(Regexp, String)), got type Pathname with value #<Pathname:/opt/homebrew/Cellar/php@8.1/8.1.21/lib/php>
      Caller: /opt/homebrew/Library/Homebrew/formula.rb:2484
      Definition: /opt/homebrew/Library/Homebrew/utils/inreplace.rb:48

https://github.com/Homebrew/homebrew-core/actions/runs/5635089949/job/15266014851#step:3:1737
