### PR TITLE
Caveats for unsigned casks

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -164,7 +164,7 @@ module Cask
       caveat :requires_rosetta_unsigned do
         next unless Hardware::CPU.arm?
 
-        requires_rosetta
+        # This should only be used immediately after caveat "requires_rosetta"
         <<~EOS
           The Apple Silicon build for this cask is unsigned so the Intel build is required
           instead.

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -161,6 +161,16 @@ module Cask
         EOS
       end
 
+      caveat :requires_rosetta_unsigned do
+        next unless Hardware::CPU.arm?
+
+        requires_rosetta
+        <<~EOS
+          The Apple Silicon build for this cask is unsigned so the Intel build is required
+          instead.
+        EOS
+      end
+
       caveat :logout do
         <<~EOS
           You must log out and log back in for the installation of #{@cask} to take effect.

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -93,6 +93,17 @@ module Cask
         EOS
       end
 
+      caveat :unsigned_artifact do
+        <<~EOS
+          #{@cask} has an unsigned binary which may prevent it from running on Apple
+          Silicon devices under standard macOS security policy. If you're sure you want
+          to trust the app, you can reinstall without quarantine attributes:
+            brew reinstall --cask --no-quarantine #{@cask}
+          For more information, refer to:
+            #{Formatter.url("https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-universal-apps-release-notes/#Code-Signing")}
+        EOS
+      end
+
       caveat :path_environment_variable do |path|
         <<~EOS
           To use #{@cask}, you may need to add the #{path} directory

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -483,6 +483,7 @@ describe Cask::Audit, :cask do
               version '1.0'
               url "https://brew.sh/index.html"
               artifact "example.pdf", target: "/Library/Application Support/example"
+              # NOTE: cask should pass when using caveat "unsigned_artifact"
             end
           RUBY
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Context: https://github.com/orgs/Homebrew/discussions/3088#discussioncomment-7623916

This is intended to systemically handle the issue of casks with unsigned artifacts that do not run on Apple Silicon (for non-obvious reasons).

Summary:

- Add a caveat for unsigned artifacts that can run on Apple Silicon but only with quarantine attributes removed (in this case the "unidentified developers" message does not appear but only some message about putting it in the trash.)
- Adjust the unsigned cask audit to run for all (new and existing) casks but skip if the new caveat is used.
  - Existing casks will need to have the caveat added. Known casks: chromium, chrome-driver, bloodhound, mark-text, copyq
- Also add another caveat to replace duplicate text in https://github.com/Homebrew/homebrew-cask/pull/160619

(I'm not sure what new tests might be needed and I was unable to run the various check `brew <check>` commands due to errors like "Error: Sorbet is not currently supported under system Ruby on macOS Sonoma.")