### PR TITLE
utils/curl: include or use explicitly.

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -4,6 +4,7 @@
 require "cask/cache"
 require "cask/cask"
 require "uri"
+require "utils/curl"
 
 module Cask
   # Loads a cask from various sources.
@@ -160,7 +161,7 @@ module Cask
 
         begin
           ohai "Downloading #{url}"
-          curl_download url, to: path
+          ::Utils::Curl.curl_download url, to: path
         rescue ErrorDuringExecution
           raise CaskUnavailableError.new(token, "Failed to download #{Formatter.url(url)}.")
         end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -11,6 +11,7 @@ module Homebrew
   # @api private
   class FormulaAuditor
     include FormulaCellarChecks
+    include Utils::Curl
 
     attr_reader :formula, :text, :problems, :new_formula_problems
 
@@ -537,12 +538,14 @@ module Homebrew
         spec.using == :homebrew_curl
       end
 
-      if (http_content_problem = curl_check_http_content(homepage,
-                                                         SharedAudits::URL_TYPE_HOMEPAGE,
-                                                         user_agents:       [:browser, :default],
-                                                         check_content:     true,
-                                                         strict:            @strict,
-                                                         use_homebrew_curl: use_homebrew_curl))
+      if (http_content_problem = curl_check_http_content(
+        homepage,
+        SharedAudits::URL_TYPE_HOMEPAGE,
+        user_agents:       [:browser, :default],
+        check_content:     true,
+        strict:            @strict,
+        use_homebrew_curl: use_homebrew_curl,
+      ))
         problem http_content_problem
       end
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -6,6 +6,7 @@ require "extend/cachable"
 require "tab"
 require "utils/bottles"
 require "service"
+require "utils/curl"
 
 require "active_support/core_ext/hash/deep_transform_values"
 
@@ -591,7 +592,7 @@ module Formulary
       end
       HOMEBREW_CACHE_FORMULA.mkpath
       FileUtils.rm_f(path)
-      curl_download url, to: path
+      Utils::Curl.curl_download url, to: path
       super
     rescue MethodDeprecatedError => e
       if (match_data = url.match(%r{github.com/(?<user>[\w-]+)/(?<repo>[\w-]+)/}).presence)

--- a/Library/Homebrew/github_releases.rb
+++ b/Library/Homebrew/github_releases.rb
@@ -9,7 +9,6 @@ require "json"
 # @api private
 class GitHubReleases
   include Context
