### PR TITLE
config: fallback to ::OS_VERSION

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -19,7 +19,7 @@ module OS
         end
       elsif (redhat_release = Pathname.new("/etc/redhat-release")).readable?
         redhat_release.read.chomp
-      elsif ::OS_VERSION and ! ::OS_VERSION.empty?
+      elsif ::OS_VERSION.present?
         ::OS_VERSION
       else
         "Unknown"

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -19,6 +19,8 @@ module OS
         end
       elsif (redhat_release = Pathname.new("/etc/redhat-release")).readable?
         redhat_release.read.chomp
+      elsif ::OS_VERSION and ! ::OS_VERSION.empty?
+        ::OS_VERSION
       else
         "Unknown"
       end


### PR DESCRIPTION
In Linux systems where lsb_release is not available by default, `brew config` now falls back to `PRETTY_NAME` (`HOMEBREW_OS_VERSION`).

Before:
```console
$ brew config
HOMEBREW_VERSION: 4.1.2-30-gc346a5c
ORIGIN: https://github.com/Homebrew/brew
HEAD: c346a5c97adef16fcc439b53cc6e757b64b71cb4
Last commit: 14 hours ago
Core tap JSON: 29 Jul 04:16 UTC
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_DISPLAY: :0
HOMEBREW_EDITOR: /usr/bin/nano
HOMEBREW_EVAL_ALL: set
HOMEBREW_MAKE_JOBS: 4
Homebrew Ruby: 2.6.10 => /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.10_1/bin/ruby
CPU: quad-core 64-bit skylake
Clang: N/A
Git: 2.41.0 => /bin/git
Curl: 8.2.1 => /bin/curl
Kernel: Linux 6.4.4-200.fc38.x86_64 x86_64 GNU/Linux
OS: Unknown
Host glibc: 2.37
/usr/bin/gcc: 13.1.1
/usr/bin/ruby: N/A
glibc: N/A
gcc@11: N/A
gcc: N/A
xorg: N/A
```

After:
```console
$ brew config
HOMEBREW_VERSION: 4.1.2-30-gc346a5c-dirty
ORIGIN: https://github.com/Homebrew/brew
HEAD: c346a5c97adef16fcc439b53cc6e757b64b71cb4
Last commit: 14 hours ago
Core tap JSON: 29 Jul 04:37 UTC
HOMEBREW_PREFIX: /home/linuxbrew/.linuxbrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_DISPLAY: :0
HOMEBREW_EDITOR: /usr/bin/nano
HOMEBREW_EVAL_ALL: set
HOMEBREW_MAKE_JOBS: 4
Homebrew Ruby: 2.6.10 => /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.10_1/bin/ruby
CPU: quad-core 64-bit skylake
Clang: N/A
Git: 2.41.0 => /bin/git
Curl: 8.2.1 => /bin/curl
Kernel: Linux 6.4.4-200.fc38.x86_64 x86_64 GNU/Linux
OS: Arch Linux
Host glibc: 2.37
/usr/bin/gcc: 13.1.1
/usr/bin/ruby: N/A
glibc: N/A
gcc@11: N/A
gcc: N/A
xorg: N/A
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I do not believe the `brew tests` failures are related to the change.

<details>
<summary> brew tests </summary>
<pre>
$ brew tests
Randomized with seed 56127
4 processes for 355 specs, ~ 88 specs per process
................................................................................................................................................................................................................****....F......F..................F.................................................F..........F.........................................................F...............FF..FFFF.................F................................F......FFFFFF...........................................F.......................FF.......................................F....................................................................F..........................F.......F........................F.........................................FF...........................................FF.................................................................F..................................................................................F..FFF...FF.F.F..F................F..F......................................................F...................................................................................F.............F..............................................F.........................F...............................................................................................................********.................................................................................................................................................................................................................................................................................................................................................................................................................................................**......................................................................................................................................................................*..................................................F......F..F.............................F..........F.FF...F.FFF.................FFFF....F......................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) UnpackStrategy::Jar #extract
     # Unzip is not installed.
     # ./test/unpack_strategy/shared_examples.rb:12

  2) UnpackStrategy::Jar is correctly detected
     # Unzip is not installed.
     # ./test/unpack_strategy/shared_examples.rb:6

.
Failures:

  1) RuboCop::Cop::FormulaAudit::UsesFromMacos expect formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  2) RuboCop::Cop::FormulaAudit::UsesFromMacos cpio formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  3) RuboCop::Cop::FormulaAudit::UsesFromMacos bash formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  4) RuboCop::Cop::FormulaAudit::UsesFromMacos groff formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  5) RuboCop::Cop::FormulaAudit::UsesFromMacos vim formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  6) RuboCop::Cop::FormulaAudit::UsesFromMacos php formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  7) RuboCop::Cop::FormulaAudit::UsesFromMacos perl formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  8) RuboCop::Cop::FormulaAudit::UsesFromMacos mandoc formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  9) RuboCop::Cop::FormulaAudit::UsesFromMacos gzip formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  10) RuboCop::Cop::FormulaAudit::UsesFromMacos xz formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  11) RuboCop::Cop::FormulaAudit::UsesFromMacos openssl formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  12) RuboCop::Cop::FormulaAudit::UsesFromMacos git formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  13) RuboCop::Cop::FormulaAudit::UsesFromMacos less formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  14) RuboCop::Cop::FormulaAudit::UsesFromMacos python formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  15) RuboCop::Cop::FormulaAudit::UsesFromMacos rsync formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  16) RuboCop::Cop::FormulaAudit::UsesFromMacos zsh formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/uses_from_macos_spec.rb:20
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Failures:

  1) brew --prefix prints the prefix for a Formula
     Failure/Error:
       expect { brew_sh "--prefix", "wget" }
         .to output("#{ENV.fetch("HOMEBREW_PREFIX")}/opt/wget\n").to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     
          expected block to output "/home/linuxbrew/.linuxbrew/opt/wget\n" to stdout, but output nothing
     
       ...and:
     
             expected block to not output to stderr, but output "Error: No available formula with the name \"wget\".\n"
     
          ...and:
     
             expected #<Proc:0x000055e50e983868@/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test/cmd/--prefix_spec.rb:16> to be a success
     # ./test/cmd/--prefix_spec.rb:16:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:49:in `block (2 levels) in <top (required)>'
