### PR TITLE
cmd/untap: fix untapping syntax failure.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1950,6 +1950,13 @@ class Formula
     end
   end
 
+  # An array of all currently installed formula names.
+  # @private
+  sig { returns(T::Array[String]) }
+  def self.installed_formula_names
+    racks.map(&:basename).map(&:to_s)
+  end
+
   # An array of all installed {Formula}
   # @private
   def self.installed


### PR DESCRIPTION
If an installed cask is invalid on attempting an untap: it will prevent untapping that cask.

Fix this in two ways: one more specific to `untap` and one more generally to other commands too:
- specific: only read the actual formulae/casks from the tap we're untapping instead of all of those that are installed
- general: rescue more exceptions in `Cask::Caskroom.casks` (like we already do for `Formula.installed`

Fixes https://github.com/Homebrew/brew/issues/16321