### PR TITLE
dependency_collector: distinguish macOS deps by OS

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -261,4 +261,9 @@ class UsesFromMacOSDependency < Dependency
   def dup_with_formula_name(formula)
     self.class.new(formula.full_name.to_s, tags, env_proc, option_names, bounds: bounds)
   end
+
+  sig { returns(String) }
+  def inspect
+    "#<#{self.class.name}: #{name.inspect} #{tags.inspect} #{bounds.inspect}>"
+  end
 end

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -65,6 +65,8 @@ class DependencyCollector
   def cache_key(spec)
     if spec.is_a?(Resource) && spec.download_strategy <= CurlDownloadStrategy
       File.extname(spec.url)
+    elsif spec.is_a?(UsesFromMacOSDependency)
+      "#{spec.name}-#{spec.bounds}"
     else
       spec
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
`uses_from_macos` dependencies need to indicate their OS bounds when being cached. Fixes #15907. 

```
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info gitless glib --json | jq '.[].uses_from_macos_bounds'
[
  {}
]
[
  {
    "since": "catalina"
  },
  {
    "since": "catalina"
  }
]

$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info glib gitless --json | jq '.[].uses_from_macos_bounds'
[
  {
    "since": "catalina"
  },
  {
    "since": "catalina"
  }
]
[
  {}
]
```