### PR TITLE
dev-cmd/edit: Move path specific functions to Pathname

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -121,7 +121,7 @@ module Homebrew
            !Homebrew::EnvConfig.no_env_hints?
           opoo <<~EOS
             `brew install` ignores locally edited #{(path.core_cask_path? || path.core_cask_tap?) ? "casks" : "formulae"} if
-            `HOMEBREW_NO_INSTALL_FROM_API` is not set.
+            HOMEBREW_NO_INSTALL_FROM_API is not set.
           EOS
           break
         end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -28,22 +28,22 @@ module Homebrew
     end
   end
 
-  sig { returns(T::Boolean) }
+  sig { params(path: Pathname).returns(T::Boolean) }
   def core_formula_path?(path)
     path.fnmatch?("**/homebrew-core/Formula/**.rb", File::FNM_DOTMATCH)
   end
 
-  sig { returns(T::Boolean) }
+  sig { params(path: Pathname).returns(T::Boolean) }
   def core_cask_path?(path)
     path.fnmatch?("**/homebrew-cask/Casks/**.rb", File::FNM_DOTMATCH)
   end
 
-  sig { returns(T::Boolean) }
+  sig { params(path: Pathname).returns(T::Boolean) }
   def core_formula_tap?(path)
     path == CoreTap.instance.path
   end
 
-  sig { returns(T::Boolean) }
+  sig { params(path: Pathname).returns(T::Boolean) }
   def core_cask_tap?(path)
     path == CoreCaskTap.instance.path
   end
@@ -105,7 +105,7 @@ module Homebrew
     else
       expanded_paths = args.named.to_paths
       expanded_paths.each do |path|
-        raise_with_message(path, args.cask?) unless path.exist?
+        raise_with_message!(path, args.cask?) unless path.exist?
       end
 
       if expanded_paths.any? do |path|

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -7,6 +7,32 @@ require "cli/parser"
 module Homebrew
   module_function
 
+  module Refinements
+    refine Pathname do
+      sig { returns(T::Boolean) }
+      def core_formula_path?
+        fnmatch?("**/homebrew-core/Formula/**.rb", File::FNM_DOTMATCH)
+      end
+
+      sig { returns(T::Boolean) }
+      def core_cask_path?
+        fnmatch?("**/homebrew-cask/Casks/**.rb", File::FNM_DOTMATCH)
+      end
+
+      sig { returns(T::Boolean) }
+      def core_formula_tap?
+        self == CoreTap.instance.path
+      end
+
+      sig { returns(T::Boolean) }
+      def core_cask_tap?
+        self == CoreCaskTap.instance.path
+      end
+    end
+  end
+
+  using Refinements
+
   sig { returns(CLI::Parser) }
   def edit_args
     Homebrew::CLI::Parser.new do

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -86,10 +86,13 @@ module Homebrew
     else
       expanded_paths = args.named.to_paths
       expanded_paths.each do |path|
-        if path.exist? &&
-            (path.core_formula_path? || path.core_cask_path? || path.core_formula_tap? || path.core_cask_tap?) &&
-            !Homebrew::EnvConfig.no_install_from_api? &&
-            !Homebrew::EnvConfig.no_env_hints?
+        fail(path, args.cask?) unless path.exist?
+      end
+
+      expanded_paths.each do |path|
+        if (path.core_formula_path? || path.core_cask_path? || path.core_formula_tap? || path.core_cask_tap?) &&
+           !Homebrew::EnvConfig.no_install_from_api? &&
+           !Homebrew::EnvConfig.no_env_hints?
           opoo <<~EOS
             `brew install` ignores locally edited #{(path.core_cask_path? || path.core_cask_tap?) ? "casks" : "formulae"} if
             `HOMEBREW_NO_INSTALL_FROM_API` is not set.
@@ -97,12 +100,7 @@ module Homebrew
           break
         end
       end
-
-      expanded_paths.each do |path|
-        if not path.exist?
-          fail(path, args.cask?)
-        end
-      end
+      expanded_paths
     end
 
     if args.print_path?

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -29,7 +29,7 @@ module Homebrew
   end
 
   sig { void }
-  def fail(path, cask)
+  def fail_with_message(path, cask)
     name = path.basename(".rb").to_s
 
     if (tap_match = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + /$/.source).match(path.to_s))
@@ -86,7 +86,7 @@ module Homebrew
     else
       expanded_paths = args.named.to_paths
       expanded_paths.each do |path|
-        fail(path, args.cask?) unless path.exist?
+        fail_with_message(path, args.cask?) unless path.exist?
       end
 
       expanded_paths.each do |path|

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -54,7 +54,7 @@ module Homebrew
     end
   end
 
-  sig { void }
+  sig { params(path: Pathname, cask: T::Boolean).void }
   def fail_with_message(path, cask)
     name = path.basename(".rb").to_s
 

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -118,8 +118,9 @@ module Homebrew
         if (path.core_formula_path? || path.core_cask_path? || path.core_formula_tap? || path.core_cask_tap?) &&
            !Homebrew::EnvConfig.no_install_from_api? &&
            !Homebrew::EnvConfig.no_env_hints?
+          path_type = (path.core_cask_path? || path.core_cask_tap?) ? "casks" : "formulae"
           opoo <<~EOS
