### PR TITLE
brew.sh: always run test-bot under Ruby 3

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -502,7 +502,7 @@ case "$*" in
     ;;
 esac
 
-if [[ -n "${HOMEBREW_DEVELOPER}" ]]
+if [[ -n "${HOMEBREW_DEVELOPER}" || "$1" == "test-bot" ]]
 then
   export HOMEBREW_RUBY3="1"
 fi


### PR DESCRIPTION
We set `HOMEBREW_DEVELOPER` within `test-bot` so we end up running a mixed 2.6 and 3.1 mode that installs and uninstalls Ruby 3 repeatedly depending on the command.

Easiest fix is to force test-bot to be Ruby 3. Stuff like `brew -v test-bot` isn't detected here but this code is going to disappear on Monday anyway.

Fixes https://github.com/Homebrew/homebrew-test-bot/issues/988