### PR TITLE
formula_{auditor,versions}: handle sharding.

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -770,9 +770,9 @@ module Homebrew
       newest_committed_revision = T.let(nil, T.nilable(Integer))
       newest_committed_url = T.let(nil, T.nilable(String))
 
-      fv.rev_list("origin/HEAD") do |rev|
+      fv.rev_list("origin/HEAD") do |revision, path|
         begin
-          fv.formula_at_revision(rev) do |f|
+          fv.formula_at_revision(revision, path) do |f|
             stable = f.stable
             next if stable.blank?
 

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -15,54 +15,62 @@ class FormulaVersions
     ErrorDuringExecution, LoadError, MethodDeprecatedError
   ].freeze
 
-  MAX_VERSIONS_DEPTH = 2
-
-  attr_reader :name, :path, :repository, :entry_name
-
+  sig { params(formula: Formula).void }
   def initialize(formula)
     @name = formula.name
     @path = formula.path
-    @repository = formula.tap.path
-    @entry_name = @path.relative_path_from(repository).to_s
-    @current_formula = formula
+    @repository = T.must(formula.tap).path
+    @relative_path = @path.relative_path_from(repository).to_s
+    # Also look at e.g. older homebrew-core paths before sharding.
+    if (match = @relative_path.match(%r{^(HomebrewFormula|Formula)/([a-z]|lib)/(.+)}))
+      @old_relative_path = "#{match[1]}/#{match[3]}"
+    end
     @formula_at_revision = {}
   end
 
   def rev_list(branch)
     repository.cd do
       rev_list_cmd = ["git", "rev-list", "--abbrev-commit", "--remove-empty"]
-      rev_list_cmd << "--first-parent" if repository != CoreTap.instance.path
-      Utils.popen_read(*rev_list_cmd, branch, "--", entry_name) do |io|
-        yield io.readline.chomp until io.eof?
+      [relative_path, old_relative_path].compact.each do |entry|
+        Utils.popen_read(*rev_list_cmd, branch, "--", entry) do |io|
+          yield [io.readline.chomp, entry] until io.eof?
+        end
       end
     end
   end
 
-  sig { params(rev: String).returns(String) }
-  def file_contents_at_revision(rev)
-    repository.cd { Utils.popen_read("git", "cat-file", "blob", "#{rev}:#{entry_name}") }
-  end
-
   sig {
     type_parameters(:U)
-      .params(rev: String, _block: T.proc.params(arg0: Formula).returns(T.type_parameter(:U)))
-      .returns(T.nilable(T.type_parameter(:U)))
+      .params(
+        revision:              String,
+        formula_relative_path: String,
+        _block:                T.proc.params(arg0: Formula).returns(T.type_parameter(:U)),
+      ).returns(T.nilable(T.type_parameter(:U)))
   }
-  def formula_at_revision(rev, &_block)
+  def formula_at_revision(revision, formula_relative_path = relative_path, &_block)
     Homebrew.raise_deprecation_exceptions = true
 
-    yield @formula_at_revision[rev] ||= begin
-      contents = file_contents_at_revision(rev)
+    yield @formula_at_revision[revision] ||= begin
+      contents = file_contents_at_revision(revision, formula_relative_path)
       nostdout { Formulary.from_contents(name, path, contents, ignore_errors: true) }
     end
   rescue *IGNORED_EXCEPTIONS => e
     # We rescue these so that we can skip bad versions and
     # continue walking the history
-    odebug "#{e} in #{name} at revision #{rev}", e.backtrace
+    odebug "#{e} in #{name} at revision #{revision}", e.backtrace
   rescue FormulaUnavailableError
     nil
   ensure
     Homebrew.raise_deprecation_exceptions = false
+  end
+
+  private
+
+  attr_reader :name, :path, :repository, :relative_path, :old_relative_path
+
+  sig { params(revision: String, relative_path: String).returns(String) }
+  def file_contents_at_revision(revision, relative_path)
+    repository.cd { Utils.popen_read("git", "cat-file", "blob", "#{revision}:#{relative_path}") }
   end
 
   def nostdout(&block)


### PR DESCRIPTION
Ensure that `FormulaVersions` correctly also looks at older paths for sharded formulae.

While we're here, also cleanup `FormulaVersions` a bit to have more signatures, cleanup dead code, make more code private, improve variable naming.

Partial solution for https://github.com/Homebrew/brew/issues/15856