### PR TITLE
os/mac/hardware: remove TODO.

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -11,13 +11,9 @@ module Hardware
     end
     if CPU.arch == :arm64
       :arm_vortex_tempest
-    # TODO: this cannot be re-enabled until either Rosetta 2 supports AVX
-    # instructions in bottles or Homebrew refuses to run under Rosetta 2 (when
-    # ARM support is sufficiently complete):
+    # This cannot use a newer CPU e.g. ivybridge because Rosetta 2 does not
+    # support AVX instructions in bottles:
     #   https://github.com/Homebrew/homebrew-core/issues/67713
-    #
-    # elsif version >= :big_sur
-    #   :ivybridge
     elsif version >= :mojave
       :nehalem
     else


### PR DESCRIPTION
As discussed in comments, this TODO can pretty much never be done so doesn't make sense to leave as-is.