### PR TITLE
Livecheck: allow quiet output with `--newer-only`

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -397,7 +397,7 @@ module Homebrew
         end
       end
 
-      puts "No newer upstream versions." if newer_only && !has_a_newer_upstream_version && !debug && !json
+      puts "No newer upstream versions." if newer_only && !has_a_newer_upstream_version && !debug && !json && !quiet
 
       return unless json
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Checking multiple formulae/casks with livecheck becomes incredibly noisy when using `--newer-only`. This PR allows us to silence the `"No newer upstream versions."` output by passing `--quiet`.