### PR TITLE
Further split up Gemfile into groups

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -13,7 +13,7 @@ then
 fi
 
 # install Homebrew's development gems
-brew install-bundler-gems --groups=sorbet
+brew install-bundler-gems --groups=all
 
 # install Homebrew formulae we might need
 brew install shellcheck shfmt gh gnu-tar

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
+          key: ${{ runner.os }}-rubygems-syntax-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-syntax-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=style,typecheck
 
       - name: Install shellcheck and shfmt
         run: brew install shellcheck shfmt
@@ -82,11 +82,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
+          key: ${{ runner.os }}-rubygems-tap-syntax-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-tap-syntax-
 
       - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
+        run: brew install-bundler-gems --groups=style
 
       - name: Run brew style on homebrew-core
         run: brew style homebrew/core
@@ -138,16 +138,6 @@ jobs:
           cask: false
           test-bot: false
 
-      - name: Cache Bundler RubyGems
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
-      - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
-
       - name: Run brew readall on homebrew/core
         run: brew readall --os=all --arch=all --aliases homebrew/core
 
@@ -170,16 +160,6 @@ jobs:
           core: true
           cask: true
           test-bot: false
-
-      - name: Cache Bundler RubyGems
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
-      - name: Install Bundler RubyGems
-        run: brew install-bundler-gems --groups=all
 
       - name: Set up Homebrew all cask taps
         run: |
@@ -285,16 +265,6 @@ jobs:
           core: false
           cask: false
           test-bot: false
-
-      - name: Cache Bundler RubyGems
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
-      - name: Install Bundler RubyGems
-        run: brew install-bundler-gems
 
       - name: Run brew update-tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN mkdir -p \
   && git -C .linuxbrew/Homebrew remote set-url origin https://github.com/Homebrew/brew \
   && git -C .linuxbrew/Homebrew fetch origin \
   && HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap --force homebrew/core \
-  && brew install-bundler-gems \
+  && brew install-bundler-gems --groups=all \
   && brew cleanup \
   && { git -C .linuxbrew/Homebrew config --unset gc.auto; true; } \
   && { git -C .linuxbrew/Homebrew config --unset homebrew.devcmdrun; true; } \

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+# The default case (no envs), should always be a restrictive bound on the lowest supported minor version.
+# This is the branch that Dependabot will use.
 if ENV.fetch("HOMEBREW_DEVELOPER", "").empty? || ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", "").empty?
   ruby "~> 2.6.0"
 else
@@ -12,51 +14,68 @@ end
 # * nokogiri - use rexml instead for XML parsing
 
 # installed gems (should all be require: false)
-gem "bootsnap", require: false
-gem "byebug", require: false
-gem "json_schemer", require: false
-gem "minitest", require: false
-gem "parallel_tests", require: false
-gem "pry", require: false
-gem "ronn", require: false
-gem "rspec", require: false
-gem "rspec-github", require: false
-gem "rspec-its", require: false
-gem "rspec_junit_formatter", require: false
-gem "rspec-retry", require: false
-gem "rspec-sorbet", require: false
-gem "rubocop", require: false
-gem "rubocop-ast", require: false
-gem "simplecov", require: false
-gem "simplecov-cobertura", require: false
-gem "warning", require: false
-
-group :sorbet, optional: true do
-  gem "parlour", require: false
-  gem "sorbet-static-and-runtime", require: false
-  gem "spoom", require: false
-  gem "tapioca", require: false
+# ALL gems that are not vendored should be in a group
+group :ast, optional: true do
+  gem "rubocop-ast", require: false
 end
-
+group :bootsnap, optional: true do
+  gem "bootsnap", require: false
+end
+group :formula_test, optional: true do
+  gem "minitest", require: false
+end
+group :livecheck, optional: true do
+  gem "ruby-progressbar", require: false
+end
+group :man, optional: true do
+  gem "ronn", require: false
+end
+group :pr_publish, optional: true do
+  gem "json_schemer", require: false
+end
 group :prof, optional: true do
   # NOTE: ruby-prof v1.4.3 is the last version that supports Ruby 2.6.x
   # TODO: remove explicit version when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
   gem "ruby-prof", "1.4.3", require: false
   gem "stackprof", require: false
 end
