### PR TITLE
bump-cask-pr: deprecate online flag

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -30,7 +30,7 @@ module Homebrew
       switch "--no-audit",
              description: "Don't run `brew audit` before opening the PR."
       switch "--online",
-             description: "Run `brew audit --online` before opening the PR."
+             hidden:      true
       switch "--no-style",
              description: "Don't run `brew style --fix` before opening the PR."
       switch "--no-browse",
@@ -67,6 +67,7 @@ module Homebrew
   def bump_cask_pr
     args = bump_cask_pr_args.parse
 
+    # odeprecated "brew bump-cask-pr --online" if args.online?
     # This will be run by `brew audit` or `brew style` later so run it first to
     # not start spamming during normal output.
     Homebrew.install_bundler_gems! if !args.no_audit? || !args.no_style?
@@ -268,21 +269,16 @@ module Homebrew
     if args.dry_run?
       if args.no_audit?
         ohai "Skipping `brew audit`"
-      elsif args.online?
-        ohai "brew audit --cask --online #{cask.full_name}"
       else
-        ohai "brew audit --cask #{cask.full_name}"
+        ohai "brew audit --cask --online #{cask.full_name}"
       end
       return
     end
     failed_audit = false
     if args.no_audit?
       ohai "Skipping `brew audit`"
-    elsif args.online?
-      system HOMEBREW_BREW_FILE, "audit", "--cask", "--online", cask.full_name
-      failed_audit = !$CHILD_STATUS.success?
     else
-      system HOMEBREW_BREW_FILE, "audit", "--cask", cask.full_name
+      system HOMEBREW_BREW_FILE, "audit", "--cask", "--online", cask.full_name
       failed_audit = !$CHILD_STATUS.success?
     end
     return unless failed_audit


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR deprecates `brew bump-cask-pr --online` and makes online audits the default setting.

PRs created via bump-cask-pr skip full auditing. Occasionally, the bumped cask version does not match with the livecheck version leading to PRs that fail CI and clogging the PR queue until the livecheck version catches up.

Given that a --no-audit flag already exists, adding an --offline flag seems redundant. However, if there are any edge cases I'm missing, happy to discuss more.