### PR TITLE
tap: optimise `CoreTap#formula_files_by_name`

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1138,12 +1138,13 @@ class CoreTap < AbstractCoreTap
   def formula_files_by_name
     return super if Homebrew::EnvConfig.no_install_from_api?
 
+    tap_path = path.to_s
     Homebrew::API::Formula.all_formulae.each_with_object({}) do |item, hash|
       name, formula_hash = item
       # If there's more than one item with the same path: use the longer one to prioritise more specific results.
       existing_path = hash[name]
-      new_path = path/formula_hash["ruby_source_path"]
-      hash[name] = new_path if existing_path.nil? || existing_path.to_s.length < new_path.to_s.length
+      new_path = File.join(tap_path, formula_hash["ruby_source_path"]) # Pathname equivalent is slow in a tight loop
+      hash[name] = Pathname(new_path) if existing_path.nil? || existing_path.to_s.length < new_path.length
     end
   end
 end


### PR DESCRIPTION
In a loop that's iterated nearly 7000 times, `Pathname#/` is actually quite slow. It does a lot more than one might think it does: https://github.com/ruby/ruby/blob/24fe22a5da21c9df8584a4ce6b6d1ce18ac41cc2/ext/pathname/lib/pathname.rb#L362-L402 (+ regex matching in `chop_basename`). We however don't need logic like `..` resolving.

We can turn 0.2s to 0.02s by using `File.join` and later making it `Pathname`. There's still a bit of string copying going on, meaning it can spike to 0.1s if it triggers the GC, but it's nevertheless much better than before.