### PR TITLE
tap: always create new casks in subdirectory.

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1134,9 +1134,6 @@ class CoreCaskTap < AbstractCoreTap
   sig { params(token: String).returns(Pathname) }
   def new_cask_path(token)
     cask_subdir = token[0].to_s
-
-    return super unless (cask_dir/cask_subdir).directory?
-
     cask_dir/cask_subdir/"#{token.downcase}.rb"
   end
 


### PR DESCRIPTION
After https://github.com/Homebrew/homebrew-cask/pull/152603 is merged, for homebrew-cask, all casks should now be created in subdirectories, even if that subdirectory doesn't yet exist.