### PR TITLE
Enable Ruby 3 for all users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,7 @@ RUN apt-get update \
 USER linuxbrew
 COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}" \
-  XDG_CACHE_HOME=/home/linuxbrew/.cache \
-  HOMEBREW_RUBY3=1
+  XDG_CACHE_HOME=/home/linuxbrew/.cache
 WORKDIR /home/linuxbrew
 
 RUN mkdir -p \

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -502,10 +502,8 @@ case "$*" in
     ;;
 esac
 
-if [[ -n "${HOMEBREW_DEVELOPER}" || "$1" == "test-bot" ]]
-then
-  export HOMEBREW_RUBY3="1"
-fi
+# TODO: remove this after we want Dependabot to point to 3.1 minimum and system macOS Ruby code is gone
+export HOMEBREW_RUBY3="1"
 
 # TODO: bump version when new macOS is released or announced and update references in:
 # - docs/Installation.md
@@ -589,16 +587,8 @@ then
     fi
   fi
 
-  # Set a variable when the macOS system Ruby is new enough to avoid spawning
-  # a Ruby process unnecessarily.
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "120601" || -n "${HOMEBREW_RUBY3}" ]]
-  then
-    unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
-  else
-    # Used in ruby.sh.
-    # shellcheck disable=SC2034
-    HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH="1"
-  fi
+  # System Ruby usage is deprecated. TODO: clean this up once 2.6 is fully ditched.
+  unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
 else
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
   # Don't try to follow /etc/os-release

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -466,11 +466,7 @@ module Homebrew
 
     def cleanup_portable_ruby
       vendor_dir = HOMEBREW_LIBRARY/"Homebrew/vendor"
-      portable_ruby_latest_version = if ENV["HOMEBREW_RUBY3"]
-        (vendor_dir/"portable-ruby-version").read.chomp
-      else
-        "2.6.10_1"
-      end
+      portable_ruby_latest_version = (vendor_dir/"portable-ruby-version").read.chomp
 
       portable_rubies_to_remove = []
       Pathname.glob(vendor_dir/"portable-ruby/*.*").select(&:directory?).each do |path|

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -20,37 +20,19 @@ then
      # use a x86_64 Portable Ruby.
      [[ "${HOMEBREW_PHYSICAL_PROCESSOR}" == "arm64" && "${HOMEBREW_PREFIX}" == "/usr/local" ]]
   then
-    if [[ -n "${HOMEBREW_RUBY3}" ]]
-    then
-      ruby_FILENAME="portable-ruby-3.1.4.el_capitan.bottle.tar.gz"
-      ruby_SHA="02180ca8b8295422ae84921bcf034b7ee8ce5575488bd5e6a37a192e53cd5d34"
-    else
-      ruby_FILENAME="portable-ruby-2.6.10_1.el_capitan.bottle.tar.gz"
-      ruby_SHA="61029cec31c68a1fae1fa90fa876adf43d0becff777da793f9b5c5577f00567a"
-    fi
+    ruby_FILENAME="portable-ruby-3.1.4.el_capitan.bottle.tar.gz"
+    ruby_SHA="02180ca8b8295422ae84921bcf034b7ee8ce5575488bd5e6a37a192e53cd5d34"
   elif [[ "${HOMEBREW_PHYSICAL_PROCESSOR}" == "arm64" ]]
   then
-    if [[ -n "${HOMEBREW_RUBY3}" ]]
-    then
-      ruby_FILENAME="portable-ruby-3.1.4.arm64_big_sur.bottle.tar.gz"
-      ruby_SHA="d783cbeb6e6ef0d71c0b442317b54554370decd6fac66bf2d4938c07a63f67be"
-    else
-      ruby_FILENAME="portable-ruby-2.6.10_1.arm64_big_sur.bottle.tar.gz"
-      ruby_SHA="905b0c3896164ae8067a22fff2fd0b80b16d3c8bb72441403eedf69da71ec717"
-    fi
+    ruby_FILENAME="portable-ruby-3.1.4.arm64_big_sur.bottle.tar.gz"
+    ruby_SHA="d783cbeb6e6ef0d71c0b442317b54554370decd6fac66bf2d4938c07a63f67be"
   fi
 elif [[ -n "${HOMEBREW_LINUX}" ]]
 then
   case "${HOMEBREW_PROCESSOR}" in
     x86_64)
