### PR TITLE
formula: drop old pip feature flag

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1705,8 +1705,7 @@ class Formula
            build_isolation: T::Boolean).returns(T::Array[String])
   }
   def std_pip_args(prefix: self.prefix, build_isolation: false)
-    args = ["--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed",
-            "--use-feature=no-binary-enable-wheel-cache", "--no-compile"]
+    args = ["--verbose", "--no-deps", "--no-binary=:all:", "--ignore-installed", "--no-compile"]
     args << "--prefix=#{prefix}" if prefix
     args << "--no-build-isolation" unless build_isolation
     args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

This was made the default behavior in [pip 23.1](https://github.com/pypa/pip/commit/fded808c8cab13e9fef65f3ac8256ec37a27d743#diff-eac56dce076aa027ef42fa51826df01e1b996d4e374d6c572c83af9fe4b13895R999), which all our pythons now ship.
