### PR TITLE
cmd/fetch & cmd/audit: handle unsupported os/arch combos

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -166,8 +166,8 @@ module Homebrew
           SimulateSystem.with os: os, arch: arch do
             cask = Cask::CaskLoader.load(ref)
 
-            if cask.depends_on.macos&.satisfied? == false
-              opoo "#{cask.token}: #{cask.depends_on.macos.message(type: :cask)}"
+            if cask.url.nil?
+              opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
               next
             end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -242,10 +242,17 @@ module Homebrew
         next [] if os == :linux
 
         SimulateSystem.with os: os, arch: arch do
+          simulated_cask = Cask::CaskLoader.load(path)
+
+          if simulated_cask.url.nil?
+            opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
+            next []
+          end
+
           odebug "Auditing Cask #{cask} on os #{os} and arch #{arch}"
 
           Cask::Auditor.audit(
-            Cask::CaskLoader.load(path),
+            simulated_cask,
             # For switches, we add `|| nil` so that `nil` will be passed
             # instead of `false` if they aren't set.
             # This way, we can distinguish between "not set" and "set to false".


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to #15943 as described here: https://github.com/Homebrew/brew/pull/15943#issuecomment-1705486026

It's possible for casks to only run on certain os/arch combinations but we don't check for them in the fetch and audit commands.

At first, I tried to check if the macos version was satisfied in a previous PR but that doesn't work correctly because MacOSRequirement and ArchRequirement don't respect SimulateSystem.

Instead I'm just checking to see if the url stanza is defined for each os/arch combination and skipping those casks where it ends up being nil. This is kind of brute forcing it but should work.

Testing:
1. `brew audit`
Run `brew audit --skip-style --except=version homebrew/cask/gpgfrontend --os=all -d` and five of the audits should warn about unsupported os/arch combinations.
2. `brew fetch`
```
/u/l/Homebrew (handle-nil-urls-in-fetch-and-audit-cmds|✚1) $ brew fetch gpgfrontend --os=catalina
Warning: Cask gpgfrontend is not supported on os catalina and arch intel
```

Are there any scenarios where we'd want to audit a cask with a nil url?