### PR TITLE
pkg installer: install cached API data.

### DIFF
--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -20,17 +20,16 @@ jobs:
       TEMPORARY_KEYCHAIN_FILE: 'homebrew_installer_signing.keychain-db'
       MIN_MACOS_VERSION: '11.0'
       PKG_APPLE_DEVELOPER_TEAM_ID: ${{ secrets.PKG_APPLE_DEVELOPER_TEAM_ID }}
+      HOMEBREW_NO_ANALYTICS_THIS_RUN: 1
+      HOMEBREW_NO_ANALYTICS_MESSAGE_OUTPUT: 1
     steps:
-      - name: Checkout to brew subdirectory
-        uses: actions/checkout@v3
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
         with:
-          path: brew
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Get Homebrew version from Git
-        id: print-version
-        run: echo "version=$(git -C brew describe --tags --always)" >> "${GITHUB_OUTPUT}"
+          core: false
+          cask: false
+          test-bot: false
 
       - name: Install Pandoc
         run: brew install pandoc
@@ -61,6 +60,20 @@ jobs:
       - name: Clean up temporary certificate file
         if: ${{ always() }}
         run: rm -f "${RUNNER_TEMP}/${TEMPORARY_CERTIFICATE_FILE}"
+
+      - name: Checkout another Homebrew to brew subdirectory
+        uses: actions/checkout@v3
+        with:
+          path: brew
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Get Homebrew version from Git
+        id: print-version
+        run: echo "version=$(git -C brew describe --tags --always)" >> "${GITHUB_OUTPUT}"
+
+      - name: Copy Homebrew API cache to brew subdirectory
+        run: cp -vR ~/Library/Caches/Homebrew/api brew/cache_api
 
       - name: Open macOS keychain
         run: security list-keychain -d user -s "${RUNNER_TEMP}/${TEMPORARY_KEYCHAIN_FILE}"

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -3,7 +3,7 @@
 # $2 Location of the Homebrew installation we may need to move into place
 # $3 Target install location (unused)
 # $4 System root directory (unused)
-set -xeu
+set -eu
 
 # disable analytics while installing
 export HOMEBREW_NO_ANALYTICS_THIS_RUN=1
@@ -23,23 +23,26 @@ export PATH="/Library/Developer/CommandLineTools/usr/bin:/Applications/Xcode.app
 
 # reset Git repository
 cd "${homebrew_directory}"
+git config --global --add safe.directory "${homebrew_directory}"
 git reset --hard
-git checkout -f master
-git branch | grep -v '\*' | xargs -n 1 git branch -D
+git checkout --force master
+git branch | grep -v '\*' | xargs -n 1 git branch --delete --force
+git config --global --unset safe.directory
 
 # move to /usr/local if on x86_64
 if [[ $(uname -m) == "x86_64" ]]
 then
-  mv "${homebrew_directory}" "/usr/local/Homebrew"
+  mv -v "${homebrew_directory}" "/usr/local/Homebrew"
   # create symlink to /usr/local/bin/brew
-  ln -s "/usr/local/Homebrew/bin/brew" "/usr/local/bin/brew"
+  sudo mkdir -vp /usr/local/bin
+  ln -svf "../Homebrew/bin/brew" "/usr/local/bin/brew"
 
   homebrew_directory="/usr/local"
   cd "${homebrew_directory}"
 fi
 
 # create missing directories
-sudo mkdir -p Cellar Frameworks etc include lib opt sbin share var/homebrew/linked
+sudo mkdir -vp Cellar Frameworks etc include lib opt sbin share var/homebrew/linked
 
 # set permissions
 logged_in_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
@@ -50,3 +53,9 @@ then
 else
   chown -R "${logged_in_user}:${group}" .
 fi
+
+# move API cache to ~/Library/Caches/Homebrew
+user_api_cache_dir=~"${logged_in_user}"/Library/Caches/Homebrew/api
+mkdir -vp "${user_api_cache_dir}"
+mv -v "${homebrew_directory}/cache_api/"* "${user_api_cache_dir}"
+rm -vrf "${homebrew_directory}/cache_api"


### PR DESCRIPTION
Continuing with the goals of making the installer:
- more useful
- entirely offline

Let's pre-download the API data from a `brew update` run and install it into the logged-in user's home directory.

While we're here, in the `postinstall` script:
- use longer arguments for various commands
- fix an issue with symlinking on Intel if `/usr/local/bin` doesn't already exist
- unset `bash -x` and use `-v` on more commands instead