### PR TITLE
audit(github): also permit refs/heads in GitHub URLs

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -217,11 +217,11 @@ module RuboCop
             problem "Use /archive/ URLs for GitHub tarballs (url is #{url})."
           end
 
-          archive_ref_tags_gh_pattern = %r{https://.*github.*/archive/(?![a-fA-F0-9]{40})(?!refs/tags/).*\.tar\.gz$}
-          audit_urls(urls, archive_ref_tags_gh_pattern) do |_, url|
+          archive_refs_gh_pattern = %r{https://.*github.+/archive/(?![a-fA-F0-9]{40})(?!refs/(tags|heads)/)(.*)\.tar\.gz$}
+          audit_urls(urls, archive_refs_gh_pattern) do |match, url|
             next if url.end_with?(".git")
 
-            problem "Use /archive/refs/tags URLs for GitHub tarballs (url is #{url})."
+            problem "Use refs/tags/#{match[2]} or refs/heads/#{match[2]} for GitHub references (url is #{url})."
           end
 
           # Don't use GitHub .zip files


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the issue mentioned in https://github.com/Homebrew/brew/pull/16126#issuecomment-1780014268.

I would have added an auto-corrector, but I don't think we can choose whether the user provided a tag reference or branch reference.