### PR TITLE
Enable Sorbet after running a developer command

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -912,27 +912,6 @@ then
   export HOMEBREW_DEVELOPER_COMMAND="1"
 fi
 
-if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEVELOPER_COMMAND}" ]]
-then
-  # Always run with Sorbet for Homebrew developers or Homebrew developer commands.
-  export HOMEBREW_SORBET_RUNTIME="1"
-fi
-
-# NO_SORBET_RUNTIME_COMMANDS are currently failing with Sorbet for homebrew/core.
-# TODO: fix this and remove this if block.
-if [[ -n "${HOMEBREW_SORBET_RUNTIME}" ]]
-then
-  NO_SORBET_RUNTIME_COMMANDS=(
-  )
-
-  if check-array-membership "${HOMEBREW_COMMAND}" "${NO_SORBET_RUNTIME_COMMANDS[@]}"
-  then
-    unset HOMEBREW_SORBET_RUNTIME
-  fi
-
-  unset NO_SORBET_RUNTIME_COMMANDS
-fi
-
 # Provide a (temporary, undocumented) way to disable Sorbet globally if needed
 # to avoid reverting the above.
 if [[ -n "${HOMEBREW_NO_SORBET_RUNTIME}" ]]
@@ -955,6 +934,12 @@ EOS
 
   git config --file="${HOMEBREW_GIT_CONFIG_FILE}" --replace-all homebrew.devcmdrun true 2>/dev/null
   export HOMEBREW_DEV_CMD_RUN="1"
+fi
+
+if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEV_CMD_RUN}" ]]
+then
+  # Always run with Sorbet for Homebrew developers or when a Homebrew developer command has been run.
+  export HOMEBREW_SORBET_RUNTIME="1"
 fi
 
 if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh" ]]

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -126,6 +126,10 @@ class DependencyCollector
   sig { void }
   def init_global_dep_tree_if_needed!; end
 
+  sig {
+    params(spec: T.any(String, Resource, Symbol, Requirement, Dependency, Class),
+           tags: T::Array[Symbol]).returns(T.any(Dependency, Requirement, NilClass))
+  }
   def parse_spec(spec, tags)
     raise ArgumentError, "Implicit dependencies cannot be manually specified" if tags.include?(:implicit)
 
@@ -140,8 +144,6 @@ class DependencyCollector
       spec
     when Class
       parse_class_spec(spec, tags)
-    else
-      raise TypeError, "Unsupported type #{spec.class.name} for #{spec.inspect}"
     end
   end
 

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -194,14 +194,11 @@ class Resource < Downloadable
   def version(val = nil)
     return super() if val.nil?
 
-    @version = case T.unsafe(val)
+    @version = case val
     when String
       val.blank? ? Version::NULL : Version.new(val)
     when Version
       val
-    else
-      # TODO: This can probably go if/when typechecking is enforced in taps.
-      raise TypeError, "version '#{val.inspect}' should be a string"
     end
   end
 

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -80,75 +80,63 @@ module Homebrew
       end
 
       command ||= on_system_conditional(macos: macos, linux: linux)
-      case T.unsafe(command)
+      case command
       when nil
         @run
       when String, Pathname
         @run = [command]
       when Array
         @run = command
