### PR TITLE
readall: check hash generation works

### DIFF
--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -58,6 +58,7 @@ module Readall
         readall_formula_class = Formulary.load_formula(formula_name, file, formula_contents, readall_namespace,
                                                        flags: [], ignore_errors: false)
         readall_formula = readall_formula_class.new(formula_name, file, :stable, tap: tap)
+        readall_formula.to_hash
         cache[:valid_formulae][file] = if readall_formula.on_system_blocks_exist?
           [bottle_tag, *cache[:valid_formulae][file]]
         else


### PR DESCRIPTION
Rationale is that we could swap `brew generate-formula-api` (90s) with this (15s) addition to `brew readall`.

If `to_hash` fails, there is likely a typo or other sort of error in the formula that would render various brew operations non-functional on that formula, e.g. `brew info` or simply `brew install`, alongwith API generation itself.

In theory, a passing `brew readall` should now guarantee API generation works (excluding `brew` bugs in the command itself of course).