### PR TITLE
create: Fix getting name from GitHub archives

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -172,13 +172,12 @@ module Homebrew
       fetch:   !args.no_fetch?,
       head:    args.HEAD?,
     )
-    if fc.name.blank?
-      stem = Pathname.new(args.named.first).stem.rpartition("=").last
-      print "Formula name [#{stem}]: "
-      fc.name = __gets || stem
-    end
-
     fc.parse_url
+    # ask for confirmation if name wasn't passed explicitly
+    if args.set_name.blank?
+      print "Formula name [#{fc.name}]: "
+      fc.name = __gets || fc.name
+    end
 
     fc.verify
 

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "formula_creator"
+
+describe Homebrew::FormulaCreator do
+  it "gets name from GitHub archive URL" do
+    t = described_class.name_from_url("https://github.com/abitrolly/lapce/archive/v0.3.0.tar.gz")
+    expect(t).to eq("lapce")
+  end
+
+  it "gets name from gitweb URL" do
+    t = described_class.name_from_url("http://www.codesrc.com/gitweb/index.cgi?p=libzipper.git;a=summary")
+    expect(t).to eq("libzipper")
+  end
+
+  it "gets name from GitHub repo URL" do
+    t = described_class.name_from_url("https://github.com/abitrolly/lapce.git")
+    expect(t).to eq("lapce")
+  end
+
+  it "gets name from GitHub download URL" do
+    t = described_class.name_from_url("https://github.com/stella-emu/stella/releases/download/6.7/stella-6.7-src.tar.xz")
+    expect(t).to eq("stella")
+  end
+
+  it "gets name from generic tarball URL" do
+    t = described_class.name_from_url("http://digit-labs.org/files/tools/synscan/releases/synscan-5.02.tar.gz")
+    expect(t).to eq("synscan")
+  end
+end


### PR DESCRIPTION
`brew create https://github.com/lapce/lapce/archive/v0.3.0.tar.gz` currently gets the wrong name `v3.0.0` from the URL. The PR fixes that.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