-      if [[ -n "${HOMEBREW_RUBY3}" ]]
-      then
-        ruby_FILENAME="portable-ruby-3.1.4.x86_64_linux.bottle.tar.gz"
-        ruby_SHA="f7be167f7ac4f296b9f4c5874ceeea4aafd9999c3c7f2b0378cae7dd273e2322"
-      else
-        ruby_FILENAME="portable-ruby-2.6.10_1.x86_64_linux.bottle.tar.gz"
-        ruby_SHA="68923daf3e139482b977c3deba63a3b54ea37bb5f716482948878819ef911bad"
-      fi
+      ruby_FILENAME="portable-ruby-3.1.4.x86_64_linux.bottle.tar.gz"
+      ruby_SHA="f7be167f7ac4f296b9f4c5874ceeea4aafd9999c3c7f2b0378cae7dd273e2322"
       ;;
     *) ;;
   esac
@@ -71,13 +53,8 @@ then
   fi
   ruby_URLs+=(
     "https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:${ruby_SHA}"
+    "https://github.com/Homebrew/homebrew-portable-ruby/releases/download/3.1.4/${ruby_FILENAME}"
   )
-  if [[ -n "${HOMEBREW_RUBY3}" ]]
-  then
-    ruby_URLs+=("https://github.com/Homebrew/homebrew-portable-ruby/releases/download/3.1.4/${ruby_FILENAME}")
-  else
-    ruby_URLs+=("https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.6.10_1/${ruby_FILENAME}")
-  fi
   ruby_URL="${ruby_URLs[0]}"
 fi
 
@@ -323,12 +300,7 @@ homebrew-vendor-install() {
   VENDOR_FILENAME="${!filename_var}"
   VENDOR_SHA="${!sha_var}"
   VENDOR_URL="${!url_var}"
-  if [[ -z "${HOMEBREW_RUBY3}" && "${VENDOR_NAME}" == "ruby" ]]
-  then
-    VENDOR_VERSION="2.6.10_1" # EOL - phasing out
-  else
-    VENDOR_VERSION="$(cat "${VENDOR_DIR}/portable-${VENDOR_NAME}-version")"
-  fi
+  VENDOR_VERSION="$(cat "${VENDOR_DIR}/portable-${VENDOR_NAME}-version")"
 
   if [[ -z "${VENDOR_URL}" || -z "${VENDOR_SHA}" ]]
   then

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -133,12 +133,7 @@ If there's no Homebrew Portable Ruby available for your processor:
   vendor_ruby_root="${vendor_dir}/portable-ruby/current"
   vendor_ruby_path="${vendor_ruby_root}/bin/ruby"
   vendor_ruby_terminfo="${vendor_ruby_root}/share/terminfo"
-  if [[ -n "${HOMEBREW_RUBY3}" ]]
-  then
-    vendor_ruby_latest_version="$(cat "${vendor_dir}/portable-ruby-version")"
-  else
-    vendor_ruby_latest_version="2.6.10_1" # EOL - phasing out
-  fi
+  vendor_ruby_latest_version="$(cat "${vendor_dir}/portable-ruby-version")"
   vendor_ruby_current_version="$(readlink "${vendor_ruby_root}")"
 
   unset HOMEBREW_RUBY_PATH


### PR DESCRIPTION
This will:
- Make all macOS users use Portable Ruby (subsequent cleanup of system Ruby logic will follow later).
- Remove availability of Portable Ruby 2.6
- Allow system Ruby 3.1 to be used on Linux

This will not:
- Require system Ruby users on Linux to change their Ruby from 2.6. That is a breaking change and will follow after 4.1.23, which will likely be the final 4.1.x.

This will apply to dev-cmd users immediately once this is merged and all other users when 4.1.23 is tagged.

Draft because #16267 needs to be merged first. Consider this otherwise ready for review.