### PR TITLE
docs: remove `pip search` recommendation

### DIFF
--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -71,7 +71,7 @@ Some formulae provide Python bindings.
 
 ## Policy for non-brewed Python bindings
 
-These should be installed via `pip install <package>`. To discover, you can use `pip search` or <https://pypi.org>.
+These should be installed via `pip install <package>`. To discover, you can use <https://pypi.org/search>.
 
 **Note:** macOS's system Python does not provide `pip`. Follow the [pip documentation](https://pip.pypa.io/en/stable/installation/) to install it for your system Python if you would like it.
 


### PR DESCRIPTION
This is no longer supported and will just error with:
```
ERROR: XMLRPC request failed [code: -32500]
RuntimeError: PyPI no longer supports 'pip search' (or XML-RPC search).
Please use https://pypi.org/search (via a browser) instead. See
https://warehouse.pypa.io/api-reference/xml-rpc.html#deprecated-methods
for more information.
```

Also use same URL that error message recommends.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
