### PR TITLE
workflows/docs: bump rubydoc test Ruby

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
           test-bot: false
 
       - name: Checkout Homebrew/rubydoc.brew.sh
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           repository: Homebrew/rubydoc.brew.sh
           path: rubydoc
@@ -68,7 +68,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Process rubydoc comments


### PR DESCRIPTION
Matches Ruby use in rubydoc.brew.sh.

Technically speaking rubydoc.brew.sh still deploys with the EOL 2.7.4: https://pages.github.com/versions/ (and not even the latest 2.7.8!) and it's likely going to remain frozen at that. However we will need 3.1 for YARD generation, and YARD generation results are committed the repository, so as long as we don't touch the Jekyll side too much it'll probably be ok, not that the CI on this side tests that anyway.