### PR TITLE
Use HOMEBREW_CURLRC in vendor-install

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -111,6 +111,9 @@ fetch() {
   if [[ -z "${HOMEBREW_CURLRC}" ]]
   then
     curl_args[${#curl_args[*]}]="-q"
+  elif [[ "${HOMEBREW_CURLRC}" == /* ]]
+  then
+    curl_args+=("-q" "--config" "${HOMEBREW_CURLRC}")
   fi
 
   # Authorization is needed for GitHub Packages but harmless on GitHub Releases


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Following https://github.com/Homebrew/brew/pull/15853, there is another place we call `curl` that can also make use of `HOMEBREW_CURLRC` to set `--config`. `HOMEBREW_ARTIFACT_DOMAIN` is used in line 48 here, so the change in `Utils::Curl` didn't have any effect.

I missed this because I didn't test installing Homebrew from scratch with this set 😅 