### PR TITLE
Partially support `pour_bottle?` in API

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2235,6 +2235,7 @@ class Formula
       "revision"                 => revision,
       "version_scheme"           => version_scheme,
       "bottle"                   => {},
+      "pour_bottle_only_if"      => self.class.pour_bottle_only_if&.to_s,
       "keg_only"                 => keg_only?,
       "keg_only_reason"          => keg_only_reason&.to_hash,
       "options"                  => [],
@@ -3538,6 +3539,7 @@ class Formula
     # <pre>pour_bottle? only_if: :clt_installed</pre>
     def pour_bottle?(only_if: nil, &block)
       @pour_bottle_check = PourBottleCheck.new(self)
+      @pour_bottle_only_if = only_if
 
       if only_if.present? && block.present?
         raise ArgumentError, "Do not pass both a preset condition and a block to `pour_bottle?`"
@@ -3570,6 +3572,9 @@ class Formula
 
       @pour_bottle_check.instance_eval(&block)
     end
+
+    # @private
+    attr_reader :pour_bottle_only_if
 
     # Deprecates a {Formula} (on the given date) so a warning is
     # shown on each installation. If the date has not yet passed the formula

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -291,6 +291,10 @@ module Formulary
         end
       end
 
+      if (pour_bottle_only_if = json_formula["pour_bottle_only_if"])
+        pour_bottle? only_if: pour_bottle_only_if.to_sym
+      end
+
       if (keg_only_reason = json_formula["keg_only_reason"].presence)
         reason = Formulary.convert_to_string_or_symbol keg_only_reason["reason"]
         keg_only reason, keg_only_reason["explanation"]


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/pull/156536.

Block syntax of `pour_bottle?` is not supported, as that involves Ruby code. It seems we've phased that out in Homebrew/core already.