### PR TITLE
Improve coverage tracking

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -28,9 +28,9 @@ SimpleCov.start do
                .map { |p| "#{p}/**/*.rb" }.join(",")
   files = "#{SimpleCov.root}/{#{subdirs},*.rb}"
 
-  if ENV["HOMEBREW_INTEGRATION_TEST"]
+  if (integration_test_number = ENV.fetch("HOMEBREW_INTEGRATION_TEST", nil))
     # This needs a unique name so it won't be overwritten
-    command_name "brew_i#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
+    command_name "brew_i:#{integration_test_number}"
 
     # be quiet, the parent process will be in charge of output and checking coverage totals
     SimpleCov.print_error_status = false
@@ -51,21 +51,23 @@ SimpleCov.start do
       raise if $ERROR_INFO.is_a?(SystemExit)
     end
   else
-    command_name "brew#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
+    command_name "brew:#{ENV.fetch("TEST_ENV_NUMBER", $PROCESS_ID)}"
 
     # Not using this during integration tests makes the tests 4x times faster
     # without changing the coverage.
     track_files files
   end
 
-  add_filter %r{^/build.rb$}
-  add_filter %r{^/config.rb$}
-  add_filter %r{^/constants.rb$}
-  add_filter %r{^/postinstall.rb$}
-  add_filter %r{^/test.rb$}
-  add_filter %r{^/dev-cmd/tests.rb$}
+  add_filter %r{^/build\.rb$}
+  add_filter %r{^/config\.rb$}
+  add_filter %r{^/constants\.rb$}
+  add_filter %r{^/postinstall\.rb$}
+  add_filter %r{^/test\.rb$}
+  add_filter %r{^/dev-cmd/tests\.rb$}
+  add_filter %r{^/sorbet/}
   add_filter %r{^/test/}
   add_filter %r{^/vendor/}
+  add_filter %r{^/yard/}
 
   require "rbconfig"
   host_os = RbConfig::CONFIG["host_os"]
@@ -74,15 +76,18 @@ SimpleCov.start do
 
   # Add groups and the proper project name to the output.
   project_name "Homebrew"
-  add_group "Cask", %r{^/cask/}
+  add_group "Cask", %r{^/cask(/|\.rb$)}
   add_group "Commands", [%r{/cmd/}, %r{^/dev-cmd/}]
   add_group "Extensions", %r{^/extend/}
+  add_group "Livecheck", %r{^/livecheck(/|\.rb$)}
   add_group "OS", [%r{^/extend/os/}, %r{^/os/}]
   add_group "Requirements", %r{^/requirements/}
+  add_group "RuboCops", %r{^/rubocops/}
+  add_group "Unpack Strategies", %r{^/unpack_strategy(/|\.rb$)}
   add_group "Scripts", [
-    %r{^/brew.rb$},
-    %r{^/build.rb$},
-    %r{^/postinstall.rb$},
-    %r{^/test.rb$},
+    %r{^/brew\.rb$},
+    %r{^/build\.rb$},
+    %r{^/postinstall\.rb$},
+    %r{^/test\.rb$},
   ]
 end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -54,13 +54,9 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
 
   # Generate unique ID to be able to
   # properly merge coverage results.
-  def command_id_from_args(args)
-    @command_count ||= 0
-    pretty_args = args.join(" ").gsub(TEST_TMPDIR, "@TMPDIR@")
-    file_and_line = caller.second
-                          .sub(/(.*\d+):.*/, '\1')
-                          .sub("#{HOMEBREW_LIBRARY_PATH}/test/", "")
-    "#{file_and_line}:brew #{pretty_args}:#{@command_count += 1}"
+  def command_id
+    Thread.current[:brew_integration_test_number] ||= 0
+    "#{ENV.fetch("TEST_ENV_NUMBER", "")}:#{Thread.current[:brew_integration_test_number] += 1}"
   end
 
   # Runs a `brew` command with the test configuration
@@ -81,7 +77,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
       "PATH"                        => path,
       "HOMEBREW_PATH"               => path,
       "HOMEBREW_BREW_FILE"          => HOMEBREW_PREFIX/"bin/brew",
-      "HOMEBREW_INTEGRATION_TEST"   => command_id_from_args(args),
+      "HOMEBREW_INTEGRATION_TEST"   => command_id,
       "HOMEBREW_TEST_TMPDIR"        => TEST_TMPDIR,
       "HOMEBREW_DEV_CMD_RUN"        => "true",
       "HOMEBREW_USE_RUBY_FROM_PATH" => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
@@ -103,19 +99,11 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
             onoe e
           end
         end
-        libs = specs.flat_map do |spec|
-          full_gem_path = spec.full_gem_path
-          # full_require_paths isn't available in RubyGems < 2.2.
-          spec.require_paths.map do |lib|
-            next lib if lib.include?(full_gem_path)
-
-            "#{full_gem_path}/#{lib}"
-          end
-        end
-        libs.each { |lib| ruby_args << "-I" << lib }
+        specs.flat_map(&:full_require_paths).each { |lib| ruby_args << "-I" << lib }
         ruby_args << "-rsimplecov"
       end
       ruby_args << "-r#{HOMEBREW_LIBRARY_PATH}/test/support/helper/integration_mocks"
+      ruby_args << "-e" << "$0 = ARGV.shift; load($0)"
       ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
     end
 


### PR DESCRIPTION
* Fix integration test coverage tracking not working properly (would overwrite each other as the unique ID was generated but not read) - this regressed as the fix for #14662 overcombined command names
* Fix `brew.rb` not being tracked
* Simplify integration test unique ID generation (to avoid regressing back to the state prior to #14662 too much - it will unavoidably have a little but still should be significantly shorter than before)
* Exclude `sorbet` and `yard` directories from coverage tracking - these are used in non-brew tools and are out of scope for rspec testing.
* Fix up some regexes and add some groups for livecheck etc.
* Remove RubyGems < 2.2 compatibility code. We already no longer support it: https://github.com/Homebrew/brew/blob/39c2296ffbd9c2a225d6d64b234ef5584622599a/Library/Homebrew/utils/gems.rb#L89