### PR TITLE
cask/url: accept Class for using in Cask::URL#initialize

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -148,7 +148,7 @@ module Cask
       params(
         uri:             T.nilable(T.any(URI::Generic, String)),
         verified:        T.nilable(String),
-        using:           T.nilable(Symbol),
+        using:           T.any(Class, Symbol, NilClass),
         tag:             T.nilable(String),
         branch:          T.nilable(String),
         revisions:       T.nilable(T::Array[String]),


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

---

#### Commits _(oldest to newest)_

b4feaf27d9 cask/url: accept Class for using in Cask::URL#initialize

https://github.com/Homebrew/brew/pull/15754 fixed `Cask::URL::DSL#initialize`, but we also need to fix `Cask::URL#initialize` as that takes the same parameters.

Error:

```
Error: Cask 'mycask' definition is invalid: 'url' stanza failed
  with: Parameter 'using': Expected type T.nilable(Symbol), got type Class
  with value MyCustomDownloadStrategy
Caller:
  /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:113
```

Refs: https://github.com/Homebrew/brew/issues/15750

<br/>