### PR TITLE
cask: add `installed_time` to JSON output.

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -321,6 +321,7 @@ module Cask
         "appcast"              => appcast,
         "version"              => version,
         "installed"            => installed_version,
+        "installed_time"       => install_time&.to_i,
         "outdated"             => outdated?,
         "sha256"               => sha256,
         "artifacts"            => artifacts_list,

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -20,6 +20,7 @@
   "appcast": null,
   "version": "1.2.3",
   "installed": null,
+  "installed_time": null,
   "outdated": false,
   "sha256": "c64c05bdc0be845505d6e55e69e696a7f50d40846e76155f0c85d5ff5e7bbb84",
   "artifacts": [


### PR DESCRIPTION
This is provided for formulae in `installed.time` and is useful to have for casks as well as formulae so let's output it here too.
