### PR TITLE
Speed up keg installation with fewer code-signing calls

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -18,7 +18,7 @@ class Keg
   end
 
   def change_rpath(file, old_prefix, new_prefix)
-    return if !file.elf? || !file.dynamic_elf?
+    return false if !file.elf? || !file.dynamic_elf?
 
     updated = {}
     old_rpath = file.rpath
@@ -51,6 +51,7 @@ class Keg
     updated[:interpreter] = new_interpreter if old_interpreter != new_interpreter
 
     file.patch!(interpreter: updated[:interpreter], rpath: updated[:rpath])
+    true
   end
 
   def detect_cxx_stdlibs(options = {})

--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -2,13 +2,14 @@
 # frozen_string_literal: true
 
 class Keg
+  sig { params(id: String, file: Pathname).returns(T::Boolean) }
   def change_dylib_id(id, file)
-    return if file.dylib_id == id
+    return false if file.dylib_id == id
 
     @require_relocation = true
     odebug "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}"
     file.change_dylib_id(id, strict: false)
-    codesign_patched_binary(file)
+    true
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing dylib ID of #{file}
@@ -18,13 +19,14 @@ class Keg
     raise
   end
 
+  sig { params(old: String, new: String, file: Pathname).returns(T::Boolean) }
   def change_install_name(old, new, file)
-    return if old == new
+    return false if old == new
 
     @require_relocation = true
     odebug "Changing install name in #{file}\n  from #{old}\n    to #{new}"
     file.change_install_name(old, new, strict: false)
-    codesign_patched_binary(file)
+    true
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing install name in #{file}
@@ -34,13 +36,14 @@ class Keg
     raise
   end
 
+  sig { params(old: Pathname, new: Pathname, file: MachOShim).returns(T::Boolean) }
   def change_rpath(old, new, file)
-    return if old == new
+    return false if old == new
 
     @require_relocation = true
     odebug "Changing rpath in #{file}\n  from #{old}\n    to #{new}"
     file.change_rpath(old, new, strict: false)
-    codesign_patched_binary(file)
+    true
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing rpath in #{file}
@@ -50,10 +53,11 @@ class Keg
     raise
   end
 
+  sig { params(rpath: String, file: MachOShim).returns(T::Boolean) }
   def delete_rpath(rpath, file)
     odebug "Deleting rpath #{rpath} in #{file}"
     file.delete_rpath(rpath, strict: false)
-    codesign_patched_binary(file)
+    true
   rescue MachO::MachOError
     onoe <<~EOS
       Failed deleting rpath #{rpath} in #{file}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I noticed some formulae in the `osrf/simulation` tap starting taking much longer to install on macOS Intel processors after https://github.com/Homebrew/brew/pull/15903 was merged. That only adds a call to `codesign --verify` for files, which quickly returns for unsigned files, but this code-signing method is called within loops over every library that each installed dylib links against, so it is called many times. I noticed on my machine that the `osrf/simulation/gz-sim8` formula bottle pouring time has increased from 1 minute to over 6 minutes.

I believe that the methods in `os/mac/keg` are only called from two methods in `extend/os/mac/keg_relocate`. This pull request removes the calls to `codesign_patched_binary` from `os/mac/keg` and replaces that with individual calls to that method at the end of each loop in the `relocate_dynamic_linkage` and `fix_dynamic_linkage` methods in `extend/os/mac/keg_relocate`, which reduces bottle pouring times back to the times I was seeing before https://github.com/Homebrew/brew/pull/15903 was merged.

If we want to retain the current behavior of the methods in `os/mac/keg`, we could add to these methods an optional `codesign` parameter that defaults to true but explicitly pass `false` to those methods from `relocate_dynamic_linkage` and `fix_dynamic_linkage` (see https://github.com/Homebrew/brew/compare/master...scpeters:keg_codesign_fewer_times). Please let me know if that approach is preferred, and we can use that other branch instead, but I started with this one because it is simpler.