### PR TITLE
formula: add `PIP_CACHE_DIR` to build env

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -30,6 +30,7 @@ module Homebrew
           glide_home
           java_cache
           npm_cache
+          pip_cache
           gclient_cache
         ].include?(pathname.basename.to_s)
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2880,6 +2880,7 @@ class Formula
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",
       CURL_HOME:               ENV.fetch("CURL_HOME") { Dir.home },
+      PIP_CACHE_DIR:           "#{HOMEBREW_CACHE}/pip_cache",
       PYTHONDONTWRITEBYTECODE: "1",
     }
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2879,8 +2879,8 @@ class Formula
       GOCACHE:                 "#{HOMEBREW_CACHE}/go_cache",
       GOPATH:                  "#{HOMEBREW_CACHE}/go_mod_cache",
       CARGO_HOME:              "#{HOMEBREW_CACHE}/cargo_cache",
-      CURL_HOME:               ENV.fetch("CURL_HOME") { Dir.home },
       PIP_CACHE_DIR:           "#{HOMEBREW_CACHE}/pip_cache",
+      CURL_HOME:               ENV.fetch("CURL_HOME") { Dir.home },
       PYTHONDONTWRITEBYTECODE: "1",
     }
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

This should give us a nice speed up when rebuilding the same pip package multiple times (esp useful to save CI time in python version bump PRs)

Timings for `brew reinstall -s black`:
Before (no cache): 47s
After (with cache): 28s
