### PR TITLE
formula: use pip's `--no-compile`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1707,7 +1707,7 @@ class Formula
   }
   def std_pip_args(prefix: self.prefix, build_isolation: false)
     args = ["--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed",
-            "--use-feature=no-binary-enable-wheel-cache"]
+            "--use-feature=no-binary-enable-wheel-cache", "--no-compile"]
     args << "--prefix=#{prefix}" if prefix
     args << "--no-build-isolation" unless build_isolation
     args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

`pip` defaults to compiling bytecode for packages. But since we already [remove these when bottling](https://github.com/Homebrew/brew/blob/3eb48a828d44643b8d427f647227a277b1a4c1bf/Library/Homebrew/keg.rb#L528), let's add [`--no-compile`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-compile) to stop pip from creating these in the first place. This is also theoretically faster, but at least on my machine not too significant. For example, `brew install -s black` is 2s faster (41s before, 39s after).

Similiar motivation as https://github.com/Homebrew/brew/pull/14338, but pip doesn't respect `PYTHONDONTWRITEBYTECODE` by explicitly using [`compileall`](https://github.com/pypa/pip/blob/a19ade74a5cebbe73e8ab6e88f4123e0e2e54c06/src/pip/_internal/operations/install/wheel.py#L617)
