### PR TITLE
cmd/fetch: support retrying manifest downloads

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -129,7 +129,12 @@ module Homebrew
                   next
                 end
 
-                formula.fetch_bottle_tab
+                begin
+                  bottle.fetch_tab
+                rescue DownloadError
+                  retry if retry_fetch?(bottle, args: args)
+                  raise
+                end
                 fetch_formula(bottle, args: args)
               rescue Interrupt
                 raise


### PR DESCRIPTION
Mitigation for ghcr.io networking issues

...and also a functionality that makes sense to have given `--retry` is largely to smooth out network instability, and retrying the blobs is already supported.