### PR TITLE
keg_relocate: fix all text files being marked as changed

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -424,6 +424,7 @@ class GitHubPackages
     end
 
     index_json_sha256, index_json_size = write_image_index(manifests, blobs, formula_annotations_hash)
+    raise "Image index too large!" if index_json_size >= 4 * 1024 * 1024 # GitHub will error 500 if too large
 
     write_index_json(index_json_sha256, index_json_size, root,
                      "org.opencontainers.image.ref.name" => version_rebuild)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -34,7 +34,7 @@ class Keg
       @replacement_map.fetch(key)
     end
 
-    sig { params(text: String).void }
+    sig { params(text: String).returns(T::Boolean) }
     def replace_text(text)
       replacements = @replacement_map.values.to_h
 
@@ -47,7 +47,7 @@ class Keg
         changed = text.gsub!(key, replacements[key])
         any_changed ||= changed
       end
-      any_changed
+      !any_changed.nil?
     end
 
     sig { params(path: T.any(String, Regexp)).returns(Regexp) }


### PR DESCRIPTION
This was wildly inflating our image indexes.

Also add an abort before upload if the image index is >= 4MB (assuming 1024 * 1024 bytes = MB here).