### PR TITLE
Unset HOMEBREW_RUBY3 after updates

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -358,6 +358,8 @@ auto-update() {
     # Restore user path as it'll be refiltered by HOMEBREW_BREW_FILE (bin/brew)
     export PATH=${HOMEBREW_PATH}
 
+    unset HOMEBREW_RUBY3
+
     # exec a new process to set any new environment variables.
     exec "${HOMEBREW_BREW_FILE}" "$@"
   fi

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -893,7 +893,10 @@ EOS
      [[ ! -f "${HOMEBREW_CACHE}/all_commands_list.txt" ]] ||
      [[ -n "${HOMEBREW_DEVELOPER}" && -z "${HOMEBREW_UPDATE_AUTO}" ]]
   then
-    brew update-report "$@"
+    (
+      unset HOMEBREW_RUBY3
+      brew update-report "$@"
+    )
     return $?
   elif [[ -z "${HOMEBREW_UPDATE_AUTO}" && -z "${HOMEBREW_QUIET}" ]]
   then


### PR DESCRIPTION
Temporary until the next tag. Unset before spawning new brew subprocesses - the new process will pick up the correct default.

Should fix downgrades from master to 4.1.22?