### PR TITLE
audit(github): prefer `/archive/refs/tags` urls over `/archive`

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -217,7 +217,7 @@ module RuboCop
             problem "Use /archive/ URLs for GitHub tarballs (url is #{url})."
           end
 
-          archive_ref_tags_gh_pattern = %r{https://.*github.*/archive(?!/refs/tags)/.*\.tar\.gz$}
+          archive_ref_tags_gh_pattern = %r{https://.*github.*/archive/(?![a-fA-F0-9]{40})(?!refs/tags/).*\.tar\.gz$}
           audit_urls(urls, archive_ref_tags_gh_pattern) do |_, url|
             next if url.end_with?(".git")
 

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -217,6 +217,13 @@ module RuboCop
             problem "Use /archive/ URLs for GitHub tarballs (url is #{url})."
           end
 
+          archive_ref_tags_gh_pattern = %r{https://.*github.*/archive(?!/refs/tags)/.*\.tar\.gz$}
+          audit_urls(urls, archive_ref_tags_gh_pattern) do |_, url|
+            next if url.end_with?(".git")
+
+            problem "Use /archive/refs/tags URLs for GitHub tarballs (url is #{url})."
+          end
+
           # Don't use GitHub .zip files
           zip_gh_pattern = %r{https://.*github.*/(archive|releases)/.*\.zip$}
           audit_urls(urls, zip_gh_pattern) do |_, url|

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -157,7 +157,7 @@ module SharedAudits
 
   def github_tag_from_url(url)
     url = url.to_s
-    tag = url.match(%r{^https://github\.com/[\w-]+/[\w-]+/archive/([^/]+)\.(tar\.gz|zip)$})
+    tag = url.match(%r{^https://github\.com/[\w-]+/[\w-]+/archive/refs/tags/([^/]+)\.(tar\.gz|zip)$})
              .to_a
              .second
     tag ||= url.match(%r{^https://github\.com/[\w-]+/[\w-]+/releases/download/([^/]+)/})


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

followup https://github.com/mislav/bump-homebrew-formula-action/pull/53

seeing couple of issues recently in homebrew-core for the artifact urls
