### PR TITLE
formulary: fix loading from taps

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -926,7 +926,7 @@ module Formulary
   def self.tap_loader_for(tapped_name, warn:)
     name, path, tap = Formulary.tap_formula_name_path(tapped_name, warn: warn)
 
-    if name.exclude?("/") && !Homebrew::EnvConfig.no_install_from_api? &&
+    if tap.core_tap? && !Homebrew::EnvConfig.no_install_from_api? &&
        Homebrew::API::Formula.all_formulae.key?(name)
       FormulaAPILoader.new(name)
     else


### PR DESCRIPTION
~~check `tapped_name` for "/" instead of parsed `name`~~

Use `tap.core_tap?` instead of checking formula name

I'm not 100% sure this is the correct fix but from my reading of the code it seems plausible

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Got a sorbet error running `brew typecheck` and `brew tests` but since it's such a small change I hope that's not a deal breaker