### PR TITLE
Formula, BuildError: Update type signatures

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -479,7 +479,7 @@ class BuildError < RuntimeError
     params(
       formula: T.nilable(Formula),
       cmd:     T.any(String, Pathname),
-      args:    T::Array[T.any(String, Pathname, Integer)],
+      args:    T::Array[T.any(String, Integer, Pathname, Symbol)],
       env:     T::Hash[String, T.untyped],
     ).void
   }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2629,7 +2629,7 @@ class Formula
   #
   # # If there is a "make install" available, please use it!
   # system "make", "install"</pre>
-  sig { params(cmd: T.any(String, Pathname), args: T.any(String, Pathname, Integer)).void }
+  sig { params(cmd: T.any(String, Pathname), args: T.any(String, Integer, Pathname, Symbol)).void }
   def system(cmd, *args)
     verbose_using_dots = Homebrew::EnvConfig.verbose_using_dots?
 
@@ -2794,7 +2794,7 @@ class Formula
   end
 
   # Runs `xcodebuild` without Homebrew's compiler environment variables set.
-  sig { params(args: T.any(String, Pathname)).void }
+  sig { params(args: T.any(String, Integer, Pathname, Symbol)).void }
   def xcodebuild(*args)
     removed = ENV.remove_cc_etc
 

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -141,11 +141,11 @@ describe "Exception" do
   end
 
   describe BuildError do
-    subject { described_class.new(formula, "badprg", %w[arg1 arg2], {}) }
+    subject { described_class.new(formula, "badprg", ["arg1", 2, Pathname.new("arg3"), :arg4], {}) }
 
     let(:formula) { instance_double(Formula, name: "foo") }
 
-    its(:to_s) { is_expected.to eq("Failed executing: badprg arg1 arg2") }
+    its(:to_s) { is_expected.to eq("Failed executing: badprg arg1 2 arg3 arg4") }
   end
 
   describe OperationInProgressError do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We're seeing [type errors](https://github.com/Homebrew/homebrew-core/issues/142308) when building formulae that use something like `xcodebuild ..., "-arch", Hardware::CPU.arch`, since `CPU.arch` is a symbol. We've been addressing these issues by calling `#to_s` on the value but there was some talk about simply expanding the type signatures to accommodate anything that will be cast to a `String`.

There's maybe still an argument to be made for doing string conversion in formulae but expanding the type signatures will resolve a number of existing type errors if we simply want to rely on implicit type casting.

Past that, this also updates the type signature for `BuildError` to align with the `#system` signature changes, as we receive a new type error otherwise.