### PR TITLE
Pass original tap to formula when loaded from the API via `TapLoader`

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -915,6 +915,7 @@ module Formulary
         name, path = Formulary.tap_formula_name_path(new_tapped_name, warn: false)
         old_name = tapped_name
         new_name = new_tap.core_tap? ? name : new_tapped_name
+        tap = new_tap
       end
 
       opoo "Formula #{old_name} was renamed to #{new_name}." if warn && old_name && new_name
@@ -926,9 +927,9 @@ module Formulary
   def self.tap_loader_for(tapped_name, warn:)
     name, path, tap = Formulary.tap_formula_name_path(tapped_name, warn: warn)
 
-    if Tap.from_path(path).core_tap? && !Homebrew::EnvConfig.no_install_from_api? &&
+    if tap.core_tap? && !Homebrew::EnvConfig.no_install_from_api? &&
        Homebrew::API::Formula.all_formulae.key?(name)
-      FormulaAPILoader.new(name, tap: tap)
+      FormulaAPILoader.new(name)
     else
       TapLoader.new(name, path, tap: tap)
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -667,8 +667,8 @@ module Formulary
 
   # Load formulae from the API.
   class FormulaAPILoader < FormulaLoader
-    def initialize(name)
-      super name, Formulary.core_path(name)
+    def initialize(name, tap: CoreTap.instance)
+      super name, Formulary.core_path(name), tap: tap
     end
 
     def klass(flags:, ignore_errors:)
@@ -926,9 +926,9 @@ module Formulary
   def self.tap_loader_for(tapped_name, warn:)
     name, path, tap = Formulary.tap_formula_name_path(tapped_name, warn: warn)
 
-    if name.exclude?("/") && !Homebrew::EnvConfig.no_install_from_api? &&
+    if Tap.from_path(path).core_tap? && !Homebrew::EnvConfig.no_install_from_api? &&
        Homebrew::API::Formula.all_formulae.key?(name)
-      FormulaAPILoader.new(name)
+      FormulaAPILoader.new(name, tap: tap)
     else
       TapLoader.new(name, path, tap: tap)
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -667,8 +667,8 @@ module Formulary
 
   # Load formulae from the API.
   class FormulaAPILoader < FormulaLoader
-    def initialize(name, tap: CoreTap.instance)
-      super name, Formulary.core_path(name), tap: tap
+    def initialize(name)
+      super name, Formulary.core_path(name)
     end
 
     def klass(flags:, ignore_errors:)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -912,10 +912,9 @@ module Formulary
         new_tap = Tap.fetch new_tap_name
         new_tap.ensure_installed!
         new_tapped_name = "#{new_tap_name}/#{name}"
-        name, path = Formulary.tap_formula_name_path(new_tapped_name, warn: false)
+        name, path, tap = Formulary.tap_formula_name_path(new_tapped_name, warn: false)
         old_name = tapped_name
         new_name = new_tap.core_tap? ? name : new_tapped_name
-        tap = new_tap
       end
 
       opoo "Formula #{old_name} was renamed to #{new_name}." if warn && old_name && new_name

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -211,7 +211,7 @@ describe Formulary do
         EOS
         formula = described_class.factory("#{tap}/#{formula_name}")
         expect(formula).to be_a(Formula)
-        expect(formula.tap).to eq(tap)
+        expect(formula.tap).to eq(CoreTap.instance)
         expect(formula.path).to eq(formula_path)
       end
 
@@ -223,7 +223,7 @@ describe Formulary do
         EOS
         formula = described_class.factory("#{tap}/#{formula_name}")
         expect(formula).to be_a(Formula)
-        expect(formula.tap).to eq(tap)
+        expect(formula.tap).to eq(another_tap)
         expect(formula.path).to eq(another_tap_formula_path)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/16213

Follow-up to https://github.com/Homebrew/brew/pull/16207

Supercedes https://github.com/Homebrew/brew/pull/16215

This PR fixes the `TapLoader` refactoring to properly pass the old tap to the newly created formula, even though it is referencing the new formula file. This is consistent with the old behavior. This also fixes the newly-created issue where migrating to a different non-core tap but with the same name as a core tap incorrectly chooses the core formula.

Finally, this PR adds some more tests.

CC @MikeMcQuaid, @Bo98, and @amancevice
