### PR TITLE
Don't reinstall dependency when latest already installed

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -55,24 +55,24 @@ class Dependency
     end
     return false unless formula
 
-    if minimum_version.present?
-      installed_version = formula.any_installed_version
-      return false unless installed_version
+    return true if formula.latest_version_installed?
 
-      # Tabs prior to 4.1.18 did not have revision or pkg_version fields.
-      # As a result, we have to be more conversative when we do not have
-      # a minimum revision from the tab and assume that if the formula has a
-      # the same version and a non-zero revision that it needs upgraded.
-      if minimum_revision.present?
-        minimum_pkg_version = PkgVersion.new(minimum_version, minimum_revision)
-        installed_version >= minimum_pkg_version
-      elsif installed_version.version == minimum_version
-        formula.revision.zero?
-      else
-        installed_version.version > minimum_version
-      end
+    return false if minimum_version.blank?
+
+    installed_version = formula.any_installed_version
+    return false unless installed_version
+
+    # Tabs prior to 4.1.18 did not have revision or pkg_version fields.
+    # As a result, we have to be more conversative when we do not have
+    # a minimum revision from the tab and assume that if the formula has a
+    # the same version and a non-zero revision that it needs upgraded.
+    if minimum_revision.present?
+      minimum_pkg_version = PkgVersion.new(minimum_version, minimum_revision)
+      installed_version >= minimum_pkg_version
+    elsif installed_version.version == minimum_version
+      formula.revision.zero?
     else
-      formula.latest_version_installed?
+      installed_version.version > minimum_version
     end
   end
 

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -82,6 +82,8 @@ module Homebrew
               end
               next false if dependency_formula.nil?
 
+              next true if dependency_formula.latest_version_installed?
+
               installed_version = dependency_formula.any_installed_version
               next false unless installed_version
 


### PR DESCRIPTION
When dealing with old bottles without the revision information, we assume any revision > 0 means the formula needs installing. However we don't check whether it is already at the latest revision, so we could return `false` for `Dependency#installed?` for something that is already at the latest.

This PR makes it so `Formula#latest_version_installed?` is checked before any minimum version checking. If it's at the latest we don't need to do any further checking and can say the dependency is good. This also fixes the case where if we might downgrade a formula for some reason, we will now just call the latest version good instead of permanently calling it not installed for not being above a minimum version.