### PR TITLE
Deprecate `--new-formula`/`--new-cask` options.

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -160,11 +160,12 @@ module Homebrew
         return if global_switch
 
         description = option_description(description, *names, hidden: hidden)
-        if replacement.nil?
-          process_option(*names, description, type: :switch, hidden: hidden)
-        else
-          description += " (disabled#{"; replaced by #{replacement}" if replacement.present?})"
+        process_option(*names, description, type: :switch, hidden: hidden) unless disable
+
+        if replacement || disable
+          description += " (#{disable ? "disabled" : "deprecated"}#{"; replaced by #{replacement}" if replacement})"
         end
+
         @parser.public_send(method, *names, *wrap_option_desc(description)) do |value|
           # This odeprecated should stick around indefinitely.
           odeprecated "the `#{names.first}` switch", replacement, disable: disable if !replacement.nil? || disable


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

See https://github.com/Homebrew/homebrew-cask/pull/161724.

Both `--new-formula` as well as `--new-cask` do the same thing as `--new`, so they're not needed anymore.