### PR TITLE
service: support multiple sockets in DSL

### DIFF
--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -14,6 +14,15 @@ describe Homebrew::Service do
     end
   end
 
+  def stub_formula_with_service_sockets(sockets_var)
+    stub_formula do
+      service do
+        run opt_bin/"beanstalkd"
+        sockets sockets_var
+      end
+    end
+  end
+
   describe "#std_service_path_env" do
     it "returns valid std_service_path_env" do
       f = stub_formula do
@@ -102,43 +111,33 @@ describe Homebrew::Service do
   end
 
   describe "#sockets" do
-    it "throws for missing type" do
-      f = stub_formula do
-        service do
-          run opt_bin/"beanstalkd"
-          sockets "127.0.0.1:80"
-        end
-      end
+    let(:sockets_type_error_message) { "Service#sockets a formatted socket definition as <type>://<host>:<port>" }
 
-      expect do
-        f.service.manual_command
-      end.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
+    it "throws for missing type" do
+      [
+        stub_formula_with_service_sockets("127.0.0.1:80"),
+        stub_formula_with_service_sockets({ "Socket" => "127.0.0.1:80" }),
+      ].each do |f|
+        expect { f.service.manual_command }.to raise_error TypeError, sockets_type_error_message
+      end
     end
 
     it "throws for missing host" do
-      f = stub_formula do
-        service do
-          run opt_bin/"beanstalkd"
-          sockets "tcp://:80"
-        end
+      [
+        stub_formula_with_service_sockets("tcp://:80"),
+        stub_formula_with_service_sockets({ "Socket" => "tcp://:80" }),
+      ].each do |f|
+        expect { f.service.manual_command }.to raise_error TypeError, sockets_type_error_message
       end
-
-      expect do
-        f.service.manual_command
-      end.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
     end
 
     it "throws for missing port" do
-      f = stub_formula do
-        service do
-          run opt_bin/"beanstalkd"
-          sockets "tcp://127.0.0.1"
-        end
+      [
+        stub_formula_with_service_sockets("tcp://127.0.0.1"),
+        stub_formula_with_service_sockets({ "Socket" => "tcp://127.0.0.1" }),
+      ].each do |f|
+        expect { f.service.manual_command }.to raise_error TypeError, sockets_type_error_message
       end
-
-      expect do
-        f.service.manual_command
-      end.to raise_error TypeError, "Service#sockets a formatted socket definition as <type>://<host>:<port>"
     end
   end
 
@@ -259,10 +258,59 @@ describe Homebrew::Service do
     end
 
     it "returns valid plist with socket" do
+      plist_expect = <<~EOS
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        \t<key>Label</key>
+        \t<string>homebrew.mxcl.formula_name</string>
+        \t<key>LimitLoadToSessionType</key>
+        \t<array>
+        \t\t<string>Aqua</string>
+        \t\t<string>Background</string>
+        \t\t<string>LoginWindow</string>
+        \t\t<string>StandardIO</string>
+        \t\t<string>System</string>
+        \t</array>
+        \t<key>ProgramArguments</key>
+        \t<array>
+        \t\t<string>#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd</string>
+        \t</array>
+        \t<key>RunAtLoad</key>
+        \t<true/>
+        \t<key>Sockets</key>
+        \t<dict>
+        \t\t<key>Listeners</key>
+        \t\t<dict>
+        \t\t\t<key>SockFamily</key>
+        \t\t\t<string>IPv4v6</string>
+        \t\t\t<key>SockNodeName</key>
+        \t\t\t<string>127.0.0.1</string>
+        \t\t\t<key>SockProtocol</key>
+        \t\t\t<string>TCP</string>
+        \t\t\t<key>SockServiceName</key>
+        \t\t\t<string>80</string>
+        \t\t</dict>
+        \t</dict>
+        </dict>
+        </plist>
+      EOS
+
+      [
+        stub_formula_with_service_sockets("tcp://127.0.0.1:80"),
+        stub_formula_with_service_sockets({ "Listeners" => "tcp://127.0.0.1:80" }),
+      ].each do |f|
+        plist = f.service.to_plist
+        expect(plist).to eq(plist_expect)
+      end
+    end
+
+    it "returns valid plist with multiple sockets" do
       f = stub_formula do
         service do
           run [opt_bin/"beanstalkd", "test"]
-          sockets "tcp://127.0.0.1:80"
+          sockets "Socket" => "tcp://0.0.0.0:80", "SocketTLS" => "tcp://0.0.0.0:443"
         end
       end
 
@@ -291,16 +339,27 @@ describe Homebrew::Service do
         \t<true/>
         \t<key>Sockets</key>
         \t<dict>
-        \t\t<key>Listeners</key>
+        \t\t<key>Socket</key>
         \t\t<dict>
         \t\t\t<key>SockFamily</key>
         \t\t\t<string>IPv4v6</string>
         \t\t\t<key>SockNodeName</key>
-        \t\t\t<string>127.0.0.1</string>
+        \t\t\t<string>0.0.0.0</string>
         \t\t\t<key>SockProtocol</key>
         \t\t\t<string>TCP</string>
         \t\t\t<key>SockServiceName</key>
         \t\t\t<string>80</string>
