### PR TITLE
dev-cmd/bump-cask-pr: replace url before downloading files

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -116,22 +116,6 @@ module Homebrew
     branch_name = "bump-#{cask.token}"
     commit_message = nil
 
-    if new_version.present?
-      # For simplicity, our naming defers to the arm version if we multiple architectures are specified
-      branch_version = new_version.arm || new_version.general
-      if branch_version.is_a?(Cask::DSL::Version)
-        commit_version = if branch_version.before_comma == cask.version.before_comma
-          branch_version
-        else
-          branch_version.before_comma
-        end
-        branch_name = "bump-#{cask.token}-#{branch_version.tr(",:", "-")}"
-        commit_message ||= "#{cask.token} #{commit_version}"
-      end
-      replacement_pairs = replace_version_and_checksum(cask, new_hash, new_version, replacement_pairs)
-    end
-    # Now that we have all replacement pairs, we will replace them further down
-
     old_contents = File.read(cask.sourcefile_path)
 
     if new_base_url
@@ -147,6 +131,22 @@ module Homebrew
         new_base_url.to_s,
       ]
     end
+
+    if new_version.present?
+      # For simplicity, our naming defers to the arm version if we multiple architectures are specified
+      branch_version = new_version.arm || new_version.general
+      if branch_version.is_a?(Cask::DSL::Version)
+        commit_version = if branch_version.before_comma == cask.version.before_comma
+          branch_version
+        else
+          branch_version.before_comma
+        end
+        branch_name = "bump-#{cask.token}-#{branch_version.tr(",:", "-")}"
+        commit_message ||= "#{cask.token} #{commit_version}"
+      end
+      replacement_pairs = replace_version_and_checksum(cask, new_hash, new_version, replacement_pairs)
+    end
+    # Now that we have all replacement pairs, we will replace them further down
 
     commit_message ||= "#{cask.token}: update checksum" if new_hash
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Previously it was possible for both the version and url to be changed. This would cause the old url to be used to download the cask and check the checksum since the version and checksum were replaced in the cask first and then the url would be replaced. This meant that the resulting checksum was wrong if a url was provided and might be completely invalid if it was interpolated causing a download failure as shown in #16114.

Closes #16114