### PR TITLE
Version: Improve date version parsing

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -376,8 +376,9 @@ class Version
 
   VERSION_PARSERS = [
     # date-based versioning
+    # e.g. 2023-09-28.tar.gz
     # e.g. ltopers-v2017-04-14.tar.gz
-    StemParser.new(/-v?(\d{4}-\d{2}-\d{2})/),
+    StemParser.new(/[._-]?v?(\d{4}-\d{2}-\d{2})/),
 
     # GitHub tarballs
     # e.g. https://github.com/foo/bar/tarball/v1.2.3


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The existing date version parsing regex only matches file names that have a prefix (e.g., `ltopers-v2017-04-14.tar.gz`), so it doesn't match files like `2023-09-28.tar.gz`. There are a handful of formulae that have to manually specify the version as a result (e.g., `marksman`, `sqtop`, etc.). `bootloadhid` is also affected but that's because the filename uses a dot as the prefix delimiter (e.g., `bootloadHID.2012-12-08.tar.gz`) and the regex only matches a hyphen.

This addresses these shortcomings by using `[._-]` as the prefix delimiter and making it optional.