### PR TITLE
Adding GHA permission for GitHub Packages

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -114,7 +114,7 @@ module Homebrew
           runs-on: ubuntu-22.04
           permissions:
             contents: write
-            packages: #{args.github_packages ? "write" : "none"}
+            packages: #{args.github_packages? ? "write" : "none"}
             pull-requests: write
           steps:
             - name: Set up Homebrew

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -114,6 +114,7 @@ module Homebrew
           runs-on: ubuntu-22.04
           permissions:
             contents: write
+            packages: #{args.github_packages ? "write" : "none"}
             pull-requests: write
           steps:
             - name: Set up Homebrew


### PR DESCRIPTION
Followup to https://github.com/Homebrew/brew/pull/16097 (CC: @JameelKaisar). When a tap stores bottles in GitHub Packages, then the publish workflow requires the corresponding write permission.

The error message raised was: `level=fatal msg="copying image 1/2 from manifest list: writing blob: initiating layer upload to /v2/davidchall/hep/fastjet/blobs/uploads/ in ghcr.io: denied: installation not allowed to Write organization package"`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