+        \t\t</dict>
+        \t\t<key>SocketTLS</key>
+        \t\t<dict>
+        \t\t\t<key>SockFamily</key>
+        \t\t\t<string>IPv4v6</string>
+        \t\t\t<key>SockNodeName</key>
+        \t\t\t<string>0.0.0.0</string>
+        \t\t\t<key>SockProtocol</key>
+        \t\t\t<string>TCP</string>
+        \t\t\t<key>SockServiceName</key>
+        \t\t\t<string>443</string>
         \t\t</dict>
         \t</dict>
         </dict>

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -281,7 +281,7 @@ describe Homebrew::Service do
         \t<true/>
         \t<key>Sockets</key>
         \t<dict>
-        \t\t<key>Listeners</key>
+        \t\t<key>listeners</key>
         \t\t<dict>
         \t\t\t<key>SockFamily</key>
         \t\t\t<string>IPv4v6</string>
@@ -299,7 +299,7 @@ describe Homebrew::Service do
 
       [
         stub_formula_with_service_sockets("tcp://127.0.0.1:80"),
-        stub_formula_with_service_sockets({ "Listeners" => "tcp://127.0.0.1:80" }),
+        stub_formula_with_service_sockets({ listeners: "tcp://127.0.0.1:80" }),
       ].each do |f|
         plist = f.service.to_plist
         expect(plist).to eq(plist_expect)
@@ -310,7 +310,7 @@ describe Homebrew::Service do
       f = stub_formula do
         service do
           run [opt_bin/"beanstalkd", "test"]
-          sockets "Socket" => "tcp://0.0.0.0:80", "SocketTLS" => "tcp://0.0.0.0:443"
+          sockets socket: "tcp://0.0.0.0:80", socket_tls: "tcp://0.0.0.0:443"
         end
       end
 
@@ -339,7 +339,7 @@ describe Homebrew::Service do
         \t<true/>
         \t<key>Sockets</key>
         \t<dict>
-        \t\t<key>Socket</key>
+        \t\t<key>socket</key>
         \t\t<dict>
         \t\t\t<key>SockFamily</key>
         \t\t\t<string>IPv4v6</string>
@@ -350,7 +350,7 @@ describe Homebrew::Service do
         \t\t\t<key>SockServiceName</key>
         \t\t\t<string>80</string>
         \t\t</dict>
-        \t\t<key>SocketTLS</key>
+        \t\t<key>socket_tls</key>
         \t\t<dict>
         \t\t\t<key>SockFamily</key>
         \t\t\t<string>IPv4v6</string>
@@ -1049,7 +1049,7 @@ describe Homebrew::Service do
         run_type:              :immediate,
         working_dir:           "/$HOME",
         cron:                  "0 0 * * 0",
-        sockets:               { "Listeners" => "tcp://0.0.0.0:80" },
+        sockets:               { listeners: "tcp://0.0.0.0:80" },
       }
     end
 

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -990,7 +990,7 @@ describe Homebrew::Service do
         run_type:              :immediate,
         working_dir:           "/$HOME",
         cron:                  "0 0 * * 0",
-        sockets:               "tcp://0.0.0.0:80",
+        sockets:               { "Listeners" => "tcp://0.0.0.0:80" },
       }
     end
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1052,7 +1052,7 @@ The `sockets` method accepts a formatted socket definition as `<type>://<host>:<
 
 Please note that sockets will be accessible on IPv4 and IPv6 addresses by default.
 
-If you only need one socket and you don't care about the name (the default is `Listeners`):
+If you only need one socket and you don't care about the name (the default is `listeners`):
 
 ```rb
 service do
@@ -1066,7 +1066,7 @@ If you need multiple sockets and/or you want to specify the name:
 ```rb
 service do
   run [opt_bin/"beanstalkd", "test"]
-  sockets "Socket" => "tcp://0.0.0.0:80", "SocketTLS" => "tcp://0.0.0.0:443"
+  sockets http: "tcp://0.0.0.0:80", https: "tcp://0.0.0.0:443"
 end
 ```
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1052,6 +1052,24 @@ The `sockets` method accepts a formatted socket definition as `<type>://<host>:<
 
 Please note that sockets will be accessible on IPv4 and IPv6 addresses by default.
 
+If you only need one socket and you don't care about the name (the default is `Listeners`):
+
+```rb
+service do
+  run [opt_bin/"beanstalkd", "test"]
+  sockets "tcp://127.0.0.1:80"
+end
+```
+
+If you need multiple sockets and/or you want to specify the name:
+
+```rb
+service do
+  run [opt_bin/"beanstalkd", "test"]
+  sockets "Socket" => "tcp://0.0.0.0:80", "SocketTLS" => "tcp://0.0.0.0:443"
+end
+```
+
 ### Using environment variables
 
 Homebrew has multiple levels of environment variable filtering which affects which variables are available to formulae.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Closes #15945

This adds support for multiple named sockets to the service DSL. It also retains backwards compatibility with the previous DSL where you can declare one socket. The only change is that the default socket name is now `listeners` instead of `Listeners` to go along with lowercase Ruby symbol naming conventions.

CC: @SMillerDev