### PR TITLE
cask/url: accept `Class` for `using`.

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -24,7 +24,7 @@ module Cask
         params(
           uri:        T.any(URI::Generic, String),
           verified:   T.nilable(String),
-          using:      T.nilable(Symbol),
+          using:      T.any(Class, Symbol, NilClass),
           tag:        T.nilable(String),
           branch:     T.nilable(String),
           revisions:  T.nilable(T::Array[String]),


### PR DESCRIPTION
Fixes #15750.