### PR TITLE
cask/audit: format-check block URLs only if online

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -311,6 +311,7 @@ module Cask
     sig { void }
     def audit_download_url_format
       return unless cask.url
+      return if block_url_offline?
 
       odebug "Auditing URL format"
       if bad_sourceforge_url?


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Cask URLs specified in [block format](https://docs.brew.sh/Cask-Cookbook#using-a-block-to-defer-code-execution) require a network request to resolve to string format. So, only audit these URLs if `--online` is specified. Fixes #15914.

Before:
```
$ brew audit --skip-style --except=version -d dolphin-dev
==> Auditing Cask dolphin-dev on os high_sierra and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask-versions/Casks/dolphin-dev.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
/usr/bin/env /usr/local/Homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.1.7-4-g9809473\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.13.6\)\ curl/7.54.0 --header Accept-Language:\ en --retry 3 --fail --silent --location https://dolphin-emu.org/download/list/master/1/
```

After:
```
$ brew audit --skip-style --except=version -d dolphin-dev
==> Auditing Cask dolphin-dev on os high_sierra and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask-versions/Casks/dolphin-dev.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value

$ brew audit --skip-style --except=version -d dolphin-dev --online
==> Auditing Cask dolphin-dev on os high_sierra and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask-versions/Casks/dolphin-dev.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
/usr/bin/env /usr/local/Homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.1.7-5-gcaafd78-dirty\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.13.6\)\ curl/7.54.0 --header Accept-Language:\ en --retry 3 --fail --silent --location https://dolphin-emu.org/download/list/master/1/
/usr/bin/env /usr/local/Homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.1.7-5-gcaafd78-dirty\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.13.6\)\ curl/7.54.0 --header Accept-Language:\ en --connect-timeout 15 --max-time 25 --retry 3 --retry-max-time 25 --dump-header - --output /private/tmp/20230829-45114-145ki0n --location https://dl.dolphin-emu.org/builds/42/5b/dolphin-master-5.0-20054-universal.dmg
...

$ brew audit --skip-style --except=version -d vlc
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromDefaultTapPathLoader): loading vlc
==> Auditing Cask vlc on os high_sierra and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/v/vlc.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
==> Auditing GitHub prerelease
```