### PR TITLE
Livecheck#preprocess_url: compare with URI host

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -561,25 +561,24 @@ module Homebrew
       end
 
       host = uri.host
-      domain = uri.domain
       path = uri.path
       return url if host.nil? || path.nil?
 
-      domain = host = "github.com" if host == "github.s3.amazonaws.com"
+      host = "github.com" if host == "github.s3.amazonaws.com"
       path = path.delete_prefix("/").delete_suffix(".git")
       scheme = uri.scheme
 
-      if domain == "github.com"
+      if host == "github.com"
         return url if path.match? %r{/releases/latest/?$}
 
         owner, repo = path.delete_prefix("downloads/").split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}.git"
-      elsif GITEA_INSTANCES.include?(domain)
+      elsif GITEA_INSTANCES.include?(host)
         return url if path.match? %r{/releases/latest/?$}
 
         owner, repo = path.split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}.git"
-      elsif GOGS_INSTANCES.include?(domain)
+      elsif GOGS_INSTANCES.include?(host)
         owner, repo = path.split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}.git"
       # sourcehut


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We now have a `gitea` formula in homebrew/core and its `stable` URL uses a dl.gitea.com tarball. Since the URL's domain is gitea.com, livecheck tries to preprocess the URL into a `.git` URL but the resulting URL doesn't work because it's not a Git repository (see https://github.com/Homebrew/homebrew-core/pull/141337).

Gitea repositories use gitea.com (with no subdomain), so `#preprocess_url` should be comparing the URI host (`dl.gitea.com`) instead of the domain (`gitea.com`). This change allows gitea.com repository URLs to continue to be preprocessed into a `.git` URL while dl.gitea.com URLs are left untouched.

This makes the same change for the other domains, as they don't use a subdomain either.