### PR TITLE
utils/gems: update to Bundler 2.4

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -230,4 +230,4 @@ RUBY VERSION
    ruby 2.6.10p210
 
 BUNDLED WITH
-   2.3.26
+   2.4.18

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -10,7 +10,7 @@ require "English"
 module Homebrew
   # Keep in sync with the `Gemfile.lock`'s BUNDLED WITH.
   # After updating this, run `brew vendor-gems --update=--bundler`.
-  HOMEBREW_BUNDLER_VERSION = "2.3.26"
+  HOMEBREW_BUNDLER_VERSION = "2.4.18"
 
   module_function
 
@@ -64,6 +64,8 @@ module Homebrew
   def setup_gem_environment!(setup_path: true)
     require "rubygems"
     raise "RubyGems too old!" if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.2.0")
+
+    ENV["BUNDLER_NO_OLD_RUBYGEMS_WARNING"] = "1"
 
     # Match where our bundler gems are.
     gem_home = "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"

--- a/Library/Homebrew/vendor/bundle/bundler/setup.rb
+++ b/Library/Homebrew/vendor/bundle/bundler/setup.rb
@@ -14,13 +14,17 @@ unless defined?(Gem)
     end
   end
 end
-kernel = (class << ::Kernel; self; end)
-[kernel, ::Kernel].each do |k|
-  if k.private_method_defined?(:gem_original_require)
-    private_require = k.private_method_defined?(:require)
-    k.send(:remove_method, :require)
-    k.send(:define_method, :require, k.instance_method(:gem_original_require))
-    k.send(:private, :require) if private_require
+if Gem.respond_to?(:discover_gems_on_require=)
+  Gem.discover_gems_on_require = false
+else
+  kernel = (class << ::Kernel; self; end)
+  [kernel, ::Kernel].each do |k|
+    if k.private_method_defined?(:gem_original_require)
+      private_require = k.private_method_defined?(:require)
+      k.send(:remove_method, :require)
+      k.send(:define_method, :require, k.instance_method(:gem_original_require))
+      k.send(:private, :require) if private_require
+    end
   end
 end
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/concurrent-ruby-1.2.2/lib/concurrent-ruby")


### PR DESCRIPTION
With a new dependency resolver that might work a bit better for some edge cases.

We're reaching the limit of what is supported under Ruby 2.6 here too, as we now need a `BUNDLER_NO_OLD_RUBYGEMS_WARNING` to avoid warning spam. Support for Ruby 2.6 could be dropped as soon as the end of this year.