### PR TITLE
Make formula upgrades more liberal based on bottle

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -271,6 +271,7 @@ module Homebrew
 
       already_broken_dependents = check_broken_dependents(installed_formulae)
 
+      # TODO: this should be refactored to use FormulaInstaller new logic
       outdated_dependents =
         installed_formulae.flat_map(&:runtime_installed_formula_dependents)
                           .uniq


### PR DESCRIPTION
When we're installing a formula from a bottle, we currently always upgrade all dependencies in the dependency tree to be safe.

However, if we're installing a bottle and the `runtime_dependencies` within that bottle's tab all have older or equal versions to those already installed: we do not need to upgrade these dependencies.

This should help a lot of upgrading a lot of the time, at least for users using bottles (which is the huge majority).

The only downside or other noticeable change is that this requires us to download or attempt to download the bottle tab before we compute the dependencies at installation time.