### PR TITLE
Sayonara Ruby 2.6

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -81,8 +81,3 @@ gem "plist"
 gem "ruby-macho"
 gem "sorbet-runtime"
 gem "warning"
-
-# TODO: remove when HOMEBREW_REQUIRED_RUBY_VERSION >= 2.7
-install_if -> { RUBY_VERSION < "2.7" } do
-  gem "did_you_mean"
-end

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -18,7 +18,6 @@ GEM
     commander (4.6.0)
       highline (~> 2.0.0)
     concurrent-ruby (1.2.2)
-    did_you_mean (1.6.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
     elftools (1.2.0)
@@ -193,7 +192,6 @@ DEPENDENCIES
   addressable
   bootsnap
   byebug
-  did_you_mean
   json_schemer
   minitest
   parallel_tests

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -585,9 +585,6 @@ then
       HOMEBREW_FORCE_BREWED_GIT="1"
     fi
   fi
-
-  # System Ruby usage is deprecated. TODO: clean this up once 2.6 is fully ditched.
-  unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
 else
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
   # Don't try to follow /etc/os-release
@@ -651,7 +648,6 @@ Your Git executable: $(unset git && type -p "${HOMEBREW_GIT}")"
   fi
 
   HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION="2.13"
-  unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
 
   HOMEBREW_CORE_REPOSITORY_ORIGIN="$("${HOMEBREW_GIT}" -C "${HOMEBREW_CORE_REPOSITORY}" remote get-url origin 2>/dev/null)"
   if [[ "${HOMEBREW_CORE_REPOSITORY_ORIGIN}" =~ (/linuxbrew|Linuxbrew/homebrew)-core(\.git)?$ ]]
@@ -742,7 +738,6 @@ export HOMEBREW_USER_AGENT
 export HOMEBREW_USER_AGENT_CURL
 export HOMEBREW_API_DEFAULT_DOMAIN
 export HOMEBREW_BOTTLE_DEFAULT_DOMAIN
-export HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
 export HOMEBREW_CURL_SPEED_LIMIT
 export HOMEBREW_CURL_SPEED_TIME
 

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -33,9 +33,6 @@ module Homebrew
 
     ENV["BUNDLE_WITH"] = Homebrew.valid_gem_groups.join(":")
 
-    # System Ruby does not pick up the correct SDK by default.
-    ENV["SDKROOT"] = MacOS.sdk_path if ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"]
-
     ohai "cd #{HOMEBREW_LIBRARY_PATH}"
     HOMEBREW_LIBRARY_PATH.cd do
       if args.update

--- a/Library/Homebrew/extend/os/mac/cleanup.rb
+++ b/Library/Homebrew/extend/os/mac/cleanup.rb
@@ -8,7 +8,7 @@ module Homebrew
     def use_system_ruby?
       return false if Homebrew::EnvConfig.force_vendor_ruby?
 
-      ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"].present?
+      Homebrew::EnvConfig.developer? && ENV["HOMEBREW_USE_RUBY_FROM_PATH"].present?
     end
   end
 end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -204,19 +204,6 @@ module Homebrew
         EOS
       end
 
-      def check_ruby_version
-        return unless ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"]
-        return if RUBY_VERSION == HOMEBREW_REQUIRED_RUBY_VERSION
-        return if Homebrew::EnvConfig.developer? && OS::Mac.version.prerelease?
-
-        <<~EOS
-          Ruby version #{RUBY_VERSION} is unsupported on macOS #{MacOS.version}. Homebrew
-          is developed and tested on Ruby #{HOMEBREW_REQUIRED_RUBY_VERSION}, and may not work correctly
-          on other Rubies. Patches are accepted as long as they don't cause breakage
-          on supported Rubies.
-        EOS
-      end
-
       def check_xcode_prefix
         prefix = MacOS::Xcode.prefix
         return if prefix.nil?

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -7,18 +7,9 @@ module SystemConfig
   class << self
     include SystemCommand::Mixin
 
-    undef describe_homebrew_ruby, describe_clang
+    undef describe_clang
 
-    def describe_homebrew_ruby
-      s = describe_homebrew_ruby_version
-
-      if RUBY_PATH.to_s.match?(%r{^/System/Library/Frameworks/Ruby\.framework/Versions/[12]\.[089]/usr/bin/ruby})
-        s
-      else
-        "#{s} => #{RUBY_PATH}"
-      end
-    end
-
+    sig { returns(String) }
     def describe_clang
       return "N/A" if clang.null?
 

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -40,9 +40,4 @@ $LOAD_PATH.push HOMEBREW_LIBRARY_PATH.to_s unless $LOAD_PATH.include?(HOMEBREW_L
 require_relative "../vendor/bundle/bundler/setup"
 $LOAD_PATH.unshift "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/" \
                    "bundler-#{Homebrew::HOMEBREW_BUNDLER_VERSION}/lib"
-if ruby_major == 2 && ruby_minor == 6
-  # TEMP: Ruby 3 transition
-  $LOAD_PATH.unshift "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/" \
-                     "did_you_mean-1.6.3/lib"
-end
 $LOAD_PATH.uniq!

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -93,18 +93,8 @@ module SystemConfig
     end
 
     sig { returns(String) }
-    def describe_homebrew_ruby_version
-      case RUBY_VERSION
-      when /^1\.[89]/, /^2\.0/
-        "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
-      else
-        RUBY_VERSION
-      end
-    end
-
-    sig { returns(String) }
     def describe_homebrew_ruby
-      "#{describe_homebrew_ruby_version} => #{RUBY_PATH}"
+      "#{RUBY_VERSION} => #{RUBY_PATH}"
     end
 
     sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -30,7 +30,7 @@ describe "brew irb" do
       # TODO: newer Ruby only supports history saving in interactive sessions
       # and not if you feed in data from a file or stdin like we are doing here.
       # The test will need to be adjusted for this to work.
-      expect(history_file).to exist if RUBY_VERSION < "2.7"
+      # expect(history_file).to exist
     end
   end
 end

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -30,17 +30,6 @@ describe Homebrew::Diagnostic::Checks do
       .to match("Xcode alone is not sufficient on El Capitan")
   end
 
-  specify "#check_ruby_version" do
-    macos_version = MacOSVersion.new("10.12")
-    allow(OS::Mac).to receive(:version).and_return(macos_version)
-    allow(OS::Mac).to receive(:full_version).and_return(macos_version)
-    stub_const("RUBY_VERSION", "1.8.6")
-    ENV["HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH"] = "1"
-
-    expect(checks.check_ruby_version)
-      .to match "Ruby version 1.8.6 is unsupported on macOS 10.12"
-  end
-
   describe "#check_if_supported_sdk_available" do
     let(:macos_version) { MacOSVersion.new("11") }
 

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -18,6 +18,10 @@ test_ruby() {
     "${HOMEBREW_REQUIRED_RUBY_VERSION}" 2>/dev/null
 }
 
+system_ruby_supported() {
+  ([[ -z "${HOMEBREW_MACOS}" ]] || can_use_ruby_from_path)
+}
+
 can_use_ruby_from_path() {
   if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_TESTS}" ]] && [[ -n "${HOMEBREW_USE_RUBY_FROM_PATH}" ]]
   then
@@ -39,47 +43,37 @@ find_first_valid_ruby() {
   done
 }
 
-# HOMEBREW_MACOS is set by brew.sh
 # HOMEBREW_PATH is set by global.rb
 # shellcheck disable=SC2154
 find_ruby() {
-  if [[ -n "${HOMEBREW_MACOS}" ]] && ! can_use_ruby_from_path
+  local valid_ruby
+
+  # Prioritise rubies from the filtered path (/usr/bin etc) unless explicitly overridden.
+  if ! can_use_ruby_from_path
   then
-    echo "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
-  else
-    local valid_ruby
-
-    # Prioritise rubies from the filtered path (/usr/bin etc) unless explicitly overridden.
-    if ! can_use_ruby_from_path
-    then
-      # function which() is set by brew.sh
-      # it is aliased to `type -P`
-      # shellcheck disable=SC2230
-      valid_ruby=$(find_first_valid_ruby < <(which -a ruby))
-    fi
-
-    if [[ -z "${valid_ruby}" ]]
-    then
-      # Same as above
-      # shellcheck disable=SC2230
-      valid_ruby=$(find_first_valid_ruby < <(PATH="${HOMEBREW_PATH}" which -a ruby))
-    fi
-
-    echo "${valid_ruby}"
+    # function which() is set by brew.sh
+    # it is aliased to `type -P`
+    # shellcheck disable=SC2230
+    valid_ruby=$(find_first_valid_ruby < <(which -a ruby))
   fi
+
+  if [[ -z "${valid_ruby}" ]]
+  then
+    # Same as above
+    # shellcheck disable=SC2230
+    valid_ruby=$(find_first_valid_ruby < <(PATH="${HOMEBREW_PATH}" which -a ruby))
+  fi
+
+  echo "${valid_ruby}"
 }
 
 # HOMEBREW_FORCE_VENDOR_RUBY is from the user environment
-# HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH are set by brew.sh
 # shellcheck disable=SC2154
 need_vendored_ruby() {
   if [[ -n "${HOMEBREW_FORCE_VENDOR_RUBY}" ]]
   then
     return 0
-  elif [[ -n "${HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH}" ]] && ! can_use_ruby_from_path
-  then
-    return 1
-  elif ([[ -z "${HOMEBREW_MACOS}" ]] || can_use_ruby_from_path) && test_ruby "${HOMEBREW_RUBY_PATH}"
+  elif system_ruby_supported && test_ruby "${HOMEBREW_RUBY_PATH}"
   then
     return 1
   else
@@ -96,8 +90,6 @@ setup-ruby-path() {
   local vendor_ruby_terminfo
   local vendor_ruby_latest_version
   local vendor_ruby_current_version
-  # When bumping check if HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH (in brew.sh)
-  # also needs to be changed.
   local ruby_exec
   local upgrade_fail
   local install_fail
@@ -140,7 +132,11 @@ If there's no Homebrew Portable Ruby available for your processor:
       brew vendor-install ruby || odie "${upgrade_fail}"
     fi
   else
-    HOMEBREW_RUBY_PATH="$(find_ruby)"
+    if system_ruby_supported
+    then
+      HOMEBREW_RUBY_PATH="$(find_ruby)"
+    fi
+
     if need_vendored_ruby
     then
       brew vendor-install ruby || odie "${install_fail}"


### PR DESCRIPTION
Remove Ruby 2.6 & macOS system Ruby support code.

Separate from #16313 to reduce revert risk as reverting vendored gem changes can be problematic. The two PRs however can be merged at the same time.

Updating RuboCop's `TargetRubyVersion` will come later.