### PR TITLE
post_install: improvements and fixes.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -826,6 +826,7 @@ case "${HOMEBREW_COMMAND}" in
   ln) HOMEBREW_COMMAND="link" ;;
   instal) HOMEBREW_COMMAND="install" ;; # gem does the same
   uninstal) HOMEBREW_COMMAND="uninstall" ;;
+  post_install) HOMEBREW_COMMAND="postinstall" ;;
   rm) HOMEBREW_COMMAND="uninstall" ;;
   remove) HOMEBREW_COMMAND="uninstall" ;;
   abv) HOMEBREW_COMMAND="info" ;;

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -28,6 +28,8 @@ module Homebrew
       if f.post_install_defined?
         fi = FormulaInstaller.new(f, **{ debug: args.debug?, quiet: args.quiet?, verbose: args.verbose? }.compact)
         fi.post_install
+      else
+        opoo "#{f}: no `post_install` method was defined in the formula!"
       end
     end
   end

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -12,23 +12,24 @@ module Commands
   # If you are going to change anything in below hash,
   # be sure to also update appropriate case statement in brew.sh
   HOMEBREW_INTERNAL_COMMAND_ALIASES = {
-    "ls"          => "list",
-    "homepage"    => "home",
-    "-S"          => "search",
-    "up"          => "update",
-    "ln"          => "link",
-    "instal"      => "install", # gem does the same
-    "uninstal"    => "uninstall",
-    "rm"          => "uninstall",
-    "remove"      => "uninstall",
-    "abv"         => "info",
-    "dr"          => "doctor",
-    "--repo"      => "--repository",
-    "environment" => "--env",
-    "--config"    => "config",
-    "-v"          => "--version",
-    "lc"          => "livecheck",
-    "tc"          => "typecheck",
+    "ls"           => "list",
+    "homepage"     => "home",
+    "-S"           => "search",
+    "up"           => "update",
+    "ln"           => "link",
+    "instal"       => "install", # gem does the same
+    "uninstal"     => "uninstall",
+    "post_install" => "postinstall",
+    "rm"           => "uninstall",
+    "remove"       => "uninstall",
+    "abv"          => "info",
+    "dr"           => "doctor",
+    "--repo"       => "--repository",
+    "environment"  => "--env",
+    "--config"     => "config",
+    "-v"           => "--version",
+    "lc"           => "livecheck",
+    "tc"           => "typecheck",
   }.freeze
   # This pattern is used to split descriptions at full stops. We only consider a
   # dot as a full stop if it is either followed by a whitespace or at the end of

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1651,6 +1651,23 @@ _brew_pin() {
   __brew_complete_installed_formulae
 }
 
+_brew_post_install() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "${cur}" in
+    -*)
+      __brewcomp "
+      --debug
+      --help
+      --quiet
+      --verbose
+      "
+      return
+      ;;
+    *) ;;
+  esac
+  __brew_complete_installed_formulae
+}
+
 _brew_postgresql_upgrade_database() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "${cur}" in
@@ -2713,6 +2730,7 @@ _brew() {
     options) _brew_options ;;
     outdated) _brew_outdated ;;
     pin) _brew_pin ;;
+    post_install) _brew_post_install ;;
     postgresql-upgrade-database) _brew_postgresql_upgrade_database ;;
     postinstall) _brew_postinstall ;;
     pr-automerge) _brew_pr_automerge ;;

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1134,6 +1134,14 @@ __fish_brew_complete_arg 'pin' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'pin' -a '(__fish_brew_suggest_formulae_installed)'
 
 
+__fish_brew_complete_cmd 'post_install' 'Rerun the post-install steps for formula'
+__fish_brew_complete_arg 'post_install' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'post_install' -l help -d 'Show this message'
+__fish_brew_complete_arg 'post_install' -l quiet -d 'Make some output more quiet'
+__fish_brew_complete_arg 'post_install' -l verbose -d 'Make some output more verbose'
+__fish_brew_complete_arg 'post_install' -a '(__fish_brew_suggest_formulae_installed)'
+
+
 __fish_brew_complete_cmd 'postgresql-upgrade-database' 'Upgrades the database for the `postgresql` formula'
 __fish_brew_complete_arg 'postgresql-upgrade-database' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'postgresql-upgrade-database' -l help -d 'Show this message'

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -68,6 +68,7 @@ nodenv-sync
 options
 outdated
 pin
+post_install
 postgresql-upgrade-database
 postinstall
 pr-automerge

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -22,6 +22,7 @@ __brew_list_aliases() {
     ln link
     instal install
     uninstal uninstall
+    post_install postinstall
     rm uninstall
     remove uninstall
     abv info
@@ -1395,6 +1396,17 @@ _brew_outdated() {
 
 # brew pin
 _brew_pin() {
+  _arguments \
+    '--debug[Display any debugging information]' \
+    '--help[Show this message]' \
+    '--quiet[Make some output more quiet]' \
+    '--verbose[Make some output more verbose]' \
+    - installed_formula \
+    '*::installed_formula:__brew_installed_formulae'
+}
+
+# brew post_install
+_brew_post_install() {
   _arguments \
     '--debug[Display any debugging information]' \
     '--help[Show this message]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -533,7 +533,7 @@ issuing the `brew upgrade` *`formula`* command. See also `unpin`.
 
 Upgrades the database for the `postgresql` formula.
 
-### `postinstall` *`installed_formula`* [...]
+### `postinstall`, `post_install` *`installed_formula`* [...]
 
 Rerun the post-install steps for *`formula`*.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -746,7 +746,7 @@ Pin the specified \fIformula\fR, preventing them from being upgraded when issuin
 .SS "\fBpostgresql\-upgrade\-database\fR"
 Upgrades the database for the \fBpostgresql\fR formula\.
 .
-.SS "\fBpostinstall\fR \fIinstalled_formula\fR [\.\.\.]"
+.SS "\fBpostinstall\fR, \fBpost_install\fR \fIinstalled_formula\fR [\.\.\.]"
 Rerun the post\-install steps for \fIformula\fR\.
 .
 .SS "\fBpyenv\-sync\fR"


### PR DESCRIPTION
- warn if running `brew postinstall` explicitly and there's no `post_install` defined in the formula
- add a `post_install` alias for `brew postinstall` to make life easier for those jumping between `postinstall` and `post_install` in e.g. Homebrew development
- refactor `post_install` formula path logic into a new method for improved readability
- handle the JSON API `post_install` formula path case

Fixes https://github.com/Homebrew/brew/issues/15775