### PR TITLE
Pull in REXML gem as it doesn't ship with Ruby 3

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -68,6 +68,11 @@ group :typecheck, optional: true do
   gem "tapioca", require: false
 end
 
+# shared gems (used by multiple groups)
+group :audit, :bump_unversioned_casks, :livecheck, optional: true do
+  gem "rexml", require: false
+end
+
 # vendored gems (no group)
 gem "activesupport"
 gem "addressable"

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -201,6 +201,7 @@ DEPENDENCIES
   patchelf
   plist
   pry
+  rexml
   ronn
   rspec
   rspec-github

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -153,6 +153,10 @@ module Homebrew
       return
     end
 
+    gem_groups = ["audit"]
+    gem_groups << "style" unless skip_style
+    Homebrew.install_bundler_gems!(groups: gem_groups)
+
     style_files = args.named.to_paths unless skip_style
 
     only_cops = args.only_cops

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -70,7 +70,10 @@ module Homebrew
     # odeprecated "brew bump-cask-pr --online" if args.online?
     # This will be run by `brew audit` or `brew style` later so run it first to
     # not start spamming during normal output.
-    Homebrew.install_bundler_gems!(groups: ["style"]) if !args.no_audit? || !args.no_style?
+    gem_groups = []
+    gem_groups << "style" if !args.no_audit? || !args.no_style?
+    gem_groups << "audit" unless args.no_audit?
+    Homebrew.install_bundler_gems!(groups: gem_groups) unless gem_groups.empty?
 
     # As this command is simplifying user-run commands then let's just use a
     # user path, too.

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -117,7 +117,7 @@ module Homebrew
 
     # This will be run by `brew audit` later so run it first to not start
     # spamming during normal output.
-    Homebrew.install_bundler_gems!(groups: ["style"]) unless args.no_audit?
+    Homebrew.install_bundler_gems!(groups: ["audit", "style"]) unless args.no_audit?
 
     tap_remote_repo = formula.tap.full_name || formula.tap.remote_repo
     remote = "origin"

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -33,6 +33,8 @@ module Homebrew
   def self.bump_unversioned_casks
     args = bump_unversioned_casks_args.parse
 
+    Homebrew.install_bundler_gems!(groups: ["bump_unversioned_casks"])
+
     state_file = if args.state_file.present?
       Pathname(args.state_file).expand_path
     else

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -66,7 +66,7 @@ module Homebrew
   def livecheck
     args = livecheck_args.parse
 
-    Homebrew.install_bundler_gems!(groups: ["livecheck"]) if args.json?
+    Homebrew.install_bundler_gems!(groups: ["livecheck"])
 
     all = args.eval_all?
 

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -62,6 +62,7 @@ module Homebrew
         # @return [Item, nil]
         sig { params(content: String).returns(T::Array[Item]) }
         def self.items_from_content(content)
+          require "rexml/document"
           xml = Xml.parse_xml(content)
           return [] if xml.blank?
 

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "rexml/document"
-
 module Homebrew
   module Livecheck
     module Strategy


### PR DESCRIPTION
REXML doesn't ship with Ruby 3 (or well it sort of does as a bundled gem, but it isn't accessible through Bundler).

So we need to add it to the Gemfile here. While not strictly necessary for Ruby 2.6, let's do it everywhere for consistency.