### PR TITLE
[shell] Override CDPATH in brew script.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -27,7 +27,7 @@ then
 fi
 
 quiet_cd() {
-  cd "$@" &>/dev/null || return
+  CDPATH='' cd -- "$@" &>/dev/null || return
 }
 
 symlink_target_directory() {


### PR DESCRIPTION
The CDPATH environment variable can affect the behavior of `cd`, and `cd` takes the `-P`, `-L` and `-e` flags. (I didn't know about `-e` until looking at the source) Make quietcd more robust by setting the CDPATH to ''.

I tested this change by running the following commands from a nonstandard directory, which caused some of tcsh's and perl's dependencies to be recompiled.

$ [path to brew] install tcsh
$ [path to brew] install perl

Here's a link to the source code of `cd` in a mirror of the bash repo.

https://github.com/bminor/bash/blob/ec8113b9861375e4e17b3307372569d429dec814/builtins/cd.def#L267

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
