### PR TITLE
formula_installer: handle another exception in fetch_bottle_tab.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1213,7 +1213,7 @@ on_request: installed_on_request?, options: options)
                                                 .index_by { |dep| dep["full_name"] }
                                                 .freeze
       true
-    rescue DownloadError
+    rescue DownloadError, ArgumentError
       @fetch_bottle_tab = true
     end
   end


### PR DESCRIPTION
Fix another way that fetching a bottle tab can fail. This pretty much only happens in CI.

Addresses https://github.com/Homebrew/homebrew-core/pull/141362#issuecomment-1705327027

CC @bayandin 