### PR TITLE
utils/gems: make `.homebrew_gem_groups` writing atomic

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -191,7 +191,16 @@ module Homebrew
   end
 
   def write_user_gem_groups(groups)
-    GEM_GROUPS_FILE.write(groups.join("\n"))
+    # Write the file atomically, in case we're working parallel
+    require "tempfile"
+    tmpfile = Tempfile.new([GEM_GROUPS_FILE.basename.to_s, "~"], GEM_GROUPS_FILE.dirname)
+    begin
+      tmpfile.write(groups.join("\n"))
+      tmpfile.close
+      File.rename(tmpfile.path.to_s, GEM_GROUPS_FILE)
+    ensure
+      tmpfile.unlink
+    end
   end
 
   def forget_user_gem_groups!


### PR DESCRIPTION
Hopefully fixes issues when running two gem-installing commands parallel (reported on Slack).

I haven't locked around Bundler itself here. I possibly will if there's still issues.