### PR TITLE
resource_auditor: relax version audit in taps

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -46,7 +46,7 @@ module Homebrew
     def audit_version
       if version.nil?
         problem "missing version"
-      elsif owner.is_a?(Formula) && !version.to_s.match?(GitHubPackages::VALID_OCI_TAG_REGEX)
+      elsif owner.is_a?(Formula) && owner.core_formula? && !version.to_s.match?(GitHubPackages::VALID_OCI_TAG_REGEX)
         problem "version #{version} does not match #{GitHubPackages::VALID_OCI_TAG_REGEX.source}"
       elsif !version.detected_from_url?
         version_text = version


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The relaxes the version regex audit introduced in https://github.com/Homebrew/brew/pull/15936 by disabling it for 3rd-party taps, to help address https://github.com/osrf/homebrew-simulation/issues/2390 (see also https://github.com/Homebrew/brew/pull/15936#issuecomment-1707635509). If this audit will be applied to 3rd-party taps, it would be nice to allow some time to comply, since bottles will need to be rebuilt.