### PR TITLE
cmd/readall: clean up todos

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -111,10 +111,7 @@ module Homebrew
         when :all
           skip_invalid_combinations = true
 
-          [
-            *MacOSVersion::SYMBOLS.keys,
-            :linux,
-          ]
+          OnSystem::ALL_OS_OPTIONS
         else
           [os_sym]
         end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -38,8 +38,6 @@ module Homebrew
   def readall
     args = readall_args.parse
 
-    odeprecated "--no-simulate", "nothing (i.e. not passing `--os` or `--arch`)" if args.no_simulate?
-
     if args.syntax? && args.no_named?
       scan_files = "#{HOMEBREW_LIBRARY_PATH}/**/*.rb"
       ruby_files = Dir.glob(scan_files).grep_v(%r{/(vendor)/})
@@ -51,8 +49,8 @@ module Homebrew
       aliases:     args.aliases?,
       no_simulate: args.no_simulate?,
     }
-    # TODO: Always pass this once `--os` and `--arch` are passed explicitly to `brew readall` in CI.
     options[:os_arch_combinations] = args.os_arch_combinations if args.os || args.arch
+
     taps = if args.no_named?
       if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
         raise UsageError, "`brew readall` needs a tap or `--eval-all` passed or `HOMEBREW_EVAL_ALL` set!"
@@ -62,6 +60,7 @@ module Homebrew
     else
       args.named.to_installed_taps
     end
+
     taps.each do |tap|
       Homebrew.failed = true unless Readall.valid_tap?(tap, options)
     end

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -6,6 +6,8 @@ require "simulate_system"
 module OnSystem
   ARCH_OPTIONS = [:intel, :arm].freeze
   BASE_OS_OPTIONS = [:macos, :linux].freeze
+  ALL_OS_OPTIONS = [*MacOSVersion::SYMBOLS.keys, :linux].freeze
+  ALL_OS_ARCH_COMBINATIONS = ALL_OS_OPTIONS.product(ARCH_OPTIONS).freeze
 
   sig { params(arch: Symbol).returns(T::Boolean) }
   def self.arch_condition_met?(arch)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2398,11 +2398,9 @@ class Formula
 
     variations = {}
 
-    os_versions = [*MacOSVersion::SYMBOLS.keys, :linux]
-
     if path.exist? && (self.class.on_system_blocks_exist? || @on_system_blocks_exist)
       formula_contents = path.read
-      os_versions.product(OnSystem::ARCH_OPTIONS).each do |os, arch|
+      OnSystem::ALL_OS_ARCH_COMBINATIONS.each do |os, arch|
         bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
         next unless bottle_tag.valid_combination?
 

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -66,20 +66,18 @@ module Readall
       true
     end
 
-    def valid_tap?(tap, aliases: false, no_simulate: false, os_arch_combinations: nil)
+    def valid_tap?(tap, aliases: false, no_simulate: false, os_arch_combinations: OnSystem::ALL_OS_ARCH_COMBINATIONS)
       success = true
 
       if aliases
         valid_aliases = valid_aliases?(tap.alias_dir, tap.formula_dir)
         success = false unless valid_aliases
       end
+
       if no_simulate
         success = false unless valid_formulae?(tap.formula_files)
         success = false unless valid_casks?(tap.cask_files)
       else
-        # TODO: Remove this default case once `--os` and `--arch` are passed explicitly to `brew readall` in CI.
-        os_arch_combinations ||= [*MacOSVersion::SYMBOLS.keys, :linux].product(OnSystem::ARCH_OPTIONS)
-
         os_arch_combinations.each do |os, arch|
           bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
           next unless bottle_tag.valid_combination?

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -342,7 +342,7 @@ class Tap
     begin
       safe_system "git", *args
 
-      if verify && !Readall.valid_tap?(self, aliases: true) && !Homebrew::EnvConfig.developer?
+      if verify && !Homebrew::EnvConfig.developer? && !Readall.valid_tap?(self, aliases: true)
         raise "Cannot tap #{name}: invalid syntax in tap!"
       end
     rescue Interrupt, RuntimeError

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1027,14 +1027,9 @@ describe Formula do
     end
 
     before do
-      # Use a more limited symbols list to shorten the variations hash
-      symbols = {
-        monterey: "12",
-        big_sur:  "11",
-        catalina: "10.15",
-        mojave:   "10.14",
-      }
-      stub_const("MacOSVersion::SYMBOLS", symbols)
+      # Use a more limited os list to shorten the variations hash
+      os_list = [:monterey, :big_sur, :catalina, :mojave, :linux]
+      stub_const("OnSystem::ALL_OS_ARCH_COMBINATIONS", os_list.product(OnSystem::ARCH_OPTIONS))
 
       # For consistency, always run on Monterey and ARM
       allow(MacOS).to receive(:version).and_return(MacOSVersion.new("12"))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Edit: We decided to keep the current behavior of running all os/arch combinations and remove the todos and deprecations.

~Removes temporary default to readall for every os/arch combination
after updating brew-test-bot and brew/cask to pass the appropriate
arguments in on CI.~

- https://github.com/Homebrew/brew/pull/15470
- https://github.com/Homebrew/brew/pull/15937#discussion_r1313889254

Also, add more constants for os/arch combinations. This allows us
to make validating all os/arch combinations the default in
`Readall.valid_tap?` which is needed to keep the same behavior
in `brew tap` that we had before. I also updated a few other
spots around the codebase to use those new constants.

~One more thing was updating the integration test. In local testing,
this didn't change the runtime so it seemed like a no-brainer.~

### Todo
1. The CI used by `homebrew/core` and `homebrew/cask` has been updated.
    - [x] https://github.com/Homebrew/homebrew-test-bot/pull/969
    - [x] https://github.com/Homebrew/homebrew-cask/pull/155397
2. The readall performance improvements PR has been merged in.
    - [x] https://github.com/Homebrew/brew/pull/16007
        - I don't actually think there's much overlap between these PRs.