### PR TITLE
dev-cmd/unbottled: add --lost option

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -21,11 +21,13 @@ module Homebrew
              description: "Skip getting analytics data and sort by number of dependents instead."
       switch "--total",
              description: "Print the number of unbottled and total formulae."
+      switch "--lost",
+             description: "Print the `homebrew/core` commits where bottles were lost in the last week."
       switch "--eval-all",
              description: "Evaluate all available formulae and casks, whether installed or not, to check them. " \
                           "Implied if `HOMEBREW_EVAL_ALL` is set."
 
-      conflicts "--dependents", "--total"
+      conflicts "--dependents", "--total", "--lost"
 
       named_args :formula
     end
@@ -41,6 +43,17 @@ module Homebrew
       Utils::Bottles::Tag.from_symbol(tag.to_sym)
     else
       Utils::Bottles.tag
+    end
+
+    if args.lost?
+      if args.named.present?
+        raise UsageError, "`brew unbottled --lost` cannot be used with formula arguments!"
+      elsif !CoreTap.instance.installed?
+        raise UsageError, "`brew unbottled --lost` requires `homebrew/core` to be tapped locally!"
+      else
+        output_lost_bottles
+        return
+      end
     end
 
     os = @bottle_tag.system
@@ -242,5 +255,54 @@ module Homebrew
     return if any_named_args
 
     puts "No unbottled dependencies found!"
+  end
+
+  def output_lost_bottles
+    # $ git log --patch -G\^\ \+sha256.\*\ sonoma: --since=@\{\'1\ week\ ago\'\}
+    git_log = %w[git log --patch]
+    git_log << "-G^ +sha256.* #{@bottle_tag}:"
+    git_log << "--since=@{'1 week ago'}"
+
+    bottle_tag_sha_regex = /^[+-] +sha256.* #{@bottle_tag}: /
+
+    processed_formulae = Set.new
+    commit = T.let(nil, T.nilable(String))
+    formula = T.let(nil, T.nilable(String))
+    lost_bottles = 0
+
+    CoreTap.instance.path.cd do
+      Utils.safe_popen_read(*git_log) do |io|
+        io.each_line do |line|
+          case line
+          when /^commit [0-9a-f]{40}$/
+            # Example match: `commit 7289b409b96a752540befef1a56b8a818baf1db7`
+            if commit && lost_bottles.positive? && processed_formulae.exclude?(formula)
+              puts "#{commit}: bottle lost for #{formula}"
+            end
+            processed_formulae << formula
+            commit = line.split.last
+            lost_bottles = 0
+          when %r{^diff --git a/Formula/}
+            # Example match: `diff --git a/Formula/a/aws-cdk.rb b/Formula/a/aws-cdk.rb`
+            formula = line.split("/").last.chomp(".rb\n")
+          when bottle_tag_sha_regex
+            # Example match: `-    sha256 cellar: :any_skip_relocation, sonoma: "f0a4..."`
+            next if processed_formulae.include?(formula)
+
+            case line.chr
+            when "+" then lost_bottles -= 1
+            when "-" then lost_bottles += 1
+            end
+          when /^[+] +sha256.* all: /
+            # Example match: `+    sha256 cellar: :any_skip_relocation, all: "9e35..."`
+            lost_bottles -= 1
+          end
+        end
+      end
+    end
+
+    return if !commit || !lost_bottles.positive? || processed_formulae.include?(formula)
+
+    puts "#{commit}: bottle lost for #{formula}"
   end
 end

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -260,12 +260,14 @@ module Homebrew
   def output_lost_bottles
     ohai ":#{@bottle_tag} lost bottles"
 
-    # $ git log --patch -G'^ +sha256.* sonoma:' --since=@{'1 week ago'}
+    bottle_tag_regex_fragment = " +sha256.* #{@bottle_tag}: "
+
+    # $ git log --patch --no-ext-diff -G'^ +sha256.* sonoma:' --since=@{'1 week ago'}
     git_log = %w[git log --patch --no-ext-diff]
-    git_log << "-G^ +sha256.* #{@bottle_tag}:"
+    git_log << "-G^#{bottle_tag_regex_fragment}"
     git_log << "--since=@{'1 week ago'}"
 
