### PR TITLE
Gemfile.lock: restore missing platform

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  aarch64-linux
   arm-linux
   arm64-darwin
   x86_64-darwin


### PR DESCRIPTION
Bundler locally didn't reject it so seems like something's odd with Dependabot. Will investigate soon, but restore for now as `unf_ext` has nothing to do with it.

https://github.com/Homebrew/brew/pull/16225#pullrequestreview-1735842152