### PR TITLE
fix: ignore quarantine for linux cask download

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -114,3 +114,5 @@ module Cask
     end
   end
 end
+
+require "extend/os/cask/download"

--- a/Library/Homebrew/extend/os/cask/download.rb
+++ b/Library/Homebrew/extend/os/cask/download.rb
@@ -1,0 +1,4 @@
+# typed: true
+# frozen_string_literal: true
+
+require "extend/os/linux/cask/download" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/cask/download.rb
+++ b/Library/Homebrew/extend/os/linux/cask/download.rb
@@ -1,0 +1,13 @@
+# typed: true
+# frozen_string_literal: true
+
+module Cask
+  class Download
+    undef quarantine
+
+    def quarantine(_path)
+      opoo "Cannot quarantine download: No xattr available on linux." if @quarantine
+      nil
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Override the `quarantine` method for cask download on Linux. This should, in most cases, allow `bump-cask-pr` to function on Linux.