-  include Utils::Curl
 
   URL_REGEX = %r{https://github\.com/([\w-]+)/([\w-]+)?/releases/download/(.+)}.freeze
 

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -123,10 +123,12 @@ module Homebrew
           raise HomebrewCurlDownloadStrategyError, url if
             strategy <= HomebrewCurlDownloadStrategy && !Formula["curl"].any_version_installed?
 
-          if (http_content_problem = curl_check_http_content(url,
-                                                             "source URL",
-                                                             specs:             specs,
-                                                             use_homebrew_curl: @use_homebrew_curl))
+          if (http_content_problem = Utils::Curl.curl_check_http_content(
+            url,
+            "source URL",
+            specs:             specs,
+            use_homebrew_curl: @use_homebrew_curl,
+          ))
             problem http_content_problem
           end
         elsif strategy <= GitDownloadStrategy

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -128,11 +128,11 @@ module SystemConfig
 
     sig { returns(String) }
     def describe_curl
-      out, = system_command(curl_executable, args: ["--version"], verbose: false)
+      out, = system_command(Utils::Curl.curl_executable, args: ["--version"], verbose: false)
 
       match_data = /^curl (?<curl_version>[\d.]+)/.match(out)
       if match_data
-        "#{match_data[:curl_version]} => #{curl_path}"
+        "#{match_data[:curl_version]} => #{Utils::Curl.curl_path}"
       else
         "N/A"
       end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -167,7 +167,7 @@ RSpec.configure do |config|
 
   config.before(:each, :needs_homebrew_curl) do
     ENV["HOMEBREW_CURL"] = HOMEBREW_BREWED_CURL_PATH
-    skip "A `curl` with TLS 1.3 support is required." unless curl_supports_tls13?
+    skip "A `curl` with TLS 1.3 support is required." unless Utils::Curl.curl_supports_tls13?
   rescue FormulaUnavailableError
     skip "No `curl` formula is available."
   end

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -3,6 +3,8 @@
 require "utils/curl"
 
 describe "Utils::Curl" do
+  include Utils::Curl
+
   let(:details) do
     details = {
       normal:     {},

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -609,6 +609,3 @@ module Utils
     end
   end
 end
-
-# FIXME: Include `Utils::Curl` explicitly everywhere it is used.
-include Utils::Curl # rubocop:disable Style/MixinUsage

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -251,7 +251,7 @@ module GitHub
 
         args += ["--dump-header", T.must(headers_tmpfile.path)]
 
-        output, errors, status = curl_output("--location", url.to_s, *args, secrets: [token])
+        output, errors, status = Utils::Curl.curl_output("--location", url.to_s, *args, secrets: [token])
         output, _, http_code = output.rpartition("\n")
         output, _, http_code = output.rpartition("\n") if http_code == "000"
         headers = headers_tmpfile.read

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -65,7 +65,7 @@ module PyPI
       else
         "https://pypi.org/pypi/#{name}/json"
       end
-      out, _, status = curl_output metadata_url, "--location", "--fail"
+      out, _, status = Utils::Curl.curl_output metadata_url, "--location", "--fail"
 
       return unless status.success?
 

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -16,7 +16,8 @@ module Repology
     last_package_in_response += "/" if last_package_in_response.present?
     url = "https://repology.org/api/v1/projects/#{last_package_in_response}?inrepo=#{repository}&outdated=1"
 
-    output, errors, = curl_output(url.to_s, "--silent", use_homebrew_curl: !curl_supports_tls13?)
+    output, errors, = Utils::Curl.curl_output(url.to_s, "--silent",
+                                              use_homebrew_curl: !Utils::Curl.curl_supports_tls13?)
     JSON.parse(output)
   rescue
     if Homebrew::EnvConfig.developer?
@@ -31,7 +32,8 @@ module Repology
   def self.single_package_query(name, repository:)
     url = "https://repology.org/api/v1/project/#{name}"
 
-    output, errors, = curl_output("--location", "--silent", url.to_s, use_homebrew_curl: !curl_supports_tls13?)
+    output, errors, = Utils::Curl.curl_output("--location", "--silent", url.to_s,
+                                              use_homebrew_curl: !Utils::Curl.curl_supports_tls13?)
 
     data = JSON.parse(output)
     { name => data }

--- a/Library/Homebrew/utils/shared_audits.rbi
+++ b/Library/Homebrew/utils/shared_audits.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module SharedAudits
+  include ::Kernel
+end

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -8,9 +8,6 @@ require "utils/github"
 #
 # @api private
 module SPDX
-  include Utils::Curl
-  extend Utils::Curl
-
   module_function
 
   DATA_PATH = (HOMEBREW_DATA_PATH/"spdx").freeze
@@ -34,8 +31,8 @@ module SPDX
 
   def download_latest_license_data!(to: DATA_PATH)
     data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{latest_tag}/json/"
-    curl_download("#{data_url}licenses.json", to: to/"spdx_licenses.json")
-    curl_download("#{data_url}exceptions.json", to: to/"spdx_exceptions.json")
+    Utils::Curl.curl_download("#{data_url}licenses.json", to: to/"spdx_licenses.json")
+    Utils::Curl.curl_download("#{data_url}exceptions.json", to: to/"spdx_exceptions.json")
   end
 
   def parse_license_expression(license_expression)


### PR DESCRIPTION
Include or use `Utils::Curl` explicitly everywhere it is used.