### PR TITLE
Update .editorconfig for golang

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,7 @@ insert_final_newline = false
 [**.md]
 trim_trailing_whitespace = true
 x-soft-wrap-text = true
+
+[*.go]
+indent_style = tab
+tab_width = 2


### PR DESCRIPTION
To view golang source code using the correct format. According to Effective Go (https://go.dev/doc/effective_go) states, tabs are used for indentation and gofmt emits them by default.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
