### PR TITLE
cmd/fetch: restore `--HEAD` functionality

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -100,7 +100,7 @@ module Homebrew
         os_arch_combinations.each do |os, arch|
           SimulateSystem.with os: os, arch: arch do
             Formulary.clear_cache
-            formula = Formulary.factory(ref)
+            formula = Formulary.factory(ref, args.HEAD? ? :head : :stable)
 
             formula.print_tap_action verb: "Fetching"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
`brew fetch` was always downloading the stable spec. This fixes that.