### PR TITLE
`cask/url` headers parameter type fix

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -157,7 +157,7 @@ module Cask
         trust_cert:      T.nilable(T::Boolean),
         cookies:         T.nilable(T::Hash[String, String]),
         referer:         T.nilable(T.any(URI::Generic, String)),
-        header:          T.nilable(String),
+        header:          T.nilable(T.any(String, T::Array[String])),
         user_agent:      T.nilable(T.any(Symbol, String)),
         data:            T.nilable(T::Hash[String, String]),
         only_path:       T.nilable(String),


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Resolves https://github.com/Homebrew/homebrew-cask/issues/159684

The `header` parameter for `url` should allow a string or an array of strings to be passed.