### PR TITLE
os/mac/mach: resolve rpaths too

### DIFF
--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -110,9 +110,20 @@ module MachOShim
       Pathname(name.sub("@loader_path", dirname)).cleanpath.to_s
     elsif name.start_with?("@executable_path") && binary_executable?
       Pathname(name.sub("@executable_path", dirname)).cleanpath.to_s
+    elsif name.start_with?("@rpath") && (target = resolve_rpath(name)).present?
+      target
     else
       name
     end
+  end
+
+  def resolve_rpath(name)
+    target = T.let(nil, T.nilable(String))
+    return unless rpaths(resolve_variable_references: true).find do |rpath|
+      File.exist?(target = File.join(rpath, name.delete_prefix("@rpath")))
+    end
+
+    target
   end
 
   def archs

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -89,18 +89,15 @@ module MachOShim
 
   def dynamically_linked_libraries(except: :none, resolve_variable_references: true)
     lcs = macho.dylib_load_commands.reject { |lc| lc.type == except }
-
     names = lcs.map(&:name).map(&:to_s).uniq
-
-    names.map! { |name| resolve_variable_name(name) } if resolve_variable_references
+    names.map!(&method(:resolve_variable_name)) if resolve_variable_references
 
     names
   end
 
   def rpaths(resolve_variable_references: true)
     names = macho.rpaths
-
-    names.map! { |name| resolve_variable_name(name) } if resolve_variable_references
+    names.map!(&method(:resolve_variable_name)) if resolve_variable_references
 
     names
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We can add a small amount of logic to `#resolve_variable_name` that will
allow us to perform (limited) resolution of rpath references. This is
for informational purposes only: failing to resolve an `@rpath`
reference will not (and should not) result in `brew linkage` failures.

`dyld` will typically have more information than we do to resolve these
references, so not failing `brew linkage` when we fail to resolve an
`@rpath` reference is the right behaviour here.

As an example, before:

    ❯ brew linkage jpeg-turbo
    System libraries:
      /usr/lib/libSystem.B.dylib
    @rpath-referenced libraries:
      @rpath/libjpeg.8.dylib
      @rpath/libturbojpeg.0.dylib

After:

    ❯ brew linkage jpeg-turbo
    System libraries:
      /usr/lib/libSystem.B.dylib
    Homebrew libraries:
      /usr/local/Cellar/jpeg-turbo/3.0.0/lib/libjpeg.8.dylib (jpeg-turbo)
      /usr/local/Cellar/jpeg-turbo/3.0.0/lib/libturbojpeg.0.dylib (jpeg-turbo)

- os/mac/mach: resolve rpaths too
- os/mac/mach: simplify

