### PR TITLE
utils/pypi: fix an incorrect return type

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -76,7 +76,7 @@ module PyPI
       end
 
       sdist = json["urls"].find { |url| url["packagetype"] == "sdist" }
-      return json["info"]["name"] if sdist.nil?
+      return if sdist.nil?
 
       @pypi_info = [
         PyPI.normalize_python_package(json["info"]["name"]), sdist["url"],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This return type is inconsistent with the parent signature, and was causing a checked type error with Sorbet on `brew-pip-audit`: https://github.com/Homebrew/brew-pip-audit/actions/runs/5654213254/job/15316828558

From a quick look, it appears to be vestigial from an older (pre-typechecked) version of this API. Returning `nil` instead makes sense, since the return here indicates the same error mode as the other `nil` returns above.

CC @alex