-            `brew install` ignores locally edited #{(path.core_cask_path? || path.core_cask_tap?) ? "casks" : "formulae"} if
+            `brew install` ignores locally edited #{path_type} if
             HOMEBREW_NO_INSTALL_FROM_API is not set.
           EOS
           break

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -81,11 +81,10 @@ module Homebrew
       action = "create a new formula"
     end
 
-    message = <<~EOS
+    raise UsageError, <<~EOS
       #{name} doesn't exist on disk.
       Run #{Formatter.identifier(command)} to #{action}!
     EOS
-    raise UsageError, message
   end
 
   sig { void }

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -114,17 +114,15 @@ module Homebrew
         fail_with_message(path, args.cask?) unless path.exist?
       end
 
-      expanded_paths.each do |path|
-        if (path.core_formula_path? || path.core_cask_path? || path.core_formula_tap? || path.core_cask_tap?) &&
+      if expanded_paths.any? do |path|
+           (path.core_formula_path? || path.core_cask_path? || path.core_formula_tap? || path.core_cask_tap?) &&
            !Homebrew::EnvConfig.no_install_from_api? &&
            !Homebrew::EnvConfig.no_env_hints?
-          path_type = (path.core_cask_path? || path.core_cask_tap?) ? "casks" : "formulae"
-          opoo <<~EOS
-            `brew install` ignores locally edited #{path_type} if
-            HOMEBREW_NO_INSTALL_FROM_API is not set.
-          EOS
-          break
-        end
+         end
+        opoo <<~EOS
+          `brew install` ignores locally edited casks and formulae if
+          HOMEBREW_NO_INSTALL_FROM_API is not set.
+        EOS
       end
       expanded_paths
     end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -32,7 +32,7 @@ module Homebrew
   def fail_with_message(path, cask)
     name = path.basename(".rb").to_s
 
-    if (tap_match = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + /$/.source).match(path.to_s))
+    if (tap_match = Regexp.new("#{HOMEBREW_TAP_DIR_REGEX.source}$").match(path.to_s))
       raise TapUnavailableError, CoreTap.instance.name if path.core_formula_tap?
       raise TapUnavailableError, CoreCaskTap.instance.name if path.core_cask_tap?
 

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -7,7 +7,7 @@ require "cli/parser"
 module Homebrew
   module_function
 
-  module Refinements
+  module EditPathnameRefinements
     refine Pathname do
       sig { returns(T::Boolean) }
       def core_formula_path?
@@ -31,7 +31,7 @@ module Homebrew
     end
   end
 
-  using Refinements
+  using EditPathnameRefinements
 
   sig { returns(CLI::Parser) }
   def edit_args

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -54,8 +54,8 @@ module Homebrew
     end
   end
 
-  sig { params(path: Pathname, cask: T::Boolean).void }
-  def fail_with_message(path, cask)
+  sig { params(path: Pathname, cask: T::Boolean).returns(T.noreturn) }
+  def raise_with_message!(path, cask)
     name = path.basename(".rb").to_s
 
     if (tap_match = Regexp.new("#{HOMEBREW_TAP_DIR_REGEX.source}$").match(path.to_s))
@@ -111,7 +111,7 @@ module Homebrew
     else
       expanded_paths = args.named.to_paths
       expanded_paths.each do |path|
-        fail_with_message(path, args.cask?) unless path.exist?
+        raise_with_message(path, args.cask?) unless path.exist?
       end
 
       if expanded_paths.any? do |path|

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -488,6 +488,26 @@ class Pathname
                  .encode(Encoding::UTF_8, invalid: :replace)
                  .split("\n")
   end
+
+  sig { returns(T::Boolean) }
+  def core_formula_path?
+    fnmatch?("**/homebrew-core/Formula/**.rb", File::FNM_DOTMATCH)
+  end
+
+  sig { returns(T::Boolean) }
+  def core_cask_path?
+    fnmatch?("**/homebrew-cask/Casks/**.rb", File::FNM_DOTMATCH)
+  end
+
+  sig { returns(T::Boolean) }
+  def core_formula_tap?
+    self == CoreTap.instance.path
+  end
+
+  sig { returns(T::Boolean) }
+  def core_cask_tap?
+    self == CoreCaskTap.instance.path
+  end
 end
 
 require "extend/os/pathname"

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -488,26 +488,6 @@ class Pathname
                  .encode(Encoding::UTF_8, invalid: :replace)
                  .split("\n")
   end
-
-  sig { returns(T::Boolean) }
-  def core_formula_path?
-    fnmatch?("**/homebrew-core/Formula/**.rb", File::FNM_DOTMATCH)
-  end
-
-  sig { returns(T::Boolean) }
-  def core_cask_path?
-    fnmatch?("**/homebrew-cask/Casks/**.rb", File::FNM_DOTMATCH)
-  end
-
-  sig { returns(T::Boolean) }
-  def core_formula_tap?
-    self == CoreTap.instance.path
-  end
-
-  sig { returns(T::Boolean) }
-  def core_cask_tap?
-    self == CoreCaskTap.instance.path
-  end
 end
 
 require "extend/os/pathname"


### PR DESCRIPTION
This PR reduces `edit.rb` complexity to solve #16015.

1. Moves to `Pathname` the logic that checks if the path is core tap, cask or formula.
2. Moves failure handler when path does not exist into separate method.

This makes the code easier to read to fix the name conflict between formula and existing directory.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
