### PR TITLE
formula_installer: pre-install implicit dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -362,7 +362,7 @@ class FormulaInstaller
     return if @compute_dependencies.blank?
 
     compute_dependencies(use_cache: false) if @compute_dependencies.any? do |dep, options|
-      next false if dep.tags != [:build, :test]
+      next false unless dep.implicit?
 
       fetch_dependencies
       install_dependency(dep, options)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
A leftover from #15566: originally added in #12296, a dependency with `[:build, :test]` was assumed to be required for downloading or extracting a package's source. Now we have `:implicit`, so just check for that. This restores curl being pre-installed for any dependency with `using: :homebrew_curl` and [subversion being pre-installed if needed on macOS 10.14 and earlier](https://github.com/Homebrew/homebrew-core/pull/87527#issuecomment-947867674). 