### PR TITLE
development_tools: allow `Symbol`s to be `locate`d

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -6,7 +6,7 @@ require "version"
 # @private
 class DevelopmentTools
   class << self
-    sig { params(tool: String).returns(T.nilable(Pathname)) }
+    sig { params(tool: T.any(String, Symbol)).returns(T.nilable(Pathname)) }
     def locate(tool)
       # Don't call tools (cc, make, strip, etc.) directly!
       # Give the name of the binary you look for as a string to this method

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -3,7 +3,7 @@
 
 class DevelopmentTools
   class << self
-    sig { params(tool: String).returns(T.nilable(Pathname)) }
+    sig { params(tool: T.any(String, Symbol)).returns(T.nilable(Pathname)) }
     def locate(tool)
       (@locate ||= {}).fetch(tool) do |key|
         @locate[key] = if needs_build_formulae? &&

--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -10,7 +10,7 @@ class DevelopmentTools
     undef installed?, default_compiler, curl_handles_most_https_certificates?,
           subversion_handles_most_https_certificates?
 
-    sig { params(tool: String).returns(T.nilable(Pathname)) }
+    sig { params(tool: T.any(String, Symbol)).returns(T.nilable(Pathname)) }
     def locate(tool)
       (@locate ||= {}).fetch(tool) do |key|
         @locate[key] = if (located_tool = generic_locate(tool))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes error seen in Homebrew/homebrew-core#138452 ([formula](https://github.com/Homebrew/homebrew-core/blob/32b17878c7f64bacfbc3153a2495594378f6afae/Formula/mbedtls.rb#L47)). `DevelopmentTools.default_compiler` can return a `Symbol` like `:clang`. Make sure its result can be fed to `DevelopmentTools.locate`.