-    bottle_tag_sha_regex = /^[+-] +sha256.* #{@bottle_tag}: /
+    bottle_tag_sha_regex = /^[+-]#{bottle_tag_regex_fragment}/
 
     processed_formulae = Set.new
     commit = T.let(nil, T.nilable(String))

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -2258,6 +2258,7 @@ _brew_unbottled() {
       --dependents
       --eval-all
       --help
+      --lost
       --quiet
       --tag
       --total

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1500,6 +1500,7 @@ __fish_brew_complete_arg 'unbottled' -l debug -d 'Display any debugging informat
 __fish_brew_complete_arg 'unbottled' -l dependents -d 'Skip getting analytics data and sort by number of dependents instead'
 __fish_brew_complete_arg 'unbottled' -l eval-all -d 'Evaluate all available formulae and casks, whether installed or not, to check them. Implied if `HOMEBREW_EVAL_ALL` is set'
 __fish_brew_complete_arg 'unbottled' -l help -d 'Show this message'
+__fish_brew_complete_arg 'unbottled' -l lost -d 'Print the `homebrew/core` commits where bottles were lost in the last week'
 __fish_brew_complete_arg 'unbottled' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'unbottled' -l tag -d 'Use the specified bottle tag (e.g. `big_sur`) instead of the current OS'
 __fish_brew_complete_arg 'unbottled' -l total -d 'Print the number of unbottled and total formulae'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1846,12 +1846,13 @@ _brew_typecheck() {
 _brew_unbottled() {
   _arguments \
     '--debug[Display any debugging information]' \
-    '(--total)--dependents[Skip getting analytics data and sort by number of dependents instead]' \
+    '(--total --lost)--dependents[Skip getting analytics data and sort by number of dependents instead]' \
     '--eval-all[Evaluate all available formulae and casks, whether installed or not, to check them. Implied if `HOMEBREW_EVAL_ALL` is set]' \
     '--help[Show this message]' \
+    '(--dependents --total)--lost[Print the `homebrew/core` commits where bottles were lost in the last week]' \
     '--quiet[Make some output more quiet]' \
     '--tag[Use the specified bottle tag (e.g. `big_sur`) instead of the current OS]' \
-    '(--dependents)--total[Print the number of unbottled and total formulae]' \
+    '(--dependents --lost)--total[Print the number of unbottled and total formulae]' \
     '--verbose[Make some output more verbose]' \
     - formula \
     '*::formula:__brew_formulae'

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1626,6 +1626,8 @@ Show the unbottled dependents of formulae.
   Skip getting analytics data and sort by number of dependents instead.
 * `--total`:
   Print the number of unbottled and total formulae.
+* `--lost`:
+  Print the `homebrew/core` commits where bottles were lost in the last week.
 * `--eval-all`:
   Evaluate all available formulae and casks, whether installed or not, to check them. Implied if `HOMEBREW_EVAL_ALL` is set.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2339,6 +2339,10 @@ Skip getting analytics data and sort by number of dependents instead\.
 Print the number of unbottled and total formulae\.
 .
 .TP
+\fB\-\-lost\fR
+Print the \fBhomebrew/core\fR commits where bottles were lost in the last week\.
+.
+.TP
 \fB\-\-eval\-all\fR
 Evaluate all available formulae and casks, whether installed or not, to check them\. Implied if \fBHOMEBREW_EVAL_ALL\fR is set\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Closes #16016

This option tries to find bottles where the bottle was removed from the formula in the past week and not added back in.

It checks the output of `git log` to see if there are any bottles that fit this criteria.

Note: This implementation does not handle renamed formula well but I assume that doesn't happen that often so having the occasional false positive is not a big deal here.

The `git log` output looks something like this for each commit.

```diff
commit 2db9033f717486f7f0c9b815165f8e75c106f4f2
Author: BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>
Date:   Mon Oct 9 01:57:41 2023 +0000

    chezmoi: update 2.40.1 bottle.

diff --git a/Formula/c/chezmoi.rb b/Formula/c/chezmoi.rb
index 6630a3a49f1..0e0b44ceb1e 100644
--- a/Formula/c/chezmoi.rb
+++ b/Formula/c/chezmoi.rb
@@ -16,15 +16,13 @@ class Chezmoi < Formula
   end

   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5e8b651e295cf9aa2e729eb20a95369f40776c417967dfd548a8d099814555e1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3110d532bce9e4b491947ed573cb8791b2e9686e8bc48ac3c9254c7821191f64"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8d4f12c92e13b30f16f8590d3baf2f5023411487618fe95d56a97498719d2ca8"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "16b9f5098a7341449a6117b33f1d7f3c81e2bbe7931483542c61318f5dabfb95"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b8fea089285495c752425255a1f7991a38db1e7dccbfbfda1d80d292f1eb1375"
-    sha256 cellar: :any_skip_relocation, ventura:        "317ae3c957e7e47c9da148810cf6552806ada43bd64e06717a8d9d4ad29d34a0"
-    sha256 cellar: :any_skip_relocation, monterey:       "fbc1730aa793c0cc4eba55de4ba917da49ab0a5bdec7f5fc6dd2dbf1a11cd74e"
-    sha256 cellar: :any_skip_relocation, big_sur:        "b103680ce7be96687331e6e4bd67179c36c029396e445ed4da28db0e3af99a34"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4033bf4f74a71d34ab9cae2a42572182c8e2f54c9c3cc8e959da6b41482b825f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6306f3c075e815900601a445f3f7abf2442796b37ac413cbeb2728b1a9875dec"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e222a15cd8c207e4a86c00c11ae52839d469c9bc4263196e46a890865d486b37"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "fd0ece6bdbac1c673a0a76cbe18d64cc6590b9c25a42e47ed528ff81515c670b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5dd6c897ed71aa81cc3c4a60b57c667707178f8fe083d0481da7bd3ad276855f"
+    sha256 cellar: :any_skip_relocation, ventura:        "d6631beca0be1dcee098840b185afd0d84003fbcfb07284037df8f1aea2e1595"
+    sha256 cellar: :any_skip_relocation, monterey:       "7a0c3e1df3ea5fc7c801758d1450b4217463e1c5f8b67be6e01a3b3a7fcbd7ea"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "eb65b49dc68b391c44a1878e26d7416b57f4685f45337c8ca6b720b3ace1dcc7"
   end

   depends_on "go" => :build
```

We parse the commit, formula name and bottle changes from this and then print that the bottle is lost if the bottle was removed and not replaced.

Examples:

```console
$ brew unbottled --lost --tag=catalina
0cd5b8ed5cece697c573b1aae68cb480ce1ed124: bottle lost for progress
d32cf49ac718953fd8a12d9e8beb22253e438459: bottle lost for glulxe
e91497afc7c48a7a541d01e71fd8dd85324cd0f5: bottle lost for bbtools
3b20c02cd83bea90e2110db94926054400779467: bottle lost for assimp
615db9c7aa328a90d96b1d4f92e8a112399e33cf: bottle lost for git-if
97ab0a4493a0cd3e9cb1381f1af1c61b39c0f3f5: bottle lost for mt32emu
fe17ca92c062f17f086d09f4f1bacc819c6e416d: bottle lost for ghr
27d4c7c7aaa354d9c91f29bded817711706eb30b: bottle lost for go-md2man
32482fe5a6771931198e22de0129535a6601fbfa: bottle lost for clingo
bd0758e78222eb4c1e78a81b9c91835f6b08c972: bottle lost for fail2ban
b8246c3284ce4f02a47fb13bdf43276d4581f02d: bottle lost for vpn-slice
0de3fbffd4d38ff6672916f4c446b1eb00fe0130: bottle lost for unoconv
80e82eed5d6abd75a300de4249f90e61565e3497: bottle lost for shared-mime-info
a3a46c4b194ab30d04081c85677c934c2a06da11: bottle lost for libcue
ffa61bd9956aeef4c1576fc25ca6ebb23462c958: bottle lost for zeromq
8366cf2fe290c26657ea14a087030b880ba60f1e: bottle lost for diceware
68c27a815aad10ea0aa9936f5362324f91fc3141: bottle lost for libnet
2c4c24508099548bc97a6df318e333e19874b0b4: bottle lost for honcho
8f6f93ee47e3cf1a570fb2c49dd380797972d6d2: bottle lost for choose
$ brew unbottled --lost --tag=arm64_ventura
$ brew unbottled --lost --tag=sonoma
94febc3a91a4e8d3443adec4192dc3153659aafb: bottle lost for victoriametrics
```