### PR TITLE
formula_creator: move initial CLI values into constructor

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -140,13 +140,12 @@ module Homebrew
   end
 
   def create_formula(args:)
-    fc = FormulaCreator.new(args.set_name, args.set_version, fetch: !args.no_fetch?, head: args.HEAD?)
+    fc = FormulaCreator.new(args.set_name, args.set_version, license: args.set_license, fetch: !args.no_fetch?, head: args.HEAD?)
     if fc.name.blank?
       stem = Pathname.new(args.named.first).stem.rpartition("=").last
       print "Formula name [#{stem}]: "
       fc.name = __gets || stem
     end
-    fc.license = args.set_license
     fc.tap = Tap.fetch(args.tap || "homebrew/core")
     raise TapUnavailableError, fc.tap.name unless fc.tap.installed?
 

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -166,6 +166,7 @@ module Homebrew
       args.set_name,
       args.set_version,
       tap:     args.tap,
+      url:     args.named.first,
       mode:    mode,
       license: args.set_license,
       fetch:   !args.no_fetch?,
@@ -177,7 +178,7 @@ module Homebrew
       fc.name = __gets || stem
     end
 
-    fc.url = args.named.first
+    fc.parse_url
 
     fc.verify
 

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -140,7 +140,7 @@ module Homebrew
   end
 
   def create_formula(args:)
