### PR TITLE
formula_auditor: handle nil tap

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -318,7 +318,11 @@ module Homebrew
 
           next unless @core_tap
 
-          unless dep_f.tap.core_tap?
+          if dep_f.tap.nil?
+            problem <<~EOS
+              Dependency '#{dep.name}' does not exist in any tap.
+            EOS
+          elsif !dep_f.tap.core_tap?
             problem <<~EOS
               Dependency '#{dep.name}' is not in homebrew/core. Formulae in homebrew/core
               should not have dependencies in external taps.


### PR DESCRIPTION
This could happen if referencing a dependency that is installed but not present in any tap.

Previously, this would crash `brew audit`.