### PR TITLE
dependency: disable renamed formula warning

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -41,7 +41,7 @@ class Dependency
   end
 
   def to_formula
-    formula = Formulary.factory(name)
+    formula = Formulary.factory(name, warn: false)
     formula.build = BuildOptions.new(options, formula.options)
     formula
   end

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -54,7 +54,7 @@ describe Utils::Autoremove do
     include_context "with formulae for dependency testing"
 
     before do
-      allow(Formulary).to receive(:factory).with("three").and_return(formula_is_build_dep)
+      allow(Formulary).to receive(:factory).with("three", { warn: false }).and_return(formula_is_build_dep)
     end
 
     context "when formulae are bottles" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
If a user has an older keg installed that refers to a dependency by an old name, after each install / uninstall / invocation of `brew uses` they'll see something like `Warning: Formula atk was renamed to at-spi2-core.` without context. I'm told this can be silenced since old names are symlinked anyway.