### PR TITLE
dev-cmd/livecheck: avoid watchlist in test

### DIFF
--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -20,7 +20,7 @@ describe "brew livecheck" do
   end
 
   it "gives an error when no arguments are given and there's no watchlist", :integration_test do
-    expect { brew "livecheck" }
+    expect { brew "livecheck", "HOMEBREW_LIVECHECK_WATCHLIST" => ".this_should_not_exist" }
       .to output(/Invalid usage: A watchlist file is required when no arguments are given\./).to_stderr
       .and not_to_output.to_stdout
       .and be_a_failure


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The existing watchlist test in `test/dev-cmd/livecheck_spec.rb` will only pass if the testing environment doesn't contain a livecheck watchlist file. When a watchlist file is present, it ends up being treated as empty (formulae and casks aren't available in tests) and produces an `Invalid usage: No formulae or casks to check` error instead. We don't have to worry about a watchlist file on CI but it's a potential issue when running `brew test` locally.

This provides a bogus `HOMEBREW_LIVECHECK_WATCHLIST` value to the `#brew` call, to ensure that any watchlist file in the testing environment is not used for this test.

-----

For what it's worth, the test used to pass even if there was a watchlist file when the default location was `~/.brew_livecheck_watchlist`. This is because the home directory is `HOMEBREW_PREFIX/Library/Homebrew/test/` in tests and there isn't a `.brew_livecheck_watchlist` file there. The default livecheck watchlist path changed in #15787 such that it's now available in the testing environment, so now we encounter this issue.