### PR TITLE
ENV/shared: fix macOS code not applying under HOMEBREW_SORBET_RUNTIME

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -2,6 +2,16 @@
 # frozen_string_literal: true
 
 module SharedEnvExtension
+  sig {
+    params(
+      formula:         T.nilable(Formula),
+      cc:              T.nilable(String),
+      build_bottle:    T.nilable(T::Boolean),
+      bottle_arch:     T.nilable(String),
+      testing_formula: T::Boolean,
+      debug_symbols:   T.nilable(T::Boolean),
+    ).void
+  }
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false,
                               debug_symbols: false)
     generic_shared_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle,
@@ -11,6 +21,7 @@ module SharedEnvExtension
     # Normalise the system Perl version used, where multiple may be available
     self["VERSIONER_PERL_VERSION"] = MacOS.preferred_perl_version
   end
+  private :setup_build_environment
 
   sig { returns(T::Boolean) }
   def no_weak_imports_support?


### PR DESCRIPTION
When redefining a method, Sorbet Runtime will not detect this properly if it does not have a type signature and the original did. This results in the new method being completely ignored and Sorbet only calling the original. I reckon is an upstream bug, but we can workaround it ourselves.

This fixes an important issue where any formulae using macOS Perl on Sonoma would not use the correct perl.