### PR TITLE
utils/gems: fix Sonoma compatibility check

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -235,9 +235,9 @@ module Homebrew
 
     valid_user_gem_groups = user_gem_groups & valid_gem_groups
     if RUBY_PLATFORM.end_with?("-darwin23")
-      raise "Sorbet is not currently supported under system Ruby on macOS Sonoma." if groups.include?("sorbet")
+      raise "Sorbet is not currently supported under system Ruby on macOS Sonoma." if groups.include?("typecheck")
 
-      valid_user_gem_groups.delete("sorbet")
+      valid_user_gem_groups.delete("typecheck")
     end
 
     # Combine the passed groups with the ones stored in settings


### PR DESCRIPTION
The group was renamed and I missed this reference.

Fixes https://github.com/orgs/Homebrew/discussions/4841 and https://github.com/Homebrew/brew/pull/16105#issuecomment-1758843240

The check will soon disappear completely when Ruby 2.6 support is dropped.