### PR TITLE
manpages: fix error under Ruby 3

### DIFF
--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -145,8 +145,8 @@ module Homebrew
 
         if long.present?
           next if Homebrew::CLI::Parser.global_options.include?([short, long, desc])
-          next if Homebrew::CLI::Parser.global_cask_options.any? do |_, option, description:, **|
-                    [long, "#{long}="].include?(option) && description == desc
+          next if Homebrew::CLI::Parser.global_cask_options.any? do |_, option, kwargs|
+                    [long, "#{long}="].include?(option) && kwargs.fetch(:description) == desc
                   end
         end
 
@@ -184,8 +184,8 @@ module Homebrew
     def self.global_cask_options_manpage
       lines = ["These options are applicable to the `install`, `reinstall`, and `upgrade` " \
                "subcommands with the `--cask` switch.\n"]
-      lines += Homebrew::CLI::Parser.global_cask_options.map do |_, long, description:, **|
-        generate_option_doc(nil, long.chomp("="), description)
+      lines += Homebrew::CLI::Parser.global_cask_options.map do |_, long, kwargs|
+        generate_option_doc(nil, long.chomp("="), kwargs.fetch(:description))
       end
       lines.join("\n")
     end


### PR DESCRIPTION
This hash deconstruction syntax is not supported in Ruby 3.