### PR TITLE
Support system Ruby 3 on Linux

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -586,7 +586,7 @@ then
 
   # Set a variable when the macOS system Ruby is new enough to avoid spawning
   # a Ruby process unnecessarily.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "120601" ]]
+  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "120601" || -n "${HOMEBREW_RUBY3}" ]]
   then
     unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
   else

--- a/Library/Homebrew/extend/os/linux/cleanup.rb
+++ b/Library/Homebrew/extend/os/linux/cleanup.rb
@@ -6,7 +6,7 @@ module Homebrew
     undef use_system_ruby?
 
     def use_system_ruby?
-      return false if Homebrew::EnvConfig.force_vendor_ruby? || ENV["HOMEBREW_RUBY3"]
+      return false if Homebrew::EnvConfig.force_vendor_ruby?
 
       rubies = [which("ruby"), which("ruby", ORIGINAL_PATHS)].compact
       system_ruby = Pathname.new("/usr/bin/ruby")
@@ -15,7 +15,7 @@ module Homebrew
       check_ruby_version = HOMEBREW_LIBRARY_PATH/"utils/ruby_check_version_script.rb"
       rubies.uniq.any? do |ruby|
         quiet_system ruby, "--enable-frozen-string-literal", "--disable=gems,did_you_mean,rubyopt",
-                     check_ruby_version, HOMEBREW_REQUIRED_RUBY_VERSION
+                     check_ruby_version, RUBY_VERSION
       end
     end
   end

--- a/Library/Homebrew/extend/os/mac/cleanup.rb
+++ b/Library/Homebrew/extend/os/mac/cleanup.rb
@@ -6,7 +6,7 @@ module Homebrew
     undef use_system_ruby?
 
     def use_system_ruby?
-      return false if Homebrew::EnvConfig.force_vendor_ruby? || ENV["HOMEBREW_RUBY3"]
+      return false if Homebrew::EnvConfig.force_vendor_ruby?
 
       ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"].present?
     end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -205,6 +205,7 @@ module Homebrew
       end
 
       def check_ruby_version
+        return unless ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"]
         return if RUBY_VERSION == HOMEBREW_REQUIRED_RUBY_VERSION
         return if Homebrew::EnvConfig.developer? && OS::Mac.version.prerelease?
 

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -10,9 +10,16 @@ test_ruby() {
     return 1
   fi
 
+  if [[ -n "${HOMEBREW_RUBY3}" ]]
+  then
+    required_ruby_version="3.1.0"
+  else
+    required_ruby_version="${HOMEBREW_REQUIRED_RUBY_VERSION}"
+  fi
+
   "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt \
     "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby_check_version_script.rb" \
-    "${HOMEBREW_REQUIRED_RUBY_VERSION}" 2>/dev/null
+    "${required_ruby_version}" 2>/dev/null
 }
 
 can_use_ruby_from_path() {
@@ -70,7 +77,7 @@ find_ruby() {
 # HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH are set by brew.sh
 # shellcheck disable=SC2154
 need_vendored_ruby() {
-  if [[ -n "${HOMEBREW_FORCE_VENDOR_RUBY}" || -n "${HOMEBREW_RUBY3}" ]]
+  if [[ -n "${HOMEBREW_FORCE_VENDOR_RUBY}" ]]
   then
     return 0
   elif [[ -n "${HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH}" ]] && ! can_use_ruby_from_path


### PR DESCRIPTION
`HOMEBREW_RUBY3` is no longer a fancy alias for `HOMEBREW_FORCE_VENDOR_RUBY` and now appropriately manages what gets passed to `ruby_check_version_script.rb`.

This means `HOMEBREW_RUBY3` is now compatible with non-x86_64 Linuxes (if you bring your own Ruby).

Also in this PR: the macOS-specific `brew doctor` Ruby version check is now disabled when running Portable Ruby. It will be removed entirely at a later date.