### PR TITLE
extend/os/linux/system_config: show glibc/gcc version for API users

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -26,7 +26,7 @@ module SystemConfig
     end
 
     def formula_linked_version(formula)
-      return "N/A" unless CoreTap.instance.installed?
+      return "N/A" if Homebrew::EnvConfig.no_install_from_api? && !CoreTap.instance.installed?
 
       Formulary.factory(formula).any_installed_version || "N/A"
     rescue FormulaUnavailableError


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I noticed that some issue reports showed `N/A` for `glibc/etc` even though Homebrew should have installed them.

Locally tried it out on Ubuntu 20.04 container and saw similar behavior, which seems due to API usage, e.g.
```
OS: Ubuntu 20.04.6 LTS
Host glibc: 2.31
/usr/bin/gcc: 9.4.0
/usr/bin/ruby: N/A
glibc: N/A
gcc@11: N/A
gcc: N/A
xorg: N/A
```
```
$ brew info glibc | grep Poured
  Poured from bottle using the formulae.brew.sh API on 2023-08-27 at 04:44:30
```

I think the original goal of conditional was to avoid auto-tapping `homebrew/core`, which I guess is only an issue now when API is disabled. May need confirmation that API logic will do what is expected.

Output with change:
```
OS: Ubuntu 20.04.6 LTS
Host glibc: 2.31
/usr/bin/gcc: 9.4.0
/usr/bin/ruby: N/A
glibc: 2.35_1
gcc@11: N/A
gcc: 13.1.0
xorg: N/A
```