### PR TITLE
utils/svn_spec: change remote used in test.

### DIFF
--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -47,7 +47,7 @@ describe Utils::Svn do
       end
 
       it "returns true when remote exists", :needs_network, :needs_svn do
-        expect(described_class).to be_remote_exists("https://github.com/Homebrew/install")
+        expect(described_class).to be_remote_exists("https://svn.apache.org/repos/asf/openoffice/trunk")
       end
     end
   end


### PR DESCRIPTION
GitHub is dropping their Subversion support so let's move to an Apache Subversion server instead.