### PR TITLE
api: add `using:` attribute to head & stable URLs

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2281,6 +2281,7 @@ class Formula
         "url"      => stable_spec.url,
         "tag"      => stable_spec.specs[:tag],
         "revision" => stable_spec.specs[:revision],
+        "using"    => (stable_spec.using if stable_spec.using.is_a?(Symbol)),
         "checksum" => stable_spec.checksum&.to_s,
       }
 
@@ -2291,6 +2292,7 @@ class Formula
       hsh["urls"]["head"] = {
         "url"    => T.must(head).url,
         "branch" => T.must(head).specs[:branch],
+        "using"  => (T.must(head).using if T.must(head).using.is_a?(Symbol)),
       }
     end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -241,7 +241,11 @@ module Formulary
 
       if (urls_stable = json_formula["urls"]["stable"].presence)
         stable do
-          url_spec = { tag: urls_stable["tag"], revision: urls_stable["revision"] }.compact
+          url_spec = {
+            tag:      urls_stable["tag"],
+            revision: urls_stable["revision"],
+            using:    urls_stable["using"]&.to_sym,
+          }.compact
           url urls_stable["url"], **url_spec
           version json_formula["versions"]["stable"]
           sha256 urls_stable["checksum"] if urls_stable["checksum"].present?
@@ -256,7 +260,10 @@ module Formulary
 
       if (urls_head = json_formula["urls"]["head"].presence)
         head do
-          url_spec = { branch: urls_head["branch"] }.compact
+          url_spec = {
+            branch: urls_head["branch"],
+            using:  urls_head["using"]&.to_sym,
+          }.compact
           url urls_head["url"], **url_spec
 
           instance_exec(:head, &add_deps)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Some formulae rely on the `using:` attribute to indicate how a resource is to be downloaded if it can't be detected via the domain name or protocol, e.g.:
- [libvorbis](https://formulae.brew.sh/formula/libvorbis)'s stable URL has `using: :homebrew_curl` as it's hosted on a TLS-1.3-only server
- [trino](https://formulae.brew.sh/formula/trino)'s stable URL has `using: :nounzip` to allow for manual hard-link-preserving decompression
- the head URLs for [abcl](https://formulae.brew.sh/formula/abcl), [global](https://formulae.brew.sh/formula/global), [nginx](https://formulae.brew.sh/formula/nginx), [objfw](https://formulae.brew.sh/formula/objfw), [squid](https://formulae.brew.sh/formula/squid) each have a `using` attribute to indicate the VCS needed to fetch their sources

This change allows from-source installations of these and similar formulae to work when using the API.

Current output:
```console
$ brew info --json pytouhou | jq .[0].urls
{
  "stable": {
    "url": "https://hg.linkmauve.fr/touhou",
    "tag": null,
    "revision": "5270c34b4c00",
    "checksum": null
  },
  "head": {
    "url": "https://hg.linkmauve.fr/touhou",
    "branch": null
  }
}

$ brew fetch --HEAD blastem
==> Downloading https://www.retrodev.com/repos/blastem
##################################################################################################################################################################### 100.0%
Downloaded to: /Users/eric/Library/Caches/Homebrew/downloads/ae00afc1c31ad2cdd9ef6e4ea0876edc8206c3c47c11a628a8593d838242aca5--blastem
SHA256: 72b87d3a585b96e977f9f29cf6fcd9dcee0e9026fc3c69d0b9fdb16b35e679e9
# this just downloads a web page
```

Future:
```console
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info --json pytouhou | jq .[0].urls
{
  "stable": {
    "url": "https://hg.linkmauve.fr/touhou",
    "tag": null,
    "revision": "5270c34b4c00",
    "checksum": null,
    "using": "hg"
  },
  "head": {
    "url": "https://hg.linkmauve.fr/touhou",
    "branch": null,
    "using": "hg"
  }
}

$ HOMEBREW_NO_INSTALL_FROM_API=1 brew fetch --HEAD blastem
==> Cloning https://www.retrodev.com/repos/blastem
requesting all changes
adding changesets
adding manifests
adding file changes
added 2346 changesets with 5011 changes to 324 files (+1 heads)
new changesets 2432d177e1ac:c76c81c21ae5
updating to branch default
300 files updated, 0 files merged, 0 files removed, 0 files unresolved
Resource: vasm
==> Downloading http://phoenix.owl.de/tags/vasm1_8i.tar.gz
##################################################################################################################################################################### 100.0%
Downloaded to: /Users/eric/Library/Caches/Homebrew/downloads/4f31e8fb49321255218db07092e8864e9e036e14c2c563c1add9ea1201164d99--vasm1_8i.tar.gz
SHA256: 9ae0b37bca11cae5cf00e4d47e7225737bdaec4028e4db2a501b4eca7df8639d
==> Downloading https://www.retrodev.com/repos/blastem/raw-rev/dbbf0100f249
##################################################################################################################################################################### 100.0%
Downloaded to: /Users/eric/Library/Caches/Homebrew/downloads/70a17ee109695d03f5ece64dd949f1b08371b9e3592a96d1738aac5868fba8c3--dbbf0100f249
SHA256: e332764bfa08e08e0f9cbbebefe73b88adb99a1e96a77a16a0aeeae827ac72ff
```