### PR TITLE
cmd/desc: fix handling of `--eval-all` with formulae

### DIFF
--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -34,7 +34,7 @@ class DescriptionCacheStore < CacheStore
     return unless eval_all
     return unless database.empty?
 
-    Formula.all.each { |f| update!(f.full_name, f.desc) }
+    Formula.all(eval_all: eval_all).each { |f| update!(f.full_name, f.desc) }
   end
 
   # Use an update report to update the {DescriptionCacheStore}.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #16188

This was caused by some refactoring of `Formula.all` a few months ago.

In this case, `--eval-all` was not propagated to the `Formula.all` command which caused a few different description related commands not to work.

Broken commands:
- `brew search --desc --eval-all TERM`
- `brew desc --search --eval-all TERM`
- `brew desc --descriptions --eval-all TERM`

These commands will fail if the cache store has not already been built locally since this specific method call is only needed when building the cache store not accessing it. The cache store file can be found at: 

```shell
"$(brew --cache)/descriptions.json"
```

Before:

```console
$ brew desc --search --eval-all test
==> Formulae
Error: Calling Formula#all without --eval-all or HOMEBREW_EVAL_ALL is disabled! There is no replacement.
$ brew search --desc --eval-all test
==> Formulae
Error: Calling Formula#all without --eval-all or HOMEBREW_EVAL_ALL is disabled! There is no replacement.
$ brew desc --description --eval-all test
==> Formulae
Error: Calling Formula#all without --eval-all or HOMEBREW_EVAL_ALL is disabled! There is no replacement.
```

After these changes, the file should be created and the commands should work as expected.