### PR TITLE
brew.sh: don't set `HOMEBREW_NO_INSTALL_FROM_API` automatically.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -533,8 +533,6 @@ then
   # shellcheck disable=SC2086,SC2183
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
   # shellcheck disable=SC2248
-  printf -v HOMEBREW_MACOS_OLDEST_SUPPORTED_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_OLDEST_SUPPORTED//./ }
-  # shellcheck disable=SC2248
   printf -v HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_OLDEST_ALLOWED//./ }
 
   # Don't include minor versions for Big Sur and later.
@@ -592,12 +590,6 @@ then
     # Used in ruby.sh.
     # shellcheck disable=SC2034
     HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH="1"
-  fi
-
-  # Don't support API at this time for older macOS versions.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "${HOMEBREW_MACOS_OLDEST_SUPPORTED_NUMERIC}" ]]
-  then
-    export HOMEBREW_NO_INSTALL_FROM_API=1
   fi
 else
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
@@ -669,12 +661,6 @@ Your Git executable: $(unset git && type -p "${HOMEBREW_GIT}")"
     # shellcheck disable=SC2034
     HOMEBREW_LINUXBREW_CORE_MIGRATION=1
   fi
-fi
-
-# Generic OS or non-default prefix: API not supported.
-if [[ (-z "${HOMEBREW_MACOS}" && -z "${HOMEBREW_LINUX}") || "${HOMEBREW_PREFIX}" != "${HOMEBREW_DEFAULT_PREFIX}" ]]
-then
-  export HOMEBREW_NO_INSTALL_FROM_API=1
 fi
 
 setup_ca_certificates() {

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -36,8 +36,6 @@ export HOMEBREW_NO_INSTALL_FROM_API=1
 
 This will make Homebrew install formulae and casks from the `homebrew/core` and `homebrew/cask` taps using local checkouts of these repositories instead of Homebrew’s API.
 
-Note that this will automatically be set on unsupported configurations (i.e. not using the default Homebrew prefix or, if on macOS, on an unsupported version).
-
 ## Unattended installation
 
 If you want a non-interactive run of the Homebrew installer that doesn't prompt for passwords (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command.


### PR DESCRIPTION
My understanding from conversations with Bo98 is that this should now work fine on both older macOS versions and non-default prefixes.

Similarly, it's super confusing when this is set automatically and you can't figure out why...