### PR TITLE
Require Ruby 3.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -294,12 +294,6 @@ jobs:
           - name: tests (macOS 13)
             test-flags: --coverage
             runs-on: macos-13
-          - name: tests (Ubuntu 22.04; Ruby 2.6)
-            runs-on: ubuntu-22.04
-            ruby: '2.6'
-          - name: tests (macOS 13; Ruby 2.6)
-            runs-on: macos-13
-            ruby: '2.6'
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -313,21 +307,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ matrix.runs-on }}-tests-rubygems${{ matrix.ruby }}-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ matrix.runs-on }}-tests-rubygems${{ matrix.ruby }}-
-
-      - name: Setup Ruby
-        if: matrix.ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler: none
-
-      - name: Setup Ruby environment
-        if: matrix.ruby
-        run: |
-          echo "HOMEBREW_USE_RUBY_FROM_PATH=1" >> "${GITHUB_ENV}"
-          rm -rf "${{ steps.set-up-homebrew.outputs.repository-path }}/Library/Homebrew/vendor/portable-ruby"
+          key: ${{ matrix.runs-on }}-tests-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.runs-on }}-tests-rubygems-
 
       - run: brew config
 
@@ -341,8 +322,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tests
-          key: ${{ runner.os }}-${{ matrix.test-flags }}-parallel_runtime_rspec${{ matrix.ruby }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ matrix.test-flags }}-parallel_runtime_rspec${{ matrix.ruby }}-
+          key: ${{ runner.os }}-${{ matrix.test-flags }}-parallel_runtime_rspec-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-${{ matrix.test-flags }}-parallel_runtime_rspec-
 
       - name: Install brew tests dependencies
         if: matrix.name != 'tests (generic OS)'

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -504,9 +504,6 @@ case "$*" in
     ;;
 esac
 
-# TODO: remove this after we want Dependabot to point to 3.1 minimum and system macOS Ruby code is gone
-export HOMEBREW_RUBY3="1"
-
 # TODO: bump version when new macOS is released or announced and update references in:
 # - docs/Installation.md
 # - https://github.com/Homebrew/install/blob/HEAD/install.sh

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,6 +1,9 @@
 # When bumping, run `brew vendor-gems --update=--ruby`
 # When bumping to a new major/minor version, also update the bounds in the Gemfile
-export HOMEBREW_REQUIRED_RUBY_VERSION=2.6.10
+export HOMEBREW_REQUIRED_RUBY_VERSION=3.1
+
+# TODO: remove this after we want Dependabot to point to 3.1 minimum
+export HOMEBREW_RUBY3="1"
 
 # HOMEBREW_LIBRARY is from the user environment
 # shellcheck disable=SC2154
@@ -10,24 +13,9 @@ test_ruby() {
     return 1
   fi
 
-  supported_ruby_versions=()
-  if [[ -n "${HOMEBREW_RUBY3}" && -z "${HOMEBREW_USE_RUBY_FROM_PATH}" ]]
-  then
-    supported_ruby_versions+=("3.1.0")
-  fi
-  supported_ruby_versions+=("${HOMEBREW_REQUIRED_RUBY_VERSION}")
-
-  for ruby_version in "${supported_ruby_versions[@]}"
-  do
-    if "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt \
-       "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby_check_version_script.rb" \
-       "${ruby_version}" 2>/dev/null
-    then
-      return 0
-    fi
-  done
-
-  return 1
+  "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt \
+    "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby_check_version_script.rb" \
+    "${HOMEBREW_REQUIRED_RUBY_VERSION}" 2>/dev/null
 }
 
 can_use_ruby_from_path() {


### PR DESCRIPTION
Merging this would mean that the next version should be a minor release (4.2.0).

This PR does not rip out all 2.6 support code. Idea here is to keep this small and easy to revert. Once 4.2.0 has shipped for 24 hours, I will rip out all the legacy code in a no-going-back move.

Draft purely because we should wait 24-48 hours in case of any bug reports with 4.1.23. This PR is otherwise ready for review, should we be ready for the next version to be a minor release.