### PR TITLE
`brew update` core/homebrew-cask taps properly

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -313,11 +313,11 @@ auto-update() {
     repo_fetch_heads=("${HOMEBREW_REPOSITORY}/.git/FETCH_HEAD")
     # We might have done an auto-update recently, but not a core/cask clone auto-update.
     # So we check the core/cask clone FETCH_HEAD too.
-    if [[ -n "${HOMEBREW_UPDATE_CORE_TAP}" && -d "${HOMEBREW_CORE_REPOSITORY}/.git" ]]
+    if [[ -n "${HOMEBREW_AUTO_UPDATE_CORE_TAP}" && -d "${HOMEBREW_CORE_REPOSITORY}/.git" ]]
     then
       repo_fetch_heads+=("${HOMEBREW_CORE_REPOSITORY}/.git/FETCH_HEAD")
     fi
-    if [[ -n "${HOMEBREW_UPDATE_CASK_TAP}" && -d "${HOMEBREW_CASK_REPOSITORY}/.git" ]]
+    if [[ -n "${HOMEBREW_AUTO_UPDATE_CASK_TAP}" && -d "${HOMEBREW_CASK_REPOSITORY}/.git" ]]
     then
       repo_fetch_heads+=("${HOMEBREW_CASK_REPOSITORY}/.git/FETCH_HEAD")
     fi
@@ -365,8 +365,8 @@ auto-update() {
   unset AUTO_UPDATE_COMMANDS
   unset AUTO_UPDATE_CORE_TAP_COMMANDS
   unset AUTO_UPDATE_CASK_TAP_COMMANDS
-  unset HOMEBREW_UPDATE_CORE_TAP
-  unset HOMEBREW_UPDATE_CASK_TAP
+  unset HOMEBREW_AUTO_UPDATE_CORE_TAP
+  unset HOMEBREW_AUTO_UPDATE_CASK_TAP
 }
 
 #####
@@ -877,7 +877,9 @@ AUTO_UPDATE_CORE_TAP_COMMANDS=(
 if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_CORE_TAP_COMMANDS[@]}"
 then
   export HOMEBREW_AUTO_UPDATE_COMMAND="1"
-  export HOMEBREW_UPDATE_CORE_TAP="1"
+  export HOMEBREW_AUTO_UPDATE_CORE_TAP="1"
+else
+  unset HOMEBREW_AUTO_UPDATE_CORE_TAP
 fi
 
 # Check for commands that should auto-update the homebrew-cask tap.
@@ -889,7 +891,9 @@ AUTO_UPDATE_CASK_TAP_COMMANDS=(
 if check-array-membership "${HOMEBREW_COMMAND}" "${AUTO_UPDATE_CASK_TAP_COMMANDS[@]}"
 then
   export HOMEBREW_AUTO_UPDATE_COMMAND="1"
-  export HOMEBREW_UPDATE_CASK_TAP="1"
+  export HOMEBREW_AUTO_UPDATE_CASK_TAP="1"
+else
+  unset HOMEBREW_AUTO_UPDATE_CORE_TAP
 fi
 
 # Disable Ruby options we don't need.

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -581,9 +581,10 @@ EOS
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
     if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]] &&
-       [[ -z "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_DEV_CMD_RUN}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
-       [[ ("${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" && -z "${HOMEBREW_UPDATE_CORE_TAP}") ||
-          ("${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" && -z "${HOMEBREW_UPDATE_CASK_TAP}") ]]
+       [[ -n "${HOMEBREW_UPDATE_AUTO}" || (-z "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_DEV_CMD_RUN}") ]] &&
+       [[ -n "${HOMEBREW_UPDATE_AUTO}" &&
+          (("${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" && -z "${HOMEBREW_AUTO_UPDATE_CORE_TAP}") ||
+          ("${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" && -z "${HOMEBREW_AUTO_UPDATE_CASK_TAP}")) ]]
     then
       continue
     fi
@@ -743,9 +744,10 @@ EOS
   for DIR in "${HOMEBREW_REPOSITORY}" "${HOMEBREW_LIBRARY}"/Taps/*/*
   do
     if [[ -z "${HOMEBREW_NO_INSTALL_FROM_API}" ]] &&
-       [[ -z "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_DEV_CMD_RUN}" || -n "${HOMEBREW_UPDATE_AUTO}" ]] &&
-       [[ ("${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" && -z "${HOMEBREW_UPDATE_CORE_TAP}") ||
-          ("${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" && -z "${HOMEBREW_UPDATE_CASK_TAP}") ]]
+       [[ -n "${HOMEBREW_UPDATE_AUTO}" || (-z "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_DEV_CMD_RUN}") ]] &&
+       [[ -n "${HOMEBREW_UPDATE_AUTO}" &&
+          (("${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" && -z "${HOMEBREW_AUTO_UPDATE_CORE_TAP}") ||
+          ("${DIR}" == "${HOMEBREW_CASK_REPOSITORY}" && -z "${HOMEBREW_AUTO_UPDATE_CASK_TAP}")) ]]
     then
       continue
     fi


### PR DESCRIPTION
The existing logic in `update.sh` was both a bit hard to follow and had some edge cases. Fix this up for improving #15775.