-      else
-        raise TypeError, "Service#run expects an Array"
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def working_dir(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @working_dir
       when String, Pathname
         @working_dir = path.to_s
-      else
-        raise TypeError, "Service#working_dir expects a String"
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def root_dir(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @root_dir
       when String, Pathname
         @root_dir = path.to_s
-      else
-        raise TypeError, "Service#root_dir expects a String or Pathname"
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def input_path(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @input_path
       when String, Pathname
         @input_path = path.to_s
-      else
-        raise TypeError, "Service#input_path expects a String or Pathname"
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def log_path(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @log_path
       when String, Pathname
         @log_path = path.to_s
-      else
-        raise TypeError, "Service#log_path expects a String"
       end
     end
 
     sig { params(path: T.nilable(T.any(String, Pathname))).returns(T.nilable(String)) }
     def error_log_path(path = nil)
-      case T.unsafe(path)
+      case path
       when nil
         @error_log_path
       when String, Pathname
         @error_log_path = path.to_s
-      else
-        raise TypeError, "Service#error_log_path expects a String"
       end
     end
 
@@ -157,7 +145,7 @@ module Homebrew
         .returns(T.nilable(T::Hash[Symbol, T.untyped]))
     }
     def keep_alive(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @keep_alive
       when true, false
@@ -169,20 +157,16 @@ module Homebrew
         end
 
         @keep_alive = value
-      else
-        raise TypeError, "Service#keep_alive expects a Boolean or Hash"
       end
     end
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def require_root(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @require_root
       when true, false
         @require_root = value
-      else
-        raise TypeError, "Service#require_root expects a Boolean"
       end
     end
 
@@ -195,19 +179,17 @@ module Homebrew
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def run_at_load(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @run_at_load
       when true, false
         @run_at_load = value
-      else
-        raise TypeError, "Service#run_at_load expects a Boolean"
       end
     end
 
     sig { params(value: T.nilable(String)).returns(T.nilable(T::Hash[Symbol, String])) }
     def sockets(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @sockets
       when String
@@ -216,8 +198,6 @@ module Homebrew
 
         type, host, port = match.captures
         @sockets = { host: host, port: port, type: type }
-      else
-        raise TypeError, "Service#sockets expects a String"
       end
     end
 
@@ -230,31 +210,27 @@ module Homebrew
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def launch_only_once(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @launch_only_once
       when true, false
         @launch_only_once = value
-      else
-        raise TypeError, "Service#launch_only_once expects a Boolean"
       end
     end
 
     sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
     def restart_delay(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @restart_delay
       when Integer
         @restart_delay = value
-      else
-        raise TypeError, "Service#restart_delay expects an Integer"
       end
     end
 
     sig { params(value: T.nilable(Symbol)).returns(T.nilable(Symbol)) }
     def process_type(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @process_type
       when :background, :standard, :interactive, :adaptive
@@ -263,46 +239,38 @@ module Homebrew
         raise TypeError, "Service#process_type allows: " \
                          "'#{PROCESS_TYPE_BACKGROUND}'/'#{PROCESS_TYPE_STANDARD}'/" \
                          "'#{PROCESS_TYPE_INTERACTIVE}'/'#{PROCESS_TYPE_ADAPTIVE}'"
-      else
-        raise TypeError, "Service#process_type expects a Symbol"
       end
     end
 
     sig { params(value: T.nilable(Symbol)).returns(T.nilable(Symbol)) }
     def run_type(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @run_type
       when :immediate, :interval, :cron
         @run_type = value
       when Symbol
         raise TypeError, "Service#run_type allows: '#{RUN_TYPE_IMMEDIATE}'/'#{RUN_TYPE_INTERVAL}'/'#{RUN_TYPE_CRON}'"
-      else
-        raise TypeError, "Service#run_type expects a Symbol"
       end
     end
 
     sig { params(value: T.nilable(Integer)).returns(T.nilable(Integer)) }
     def interval(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @interval
       when Integer
         @interval = value
-      else
-        raise TypeError, "Service#interval expects an Integer"
       end
     end
 
     sig { params(value: T.nilable(String)).returns(T.nilable(Hash)) }
     def cron(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @cron
       when String
         @cron = parse_cron(T.must(value))
-      else
-        raise TypeError, "Service#cron expects a String"
       end
     end
 
@@ -354,23 +322,19 @@ module Homebrew
 
     sig { params(variables: T::Hash[Symbol, String]).returns(T.nilable(T::Hash[Symbol, String])) }
     def environment_variables(variables = {})
-      case T.unsafe(variables)
+      case variables
       when Hash
         @environment_variables = variables.transform_values(&:to_s)
-      else
-        raise TypeError, "Service#environment_variables expects a hash"
       end
     end
 
     sig { params(value: T.nilable(T::Boolean)).returns(T.nilable(T::Boolean)) }
     def macos_legacy_timers(value = nil)
-      case T.unsafe(value)
+      case value
       when nil
         @macos_legacy_timers
       when true, false
         @macos_legacy_timers = value
-      else
-        raise TypeError, "Service#macos_legacy_timers expects a Boolean"
       end
     end
 

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -24,8 +24,6 @@ class Version
 
     sig { params(val: String).returns(Token) }
     def self.create(val)
-      raise TypeError, "Token value must be a string; got a #{val.class} (#{val})" unless val.respond_to?(:to_str)
-
       case val
       when /\A#{AlphaToken::PATTERN}\z/o   then AlphaToken
       when /\A#{BetaToken::PATTERN}\z/o    then BetaToken
@@ -492,8 +490,6 @@ class Version
 
   sig { params(val: T.any(PkgVersion, String, Version), detected_from_url: T::Boolean).void }
   def initialize(val, detected_from_url: false)
-    raise TypeError, "Version value must be a string; got a #{val.class} (#{val})" unless val.respond_to?(:to_str)
-
     version = val.to_str
     raise ArgumentError, "Version must not be empty" if version.blank?
 


### PR DESCRIPTION
We have no commands with Sorbet disabled and have had Sorbet enabled for developers for a decent amount of time. As a result, we can enable it for everyone who has run a developer command.

This also allows a bunch of `raise TypeError`s to be removed in favour of relying on Sorbet here instead.