### PR TITLE
fix(docs): update fish completions command

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -72,10 +72,10 @@ If your `fish` is from somewhere else, add the following to your `~/.config/fish
 
 ```sh
 if test -d (brew --prefix)"/share/fish/completions"
-    set -gx fish_complete_path $fish_complete_path (brew --prefix)/share/fish/completions
+    set -p fish_complete_path (brew --prefix)/share/fish/completions
 end
 
 if test -d (brew --prefix)"/share/fish/vendor_completions.d"
-    set -gx fish_complete_path $fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+    set -p fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
 end
 ```


### PR DESCRIPTION
This PR updates the `fish` configuration that should be used in order for shell completions provided from `brew` to work.

As [the docs](https://fishshell.com/docs/current/completions.html) explain, with the current command completions inside `(brew --prefix)/share/fish` are appended to `fish_complete_path`, but since `fish` will use the first available file, we want `(brew --prefix)/share/fish` to be prepended instead.

Closes #16159. Given my explanation above, I think that what was happening is that [this file](https://github.com/fish-shell/fish-shell/blob/496fc03b9880891ea3da4989cee50cf7381e707c/share/completions/brew.fish) was being used instead of the "real" one vendored by `brew`.