### PR TITLE
Lazy load Debrew (fixes setupterm error on some environments)

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -12,7 +12,6 @@ require_relative "global"
 require "build_options"
 require "keg"
 require "extend/ENV"
-require "debrew"
 require "fcntl"
 require "socket"
 require "cmd/install"
@@ -126,7 +125,10 @@ class Build
     }
 
     with_env(new_env) do
-      formula.extend(Debrew::Formula) if args.debug?
+      if args.debug?
+        require "debrew"
+        formula.extend(Debrew::Formula)
+      end
 
       formula.update_head_version
 

--- a/Library/Homebrew/debrew.rb
+++ b/Library/Homebrew/debrew.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "mutex_m"
-require "debrew/irb"
 require "ignorable"
 
 # Helper module for debugging formulae.
@@ -117,7 +116,10 @@ module Debrew
               set_trace_func proc { |event, _, _, id, binding, klass|
                 if klass == Object && id == :raise && event == "return"
                   set_trace_func(nil)
-                  mu_synchronize { IRB.start_within(binding) }
+                  mu_synchronize do
+                    require "debrew/irb"
+                    IRB.start_within(binding)
+                  end
                 end
               }
 

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -6,7 +6,6 @@ raise "#{__FILE__} must not be loaded via `require`." if $PROGRAM_NAME != __FILE
 old_trap = trap("INT") { exit! 130 }
 
 require_relative "global"
-require "debrew"
 require "fcntl"
 require "socket"
 require "cli/parser"
@@ -20,7 +19,10 @@ begin
   trap("INT", old_trap)
 
   formula = args.named.to_resolved_formulae.first
-  formula.extend(Debrew::Formula) if args.debug?
+  if args.debug?
+    require "debrew"
+    formula.extend(Debrew::Formula)
+  end
   formula.run_post_install
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.puts e.to_json

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -8,7 +8,6 @@ old_trap = trap("INT") { exit! 130 }
 require_relative "global"
 require "extend/ENV"
 require "timeout"
-require "debrew"
 require "formula_assertions"
 require "formula_free_port"
 require "fcntl"
@@ -35,7 +34,10 @@ begin
   formula = T.must(args.named.to_resolved_formulae.first)
   formula.extend(Homebrew::Assertions)
   formula.extend(Homebrew::FreePort)
-  formula.extend(Debrew::Formula) if args.debug?
+  if args.debug?
+    require "debrew"
+    formula.extend(Debrew::Formula)
+  end
 
   ENV.extend(Stdenv)
   ENV.setup_build_environment(formula: formula, testing_formula: true)


### PR DESCRIPTION
Likely fix for #16299

Only the IRB change is strictly needed, but I thought might as well lazy load the whole thing for miniscule speed improvements given `--debug` is relatively rare.