### PR TITLE
unpack_strategy/zip: fix extraction issues on macOS without developer mode

### DIFF
--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -6,10 +6,9 @@ require "system_command"
 module UnpackStrategy
   class Zip
     module MacOSZipExtension
-      include UnpackStrategy
-      include SystemCommand::Mixin
+      private
 
-      sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+      sig { params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
       def extract_to_dir(unpack_dir, basename:, verbose:)
         with_env(TZ: "UTC") do
           if merge_xattrs && contains_extended_attributes?(path)
@@ -57,8 +56,6 @@ module UnpackStrategy
           end
         end
       end
-
-      private
 
       sig { params(path: Pathname).returns(T::Boolean) }
       def contains_extended_attributes?(path)

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rbi
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rbi
@@ -1,5 +1,5 @@
 # typed: strict
 
 module UnpackStrategy::Zip::MacOSZipExtension
-  include Kernel
+  requires_ancestor { UnpackStrategy }
 end


### PR DESCRIPTION
Before:

```rb
> UnpackStrategy::Zip.ancestors
[UnpackStrategy::Zip::MacOSZipExtension, UnpackStrategy, SystemCommand::Mixin, UnpackStrategy::Zip, UnpackStrategy, Object, SystemCommand::Mixin, JSON::Ext::Generator::GeneratorMethods::Object, Kernel, BasicObject]
```

After:

```rb
> UnpackStrategy::Zip.ancestors
[UnpackStrategy::Zip::MacOSZipExtension, UnpackStrategy::Zip, UnpackStrategy, Object, SystemCommand::Mixin, JSON::Ext::Generator::GeneratorMethods::Object, Kernel, BasicObject]
```

We were skipping the generic OS `extract_to_dir` and directly going to the unpack strategy baseclass.

For some reason, this didn't happen with Sorbet Runtime enabled as it seems to break the ancestor rules (coincidentally to our favour on this occasion).

Fixes #16287.