### PR TITLE
standalone/bootsnap: relax restrictions

### DIFF
--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -5,15 +5,9 @@
 # rubocop:disable Rails
 homebrew_bootsnap_enabled = ENV["HOMEBREW_NO_BOOTSNAP"].nil? && !ENV["HOMEBREW_BOOTSNAP"].nil?
 
-# portable ruby doesn't play nice with bootsnap
-
-homebrew_bootsnap_enabled &&= !RUBY_PATH.to_s.include?("/vendor/portable-ruby/")
-
+# we need some development tools to build bootsnap native code
 homebrew_bootsnap_enabled &&= if ENV["HOMEBREW_MACOS_VERSION"]
-  # Apple Silicon doesn't play nice with bootsnap
-  ENV["HOMEBREW_PROCESSOR"] == "Intel" &&
-    # we need some development tools to build bootsnap native code
-    (File.directory?("/Applications/Xcode.app") || File.directory?("/Library/Developer/CommandLineTools"))
+  File.directory?("/Applications/Xcode.app") || File.directory?("/Library/Developer/CommandLineTools")
 else
   File.executable?("/usr/bin/clang") || File.executable?("/usr/bin/gcc")
 end


### PR DESCRIPTION
I've tried it on Portable Ruby 2.6 and 3.1 and it seems to have no issues there.

I'm also trying removing the Apple Silicon restriction here. I don't have an arm64 machine so I'd appreciate if someone could try it out first.

I suspect the original issue was that the load cache didn't previously key on Ruby platform and version, so it could mix system and portable Ruby load paths together which would lead to disaster. This issue was addressed in Bootsnap 1.9.4, released January 2022.

The breakage using Bootsnap with `ruby/setup-ruby` is still a mystery, but that case wasn't restricted here anyway.