### PR TITLE
service: correctly quote arguments.

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -398,7 +398,7 @@ module Homebrew
       vars = @environment_variables.except(:PATH)
                                    .map { |k, v| "#{k}=\"#{v}\"" }
 
-      out = vars + command if command?
+      out = vars + T.must(command).map { |arg| Utils::Shell.sh_quote(arg) } if command?
       out.join(" ")
     end
 


### PR DESCRIPTION
If you have a run argument with a space in it: it will need to be quoted to be passed through correctly when run as a manual command.

Will allow removing manual quoting differences e.g. in https://github.com/Homebrew/homebrew-core/blob/66ebc5d0f0c0df80d96e901b94d4bcf5bc900534/Formula/n/nginx.rb#L149-L153

Fixes #15871.