### PR TITLE
bin/brew: improve handling of unset `HOME`

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -110,22 +110,11 @@ then
 elif [[ -n "${HOME-}" ]]
 then
   HOMEBREW_USER_CONFIG_HOME="${HOME}/.homebrew"
-elif [[ -n "${USER-}" ]]
+elif [[ -n "${USER-}" ]] || [[ -n "${LOGNAME-}" ]]
 then
-  if [[ "${OSTYPE}" == "darwin"* ]]
-  then
-    HOMEBREW_USER_CONFIG_HOME="/Users/${USER}/.homebrew"
-  else
-    HOMEBREW_USER_CONFIG_HOME="/home/${USER}/.homebrew"
-  fi
-elif [[ -n "${LOGNAME-}" ]]
-then
-  if [[ "${OSTYPE}" == "darwin"* ]]
-  then
-    HOMEBREW_USER_CONFIG_HOME="/Users/${LOGNAME}/.homebrew"
-  else
-    HOMEBREW_USER_CONFIG_HOME="/home/${LOGNAME}/.homebrew"
-  fi
+  # https://superuser.com/a/1613980
+  HOME="$(/bin/bash -c "cd ~$(printf %q "${USER:-${LOGNAME}}") && pwd")"
+  HOMEBREW_USER_CONFIG_HOME="${HOME}/.homebrew"
 else
   echo "Error: \$HOME or \$USER or \$LOGNAME must be set to run brew." >&2
   exit 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A little bit of shell voodoo allows us to pass deriving `HOME` from
`USER` or `LOGNAME` to the shell. This also fixes [1], and helps
deduplicate things here.

[1] https://github.com/Homebrew/brew/pull/15818#issuecomment-1665349233

