### PR TITLE
Improve performance of `brew readall`

### DIFF
--- a/Library/Homebrew/extend/os/mac/readall.rb
+++ b/Library/Homebrew/extend/os/mac/readall.rb
@@ -3,7 +3,7 @@
 
 module Readall
   class << self
-    def valid_casks?(casks, os_name: nil, arch: Hardware::CPU.type)
+    def valid_casks?(tap, os_name: nil, arch: Hardware::CPU.type)
       return true if os_name == :linux
 
       current_macos_version = if os_name.is_a?(Symbol)
@@ -13,7 +13,7 @@ module Readall
       end
 
       success = T.let(true, T::Boolean)
-      casks.each do |file|
+      tap.cask_files.each do |file|
         cask = Cask::CaskLoader.load(file)
 
         # Fine to have missing URLs for unsupported macOS

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2398,7 +2398,7 @@ class Formula
 
     variations = {}
 
-    if path.exist? && (self.class.on_system_blocks_exist? || @on_system_blocks_exist)
+    if path.exist? && on_system_blocks_exist?
       formula_contents = path.read
       OnSystem::ALL_OS_ARCH_COMBINATIONS.each do |os, arch|
         bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
@@ -2450,6 +2450,11 @@ class Formula
       }
     end
     hash
+  end
+
+  # @private
+  def on_system_blocks_exist?
+    self.class.on_system_blocks_exist? || @on_system_blocks_exist
   end
 
   # @private

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -196,6 +196,7 @@ RSpec.configure do |config|
     Tab.clear_cache
     Dependency.clear_cache
     Requirement.clear_cache
+    Readall.clear_cache if defined?(Readall)
     FormulaInstaller.clear_attempted
     FormulaInstaller.clear_installed
     FormulaInstaller.clear_fetched
@@ -251,6 +252,7 @@ RSpec.configure do |config|
       Tab.clear_cache
       Dependency.clear_cache
       Requirement.clear_cache
+      Readall.clear_cache if defined?(Readall)
 
       FileUtils.rm_rf [
         *TEST_DIRECTORIES,


### PR DESCRIPTION
* Significantly improve base performance (60s -> 30s for Homebrew/core before the extra checks were added)
* Add `to_hash` check to ensure the method used for API generation (and `brew info` etc) doesn't error. This increases that 30s back up to 47s (after some optimisations) _but_ does mean we could remove the 90 second `brew generate-formula-api` call in tap_syntax checks as the other elements of that command shouldn't be affected by formula changes.

These changes affect formulae only. I have not touched casks.