### PR TITLE
cask/audit: add audit_min_os

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -544,6 +544,7 @@ module Cask
     sig { void }
     def audit_min_os
       return unless online?
+      return unless strict?
 
       odebug "Auditing minimum OS version"
 
@@ -630,6 +631,7 @@ module Cask
           break if plist_min_os
         end
       end
+
       begin
         MacOSVersion.new(plist_min_os).strip_patch
       rescue MacOSVersion::Error


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds an audit to ensure that the minimum macOS version specified in the cask matches the minimum macOS version specified by the developer. 

It does so by:
1. Hijacking `audit_livecheck_min_os` to obtain the sparkle version information.
2. Adding `audit_plist_min_os` to extract the version information from `Info.plist`.
3. Comparing the cask min_os version with the extracted value. If both a sparkle min_os and plist min_os are present, we take the larger value of the two.

Note: This will break a lot of casks.