### PR TITLE
dev-cmd/audit: fix for Ruby 3

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -345,9 +345,11 @@ module Homebrew
   end
 
   def self.format_problem_lines(problems)
-    problems.map do |message:, location:, corrected:|
-      status = " #{Formatter.success("[corrected]")}" if corrected
+    problems.map do |problem|
+      status = " #{Formatter.success("[corrected]")}" if problem.fetch(:corrected)
+      location = problem.fetch(:location)
       location = "#{location.line&.to_s&.prepend("line ")}#{location.column&.to_s&.prepend(", col ")}: " if location
+      message = problem.fetch(:message)
       "* #{location}#{message.chomp.gsub("\n", "\n    ")}#{status}"
     end
   end


### PR DESCRIPTION
This type of hash destructuring is not supported.

There's a new syntax, but it doesn't work with 2.6.

So just do `fetch` to support both for now.