### PR TITLE
dev-cmd/bump-cask-pr: fix --sha256

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -208,10 +208,10 @@ module Homebrew
           replacement_pairs << [/"#{old_hash}"/, ":no_check"] if old_hash != :no_check
         elsif old_hash == :no_check && new_hash != :no_check
           replacement_pairs << [":no_check", "\"#{new_hash}\""] if new_hash.is_a?(String)
+        elsif new_hash && !cask.on_system_blocks_exist? && cask.languages.empty?
+          replacement_pairs << [old_hash.to_s, new_hash.to_s]
         elsif old_hash != :no_check
-          if new_hash && cask.languages.present?
-            opoo "Multiple checksum replacements required; ignoring specified `--sha256` argument."
-          end
+          opoo "Multiple checksum replacements required; ignoring specified `--sha256` argument." if new_hash
           languages = if cask.languages.empty?
             [nil]
           else
@@ -232,9 +232,6 @@ module Homebrew
                                     download.sha256]
             end
           end
-        elsif new_hash
-          opoo "Cask contains multiple hashes; only updating hash for current arch." if cask.on_system_blocks_exist?
-          replacement_pairs << [old_hash.to_s, new_hash.to_s]
         end
       end
     end


### PR DESCRIPTION
It didn't seem to do anything and was always fetching the remote sha256

There's more that could be done here to make it a bit smarter. It currently (intentionally but not ideally) refuses to use it when on_system blocks are present even if those blocks are actually just older macOS handling as it can't tell the difference between on_os and on_arch. I've just done enough here to get the base functionality back.