### PR TITLE
dev-cmd/pr-upload: fix gems not being installed with --upload-only

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -92,6 +92,8 @@ module Homebrew
     odie "No bottle JSON files found in the current working directory" if json_files.blank?
     bottles_hash = bottles_hash_from_json_files(json_files, args)
 
+    Homebrew.install_bundler_gems!(groups: ["pr_upload"])
+
     unless args.upload_only?
       bottle_args = ["bottle", "--merge", "--write"]
       bottle_args << "--verbose" if args.verbose?
@@ -124,8 +126,6 @@ module Homebrew
       end
 
       check_bottled_formulae!(bottles_hash)
-
-      Homebrew.install_bundler_gems!(groups: ["pr_upload", "style"])
 
       safe_system HOMEBREW_BREW_FILE, *bottle_args
 


### PR DESCRIPTION
Gem install was incorrectly inside the `unless args.upload_only?` block.