### PR TITLE
workflows/tests: split gem cache per OS version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,8 +313,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems${{ matrix.ruby }}-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems${{ matrix.ruby }}-
+          key: ${{ matrix.runs-on }}-tests-rubygems${{ matrix.ruby }}-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.runs-on }}-tests-rubygems${{ matrix.ruby }}-
 
       - name: Setup Ruby
         if: matrix.ruby


### PR DESCRIPTION
While it is fairly safe to install a gem built on Ubuntu 20.04 on later versions like 22.04, it is _not_ safe to install a gem built on Ubuntu 22.04 on earlier versions like 20.04. The same applies to macOS too, albeit sometimes more discretely.

Easiest fix to that is to split the cache further. We probably want to re-test the initial compile once every new OS version anyway to make sure new compilers/headers/etc remain compatible.