### PR TITLE
workflows/tests: workaround GitHub Actions python issues.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -363,7 +363,10 @@ jobs:
 
       - name: Install brew tests macOS dependencies
         if: runner.os != 'Linux'
-        run: brew install subversion
+        run: |
+          # Workaround GitHub Actions Python issues
+          brew unlink python && brew link --overwrite python
+          brew install subversion
 
         # brew tests doesn't like world writable directories
       - name: Cleanup permissions


### PR DESCRIPTION
As-is there's a Python installed but not properly linked which breaks anything that depends on Python being installed on macOS e.g. Subversion.