### PR TITLE
cmd/untap: be more careful about formula tap.

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -40,7 +40,9 @@ module Homebrew
             next
           end
 
-          formula if formula.any_version_installed?
+          # Can't use Formula#any_version_installed? because it doesn't consider
+          # taps correctly.
+          formula if formula.installed_kegs.any? { |keg| keg.tab.tap == tap }
         end.compact
 
         installed_cask_tokens = T.let(nil, T.nilable(T::Set[String]))


### PR DESCRIPTION
`Formula#any_version_installed?` doesn't consider taps so we need to manually check the tabs from the kegs instead.

See https://github.com/Homebrew/brew/pull/16330#issuecomment-1854007492 onwards for relevant discussion.