### PR TITLE
Store and use revision in tab runtime dependencies

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -46,7 +46,8 @@ class Dependency
     formula
   end
 
-  def installed?(minimum_version: nil)
+  sig { params(minimum_version: T.nilable(Version), minimum_revision: T.nilable(Integer)).returns(T::Boolean) }
+  def installed?(minimum_version: nil, minimum_revision: nil)
     formula = begin
       to_formula
     rescue FormulaUnavailableError
@@ -55,14 +56,29 @@ class Dependency
     return false unless formula
 
     if minimum_version.present?
-      formula.any_version_installed? && (formula.any_installed_version.version >= minimum_version)
+      installed_version = formula.any_installed_version
+      return false unless installed_version
+
+      # Tabs prior to 4.1.18 did not have revision or pkg_version fields.
+      # As a result, we have to be more conversative when we do not have
+      # a minimum revision from the tab and assume that if the formula has a
+      # the same version and a non-zero revision that it needs upgraded.
+      if minimum_revision.present?
+        minimum_pkg_version = PkgVersion.new(minimum_version, minimum_revision)
+        installed_version >= minimum_pkg_version
+      elsif installed_version.version == minimum_version
+        formula.revision.zero?
+      else
+        installed_version.version > minimum_version
+      end
     else
       formula.latest_version_installed?
     end
   end
 
-  def satisfied?(inherited_options = [], minimum_version: nil)
-    installed?(minimum_version: minimum_version) && missing_options(inherited_options).empty?
+  def satisfied?(inherited_options = [], minimum_version: nil, minimum_revision: nil)
+    installed?(minimum_version: minimum_version, minimum_revision: minimum_revision) &&
+      missing_options(inherited_options).empty?
   end
 
   def missing_options(inherited_options)
@@ -248,8 +264,9 @@ class UsesFromMacOSDependency < Dependency
     [name, tags, bounds].hash
   end
 
-  def installed?(minimum_version: nil)
-    use_macos_install? || super(minimum_version: minimum_version)
+  sig { params(minimum_version: T.nilable(Version), minimum_revision: T.nilable(Integer)).returns(T::Boolean) }
+  def installed?(minimum_version: nil, minimum_revision: nil)
+    use_macos_install? || super(minimum_version: minimum_version, minimum_revision: minimum_revision)
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -616,11 +616,14 @@ on_request: installed_on_request?, options: options)
       keep_build_test ||= dep.build? && !install_bottle_for?(dependent, build) &&
                           (formula.head? || !dependent.latest_version_installed?)
 
-      bottle_runtime_version = @bottle_tab_runtime_dependencies.dig(dep.name, "version")
+      bottle_runtime_version = @bottle_tab_runtime_dependencies.dig(dep.name, "version").presence
+      bottle_runtime_version = Version.new(bottle_runtime_version) if bottle_runtime_version
+      bottle_runtime_revision = @bottle_tab_runtime_dependencies.dig(dep.name, "revision")
 
       if dep.prune_from_option?(build) || ((dep.build? || dep.test?) && !keep_build_test)
         Dependency.prune
-      elsif dep.satisfied?(inherited_options[dep.name], minimum_version: bottle_runtime_version)
+      elsif dep.satisfied?(inherited_options[dep.name], minimum_version:  bottle_runtime_version,
+                                                        minimum_revision: bottle_runtime_revision)
         Dependency.skip
       end
     end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -226,6 +226,8 @@ class Tab
       {
         "full_name"         => f.full_name,
         "version"           => f.version.to_s,
+        "revision"          => f.revision,
+        "pkg_version"       => f.pkg_version.to_s,
         "declared_directly" => formula.deps.include?(dep),
       }
     end

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -141,7 +141,8 @@ describe Tab do
     tab.homebrew_version = "1.1.6"
     tab.runtime_dependencies = runtime_deps_hash
     expect(tab.runtime_dependencies).to eql(
-      [{ "full_name" => "foo", "version" => "1.0", "declared_directly" => false }],
+      [{ "full_name" => "foo", "version" => "1.0", "revision" => 0, "pkg_version" => "1.0",
+"declared_directly" => false }],
     )
   end
 
@@ -255,6 +256,7 @@ describe Tab do
       tap = Tap.new("user", "repo")
       from_tap = formula("from_tap", path: tap.path/"Formula/from_tap.rb") do
         url "from_tap-1.0"
+        revision 1
       end
       stub_formula_loader from_tap
 
@@ -266,8 +268,10 @@ describe Tab do
       tab = described_class.create(f, compiler, stdlib)
 
       runtime_dependencies = [
-        { "full_name" => "bar", "version" => "2.0", "declared_directly" => true },
-        { "full_name" => "user/repo/from_tap", "version" => "1.0", "declared_directly" => true },
+        { "full_name" => "bar", "version" => "2.0", "revision" => 0, "pkg_version" => "2.0",
+"declared_directly" => true },
+        { "full_name" => "user/repo/from_tap", "version" => "1.0", "revision" => 1, "pkg_version" => "1.0_1",
+"declared_directly" => true },
       ]
       expect(tab.runtime_dependencies).to eq(runtime_dependencies)
 


### PR DESCRIPTION
Should fix `brew upgrade <pkg>` producing broken installs. We were treating two packages with the same version but different revisions as compatible (because we didn't store revision info at all). This was often incorrect and lead to several reports of broken installs.