### PR TITLE
Add/use `HOMEBREW_INSTALL_FROM_API_UNSUPPORTED`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -597,6 +597,7 @@ then
   # Don't support API at this time for older macOS versions.
   if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "${HOMEBREW_MACOS_OLDEST_SUPPORTED_NUMERIC}" ]]
   then
+    export HOMEBREW_INSTALL_FROM_API_UNSUPPORTED=1
     export HOMEBREW_NO_INSTALL_FROM_API=1
   fi
 else
@@ -674,6 +675,7 @@ fi
 # Generic OS or non-default prefix: API not supported.
 if [[ (-z "${HOMEBREW_MACOS}" && -z "${HOMEBREW_LINUX}") || "${HOMEBREW_PREFIX}" != "${HOMEBREW_DEFAULT_PREFIX}" ]]
 then
+  export HOMEBREW_INSTALL_FROM_API_UNSUPPORTED=1
   export HOMEBREW_NO_INSTALL_FROM_API=1
 fi
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -377,7 +377,8 @@ module Homebrew
                          !ENV["HOMEBREW_GITHUB_HOSTED_RUNNER"] &&
                          !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
     no_install_from_api_set = Homebrew::EnvConfig.no_install_from_api? &&
-                              !Homebrew::EnvConfig.automatically_set_no_install_from_api?
+                              !Homebrew::EnvConfig.automatically_set_no_install_from_api? &&
+                              !Homebrew::EnvConfig.install_from_api_unsupported?
     return if !no_auto_update_set && !no_install_from_api_set && !auto_update_secs_set
 
     ohai "You have set:"

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -488,5 +488,10 @@ module Homebrew
     def automatically_set_no_install_from_api?
       ENV["HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API"].present?
     end
+
+    sig { returns(T::Boolean) }
+    def install_from_api_unsupported?
+      ENV["HOMEBREW_INSTALL_FROM_API_UNSUPPORTED"].present?
+    end
   end
 end


### PR DESCRIPTION
When we're automatically setting `HOMEBREW_NO_INSTALL_FROM_API` when on an old macOS version or with a non-default prefix (e.g. cases where you're going to be mostly building from source).

My initial plan was to set `HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API` in these cases but it's used differently enough it made sense to add another internal variable instead: `HOMEBREW_INSTALL_FROM_API_UNSUPPORTED`.

At the moment this is only used to avoid printing the "You have set `HOMEBREW_NO_INSTALL_FROM_API`" message inside `brew update` but may make sense to use in other places over time.

Ideally, we'll get rid of these automatic sets of `HOMEBREW_NO_INSTALL_FROM_API` and perhaps even the variable entirely.