### PR TITLE
Dockerfile: set `XDG_CACHE_HOME` to fix `umask` in GitHub Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update \
 USER linuxbrew
 COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}" \
+  XDG_CACHE_HOME=/home/linuxbrew/.cache \
   HOMEBREW_RUBY3=1
 WORKDIR /home/linuxbrew
 


### PR DESCRIPTION
#16242 wasn't applying to GitHub Actions.

That's because GitHub Actions force sets HOME to `/github/home`, which is a mounted directory with its own permissions. Avoid this for curl downloads by setting `XDG_CACHE_HOME` to the original home's `.cache` directory.