### PR TITLE
utils/analytics: don't fail on invalid version

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -485,8 +485,8 @@ HOMEBREW_VERSION="$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" describe --tag
 HOMEBREW_USER_AGENT_VERSION="${HOMEBREW_VERSION}"
 if [[ -z "${HOMEBREW_VERSION}" ]]
 then
-  HOMEBREW_VERSION=">=2.5.0 (shallow or no git repository)"
-  HOMEBREW_USER_AGENT_VERSION="2.X.Y"
+  HOMEBREW_VERSION=">=4.1.0 (shallow or no git repository)"
+  HOMEBREW_USER_AGENT_VERSION="4.X.Y"
 fi
 
 HOMEBREW_CORE_REPOSITORY="${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core"

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -313,8 +313,12 @@ options: options)
       sig { returns(T::Hash[Symbol, String]) }
       def default_fields_influx
         @default_fields_influx ||= begin
-          version = HOMEBREW_VERSION.match(/^[\d.]+/)[0]
-          version = "#{version}-dev" if HOMEBREW_VERSION.include?("-")
+          version = if (match_data = HOMEBREW_VERSION.match(/^[\d.]+/))
+            suffix = "-dev" if HOMEBREW_VERSION.include?("-")
+            match_data[0] + suffix.to_s
+          else
+            ">=4.1.22"
+          end
 
           # Only include OS versions with an actual name.
           os_name_and_version = if (os_version = OS_VERSION.presence) && os_version.downcase.match?(/^[a-z]/)


### PR DESCRIPTION
If the git repo is broken, `HOMEBREW_VERSION` could be set to:

https://github.com/Homebrew/brew/blob/251a098fbf1c02ca95f53b4806e5b6da8d5e4a80/Library/Homebrew/brew.sh#L488

This causes an error in `utils/analytics` which expects `HOMEBREW_VERSION` to match a regex, and therefore breaks any formula installs. Avoid that by defaulting to "unknown" if the fallback HOMEBREW_VERSION is detected.

I've seen two reports of this in two days - not entirely sure why it's suddenly come up.