### PR TITLE
formula_installer: use cached fetched formula instance when available

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -96,6 +96,9 @@ class FormulaInstaller
     @requirement_messages = []
     @poured_bottle = false
     @start_time = nil
+
+    # Take the original formula instance, which might have been swapped from an API instance to a source instance
+    @formula = previously_fetched_formula if previously_fetched_formula
   end
 
   def self.attempted
@@ -1179,9 +1182,17 @@ on_request: installed_on_request?, options: options)
     deps.each { |dep, _options| fetch_dependency(dep) }
   end
 
+  sig { returns(T.nilable(Formula)) }
+  def previously_fetched_formula
+    # We intentionally don't compare classes here.
+    self.class.fetched.find do |fetched_formula|
+      fetched_formula.full_name == formula.full_name && fetched_formula.active_spec_sym == formula.active_spec_sym
+    end
+  end
+
   sig { void }
   def fetch
-    return if self.class.fetched.include?(formula)
+    return if previously_fetched_formula
 
     fetch_dependencies
 


### PR DESCRIPTION
Had just about enough energy to get this one done tonight too.

We detect whether we want an API formula or need a Ruby source formula fairly late on (after the formula installer has been first created), so we swap the formula instance within the installer.

Unfortunately, dependencies use separate instances of the installer for their fetch and install stages so we can't rely on the `fetch` method being called like we could normally. The dependency handling should probably be refactored to not create separate instances like that as it'll eliminate these type of bugs occurring in the future (or we alternatively commit to separate fetcher and installer classes), as well as help tackle the growingly fragile amount of assumptions FormulaInstaller currently has on the way it is called (e.g. some steps are incorrectly cached without considering some options, but we get away with it based on how things are set up on the CLI side and how things like formula options are rarely used in complex dependency trees). But that's a non-trivial task that I definitely won't have time for this week.

Fixes https://github.com/Homebrew/brew/pull/15765#issuecomment-1652856355