### PR TITLE
dev-cmd/edit: suggest tapping core repositories if untapped

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -244,7 +244,7 @@ module Cask
 
       def initialize(token, from_json: nil)
         @token = token.sub(%r{^homebrew/(?:homebrew-)?cask/}i, "")
-        @path = CaskLoader.default_path(token)
+        @path = CaskLoader.default_path(@token)
         @from_json = from_json
       end
 

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -304,9 +304,19 @@ class TapUnavailableError < RuntimeError
   def initialize(name)
     @name = name
 
-    super <<~EOS
-      No available tap #{name}.
-    EOS
+    message = "No available tap #{name}.\n"
+    if [CoreTap.instance.name, CoreCaskTap.instance.name].include?(name)
+      command = "brew tap --force #{name}"
+      message += <<~EOS
+        Run #{Formatter.identifier(command)} to tap #{name}!
+      EOS
+    else
+      command = "brew tap-new #{name}"
+      message += <<~EOS
+        Run #{Formatter.identifier(command)} to create a new #{name} tap!
+      EOS
+    end
+    super message.freeze
   end
 end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1004,7 +1004,8 @@ module Formulary
   end
 
   def self.find_formula_in_tap(name, tap)
-    filename = "#{name}.rb"
+    filename = name.dup
+    filename << ".rb" unless filename.end_with?(".rb")
 
     Tap.formula_files_by_name(tap).fetch(filename, tap.formula_dir/filename)
   end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -131,7 +131,7 @@ describe "Exception" do
   describe TapUnavailableError do
     subject { described_class.new("foo") }
 
-    its(:to_s) { is_expected.to eq("No available tap foo.\n") }
+    its(:to_s) { is_expected.to eq("No available tap foo.\nRun brew tap-new foo to create a new foo tap!\n") }
   end
 
   describe TapAlreadyTappedError do

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -927,6 +927,7 @@ _brew_edit() {
   esac
   __brew_complete_formulae
   __brew_complete_casks
+  __brew_complete_tapped
 }
 
 _brew_environment() {

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -670,7 +670,7 @@ __fish_brew_complete_arg 'dr' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'dr' -a '(__fish_brew_suggest_diagnostic_checks)'
 
 
-__fish_brew_complete_cmd 'edit' 'Open a formula or cask in the editor set by `EDITOR` or `HOMEBREW_EDITOR`, or open the Homebrew repository for editing if no formula is provided'
+__fish_brew_complete_cmd 'edit' 'Open a formula, cask or tap in the editor set by `EDITOR` or `HOMEBREW_EDITOR`, or open the Homebrew repository for editing if no argument is provided'
 __fish_brew_complete_arg 'edit' -l cask -d 'Treat all named arguments as casks'
 __fish_brew_complete_arg 'edit' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'edit' -l formula -d 'Treat all named arguments as formulae'
@@ -680,6 +680,7 @@ __fish_brew_complete_arg 'edit' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'edit' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'edit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
 __fish_brew_complete_arg 'edit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'edit' -a '(__fish_brew_suggest_taps_installed)'
 
 
 __fish_brew_complete_cmd 'environment' 'Summarise Homebrew\'s build environment as a plain list'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -164,7 +164,7 @@ __brew_internal_commands() {
     'dispatch-build-bottle:Build bottles for these formulae with GitHub Actions'
     'docs:Open Homebrew'\''s online documentation (https://docs.brew.sh) in a browser'
     'doctor:Check your system for potential problems'
-    'edit:Open a formula or cask in the editor set by `EDITOR` or `HOMEBREW_EDITOR`, or open the Homebrew repository for editing if no formula is provided'
+    'edit:Open a formula, cask or tap in the editor set by `EDITOR` or `HOMEBREW_EDITOR`, or open the Homebrew repository for editing if no argument is provided'
     'extract:Look through repository history to find the most recent version of formula and create a copy in tap'
     'fetch:Download a bottle (if available) or source packages for formulae and binaries for casks'
     'formula:Display the path where formula is located'
@@ -853,7 +853,9 @@ _brew_edit() {
     '*::formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*::cask:__brew_casks' \
+    - tap \
+    '*::tap:__brew_any_tap'
 }
 
 # brew environment

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1240,10 +1240,10 @@ Build bottles for these formulae with GitHub Actions.
 * `--linux-wheezy`:
   Use Debian Wheezy container for building the bottle on Linux.
 
-### `edit` [*`options`*] [*`formula`*|*`cask`* ...]
+### `edit` [*`options`*] [*`formula`*|*`cask`*|*`tap`* ...]
 
-Open a *`formula`* or *`cask`* in the editor set by `EDITOR` or `HOMEBREW_EDITOR`,
-or open the Homebrew repository for editing if no formula is provided.
+Open a *`formula`*, *`cask`* or *`tap`* in the editor set by `EDITOR` or `HOMEBREW_EDITOR`,
+or open the Homebrew repository for editing if no argument is provided.
 
 * `--formula`:
   Treat all named arguments as formulae.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1804,8 +1804,8 @@ Dispatch bottle for Linux (using self\-hosted runner)\.
 \fB\-\-linux\-wheezy\fR
 Use Debian Wheezy container for building the bottle on Linux\.
 .
-.SS "\fBedit\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
-Open a \fIformula\fR or \fIcask\fR in the editor set by \fBEDITOR\fR or \fBHOMEBREW_EDITOR\fR, or open the Homebrew repository for editing if no formula is provided\.
+.SS "\fBedit\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR|\fItap\fR \.\.\.]"
+Open a \fIformula\fR, \fIcask\fR or \fItap\fR in the editor set by \fBEDITOR\fR or \fBHOMEBREW_EDITOR\fR, or open the Homebrew repository for editing if no argument is provided\.
 .
 .TP
 \fB\-\-formula\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Addresses the issue brought up in #15664 by suggesting homebrew/core or homebrew/cask be tapped when attempting to edit a formula or cask and either repo is untapped. Also expands `edit`'s handling of tap arguments and fixes a few other related bugs.