### PR TITLE
Add missing permissions to actions publish

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -112,6 +112,9 @@ module Homebrew
         pr-pull:
           if: contains(github.event.pull_request.labels.*.name, '#{label}')
           runs-on: ubuntu-22.04
+          permissions:
+            contents: write
+            pull-requests: write
           steps:
             - name: Set up Homebrew
               uses: Homebrew/actions/setup-homebrew@master
@@ -138,6 +141,14 @@ module Homebrew
               env:
                 BRANCH: ${{ github.event.pull_request.head.ref }}
               run: git push --delete origin $BRANCH
+
+            - name: Close pr
+              if: github.event.pull_request.head.repo.fork == false
+              env:
+                GITHUB_TOKEN: ${{ github.token }}
+                PULL_REQUEST: ${{ github.event.pull_request.number }}
+                REPO: ${{ github.repository }}
+              run: gh pr close $PULL_REQUEST --repo $REPO
     YAML
 
     (tap.path/".github/workflows").mkpath

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -141,14 +141,6 @@ module Homebrew
               env:
                 BRANCH: ${{ github.event.pull_request.head.ref }}
               run: git push --delete origin $BRANCH
-
-            - name: Close pr
-              if: github.event.pull_request.head.repo.fork == false
-              env:
-                GITHUB_TOKEN: ${{ github.token }}
-                PULL_REQUEST: ${{ github.event.pull_request.number }}
-                REPO: ${{ github.repository }}
-              run: gh pr close $PULL_REQUEST --repo $REPO
     YAML
 
     (tap.path/".github/workflows").mkpath


### PR DESCRIPTION
This commit enhances the publish actions script by including a step to close the pull request after
committing the changes. The existing script deletes the branch after pushing the commits, but lacks
the functionality to close the associated PR.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Permissions Added:
- contents: write
- pull-requests: write

See: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs