### PR TITLE
brew.sh: don't set `HOMEBREW_NO_INSTALL_FROM_API` automatically.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -533,8 +533,6 @@ then
   # shellcheck disable=SC2086,SC2183
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
   # shellcheck disable=SC2248
-  printf -v HOMEBREW_MACOS_OLDEST_SUPPORTED_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_OLDEST_SUPPORTED//./ }
-  # shellcheck disable=SC2248
   printf -v HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_OLDEST_ALLOWED//./ }
 
   # Don't include minor versions for Big Sur and later.
@@ -592,13 +590,6 @@ then
     # Used in ruby.sh.
     # shellcheck disable=SC2034
     HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH="1"
-  fi
-
-  # Don't support API at this time for older macOS versions.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "${HOMEBREW_MACOS_OLDEST_SUPPORTED_NUMERIC}" ]]
-  then
-    export HOMEBREW_INSTALL_FROM_API_UNSUPPORTED=1
-    export HOMEBREW_NO_INSTALL_FROM_API=1
   fi
 else
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
@@ -670,13 +661,6 @@ Your Git executable: $(unset git && type -p "${HOMEBREW_GIT}")"
     # shellcheck disable=SC2034
     HOMEBREW_LINUXBREW_CORE_MIGRATION=1
   fi
-fi
-
-# Generic OS or non-default prefix: API not supported.
-if [[ (-z "${HOMEBREW_MACOS}" && -z "${HOMEBREW_LINUX}") || "${HOMEBREW_PREFIX}" != "${HOMEBREW_DEFAULT_PREFIX}" ]]
-then
-  export HOMEBREW_INSTALL_FROM_API_UNSUPPORTED=1
-  export HOMEBREW_NO_INSTALL_FROM_API=1
 fi
 
 setup_ca_certificates() {

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -377,8 +377,7 @@ module Homebrew
                          !ENV["HOMEBREW_GITHUB_HOSTED_RUNNER"] &&
                          !ENV["GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"]
     no_install_from_api_set = Homebrew::EnvConfig.no_install_from_api? &&
-                              !Homebrew::EnvConfig.automatically_set_no_install_from_api? &&
-                              !Homebrew::EnvConfig.install_from_api_unsupported?
+                              !Homebrew::EnvConfig.automatically_set_no_install_from_api?
     return if !no_auto_update_set && !no_install_from_api_set && !auto_update_secs_set
 
     ohai "You have set:"

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -498,10 +498,5 @@ module Homebrew
     def automatically_set_no_install_from_api?
       ENV["HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API"].present?
     end
-
-    sig { returns(T::Boolean) }
-    def install_from_api_unsupported?
-      ENV["HOMEBREW_INSTALL_FROM_API_UNSUPPORTED"].present?
-    end
   end
 end

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -38,8 +38,6 @@ export HOMEBREW_NO_INSTALL_FROM_API=1
 
 This will make Homebrew install formulae and casks from the `homebrew/core` and `homebrew/cask` taps using local checkouts of these repositories instead of Homebrew’s API.
 
-Note that this will automatically be set on unsupported configurations (i.e. not using the default Homebrew prefix or, if on macOS, on an unsupported version).
-
 ## Unattended installation
 
 If you want a non-interactive run of the Homebrew installer that doesn't prompt for passwords (e.g. in automation scripts), prepend [`NONINTERACTIVE=1`](https://github.com/Homebrew/install/#install-homebrew-on-macos-or-linux) to the installation command.


### PR DESCRIPTION
My understanding is that now https://github.com/Homebrew/brew/pull/15778 has been merged this should now work fine on both older macOS versions and non-default prefixes so let's try this again.

Maintainers: if we get user reports for this breaking things from source on unsupported configurations (i.e. users with non-default prefixes or old macOS versions) try to fix forward if possible but feel free to insta-revert if it causes any issues with any of our CI.

CC @Bo98 @gerlero FYI