### PR TITLE
Gemfile: load REXML gem for `brew bump`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -58,6 +58,8 @@ module Homebrew
   def bump
     args = bump_args.parse
 
+    Homebrew.install_bundler_gems!(groups: ["livecheck"])
+
     if args.limit.present? && !args.formula? && !args.cask?
       raise UsageError, "`--limit` must be used with either `--formula` or `--cask`."
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently our `autobump` workflow in `homebrew-cask` (and in my personal tap) is failing due to the `:sparkle` `livecheck` strategy requiring the REXML gem.
This started occurring after the Ruby3 on CI update, as REXML is no longer an included gem.