### PR TITLE
dev-cmd/audit: load formulae from files

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -122,7 +122,7 @@ module Homebrew
       if args.tap
         Tap.fetch(args.tap).then do |tap|
           [
-            tap.formula_names.map { |name| Formula[name] },
+            tap.formula_files.map { |path| Formulary.factory(path) },
             tap.cask_files.map { |path| Cask::CaskLoader.load(path) },
           ]
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a test to see if this will fix some flaky checks on CI that are caused by missing formulae while auditing the core tap.

- https://github.com/Homebrew/brew/issues/16037