### PR TITLE
Make more warnings quiet with environment hints disabled.

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -18,6 +18,8 @@ module FormulaCellarChecks
   def problem_if_output(output); end
 
   def check_env_path(bin)
+    return if Homebrew::EnvConfig.no_env_hints?
+
     # warn the user if stuff was installed outside of their PATH
     return unless bin.directory?
     return if bin.children.empty?

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -256,10 +256,12 @@ module Homebrew
       verbose: false
     )
       if Homebrew::EnvConfig.no_installed_dependents_check?
-        opoo <<~EOS
-          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK is set: not checking for outdated
-          dependents or dependents with broken linkage!
-        EOS
+        unless Homebrew::EnvConfig.no_env_hints?
+          opoo <<~EOS
+            HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK is set: not checking for outdated
+            dependents or dependents with broken linkage!
+          EOS
+        end
         return
       end
 


### PR DESCRIPTION
Combined with https://github.com/Homebrew/homebrew-test-bot/pull/963 this should make `brew test-bot` output a bit quieter and less annoying.