### PR TITLE
formula: bump `-s -w` as default `std_go_args`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1674,8 +1674,13 @@ class Formula
            ldflags: T.nilable(T.any(String, T::Array[String]))).returns(T::Array[String])
   }
   def std_go_args(output: bin/name, ldflags: nil)
+    default_ldflags = "-s -w"
+
     args = ["-trimpath", "-o=#{output}"]
-    args += ["-ldflags=#{Array(ldflags).join(" ")}"] if ldflags
+
+    # Ensure there is no dups for `-s -w` in ldflags
+    combined_ldflags = ldflags&.include?(default_ldflags) ? [ldflags] : [default_ldflags, ldflags].compact
+    args += ["-ldflags=#{combined_ldflags.join(" ")}"]
     args
   end
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -163,7 +163,7 @@ module Homebrew
             system "shards", "build", "--release"
             bin.install "bin/#{name}"
         <% elsif mode == :go %>
-            system "go", "build", *std_go_args(ldflags: "-s -w")
+            system "go", "build", *std_go_args
         <% elsif mode == :meson %>
             system "meson", "setup", "build", *std_meson_args
             system "meson", "compile", "-C", "build", "--verbose"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We have used `-s -w` for std_go_args for quite some time, now bump it to be std_go_args.