### PR TITLE
Tips-N'-Tricks: homebrew.man.conf for Terminal.app

### DIFF
--- a/docs/Tips-N'-Tricks.md
+++ b/docs/Tips-N'-Tricks.md
@@ -104,3 +104,19 @@ $ brew install --cask --adopt textmate
 - [homebrew-mode](https://github.com/dunn/homebrew-mode) provides syntax highlighting for inline patches as well as a number of helper functions for editing formula files.
 
 - [pcmpl-homebrew](https://github.com/hiddenlotus/pcmpl-homebrew) provides completion for emacs shell-mode and eshell-mode.
+
+## Terminal.app: Enable the "Open man Page" contextual menu item
+
+In the macOS Terminal, you can right-click on a command name (like `ls` or `tar`) and pop open its manpage in a new window by selecting "Open man Page".
+
+Terminal needs an extra hint on where to find manpages installed by Homebrew because it doesn't load normal dotfiles like `~/.bash_profile` or `~/.zshrc`.
+
+```console
+$ sudo mkdir -p /usr/local/etc/man.d
+$ sudo nano /usr/local/etc/man.d/homebrew.man.conf
+```
+Add the following to the new file `homebrew.man.conf`:
+```
+### Homebrew
+MANPATH /opt/homebrew/share/man
+```


### PR DESCRIPTION
Add instructions for fixing Terminal.app's "Open man Page" command by creating homebrew.man.conf.
Re #16074.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [-] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [-] Have you successfully run `brew typecheck` with your changes locally?
- [-] Have you successfully run `brew tests` with your changes locally?

-----
