### PR TITLE
pypi: support updating resources for git clones

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -228,7 +228,13 @@ module PyPI
     main_package = if package_name.present?
       Package.new(package_name)
     else
-      Package.new(T.must(formula.stable).url, is_url: true)
+      stable = T.must(formula.stable)
+      url = if stable.specs[:tag].present?
+        url = "git+#{stable.url}@#{stable.specs[:tag]}"
+      else
+        stable.url
+      end
+      Package.new(url, is_url: true)
     end
 
     if version.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

This teaches `brew update-python-resources` how to handle a formula with a git url, like [`arcade-learning-environment`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/arcade-learning-environment.rb).

Before:

```console
$ brew update-python-resources arcade-learning-environment
Error: Unable to determine metadata for "https://github.com/mgbellemare/Arcade-Learning-Environment.git" because of a failure when running
`/opt/homebrew/opt/python@3.11/bin/python3 -m pip install -q --no-deps --dry-run --ignore-installed --report /dev/stdout https://github.com/mgbellemare/Arcade-Learning-Environment.git`.
Please report this issue:
  https://docs.brew.sh/Troubleshooting

```

After:

```console
$ brew update-python-resources arcade-learning-environment
==> Retrieving PyPI dependencies for "git+https://github.com/mgbellemare/Arcade-Learning-Environment.git@v0.8.1"...
==> Getting PyPI info for "importlib-resources==6.0.0"
==> Getting PyPI info for "numpy==1.25.2"
==> Updating resource blocks
```
