### PR TITLE
Bump VENDOR_VERSION in gems.rb

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -14,7 +14,7 @@ module Homebrew
 
   # Bump this whenever a committed vendored gem is later added to gitignore.
   # This will trigger it to reinstall properly if `brew install-bundler-gems` needs it.
-  VENDOR_VERSION = 1
+  VENDOR_VERSION = 2
   private_constant :VENDOR_VERSION
 
   RUBY_BUNDLE_VENDOR_DIRECTORY = (HOMEBREW_LIBRARY_PATH/"vendor/bundle/ruby").freeze


### PR DESCRIPTION
Per the code [comment](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/gems.rb#L15-L16), it seems I should bump this after ignoring a pair of committed vendored gems in https://github.com/Homebrew/brew/pull/16259 :

https://github.com/Homebrew/brew/pull/16259/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947R102 https://github.com/Homebrew/brew/pull/16259/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947R109

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
