### PR TITLE
Handle nil cask urls caused by unsupported macOS version

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -277,7 +277,7 @@ module Cask
             sha256 json_cask[:sha256]
           end
 
-          url json_cask[:url], **json_cask.fetch(:url_specs, {})
+          url json_cask[:url], **json_cask.fetch(:url_specs, {}) if json_cask[:url].present?
           appcast json_cask[:appcast] if json_cask[:appcast].present?
           json_cask[:name].each do |cask_name|
             name cask_name

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -24,6 +24,8 @@ module Cask
 
     sig { override.returns(T.nilable(::URL)) }
     def url
+      return if cask.url.nil?
+
       @url ||= ::URL.new(cask.url.to_s, cask.url.specs)
     end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -309,9 +309,6 @@ on_request: true)
       end
     end
 
-    # TODO: move dependencies to a separate class,
-    #       dependencies should also apply for `brew cask stage`,
-    #       override dependencies with `--force` or perhaps `--force-deps`
     def satisfy_cask_and_formula_dependencies
       return if installed_as_dependency?
 

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -167,6 +167,11 @@ module Homebrew
           SimulateSystem.with os: os, arch: arch do
             cask = Cask::CaskLoader.load(ref)
 
+            if cask.depends_on.macos&.satisfied? == false
+              opoo "#{cask.token}: #{cask.depends_on.macos.message(type: :cask)}"
+              next
+            end
+
             quarantine = args.quarantine?
             quarantine = true if quarantine.nil?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The goal here is to handle the case where a cask might have a nil url stanza because that cask is not available on the current version of macOS or the given architecture. This just moves those checks from the end of the `Cask::Installer#fetch` method to the beginning so that we don't try and download casks that are missing urls. A similar change was also applied to the `brew fetch` command.

This will now provide a helpful error message like so:
```
Error: This software does not run on macOS versions older than Big Sur.
```

Beyond that it no longer tries to run the url stanza with a nil value when loading casks from the API.