+group :pry, optional: true do
+  gem "pry", require: false
+end
+group :style, optional: true do
+  gem "rubocop", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
+  gem "rubocop-sorbet", require: false
+end
+group :tests, optional: true do
+  gem "byebug", require: false
+  gem "parallel_tests", require: false
+  gem "rspec", require: false
+  gem "rspec-github", require: false
+  gem "rspec-its", require: false
+  gem "rspec_junit_formatter", require: false
+  gem "rspec-retry", require: false
+  gem "rspec-sorbet", require: false
+  gem "simplecov", require: false
+  gem "simplecov-cobertura", require: false
+end
+group :typecheck, optional: true do
+  gem "parlour", require: false
+  gem "sorbet-static-and-runtime", require: false
+  gem "spoom", require: false
+  gem "tapioca", require: false
+end
 
-# vendored gems
+# vendored gems (no group)
 gem "activesupport"
 gem "addressable"
-gem "concurrent-ruby"
 gem "patchelf"
 gem "plist"
-gem "rubocop-performance"
-gem "rubocop-rails"
-gem "rubocop-rspec"
-gem "rubocop-sorbet"
 gem "ruby-macho"
 gem "sorbet-runtime"
+gem "warning"
 
 # TODO: remove when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
 install_if -> { RUBY_VERSION < "2.7" } do

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -193,7 +193,6 @@ DEPENDENCIES
   addressable
   bootsnap
   byebug
-  concurrent-ruby
   did_you_mean
   json_schemer
   minitest
@@ -217,6 +216,7 @@ DEPENDENCIES
   rubocop-sorbet
   ruby-macho
   ruby-prof (= 1.4.3)
+  ruby-progressbar
   simplecov
   simplecov-cobertura
   sorbet-runtime

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -94,7 +94,7 @@ module Homebrew
     args = bottle_args.parse
 
     if args.merge?
-      Homebrew.install_bundler_gems!
+      Homebrew.install_bundler_gems!(groups: ["ast"])
       return merge(args: args)
     end
 

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -70,7 +70,7 @@ module Homebrew
     # odeprecated "brew bump-cask-pr --online" if args.online?
     # This will be run by `brew audit` or `brew style` later so run it first to
     # not start spamming during normal output.
-    Homebrew.install_bundler_gems! if !args.no_audit? || !args.no_style?
+    Homebrew.install_bundler_gems!(groups: ["style"]) if !args.no_audit? || !args.no_style?
 
     # As this command is simplifying user-run commands then let's just use a
     # user path, too.

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -117,7 +117,7 @@ module Homebrew
 
     # This will be run by `brew audit` later so run it first to not start
     # spamming during normal output.
-    Homebrew.install_bundler_gems! unless args.no_audit?
+    Homebrew.install_bundler_gems!(groups: ["style"]) unless args.no_audit?
 
     tap_remote_repo = formula.tap.full_name || formula.tap.remote_repo
     remote = "origin"

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -51,7 +51,7 @@ module Homebrew
           end
         end
       else
-        Homebrew.install_bundler_gems!
+        Homebrew.install_bundler_gems!(groups: ["ast"])
         require "utils/ast"
 
         formula_ast = Utils::AST::FormulaAST.new(formula.path.read)

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -63,6 +63,7 @@ module Homebrew
     end
 
     if args.pry?
+      Homebrew.install_bundler_gems!(groups: ["pry"])
       require "pry"
     else
       require "irb"

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -66,6 +66,8 @@ module Homebrew
   def livecheck
     args = livecheck_args.parse
 
+    Homebrew.install_bundler_gems!(groups: ["livecheck"]) if args.json?
+
     all = args.eval_all?
 
     if args.debug? && args.verbose?

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -125,9 +125,7 @@ module Homebrew
 
       check_bottled_formulae!(bottles_hash)
 
-      # This will be run by `brew bottle` and `brew audit` later so run it first
-      # to not start spamming during normal output.
-      Homebrew.install_bundler_gems!
+      Homebrew.install_bundler_gems!(groups: ["pr_upload", "style"])
 
       safe_system HOMEBREW_BREW_FILE, *bottle_args
 

