### PR TITLE
cli/parser: depopulate commands' internal args lists

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -614,7 +614,7 @@ module Homebrew
         @processed_options.reject! { |existing| existing.second == option.long.first } if option.long.first.present?
         @processed_options << [option.short.first, option.long.first, option.arg, option.desc.first, hidden]
 
-        args.select! { |a| a.start_with?("-") }
+        args.pop # last argument is the description
         if type == :switch
           disable_switch(*args)
         else

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -515,8 +515,8 @@ module Homebrew
         end
       end
 
-      def disable_switch(*names)
-        names.each do |name|
+      def disable_switch(*args)
+        args.each do |name|
           @args["#{option_to_name(name)}?"] = if name.start_with?("--[no-]")
             nil
           else
@@ -614,6 +614,7 @@ module Homebrew
         @processed_options.reject! { |existing| existing.second == option.long.first } if option.long.first.present?
         @processed_options << [option.short.first, option.long.first, option.arg, option.desc.first, hidden]
 
+        args.select! { |a| a.start_with?("-") }
         if type == :switch
           disable_switch(*args)
         else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Each command's `args` was including both options and their descriptions. This trims them down to including just short and long options.

Before: (for e.g. `brew --cache`'s `args`)
```
==> #<Homebrew::CLI::Args named=[], remaining=[], d?=true, debug?=true, Display any debugging information.?=false, q?=false, quiet?=false, Make some output more quiet.?=false, v?=false, verbose?=false, Make some output more verbose.?=false, ...
```

After:
```
==> #<Homebrew::CLI::Args named=[], remaining=[], d?=true, debug?=true, q?=false, quiet?=false, v?=false, verbose?=false, h?=false, help?=false, os=nil, arch=nil, s?=false, build_from_source?=false, force_bottle?=false, bottle_tag=nil, HEAD?=false, formula?=false, formulae?=false, cask?=false, casks?=false>
```
