### PR TITLE
extend/kernel: fix `odisabled` kwargs handling

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -155,10 +155,10 @@ module Kernel
     end
   end
 
-  def odisabled(method, replacement = nil, options = {})
+  def odisabled(method, replacement = nil, **options)
     options = { disable: true, caller: caller }.merge(options)
     # This odeprecated should stick around indefinitely.
-    odeprecated(method, replacement, options)
+    odeprecated(method, replacement, **options)
   end
 
   def pretty_installed(formula)


### PR DESCRIPTION
Fix for Ruby 3