-    fc = FormulaCreator.new(args.set_name, args.set_version, !args.no_fetch?, args.HEAD?)
+    fc = FormulaCreator.new(args.set_name, args.set_version, fetch: !args.no_fetch?, head: args.HEAD?)
     if fc.name.blank?
       stem = Pathname.new(args.named.first).stem.rpartition("=").last
       print "Formula name [#{stem}]: "

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -143,6 +143,7 @@ module Homebrew
     fc = FormulaCreator.new(
       args.set_name,
       args.set_version,
+      tap:     args.tap,
       license: args.set_license,
       fetch:   !args.no_fetch?,
       head:    args.HEAD?,
@@ -152,7 +153,6 @@ module Homebrew
       print "Formula name [#{stem}]: "
       fc.name = __gets || stem
     end
-    fc.tap = Tap.fetch(args.tap || "homebrew/core")
     raise TapUnavailableError, fc.tap.name unless fc.tap.installed?
 
     fc.url = args.named.first

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -140,7 +140,13 @@ module Homebrew
   end
 
   def create_formula(args:)
-    fc = FormulaCreator.new(args.set_name, args.set_version, license: args.set_license, fetch: !args.no_fetch?, head: args.HEAD?)
+    fc = FormulaCreator.new(
+      args.set_name,
+      args.set_version,
+      license: args.set_license,
+      fetch:   !args.no_fetch?,
+      head:    args.HEAD?,
+    )
     if fc.name.blank?
       stem = Pathname.new(args.named.first).stem.rpartition("=").last
       print "Formula name [#{stem}]: "

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -140,24 +140,7 @@ module Homebrew
   end
 
   def create_formula(args:)
-    fc = FormulaCreator.new(
-      args.set_name,
-      args.set_version,
-      tap:     args.tap,
-      license: args.set_license,
-      fetch:   !args.no_fetch?,
-      head:    args.HEAD?,
-    )
-    if fc.name.blank?
-      stem = Pathname.new(args.named.first).stem.rpartition("=").last
-      print "Formula name [#{stem}]: "
-      fc.name = __gets || stem
-    end
-    raise TapUnavailableError, fc.tap.name unless fc.tap.installed?
-
-    fc.url = args.named.first
-
-    fc.mode = if args.autotools?
+    mode = if args.autotools?
       :autotools
     elsif args.cmake?
       :cmake
@@ -178,6 +161,24 @@ module Homebrew
     elsif args.rust?
       :rust
     end
+
+    fc = FormulaCreator.new(
+      args.set_name,
+      args.set_version,
+      tap:     args.tap,
+      mode:    mode,
+      license: args.set_license,
+      fetch:   !args.no_fetch?,
+      head:    args.HEAD?,
+    )
+    if fc.name.blank?
+      stem = Pathname.new(args.named.first).stem.rpartition("=").last
+      print "Formula name [#{stem}]: "
+      fc.name = __gets || stem
+    end
+    raise TapUnavailableError, fc.tap.name unless fc.tap.installed?
+
+    fc.url = args.named.first
 
     # Check for disallowed formula, or names that shadow aliases,
     # unless --force is specified.

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -140,15 +140,12 @@ module Homebrew
   end
 
   def create_formula(args:)
-    fc = FormulaCreator.new(!args.no_fetch?, args.HEAD?)
-    fc.name = if args.set_name.blank?
+    fc = FormulaCreator.new(args.set_name, args.set_version, !args.no_fetch?, args.HEAD?)
+    if fc.name.blank?
       stem = Pathname.new(args.named.first).stem.rpartition("=").last
       print "Formula name [#{stem}]: "
-      __gets || stem
-    else
-      args.set_name
+      fc.name = __gets || stem
     end
-    fc.version = args.set_version
     fc.license = args.set_license
     fc.tap = Tap.fetch(args.tap || "homebrew/core")
     raise TapUnavailableError, fc.tap.name unless fc.tap.installed?

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -176,9 +176,10 @@ module Homebrew
       print "Formula name [#{stem}]: "
       fc.name = __gets || stem
     end
-    raise TapUnavailableError, fc.tap.name unless fc.tap.installed?
 
     fc.url = args.named.first
+
+    fc.verify
 
     # Check for disallowed formula, or names that shadow aliases,
     # unless --force is specified.

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -140,7 +140,7 @@ module Homebrew
   end
 
   def create_formula(args:)
-    fc = FormulaCreator.new(args)
+    fc = FormulaCreator.new(args, !args.no_fetch?)
     fc.name = if args.set_name.blank?
       stem = Pathname.new(args.named.first).stem.rpartition("=").last
       print "Formula name [#{stem}]: "

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -140,7 +140,7 @@ module Homebrew
   end
 
   def create_formula(args:)
-    fc = FormulaCreator.new(args, !args.no_fetch?)
+    fc = FormulaCreator.new(!args.no_fetch?, args.HEAD?)
     fc.name = if args.set_name.blank?
       stem = Pathname.new(args.named.first).stem.rpartition("=").last
       print "Formula name [#{stem}]: "

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -15,7 +15,7 @@ module Homebrew
       params(name: T.nilable(String), version: T.nilable(String), tap: T.nilable(String), url: String,
              mode: T.nilable(Symbol), license: T.nilable(String), fetch: T::Boolean, head: T::Boolean).void
     }
-    def initialize(name, version, tap:, url:, mode:, license:, fetch: true, head: false)
+    def initialize(name, version, tap:, url:, mode:, license:, fetch:, head:)
       @name = name
       @version = Version.new(version) if version
       @tap = Tap.fetch(tap || "homebrew/core")

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,13 +12,14 @@ module Homebrew
     attr_accessor :name
 
     sig {
-      params(name: T.nilable(String), version: T.nilable(String), tap: T.nilable(String), mode: T.nilable(Symbol),
-             license: T.nilable(String), fetch: T::Boolean, head: T::Boolean).void
+      params(name: T.nilable(String), version: T.nilable(String), tap: T.nilable(String), url: String,
+             mode: T.nilable(Symbol), license: T.nilable(String), fetch: T::Boolean, head: T::Boolean).void
     }
-    def initialize(name, version, tap:, mode:, license:, fetch: true, head: false)
+    def initialize(name, version, tap:, url:, mode:, license:, fetch: true, head: false)
       @name = name
       @version = Version.new(version) if version
       @tap = Tap.fetch(tap || "homebrew/core")
+      @url = url
       @mode = mode
       @license = license
       @fetch = fetch
