### PR TITLE
Allow HOMEBREW_CURLRC to specify a path for curl `--config`

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -132,9 +132,10 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_CURLRC:                           {
-        description: "If set, do not pass `--disable` when invoking `curl`(1), which disables the " \
-                     "use of `curlrc`.",
-        boolean:     true,
+        description: "If set to an absolute path (i.e. beginning with `/`), pass it with `--config` when invoking " \
+                     "`curl`(1). " \
+                     "If set but _not_ a valid path, do not pass `--disable`, which disables the " \
+                     "use of `.curlrc`.",
       },
       HOMEBREW_DEBUG:                            {
         description: "If set, always assume `--debug` when running commands.",

--- a/Library/Homebrew/env_config.rbi
+++ b/Library/Homebrew/env_config.rbi
@@ -67,8 +67,8 @@ module Homebrew::EnvConfig
   sig { returns(T::Boolean) }
   def self.curl_verbose?; end
 
-  sig { returns(T::Boolean) }
-  def self.curlrc?; end
+  sig { returns(T.nilable(String)) }
+  def self.curlrc; end
 
   sig { returns(T::Boolean) }
   def self.debug?; end

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -313,9 +313,25 @@ describe "Utils::Curl" do
       expect(curl_args(*args).first).to eq("--disable")
     end
 
-    it "doesn't return `--disable` as the first argument when HOMEBREW_CURLRC is set" do
+    it "doesn't return `--disable` as the first argument when HOMEBREW_CURLRC is set but not a path" do
       ENV["HOMEBREW_CURLRC"] = "1"
       expect(curl_args(*args).first).not_to eq("--disable")
+    end
+
+    it "doesn't return `--config` when HOMEBREW_CURLRC is unset" do
+      expect(curl_args(*args)).not_to include(a_string_starting_with("--config"))
+    end
+
+    it "returns `--config` when HOMEBREW_CURLRC is a valid path" do
+      Tempfile.create do |tmpfile|
+        path = tmpfile.path
+        ENV["HOMEBREW_CURLRC"] = path
+        # We still expect --disable
+        expect(curl_args(*args).first).to eq("--disable")
+        expect(curl_args(*args).join(" ")).to include("--config #{path}")
+      end
+    ensure
+      ENV["HOMEBREW_CURLRC"] = nil
     end
 
     it "uses `--connect-timeout` when `:connect_timeout` is Numeric" do

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -71,7 +71,16 @@ module Utils
       args = []
 
       # do not load .curlrc unless requested (must be the first argument)
-      args << "--disable" unless Homebrew::EnvConfig.curlrc?
+      curlrc = Homebrew::EnvConfig.curlrc
+      if curlrc&.start_with?("/")
+        # If the file exists, we still want to disable loading the default curlrc.
+        args << "--disable" << "--config" << curlrc
+      elsif curlrc
+        # This matches legacy behavior: `HOMEBREW_CURLRC` was a bool,
+        # omitting `--disable` when present.
+      else
+        args << "--disable"
+      end
 
       # echo any cookies received on a redirect
       args << "--cookie" << "/dev/null"

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2176,7 +2176,7 @@ prefix-specific files take precedence over system-wide files (unless
   <br>If set, pass `--verbose` when invoking `curl`(1).
 
 - `HOMEBREW_CURLRC`
-  <br>If set, do not pass `--disable` when invoking `curl`(1), which disables the use of `curlrc`.
+  <br>If set to an absolute path (i.e. beginning with `/`), pass it with `--config` when invoking `curl`(1). If set but _not_ a valid path, do not pass `--disable`, which disables the use of `.curlrc`.
 
 - `HOMEBREW_DEBUG`
   <br>If set, always assume `--debug` when running commands.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -3149,7 +3149,7 @@ If set, pass \fB\-\-verbose\fR when invoking \fBcurl\fR(1)\.
 \fBHOMEBREW_CURLRC\fR
 .
 .br
-If set, do not pass \fB\-\-disable\fR when invoking \fBcurl\fR(1), which disables the use of \fBcurlrc\fR\.
+If set to an absolute path (i\.e\. beginning with \fB/\fR), pass it with \fB\-\-config\fR when invoking \fBcurl\fR(1)\. If set but \fInot\fR a valid path, do not pass \fB\-\-disable\fR, which disables the use of \fB\.curlrc\fR\.
 .
 .TP
 \fBHOMEBREW_DEBUG\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We're using a custom `HOMEBREW_ARTIFACT_DOMAIN` that requires some additional flags in `.curlrc`. We would like to set `HOMEBREW_CURLRC` and the value for `CURL_HOME` in `/etc/homebrew/brew.env` to support this without relying on the user's `.curlrc`.