### PR TITLE
Xml: Add #element_text method

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -95,16 +95,16 @@ module Homebrew
               os = enclosure["os"].presence
             end
 
-            title = item.elements["title"]&.text&.strip&.presence
-            link = item.elements["link"]&.text&.strip&.presence
+            title = Xml.element_text(item, "title")
+            link = Xml.element_text(item, "link")
             url ||= link
-            channel = item.elements["channel"]&.text&.strip&.presence
-            release_notes_link = item.elements["releaseNotesLink"]&.text&.strip&.presence
-            short_version ||= item.elements["shortVersionString"]&.text&.strip&.presence
-            version ||= item.elements["version"]&.text&.strip&.presence
+            channel = Xml.element_text(item, "channel")
+            release_notes_link = Xml.element_text(item, "releaseNotesLink")
+            short_version ||= Xml.element_text(item, "shortVersionString")
+            version ||= Xml.element_text(item, "version")
 
             minimum_system_version_text =
-              item.elements["minimumSystemVersion"]&.text&.strip&.gsub(/\A\D+|\D+\z/, "")&.presence
+              Xml.element_text(item, "minimumSystemVersion")&.gsub(/\A\D+|\D+\z/, "")
             if minimum_system_version_text.present?
               minimum_system_version = begin
                 MacOSVersion.new(minimum_system_version_text)
@@ -113,7 +113,7 @@ module Homebrew
               end
             end
 
-            pub_date = item.elements["pubDate"]&.text&.strip&.presence&.then do |date_string|
+            pub_date = Xml.element_text(item, "pubDate")&.then do |date_string|
               Time.parse(date_string)
             rescue ArgumentError
               # Omit unparsable strings (e.g. non-English dates)

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -72,6 +72,30 @@ module Homebrew
           end
         end
 
+        # Retrieves the stripped inner text of an `REXML` element. Returns
+        # `nil` if the optional child element doesn't exist or the text is
+        # blank.
+        # @param element [REXML::Element] an `REXML` element to retrieve text
+        #   from, either directly or from a child element
+        # @param child_path [String, nil] the XPath of a child element to
+        #   retrieve text from
+        # @return [String, nil]
+        sig {
+          params(
+            element:    REXML::Element,
+            child_path: T.nilable(String),
+          ).returns(T.nilable(String))
+        }
+        def self.element_text(element, child_path = nil)
+          element = element.get_elements(child_path).first if child_path.present?
+          return if element.nil?
+
+          text = element.text
+          return if text.blank?
+
+          text.strip
+        end
+
         # Parses XML text and identifies versions using a `strategy` block.
         # If a regex is provided, it will be passed as the second argument to
         # the  `strategy` block (after the parsed XML data).

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -183,11 +183,11 @@ describe Homebrew::Livecheck::Strategy::Xml do
 
       # Returning an array of strings from block
       expect(xml.versions_from_content(content_version_text, regex) do |xml, regex|
-        xml.get_elements("versions//version").map { |item| item.text[regex, 1] }
+        xml.get_elements("/versions/version").map { |item| item.text[regex, 1] }
       end).to eq(content_matches)
 
       expect(xml.versions_from_content(content_version_attr, regex) do |xml, regex|
-        xml.get_elements("items//item").map do |item|
+        xml.get_elements("/items/item").map do |item|
           version = item["version"]
           next if version.blank?
 
@@ -214,7 +214,7 @@ describe Homebrew::Livecheck::Strategy::Xml do
   describe "::find_versions?" do
     it "finds versions in provided_content using a block" do
       expect(xml.find_versions(url: http_url, regex: regex, provided_content: content_version_text) do |xml, regex|
-        xml.get_elements("versions//version").map { |item| item.text[regex, 1] }
+        xml.get_elements("/versions/version").map { |item| item.text[regex, 1] }
       end).to eq(find_versions_cached_return_hash)
 
       # NOTE: A regex should be provided using the `#regex` method in a
@@ -223,7 +223,7 @@ describe Homebrew::Livecheck::Strategy::Xml do
       # regex isn't provided.
       expect(xml.find_versions(url: http_url, provided_content: content_version_text) do |xml|
         regex = /^v?(\d+(?:\.\d+)+)$/i.freeze
-        xml.get_elements("versions//version").map { |item| item.text[regex, 1] }
+        xml.get_elements("/versions/version").map { |item| item.text[regex, 1] }
       end).to eq(find_versions_cached_return_hash.merge({ regex: nil }))
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As discussed in https://github.com/Homebrew/brew/pull/16196#discussion_r1389066974, this refactors verbose code in the `Sparkle` strategy where we access element text into a reusable `Xml#element_text` method, replacing chained calls like `item.elements["title"]&.text&.strip&.presence` with `Xml.element_text(item, "title")`.

`#element_text` is only used to retrieve the text of a child element in the `Sparkle` strategy but it can also retrieve the text from the provided element if the `child_path` argument is omitted (i.e., `Xml.element_text(item)`). This will allow us to also avoid similar calls like `item.text.strip.presence` in the future.