### PR TITLE
dev-cmd/bump: reduce unnecessary output

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -436,6 +436,8 @@ module Homebrew
       Current #{version_label}  #{current_versions}
       Latest livecheck version: #{new_versions}
       Latest Repology version:  #{repology_latest}
+    EOS
+    puts <<~EOS unless args.no_pull_requests?
       Open pull requests:       #{open_pull_requests || "none"}
       Closed pull requests:     #{closed_pull_requests || "none"}
     EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
When using `brew bump` with `--no-pull-requests`, omit the open & closed pull requests lines which will always be "none" and may therefore be inaccurate. 

Also added a method to always skip both head-only and disabled formulae. This fixes an issue that would occur with the command's non-argument form if a matched formula was head-only.