### PR TITLE
Improve use of `whoami`

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -411,7 +411,7 @@ EOS
 ${HOMEBREW_REPOSITORY} is not writable. You should change the
 ownership and permissions of ${HOMEBREW_REPOSITORY} back to your
 user account:
-  sudo chown -R \$(whoami) ${HOMEBREW_REPOSITORY}
+  sudo chown -R ${USER-\$(whoami)} ${HOMEBREW_REPOSITORY}
 EOS
   fi
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -352,7 +352,7 @@ module Homebrew
 
           You should create these directories and change their ownership to your user.
             sudo mkdir -p #{not_exist_dirs.join(" ")}
-            sudo chown -R $(whoami) #{not_exist_dirs.join(" ")}
+            sudo chown -R #{current_user} #{not_exist_dirs.join(" ")}
         EOS
       end
 
@@ -367,7 +367,7 @@ module Homebrew
           #{not_writable_dirs.join("\n")}
 
           You should change the ownership of these directories to your user.
-            sudo chown -R $(whoami) #{not_writable_dirs.join(" ")}
+            sudo chown -R #{current_user} #{not_writable_dirs.join(" ")}
 
           And make sure that your user has write permission.
             chmod u+w #{not_writable_dirs.join(" ")}
@@ -916,7 +916,7 @@ module Homebrew
         <<~EOS
           The staging path #{user_tilde(path.to_s)} is not writable by the current user.
           To fix, run:
-            sudo chown -R $(whoami):staff #{user_tilde(path.to_s)}
+            sudo chown -R #{current_user} #{user_tilde(path.to_s)}
         EOS
       end
 
@@ -1026,6 +1026,10 @@ module Homebrew
 
       def cask_checks
         all.grep(/^check_cask_/)
+      end
+
+      def current_user
+        ENV.fetch("USER", "$(whoami)")
       end
     end
   end

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -86,7 +86,7 @@ module Homebrew
     rescue Errno::EACCES, Errno::ENOTEMPTY
       odie <<~EOS
         Could not rename #{keg.name} keg! Check/fix its permissions:
-          sudo chown -R $(whoami) #{keg}
+          sudo chown -R #{ENV.fetch("USER", "$(whoami)")} #{keg}
       EOS
     end
   end

--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -13,7 +13,7 @@ lock() {
     odie <<EOS
 Can't create ${name} lock in ${lock_dir}!
 Fix permissions by running:
-  sudo chown -R \$(whoami) ${HOMEBREW_PREFIX}/var/homebrew
+  sudo chown -R ${USER-\$(whoami)} ${HOMEBREW_PREFIX}/var/homebrew
 EOS
   fi
   # 200 is the file descriptor used in the lock.


### PR DESCRIPTION
If you're e.g. running Homebrew over `sudo`: shelling out to `whoami` is less effective than just telling people which user you're running as when we run the check.