### PR TITLE
Sparkle: Surface more Item values

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -35,13 +35,21 @@ module Homebrew
           # @api public
           :title,
           # @api public
+          :link,
+          # @api public
           :channel,
-          # @api private
+          # @api public
+          :release_notes_link,
+          # @api public
           :pub_date,
+          # @api public
+          :os,
           # @api public
           :url,
           # @api private
           :bundle_version,
+          # @api public
+          :minimum_system_version,
           keyword_init: true,
         ) do
           extend Forwardable
@@ -84,12 +92,14 @@ module Homebrew
               os = enclosure["os"]
             end
 
-            channel = item.elements["channel"]&.text
-            url ||= item.elements["link"]&.text
+            title = item.elements["title"]&.text&.strip
+            link = item.elements["link"]&.text&.strip
+            url ||= link
+            channel = item.elements["channel"]&.text&.strip
+            release_notes_link = item.elements["releaseNotesLink"]&.text&.strip
             short_version ||= item.elements["shortVersionString"]&.text&.strip
             version ||= item.elements["version"]&.text&.strip
 
-            title = item.elements["title"]&.text&.strip
             pub_date = item.elements["pubDate"]&.text&.strip&.presence&.then do |date_string|
               Time.parse(date_string)
             rescue ArgumentError
@@ -117,11 +127,15 @@ module Homebrew
             end
 
             data = {
-              title:          title,
-              channel:        channel,
-              pub_date:       pub_date,
-              url:            url,
-              bundle_version: bundle_version,
+              title:                  title,
+              link:                   link,
+              channel:                channel,
+              release_notes_link:     release_notes_link,
+              pub_date:               pub_date,
+              os:                     os,
+              url:                    url,
+              bundle_version:         bundle_version,
+              minimum_system_version: minimum_system_version,
             }.compact
             next if data.empty?
 

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -29,32 +29,42 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
   let(:item_hashes) do
     {
       v123: {
-        title:         "Version 1.2.3",
-        pub_date:      "Fri, 01 Jan 2021 01:23:45 +0000",
-        url:           "https://www.example.com/example/example-1.2.3.tar.gz",
-        short_version: "1.2.3",
-        version:       "123",
+        title:                  "Version 1.2.3",
+        release_notes_link:     "https://www.example.com/example/1.2.3.html",
+        pub_date:               "Fri, 01 Jan 2021 01:23:45 +0000",
+        url:                    "https://www.example.com/example/example-1.2.3.tar.gz",
+        short_version:          "1.2.3",
+        version:                "123",
+        minimum_system_version: "10.10",
       },
       v122: {
-        title:         "Version 1.2.2",
-        pub_date:      "Not a parseable date string",
-        url:           "https://www.example.com/example/example-1.2.2.tar.gz",
-        short_version: "1.2.2",
-        version:       "122",
+        title:                  "Version 1.2.2",
+        release_notes_link:     "https://www.example.com/example/1.2.2.html",
+        pub_date:               "Not a parseable date string",
+        link:                   "https://www.example.com/example/example-1.2.2.tar.gz",
+        short_version:          "1.2.2",
+        version:                "122",
+        minimum_system_version: "10.10",
       },
       v121: {
-        title:         "Version 1.2.1",
-        pub_date:      "Thu, 31 Dec 2020 01:23:45 +0000",
-        url:           "https://www.example.com/example/example-1.2.1.tar.gz",
-        short_version: "1.2.1",
-        version:       "121",
+        title:                  "Version 1.2.1",
+        release_notes_link:     "https://www.example.com/example/1.2.1.html",
+        pub_date:               "Thu, 31 Dec 2020 01:23:45 +0000",
+        os:                     "osx",
+        url:                    "https://www.example.com/example/example-1.2.1.tar.gz",
+        short_version:          "1.2.1",
+        version:                "121",
+        minimum_system_version: "10.10",
       },
       v120: {
-        title:         "Version 1.2.0",
-        pub_date:      "Wed, 30 Dec 2020 01:23:45 +0000",
-        url:           "https://www.example.com/example/example-1.2.0.tar.gz",
-        short_version: "1.2.0",
-        version:       "120",
+        title:                  "Version 1.2.0",
+        release_notes_link:     "https://www.example.com/example/1.2.0.html",
+        pub_date:               "Wed, 30 Dec 2020 01:23:45 +0000",
+        os:                     "macos",
+        url:                    "https://www.example.com/example/example-1.2.0.tar.gz",
+        short_version:          "1.2.0",
+        version:                "120",
+        minimum_system_version: "10.10",
       },
     }
   end
