### PR TITLE
test: fix a couple failures on certain systems

### DIFF
--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -284,6 +284,7 @@ describe Caveats do
         let(:caveats) { described_class.new(f).caveats }
 
         it "adds the correct amount of new lines to the output" do
+          expect(Utils::Service).to receive(:launchctl?).at_least(:once).and_return(true)
           expect(caveats).to include("something else")
           expect(caveats).to include("keg-only")
           expect(caveats).to include("if you don't want/need a background service")

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -65,7 +65,8 @@ describe UnpackStrategy do
         it "does not make other files writable" do
           strategy.extract_nestedly(to: unpack_dir)
 
-          expect(unpack_dir/executable).not_to be_writable
+          # We don't check `writable?` here as that's always true as root.
+          expect((unpack_dir/executable).stat.mode & 0222).to be_zero
         end
       end
     end


### PR DESCRIPTION
* `test/caveats_spec` could fail if neither launchctl or systemd were available (e.g. Ubuntu images without systemd installed).
  - We should probably adjust generic OS tests to assume neither are available.
* `test/unpack_strategy_spec` could fail if run as root as `writable?` is always true as root.