### PR TITLE
docs: use relative path for custom header images

### DIFF
--- a/docs/Brew-Test-Bot.md
+++ b/docs/Brew-Test-Bot.md
@@ -1,6 +1,6 @@
 ---
-logo: https://brew.sh/assets/img/brewtestbot.png
-image: https://brew.sh/assets/img/brewtestbot.png
+logo: /assets/img/brewtestbot.png
+image: /assets/img/brewtestbot.png
 ---
 
 # Brew Test Bot

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -1,6 +1,6 @@
 ---
-logo: https://brew.sh/assets/img/linuxbrew.png
-image: https://brew.sh/assets/img/linuxbrew.png
+logo: /assets/img/linuxbrew.png
+image: /assets/img/linuxbrew.png
 redirect_from:
   - /linux
   - /Linux


### PR DESCRIPTION
Follow-up to Homebrew/brew.sh#980, fixes Homebrew/brew.sh#981.