### PR TITLE
Improve cask audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -226,6 +226,7 @@ module Cask
     sig { void }
     def audit_sha256_no_check_if_latest
       return unless cask.sha256
+      return unless cask.version
 
       odebug "Auditing sha256 :no_check with version :latest"
       return unless cask.version.latest?
@@ -268,7 +269,7 @@ module Cask
 
     sig { void }
     def audit_latest_with_livecheck
-      return unless cask.version.latest?
+      return unless cask.version&.latest?
       return unless cask.livecheckable?
       return if cask.livecheck.skip?
 
@@ -277,7 +278,7 @@ module Cask
 
     sig { void }
     def audit_latest_with_auto_updates
-      return unless cask.version.latest?
+      return unless cask.version&.latest?
       return unless cask.auto_updates
 
       add_error "Casks with `version :latest` should not use `auto_updates`."
@@ -288,7 +289,8 @@ module Cask
     sig { params(livecheck_result: T.any(NilClass, T::Boolean, Symbol)).void }
     def audit_hosting_with_livecheck(livecheck_result: audit_livecheck_version)
       return if cask.discontinued?
-      return if cask.version.latest?
+      return if cask.version&.latest?
+      return unless cask.url
       return if block_url_offline?
       return if cask.livecheckable?
       return if livecheck_result == :auto_detected
@@ -328,6 +330,7 @@ module Cask
 
     sig { void }
     def audit_unnecessary_verified
+      return unless cask.url
       return if block_url_offline?
       return unless verified_present?
       return unless url_match_homepage?
@@ -340,6 +343,7 @@ module Cask
 
     sig { void }
     def audit_missing_verified
+      return unless cask.url
       return if block_url_offline?
       return if file_url?
       return if url_match_homepage?
@@ -352,6 +356,7 @@ module Cask
 
     sig { void }
     def audit_no_match
+      return unless cask.url
       return if block_url_offline?
       return unless verified_present?
       return if verified_matches_url?
@@ -453,6 +458,7 @@ module Cask
 
     sig { void }
     def audit_livecheck_unneeded_long_version
+      return if cask.version.nil? || cask.url.nil?
       return if cask.livecheck.strategy != :sparkle
       return unless cask.version.csv.second
       return if cask.url.to_s.include? cask.version.csv.second
@@ -506,6 +512,7 @@ module Cask
     sig { returns(T.any(NilClass, T::Boolean, Symbol)) }
     def audit_livecheck_version
       return unless online?
+      return unless cask.version
 
       referenced_cask, = Homebrew::Livecheck.resolve_livecheck_reference(cask)
 

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -36,6 +36,8 @@ module Cask
 
     sig { override.returns(T.nilable(Version)) }
     def version
+      return if cask.version.nil?
+
       @version ||= Version.new(cask.version)
     end
 

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -166,7 +166,7 @@ module Homebrew
           SimulateSystem.with os: os, arch: arch do
             cask = Cask::CaskLoader.load(ref)
 
-            if cask.url.nil?
+            if cask.url.nil? || cask.sha256.nil?
               opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
               next
             end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -242,17 +242,10 @@ module Homebrew
         next [] if os == :linux
 
         SimulateSystem.with os: os, arch: arch do
-          simulated_cask = Cask::CaskLoader.load(path)
-
-          if simulated_cask.url.nil?
-            opoo "Cask #{cask} is not supported on os #{os} and arch #{arch}"
-            next []
-          end
-
           odebug "Auditing Cask #{cask} on os #{os} and arch #{arch}"
 
           Cask::Auditor.audit(
-            simulated_cask,
+            Cask::CaskLoader.load(path),
             # For switches, we add `|| nil` so that `nil` will be passed
             # instead of `false` if they aren't set.
             # This way, we can distinguish between "not set" and "set to false".


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Another follow-up to #15943 and #15956.

- check for cask.url in audit steps
- check for cask.version in audit steps
- check for cask.sha256 in fetch command
- stop omitting casks based on nil url in audit command

It would be nice to be able to omit casks from the audit if the os is not supported but there is not easy way to do that without updating the SimulateSystem code or refactoring how MacOSRequirement's are defined in the DSL.

At the end of the day, these changes make it so that you won't try to fetch a cask if the url or sha256 is missing (we'd expect the sha256 value to be `:no_check` if it's been omitted on purpose). It also allows the audit to accept casks with nil urls and versions since we already check for those. The problem was that we had some audit steps which assumed those values would be valid (non-nil) and now they don't.

Results for `brew audit --skip-style homebrew/cask/calhash -os=all --debug`

```
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::TapLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Formula/calhash.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapLoader): loading homebrew/cask/calhash
==> Auditing Cask calhash on os sonoma and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
==> Auditing GitHub prerelease
==> Auditing Cask calhash on os ventura and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
==> Auditing GitHub prerelease
==> Auditing Cask calhash on os monterey and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
==> Auditing GitHub prerelease
==> Auditing Cask calhash on os big_sur and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
==> Auditing GitHub prerelease
==> Auditing Cask calhash on os catalina and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing version :latest does not appear as a string ('latest')
==> Auditing sha256 :no_check with version :latest
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing URL format
==> Auditing GitHub prerelease
==> Auditing Cask calhash on os mojave and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing GitHub prerelease
audit for calhash: failed
 - a version stanza is required
 - a url stanza is required
==> Auditing Cask calhash on os high_sierra and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing GitHub prerelease
audit for calhash: failed
 - a version stanza is required
 - a url stanza is required
==> Auditing Cask calhash on os sierra and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing GitHub prerelease
audit for calhash: failed
 - a version stanza is required
 - a url stanza is required
==> Auditing Cask calhash on os el_capitan and arch intel
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromTapPathLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/c/calhash.rb
==> Auditing pkg stanza: allow_untrusted
==> Auditing stanzas which require an uninstall
==> Auditing preflight and postflight stanzas
==> Auditing single uninstall_* and zap stanzas
==> Auditing required stanzas
==> Auditing sha256 string is a legal SHA-256 digest
==> Auditing sha256 is not a known invalid value
==> Auditing GitHub prerelease
audit for calhash: failed
 - a version stanza is required
 - a url stanza is required
calhash
  * a version stanza is required
  * a url stanza is required
Error: 2 problems in 1 cask detected.
```