### PR TITLE
Enable Ruby 3 for `HOMEBREW_DEVELOPER` and the Docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -294,12 +294,12 @@ jobs:
           - name: tests (macOS 13)
             test-flags: --coverage
             runs-on: macos-13
-          - name: tests (Ubuntu 22.04; Ruby 3.1)
+          - name: tests (Ubuntu 22.04; Ruby 2.6)
             runs-on: ubuntu-22.04
-            ruby: '3.1'
-          - name: tests (macOS 13; Ruby 3.1)
+            ruby: '2.6'
+          - name: tests (macOS 13; Ruby 2.6)
             runs-on: macos-13
-            ruby: '3.1'
+            ruby: '2.6'
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -321,6 +321,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler: none
 
       - name: Setup Ruby environment
         if: matrix.ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN apt-get update \
 
 USER linuxbrew
 COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew
-ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}" \
+  HOMEBREW_RUBY3=1
 WORKDIR /home/linuxbrew
 
 RUN mkdir -p \

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -945,6 +945,11 @@ then
   export HOMEBREW_SORBET_RUNTIME="1"
 fi
 
+if [[ -n "${HOMEBREW_DEVELOPER}" ]]
+then
+  export HOMEBREW_RUBY3="1"
+fi
+
 if [[ -f "${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh" ]]
 then
   HOMEBREW_BASH_COMMAND="${HOMEBREW_LIBRARY}/Homebrew/cmd/${HOMEBREW_COMMAND}.sh"

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -10,16 +10,24 @@ test_ruby() {
     return 1
   fi
 
+  supported_ruby_versions=()
   if [[ -n "${HOMEBREW_RUBY3}" && -z "${HOMEBREW_USE_RUBY_FROM_PATH}" ]]
   then
-    required_ruby_version="3.1.0"
-  else
-    required_ruby_version="${HOMEBREW_REQUIRED_RUBY_VERSION}"
+    supported_ruby_versions+=("3.1.0")
   fi
+  supported_ruby_versions+=("${HOMEBREW_REQUIRED_RUBY_VERSION}")
 
-  "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt \
-    "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby_check_version_script.rb" \
-    "${required_ruby_version}" 2>/dev/null
+  for ruby_version in "${supported_ruby_versions[@]}"
+  do
+    if "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt \
+       "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby_check_version_script.rb" \
+       "${ruby_version}" 2>/dev/null
+    then
+      return 0
+    fi
+  done
+
+  return 1
 }
 
 can_use_ruby_from_path() {

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -10,7 +10,7 @@ test_ruby() {
     return 1
   fi
 
-  if [[ -n "${HOMEBREW_RUBY3}" ]]
+  if [[ -n "${HOMEBREW_RUBY3}" && -z "${HOMEBREW_USE_RUBY_FROM_PATH}" ]]
   then
     required_ruby_version="3.1.0"
   else


### PR DESCRIPTION
Time to start a fire?

This will enable it in virtually all Homebrew CI, as well as any user of the Docker image.