### PR TITLE
Deprecate `postgresql-upgrade-database`

### DIFF
--- a/Library/Homebrew/cmd/postgresql-upgrade-database.rb
+++ b/Library/Homebrew/cmd/postgresql-upgrade-database.rb
@@ -15,12 +15,17 @@ module Homebrew
       EOS
 
       named_args :none
+
+      hide_from_man_page!
     end
   end
 
   sig { void }
   def postgresql_upgrade_database
     postgresql_upgrade_database_args.parse
+
+    odeprecated "brew postgresql_upgrade_database",
+                "using new, versioned e.g. `var/postgres@14` datadir and `pg_upgrade`"
 
     name = "postgresql"
     pg = Formula[name]

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -529,10 +529,6 @@ information is displayed in interactive shells, and suppressed otherwise.
 Pin the specified *`formula`*, preventing them from being upgraded when
 issuing the `brew upgrade` *`formula`* command. See also `unpin`.
 
-### `postgresql-upgrade-database`
-
-Upgrades the database for the `postgresql` formula.
-
 ### `postinstall`, `post_install` *`installed_formula`* [...]
 
 Rerun the post-install steps for *`formula`*.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -743,9 +743,6 @@ Also include outdated casks including those with \fBauto_updates true\fR\.
 .SS "\fBpin\fR \fIinstalled_formula\fR [\.\.\.]"
 Pin the specified \fIformula\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR \fIformula\fR command\. See also \fBunpin\fR\.
 .
-.SS "\fBpostgresql\-upgrade\-database\fR"
-Upgrades the database for the \fBpostgresql\fR formula\.
-.
 .SS "\fBpostinstall\fR, \fBpost_install\fR \fIinstalled_formula\fR [\.\.\.]"
 Rerun the post\-install steps for \fIformula\fR\.
 .


### PR DESCRIPTION
This is an out-of-band deprecation but this command is broken and we're not going to fix it so it's not really worth a deprecation cycle.

See https://github.com/orgs/Homebrew/discussions/4685 and https://github.com/Homebrew/homebrew-core/pull/138201