### PR TITLE
dev-cmd/bump : stop using API to load formulae/casks

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -79,10 +79,12 @@ module Homebrew
       end
     end
 
-    if formulae_and_casks.present?
-      handle_formula_and_casks(formulae_and_casks, args)
-    else
-      handle_api_response(args)
+    Homebrew.with_no_api_env do
+      if formulae_and_casks.present?
+        handle_formula_and_casks(formulae_and_casks, args)
+      else
+        handle_api_response(args)
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #15825

Even though the command already sets without_api that only affects how named args are loaded. In this command, we used to load many formulae and casks all at once using the API according to user settings. Now we just mandate that all loading must skip the API.

This is kind of a brute force sort of fix. Ideally, we wouldn't be wrapping so much code with the `Homebrew.with_no_api_env` block but otherwise I think we'd just be doing it in a loop which is probably worse.
