### PR TITLE
get_repo_license: allow GitHub's IP not permitted error

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -504,6 +504,8 @@ module GitHub
     response["license"]["spdx_id"]
   rescue API::HTTPNotFoundError
     nil
+  rescue API::AuthenticationFailedError => e
+    raise unless e.message.match?(API::GITHUB_IP_ALLOWLIST_ERROR)
   end
 
   def self.pull_request_title_regex(name, version = nil)

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -60,6 +60,10 @@ module GitHub
       end
     end
 
+    GITHUB_IP_ALLOWLIST_ERROR = Regexp.new("Although you appear to have the correct authorization credentials, " \
+                                           "the `(.+)` organization has an IP allow list enabled, " \
+                                           "and your IP address is not permitted to access this resource").freeze
+
     NO_CREDENTIALS_MESSAGE = <<~MESSAGE
       No GitHub credentials found in macOS Keychain, GitHub CLI or the environment.
       #{GitHub.pat_blurb}

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -12,10 +12,6 @@ module SharedAudits
 
   URL_TYPE_HOMEPAGE = "homepage URL"
 
-  GITHUB_IP_ALLOWLIST_ERROR = Regexp.new("Although you appear to have the correct authorization credentials, " \
-                                         "the `(.+)` organization has an IP allow list enabled, " \
-                                         "and your IP address is not permitted to access this resource").freeze
-
   module_function
 
   def github_repo_data(user, repo)
@@ -26,7 +22,7 @@ module SharedAudits
   rescue GitHub::API::HTTPNotFoundError
     nil
   rescue GitHub::API::AuthenticationFailedError => e
-    raise unless e.message.match?(GITHUB_IP_ALLOWLIST_ERROR)
+    raise unless e.message.match?(GitHub::API::GITHUB_IP_ALLOWLIST_ERROR)
   end
 
   def github_release_data(user, repo, tag)
@@ -39,7 +35,7 @@ module SharedAudits
   rescue GitHub::API::HTTPNotFoundError
     nil
   rescue GitHub::API::AuthenticationFailedError => e
-    raise unless e.message.match?(GITHUB_IP_ALLOWLIST_ERROR)
+    raise unless e.message.match?(GitHub::API::GITHUB_IP_ALLOWLIST_ERROR)
   end
 
   def github_release(user, repo, tag, formula: nil, cask: nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Continuation of https://github.com/Homebrew/brew/pull/15909:
- Catch `AuthenticationFailedError` in `get_repo_license` as well.

Tested it by adding to `def self.open_rest`
```ruby
raise AuthenticationFailedError.new(
  :env_token,
  "Although you appear to have the correct authorization credentials, the `Shopify` organization has an IP allow list enabled, and your IP address is not permitted to access this resource.",
)
```
and running `brew audit --online --new-formula toxiproxy` (from https://github.com/Homebrew/homebrew-core/pull/140255)