@@ -63,8 +73,8 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
     v123_item = <<~EOS
       <item>
         <title>#{item_hashes[:v123][:title]}</title>
-        <sparkle:minimumSystemVersion>10.10</sparkle:minimumSystemVersion>
-        <sparkle:releaseNotesLink>https://www.example.com/example/#{item_hashes[:v123][:short_version]}.html</sparkle:releaseNotesLink>
+        <sparkle:minimumSystemVersion>#{item_hashes[:v123][:minimum_system_version]}</sparkle:minimumSystemVersion>
+        <sparkle:releaseNotesLink>#{item_hashes[:v123][:release_notes_link]}</sparkle:releaseNotesLink>
         <pubDate>#{item_hashes[:v123][:pub_date]}</pubDate>
         <enclosure url="#{item_hashes[:v123][:url]}" sparkle:shortVersionString="#{item_hashes[:v123][:short_version]}" sparkle:version="#{item_hashes[:v123][:version]}" length="12345678" type="application/octet-stream" sparkle:dsaSignature="ABCDEF+GHIJKLMNOPQRSTUVWXYZab/cdefghijklmnopqrst/uvwxyz1234567==" />
       </item>
@@ -73,32 +83,32 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
     v122_item = <<~EOS
       <item>
         <title>#{item_hashes[:v122][:title]}</title>
-        <sparkle:minimumSystemVersion>10.10</sparkle:minimumSystemVersion>
-        <sparkle:releaseNotesLink>https://www.example.com/example/#{item_hashes[:v122][:short_version]}.html</sparkle:releaseNotesLink>
+        <link>#{item_hashes[:v122][:link]}</link>
+        <sparkle:minimumSystemVersion>#{item_hashes[:v122][:minimum_system_version]}</sparkle:minimumSystemVersion>
+        <sparkle:releaseNotesLink>#{item_hashes[:v122][:release_notes_link]}</sparkle:releaseNotesLink>
         <pubDate>#{item_hashes[:v122][:pub_date]}</pubDate>
         <sparkle:version>#{item_hashes[:v122][:version]}</sparkle:version>
         <sparkle:shortVersionString>#{item_hashes[:v122][:short_version]}</sparkle:shortVersionString>
-        <link>#{item_hashes[:v122][:url]}</link>
       </item>
     EOS
 
     v121_item_with_osx_os = <<~EOS
       <item>
         <title>#{item_hashes[:v121][:title]}</title>
-        <sparkle:minimumSystemVersion>10.10</sparkle:minimumSystemVersion>
-        <sparkle:releaseNotesLink>https://www.example.com/example/#{item_hashes[:v121][:short_version]}.html</sparkle:releaseNotesLink>
+        <sparkle:minimumSystemVersion>#{item_hashes[:v121][:minimum_system_version]}</sparkle:minimumSystemVersion>
+        <sparkle:releaseNotesLink>#{item_hashes[:v121][:release_notes_link]}</sparkle:releaseNotesLink>
         <pubDate>#{item_hashes[:v121][:pub_date]}</pubDate>
