### PR TITLE
Reset requirement cache (again) after `recursive_dependencies.map(&:to_formula)` invalidates singleton cache

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -239,7 +239,10 @@ class Requirement
         end
       end
 
-      cache[cache_key][cache_id dependent] = reqs.dup if cache_key.present?
+      if cache_key.present?
+        cache[cache_key] ||= {}
+        cache[cache_key][cache_id dependent] = reqs.dup
+      end
       reqs
     end
 

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -240,6 +240,9 @@ class Requirement
       end
 
       if cache_key.present?
+        # Even though we setup the cache above
+        # 'dependent.recursive_dependencies.map(&:to_formula)'
+        # is invalidating the singleton cache
         cache[cache_key] ||= {}
         cache[cache_key][cache_id dependent] = reqs.dup
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew deps <my custom tap>/<my custom formula>`

can blow up with 

```
Error: undefined method `[]=' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/opt/homebrew/Library/Homebrew/requirement.rb:242:in `expand'
/opt/homebrew/Library/Homebrew/dependencies_helpers.rb:43:in `recursive_includes'
/opt/homebrew/Library/Homebrew/cmd/deps.rb:198:in `deps_for_dependent'
/opt/homebrew/Library/Homebrew/cmd/deps.rb:208:in `block in deps_for_dependents'
/opt/homebrew/Library/Homebrew/cmd/deps.rb:208:in `map'
/opt/homebrew/Library/Homebrew/cmd/deps.rb:208:in `deps_for_dependents'
/opt/homebrew/Library/Homebrew/cmd/deps.rb:148:in `deps'
/opt/homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```

I can't provide a reproduction case at this moment, but the source of the bug seems to be that:

1. Yes, we do already set `cache[cache_key] ||= {}` on line 225
2. But, `formulae = dependent.recursive_dependencies.map(&:to_formula)` if you look under the hood, `to_formula` seems to clear the singleton cache
3. Therefore when we get to the point that we're setting a new key, the entire cache is empty.