### PR TITLE
python: create venv's `--without-pip`

### DIFF
--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -15,8 +15,13 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
   describe "#create" do
     it "creates a venv" do
-      expect(formula).to receive(:system).with("python", "-m", "venv", "--system-site-packages", dir)
+      expect(formula).to receive(:system).with("python", "-m", "venv", "--system-site-packages", "--without-pip", dir)
       virtualenv.create
+    end
+
+    it "creates a venv with pip" do
+      expect(formula).to receive(:system).with("python", "-m", "venv", "--system-site-packages", dir)
+      virtualenv.create(without_pip: false)
     end
   end
 
@@ -25,7 +30,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(formula).to receive(:std_pip_args).with(prefix:          false,
                                                      build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "--std-pip-args", "foo")
+        .with("python", "-m", "pip", "--python=#{dir}/bin/python", "install", "--std-pip-args", "foo")
         .and_return(true)
       virtualenv.pip_install "foo"
     end
@@ -34,7 +39,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(formula).to receive(:std_pip_args).with(prefix:          false,
                                                      build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "--std-pip-args", "foo", "bar")
+        .with("python", "-m", "pip", "--python=#{dir}/bin/python", "install", "--std-pip-args", "foo", "bar")
         .and_return(true)
 
       virtualenv.pip_install <<~EOS
@@ -47,13 +52,13 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(formula).to receive(:std_pip_args).with(prefix:          false,
                                                      build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "--std-pip-args", "foo")
+        .with("python", "-m", "pip", "--python=#{dir}/bin/python", "install", "--std-pip-args", "foo")
         .and_return(true)
 
       expect(formula).to receive(:std_pip_args).with(prefix:          false,
                                                      build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "--std-pip-args", "bar")
+        .with("python", "-m", "pip", "--python=#{dir}/bin/python", "install", "--std-pip-args", "bar")
         .and_return(true)
 
       virtualenv.pip_install ["foo", "bar"]
@@ -66,7 +71,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(formula).to receive(:std_pip_args).with(prefix:          false,
                                                      build_isolation: true).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "--std-pip-args", Pathname.pwd)
+        .with("python", "-m", "pip", "--python=#{dir}/bin/python", "install", "--std-pip-args", Pathname.pwd)
         .and_return(true)
 
       virtualenv.pip_install res
@@ -76,7 +81,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(formula).to receive(:std_pip_args).with(prefix:          false,
                                                      build_isolation: false).and_return(["--std-pip-args"])
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "--std-pip-args", "foo")
+        .with("python", "-m", "pip", "--python=#{dir}/bin/python", "install", "--std-pip-args", "foo")
         .and_return(true)
       virtualenv.pip_install("foo", build_isolation: false)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Currently, `virtualenv_install_with_resources` creates a venv with a full copy of `pip`. This is pretty wasteful, since we really only need it at build time to install resources. Instead, we can:

1. Create a venv using [`--without-pip`](https://docs.python.org/3/library/venv.html#creating-virtual-environments)
2. Use `python@x.y`'s `pip` to install resources into this venv, using the [`--python` option](https://pip.pypa.io/en/stable/topics/python-option/#managing-a-different-python-interpreter)
3. Tangentially, remove all shell `activate` scripts (which admittedly doesn't save much but aren't necessary)

As a result, this saves ~7MB of disk space per venv:

```console
$ brew install black
...
==> Summary
🍺  /opt/homebrew/Cellar/black/23.7.0_1: 1,121 files, 13.5MB
$ brew reinstall -s black
...
==> Summary
🍺  /opt/homebrew/Cellar/black/23.7.0_1: 558 files, 6.6MB, built in 41 seconds
```

Note I don't foresee this causing any issues, but I've left an opt-out to be safe.
