### PR TITLE
formula: add global caching for `declared_runtime_dependencies`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2579,7 +2579,8 @@ class Formula
   # Returns a list of Dependency objects that are declared in the formula.
   # @private
   def declared_runtime_dependencies
-    recursive_dependencies do |_, dependency|
+    cache_key = "Formula#declared_runtime_dependencies" unless build.any_args_or_options?
+    Dependency.expand(self, cache_key: cache_key) do |_, dependency|
       Dependency.prune if dependency.build?
       next if dependency.required?
 


### PR DESCRIPTION
This improves `brew audit --except=installed --tap=homebrew/core` times from ~45s (with #16007 applied) to ~30s.

This optimisation is not enabled for formulae with options as I'm not 100% confident caching would behave correctly here. Though that doesn't matter for Homebrew/core, and third-party taps typically are much smaller scale that `brew audit` is already quick.