......................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Language::Python::Virtualenv::Virtualenv#create creates a venv
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:17

  2) Language::Python::Virtualenv::Virtualenv#pip_install works without build isolation
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:75

  3) Language::Python::Virtualenv::Virtualenv#pip_install accepts a Resource
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:62

  4) Language::Python::Virtualenv::Virtualenv#pip_install accepts an array
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:46

  5) Language::Python::Virtualenv::Virtualenv#pip_install accepts a multi-line strings
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:33

  6) Language::Python::Virtualenv::Virtualenv#pip_install accepts a string
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:24

  7) Language::Python::Virtualenv::Virtualenv#pip_install_and_link can link manpages
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:114

  8) Language::Python::Virtualenv::Virtualenv#pip_install_and_link can link scripts
     # Python is not installed.
     # ./test/language/python/virtualenv_spec.rb:91

  9) UnpackStrategy::Zip when unzip is available #extract
     # Unzip is not installed.
     # ./test/unpack_strategy/shared_examples.rb:12

..
Failures:

  1) RuboCop::Cop::FormulaAudit::ProvidedByMacos unzip formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  2) RuboCop::Cop::FormulaAudit::ProvidedByMacos berkeley-db formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  3) RuboCop::Cop::FormulaAudit::ProvidedByMacos tcl-tk formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  4) RuboCop::Cop::FormulaAudit::ProvidedByMacos apr formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  5) RuboCop::Cop::FormulaAudit::ProvidedByMacos ssh-copy-id formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  6) RuboCop::Cop::FormulaAudit::ProvidedByMacos libxcrypt formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  7) RuboCop::Cop::FormulaAudit::ProvidedByMacos cups formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  8) RuboCop::Cop::FormulaAudit::ProvidedByMacos zlib formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  9) RuboCop::Cop::FormulaAudit::ProvidedByMacos libressl formula exists
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
     
       expected true
            got false
     Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
     # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  10) RuboCop::Cop::FormulaAudit::ProvidedByMacos gperf formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  11) RuboCop::Cop::FormulaAudit::ProvidedByMacos libpcap formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  12) RuboCop::Cop::FormulaAudit::ProvidedByMacos libffi formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  13) RuboCop::Cop::FormulaAudit::ProvidedByMacos ncompress formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  14) RuboCop::Cop::FormulaAudit::ProvidedByMacos libiconv formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  15) RuboCop::Cop::FormulaAudit::ProvidedByMacos netcat formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  16) RuboCop::Cop::FormulaAudit::ProvidedByMacos swift formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  17) RuboCop::Cop::FormulaAudit::ProvidedByMacos llvm formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  18) RuboCop::Cop::FormulaAudit::ProvidedByMacos file-formula formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  19) RuboCop::Cop::FormulaAudit::ProvidedByMacos bc formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  20) RuboCop::Cop::FormulaAudit::ProvidedByMacos gnu-getopt formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  21) RuboCop::Cop::FormulaAudit::ProvidedByMacos expat formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  22) RuboCop::Cop::FormulaAudit::ProvidedByMacos zip formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  23) RuboCop::Cop::FormulaAudit::ProvidedByMacos ncurses formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  24) RuboCop::Cop::FormulaAudit::ProvidedByMacos libarchive formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  25) RuboCop::Cop::FormulaAudit::ProvidedByMacos sqlite formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  26) RuboCop::Cop::FormulaAudit::ProvidedByMacos bzip2 formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  27) RuboCop::Cop::FormulaAudit::ProvidedByMacos whois formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  28) RuboCop::Cop::FormulaAudit::ProvidedByMacos libxml2 formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  29) RuboCop::Cop::FormulaAudit::ProvidedByMacos pod2man formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  30) RuboCop::Cop::FormulaAudit::ProvidedByMacos ed formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  31) RuboCop::Cop::FormulaAudit::ProvidedByMacos bison formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  32) RuboCop::Cop::FormulaAudit::ProvidedByMacos unifdef formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  33) RuboCop::Cop::FormulaAudit::ProvidedByMacos openldap formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  34) RuboCop::Cop::FormulaAudit::ProvidedByMacos m4 formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  35) RuboCop::Cop::FormulaAudit::ProvidedByMacos net-snmp formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  36) RuboCop::Cop::FormulaAudit::ProvidedByMacos krb5 formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  37) RuboCop::Cop::FormulaAudit::ProvidedByMacos rpcgen formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  38) RuboCop::Cop::FormulaAudit::ProvidedByMacos libxslt formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  39) RuboCop::Cop::FormulaAudit::ProvidedByMacos lsof formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  40) RuboCop::Cop::FormulaAudit::ProvidedByMacos pax formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  41) RuboCop::Cop::FormulaAudit::ProvidedByMacos icu4c formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  42) RuboCop::Cop::FormulaAudit::ProvidedByMacos curl formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  43) RuboCop::Cop::FormulaAudit::ProvidedByMacos cyrus-sasl formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  44) RuboCop::Cop::FormulaAudit::ProvidedByMacos flex formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  45) RuboCop::Cop::FormulaAudit::ProvidedByMacos pcsc-lite formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  46) RuboCop::Cop::FormulaAudit::ProvidedByMacos dyld-headers formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  47) RuboCop::Cop::FormulaAudit::ProvidedByMacos libedit formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'

  48) RuboCop::Cop::FormulaAudit::ProvidedByMacos ruby formula exists
      Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
      
        expected true
             got false
      Shared Example Group: "formulae exist" called from ./test/rubocops/provided_by_macos_spec.rb:42
      # ./test/support/helper/spec/shared_examples/formulae_exist.rb:9:in `block (3 levels) in <top (required)>'
......................................................................................................................................................................................................................................................................................................................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) Language::Python#homebrew_site_packages returns the Homebrew site packages location
     # Python is not installed.
     # ./test/language/python_spec.rb:20

  2) Language::Python#major_minor_version returns a Version for Python 2
     # Python is not installed.
     # ./test/language/python_spec.rb:7

  3) Language::Python#user_site_packages can determine user site packages location
     # Python is not installed.
     # ./test/language/python_spec.rb:27

  4) Language::Python#site_packages gives a different location between PyPy and Python 2
     # Python is not installed.
     # ./test/language/python_spec.rb:14




Took 188 seconds (3:08)
Tests Failed
</pre>
</details>