### PR TITLE
api: ignore HTTPS errors if minimum curl version isn't installed

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -54,9 +54,8 @@ module Homebrew
         --speed-time #{ENV.fetch("HOMEBREW_CURL_SPEED_TIME")}
       ]
 
-      insecure_download = (ENV["HOMEBREW_SYSTEM_CA_CERTIFICATES_TOO_OLD"].present? ||
-                           ENV["HOMEBREW_FORCE_BREWED_CA_CERTIFICATES"].present?) &&
-                          !(HOMEBREW_PREFIX/"etc/ca-certificates/cert.pem").exist?
+      insecure_download = DevelopmentTools.ca_file_substitution_required? ||
+                          DevelopmentTools.curl_substitution_required?
       skip_download = target.exist? &&
                       !target.empty? &&
                       (!Homebrew.auto_update_command? ||
@@ -69,9 +68,7 @@ module Homebrew
           args = curl_args.dup
           args.prepend("--time-cond", target.to_s) if target.exist? && !target.empty?
           if insecure_download
-            opoo "Using --insecure with curl to download #{endpoint} " \
-                 "because we need it to run `brew install ca-certificates`. " \
-                 "Checksums will still be verified."
+            opoo DevelopmentTools.insecure_download_warning(endpoint)
             args.append("--insecure")
           end
           unless skip_download

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -36,6 +36,14 @@ class DevelopmentTools
       installation_instructions
     end
 
+    sig { params(resource: String).returns(String) }
+    def insecure_download_warning(resource)
+      package = curl_handles_most_https_certificates? ? "ca-certificates" : "curl"
+      "Using `--insecure` with curl to download #{resource} because we need it to run " \
+        "`brew install #{package}` in order to download securely from now on. " \
+        "Checksums will still be verified."
+    end
+
     sig { returns(Symbol) }
     def default_compiler
       :clang
@@ -121,6 +129,17 @@ class DevelopmentTools
     sig { returns(T::Boolean) }
     def curl_handles_most_https_certificates?
       true
+    end
+
+    sig { returns(T::Boolean) }
+    def ca_file_substitution_required?
+      (!ca_file_handles_most_https_certificates? || ENV["HOMEBREW_FORCE_BREWED_CA_CERTIFICATES"].present?) &&
+        !(HOMEBREW_PREFIX/"etc/ca-certificates/cert.pem").exist?
+    end
+
+    sig { returns(T::Boolean) }
+    def curl_substitution_required?
+      !curl_handles_most_https_certificates? && !HOMEBREW_BREWED_CURL_PATH.exist?
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -577,9 +577,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     if meta[:insecure]
       unless @insecure_warning_shown
-        opoo "Using --insecure with curl to download `ca-certificates` " \
-             "because we need it installed to download securely from now on. " \
-             "Checksums will still be verified."
+        opoo DevelopmentTools.insecure_download_warning("an updated certificates file")
         @insecure_warning_shown = true
       end
       args += ["--insecure"]

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -56,7 +56,8 @@ class Resource < Downloadable
     return if !owner.respond_to?(:full_name) || owner.full_name != "ca-certificates"
     return if Homebrew::EnvConfig.no_insecure_redirect?
 
-    @insecure = !specs[:bottle] && !DevelopmentTools.ca_file_handles_most_https_certificates?
+    @insecure = !specs[:bottle] && (DevelopmentTools.ca_file_substitution_required? ||
+                                    DevelopmentTools.curl_substitution_required?)
     return if @url.nil?
 
     specs = if @insecure


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Similar to the situation addressed in #15895, a system with a built-in `curl` that's too old to handle some certificates (e.g. OS X 10.11) won't be able to fetch the dependencies for compiling a newer `curl`, which is run by update.sh as part of the initial install process. That's been partially resolved by #16079 which fixes mirror support, and this PR finishes the job by:

- in *development_tools.rb*, adding two functions to wrap the task of checking if the system CA certificates or `curl` need replacing; each just checks if they're a) too old and b) haven't been replaced yet. Also added is a function for generating the insecure download warning, called by *api.rb* and *download_strategy.rb*.
- in *api.rb*, setting the flag to use `--insecure` when fetching the API files if either the system CA certificates or `curl` need replacing. Both need to be checked because *brew.sh* is written to specify that either of them is too old, but not both. 
- in *resource.rb*, modifying the line that allows the `ca-certificates` package to be downloaded with `--insecure` if either the system CA certificates or `curl` need replacing. 

On a fresh OS X 10.11 system this results in a working installation.