--- a/Library/Homebrew/dev-cmd/rubocop.sh
+++ b/Library/Homebrew/dev-cmd/rubocop.sh
@@ -14,13 +14,15 @@ homebrew-rubocop() {
   GEM_VERSION="$("${HOMEBREW_RUBY_PATH}" "${HOMEBREW_RUBY_DISABLE_OPTIONS}" -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]')"
   GEM_HOME="${HOMEBREW_LIBRARY}/Homebrew/vendor/bundle/ruby/${GEM_VERSION}"
   BUNDLE_GEMFILE="${HOMEBREW_LIBRARY}/Homebrew/Gemfile"
+  BUNDLE_WITH="style"
 
   export GEM_HOME
   export BUNDLE_GEMFILE
+  export BUNDLE_WITH
 
   if ! bundle check &>/dev/null
   then
-    "${HOMEBREW_BREW_FILE}" install-bundler-gems
+    "${HOMEBREW_BREW_FILE}" install-bundler-gems --add-groups=style
   fi
 
   export PATH="${GEM_HOME}/bin:${PATH}"

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -85,10 +85,6 @@ module Homebrew
                 key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
                 restore-keys: ${{ runner.os }}-rubygems-
 
-            - name: Install Homebrew Bundler RubyGems
-              if: steps.cache.outputs.cache-hit != 'true'
-              run: brew install-bundler-gems
-
             - run: brew test-bot --only-cleanup-before
 
             - run: brew test-bot --only-setup

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -35,7 +35,7 @@ module Homebrew
   def test
     args = test_args.parse
 
-    Homebrew.install_bundler_gems!(setup_path: false)
+    Homebrew.install_bundler_gems!(groups: ["formula_test"], setup_path: false)
 
     require "formula_assertions"
     require "formula_free_port"

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -88,7 +88,8 @@ module Homebrew
   def tests
     args = tests_args.parse
 
-    Homebrew.install_bundler_gems!(groups: ["prof"])
+    # Given we might be testing various commands, we probably want everything (except sorbet-static)
+    Homebrew.install_bundler_gems!(groups: Homebrew.valid_gem_groups - ["sorbet"])
 
     require "byebug" if args.byebug?
 

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -40,7 +40,7 @@ module Homebrew
     args = typecheck_args.parse
 
     update = args.update? || args.update_all?
-    groups = update ? Homebrew.valid_gem_groups : ["sorbet"]
+    groups = update ? Homebrew.valid_gem_groups : ["typecheck"]
     Homebrew.install_bundler_gems!(groups: groups)
 
     HOMEBREW_LIBRARY_PATH.cd do

--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -28,7 +28,7 @@ module Homebrew
     )
 
     def self.regenerate_man_pages(quiet:)
-      Homebrew.install_bundler_gems!
+      Homebrew.install_bundler_gems!(groups: ["man"])
 
       markup = build_man_page(quiet: quiet)
       convert_man_page(markup, TARGET_DOC_PATH/"Manpage.md")

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -23,7 +23,7 @@ if homebrew_bootsnap_enabled
     require "bootsnap"
   rescue LoadError
     unless ENV["HOMEBREW_BOOTSNAP_RETRY"]
-      Homebrew.install_bundler_gems!(only_warn_on_failure: true)
+      Homebrew.install_bundler_gems!(groups: ["bootsnap"], only_warn_on_failure: true)
 
       ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"
       exec ENV.fetch("HOMEBREW_BREW_FILE"), *ARGV

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -82,7 +82,7 @@ module Homebrew
     def self.run_rubocop(files, output_type,
                          fix: false, except_cops: nil, only_cops: nil, display_cop_names: false, reset_cache: false,
                          debug: false, verbose: false)
-      Homebrew.install_bundler_gems!
+      Homebrew.install_bundler_gems!(groups: ["style"])
 
       require "warnings"
 


### PR DESCRIPTION
A full `brew install-bundler-gems` is somewhat slow. This PR splits up the gem groups further to allow faster runs in CI etc, as well as allow a base `brew install-bundler-gems --groups=` only install what we already vendor (roughly). This could be used in future PRs to bootstrap a new Ruby.

Draft because this requires #15952.