### PR TITLE
Version: Improve date version parsing

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -376,8 +376,9 @@ class Version
 
   VERSION_PARSERS = [
     # date-based versioning
+    # e.g. 2023-09-28.tar.gz
     # e.g. ltopers-v2017-04-14.tar.gz
-    StemParser.new(/-v?(\d{4}-\d{2}-\d{2})/),
+    StemParser.new(/(?:^|[._-]?)v?(\d{4}-\d{2}-\d{2})/),
 
     # GitHub tarballs
     # e.g. https://github.com/foo/bar/tarball/v1.2.3


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This reintroduces the date version changes from https://github.com/Homebrew/brew/pull/16081. We reverted this change in https://github.com/Homebrew/brew/pull/16083 because the "tap syntax" job in homebrew/core was failing with the following audit errors:

```
  bootloadhid
    * Stable: version 2012-12-08 is redundant with version scanned from URL
  exploitdb
    * Stable: version 2023-10-03 is redundant with version scanned from URL
  marksman
    * Stable: version 2023-07-25 is redundant with version scanned from URL
  rust-analyzer
    * Stable: version 2023-10-02 is redundant with version scanned from URL
  sqtop
    * Stable: version 2015-02-08 is redundant with version scanned from URL
  star
    * Stable: version 2023-09-28 is redundant with version scanned from URL
  Error: 6 problems in 6 formulae detected.
```

This `Version` change needs to be in a new `brew` release before we can remove the redundant `#version` calls in related formulae, so we will need to careful about how we merge this. If we want the least amount of disruption, we will need to create a `brew` release immediately after merging this and then merge the homebrew/core PR to address the redundant versions (https://github.com/Homebrew/homebrew-core/pull/149552).

This isn't a pressing change, so feel free to wait until the next planned `brew` release to merge this.

-----

For what it's worth, there was some confusion about why the "formula audit" job in brew CI didn't surface the aforementioned audit errors and it's because we specifically omit version audits. Basically, we need to be able to merge `Version` changes in brew before modifying formulae in homebrew/core but brew CI will fail with `version 1.2.3 is redundant with version scanned from URL` errors unless we omit version audits (see the original PR to introduce `--except=version`: https://github.com/Homebrew/brew/pull/11542). I'm open to better ways of achieving the same goal but that's where we are at the moment.