### PR TITLE
Make `inreplace` a purely static method

### DIFF
--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -6,8 +6,6 @@ require "utils/inreplace"
 
 module Cask
   class Migrator
-    extend ::Utils::Inreplace
-
     attr_reader :old_cask, :new_cask
 
     sig { params(old_cask: Cask, new_cask: Cask).void }
@@ -74,7 +72,7 @@ module Cask
     def self.replace_caskfile_token(path, old_token, new_token)
       case path.extname
       when ".rb"
-        inreplace path, /\A\s*cask\s+"#{Regexp.escape(old_token)}"/, "cask #{new_token.inspect}"
+        ::Utils::Inreplace.inreplace path, /\A\s*cask\s+"#{Regexp.escape(old_token)}"/, "cask #{new_token.inspect}"
       when ".json"
         json = JSON.parse(path.read)
         json["token"] = new_token

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -59,7 +59,6 @@ require "extend/api_hashable"
 # end</pre>
 class Formula
   include FileUtils
-  include Utils::Inreplace
   include Utils::Shebang
   include Utils::Shell
   include Context
@@ -2563,7 +2562,7 @@ class Formula
     ).void
   }
   def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
-    super(paths, before, after, audit_result)
+    Utils::Inreplace.inreplace(paths, before, after, audit_result)
   rescue Utils::Inreplace::Error => e
     onoe e.to_s
     raise BuildError.new(self, "inreplace", Array(paths), {})

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2562,7 +2562,7 @@ class Formula
     ).void
   }
   def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
-    Utils::Inreplace.inreplace(paths, before, after, audit_result)
+    Utils::Inreplace.inreplace(paths, before, after, audit_result: audit_result)
   rescue Utils::Inreplace::Error => e
     onoe e.to_s
     raise BuildError.new(self, "inreplace", Array(paths), {})

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -18,8 +18,6 @@ module Utils
       end
     end
 
-    module_function
-
     # Sometimes we have to change a bit before we install. Mostly we
     # prefer a patch, but if you need the {Formula#prefix prefix} of
     # this formula in the patch you have to resort to `inreplace`,
@@ -45,7 +43,7 @@ module Utils
         audit_result: T::Boolean,
       ).void
     }
-    def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
+    def self.inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
       paths = Array(paths)
       after &&= after.to_s
       before = before.to_s if before.is_a?(Pathname)
@@ -73,7 +71,7 @@ module Utils
     end
 
     # @api private
-    def inreplace_pairs(path, replacement_pairs, read_only_run: false, silent: false)
+    def self.inreplace_pairs(path, replacement_pairs, read_only_run: false, silent: false)
       str = File.binread(path)
       contents = StringInreplaceExtension.new(str)
       replacement_pairs.each do |old, new|

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -43,7 +43,7 @@ module Utils
         audit_result: T::Boolean,
       ).void
     }
-    def self.inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
+    def self.inreplace(paths, before = nil, after = nil, audit_result: true)
       paths = Array(paths)
       after &&= after.to_s
       before = before.to_s if before.is_a?(Pathname)

--- a/Library/Homebrew/utils/inreplace.rbi
+++ b/Library/Homebrew/utils/inreplace.rbi
@@ -1,7 +1,0 @@
-# typed: strict
-
-module Utils
-  module Inreplace
-    include Kernel
-  end
-end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Small follow-up to https://github.com/Homebrew/brew/pull/15800 where I noticed `Formula` added `Utils::Inreplace` to its ancestor chain, but only referenced the namespace in one place. I think it's better to directly call the method there (line 2565):

- Humans/Sorbet can better identify the source of the `super` method
- Formula ancestor chain is simplified
- We can remove an `.rbi` file
- The `inreplace` api is more clear and consistent (`module_function`s make it unclear whether a namespace should be included or invoked statically)