### PR TITLE
cask/audit: audit for appropriate sharding directory

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -717,6 +717,18 @@ module Cask
                                           strict:        strict?)
     end
 
+    sig { void }
+    def audit_cask_path
+      return if cask.tap != "homebrew/cask"
+
+      cask_subdir = cask.token[0].downcase
+      expected_path = "Casks/#{cask_subdir}/#{cask.token}.rb"
+
+      return if cask.ruby_source_path.to_s.end_with?(expected_path)
+
+      add_error "Cask should be located in '#{expected_path}'"
+    end
+
     # sig {
     #   params(url_to_check: T.any(String, URL), url_type: String, cask_token: String, tap: Tap,
     #          options: T.untyped).void

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -721,8 +721,7 @@ module Cask
     def audit_cask_path
       return if cask.tap != "homebrew/cask"
 
-      cask_subdir = cask.token[0].downcase
-      expected_path = "Casks/#{cask_subdir}/#{cask.token}.rb"
+      expected_path = cask.tap.new_cask_path(cask.token)
 
       return if cask.ruby_source_path.to_s.end_with?(expected_path)
 

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -723,7 +723,7 @@ module Cask
 
       expected_path = cask.tap.new_cask_path(cask.token)
 
-      return if cask.ruby_source_path.to_s.end_with?(expected_path)
+      return if cask.sourcefile_path.to_s.end_with?(expected_path)
 
       add_error "Cask should be located in '#{expected_path}'"
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds an audit to ensure casks are in the appropriate subdirectory.
Should help address the issue raised in https://github.com/Homebrew/homebrew-cask/pull/152603