-        <enclosure os="osx" url="#{item_hashes[:v121][:url]}" sparkle:shortVersionString="#{item_hashes[:v121][:short_version]}" sparkle:version="#{item_hashes[:v121][:version]}" length="12345678" type="application/octet-stream" sparkle:dsaSignature="ABCDEF+GHIJKLMNOPQRSTUVWXYZab/cdefghijklmnopqrst/uvwxyz1234567==" />
+        <enclosure os="#{item_hashes[:v121][:os]}" url="#{item_hashes[:v121][:url]}" sparkle:shortVersionString="#{item_hashes[:v121][:short_version]}" sparkle:version="#{item_hashes[:v121][:version]}" length="12345678" type="application/octet-stream" sparkle:dsaSignature="ABCDEF+GHIJKLMNOPQRSTUVWXYZab/cdefghijklmnopqrst/uvwxyz1234567==" />
       </item>
     EOS
 
     v120_item_with_macos_os = <<~EOS
       <item>
         <title>#{item_hashes[:v120][:title]}</title>
-        <sparkle:minimumSystemVersion>10.10</sparkle:minimumSystemVersion>
-        <sparkle:releaseNotesLink>https://www.example.com/example/#{item_hashes[:v120][:short_version]}.html</sparkle:releaseNotesLink>
+        <sparkle:minimumSystemVersion>#{item_hashes[:v120][:minimum_system_version]}</sparkle:minimumSystemVersion>
+        <sparkle:releaseNotesLink>#{item_hashes[:v120][:release_notes_link]}</sparkle:releaseNotesLink>
         <pubDate>#{item_hashes[:v120][:pub_date]}</pubDate>
-        <enclosure os="macos" url="#{item_hashes[:v120][:url]}" sparkle:shortVersionString="#{item_hashes[:v120][:short_version]}" sparkle:version="#{item_hashes[:v120][:version]}" length="12345678" type="application/octet-stream" sparkle:dsaSignature="ABCDEF+GHIJKLMNOPQRSTUVWXYZab/cdefghijklmnopqrst/uvwxyz1234567==" />
+        <enclosure os="#{item_hashes[:v120][:os]}" url="#{item_hashes[:v120][:url]}" sparkle:shortVersionString="#{item_hashes[:v120][:short_version]}" sparkle:version="#{item_hashes[:v120][:version]}" length="12345678" type="application/octet-stream" sparkle:dsaSignature="ABCDEF+GHIJKLMNOPQRSTUVWXYZab/cdefghijklmnopqrst/uvwxyz1234567==" />
       </item>
     EOS
 
@@ -131,8 +141,8 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
     no_versions_item = create_appcast_xml <<~EOS
       <item>
         <title>Version</title>
-        <sparkle:minimumSystemVersion>10.10</sparkle:minimumSystemVersion>
-        <sparkle:releaseNotesLink>https://www.example.com/example/#{item_hashes[:v123][:short_version]}.html</sparkle:releaseNotesLink>
+        <sparkle:minimumSystemVersion>#{item_hashes[:v123][:minimum_system_version]}</sparkle:minimumSystemVersion>
+        <sparkle:releaseNotesLink>#{item_hashes[:v123][:release_notes_link]}</sparkle:releaseNotesLink>
         <pubDate>#{item_hashes[:v123][:pub_date]}</pubDate>
         <enclosure url="#{item_hashes[:v123][:url]}" length="12345678" type="application/octet-stream" sparkle:dsaSignature="ABCDEF+GHIJKLMNOPQRSTUVWXYZab/cdefghijklmnopqrst/uvwxyz1234567==" />
       </item>
