### PR TITLE
cmd/install: upgrade already installed casks

### DIFF
--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -132,21 +132,6 @@ module Cask
     end
   end
 
-  # Error when a cask is already installed.
-  #
-  # @api private
-  class CaskAlreadyInstalledError < AbstractCaskErrorWithToken
-    sig { returns(String) }
-    def to_s
-      <<~EOS
-        Cask '#{token}' is already installed.
-
-        To re-install #{token}, run:
-          #{Formatter.identifier("brew reinstall --cask #{token}")}
-      EOS
-    end
-  end
-
   # Error when there is a cyclic cask dependency.
   #
   # @api private

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -91,11 +91,6 @@ module Cask
       Migrator.migrate_if_needed(@cask)
 
       old_config = @cask.config
-      if @cask.installed? && !force? && !reinstall? && !upgrade?
-        return if quiet?
-
-        raise CaskAlreadyInstalledError, @cask
-      end
       predecessor = @cask if reinstall? && @cask.installed?
 
       check_conflicts

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -315,7 +315,7 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_NO_INSTALL_UPGRADE:               {
-        description: "If set, `brew install` <formula> will not upgrade <formula> if it is installed but " \
+        description: "If set, `brew install` <formula/cask> will not upgrade <formula/cask> if it is installed but " \
                      "outdated.",
         boolean:     true,
       },

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -141,21 +141,6 @@ describe Cask::Installer, :cask do
       end.not_to raise_error
     end
 
-    # unlike the CLI, the internal interface throws exception on double-install
-    it "installer method raises an exception when already-installed Casks are attempted" do
-      transmission = Cask::CaskLoader.load(cask_path("local-transmission"))
-
-      expect(transmission).not_to be_installed
-
-      installer = described_class.new(transmission)
-
-      installer.install
-
-      expect do
-        installer.install
-      end.to raise_error(Cask::CaskAlreadyInstalledError)
-    end
-
     it "allows already-installed Casks to be installed if force is provided" do
       transmission = Cask::CaskLoader.load(cask_path("local-transmission"))
 
@@ -313,7 +298,7 @@ describe Cask::Installer, :cask do
         caffeine = Cask::CaskLoader.load(path)
         expect(caffeine).to receive(:loaded_from_api?).twice.and_return(true)
         expect(caffeine).to receive(:caskfile_only?).twice.and_return(true)
-        expect(caffeine).to receive(:installed_caskfile).twice.and_return(invalid_path)
+        expect(caffeine).to receive(:installed_caskfile).once.and_return(invalid_path)
 
         described_class.new(caffeine).install
         expect(Cask::CaskLoader.load(path)).to be_installed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Resolves #15295. This is a breaking change so it might be a good idea to wait for the next minor release at the very least.

Previously, the behavior was to warn users that a cask was already installed and then skip modifying the installed version. This is different to how we handled things with formulas. For them we would upgrade any already installed formulas. This just brings casks in line with what we already do with formulas.

Changes:
- cmd/install: Upgrade already installed casks if HOMEBREW_NO_INSTALL_UPGRADE is not set
- env_config: Update wording of HOMEBREW_NO_INSTALL_UPGRADE to include casks
- remove error that was only used to alert about already installed casks

Note:
- The upgrade command for casks defaults to --greedy when you pass named casks to the command which means that this will always default to that behavior since you must specify the name of the cask when installing.