### PR TITLE
Cask#full_name: properly output Homebrew org names

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -793,7 +793,7 @@ module Cask
 
     sig { void }
     def audit_cask_path
-      return if cask.tap != "homebrew/cask"
+      return unless cask.tap.core_cask_tap?
 
       expected_path = cask.tap.new_cask_path(cask.token)
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -122,7 +122,7 @@ module Cask
 
     def full_name
       return token if tap.nil?
-      return token if tap.user == "Homebrew"
+      return token if tap.core_cask_tap?
 
       "#{tap.name}/#{token}"
     end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -73,8 +73,8 @@ module Homebrew
       other_taps = {}
       formulae_and_casks_to_check.each do |formula_or_cask|
         next if formula_or_cask.tap.blank?
-        next if formula_or_cask.tap.name == CoreTap.instance.name
-        next if formula_or_cask.tap.name == "homebrew/cask"
+        next if formula_or_cask.tap.core_tap?
+        next if formula_or_cask.tap.core_cask_tap?
         next if other_taps[formula_or_cask.tap.name]
 
         other_taps[formula_or_cask.tap.name] = formula_or_cask.tap

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -307,7 +307,7 @@ describe Cask::Audit, :cask do
         let(:cask_token) { "token-beta" }
 
         it "fails if the cask is from an official tap" do
-          allow(cask).to receive(:tap).and_return(Tap.fetch("homebrew/cask"))
+          allow(cask).to receive(:tap).and_return(CoreCaskTap.instance)
 
           expect(run).to error_with(/token contains version designation/)
         end
@@ -369,7 +369,7 @@ describe Cask::Audit, :cask do
 
       context "when cask token is in tap_migrations.json and" do
         let(:cask_token) { "token-migrated" }
-        let(:tap) { Tap.fetch("homebrew/cask") }
+        let(:tap) { CoreCaskTap.instance }
 
         before do
           allow(tap).to receive(:tap_migrations).and_return({ cask_token => "homebrew/core" })


### PR DESCRIPTION
This was not returning the full name correctly for e.g. anything in Homebrew/homebrew-fonts.

While we're here, fix up a few other places where `tap.core_cask_tap?` can be used more appropriately.