### PR TITLE
rubocops/text: Declare "revision 0" in formulae as unnecessary

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -48,6 +48,10 @@ module RuboCop
             problem "\"Formula.factory(name)\" is deprecated in favor of \"Formula[name]\""
           end
 
+          find_method_with_args(body_node, :revision, 0) do
+            problem "\"revision 0\" is unnecessary"
+          end
+
           find_method_with_args(body_node, :system, "xcodebuild") do
             problem %q(use "xcodebuild *args" instead of "system 'xcodebuild', *args")
           end

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -24,6 +24,17 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
+    it "reports an offense if 'revision 0' is present" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          revision 0
+          ^^^^^^^^^^ FormulaAudit/Text: "revision 0" is unnecessary
+        end
+      RUBY
+    end
+
     it "reports an offense if both openssl and libressl are dependencies" do
       expect_offense(<<~RUBY)
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This came up in a user contribution recently so here's a RuboCop for it.
- I'm getting some weird test failures on Sonoma for some reason so I'll rely on CI for running all of `brew tests` rather than just the one I wrote.