### PR TITLE
formulary: load from API for formula renames

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -149,6 +149,8 @@ module Formulary
 
     class_name = class_s(name)
     json_formula = Homebrew::API::Formula.all_formulae[name]
+    raise FormulaUnavailableError, name if json_formula.nil?
+
     json_formula = Homebrew::API.merge_variations(json_formula)
 
     uses_from_macos_names = json_formula["uses_from_macos"].map do |dep|
@@ -963,6 +965,10 @@ module Formulary
     end
 
     if CoreTap.instance.formula_renames.key?(ref)
+      unless Homebrew::EnvConfig.no_install_from_api?
+        return FormulaAPILoader.new(CoreTap.instance.formula_renames[ref])
+      end
+
       return TapLoader.new("#{CoreTap.instance}/#{ref}", from: from, warn: warn)
     end
 


### PR DESCRIPTION
It was correctly getting the renames from the API, but it was attempting to load the new formula from an installed tap only which will fail for those with Homebrew/core untapped.

Fixes #16107