### PR TITLE
Allow configuring Homebrew with `.env` files

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -241,8 +241,9 @@ module Homebrew
       HOMEBREW_LIVECHECK_WATCHLIST:              {
         description:  "Consult this file for the list of formulae to check by default when no formula argument " \
                       "is passed to `brew livecheck`.",
-        default_text: "`$HOME/.brew_livecheck_watchlist`",
-        default:      "~/.brew_livecheck_watchlist",
+        default_text: "`$XDG_CONFIG_HOME/homebrew/livecheck_watchlist.txt` if `$XDG_CONFIG_HOME` is set " \
+                      "or `$HOME/.homebrew/livecheck_watchlist.txt` otherwise.",
+        default:      "#{ENV.fetch("HOMEBREW_USER_CONFIG_HOME")}/livecheck_watchlist.txt",
       },
       HOMEBREW_LOGS:                             {
         description:  "Use this directory to store log files.",
@@ -361,6 +362,11 @@ module Homebrew
       HOMEBREW_SVN:                              {
         description:  "Use this as the `svn`(1) binary.",
         default_text: "A Homebrew-built Subversion (if installed), or the system-provided binary.",
+      },
+      HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY:        {
+        description: "If set in Homebrew's system-wide environment file (`/etc/homebrew/brew.env`), " \
+                     "the system-wide environment file will be loaded last to override any prefix or user settings.",
+        boolean:     true,
       },
       HOMEBREW_TEMP:                             {
         description:  "Use this path as the temporary directory for building packages. Changing " \

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -144,6 +144,20 @@ Note that environment variables must have a value set to be detected. For
 example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 `export HOMEBREW_NO_INSECURE_REDIRECT`.
 
+`HOMEBREW_*` environment variables can also be set in Homebrew's environment
+files:
+
+* `/etc/homebrew/brew.env` (system-wide)
+
+* `$HOMEBREW_PREFIX/etc/homebrew/brew.env` (prefix-specific)
+
+* `$XDG_CONFIG_HOME/homebrew/brew.env` if `$XDG_CONFIG_HOME` is set or
+  `$HOME/.homebrew/brew.env` otherwise (user-specific)
+
+User-specific environment files take precedence over prefix-specific files and
+prefix-specific files take precedence over system-wide files (unless
+`HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY` is set, see below).
+
 <%= environment_variables %>
 
 ## USING HOMEBREW BEHIND A PROXY

--- a/bin/brew
+++ b/bin/brew
@@ -68,11 +68,60 @@ then
   then
     HOMEBREW_PREFIX="/usr/local"
   fi
+  unset USR_LOCAL_BREW_FILE_DIRECTORY USR_LOCAL_HOMEBREW_REPOSITORY
 fi
+
+unset BREW_FILE_DIRECTORY
 
 # If the location of HOMEBREW_LIBRARY changes
 # keg_relocate.rb, formula_cellar_checks.rb, and test/global_spec.rb need to change.
 HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
+
+# Load Homebrew's variable configuration files from disk.
+# First, load the system-wide configuration.
+if [[ -f "/etc/homebrew/brew.env" ]]
+then
+  unset SYSTEM_ENV_TAKES_PRIORITY
+  # only load HOMEBREW_*=* lines
+  SYSTEM_HOMEBREW_ENV="$(grep -E '^HOMEBREW_[A-Z_]+=.*$' "/etc/homebrew/brew.env")"
+  if [[ -n "${HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY-}" ]]
+  then
+    SYSTEM_ENV_TAKES_PRIORITY="1"
+  else
+    eval "${SYSTEM_HOMEBREW_ENV}"
+  fi
+fi
+
+# Next, load the prefix configuration
+if [[ -f "${HOMEBREW_PREFIX}/etc/homebrew/brew.env" ]]
+then
+  # only load HOMEBREW_*=* lines
+  PREFIX_HOMEBREW_ENV="$(grep -E '^HOMEBREW_[A-Z_]+=.*$' "${HOMEBREW_PREFIX}/etc/homebrew/brew.env")"
+  eval "${PREFIX_HOMEBREW_ENV}"
+  unset PREFIX_HOMEBREW_ENV
+fi
+
+# Finally, load the user configuration
+if [[ -n "${XDG_CONFIG_HOME-}" ]]
+then
+  HOMEBREW_USER_CONFIG_HOME="${XDG_CONFIG_HOME}/homebrew"
+else
+  HOMEBREW_USER_CONFIG_HOME="${HOME}/.homebrew"
+fi
+if [[ -f "${HOMEBREW_USER_CONFIG_HOME}/brew.env" ]]
+then
+  # only load HOMEBREW_*=* lines
+  USER_HOMEBREW_ENV="$(grep -E '^HOMEBREW_[A-Z_]+=.*$' "${HOMEBREW_USER_CONFIG_HOME}/brew.env")"
+  eval "${USER_HOMEBREW_ENV}"
+  unset USER_HOMEBREW_ENV
+fi
+
+# If the system configuration takes priority, load it last.
+if [[ -n "${SYSTEM_ENV_TAKES_PRIORITY-}" ]]
+then
+  eval "${SYSTEM_HOMEBREW_ENV}"
+fi
+unset SYSTEM_HOMEBREW_ENV
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
@@ -121,6 +170,7 @@ export HOMEBREW_BREW_FILE
 export HOMEBREW_PREFIX
 export HOMEBREW_REPOSITORY
 export HOMEBREW_LIBRARY
+export HOMEBREW_USER_CONFIG_HOME
 
 # set from user environment
 # shellcheck disable=SC2154

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1332,7 +1332,7 @@ Check for newer versions of formulae and/or casks from upstream.
 
 If no formula or cask argument is passed, the list of formulae and
 casks to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST` or
-`~/.brew_livecheck_watchlist`.
+`~/.homebrew/livecheck_watchlist.txt`.
 
 * `--full-name`:
   Print formulae and casks with fully-qualified names.
@@ -2059,6 +2059,20 @@ Note that environment variables must have a value set to be detected. For
 example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 `export HOMEBREW_NO_INSECURE_REDIRECT`.
 
+`HOMEBREW_*` environment variables can also be set in Homebrew's environment
+files:
+
+* `/etc/homebrew/brew.env` (system-wide)
+
+* `$HOMEBREW_PREFIX/etc/homebrew/brew.env` (prefix-specific)
+
+* `$XDG_CONFIG_HOME/homebrew/brew.env` if `$XDG_CONFIG_HOME` is set or
+  `$HOME/.homebrew/brew.env` otherwise (user-specific)
+
+User-specific environment files take precedence over prefix-specific files and
+prefix-specific files take precedence over system-wide files (unless
+`HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY` is set, see below).
+
 - `HOMEBREW_API_DOMAIN`
   <br>Use this URL as the download mirror for Homebrew JSON API. If metadata files at that URL are temporarily unavailable, the default API domain will be used as a fallback mirror.
 
@@ -2243,7 +2257,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_LIVECHECK_WATCHLIST`
   <br>Consult this file for the list of formulae to check by default when no formula argument is passed to `brew livecheck`.
 
-  *Default:* `$HOME/.brew_livecheck_watchlist`
+  *Default:* `$XDG_CONFIG_HOME/homebrew/livecheck_watchlist.txt` if `$XDG_CONFIG_HOME` is set or `$HOME/.homebrew/livecheck_watchlist.txt` otherwise.
 
 - `HOMEBREW_LOGS`
   <br>Use this directory to store log files.
@@ -2327,6 +2341,9 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>Use this as the `svn`(1) binary.
 
   *Default:* A Homebrew-built Subversion (if installed), or the system-provided binary.
+
+- `HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY`
+  <br>If set in Homebrew's system-wide environment file (`/etc/homebrew/brew.env`), the system-wide environment file will be loaded last to override any prefix or user settings.
 
 - `HOMEBREW_TEMP`
   <br>Use this path as the temporary directory for building packages. Changing this may be needed if your system temporary directory and Homebrew prefix are on different volumes, as macOS has trouble moving symlinks across volumes when the target does not yet exist. This issue typically occurs when using FileVault or custom SSD configurations.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1900,7 +1900,7 @@ Print the cached linkage values stored in \fBHOMEBREW_CACHE\fR, set by a previou
 Check for newer versions of formulae and/or casks from upstream\.
 .
 .P
-If no formula or cask argument is passed, the list of formulae and casks to check is taken from \fBHOMEBREW_LIVECHECK_WATCHLIST\fR or \fB~/\.brew_livecheck_watchlist\fR\.
+If no formula or cask argument is passed, the list of formulae and casks to check is taken from \fBHOMEBREW_LIVECHECK_WATCHLIST\fR or \fB~/\.homebrew/livecheck_watchlist\.txt\fR\.
 .
 .TP
 \fB\-\-full\-name\fR
@@ -2935,6 +2935,23 @@ Many Homebrew Cask commands accept one or more \fIcask\fR arguments\. These can 
 .SH "ENVIRONMENT"
 Note that environment variables must have a value set to be detected\. For example, run \fBexport HOMEBREW_NO_INSECURE_REDIRECT=1\fR rather than just \fBexport HOMEBREW_NO_INSECURE_REDIRECT\fR\.
 .
+.P
+\fBHOMEBREW_*\fR environment variables can also be set in Homebrew\'s environment files:
+.
+.IP "\(bu" 4
+\fB/etc/homebrew/brew\.env\fR (system\-wide)
+.
+.IP "\(bu" 4
+\fB$HOMEBREW_PREFIX/etc/homebrew/brew\.env\fR (prefix\-specific)
+.
+.IP "\(bu" 4
+\fB$XDG_CONFIG_HOME/homebrew/brew\.env\fR if \fB$XDG_CONFIG_HOME\fR is set or \fB$HOME/\.homebrew/brew\.env\fR otherwise (user\-specific)
+.
+.IP "" 0
+.
+.P
+User\-specific environment files take precedence over prefix\-specific files and prefix\-specific files take precedence over system\-wide files (unless \fBHOMEBREW_SYSTEM_ENV_TAKES_PRIORITY\fR is set, see below)\.
+.
 .TP
 \fBHOMEBREW_API_DOMAIN\fR
 .
@@ -3281,7 +3298,7 @@ Print this text before the installation summary of each successful build\.
 Consult this file for the list of formulae to check by default when no formula argument is passed to \fBbrew livecheck\fR\.
 .
 .IP
-\fIDefault:\fR \fB$HOME/\.brew_livecheck_watchlist\fR
+\fIDefault:\fR \fB$XDG_CONFIG_HOME/homebrew/livecheck_watchlist\.txt\fR if \fB$XDG_CONFIG_HOME\fR is set or \fB$HOME/\.homebrew/livecheck_watchlist\.txt\fR otherwise\.
 .
 .TP
 \fBHOMEBREW_LOGS\fR
@@ -3441,6 +3458,12 @@ Use this as the \fBsvn\fR(1) binary\.
 .
 .IP
 \fIDefault:\fR A Homebrew\-built Subversion (if installed), or the system\-provided binary\.
+.
+.TP
+\fBHOMEBREW_SYSTEM_ENV_TAKES_PRIORITY\fR
+.
+.br
+If set in Homebrew\'s system\-wide environment file (\fB/etc/homebrew/brew\.env\fR), the system\-wide environment file will be loaded last to override any prefix or user settings\.
 .
 .TP
 \fBHOMEBREW_TEMP\fR


### PR DESCRIPTION
For a long time people have requested some sort of configuration files for Homebrew. Now: here's the first version of that.

Similarly to how you can configure Git for a system, a repository or a user: you can configure Homebrew for a system, a prefix or a user.

The system-wide configuration file is `/etc/homebrew/brew.env`, the prefix-specific configuration file is `$HOMEBREW_PREFIX/etc/homebrew/brew.env` and the user-specific configuration file is `~/.homebrew/brew.env`.

As we need to read these files from Bash in `bin/brew` (so they can) influence functionality ASAP: they are in a simple format that Bash can read. It may be that we have more complex array or hash data in future that's configured through JSON or YAML (most likely JSON as we use it more) and stored in a `brew.json`/`brew.yaml` file in the same directory.

As this is relying on `eval` in Bash which is fairly dangerous: we filter the lines with a regex to ensure we're only permitting setting `HOMEBREW_*` variables and nothing more.

To give a bit of power to system administrators, the `HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY` variable can be set in `/etc/homebrew/brew.env` to ensure that the system-wide configuration file is loaded last and overrides any prefix or user settings.

Now that we have an actual location for configuration files, let's also change the `brew livecheck` watchlist configuration file to be in this directory and deprecate the existing location. As this is a developer command and the mitigation is to just move the file: we don't need to follow the normal deprecation process here.