### PR TITLE
package/Distribution: always require CLT.

### DIFF
--- a/package/Distribution.xml
+++ b/package/Distribution.xml
@@ -31,13 +31,13 @@
   </allowed-os-versions>
 
   <script>
+    // See https://developer.apple.com/documentation/installer_js
     function installation_check() {
-      if (system.files.fileExistsAtPath("/Library/Developer/CommandLineTools/usr/bin/git") ||
-          system.files.fileExistsAtPath("/Applications/Xcode.app/Contents/Developer/usr/bin/git")) {
+      if (system.files.fileExistsAtPath("/Library/Developer/CommandLineTools/usr/bin/git")) {
         return true;
       } else {
-        my.result.title = "Xcode Command Line Tools (CLT) are missing";
-        my.result.message = "You must install the Xcode Command Line Tools (CLT) or Xcode before installing Homebrew. Install the CLT by running `xcode-select --install` from a Terminal.";
+        my.result.title = "Command Line Tools (CLT) are missing";
+        my.result.message = "You must install the Command Line Tools (CLT) before installing Homebrew by running `xcode-select --install` from a Terminal.";
         my.result.type = "Fatal";
         return false;
       }


### PR DESCRIPTION
We always require it in `install.sh` and we need it for all but the latest version of macOS so this seems a simpler compromise.

Fixes #15802