### PR TITLE
cli/parser: check env var directly if there's no `EnvConfig` method.

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -185,7 +185,12 @@ module Homebrew
       def env?(env)
         return if env.blank?
 
-        Homebrew::EnvConfig.try(:"#{env}?")
+        method_name = :"#{env}?"
+        if Homebrew::EnvConfig.respond_to?(method_name)
+          Homebrew::EnvConfig.public_send(method_name)
+        else
+          ENV.fetch("HOMEBREW_#{env.upcase}", nil)
+        end
       end
 
       def description(text = nil)


### PR DESCRIPTION
Before this change, external commands, whether official or not, cannot use the `env:` DSL for `Homebrew::CLI::Parser` without adding their environment variable to `Homebrew::EnvConfig`.

Instead, if the method is not defined, check the environment variable directly. This allows `env:` to be used as expected and allows simplifying some (new) code in e.g. `brew bundle`.