### PR TITLE
formula: fix specified_path for aliases without core tap

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -343,13 +343,14 @@ class Formula
 
   # The path that was specified to find this formula.
   def specified_path
-    default_specified_path = Pathname(T.must(alias_path)) if alias_path.present?
-    default_specified_path ||= @unresolved_path
+    alias_pathname = Pathname(T.must(alias_path)) if alias_path.present?
+    return alias_pathname if alias_pathname&.exist?
 
-    return default_specified_path if default_specified_path.presence&.exist?
+    return @unresolved_path if @unresolved_path.exist?
+
     return local_bottle_path if local_bottle_path.presence&.exist?
 
-    default_specified_path
+    alias_pathname || @unresolved_path
   end
 
   # The name specified to find this formula.


### PR DESCRIPTION
This previously assumed a non-nil alias_path would always exist where the unresolved path exists. This is not always true with untapped core taps - e.g. if we download the Ruby source or use it from a bottle (post-install) then the we have the original file but not the aliased symlink.

Fixes some errors installing by alias, e.g.
```console
Error: An exception occurred within a child process:
  FormulaUnavailableError: No available formula with the name "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Aliases/crypto++".
```

Technically speaking this means methods like `alias_name` etc will not be set in postinstall etc, but I don't think any formula uses that information and would be a bigger refactor to fix.