### PR TITLE
cli/named_args: better handle name conflicts in #to_paths

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -221,6 +221,10 @@ module Homebrew
         to_formulae_to_casks(only: only, method: :resolve)
       end
 
+      LOCAL_PATH_REGEX = %r{^/|[.]|/$}.freeze
+      TAP_NAME_REGEX = %r{^[^./]+/[^./]+$}.freeze
+      private_constant :LOCAL_PATH_REGEX, :TAP_NAME_REGEX
+
       # Keep existing paths and try to convert others to tap, formula or cask paths.
       # If a cask and formula with the same name exist, includes both their paths
       # unless `only` is specified.
@@ -230,9 +234,9 @@ module Homebrew
         @to_paths[only] ||= Homebrew.with_no_api_env_if_needed(@without_api) do
           downcased_unique_named.flat_map do |name|
             path = Pathname(name).expand_path
-            if only.nil? && File.exist?(name)
+            if only.nil? && name.match?(LOCAL_PATH_REGEX) && path.exist?
               path
-            elsif name.count("/") == 1 && !name.start_with?("./", "/")
+            elsif name.match?(TAP_NAME_REGEX)
               tap = Tap.fetch(name)
 
               if recurse_tap


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Closes #16015

Before we used to evaluate all named arguments as local paths first. This means that the following could be a name conflict.

```
brew edit src
```

If there was a local file or directory named src, it would default to that. Otherwise it would search for a formula/cask with the same name and return that.

Now it will only default to the local path if the named argument starts or ends with a slash (`/`) or includes a period (`.`). This means that in the event of a name clash with a normal package name it will default to the package instead of the local file.

It also fixes an edge case where the following would be interpreted as a tap name if no local directory existed with the same name.

```
brew edit src/
```

Example:

```console
$ pwd
/Users/kevinrobell/test
$ ls
jrnl     jrnl.rb  src/
$ brew edit --print-path jrnl
Warning: `brew install` ignores locally edited casks and formulae if
HOMEBREW_NO_INSTALL_FROM_API is not set.
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/j/jrnl.rb
$ brew edit --print-path jrnl.rb
/Users/kevinrobell/test/jrnl.rb
$ brew edit --print-path ./jrnl
/Users/kevinrobell/test/jrnl
$ brew edit --print-path src
Warning: `brew install` ignores locally edited casks and formulae if
HOMEBREW_NO_INSTALL_FROM_API is not set.
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/s/src.rb
$ brew edit --print-path src/
/Users/kevinrobell/test/src
```

Note: `CLI::NamedArgs#to_paths` is used in the following commands.
- `brew audit`
- `brew bump-unversioned-casks`
- `brew cat`
- `brew edit`
- `brew log`
- `brew style`

---

As an aside, the following used to work before but now doesn't work for formulae after tap sharding.

```rb
brew(main):001:0> Formulary.path "jrnl"
=> #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/j/jrnl.rb>
brew(main):002:0> Formulary.path "jrnl.rb"
=> #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/jrnl.rb>
```

It does work for casks though.

```rb
brew(main):003:0> Cask::CaskLoader.path "virtualbox"
=> #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/v/virtualbox.rb>
brew(main):004:0> Cask::CaskLoader.path "virtualbox.rb"
=> #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/v/virtualbox.rb>
```
