### PR TITLE
tap: fix repair not working in some cases

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -427,12 +427,14 @@ class Tap
     args = %w[fetch]
     args << "--quiet" if quiet
     args << "origin"
+    args << "+refs/heads/*:refs/remotes/origin/*"
     safe_system "git", "-C", path, *args
     git_repo.set_head_origin_auto
 
     new_upstream_head = T.must(git_repo.origin_branch_name)
     return if new_upstream_head == current_upstream_head
 
+    safe_system "git", "-C", path, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"
     git_repo.rename_branch old: current_upstream_head, new: new_upstream_head
     git_repo.set_upstream_branch local: new_upstream_head, origin: new_upstream_head
 


### PR DESCRIPTION
I recently got:

```console
Error: Some taps failed to update!
The following taps can not read their remote branches:
  heroku/brew
This is happening because the remote branch was renamed or deleted.
Reset taps to point to the correct remote branches by running `brew tap --repair`
```

but the instructed `brew tap --repair` didn't work:

```console
$ brew tap --repair
fatal: couldn't find remote ref refs/heads/master
Error: Failure while executing; `git -C /usr/local/Homebrew/Library/Taps/heroku/homebrew-brew fetch origin` exited with 128.
```

That was because of some previous default:

```console
$ git -C /usr/local/Homebrew/Library/Taps/heroku/homebrew-brew config remote.origin.fetch
+refs/heads/master:refs/remotes/origin/master
```


