### PR TITLE
os/mac/keg: fix `change_rpath` type signature.

### DIFF
--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -36,7 +36,6 @@ class Keg
     raise
   end
 
-  sig { params(old: Pathname, new: Pathname, file: MachOShim).returns(T::Boolean) }
   def change_rpath(old, new, file)
     return false if old == new
 


### PR DESCRIPTION
Fixes #15990
Fixes https://github.com/Homebrew/brew/issues/15993