### PR TITLE
formula_creator: Remove `path` attr to reduce code complexity

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -200,7 +200,7 @@ module Homebrew
       end
     end
 
-    path = fc.generate!
+    path = fc.write_formula!
 
     formula = Homebrew.with_no_api_env do
       Formula[fc.name]

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -200,7 +200,7 @@ module Homebrew
       end
     end
 
-    fc.generate!
+    path = fc.generate!
 
     formula = Homebrew.with_no_api_env do
       Formula[fc.name]
@@ -208,7 +208,7 @@ module Homebrew
     PyPI.update_python_resources! formula, ignore_non_pypi_packages: true if args.python?
 
     puts "Please run `brew audit --new #{fc.name}` before submitting, thanks."
-    fc.path
+    path
   end
 
   def __gets

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -50,7 +50,8 @@ module Homebrew
     end
 
     def write_formula!
-      raise "name should not be empty" if @name.to_s == ''
+      raise "name should not be empty" if @name.to_s == ""
+
       path = @tap.new_formula_path(@name)
       raise "#{path} already exists" if path.exist?
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -49,7 +49,7 @@ module Homebrew
       @head || args.HEAD?
     end
 
-    def generate!
+    def write_formula!
       path = @tap.new_formula_path(@name)
       raise "#{path} already exists" if path.exist?
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -50,7 +50,8 @@ module Homebrew
     end
 
     def write_formula!
-      raise "name should not be empty" if @name.to_s == ""
+      raise ArgumentError, "name is blank!" if @name.blank?
+      raise ArgumentError, "tap is blank!" if @tap.blank?
 
       path = @tap.new_formula_path(@name)
       raise "#{path} already exists" if path.exist?

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -10,7 +10,7 @@ module Homebrew
   # @api private
   class FormulaCreator
     attr_reader :args, :url, :sha256, :desc, :homepage
-    attr_accessor :name, :version, :tap, :path, :mode, :license
+    attr_accessor :name, :version, :tap, :mode, :license
 
     def initialize(args)
       @args = args
@@ -34,18 +34,11 @@ module Homebrew
           @name = path.basename.to_s[/(.*?)[-_.]?#{Regexp.escape(path.version.to_s)}/, 1]
         end
       end
-      update_path
       @version = if @version
         Version.new(@version)
       else
         Version.detect(url)
       end
-    end
-
-    def update_path
-      return if @name.nil? || @tap.nil?
-
-      @path = @tap.new_formula_path(@name)
     end
 
     def fetch?
@@ -57,6 +50,7 @@ module Homebrew
     end
 
     def generate!
+      path = @tap.new_formula_path(@name)
       raise "#{path} already exists" if path.exist?
 
       if version.nil? || version.null?
@@ -86,6 +80,7 @@ module Homebrew
 
       path.dirname.mkpath
       path.write ERB.new(template, trim_mode: ">").result(binding)
+      path
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -50,6 +50,7 @@ module Homebrew
     end
 
     def write_formula!
+      raise "name should not be empty" if @name.to_s == ''
       path = @tap.new_formula_path(@name)
       raise "#{path} already exists" if path.exist?
 


### PR DESCRIPTION
`path` attribute is used only once, and it is easier to calculate it on the fly than to update its state after different methods.

Factored out from #16238 to keep it clean.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
