### PR TITLE
utils/service: assume no service system during generic OS tests

### DIFF
--- a/Library/Homebrew/utils/service.rb
+++ b/Library/Homebrew/utils/service.rb
@@ -25,6 +25,7 @@ module Utils
     sig { returns(T.nilable(Pathname)) }
     def self.launchctl
       return @launchctl if defined? @launchctl
+      return if ENV["HOMEBREW_TEST_GENERIC_OS"]
 
       @launchctl = which("launchctl")
     end
@@ -33,6 +34,7 @@ module Utils
     sig { returns(T.nilable(Pathname)) }
     def self.systemctl
       return @systemctl if defined? @systemctl
+      return if ENV["HOMEBREW_TEST_GENERIC_OS"]
 
       @systemctl = which("systemctl")
     end


### PR DESCRIPTION
Should fail until rebased on #16303.

Provides a test flow that's different to the usual macOS and Linux runs, increasing coverage.