### PR TITLE
cli/named_args: don't interpret `--formula`/`--cask` args as paths

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -230,7 +230,7 @@ module Homebrew
         @to_paths[only] ||= Homebrew.with_no_api_env_if_needed(@without_api) do
           downcased_unique_named.flat_map do |name|
             path = Pathname(name)
-            if File.exist?(name)
+            if only.nil? && File.exist?(name)
               path
             elsif name.count("/") == 1 && !name.start_with?("./", "/")
               tap = Tap.fetch(name)


### PR DESCRIPTION
As demonstrated in #16015, if you do `brew edit something` where `something` is both a file/directory in your working directory and a package name, there was no way to specify that you want the package without changing working directories.

This PR makes it so `--formula` and `--cask` is able to do that.