### PR TITLE
utils/repology: update API URL

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -21,7 +21,7 @@ module Kernel
       Context.current.verbose?
     end
 
-    title = Tty.truncate(title) if $stdout.tty? && !verbose
+    title = Tty.truncate(title.to_s) if $stdout.tty? && !verbose
     Formatter.headline(title, color: :blue)
   end
 
@@ -50,7 +50,7 @@ module Kernel
       Context.current.verbose?
     end
 
-    title = Tty.truncate(title) if $stdout.tty? && !verbose && truncate == :auto
+    title = Tty.truncate(title.to_s) if $stdout.tty? && !verbose && truncate == :auto
     Formatter.headline(title, color: :green)
   end
 

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -29,8 +29,7 @@ module Repology
   end
 
   def self.single_package_query(name, repository:)
-    url = "https://repology.org/tools/project-by?repo=#{repository}&" \
-          "name_type=srcname&target_page=api_v1_project&name=#{name}"
+    url = "https://repology.org/api/v1/project/#{name}"
 
     output, errors, = curl_output("--location", "--silent", url.to_s, use_homebrew_curl: !curl_supports_tls13?)
 


### PR DESCRIPTION
The [Repology API](https://repology.org/api) has changed since our original implementation, but since it's been redirecting it hasn't been an issue for us until #15804 noted that packages like `bonnie++` weren't being checked by `brew bump`. With the original API scheme the fix would be to [URL-encode the plus sign characters](https://repology.org/tools/project-by?repo=homebrew&name_type=srcname&target_page=api_v1_project&name=bonnie%2B%2B), but simply updating the URL fixed it as well. 

(The current API unfortunately doesn't have the option of returning just the results for a single package in a single repository, so we've been wading through the results of every repository a given package is in, which has been slowing down the command considerably.)
```
$ brew bump --no-pull-requests --formula -d bonnie++
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/bonnie++.rb
/usr/bin/env /usr/local/opt/curl/bin/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.1.3-23-gd2863d0-dirty\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.13.6\)\ curl/7.54.0 --header Accept-Language:\ en --retry 3 --location --silent https://repology.org/api/v1/project/bonnie\+\+
==> bonnie++ is up to date!
Current formula version:  2.00a
Latest livecheck version: 2.00a
Latest Repology version:  2.00a
Open pull requests:       none
Closed pull requests:     none
```
Fixes #15804 (both mentioned issues).