### PR TITLE
cmd/audit: improve performance of versioned formula names

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -489,20 +489,19 @@ class Formula
     name.include?("@")
   end
 
-  # Returns any `@`-versioned formulae names for any formula (including versioned formulae).
+  # Returns any other `@`-versioned formulae names for any formula (including versioned formulae).
   sig { returns(T::Array[String]) }
   def versioned_formulae_names
     versioned_names = if tap
-      name_prefix = "#{name.gsub(/(@[\d.]+)?$/, "")}@"
-      T.must(tap).formula_names.select do |name|
-        name.start_with?(name_prefix)
-      end
+      name_prefix = name.gsub(/(@[\d.]+)?$/, "")
+      T.must(tap).prefix_to_versioned_formulae_names.fetch(name_prefix, [])
     elsif path.exist?
       Pathname.glob(path.to_s.gsub(/(@[\d.]+)?\.rb$/, "@*.rb"))
               .map { |path| path.basename(".rb").to_s }
+              .sort
     else
       raise "Either tap or path is required to list versioned formulae"
-    end.sort
+    end
 
     versioned_names.reject do |versioned_name|
       versioned_name == name

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -644,6 +644,17 @@ class Tap
     @formula_names ||= formula_files.map(&method(:formula_file_to_name))
   end
 
+  # A hash of all {Formula} name prefixes to versioned {Formula} in this {Tap}.
+  # @private
+  sig { returns(T::Hash[String, T::Array[String]]) }
+  def prefix_to_versioned_formulae_names
+    @prefix_to_versioned_formulae_names ||= formula_names
+                                            .select { |name| name.include?("@") }
+                                            .group_by { |name| name.gsub(/(@[\d.]+)?$/, "") }
+                                            .transform_values(&:sort)
+                                            .freeze
+  end
+
   # An array of all {Cask} tokens of this {Tap}.
   sig { returns(T::Array[String]) }
   def cask_tokens


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There is a check for other versioned formula with the same name in the file audit. This just memoizes all of the versioned formulae in a tap during the first call and then uses that much shorter list every time it checks for things.

Command:
```
brew prof --  audit --skip-style --except=version,installed --tap=homebrew/core
```

Before:
![Screen Shot 2023-09-16 at 9 07 06 AM](https://github.com/Homebrew/brew/assets/42982186/1b4b994d-8ef2-42f6-a78c-5e8ddc7e0b0a)

After:
![Screen Shot 2023-09-16 at 9 12 37 AM](https://github.com/Homebrew/brew/assets/42982186/957a7222-d9ce-476e-9f8f-698ade21a78c)

It results in a 5-10 second speed up locally for me.

Update: It looks like we're down to ~35 seconds in this repo's CI after this change and @Bo98's change in https://github.com/Homebrew/brew/pull/16008.

![Screen Shot 2023-09-16 at 9 28 34 AM](https://github.com/Homebrew/brew/assets/42982186/7f2359f4-83ff-4c5d-995d-135e2e6aa986)
