### PR TITLE
utils: Homebrew.system respect stderr

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -43,8 +43,9 @@ module Homebrew
 
   def self.system(cmd, *args, **options)
     if verbose?
-      puts "#{cmd} #{args * " "}".gsub(RUBY_PATH, "ruby")
-                                 .gsub($LOAD_PATH.join(File::PATH_SEPARATOR).to_s, "$LOAD_PATH")
+      out = (options[:out] == :err) ? $stderr : $stdout
+      out.puts "#{cmd} #{args * " "}".gsub(RUBY_PATH, "ruby")
+                                     .gsub($LOAD_PATH.join(File::PATH_SEPARATOR).to_s, "$LOAD_PATH")
     end
     _system(cmd, *args, **options)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Small fix for one thing brought up in https://github.com/Homebrew/brew/issues/16134#issuecomment-1777720185.

This caused some JSON output to break recently which is not ideal.

The change here is to check if the output should be diverted to stderr based on the options passed to system. If `:out => :err` is passed, then we should send any verbose output to stderr as well.

```console
$ brew ruby -e 'Homebrew.system("ls", :out => :err)' 2>| wc -c
     105
$ brew ruby -e 'Homebrew.system("ls")' | wc -c
     105
```