### PR TITLE
bin/brew: avoid `eval` and `grep`

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -78,28 +78,30 @@ unset BREW_FILE_DIRECTORY
 HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Load Homebrew's variable configuration files from disk.
+export_homebrew_env_file() {
+  local env_file
+
+  env_file="${1}"
+  [[ -r "${env_file}" ]] || return 0
+  while read -r line
+  do
+    # only load HOMEBREW_* lines
+    [[ "${line}" = "HOMEBREW_"* ]] || continue
+    export "${line?}"
+  done <"${env_file}"
+}
+
 # First, load the system-wide configuration.
-if [[ -f "/etc/homebrew/brew.env" ]]
+unset SYSTEM_ENV_TAKES_PRIORITY
+if [[ -n "${HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY-}" ]]
 then
-  unset SYSTEM_ENV_TAKES_PRIORITY
-  # only load HOMEBREW_*=* lines
-  SYSTEM_HOMEBREW_ENV="$(grep -E '^HOMEBREW_[A-Z_]+=.*$' "/etc/homebrew/brew.env")"
-  if [[ -n "${HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY-}" ]]
-  then
-    SYSTEM_ENV_TAKES_PRIORITY="1"
-  else
-    eval "${SYSTEM_HOMEBREW_ENV}"
-  fi
+  SYSTEM_ENV_TAKES_PRIORITY="1"
+else
+  export_homebrew_env_file "/etc/homebrew/brew.env"
 fi
 
 # Next, load the prefix configuration
-if [[ -f "${HOMEBREW_PREFIX}/etc/homebrew/brew.env" ]]
-then
-  # only load HOMEBREW_*=* lines
-  PREFIX_HOMEBREW_ENV="$(grep -E '^HOMEBREW_[A-Z_]+=.*$' "${HOMEBREW_PREFIX}/etc/homebrew/brew.env")"
-  eval "${PREFIX_HOMEBREW_ENV}"
-  unset PREFIX_HOMEBREW_ENV
-fi
+export_homebrew_env_file "${HOMEBREW_PREFIX}/etc/homebrew/brew.env"
 
 # Finally, load the user configuration
 if [[ -n "${XDG_CONFIG_HOME-}" ]]
@@ -129,20 +131,13 @@ else
   exit 1
 fi
 
-if [[ -f "${HOMEBREW_USER_CONFIG_HOME}/brew.env" ]]
-then
-  # only load HOMEBREW_*=* lines
-  USER_HOMEBREW_ENV="$(grep -E '^HOMEBREW_[A-Z_]+=.*$' "${HOMEBREW_USER_CONFIG_HOME}/brew.env")"
-  eval "${USER_HOMEBREW_ENV}"
-  unset USER_HOMEBREW_ENV
-fi
+export_homebrew_env_file "${HOMEBREW_USER_CONFIG_HOME}/brew.env"
 
 # If the system configuration takes priority, load it last.
 if [[ -n "${SYSTEM_ENV_TAKES_PRIORITY-}" ]]
 then
-  eval "${SYSTEM_HOMEBREW_ENV}"
+  export_homebrew_env_file "/etc/homebrew/brew.env"
 fi
-unset SYSTEM_HOMEBREW_ENV
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`eval` is a much bigger hammer than we need here, so let's try to avoid
that.

Also, we can use the builtin `read` instead of shelling out to `grep`
which will be slightly more efficient.
