### PR TITLE
extend/os/mac/keg: codesign on Intel if invalid signature

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -28,7 +28,11 @@ class Keg
 
   def codesign_patched_binary(file)
     return if MacOS.version < :big_sur
-    return unless Hardware::CPU.arm?
+
+    unless Hardware::CPU.arm?
+      result = system_command("codesign", args: ["--verify", file], print_stderr: false)
+      return unless result.stderr.match?(/invalid signature/i)
+    end
 
     odebug "Codesigning #{file}"
     prepare_codesign_writable_files(file) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Attempt at fixing issue mentioned in https://github.com/Homebrew/homebrew-core/issues/140244.

Due to enabling `HOMEBREW_RELOCATABLE_INSTALL_NAMES=1`, RPATH modifications are invalidating code signatures added by upstream installation script.

Possible change here to `codesign` if we detect invalid signature on Intel binary. Alternative could be on formula-by-formula basis, though harder to catch problems before distribution to users.

Snippet of debug output on `qemu`:

```
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/elf2dmp
  from /usr/local/opt/glib/lib/libglib-2.0.0.dylib
    to @loader_path/../../../../opt/glib/lib/libglib-2.0.0.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/elf2dmp

==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-edid
  from /usr/local/opt/glib/lib/libglib-2.0.0.dylib
    to @loader_path/../../../../opt/glib/lib/libglib-2.0.0.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-edid

...

==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/pixman/lib/libpixman-1.0.dylib
    to @loader_path/../../../../opt/pixman/lib/libpixman-1.0.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning (2nd try) /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/capstone/lib/libcapstone.4.dylib
    to @loader_path/../../../../opt/capstone/lib/libcapstone.4.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/libpng/lib/libpng16.16.dylib
    to @loader_path/../../../../opt/libpng/lib/libpng16.16.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/jpeg-turbo/lib/libjpeg.8.dylib
    to @loader_path/../../../../opt/jpeg-turbo/lib/libjpeg.8.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/gnutls/lib/libgnutls.30.dylib
    to @loader_path/../../../../opt/gnutls/lib/libgnutls.30.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/snappy/lib/libsnappy.1.dylib
    to @loader_path/../../../../opt/snappy/lib/libsnappy.1.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/lzo/lib/liblzo2.2.dylib
    to @loader_path/../../../../opt/lzo/lib/liblzo2.2.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/glib/lib/libgio-2.0.0.dylib
    to @loader_path/../../../../opt/glib/lib/libgio-2.0.0.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Changing install name in /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
  from /usr/local/opt/glib/lib/libgobject-2.0.0.dylib
    to @loader_path/../../../../opt/glib/lib/libgobject-2.0.0.dylib
/usr/bin/env codesign --verify /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
==> Codesigning /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
/usr/bin/env codesign --display --file-list - /usr/local/Cellar/qemu/8.1.0/bin/qemu-system-x86_64
...
```