### PR TITLE
cmd/update-report: correctly handle added/deleted formulae/casks.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -566,6 +566,17 @@ class Reporter
       @report[:R] = renamed_formulae.to_a
     end
 
+    # If any formulae/casks are marked as added and deleted, remove them from
+    # the report as we've not detected things correctly.
+    if (added_and_deleted_formulae = (@report[:A] & @report[:D]).presence)
+      @report[:A] -= added_and_deleted_formulae
+      @report[:D] -= added_and_deleted_formulae
+    end
+    if (added_and_deleted_casks = (@report[:AC] & @report[:DC]).presence)
+      @report[:AC] -= added_and_deleted_casks
+      @report[:DC] -= added_and_deleted_casks
+    end
+
     @report
   end
 


### PR DESCRIPTION
If a formulae or cask is marked as both added and deleted, we've just incorrectly detected it. Remove it from the report.

This can happen when a formula or cask is moved around in the repository e.g. with sharding.

Partial solution for https://github.com/Homebrew/brew/issues/15856