### PR TITLE
Add an audit for mismatched Python resource and PyPi package names

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -105,7 +105,7 @@ module Homebrew
       return if name == owner.name # Skip the top-level package name as we only care about `resource "foo"` blocks.
 
       url =~ %r{/(?<package_name>[^/]+)-}
-      pypi_package_name = Regexp.last_match(:package_name).gsub(/[_.]/, "-")
+      pypi_package_name = Regexp.last_match(:package_name).to_s.gsub(/[_.]/, "-")
       return if name.casecmp(pypi_package_name).zero?
 
       problem "resource name should be `#{pypi_package_name}` to match the PyPI package name"

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -104,7 +104,8 @@ module Homebrew
       return unless url.match?(%r{^https?://files\.pythonhosted\.org/packages/})
       return if name == owner.name # Skip the top-level package name as we only care about `resource "foo"` blocks.
 
-      pypi_package_name = url.split("/").last.split(/[-.]\d+?./).first.gsub(/[_.]/, "-")
+      url =~ %r{/(?<package_name>[^/]+)-}
+      pypi_package_name = Regexp.last_match(:package_name).gsub(/[_.]/, "-")
       return if name.casecmp(pypi_package_name).zero?
 
       problem "resource name should be `#{pypi_package_name}` to match the PyPI package name"

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -102,6 +102,7 @@ module Homebrew
 
     def audit_resource_name_matches_pypi_package_name_in_url
       return unless url.match?(%r{^https?://files\.pythonhosted\.org/packages/})
+      return if name == owner.name # Skip the top-level package name as we only care about `resource "foo"` blocks.
 
       pypi_package_name = url.split("/").last.split(/[-.]\d+?./).first.gsub(/[_.]/, "-")
       return if name.casecmp(pypi_package_name).zero?

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -103,7 +103,7 @@ module Homebrew
     def audit_resource_name_matches_pypi_package_name_in_url
       return unless url.match?(%r{^https?://files\.pythonhosted\.org/packages/})
 
-      pypi_package_name = url.split("/").last.split(/-\d+\.\d+./).first.tr("_", "-")
+      pypi_package_name = url.split("/").last.split(/[-.]\d+?./).first.gsub(/[_.]/, "-")
       return if name.casecmp(pypi_package_name).zero?
 
       problem "resource name should be `#{pypi_package_name}` to match the PyPI package name"

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -106,7 +106,7 @@ module Homebrew
       pypi_package_name = url.split("/").last.split(/-\d+\.\d+./).first.tr("_", "-")
       return if name.casecmp(pypi_package_name).zero?
 
-      problem "resource name should be `#{pypi_package_name}` to closer match the PyPI package name"
+      problem "resource name should be `#{pypi_package_name}` to match the PyPI package name"
     end
 
     def audit_urls

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -100,6 +100,15 @@ module Homebrew
       end
     end
 
+    def audit_resource_name_matches_pypi_package_name_in_url
+      return unless url.match?(%r{^https?://files\.pythonhosted\.org/packages/})
+
+      pypi_package_name = url.split("/").last.split(/-\d+\.\d+./).first.tr("_", "-")
+      return if name.casecmp(pypi_package_name).zero?
+
+      problem "resource name should be `#{pypi_package_name}` to closer match the PyPI package name"
+    end
+
     def audit_urls
       urls = [url] + mirrors
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -522,6 +522,27 @@ module Homebrew
       end
     end
 
+    describe "#audit_resource_name_matches_pypi_package_name_in_url" do
+      it "reports a problem if the resource name does not match the python package name" do
+        fa = formula_auditor "foo", <<~RUBY
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            sha256 "abc123"
+            homepage "https://brew.sh"
+
+            resource "Something" do
+              url "https://files.pythonhosted.org/packages/FooSomething-1.0.0.tar.gz"
+              sha256 "def456"
+            end
+          end
+        RUBY
+
+        fa.audit_specs
+        expect(fa.problems.first[:message])
+          .to match("resource name should be `FooSomething` to closer match the PyPI package name")
+      end
+    end
+
     describe "#check_service_command" do
       specify "Not installed" do
         fa = formula_auditor "foo", <<~RUBY

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -539,7 +539,7 @@ module Homebrew
 
         fa.audit_specs
         expect(fa.problems.first[:message])
-          .to match("resource name should be `FooSomething` to closer match the PyPI package name")
+          .to match("resource name should be `FooSomething` to match the PyPI package name")
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #14537.
- When people manually add or modify PyPI resources the `Resource#name` sometimes ends up out-of-sync with the PyPI package name.