@@ -30,11 +31,10 @@ module Homebrew
       raise TapUnavailableError, @tap.name unless @tap.installed?
     end
 
-    def url=(url)
-      @url = url
-      path = Pathname.new(url)
+    def parse_url
+      path = Pathname.new(@url)
       if @name.nil?
-        case url
+        case @url
         when %r{github\.com/(\S+)/(\S+)\.git}
           @user = Regexp.last_match(1)
           @name = Regexp.last_match(2)
@@ -48,7 +48,7 @@ module Homebrew
           @name = path.basename.to_s[/(.*?)[-_.]?#{Regexp.escape(path.version.to_s)}/, 1]
         end
       end
-      @version = Version.detect(url) if @version.nil?
+      @version = Version.detect(@url) if @version.nil?
     end
 
     def write_formula!

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,6 +12,7 @@ module Homebrew
     attr_reader :url, :tap, :sha256, :desc, :homepage
     attr_accessor :name
 
+    sig { params(name: T.nilable(String), version: T.nilable(String), tap: T.nilable(String), mode: T.nilable(Symbol),  license: T.nilable(String), fetch: T::Boolean, head: T::Boolean).void }
     def initialize(name, version, tap:, mode:, license:, fetch: true, head: false)
       @name = name
       @version = Version.new(version) if version

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -9,7 +9,6 @@ module Homebrew
   #
   # @api private
   class FormulaCreator
-    attr_reader :tap
     attr_accessor :name
 
     sig {
@@ -24,6 +23,11 @@ module Homebrew
       @license = license
       @fetch = fetch
       @head = head
+    end
+
+    sig { void }
+    def verify
+      raise TapUnavailableError, @tap.name unless @tap.installed?
     end
 
     def url=(url)

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -10,11 +10,12 @@ module Homebrew
   # @api private
   class FormulaCreator
     attr_reader :url, :sha256, :desc, :homepage
-    attr_accessor :name, :tap, :mode, :license
+    attr_accessor :name, :tap, :mode
 
-    def initialize(name, version, fetch: true, head: false)
+    def initialize(name, version, license:, fetch: true, head: false)
       @name = name
       @version = Version.new(version) if version
+      @license = license
       @fetch = fetch
       @head = head
     end
@@ -101,7 +102,7 @@ module Homebrew
         <% end %>
           sha256 "#{sha256}"
         <% end %>
-          license "#{license}"
+          license "#{@license}"
         <% if @head %>
           head "#{url}"
         <% end %>

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -9,8 +9,8 @@ module Homebrew
   #
   # @api private
   class FormulaCreator
-    attr_reader :url, :sha256, :desc, :homepage
-    attr_accessor :name, :tap
+    attr_reader :url, :tap, :sha256, :desc, :homepage
+    attr_accessor :name
 
     def initialize(name, version, tap:, mode:, license:, fetch: true, head: false)
       @name = name

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -9,7 +9,7 @@ module Homebrew
   #
   # @api private
   class FormulaCreator
-    attr_reader :url, :tap, :sha256, :desc, :homepage
+    attr_reader :url, :tap
     attr_accessor :name
 
     sig {
@@ -99,14 +99,14 @@ module Homebrew
           include Language::Python::Virtualenv
 
         <% end %>
-          desc "#{desc}"
-          homepage "#{homepage}"
+          desc "#{@desc}"
+          homepage "#{@homepage}"
         <% unless @head %>
           url "#{url}"
         <% unless @version.detected_from_url? %>
           version "#{@version}"
         <% end %>
-          sha256 "#{sha256}"
+          sha256 "#{@sha256}"
         <% end %>
           license "#{@license}"
         <% if @head %>

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -10,7 +10,7 @@ module Homebrew
   # @api private
   class FormulaCreator
     attr_reader :url, :sha256, :desc, :homepage
-    attr_accessor :name, :version, :tap, :mode, :license
+    attr_accessor :name, :tap, :mode, :license
 
     def initialize(name, version, fetch: true, head: false)
       @name = name
@@ -47,13 +47,13 @@ module Homebrew
       path = @tap.new_formula_path(@name)
       raise "#{path} already exists" if path.exist?
 
-      if version.nil? || version.null?
+      if @version.nil? || @version.null?
         odie "Version cannot be determined from URL. Explicitly set the version with `--set-version` instead."
       elsif @fetch
         unless @head
           r = Resource.new
           r.url(url)
-          r.version(version)
+          r.version(@version)
           r.owner = self
           @sha256 = r.fetch.sha256 if r.download_strategy == CurlDownloadStrategy
         end
@@ -96,8 +96,8 @@ module Homebrew
           homepage "#{homepage}"
         <% unless @head %>
           url "#{url}"
-        <% unless version.detected_from_url? %>
-          version "#{version}"
+        <% unless @version.detected_from_url? %>
+          version "#{@version}"
         <% end %>
           sha256 "#{sha256}"
         <% end %>
@@ -185,7 +185,7 @@ module Homebrew
         <% elsif mode == :ruby %>
             ENV["GEM_HOME"] = libexec
             system "gem", "build", "\#{name}.gemspec"
-            system "gem", "install", "\#{name}-\#{version}.gem"
+            system "gem", "install", "\#{name}-\#{@version}.gem"
             bin.install libexec/"bin/\#{name}"
             bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
         <% elsif mode == :rust %>

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,7 +12,9 @@ module Homebrew
     attr_reader :url, :sha256, :desc, :homepage
     attr_accessor :name, :version, :tap, :mode, :license
 
-    def initialize(fetch=true, head=false)
+    def initialize(name, version, fetch=true, head=false)
+      @name = name
+      @version = version
       @fetch = fetch
       @head = head
     end

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,7 +12,7 @@ module Homebrew
     attr_reader :url, :sha256, :desc, :homepage
     attr_accessor :name, :version, :tap, :mode, :license
 
-    def initialize(name, version, fetch, head)
+    def initialize(name, version, fetch: true, head: false)
       @name = name
       @version = Version.new(version) if version
       @fetch = fetch

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,7 +12,10 @@ module Homebrew
     attr_reader :url, :tap, :sha256, :desc, :homepage
     attr_accessor :name
 
-    sig { params(name: T.nilable(String), version: T.nilable(String), tap: T.nilable(String), mode: T.nilable(Symbol),  license: T.nilable(String), fetch: T::Boolean, head: T::Boolean).void }
+    sig {
+      params(name: T.nilable(String), version: T.nilable(String), tap: T.nilable(String), mode: T.nilable(Symbol),
+             license: T.nilable(String), fetch: T::Boolean, head: T::Boolean).void
+    }
     def initialize(name, version, tap:, mode:, license:, fetch: true, head: false)
       @name = name
       @version = Version.new(version) if version

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,8 +12,9 @@ module Homebrew
     attr_reader :args, :url, :sha256, :desc, :homepage
     attr_accessor :name, :version, :tap, :mode, :license
 
-    def initialize(args)
+    def initialize(args, fetch=true)
       @args = args
+      @fetch = fetch
     end
 
     def url=(url)
@@ -41,10 +42,6 @@ module Homebrew
       end
     end
 
-    def fetch?
-      !args.no_fetch?
-    end
-
     def head?
       @head || args.HEAD?
     end
@@ -58,7 +55,7 @@ module Homebrew
 
       if version.nil? || version.null?
         odie "Version cannot be determined from URL. Explicitly set the version with `--set-version` instead."
-      elsif fetch?
+      elsif @fetch
         unless head?
           r = Resource.new
           r.url(url)

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,9 +12,10 @@ module Homebrew
     attr_reader :url, :sha256, :desc, :homepage
     attr_accessor :name, :tap, :mode
 
-    def initialize(name, version, license:, fetch: true, head: false)
+    def initialize(name, version, tap:, license:, fetch: true, head: false)
       @name = name
       @version = Version.new(version) if version
+      @tap = Tap.fetch(tap || "homebrew/core")
       @license = license
       @fetch = fetch
       @head = head

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -9,12 +9,12 @@ module Homebrew
   #
   # @api private
   class FormulaCreator
-    attr_reader :args, :url, :sha256, :desc, :homepage
+    attr_reader :url, :sha256, :desc, :homepage
     attr_accessor :name, :version, :tap, :mode, :license
 
-    def initialize(args, fetch=true)
-      @args = args
+    def initialize(fetch=true, head=false)
       @fetch = fetch
+      @head = head
     end
 
     def url=(url)
@@ -42,10 +42,6 @@ module Homebrew
       end
     end
 
-    def head?
-      @head || args.HEAD?
-    end
-
     def write_formula!
       raise ArgumentError, "name is blank!" if @name.blank?
       raise ArgumentError, "tap is blank!" if @tap.blank?
@@ -56,7 +52,7 @@ module Homebrew
       if version.nil? || version.null?
         odie "Version cannot be determined from URL. Explicitly set the version with `--set-version` instead."
       elsif @fetch
-        unless head?
+        unless @head
           r = Resource.new
           r.url(url)
           r.version(version)
@@ -100,7 +96,7 @@ module Homebrew
         <% end %>
           desc "#{desc}"
           homepage "#{homepage}"
-        <% unless head? %>
+        <% unless @head %>
           url "#{url}"
         <% unless version.detected_from_url? %>
           version "#{version}"
@@ -108,7 +104,7 @@ module Homebrew
           sha256 "#{sha256}"
         <% end %>
           license "#{license}"
-        <% if head? %>
+        <% if @head %>
           head "#{url}"
         <% end %>
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -14,7 +14,7 @@ module Homebrew
 
     def initialize(name, version, fetch=true, head=false)
       @name = name
-      @version = version
+      @version = Version.new(version) if version
       @fetch = fetch
       @head = head
     end
@@ -37,11 +37,7 @@ module Homebrew
           @name = path.basename.to_s[/(.*?)[-_.]?#{Regexp.escape(path.version.to_s)}/, 1]
         end
       end
-      @version = if @version
-        Version.new(@version)
-      else
-        Version.detect(url)
-      end
+      @version = Version.detect(url) if @version.nil?
     end
 
     def write_formula!

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -9,7 +9,7 @@ module Homebrew
   #
   # @api private
   class FormulaCreator
-    attr_reader :url, :tap
+    attr_reader :tap
     attr_accessor :name
 
     sig {
@@ -59,7 +59,7 @@ module Homebrew
       elsif @fetch
         unless @head
           r = Resource.new
-          r.url(url)
+          r.url(@url)
           r.version(@version)
           r.owner = self
           @sha256 = r.fetch.sha256 if r.download_strategy == CurlDownloadStrategy
@@ -102,7 +102,7 @@ module Homebrew
           desc "#{@desc}"
           homepage "#{@homepage}"
         <% unless @head %>
-          url "#{url}"
+          url "#{@url}"
         <% unless @version.detected_from_url? %>
           version "#{@version}"
         <% end %>
@@ -110,7 +110,7 @@ module Homebrew
         <% end %>
           license "#{@license}"
         <% if @head %>
-          head "#{url}"
+          head "#{@url}"
         <% end %>
 
         <% if @mode == :cmake %>

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -12,7 +12,7 @@ module Homebrew
     attr_reader :url, :sha256, :desc, :homepage
     attr_accessor :name, :version, :tap, :mode, :license
 
-    def initialize(name, version, fetch=true, head=false)
+    def initialize(name, version, fetch, head)
       @name = name
       @version = Version.new(version) if version
       @fetch = fetch


### PR DESCRIPTION
Sets initial values for formula fields from CLI params.

Another refactoring for code clarity to keep https://github.com/Homebrew/brew/pull/16238 minimal.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
