### PR TITLE
formulary: fix type of `alias_path`

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -779,7 +779,7 @@ module Formulary
       rack:         Pathname,
       # Automatically resolves the formula's spec if not specified.
       spec:         Symbol,
-      alias_path:   Pathname,
+      alias_path:   T.any(Pathname, String),
       force_bottle: T::Boolean,
       flags:        T::Array[String],
     ).returns(Formula)
@@ -819,7 +819,7 @@ module Formulary
       keg:          Keg,
       # Automatically resolves the formula's spec if not specified.
       spec:         Symbol,
-      alias_path:   Pathname,
+      alias_path:   T.any(Pathname, String),
       force_bottle: T::Boolean,
       flags:        T::Array[String],
     ).returns(Formula)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`Formulary.from_rack` [only allows `alias_path` to be a `Pathname`](https://github.com/Homebrew/brew/blob/d2863d05b33177626e66fd4be75e92bcc3f14c99/Library/Homebrew/formulary.rb#L782). Make it happy with `String`s too.

Fixes:

    $ brew test openssl
    Error: Parameter 'alias_path': Expected type Pathname, got type String with value "/usr/local/Homebrew/Librar...homebrew-core/Aliases/openssl"
    Caller: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:113
    Definition: /usr/local/Homebrew/Library/Homebrew/formulary.rb:787
