### PR TITLE
workflows/build-pkg: install `gh`.

### DIFF
--- a/.github/workflows/build-pkg.yml
+++ b/.github/workflows/build-pkg.yml
@@ -162,6 +162,9 @@ jobs:
           name: Homebrew ${{ steps.print-version.outputs.version }}
           path: Homebrew-${{ steps.print-version.outputs.version }}.pkg
 
+      - name: Install gh
+        run: brew install gh
+
       - name: Upload installer to GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
Now that we're nuking and reinstalling Homebrew: need to install this too.