### PR TITLE
Fix cask dependency discovery

### DIFF
--- a/Library/Homebrew/utils/topological_hash.rb
+++ b/Library/Homebrew/utils/topological_hash.rb
@@ -30,6 +30,7 @@ module Utils
         else
           formula_deps = cask_or_formula.deps
                                         .reject(&:build?)
+                                        .reject(&:test?)
                                         .map(&:to_formula)
           cask_deps = cask_or_formula.requirements
                                      .map(&:cask)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
Fixes https://github.com/Homebrew/homebrew-cask/issues/152726.
This is an issue that affects only casks that have a `depends_on formula` clause, and only when that formula has uninstalled test dependencies somewhere in its tree. In this situation, `brew` when installing the cask will also install the test dependencies, even though they are not needed. Not many casks have a `depends_on formula` clause, so I don't expect the issue to be very common; so far I've seen this issue when installing the casks `neovide` and `goneovim`.

I did a search for the function this commit modifies, and it seems to only be used in `upgrade.rb` and `cask/installer.rb`, which would explain why the issue was observed only when installing casks and not formulae. I tested `brew reinstall --cask neovide` with this commit and did not observe the installation of the extraneous dependencies as in https://github.com/Homebrew/homebrew-cask/issues/152726, so this should fix that issue.

Although this did not fail the `brew style` check, I'm not entirely sure if this fix matches Homebrew's style, so please let me know if an alternate fix is preferred.