@@ -157,34 +167,53 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
   let(:items) do
     {
       v123: Homebrew::Livecheck::Strategy::Sparkle::Item.new(
-        title:          item_hashes[:v123][:title],
-        pub_date:       Time.parse(item_hashes[:v123][:pub_date]),
-        url:            item_hashes[:v123][:url],
-        bundle_version: Homebrew::BundleVersion.new(item_hashes[:v123][:short_version],
-                                                    item_hashes[:v123][:version]),
+        title:                  item_hashes[:v123][:title],
+        release_notes_link:     item_hashes[:v123][:release_notes_link],
+        pub_date:               Time.parse(item_hashes[:v123][:pub_date]),
+        url:                    item_hashes[:v123][:url],
+        bundle_version:         Homebrew::BundleVersion.new(
+          item_hashes[:v123][:short_version],
+          item_hashes[:v123][:version],
+        ),
+        minimum_system_version: item_hashes[:v123][:minimum_system_version],
       ),
       v122: Homebrew::Livecheck::Strategy::Sparkle::Item.new(
-        title:          item_hashes[:v122][:title],
+        title:                  item_hashes[:v122][:title],
+        link:                   item_hashes[:v122][:link],
+        release_notes_link:     item_hashes[:v122][:release_notes_link],
         # `#items_from_content` falls back to a default `pub_date` when
         # one isn't provided or can't be successfully parsed.
-        pub_date:       Time.new(0),
-        url:            item_hashes[:v122][:url],
-        bundle_version: Homebrew::BundleVersion.new(item_hashes[:v122][:short_version],
-                                                    item_hashes[:v122][:version]),
+        pub_date:               Time.new(0),
+        url:                    item_hashes[:v122][:link],
+        bundle_version:         Homebrew::BundleVersion.new(
+          item_hashes[:v122][:short_version],
+          item_hashes[:v122][:version],
+        ),
+        minimum_system_version: item_hashes[:v122][:minimum_system_version],
       ),
       v121: Homebrew::Livecheck::Strategy::Sparkle::Item.new(
-        title:          item_hashes[:v121][:title],
-        pub_date:       Time.parse(item_hashes[:v121][:pub_date]),
-        url:            item_hashes[:v121][:url],
-        bundle_version: Homebrew::BundleVersion.new(item_hashes[:v121][:short_version],
-                                                    item_hashes[:v121][:version]),
+        title:                  item_hashes[:v121][:title],
+        release_notes_link:     item_hashes[:v121][:release_notes_link],
+        pub_date:               Time.parse(item_hashes[:v121][:pub_date]),
+        os:                     item_hashes[:v121][:os],
+        url:                    item_hashes[:v121][:url],
+        bundle_version:         Homebrew::BundleVersion.new(
+          item_hashes[:v121][:short_version],
+          item_hashes[:v121][:version],
+        ),
+        minimum_system_version: item_hashes[:v121][:minimum_system_version],
       ),
       v120: Homebrew::Livecheck::Strategy::Sparkle::Item.new(
-        title:          item_hashes[:v120][:title],
-        pub_date:       Time.parse(item_hashes[:v120][:pub_date]),
-        url:            item_hashes[:v120][:url],
-        bundle_version: Homebrew::BundleVersion.new(item_hashes[:v120][:short_version],
-                                                    item_hashes[:v120][:version]),
+        title:                  item_hashes[:v120][:title],
+        release_notes_link:     item_hashes[:v120][:release_notes_link],
+        pub_date:               Time.parse(item_hashes[:v120][:pub_date]),
+        os:                     item_hashes[:v120][:os],
+        url:                    item_hashes[:v120][:url],
+        bundle_version:         Homebrew::BundleVersion.new(
+          item_hashes[:v120][:short_version],
+          item_hashes[:v120][:version],
+        ),
+        minimum_system_version: item_hashes[:v120][:minimum_system_version],
       ),
     }
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Historically, the `Sparkle` strategy's `Item` struct has only included basic values from the appcast that are commonly useful. Over time we've selectively added/surfaced more values as we've encountered outliers that require use of different values in a `strategy` block (e.g., #13368).

We now need to use `minimumSystemValue` (e.g., https://github.com/Homebrew/homebrew-cask/pull/158044), so this expands the `Item` struct to include any appcast value that we could conceivably want to use in the future. This will hopefully save us from having to make more modifications to the struct (and related tests) before we can use a previously-unused value in a `strategy` block.

I did livecheck runs with/without these changes and the [JSON] output remains the same, as expected.

-----

I will be creating a follow-up PR to reimplement the `#audit_livecheck_min_os` cask audit (to align with the `Sparkle` strategy's behavior) but we also need to be able to access `item.minimum_system_version` there as well. I have that work finished and will create a PR for it if/when this one is merged.