### PR TITLE
Improve Mac package for enterprise install scenarios

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -4,7 +4,7 @@ Instructions for a supported install of Homebrew are on the [homepage](https://b
 
 The script installs Homebrew to its default, supported, best prefix (`/opt/homebrew` for Apple Silicon, `/usr/local` for macOS Intel and `/home/linuxbrew/.linuxbrew` for Linux) so that [you don’t need *sudo* after Homebrew's initial installation](FAQ.md#why-does-homebrew-say-sudo-is-bad) when you `brew install`. This prefix is required for most bottles (binary packages) to be used. It is a careful script; it can be run even if you have stuff installed in the preferred prefix already. It tells you exactly what it will do before it does it too. You have to confirm everything it will do before it starts.
 
-The macOS `.pkg` installer also installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon and `/usr/local` for macOS Intel) for the same reasons as above. It's available on [Homebrew/brew's latest GitHub release](https://github.com/Homebrew/brew/releases/latest).
+The macOS `.pkg` installer also installs Homebrew to its default prefix (`/opt/homebrew` for Apple Silicon and `/usr/local` for macOS Intel) for the same reasons as above. It's available on [Homebrew/brew's latest GitHub release](https://github.com/Homebrew/brew/releases/latest). To specify an alternate install user, like in situations where the package is installed at the login window before a user has logged in, write a property list file to `/var/tmp/.homebrew_pkg_user.plist` with the value `HOMEBREW_PKG_USER`. For example, `defaults write /var/tmp/.homebrew_pkg_user HOMEBREW_PKG_USER penny`. The file and user must exist prior to install.
 
 ## macOS Requirements
 

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -14,7 +14,7 @@ export HOMEBREW_NO_ANALYTICS_MESSAGE_OUTPUT=1
 homebrew_directory="${2:-/opt/homebrew}"
 if [[ ! -d "${homebrew_directory:?}" ]]
 then
-  echo "no directory at ${homebrew_directory}!" >&2
+  echo "No directory at ${homebrew_directory}!" >&2
   exit 1
 fi
 
@@ -79,18 +79,29 @@ fi
 # create missing directories
 mkdir -vp Cellar Frameworks etc include lib opt sbin share var/homebrew/linked
 
+# optionally define an install user at /var/tmp/.homebrew_pkg_user.plist
+homebrew_pkg_user_plist="/var/tmp/.homebrew_pkg_user.plist"
+if [[ -f "${homebrew_pkg_user_plist}" ]] && [[ -n $(defaults read "${homebrew_pkg_user_plist}" HOMEBREW_PKG_USER) ]]
+then
+  homebrew_pkg_user=$(defaults read /var/tmp/.homebrew_pkg_user HOMEBREW_PKG_USER)
+# otherwise, get valid logged in user
+else
+  homebrew_pkg_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
+fi
+
 # set permissions
-logged_in_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
-group=$(id -gn "${logged_in_user}")
 if [[ "${homebrew_directory}" == "/usr/local/Homebrew" ]]
 then
-  chown -R "${logged_in_user}:${group}" Cellar Frameworks Homebrew bin etc include lib sbin share var/homebrew/linked
+  chown -R "${homebrew_pkg_user}:admin" Cellar Frameworks Homebrew bin etc include lib sbin share var
 else
-  chown -R "${logged_in_user}:${group}" .
+  chown -R "${homebrew_pkg_user}:admin" .
 fi
 
 # move API cache to ~/Library/Caches/Homebrew
-user_api_cache_dir=~"${logged_in_user}"/Library/Caches/Homebrew/api
+user_home_dir=$(dscl . read /Users/"${homebrew_pkg_user}" NFSHomeDirectory | awk '{ print $2 }')
+user_cache_dir="${user_home_dir}/Library/Caches/Homebrew"
+user_api_cache_dir="${user_cache_dir}/api"
 mkdir -vp "${user_api_cache_dir}"
 mv -v "${homebrew_directory}/cache_api/"* "${user_api_cache_dir}"
+chown -R "${homebrew_pkg_user}:staff" "${user_cache_dir}"
 rm -vrf "${homebrew_directory}/cache_api"

--- a/package/scripts/preinstall
+++ b/package/scripts/preinstall
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+homebrew_pkg_user_plist="/var/tmp/.homebrew_pkg_user.plist"
+if [[ -f "${homebrew_pkg_user_plist}" ]] && [[ -n $(defaults read "${homebrew_pkg_user_plist}" HOMEBREW_PKG_USER) ]]
+then
+  exit 0
+fi
+
+homebrew_pkg_user=$(echo "show State:/Users/ConsoleUser" | scutil | awk '/Name :/ { print $3 }')
+if [[ "${homebrew_pkg_user}" =~ _mbsetupuser|loginwindow|root ]] || [[ -z "${homebrew_pkg_user}" ]]
+then
+  echo "No valid user for Homebrew installation. Log in before install or specify an install user."
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
Thank you for investing time into a package! This PR suggests a few improvements to use with large scale enterprise deployments.

The Mac package as is assumes there's a logged in console user in order to set permissions on `/opt/homebrew` and copy cache files to `~/Library/Caches/Homebrew/api`. Usually when a person installs the package manually. However, in an enterprise environment that's often not the case.

For organizationally managed Macs using software management tools like Jamf or [Munki](https://github.com/munki/munk) which initiate installs, it's common for there to be no logged in user or that a user hasn't even been created yet during install. These solutions and similar often run at the login window via a launch daemon before a valid console user has logged in. It's also possible to use Apple's Automated Device Enrollment to deliver packages via MDM before setup assistant is complete. Introducing fallbacks in cases where there's no active console user should cover most enterprise focused edge cases.

- When a known system account such `loginwindow` is the current console user, infer the intended user by looking at the most recently created UID over 500.
- Support passing in a `HOMEBREW_PKG_USER` environment variable for admins to have better control over the target user where required (a lab environment). For example - `HOMEBREW_PKG_USER="nathaniel.strauss" installer -pkg Homebrew-4.1.15 -target /`
- Fix moving `/opt/homebrew/cache_api` to user directory. This previously did not work.
- Bump package required minimum OS to 12.0 to match Homebrew.
- Remove sudo from postinstall script. The installer already runs as root.
- Remove installing `gh` from workflow. GitHub CLI is baked into the runner. https://github.com/actions/runner-images/blob/375e9a1c270ec81a3ffd5b429dcdee9508b46124/images/macos/macos-13-Readme.md?plain=1#L57
