### PR TITLE
Revert "Make `inreplace` a purely static method"

### DIFF
--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -6,6 +6,8 @@ require "utils/inreplace"
 
 module Cask
   class Migrator
+    extend ::Utils::Inreplace
+
     attr_reader :old_cask, :new_cask
 
     sig { params(old_cask: Cask, new_cask: Cask).void }
@@ -72,7 +74,7 @@ module Cask
     def self.replace_caskfile_token(path, old_token, new_token)
       case path.extname
       when ".rb"
-        ::Utils::Inreplace.inreplace path, /\A\s*cask\s+"#{Regexp.escape(old_token)}"/, "cask #{new_token.inspect}"
+        inreplace path, /\A\s*cask\s+"#{Regexp.escape(old_token)}"/, "cask #{new_token.inspect}"
       when ".json"
         json = JSON.parse(path.read)
         json["token"] = new_token

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -59,6 +59,7 @@ require "extend/api_hashable"
 # end</pre>
 class Formula
   include FileUtils
+  include Utils::Inreplace
   include Utils::Shebang
   include Utils::Shell
   include Context
@@ -2562,7 +2563,7 @@ class Formula
     ).void
   }
   def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
-    Utils::Inreplace.inreplace(paths, before, after, audit_result: audit_result)
+    super(paths, before, after, audit_result)
   rescue Utils::Inreplace::Error => e
     onoe e.to_s
     raise BuildError.new(self, "inreplace", Array(paths), {})

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -18,6 +18,8 @@ module Utils
       end
     end
 
+    module_function
+
     # Sometimes we have to change a bit before we install. Mostly we
     # prefer a patch, but if you need the {Formula#prefix prefix} of
     # this formula in the patch you have to resort to `inreplace`,
@@ -43,7 +45,7 @@ module Utils
         audit_result: T::Boolean,
       ).void
     }
-    def self.inreplace(paths, before = nil, after = nil, audit_result: true)
+    def inreplace(paths, before = nil, after = nil, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
       paths = Array(paths)
       after &&= after.to_s
       before = before.to_s if before.is_a?(Pathname)
@@ -71,7 +73,7 @@ module Utils
     end
 
     # @api private
-    def self.inreplace_pairs(path, replacement_pairs, read_only_run: false, silent: false)
+    def inreplace_pairs(path, replacement_pairs, read_only_run: false, silent: false)
       str = File.binread(path)
       contents = StringInreplaceExtension.new(str)
       replacement_pairs.each do |old, new|

--- a/Library/Homebrew/utils/inreplace.rbi
+++ b/Library/Homebrew/utils/inreplace.rbi
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Utils
+  module Inreplace
+    include Kernel
+  end
+end


### PR DESCRIPTION
`inreplace` with block doesn't work.


See https://github.com/Homebrew/brew/pull/15807#issuecomment-1664172239 and https://github.com/Homebrew/brew/pull/15807#issuecomment-1664196619

And an example of failure in homebrew-core: https://github.com/Homebrew/homebrew-core/pull/138421

Reverts Homebrew/brew#15807