### PR TITLE
cmd/update.sh: don't switch to master when updating to a tag

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -268,7 +268,7 @@ EOS
     else
       if [[ -n "${UPSTREAM_TAG}" && "${UPSTREAM_BRANCH}" != "master" ]]
       then
-        git checkout --force -B "master" "origin/master" "${QUIET_ARGS[@]}"
+        git branch --force "master" "origin/master" "${QUIET_ARGS[@]}"
       fi
 
       git checkout --force -B "${UPSTREAM_BRANCH}" "${REMOTE_REF}" "${QUIET_ARGS[@]}"


### PR DESCRIPTION
Fixes issues seen with the `homebrew/brew:latest` image where it doesn't have the `stable` branch setup so it does a detached 4.1.22 -> master -> 4.1.22. This change avoids that intermediate master change by making that pull happen in the background to the working state.

The issues with `homebrew/brew:latest` will be fixed anyway with 4.1.23 when the vendored gems become a part of the tag, but this change is still worthwhile to prevent that class of issues in the future.

I will also look into setting fixing the branches in the Dockerfile (i.e. run `brew update` somewhere), which will also avoid the issue.