### PR TITLE
Odebug system command

### DIFF
--- a/Library/Homebrew/context.rb
+++ b/Library/Homebrew/context.rb
@@ -33,27 +33,33 @@ module Context
       @verbose = verbose
     end
 
+    sig { returns(T::Boolean) }
     def debug?
       @debug == true
     end
 
+    sig { returns(T::Boolean) }
     def quiet?
       @quiet == true
     end
 
+    sig { returns(T::Boolean) }
     def verbose?
       @verbose == true
     end
   end
 
+  sig { returns(T::Boolean) }
   def debug?
     Context.current.debug?
   end
 
+  sig { returns(T::Boolean) }
   def quiet?
     Context.current.quiet?
   end
 
+  sig { returns(T::Boolean) }
   def verbose?
     Context.current.verbose?
   end
@@ -69,8 +75,10 @@ module Context
 
     Thread.current[:context] = new_context
 
-    yield
-  ensure
-    Thread.current[:context] = old_context
+    begin
+      yield
+    ensure
+      Thread.current[:context] = old_context
+    end
   end
 end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -39,8 +39,8 @@ module Kernel
 
     return if !debug && !always_display
 
-    puts Formatter.headline(title, color: :magenta)
-    puts sput unless sput.empty?
+    $stderr.puts Formatter.headline(title, color: :magenta)
+    $stderr.puts sput unless sput.empty?
   end
 
   def oh1_title(title, truncate: :auto)

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -47,10 +47,20 @@ class SystemCommand
     each_output_line do |type, line|
       case type
       when :stdout
-        $stdout << redact_secrets(line, @secrets) if print_stdout?
+        case @print_stdout
+        when true
+          $stdout << redact_secrets(line, @secrets)
+        when :debug
+          $stderr << redact_secrets(line, @secrets) if debug?
+        end
         @output << [:stdout, line]
       when :stderr
-        $stderr << redact_secrets(line, @secrets) if print_stderr?
+        case @print_stderr
+        when true
+          $stderr << redact_secrets(line, @secrets)
+        when :debug
+          $stderr << redact_secrets(line, @secrets) if debug?
+        end
         @output << [:stderr, line]
       end
     end
@@ -69,8 +79,8 @@ class SystemCommand
       env:          T::Hash[String, String],
       input:        T.any(String, T::Array[String]),
       must_succeed: T::Boolean,
-      print_stdout: T::Boolean,
-      print_stderr: T::Boolean,
+      print_stdout: T.any(T::Boolean, Symbol),
+      print_stderr: T.any(T::Boolean, Symbol),
       debug:        T.nilable(T::Boolean),
       verbose:      T.nilable(T::Boolean),
       secrets:      T.any(String, T::Array[String]),
@@ -98,7 +108,14 @@ class SystemCommand
     @executable = executable
     @args = args
 
-    raise ArgumentError, "sudo_as_root cannot be set if sudo is false" if !sudo && sudo_as_root
+    raise ArgumentError, "`sudo_as_root` cannot be set if sudo is false" if !sudo && sudo_as_root
+
+    if print_stdout.is_a?(Symbol) && print_stdout != :debug
+      raise ArgumentError, "`print_stdout` is not a valid symbol"
+    end
+    if print_stderr.is_a?(Symbol) && print_stderr != :debug
+      raise ArgumentError, "`print_stderr` is not a valid symbol"
+    end
 
     @sudo = sudo
     @sudo_as_root = sudo_as_root
@@ -128,7 +145,7 @@ class SystemCommand
 
   attr_reader :executable, :args, :input, :chdir, :env
 
-  attr_predicate :sudo?, :sudo_as_root?, :print_stdout?, :print_stderr?, :must_succeed?
+  attr_predicate :sudo?, :sudo_as_root?, :must_succeed?
 
   sig { returns(T::Boolean) }
   def debug?

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -244,9 +244,13 @@ class SystemCommand
     write_input_to(raw_stdin)
     raw_stdin.close_write
 
+    thread_context = Context.current
     thread_ready_queue = Queue.new
     thread_done_queue = Queue.new
     line_thread = Thread.new do
+      # Ensure the new thread inherits the current context.
+      Context.current = thread_context
+
       Thread.handle_interrupt(ProcessTerminatedInterrupt => :never) do
         thread_ready_queue << true
         each_line_from [raw_stdout, raw_stderr], &block

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -109,6 +109,8 @@ RSpec.configure do |config|
 
   config.include(FileUtils)
 
+  config.include(Context)
+
   config.include(RuboCop::RSpec::ExpectOffense)
 
   config.include(Test::Helper::Cask)
@@ -236,6 +238,7 @@ RSpec.configure do |config|
       example.example.set_exception(e)
     ensure
       ENV.replace(@__env)
+      Context.current = Context::ContextStruct.new
 
       $stdout.reopen(@__stdout)
       $stderr.reopen(@__stderr)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Make `odebug` always output to `stderr` so it doesn't break normal output (e.g. when piping `--json` output).

Also add a new `print_stdout: :debug` option to `SystemCommand` which outputs the full command output to `stderr` when `HOMEBREW_DEBUG`/`--debug` is set.

Needed for https://github.com/Homebrew/homebrew-services/pull/595.