### PR TITLE
cli/parser: rescue formula specification errors

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -140,7 +140,8 @@ module Homebrew
               warn_if_cask_conflicts(name, "formula") if only != :formula
               return formula
             rescue FormulaUnreadableError, FormulaClassUnavailableError,
-                   TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
+                   TapFormulaUnreadableError, TapFormulaClassUnavailableError,
+                   FormulaSpecificationError => e
               # Need to rescue before `FormulaUnavailableError` (superclass of this)
               # The formula was found, but there's a problem with its implementation
               unreadable_error ||= e

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -653,7 +653,7 @@ module Homebrew
 
           begin
             Formulary.factory(arg, spec, flags: argv.select { |a| a.start_with?("--") })
-          rescue FormulaUnavailableError
+          rescue FormulaUnavailableError, FormulaSpecificationError
             nil
           end
         end.compact.uniq(&:name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Closes #16123

This came up recently where an outdated formula definition caused the program to crash with an ambiguous message when a user wanted to upgrade a cask instead. Catching these errors allows them to get handled later on improving error messages and defaults. Now if the only formula with the given name is invalid it will default to using the cask unless --formula is specified.

After changes:

```console
$ brew install -n vagrant
Error: Failed to load formula: vagrant
formulae require at least a URL
Warning: Treating vagrant as a cask.
==> Would install 1 cask:
vagrant
$ brew install -n vagrant --formula
Error: formulae require at least a URL
Warning: Removed Sorbet lines from backtrace!
Rerun with --verbose to see the original backtrace
/usr/local/Homebrew/Library/Homebrew/formula.rb:306:in `determine_active_spec'
/usr/local/Homebrew/Library/Homebrew/formula.rb:237:in `initialize'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:494:in `new'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:494:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:771:in `factory'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:126:in `block in load_formula_or_cask'
/usr/local/Homebrew/Library/Homebrew/api.rb:197:in `with_no_api_env_if_needed'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:118:in `load_formula_or_cask'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:83:in `block in to_formulae_and_casks'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:81:in `each'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:81:in `flat_map'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:81:in `to_formulae_and_casks'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:195:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:86:in `<main>'
```