### PR TITLE
shared_audits: allow GitHub's IP not permitted error

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -12,6 +12,10 @@ module SharedAudits
 
   URL_TYPE_HOMEPAGE = "homepage URL"
 
+  GITHUB_IP_ALLOWLIST_ERROR = Regexp.new("Although you appear to have the correct authorization credentials, " \
+                                         "the `(.+)` organization has an IP allow list enabled, " \
+                                         "and your IP address is not permitted to access this resource").freeze
+
   module_function
 
   def github_repo_data(user, repo)
@@ -21,6 +25,8 @@ module SharedAudits
     @github_repo_data["#{user}/#{repo}"]
   rescue GitHub::API::HTTPNotFoundError
     nil
+  rescue GitHub::API::AuthenticationFailedError => e
+    raise unless e.message.match?(GITHUB_IP_ALLOWLIST_ERROR)
   end
 
   def github_release_data(user, repo, tag)
@@ -32,6 +38,8 @@ module SharedAudits
     @github_release_data[id]
   rescue GitHub::API::HTTPNotFoundError
     nil
+  rescue GitHub::API::AuthenticationFailedError => e
+    raise unless e.message.match?(GITHUB_IP_ALLOWLIST_ERROR)
   end
 
   def github_release(user, repo, tag, formula: nil, cask: nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

For some formulae during the homepage audit, we're getting an error: 
```
Error: GitHub API Error: Although you appear to have the correct authorization credentials, the `<org-name>` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.
``` 
Ref https://github.com/Homebrew/homebrew-core/pull/140255#issuecomment-1689812120

This PR ignores this error in `SharedAudits` (while getting information about repo via API).


