### PR TITLE
docs: Fix GithubReleases strategy block example

### DIFF
--- a/docs/Brew-Livecheck.md
+++ b/docs/Brew-Livecheck.md
@@ -176,7 +176,7 @@ livecheck do
     json.map do |release|
       next if release["draft"] || release["prerelease"]
 
-      match = json["tag_name"]&.match(regex)
+      match = release["tag_name"]&.match(regex)
       next if match.blank?
 
       match[1]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `strategy` block example for `GithubReleases` in the `brew livecheck` documentation should be using `release` inside the `#map` block. I accidentally overlooked one instance of `json` when adapting the code from the `GithubLatest` example above it, so this PR addresses the issue.