### PR TITLE
missing_formula: remove sshpass from denylist

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -36,10 +36,6 @@ module Homebrew
           lzma is now part of the xz formula:
             brew install xz
         EOS
-        when "sshpass" then <<~EOS
-          We won't add sshpass because it makes it too easy for novice SSH users to
-          ruin SSH's security.
-        EOS
         when "gsutil" then <<~EOS
           gsutil is available through pip:
             pip3 install gsutil

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -21,7 +21,6 @@ describe Homebrew::MissingFormula do
     it { is_expected.to disallow("pil") }
     it { is_expected.to disallow("macruby") }
     it { is_expected.to disallow("lzma") }
-    it { is_expected.to disallow("sshpass") }
     it { is_expected.to disallow("gsutil") }
     it { is_expected.to disallow("gfortran") }
     it { is_expected.to disallow("play") }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should allow for the creation of an `sshpass` formula in core. Fixes https://github.com/Homebrew/brew/issues/15879.