### PR TITLE
workflows: replace `hub` with `gh`

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Open a pull request
         if: steps.commit.outputs.pull_request == 'true'
-        run: hub pull-request --no-edit
+        run: gh pr create --fill
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Open a pull request
         if: steps.update.outputs.pull_request == 'true'
-        run: hub pull-request --no-edit
+        run: gh pr create --fill
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}

--- a/.github/workflows/sponsors-maintainers-man-completions.yml
+++ b/.github/workflows/sponsors-maintainers-man-completions.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Open a pull request
         if: steps.update.outputs.pull_request == 'true'
-        run: hub pull-request --no-edit
+        run: gh pr create --fill
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}


### PR DESCRIPTION
GitHub have removed preinstalled `hub` from their images as of a couple days ago and are recommending users switch to `gh`, which will continue to be available preinstalled on all supported images.

Fixes https://github.com/Homebrew/brew/actions/runs/6425801173/job/17449002896