### PR TITLE
cmd/pin: Update pinned formula messaging

### DIFF
--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -13,6 +13,9 @@ module Homebrew
       description <<~EOS
         Pin the specified <formula>, preventing them from being upgraded when
         issuing the `brew upgrade` <formula> command. See also `unpin`.
+
+        Note: Other packages which depend on newer versions of a pinned formula
+        might not install or run correctly.
       EOS
 
       named_args :installed_formula, min: 1

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -128,7 +128,7 @@ module Homebrew
     args = upgrade_args.parse
 
     # Deprecated since this is now the default behavior.
-    # odeprecated "`brew upgrade --ignore-pinned`" if args.ignore_pinned?
+    odeprecated "`brew upgrade --ignore-pinned`" if args.ignore_pinned?
 
     formulae, casks = args.named.to_resolved_formulae_to_casks
     # If one or more formulae are specified, but no casks were

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -196,7 +196,10 @@ module Homebrew
     end
 
     if pinned.any?
-      opoo "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:"
+      Kernel.public_send(
+        formulae.any? ? :ofail : :opoo, # only fail when pinned formulae are named explicitly
+        "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:",
+      )
       puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -62,6 +62,7 @@ module Homebrew
         }],
         [:switch, "--ignore-pinned", {
           description: "Set a successful exit status even if pinned formulae are not upgraded.",
+          hidden:      true,
         }],
         [:switch, "--keep-tmp", {
           description: "Retain the temporary files created during installation.",
@@ -125,6 +126,9 @@ module Homebrew
   sig { void }
   def upgrade
     args = upgrade_args.parse
+
+    # Deprecated since this is now the default behavior.
+    # odeprecated "`brew upgrade --ignore-pinned`" if args.ignore_pinned?
 
     formulae, casks = args.named.to_resolved_formulae_to_casks
     # If one or more formulae are specified, but no casks were
@@ -191,8 +195,8 @@ module Homebrew
       end
     end
 
-    if !pinned.empty? && !args.ignore_pinned?
-      ofail "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:"
+    if pinned.any?
+      opoo "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:"
       puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -337,7 +337,7 @@ module Homebrew
 
       if pinned_dependents.present?
         plural = Utils.pluralize("dependent", pinned_dependents.count)
-        ohai "Not upgrading #{pinned_dependents.count} pinned #{plural}:"
+        opoo "Not upgrading #{pinned_dependents.count} pinned #{plural}:"
         puts(pinned_dependents.map do |f|
           "#{f.full_specified_name} #{f.pkg_version}"
         end.join(", "))

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -2565,7 +2565,6 @@ _brew_upgrade() {
       --greedy-auto-updates
       --greedy-latest
       --help
-      --ignore-pinned
       --input-methoddir
       --interactive
       --internet-plugindir

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1672,7 +1672,6 @@ __fish_brew_complete_arg 'upgrade' -l greedy -d 'Also include casks with `auto_u
 __fish_brew_complete_arg 'upgrade' -l greedy-auto-updates -d 'Also include casks with `auto_updates true`'
 __fish_brew_complete_arg 'upgrade' -l greedy-latest -d 'Also include casks with `version :latest`'
 __fish_brew_complete_arg 'upgrade' -l help -d 'Show this message'
-__fish_brew_complete_arg 'upgrade' -l ignore-pinned -d 'Set a successful exit status even if pinned formulae are not upgraded'
 __fish_brew_complete_arg 'upgrade' -l input-methoddir -d 'Target location for Input Methods (default: `~/Library/Input Methods`)'
 __fish_brew_complete_arg 'upgrade' -l interactive -d 'Download and patch formula, then open a shell. This allows the user to run `./configure --help` and otherwise determine how to turn the software package into a Homebrew package'
 __fish_brew_complete_arg 'upgrade' -l internet-plugindir -d 'Target location for Internet Plugins (default: `~/Library/Internet Plug-Ins`)'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -2060,7 +2060,6 @@ _brew_upgrade() {
     '(--formula)--greedy-auto-updates[Also include casks with `auto_updates true`]' \
     '(--formula)--greedy-latest[Also include casks with `version :latest`]' \
     '--help[Show this message]' \
-    '(--cask)--ignore-pinned[Set a successful exit status even if pinned formulae are not upgraded]' \
     '(--formula)--input-methoddir[Target location for Input Methods (default: `~/Library/Input Methods`)]' \
     '(--cask)--interactive[Download and patch formula, then open a shell. This allows the user to run `./configure --help` and otherwise determine how to turn the software package into a Homebrew package]' \
     '(--formula)--internet-plugindir[Target location for Internet Plugins (default: `~/Library/Internet Plug-Ins`)]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -541,6 +541,9 @@ information is displayed in interactive shells, and suppressed otherwise.
 Pin the specified *`formula`*, preventing them from being upgraded when
 issuing the `brew upgrade` *`formula`* command. See also `unpin`.
 
+Note: Other packages which depend on newer versions of a pinned formula
+might not install or run correctly.
+
 ### `postinstall`, `post_install` *`installed_formula`* [...]
 
 Rerun the post-install steps for *`formula`*.
@@ -797,8 +800,6 @@ upgraded formulae or, every 30 days, for all formulae.
   Install from a bottle if it exists for the current or newest version of macOS, even if it would not normally be used for installation.
 * `--fetch-HEAD`:
   Fetch the upstream repository to detect if the HEAD installation of the formula is outdated. Otherwise, the repository's HEAD will only be checked for updates when a new stable or development version has been released.
-* `--ignore-pinned`:
-  Set a successful exit status even if pinned formulae are not upgraded.
 * `--keep-tmp`:
   Retain the temporary files created during installation.
 * `--debug-symbols`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -758,6 +758,9 @@ Also include outdated casks including those with \fBauto_updates true\fR\.
 .SS "\fBpin\fR \fIinstalled_formula\fR [\.\.\.]"
 Pin the specified \fIformula\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR \fIformula\fR command\. See also \fBunpin\fR\.
 .
+.P
+Note: Other packages which depend on newer versions of a pinned formula might not install or run correctly\.
+.
 .SS "\fBpostinstall\fR, \fBpost_install\fR \fIinstalled_formula\fR [\.\.\.]"
 Rerun the post\-install steps for \fIformula\fR\.
 .
@@ -1101,10 +1104,6 @@ Install from a bottle if it exists for the current or newest version of macOS, e
 .TP
 \fB\-\-fetch\-HEAD\fR
 Fetch the upstream repository to detect if the HEAD installation of the formula is outdated\. Otherwise, the repository\'s HEAD will only be checked for updates when a new stable or development version has been released\.
-.
-.TP
-\fB\-\-ignore\-pinned\fR
-Set a successful exit status even if pinned formulae are not upgraded\.
 .
 .TP
 \fB\-\-keep\-tmp\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Resolves https://github.com/Homebrew/brew/issues/16212

The hope is that this will be clearer and less annoying for users.

A user came to us a couple weeks ago stating that it was confusing that the `brew upgrade` command printed an error when a pinned formula had a new version available and didn't get upgraded. Not upgrading a package is the expected result of pinning it.

This PR changes that message to a warning from an error. While looking into this we found that there is another message that gets printed when a package dependent doesn't get upgraded because it is pinned and that got turned into a warning from a normal message. Honestly that should be more worrying for the user anyway; it could lead to a program not working correctly in the worst case scenario.

I also added a message to the `brew pin` command warning about potential unintended behavior if a dependency gets pinned and another package requires a newer version of it.

Lastly, I added a commented out deprecation notice for the `brew upgrade --ignore-pinned` command since it's now essentially the default.