### PR TITLE
docs: Requirements: add missing `ssh` for Arch Linux

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -70,7 +70,7 @@ To install build tools, paste at a terminal prompt:
 - **Arch Linux**
 
   ```sh
-  sudo pacman -Syu base-devel procps-ng curl file git
+  sudo pacman -Syu base-devel procps-ng curl file git openssh
   ```
 
 ### ARM (unsupported)


### PR DESCRIPTION
I'm not sure why, but sometimes `ssh` is needed to install Homebrew.

The commands for other distros do install `ssh`.

Logs:
```console
$ CI=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
Warning: Running in non-interactive mode because `$CI` is set.
==> Checking for `sudo` access (which may request your password)...
==> This script will install:
/home/linuxbrew/.linuxbrew/bin/brew
/home/linuxbrew/.linuxbrew/share/doc/homebrew
/home/linuxbrew/.linuxbrew/share/man/man1/brew.1
/home/linuxbrew/.linuxbrew/share/zsh/site-functions/_brew
/home/linuxbrew/.linuxbrew/etc/bash_completion.d/brew
/home/linuxbrew/.linuxbrew/Homebrew
==> /usr/bin/sudo /bin/chown -R dracula:dracula /home/linuxbrew/.linuxbrew/Homebrew
==> Found Git: /usr/sbin/git
==> Found cURL: /usr/sbin/curl
==> Setting HOMEBREW_DEVELOPER to use Git/cURL not in /usr/bin
==> Downloading and installing Homebrew...
error: cannot run ssh: No such file or directory
fatal: unable to fork
Failed during: /usr/sbin/git fetch --force origin
```

Note: this happens in `distrobox`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
