### PR TITLE
superenv: help gettext-based configure scripts

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -120,6 +120,12 @@ module Superenv
       ENV["ac_have_clock_syscall"] = "no"
     end
 
+    # On macOS Sonoma (at least release candidate), iconv() is generally
+    # present and working, but has a minor regression that defeats the
+    # test implemented in gettext's configure script (and used by many
+    # gettext dependents).
+    ENV["am_cv_func_iconv_works"] = "yes" if MacOS.version == "14"
+
     # The tools in /usr/bin proxy to the active developer directory.
     # This means we can use them for any combination of CLT and Xcode.
     self["HOMEBREW_PREFER_CLT_PROXIES"] = "1"


### PR DESCRIPTION
Apple's iconv has a regression in macOS Sonoma. This unfortunately happens to be triggered in gettext's configure test. This patch bypasses the detection, aligning with previous macOS versions.

I first fixed it for gettext: https://github.com/Homebrew/homebrew-core/pull/142490
But the problem impacts many formulas depending on gettext, that borrow its detection script.

This seems like the safest path for us at this point.