### PR TITLE
RuboCop autofixes for Ruby 3.1

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -94,7 +94,7 @@ module Homebrew
         end
 
         mtime = insecure_download ? Time.new(1970, 1, 1) : Time.now
-        FileUtils.touch(target, mtime: mtime) unless skip_download
+        FileUtils.touch(target, mtime:) unless skip_download
         JSON.parse(target.read)
       rescue JSON::ParserError
         target.unlink

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -84,7 +84,7 @@ module Homebrew
         def write_names(regenerate: false)
           download_and_cache_data! unless cache.key?("casks")
 
-          Homebrew::API.write_names_file(all_casks.keys, "cask", regenerate: regenerate)
+          Homebrew::API.write_names_file(all_casks.keys, "cask", regenerate:)
         end
       end
     end

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -93,7 +93,7 @@ module Homebrew
         def write_names_and_aliases(regenerate: false)
           download_and_cache_data! unless cache.key?("formulae")
 
-          return unless Homebrew::API.write_names_file(all_formulae.keys, "formula", regenerate: regenerate)
+          return unless Homebrew::API.write_names_file(all_formulae.keys, "formula", regenerate:)
 
           (HOMEBREW_CACHE_API/"formula_aliases.txt").open("w") do |file|
             all_aliases.each do |alias_name, real_name|

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -78,7 +78,7 @@ begin
   # - no arguments are passed
   if empty_argv || help_flag
     require "help"
-    Homebrew::Help.help cmd, remaining_args: args.remaining, empty_argv: empty_argv
+    Homebrew::Help.help cmd, remaining_args: args.remaining, empty_argv:
     # `Homebrew::Help.help` never returns, except for unknown commands.
   end
 

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -80,7 +80,7 @@ class Build
       ENV.deps = formula_deps
       ENV.run_time_deps = run_time_deps
       ENV.setup_build_environment(
-        formula:       formula,
+        formula:,
         cc:            args.cc,
         build_bottle:  args.build_bottle?,
         bottle_arch:   args.bottle_arch,
@@ -94,7 +94,7 @@ class Build
       deps.each(&:modify_build_environment)
     else
       ENV.setup_build_environment(
-        formula:       formula,
+        formula:,
         cc:            args.cc,
         build_bottle:  args.build_bottle?,
         bottle_arch:   args.bottle_arch,
@@ -227,7 +227,7 @@ begin
 
   formula = args.named.to_formulae.first
   options = Options.create(args.flags_only)
-  build   = Build.new(formula, options, args: args)
+  build   = Build.new(formula, options, args:)
   build.install
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_hash = JSON.parse e.to_json

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -109,7 +109,7 @@ module Cask
             plist_status = command.run(
               "/bin/launchctl",
               args:         ["list", service],
-              sudo:         sudo,
+              sudo:,
               sudo_as_root: sudo,
               print_stderr: false,
             ).stdout
@@ -117,7 +117,7 @@ module Cask
               command.run!(
                 "/bin/launchctl",
                 args:         ["remove", service],
-                sudo:         sudo,
+                sudo:,
                 sudo_as_root: sudo,
               )
               sleep 1
@@ -129,7 +129,7 @@ module Cask
             paths.each { |elt| elt.prepend(Dir.home).freeze } unless sudo
             paths = paths.map { |elt| Pathname(elt) }.select(&:exist?)
             paths.each do |path|
-              command.run!("/bin/rm", args: ["-f", "--", path], sudo: sudo, sudo_as_root: sudo)
+              command.run!("/bin/rm", args: ["-f", "--", path], sudo:, sudo_as_root: sudo)
             end
             # undocumented and untested: pass a path to uninstall :launchctl
             next unless Pathname(service).exist?
@@ -137,13 +137,13 @@ module Cask
             command.run!(
               "/bin/launchctl",
               args:         ["unload", "-w", "--", service],
-              sudo:         sudo,
+              sudo:,
               sudo_as_root: sudo,
             )
             command.run!(
               "/bin/rm",
               args:         ["-f", "--", service],
-              sudo:         sudo,
+              sudo:,
               sudo_as_root: sudo,
             )
             sleep 1
@@ -502,13 +502,13 @@ module Cask
 
           # Directory counts as empty if it only contains a `.DS_Store`.
           if children.include?(ds_store = resolved_path/".DS_Store")
-            Utils.gain_permissions_remove(ds_store, command: command)
+            Utils.gain_permissions_remove(ds_store, command:)
             children.delete(ds_store)
           end
 
-          next false unless recursive_rmdir(*children, command: command)
+          next false unless recursive_rmdir(*children, command:)
 
-          Utils.gain_permissions_rmdir(resolved_path, command: command)
+          Utils.gain_permissions_rmdir(resolved_path, command:)
 
           true
         end

--- a/Library/Homebrew/cask/artifact/artifact.rb
+++ b/Library/Homebrew/cask/artifact/artifact.rb
@@ -34,7 +34,7 @@ module Cask
 
       sig { params(cask: Cask, source: T.any(String, Pathname), target: T.any(String, Pathname)).void }
       def initialize(cask, source, target:)
-        super(cask, source, target: target)
+        super(cask, source, target:)
       end
     end
   end

--- a/Library/Homebrew/cask/artifact/binary.rb
+++ b/Library/Homebrew/cask/artifact/binary.rb
@@ -10,7 +10,7 @@ module Cask
     # @api private
     class Binary < Symlinked
       def link(command: nil, **options)
-        super(command: command, **options)
+        super(command:, **options)
         return if source.executable?
 
         if source.writable?

--- a/Library/Homebrew/cask/artifact/installer.rb
+++ b/Library/Homebrew/cask/artifact/installer.rb
@@ -93,7 +93,7 @@ module Cask
       end
 
       def to_h
-        { path: path }.tap do |h|
+        { path: }.tap do |h|
           h[:args] = args unless is_a?(ManualInstaller)
         end
       end

--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -46,7 +46,7 @@ module Cask
               if target.parent.writable? && !force
                 target.rmdir
               else
-                Utils.gain_permissions_remove(target, command: command)
+                Utils.gain_permissions_remove(target, command:)
               end
             end
           else
@@ -55,7 +55,7 @@ module Cask
               same = command.run(
                 "/usr/bin/diff",
                 args:         ["--recursive", "--brief", source, target],
-                verbose:      verbose,
+                verbose:,
                 print_stdout: verbose,
               ).success?
 
@@ -76,22 +76,22 @@ module Cask
             raise CaskError, "#{message}." unless force
 
             opoo "#{message}; overwriting."
-            delete(target, force: force, command: command, **options)
+            delete(target, force:, command:, **options)
           end
         end
 
         ohai "Moving #{self.class.english_name} '#{source.basename}' to '#{target}'"
 
-        Utils.gain_permissions_mkpath(target.dirname, command: command) unless target.dirname.exist?
+        Utils.gain_permissions_mkpath(target.dirname, command:) unless target.dirname.exist?
 
-        if target.directory? && Quarantine.app_management_permissions_granted?(app: target, command: command)
+        if target.directory? && Quarantine.app_management_permissions_granted?(app: target, command:)
           if target.writable?
             source.children.each { |child| FileUtils.move(child, target/child.basename) }
           else
             command.run!("/bin/cp", args: ["-pR", *source.children, target],
                                     sudo: true)
           end
-          Quarantine.copy_xattrs(source, target, command: command)
+          Quarantine.copy_xattrs(source, target, command:)
           source.rmtree
         elsif target.dirname.writable?
           FileUtils.move(source, target)
@@ -109,7 +109,7 @@ module Cask
       def post_move(command)
         FileUtils.ln_sf target, source
 
-        add_altname_metadata(target, source.basename, command: command)
+        add_altname_metadata(target, source.basename, command:)
       end
 
       def matching_artifact?(cask)
@@ -129,7 +129,7 @@ module Cask
           raise CaskError, "#{message}." unless force
 
           opoo "#{message}; overwriting."
-          delete(source, force: force, command: command, **options)
+          delete(source, force:, command:, **options)
         end
 
         unless target.exist?
@@ -144,7 +144,7 @@ module Cask
         # We need to preserve extended attributes between copies.
         command.run!("/bin/cp", args: ["-pR", target, source], sudo: !source.parent.writable?)
 
-        delete(target, force: force, command: command, **options)
+        delete(target, force:, command:, **options)
       end
 
       def delete(target, force: false, successor: nil, command: nil, **_)
@@ -154,7 +154,7 @@ module Cask
         return unless Utils.path_occupied?(target)
 
         if target.directory? && matching_artifact?(successor) && Quarantine.app_management_permissions_granted?(
-          app: target, command: command,
+          app: target, command:,
         )
           # If an app folder is deleted, macOS considers the app uninstalled and removes some data.
           # Remove only the contents to handle this case.
@@ -162,13 +162,13 @@ module Cask
             if target.writable? && !force
               child.rmtree
             else
-              Utils.gain_permissions_remove(child, command: command)
+              Utils.gain_permissions_remove(child, command:)
             end
           end
         elsif target.parent.writable? && !force
           target.rmtree
         else
-          Utils.gain_permissions_remove(target, command: command)
+          Utils.gain_permissions_remove(target, command:)
         end
       end
     end

--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -65,9 +65,9 @@ module Cask
             "/usr/sbin/installer",
             sudo:         true,
             sudo_as_root: true,
-            args:         args,
+            args:,
             print_stdout: true,
-            env:          env,
+            env:,
           )
         end
       end

--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -57,30 +57,30 @@ module Cask
           if force && target.symlink? &&
              (target.realpath == source.realpath || target.realpath.to_s.start_with?("#{cask.caskroom_path}/"))
             opoo "#{message}; overwriting."
-            Utils.gain_permissions_remove(target, command: command)
+            Utils.gain_permissions_remove(target, command:)
           else
             raise CaskError, "#{message}."
           end
         end
 
         ohai "Linking #{self.class.english_name} '#{source.basename}' to '#{target}'"
-        create_filesystem_link(command: command)
+        create_filesystem_link(command:)
       end
 
       def unlink(command: nil, **)
         return unless target.symlink?
 
         ohai "Unlinking #{self.class.english_name} '#{target}'"
-        Utils.gain_permissions_remove(target, command: command)
+        Utils.gain_permissions_remove(target, command:)
       end
 
       def create_filesystem_link(command: nil)
-        Utils.gain_permissions_mkpath(target.dirname, command: command)
+        Utils.gain_permissions_mkpath(target.dirname, command:)
 
         command.run! "/bin/ln", args: ["-h", "-f", "-s", "--", source, target],
                                 sudo: !target.dirname.writable?
 
-        add_altname_metadata(source, target.basename, command: command)
+        add_altname_metadata(source, target.basename, command:)
       end
     end
   end

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -39,7 +39,7 @@ module Cask
       download = online || signing if download.nil?
 
       @cask = cask
-      @download = Download.new(cask, quarantine: quarantine) if download
+      @download = Download.new(cask, quarantine:) if download
       @online = online
       @strict = strict
       @signing = signing
@@ -93,7 +93,7 @@ module Cask
       # Only raise non-critical audits if the user specified `--strict`.
       return if strict_only && !@strict
 
-      errors << ({ message: message, location: location, corrected: false })
+      errors << ({ message:, location:, corrected: false })
     end
 
     def result
@@ -661,7 +661,7 @@ module Cask
 
       tag = SharedAudits.github_tag_from_url(cask.url)
       tag ||= cask.version
-      error = SharedAudits.github_release(user, repo, tag, cask: cask)
+      error = SharedAudits.github_release(user, repo, tag, cask:)
       add_error error, location: cask.url.location if error
     end
 
@@ -676,7 +676,7 @@ module Cask
 
       tag = SharedAudits.gitlab_tag_from_url(cask.url)
       tag ||= cask.version
-      error = SharedAudits.gitlab_release(user, repo, tag, cask: cask)
+      error = SharedAudits.gitlab_release(user, repo, tag, cask:)
       add_error error, location: cask.url.location if error
     end
 
@@ -814,7 +814,7 @@ module Cask
         add_error problem, location: location unless exception
       elsif exception
         add_error "#{url_to_check} is in the secure connection audit skiplist but does not need to be skipped",
-                  location: location
+                  location:
       end
     end
 

--- a/Library/Homebrew/cask/auditor.rb
+++ b/Library/Homebrew/cask/auditor.rb
@@ -85,7 +85,7 @@ module Cask
 
     def audit_languages(languages)
       original_config = cask.config
-      localized_config = original_config.merge(Config.new(explicit: { languages: languages }))
+      localized_config = original_config.merge(Config.new(explicit: { languages: }))
       cask.config = localized_config
 
       audit_cask_instance(cask)

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -112,7 +112,7 @@ module Cask
     def timestamped_versions(caskroom_path: self.caskroom_path)
       relative_paths = Pathname.glob(metadata_timestamped_path(
                                        version: "*", timestamp: "*",
-                                       caskroom_path: caskroom_path
+                                       caskroom_path:
                                      ))
                                .map { |p| p.relative_path_from(p.parent.parent) }
       # Sorbet is unaware that Pathname is sortable: https://github.com/sorbet/sorbet/issues/6844
@@ -211,8 +211,8 @@ module Cask
     end
 
     def outdated?(greedy: false, greedy_latest: false, greedy_auto_updates: false)
-      !outdated_version(greedy: greedy, greedy_latest: greedy_latest,
-                        greedy_auto_updates: greedy_auto_updates).nil?
+      !outdated_version(greedy:, greedy_latest:,
+                        greedy_auto_updates:).nil?
     end
 
     def outdated_version(greedy: false, greedy_latest: false, greedy_auto_updates: false)
@@ -236,8 +236,8 @@ module Cask
     def outdated_info(greedy, verbose, json, greedy_latest, greedy_auto_updates)
       return token if !verbose && !json
 
-      installed_version = outdated_version(greedy: greedy, greedy_latest: greedy_latest,
-                                           greedy_auto_updates: greedy_auto_updates).to_s
+      installed_version = outdated_version(greedy:, greedy_latest:,
+                                           greedy_auto_updates:).to_s
 
       if json
         {
@@ -351,10 +351,10 @@ module Cask
       if @dsl.on_system_blocks_exist?
         begin
           MacOSVersion::SYMBOLS.keys.product(OnSystem::ARCH_OPTIONS).each do |os, arch|
-            bottle_tag = ::Utils::Bottles::Tag.new(system: os, arch: arch)
+            bottle_tag = ::Utils::Bottles::Tag.new(system: os, arch:)
             next unless bottle_tag.valid_combination?
 
-            Homebrew::SimulateSystem.with os: os, arch: arch do
+            Homebrew::SimulateSystem.with(os:, arch:) do
               refresh
 
               to_h.each do |key, value|

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -43,7 +43,7 @@ module Cask
         ).returns(Cask)
       }
       def cask(header_token, **options, &block)
-        Cask.new(header_token, source: content, tap: tap, **options, config: @config, &block)
+        Cask.new(header_token, source: content, tap:, **options, config: @config, &block)
       end
     end
 
@@ -108,7 +108,7 @@ module Cask
         @config = config
 
         if path.extname == ".json"
-          return FromAPILoader.new(token, from_json: JSON.parse(@content)).load(config: config)
+          return FromAPILoader.new(token, from_json: JSON.parse(@content)).load(config:)
         end
 
         begin
@@ -255,7 +255,7 @@ module Cask
         cask_options = {
           loaded_from_api: true,
           source:          JSON.pretty_generate(json_cask),
-          config:          config,
+          config:,
           loader:          self,
         }
 
@@ -410,7 +410,7 @@ module Cask
     end
 
     def self.load(ref, config: nil, warn: true)
-      self.for(ref, warn: warn).load(config: config)
+      self.for(ref, warn:).load(config:)
     end
 
     def self.for(ref, need_path: false, warn: true)
@@ -430,7 +430,7 @@ module Cask
         end
       end
 
-      case (possible_tap_casks = tap_paths(ref, warn: warn)).count
+      case (possible_tap_casks = tap_paths(ref, warn:)).count
       when 1
         return FromTapPathLoader.new(possible_tap_casks.first)
       when 2..Float::INFINITY

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -44,19 +44,19 @@ module Cask
              "We'll set permissions properly so we won't need sudo in the future."
       end
 
-      SystemCommand.run("/bin/mkdir", args: ["-p", path], sudo: sudo)
-      SystemCommand.run("/bin/chmod", args: ["g+rwx", path], sudo: sudo)
-      SystemCommand.run("/usr/sbin/chown", args: [User.current, path], sudo: sudo)
-      SystemCommand.run("/usr/bin/chgrp", args: ["admin", path], sudo: sudo)
+      SystemCommand.run("/bin/mkdir", args: ["-p", path], sudo:)
+      SystemCommand.run("/bin/chmod", args: ["g+rwx", path], sudo:)
+      SystemCommand.run("/usr/sbin/chown", args: [User.current, path], sudo:)
+      SystemCommand.run("/usr/bin/chgrp", args: ["admin", path], sudo:)
     end
 
     sig { params(config: T.nilable(Config)).returns(T::Array[Cask]) }
     def self.casks(config: nil)
       tokens.sort.map do |token|
-        CaskLoader.load(token, config: config)
+        CaskLoader.load(token, config:)
       rescue TapCaskAmbiguityError
         tap_path = CaskLoader.tap_paths(token).first
-        CaskLoader::FromTapPathLoader.new(tap_path).load(config: config)
+        CaskLoader::FromTapPathLoader.new(tap_path).load(config:)
       rescue
         # Don't blow up because of a single unavailable cask.
         nil

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -65,7 +65,7 @@ module Cask
         default:             config.fetch("default",  {}),
         env:                 config.fetch("env",      {}),
         explicit:            config.fetch("explicit", {}),
-        ignore_invalid_keys: ignore_invalid_keys,
+        ignore_invalid_keys:,
       )
     end
 
@@ -198,9 +198,9 @@ module Cask
     sig { params(options: T.untyped).returns(String) }
     def to_json(*options)
       {
-        default:  default,
-        env:      env,
-        explicit: explicit,
+        default:,
+        env:,
+        explicit:,
       }.to_json(*options)
     end
   end

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -52,7 +52,7 @@ module Cask
       downloader.quiet! if quiet
 
       begin
-        super(verify_download_integrity: false, timeout: timeout)
+        super(verify_download_integrity: false, timeout:)
       rescue DownloadError => e
         error = CaskError.new("Download failed on Cask '#{cask}' with message: #{e.cause}")
         error.set_backtrace e.backtrace
@@ -68,7 +68,7 @@ module Cask
     def time_file_size(timeout: nil)
       raise ArgumentError, "not supported for this download strategy" unless downloader.is_a?(CurlDownloadStrategy)
 
-      T.cast(downloader, CurlDownloadStrategy).resolved_time_file_size(timeout: timeout)
+      T.cast(downloader, CurlDownloadStrategy).resolved_time_file_size(timeout:)
     end
 
     def basename

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -201,9 +201,9 @@ module Cask
 
       set_unique_stanza(:url, args.empty? && options.empty? && !block) do
         if block
-          URL.new(*args, **options, caller_location: caller_location, dsl: self, &block)
+          URL.new(*args, **options, caller_location:, dsl: self, &block)
         else
-          URL.new(*args, **options, caller_location: caller_location)
+          URL.new(*args, **options, caller_location:)
         end
       end
     end
@@ -241,7 +241,7 @@ module Cask
       set_unique_stanza(:sha256, should_return) do
         @on_system_blocks_exist = true if arm.present? || intel.present?
 
-        val = arg || on_arch_conditional(arm: arm, intel: intel)
+        val = arg || on_arch_conditional(arm:, intel:)
         case val
         when :no_check
           val
@@ -260,7 +260,7 @@ module Cask
       set_unique_stanza(:arch, should_return) do
         @on_system_blocks_exist = true
 
-        on_arch_conditional(arm: arm, intel: intel)
+        on_arch_conditional(arm:, intel:)
       end
     end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -345,7 +345,7 @@ module Cask
       define_method(klass.dsl_key) do |*args, **kwargs|
         T.bind(self, DSL)
         if [*artifacts.map(&:class), klass].include?(Artifact::StageOnly) &&
-           (artifacts.map(&:class) & ACTIVATABLE_ARTIFACT_CLASSES).any?
+           artifacts.map(&:class).intersect?(ACTIVATABLE_ARTIFACT_CLASSES)
           raise CaskInvalidError.new(cask, "'stage_only' must be the only activatable artifact.")
         end
 

--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -13,11 +13,11 @@ module Cask
         "_" => :underscores,
       }.freeze
 
-      DIVIDER_REGEX = /(#{DIVIDERS.keys.map { |v| Regexp.quote(v) }.join("|")})/.freeze
+      DIVIDER_REGEX = /(#{DIVIDERS.keys.map { |v| Regexp.quote(v) }.join("|")})/
 
-      MAJOR_MINOR_PATCH_REGEX = /^([^.,:]+)(?:.([^.,:]+)(?:.([^.,:]+))?)?/.freeze
+      MAJOR_MINOR_PATCH_REGEX = /^([^.,:]+)(?:.([^.,:]+)(?:.([^.,:]+))?)?/
 
-      INVALID_CHARACTERS = /[^0-9a-zA-Z.,:\-_+ ]/.freeze
+      INVALID_CHARACTERS = /[^0-9a-zA-Z.,:\-_+ ]/
 
       class << self
         private

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -67,7 +67,7 @@ module Cask
       verify_has_sha if require_sha? && !force?
       check_requirements
 
-      download(quiet: quiet, timeout: timeout)
+      download(quiet:, timeout:)
 
       satisfy_cask_and_formula_dependencies
     end
@@ -107,7 +107,7 @@ module Cask
 
       @cask.config = @cask.default_config.merge(old_config)
 
-      install_artifacts(predecessor: predecessor)
+      install_artifacts(predecessor:)
 
       if (tap = @cask.tap) && tap.should_report_analytics?
         ::Utils::Analytics.report_event(:cask_install, package_name: @cask.token, tap_name: tap.name,
@@ -164,8 +164,8 @@ on_request: true)
     sig { params(quiet: T.nilable(T::Boolean), timeout: T.nilable(T.any(Integer, Float))).returns(Pathname) }
     def download(quiet: nil, timeout: nil)
       # Store cask download path in cask to prevent multiple downloads in a row when checking if it's outdated
-      @cask.download ||= downloader.fetch(quiet: quiet, verify_download_integrity: @verify_download_integrity,
-                                          timeout: timeout)
+      @cask.download ||= downloader.fetch(quiet:, verify_download_integrity: @verify_download_integrity,
+                                          timeout:)
     end
 
     def verify_has_sha
@@ -195,21 +195,21 @@ on_request: true)
       if (nested_container = @cask.container&.nested)
         Dir.mktmpdir do |tmpdir|
           tmpdir = Pathname(tmpdir)
-          primary_container.extract(to: tmpdir, basename: basename, verbose: verbose?)
+          primary_container.extract(to: tmpdir, basename:, verbose: verbose?)
 
           FileUtils.chmod_R "+rw", tmpdir/nested_container, force: true, verbose: verbose?
 
           UnpackStrategy.detect(tmpdir/nested_container, merge_xattrs: true)
-                        .extract_nestedly(to: to, verbose: verbose?)
+                        .extract_nestedly(to:, verbose: verbose?)
         end
       else
-        primary_container.extract_nestedly(to: to, basename: basename, verbose: verbose?)
+        primary_container.extract_nestedly(to:, basename:, verbose: verbose?)
       end
 
       return unless quarantine?
       return unless Quarantine.available?
 
-      Quarantine.propagate(from: primary_container.path, to: to)
+      Quarantine.propagate(from: primary_container.path, to:)
     end
 
     sig { params(predecessor: T.nilable(Cask)).void }
@@ -227,7 +227,7 @@ on_request: true)
         next if artifact.is_a?(Artifact::Binary) && !binaries?
 
         artifact.install_phase(
-          command: @command, verbose: verbose?, adopt: adopt?, force: force?, predecessor: predecessor,
+          command: @command, verbose: verbose?, adopt: adopt?, force: force?, predecessor:,
         )
         already_installed_artifacts.unshift(artifact)
       end
@@ -387,7 +387,7 @@ on_request: true)
     def uninstall(successor: nil)
       load_installed_caskfile!
       oh1 "Uninstalling Cask #{Formatter.identifier(@cask)}"
-      uninstall_artifacts(clear: true, successor: successor)
+      uninstall_artifacts(clear: true, successor:)
       if !reinstall? && !upgrade?
         remove_download_sha
         remove_config_file
@@ -408,7 +408,7 @@ on_request: true)
 
     sig { params(successor: T.nilable(Cask)).void }
     def start_upgrade(successor:)
-      uninstall_artifacts(successor: successor)
+      uninstall_artifacts(successor:)
       backup
     end
 
@@ -431,7 +431,7 @@ on_request: true)
     def revert_upgrade(predecessor:)
       opoo "Reverting upgrade for Cask #{@cask}"
       restore_backup
-      install_artifacts(predecessor: predecessor)
+      install_artifacts(predecessor:)
     end
 
     def finalize_upgrade
@@ -457,7 +457,7 @@ on_request: true)
             verbose:   verbose?,
             skip:      clear,
             force:     force?,
-            successor: successor,
+            successor:,
           )
         end
 
@@ -469,7 +469,7 @@ on_request: true)
           verbose:   verbose?,
           skip:      clear,
           force:     force?,
-          successor: successor,
+          successor:,
         )
       end
     end

--- a/Library/Homebrew/cask/metadata.rb
+++ b/Library/Homebrew/cask/metadata.rb
@@ -18,7 +18,7 @@ module Cask
 
       raise CaskError, "Cannot create metadata path with empty version." if cask_version.empty?
 
-      metadata_main_container_path(caskroom_path: caskroom_path).join(cask_version)
+      metadata_main_container_path(caskroom_path:).join(cask_version)
     end
 
     def metadata_timestamped_path(version: self.version, timestamp: :latest, create: false,
@@ -26,10 +26,10 @@ module Cask
       raise CaskError, "Cannot create metadata path when timestamp is :latest." if create && timestamp == :latest
 
       path = if timestamp == :latest
-        Pathname.glob(metadata_versioned_path(version: version, caskroom_path: caskroom_path).join("*")).max
+        Pathname.glob(metadata_versioned_path(version:, caskroom_path:).join("*")).max
       else
         timestamp = new_timestamp if timestamp == :now
-        metadata_versioned_path(version: version, caskroom_path: caskroom_path).join(timestamp)
+        metadata_versioned_path(version:, caskroom_path:).join(timestamp)
       end
 
       if create && !path.directory?
@@ -45,8 +45,8 @@ module Cask
       raise CaskError, "Cannot create metadata subdir when timestamp is :latest." if create && timestamp == :latest
       raise CaskError, "Cannot create metadata subdir for empty leaf." if !leaf.respond_to?(:empty?) || leaf.empty?
 
-      parent = metadata_timestamped_path(version: version, timestamp: timestamp, create: create,
-                                         caskroom_path: caskroom_path)
+      parent = metadata_timestamped_path(version:, timestamp:, create:,
+                                         caskroom_path:)
 
       return if parent.nil?
 

--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -27,7 +27,7 @@ module Cask
       return if new_cask.token == old_cask.token
 
       migrator = new(old_cask, new_cask)
-      migrator.migrate(dry_run: dry_run)
+      migrator.migrate(dry_run:)
     end
 
     sig { params(dry_run: T::Boolean).void }

--- a/Library/Homebrew/cask/reinstall.rb
+++ b/Library/Homebrew/cask/reinstall.rb
@@ -21,14 +21,14 @@ module Cask
 
       casks.each do |cask|
         Installer.new(cask,
-                      binaries:       binaries,
-                      verbose:        verbose,
-                      force:          force,
-                      skip_cask_deps: skip_cask_deps,
-                      require_sha:    require_sha,
+                      binaries:,
+                      verbose:,
+                      force:,
+                      skip_cask_deps:,
+                      require_sha:,
                       reinstall:      true,
-                      quarantine:     quarantine,
-                      zap:            zap).install
+                      quarantine:,
+                      zap:).install
       end
     end
   end

--- a/Library/Homebrew/cask/uninstall.rb
+++ b/Library/Homebrew/cask/uninstall.rb
@@ -12,7 +12,7 @@ module Cask
 
         raise CaskNotInstalledError, cask if !cask.installed? && !force
 
-        Installer.new(cask, binaries: binaries, force: force, verbose: verbose).uninstall
+        Installer.new(cask, binaries:, force:, verbose:).uninstall
       end
     end
   end

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -44,8 +44,8 @@ module Cask
 
       outdated_casks = if casks.empty?
         Caskroom.casks(config: Config.from_args(args)).select do |cask|
-          cask.outdated?(greedy: greedy, greedy_latest: greedy_latest,
-                         greedy_auto_updates: greedy_auto_updates)
+          cask.outdated?(greedy:, greedy_latest:,
+                         greedy_auto_updates:)
         end
       else
         casks.select do |cask|
@@ -113,8 +113,8 @@ module Cask
       upgradable_casks.each do |(old_cask, new_cask)|
         upgrade_cask(
           old_cask, new_cask,
-          binaries: binaries, force: force, skip_cask_deps: skip_cask_deps, verbose: verbose,
-          quarantine: quarantine, require_sha: require_sha
+          binaries:, force:, skip_cask_deps:, verbose:,
+          quarantine:, require_sha:
         )
       rescue => e
         new_exception = e.exception("#{new_cask.full_name}: #{e}")
@@ -153,9 +153,9 @@ module Cask
       old_config = old_cask.config
 
       old_options = {
-        binaries: binaries,
-        verbose:  verbose,
-        force:    force,
+        binaries:,
+        verbose:,
+        force:,
         upgrade:  true,
       }.compact
 
@@ -165,13 +165,13 @@ module Cask
       new_cask.config = new_cask.default_config.merge(old_config)
 
       new_options = {
-        binaries:       binaries,
-        verbose:        verbose,
-        force:          force,
-        skip_cask_deps: skip_cask_deps,
-        require_sha:    require_sha,
+        binaries:,
+        verbose:,
+        force:,
+        skip_cask_deps:,
+        require_sha:,
         upgrade:        true,
-        quarantine:     quarantine,
+        quarantine:,
       }.compact
 
       new_cask_installer =

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -191,26 +191,26 @@ module Cask
       super(
         if block
           LazyObject.new do
-            uri2, options = *BlockDSL.new(uri, dsl: dsl, &block).call
+            uri2, options = *BlockDSL.new(uri, dsl:, &block).call
             options ||= {}
             DSL.new(uri2, **options)
           end
         else
           DSL.new(
             T.must(uri),
-            verified:   verified,
-            using:      using,
-            tag:        tag,
-            branch:     branch,
-            revisions:  revisions,
-            revision:   revision,
-            trust_cert: trust_cert,
-            cookies:    cookies,
-            referer:    referer,
-            header:     header,
-            user_agent: user_agent,
-            data:       data,
-            only_path:  only_path,
+            verified:,
+            using:,
+            tag:,
+            branch:,
+            revisions:,
+            revision:,
+            trust_cert:,
+            cookies:,
+            referer:,
+            header:,
+            user_agent:,
+            data:,
+            only_path:,
           )
         end
       )

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -231,7 +231,7 @@ module Homebrew
       return false if no_cleanup_formula.blank?
 
       @skip_clean_formulae ||= no_cleanup_formula.split(",")
-      @skip_clean_formulae.include?(formula.name) || (@skip_clean_formulae & formula.aliases).present?
+      @skip_clean_formulae.include?(formula.name) || @skip_clean_formulae.intersect?(formula.aliases)
     end
 
     def self.periodic_clean_due?

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -268,7 +268,7 @@ module Homebrew
                .sort_by(&:name)
                .reject { |f| Cleanup.skip_clean_formula?(f) }
                .each do |formula|
-          cleanup_formula(formula, quiet: quiet, ds_store: false, cache_db: false)
+          cleanup_formula(formula, quiet:, ds_store: false, cache_db: false)
         end
 
         Cleanup.autoremove(dry_run: dry_run?) if Homebrew::EnvConfig.autoremove?
@@ -325,16 +325,16 @@ module Homebrew
     end
 
     def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true)
-      formula.eligible_kegs_for_cleanup(quiet: quiet)
+      formula.eligible_kegs_for_cleanup(quiet:)
              .each(&method(:cleanup_keg))
-      cleanup_cache(Pathname.glob(cache/"#{formula.name}--*").map { |path| { path: path, type: nil } })
+      cleanup_cache(Pathname.glob(cache/"#{formula.name}--*").map { |path| { path:, type: nil } })
       rm_ds_store([formula.rack]) if ds_store
       cleanup_cache_db(formula.rack) if cache_db
       cleanup_lockfiles(FormulaLock.new(formula.name).path)
     end
 
     def cleanup_cask(cask, ds_store: true)
-      cleanup_cache(Pathname.glob(cache/"Cask/#{cask.token}--*").map { |path| { path: path, type: :cask } })
+      cleanup_cache(Pathname.glob(cache/"Cask/#{cask.token}--*").map { |path| { path:, type: :cask } })
       rm_ds_store([cask.caskroom_path]) if ds_store
       cleanup_lockfiles(CaskLock.new(cask.token).path)
     end
@@ -362,10 +362,10 @@ module Homebrew
       api_source_files = (cache/"api-source").glob("*/*/*/*/*") # org/repo/git_head/type/file.rb
       gh_actions_artifacts = (cache/"gh-actions-artifact").directory? ? (cache/"gh-actions-artifact").children : []
 
-      files.map { |path| { path: path, type: nil } } +
-        cask_files.map { |path| { path: path, type: :cask } } +
-        api_source_files.map { |path| { path: path, type: :api_source } } +
-        gh_actions_artifacts.map { |path| { path: path, type: :gh_actions_artifact } }
+      files.map { |path| { path:, type: nil } } +
+        cask_files.map { |path| { path:, type: :cask } } +
+        api_source_files.map { |path| { path:, type: :api_source } } +
+        gh_actions_artifacts.map { |path| { path:, type: :gh_actions_artifact } }
     end
 
     def cleanup_empty_api_source_directories(directory = cache/"api-source")

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -40,8 +40,8 @@ module Homebrew
         self[:named] = NamedArgs.new(
           *named_args.freeze,
           parent:       self,
-          cask_options: cask_options,
-          without_api:  without_api,
+          cask_options:,
+          without_api:,
           **options,
         )
       end
@@ -131,7 +131,7 @@ module Homebrew
 
         oses.product(arches).select do |os, arch|
           if skip_invalid_combinations
-            bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
+            bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
             bottle_tag.valid_combination?
           else
             true

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -79,8 +79,8 @@ module Homebrew
       )
         @to_formulae_and_casks ||= {}
         @to_formulae_and_casks[only] ||= downcased_unique_named.flat_map do |name|
-          options = { warn: warn }.compact
-          load_formula_or_cask(name, only: only, method: method, **options)
+          options = { warn: }.compact
+          load_formula_or_cask(name, only:, method:, **options)
         rescue FormulaUnreadableError, FormulaClassUnavailableError,
                TapFormulaUnreadableError, TapFormulaClassUnavailableError,
                Cask::CaskUnreadableError
@@ -100,7 +100,7 @@ module Homebrew
 
       def to_formulae_to_casks(only: parent&.only_formula_or_cask, method: nil)
         @to_formulae_to_casks ||= {}
-        @to_formulae_to_casks[[method, only]] = to_formulae_and_casks(only: only, method: method)
+        @to_formulae_to_casks[[method, only]] = to_formulae_and_casks(only:, method:)
                                                 .partition { |o| o.is_a?(Formula) || o.is_a?(Keg) }
                                                 .map(&:freeze).freeze
       end
@@ -108,7 +108,7 @@ module Homebrew
       def to_formulae_and_casks_and_unavailable(only: parent&.only_formula_or_cask, method: nil)
         @to_formulae_casks_unknowns ||= {}
         @to_formulae_casks_unknowns[method] = downcased_unique_named.map do |name|
-          load_formula_or_cask(name, only: only, method: method)
+          load_formula_or_cask(name, only:, method:)
         rescue FormulaOrCaskUnavailableError => e
           e
         end.uniq.freeze
@@ -122,7 +122,7 @@ module Homebrew
             begin
               formula = case method
               when nil, :factory
-                options = { warn: warn, force_bottle: @force_bottle, flags: @flags }.compact
+                options = { warn:, force_bottle: @force_bottle, flags: @flags }.compact
                 Formulary.factory(name, *@override_spec, **options)
               when :resolve
                 resolve_formula(name)
@@ -155,8 +155,8 @@ module Homebrew
 
             begin
               config = Cask::Config.from_args(@parent) if @cask_options
-              options = { warn: warn }.compact
-              cask = Cask::CaskLoader.load(name, config: config, **options)
+              options = { warn: }.compact
+              cask = Cask::CaskLoader.load(name, config:, **options)
 
               if unreadable_error.present?
                 onoe <<~EOS
@@ -177,8 +177,8 @@ module Homebrew
               # If we're trying to get a keg-like Cask, do our best to handle it
               # not being readable and return something that can be used.
               if want_keg_like_cask
-                cask_version = Cask::Cask.new(name, config: config).installed_version
-                cask = Cask::Cask.new(name, config: config) do
+                cask_version = Cask::Cask.new(name, config:).installed_version
+                cask = Cask::Cask.new(name, config:) do
                   version cask_version if cask_version
                 end
                 return cask
@@ -214,12 +214,12 @@ module Homebrew
 
       sig { params(uniq: T::Boolean).returns(T::Array[Formula]) }
       def to_resolved_formulae(uniq: true)
-        @to_resolved_formulae ||= to_formulae_and_casks(only: :formula, method: :resolve, uniq: uniq)
+        @to_resolved_formulae ||= to_formulae_and_casks(only: :formula, method: :resolve, uniq:)
                                   .freeze
       end
 
       def to_resolved_formulae_to_casks(only: parent&.only_formula_or_cask)
-        to_formulae_to_casks(only: only, method: :resolve)
+        to_formulae_to_casks(only:, method: :resolve)
       end
 
       LOCAL_PATH_REGEX = %r{^/|[.]|/$}.freeze
@@ -314,7 +314,7 @@ module Homebrew
         method = all_kegs ? :kegs : :default_kegs
         @to_kegs_to_casks ||= {}
         @to_kegs_to_casks[method] ||=
-          to_formulae_and_casks(only: only, ignore_unavailable: ignore_unavailable, method: method)
+          to_formulae_and_casks(only:, ignore_unavailable:, method:)
           .partition { |o| o.is_a?(Keg) }
           .map(&:freeze).freeze
       end

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -222,8 +222,8 @@ module Homebrew
         to_formulae_to_casks(only:, method: :resolve)
       end
 
-      LOCAL_PATH_REGEX = %r{^/|[.]|/$}.freeze
-      TAP_NAME_REGEX = %r{^[^./]+/[^./]+$}.freeze
+      LOCAL_PATH_REGEX = %r{^/|[.]|/$}
+      TAP_NAME_REGEX = %r{^[^./]+/[^./]+$}
       private_constant :LOCAL_PATH_REGEX, :TAP_NAME_REGEX
 
       # Keep existing paths and try to convert others to tap, formula or cask paths.

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -159,8 +159,8 @@ module Homebrew
         global_switch = names.first.is_a?(Symbol)
         return if global_switch
 
-        description = option_description(description, *names, hidden: hidden)
-        process_option(*names, description, type: :switch, hidden: hidden) unless disable
+        description = option_description(description, *names, hidden:)
+        process_option(*names, description, type: :switch, hidden:) unless disable
 
         if replacement || disable
           description += " (#{disable ? "disabled" : "deprecated"}#{"; replaced by #{replacement}" if replacement})"
@@ -171,11 +171,11 @@ module Homebrew
           odeprecated "the `#{names.first}` switch", replacement, disable: disable if !replacement.nil? || disable
           value = true if names.none? { |name| name.start_with?("--[no-]") }
 
-          set_switch(*names, value: value, from: :args)
+          set_switch(*names, value:, from: :args)
         end
 
         names.each do |name|
-          set_constraints(name, depends_on: depends_on)
+          set_constraints(name, depends_on:)
         end
 
         env_value = value_for_env(env)
@@ -211,8 +211,8 @@ module Homebrew
 
       def comma_array(name, description: nil, hidden: false)
         name = name.chomp "="
-        description = option_description(description, name, hidden: hidden)
-        process_option(name, description, type: :comma_array, hidden: hidden)
+        description = option_description(description, name, hidden:)
+        process_option(name, description, type: :comma_array, hidden:)
         @parser.on(name, OptionParser::REQUIRED_ARGUMENT, Array, *wrap_option_desc(description)) do |list|
           @args[option_to_name(name)] = list
         end
@@ -225,9 +225,9 @@ module Homebrew
           [OptionParser::OPTIONAL_ARGUMENT, :optional_flag]
         end
         names.map! { |name| name.chomp "=" }
-        description = option_description(description, *names, hidden: hidden)
+        description = option_description(description, *names, hidden:)
         if replacement.nil?
-          process_option(*names, description, type: flag_type, hidden: hidden)
+          process_option(*names, description, type: flag_type, hidden:)
         else
           description += " (disabled#{"; replaced by #{replacement}" if replacement.present?})"
         end
@@ -240,7 +240,7 @@ module Homebrew
         end
 
         names.each do |name|
-          set_constraints(name, depends_on: depends_on)
+          set_constraints(name, depends_on:)
         end
       end
 
@@ -329,9 +329,9 @@ module Homebrew
               name = o.flag
               description = "`#{f.name}`: #{o.description}"
               if name.end_with? "="
-                flag   name, description: description
+                flag(name, description:)
               else
-                switch name, description: description
+                switch name, description:
               end
 
               conflicts "--cask", name
@@ -339,7 +339,7 @@ module Homebrew
           end
         end
 
-        remaining, non_options = parse_remaining(argv, ignore_invalid_options: ignore_invalid_options)
+        remaining, non_options = parse_remaining(argv, ignore_invalid_options:)
 
         named_args = if ignore_invalid_options
           []
@@ -601,11 +601,11 @@ module Homebrew
 
         exception = if @min_named_args && @max_named_args && @min_named_args == @max_named_args &&
                        args.size != @max_named_args
-          NumberOfNamedArgumentsError.new(@min_named_args, types: types)
+          NumberOfNamedArgumentsError.new(@min_named_args, types:)
         elsif @min_named_args && args.size < @min_named_args
-          MinNamedArgumentsError.new(@min_named_args, types: types)
+          MinNamedArgumentsError.new(@min_named_args, types:)
         elsif @max_named_args && args.size > @max_named_args
-          MaxNamedArgumentsError.new(@max_named_args, types: types)
+          MaxNamedArgumentsError.new(@max_named_args, types:)
         end
 
         raise exception if exception

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -63,10 +63,10 @@ module Homebrew
         ref = formula.loaded_from_api? ? formula.full_name : formula.path
 
         os_arch_combinations.each do |os, arch|
-          SimulateSystem.with os: os, arch: arch do
+          SimulateSystem.with(os:, arch:) do
             Formulary.clear_cache
             formula = Formulary.factory(ref)
-            print_formula_cache(formula, os: os, arch: arch, args: args)
+            print_formula_cache(formula, os:, arch:, args:)
           end
         end
       else
@@ -76,7 +76,7 @@ module Homebrew
         os_arch_combinations.each do |os, arch|
           next if os == :linux
 
-          SimulateSystem.with os: os, arch: arch do
+          SimulateSystem.with(os:, arch:) do
             cask = Cask::CaskLoader.load(ref)
             print_cask_cache(cask)
           end
@@ -98,7 +98,7 @@ module Homebrew
       bottle_tag = if (bottle_tag = args.bottle_tag&.to_sym)
         Utils::Bottles::Tag.from_symbol(bottle_tag)
       else
-        Utils::Bottles::Tag.new(system: os, arch: arch)
+        Utils::Bottles::Tag.new(system: os, arch:)
       end
 
       bottle = formula.bottle_for_tag(bottle_tag)

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -48,7 +48,7 @@ module Homebrew
       end
     end
 
-    cleanup = Cleanup.new(*args.named, dry_run: args.dry_run?, scrub: args.s?, days: days)
+    cleanup = Cleanup.new(*args.named, dry_run: args.dry_run?, scrub: args.s?, days:)
     if args.prune_prefix?
       cleanup.prune_prefix_symlinks_and_directories
       return

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -119,7 +119,7 @@ module Homebrew
       end
 
       if args.graph?
-        dot_code = dot_code(dependents, recursive: recursive, args: args)
+        dot_code = dot_code(dependents, recursive:, args:)
         if args.dot?
           puts dot_code
         else
@@ -128,14 +128,14 @@ module Homebrew
         return
       end
 
-      puts_deps_tree dependents, recursive: recursive, args: args
+      puts_deps_tree(dependents, recursive:, args:)
       return
     elsif all
-      puts_deps sorted_dependents(Formula.all(eval_all: args.eval_all?) + Cask::Cask.all), recursive: recursive,
-                                                                                           args:      args
+      puts_deps(sorted_dependents(Formula.all(eval_all: args.eval_all?) + Cask::Cask.all), recursive:,
+                                                                                           args:)
       return
     elsif !args.no_named? && args.for_each?
-      puts_deps sorted_dependents(args.named.to_formulae_and_casks), recursive: recursive, args: args
+      puts_deps(sorted_dependents(args.named.to_formulae_and_casks), recursive:, args:)
       return
     end
 
@@ -150,16 +150,16 @@ module Homebrew
       else
         sorted_dependents(Formula.installed + Cask::Caskroom.casks)
       end
-      puts_deps sorted_dependents_formulae_and_casks, recursive: recursive, args: args
+      puts_deps(sorted_dependents_formulae_and_casks, recursive:, args:)
       return
     end
 
     dependents = dependents(args.named.to_formulae_and_casks)
     check_head_spec(dependents) if args.HEAD?
 
-    all_deps = deps_for_dependents(dependents, recursive: recursive, args: args, &(args.union? ? :| : :&))
-    condense_requirements(all_deps, args: args)
-    all_deps.map! { |d| dep_display_name(d, args: args) }
+    all_deps = deps_for_dependents(dependents, recursive:, args:, &(args.union? ? :| : :&))
+    condense_requirements(all_deps, args:)
+    all_deps.map! { |d| dep_display_name(d, args:) }
     all_deps.uniq!
     all_deps.sort! unless args.topological?
     puts all_deps
@@ -217,7 +217,7 @@ module Homebrew
   end
 
   def self.deps_for_dependents(dependents, args:, recursive: false, &block)
-    dependents.map { |d| deps_for_dependent(d, recursive: recursive, args: args) }.reduce(&block)
+    dependents.map { |d| deps_for_dependent(d, recursive:, args:) }.reduce(&block)
   end
 
   def self.check_head_spec(dependents)
@@ -229,10 +229,10 @@ module Homebrew
   def self.puts_deps(dependents, args:, recursive: false)
     check_head_spec(dependents) if args.HEAD?
     dependents.each do |dependent|
-      deps = deps_for_dependent(dependent, recursive: recursive, args: args)
-      condense_requirements(deps, args: args)
+      deps = deps_for_dependent(dependent, recursive:, args:)
+      condense_requirements(deps, args:)
       deps.sort_by!(&:name)
-      deps.map! { |d| dep_display_name(d, args: args) }
+      deps.map! { |d| dep_display_name(d, args:) }
       puts "#{dependent.full_name}: #{deps.join(" ")}"
     end
   end
@@ -240,7 +240,7 @@ module Homebrew
   def self.dot_code(dependents, recursive:, args:)
     dep_graph = {}
     dependents.each do |d|
-      graph_deps(d, dep_graph: dep_graph, recursive: recursive, args: args)
+      graph_deps(d, dep_graph:, recursive:, args:)
     end
 
     dot_code = dep_graph.map do |d, deps|
@@ -263,7 +263,7 @@ module Homebrew
   def self.graph_deps(formula, dep_graph:, recursive:, args:)
     return if dep_graph.key?(formula)
 
-    dependables = dependables(formula, args: args)
+    dependables = dependables(formula, args:)
     dep_graph[formula] = dependables
     return unless recursive
 
@@ -271,9 +271,9 @@ module Homebrew
       next unless dep.is_a? Dependency
 
       graph_deps(Formulary.factory(dep.name),
-                 dep_graph: dep_graph,
+                 dep_graph:,
                  recursive: true,
-                 args:      args)
+                 args:)
     end
   end
 
@@ -281,7 +281,7 @@ module Homebrew
     check_head_spec(dependents) if args.HEAD?
     dependents.each do |d|
       puts d.full_name
-      recursive_deps_tree(d, dep_stack: [], prefix: "", recursive: recursive, args: args)
+      recursive_deps_tree(d, dep_stack: [], prefix: "", recursive:, args:)
       puts
     end
   end
@@ -296,7 +296,7 @@ module Homebrew
   end
 
   def self.recursive_deps_tree(formula, dep_stack:, prefix:, recursive:, args:)
-    dependables = dependables(formula, args: args)
+    dependables = dependables(formula, args:)
     max = dependables.length - 1
     dep_stack.push formula.name
     dependables.each_with_index do |dep, i|
@@ -306,7 +306,7 @@ module Homebrew
         "├──"
       end
 
-      display_s = "#{tree_lines} #{dep_display_name(dep, args: args)}"
+      display_s = "#{tree_lines} #{dep_display_name(dep, args:)}"
 
       # Detect circular dependencies and consider them a failure if present.
       is_circular = dep_stack.include?(dep.name)
@@ -328,10 +328,10 @@ module Homebrew
       next unless dep.is_a? Dependency
 
       recursive_deps_tree(Formulary.factory(dep.name),
-                          dep_stack: dep_stack,
+                          dep_stack:,
                           prefix:    prefix + prefix_addition,
                           recursive: true,
-                          args:      args)
+                          args:)
     end
 
     dep_stack.pop

--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -68,7 +68,7 @@ module Homebrew
     else
       query = args.named.join(" ")
       string_or_regex = Search.query_regexp(query)
-      Search.search_descriptions(string_or_regex, args, search_type: search_type)
+      Search.search_descriptions(string_or_regex, args, search_type:)
     end
   end
 end

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -125,6 +125,6 @@ module Homebrew
 
     Install.perform_preinstall_checks(all_fatal: true)
     Install.perform_build_from_source_checks(all_fatal: true)
-    gistify_logs(args.named.to_resolved_formulae.first, args: args)
+    gistify_logs(args.named.to_resolved_formulae.first, args:)
   end
 end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -96,11 +96,11 @@ module Homebrew
         end
       end
 
-      print_analytics(args: args)
+      print_analytics(args:)
     elsif args.json
       all = args.eval_all?
 
-      print_json(all, args: args)
+      print_json(all, args:)
     elsif args.github?
       raise FormulaOrCaskUnspecifiedError if args.no_named?
 
@@ -108,7 +108,7 @@ module Homebrew
     elsif args.no_named?
       print_statistics
     else
-      print_info(args: args)
+      print_info(args:)
     end
   end
 
@@ -123,7 +123,7 @@ module Homebrew
   sig { params(args: CLI::Args).void }
   def print_analytics(args:)
     if args.no_named?
-      Utils::Analytics.output(args: args)
+      Utils::Analytics.output(args:)
       return
     end
 
@@ -132,11 +132,11 @@ module Homebrew
 
       case obj
       when Formula
-        Utils::Analytics.formula_output(obj, args: args)
+        Utils::Analytics.formula_output(obj, args:)
       when Cask::Cask
-        Utils::Analytics.cask_output(obj, args: args)
+        Utils::Analytics.cask_output(obj, args:)
       when FormulaOrCaskUnavailableError
-        Utils::Analytics.output(filter: obj.name, args: args)
+        Utils::Analytics.output(filter: obj.name, args:)
       else
         raise
       end
@@ -150,9 +150,9 @@ module Homebrew
 
       case obj
       when Formula
-        info_formula(obj, args: args)
+        info_formula(obj, args:)
       when Cask::Cask
-        info_cask(obj, args: args)
+        info_cask(obj, args:)
       when FormulaUnreadableError, FormulaClassUnavailableError,
          TapFormulaUnreadableError, TapFormulaClassUnavailableError,
          Cask::CaskUnreadableError
@@ -344,7 +344,7 @@ module Homebrew
     caveats = Caveats.new(formula)
     ohai "Caveats", caveats.to_s unless caveats.empty?
 
-    Utils::Analytics.formula_output(formula, args: args)
+    Utils::Analytics.formula_output(formula, args:)
   end
 
   def decorate_dependencies(dependencies)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -256,7 +256,7 @@ module Homebrew
           require_sha:    args.require_sha?,
           skip_cask_deps: args.skip_cask_deps?,
           verbose:        args.verbose?,
-          args:           args,
+          args:,
         )
       end
     end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -85,10 +85,10 @@ module Homebrew
         puts full_cask_names if full_cask_names.present?
       end
     elsif args.pinned?
-      filtered_list(args: args)
+      filtered_list(args:)
     elsif args.versions?
-      filtered_list(args: args) unless args.cask?
-      list_casks(args: args) if args.cask? || (!args.formula? && !args.multiple? && args.no_named?)
+      filtered_list(args:) unless args.cask?
+      list_casks(args:) if args.cask? || (!args.formula? && !args.multiple? && args.no_named?)
     elsif args.no_named?
       ENV["CLICOLOR"] = nil
 
@@ -116,7 +116,7 @@ module Homebrew
         system_command! "find", args: casks.map(&:caskroom_path) + find_args, print_stdout: true if casks.present?
       else
         kegs.each { |keg| PrettyListing.new keg } if kegs.present?
-        list_casks(args: args) if casks.present?
+        list_casks(args:) if casks.present?
       end
     end
   end

--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -41,11 +41,11 @@ module Homebrew
     ENV["PATH"] = PATH.new(ORIGINAL_PATHS).to_s
 
     if args.no_named?
-      git_log HOMEBREW_REPOSITORY, args: args
+      git_log(HOMEBREW_REPOSITORY, args:)
     else
       path = args.named.to_paths.first
       tap = Tap.from_path(path)
-      git_log path.dirname, path, tap, args: args
+      git_log path.dirname, path, tap, args:
     end
   end
 

--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -35,9 +35,9 @@ module Homebrew
     all = args.eval_all?
 
     if all
-      puts_options Formula.all(eval_all: args.eval_all?).sort, args: args
+      puts_options(Formula.all(eval_all: args.eval_all?).sort, args:)
     elsif args.installed?
-      puts_options Formula.installed.sort, args: args
+      puts_options(Formula.installed.sort, args:)
     elsif args.command.present?
       cmd_options = Commands.command_options(args.command)
       odie "Unknown command: #{args.command}" if cmd_options.nil?
@@ -51,7 +51,7 @@ module Homebrew
     elsif args.no_named?
       raise FormulaUnspecifiedError
     else
-      puts_options args.named.to_formulae, args: args
+      puts_options args.named.to_formulae, args:
     end
   end
 

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -55,16 +55,16 @@ module Homebrew
       odie "`brew outdated --json=v1` is no longer supported. Use brew outdated --json=v2 instead."
     when :v2, :default
       formulae, casks = if args.formula?
-        [outdated_formulae(args: args), []]
+        [outdated_formulae(args:), []]
       elsif args.cask?
-        [[], outdated_casks(args: args)]
+        [[], outdated_casks(args:)]
       else
-        outdated_formulae_casks args: args
+        outdated_formulae_casks(args:)
       end
 
       json = {
-        "formulae" => json_info(formulae, args: args),
-        "casks"    => json_info(casks, args: args),
+        "formulae" => json_info(formulae, args:),
+        "casks"    => json_info(casks, args:),
       }
       puts JSON.pretty_generate(json)
 
@@ -72,14 +72,14 @@ module Homebrew
 
     else
       outdated = if args.formula?
-        outdated_formulae args: args
+        outdated_formulae(args:)
       elsif args.cask?
-        outdated_casks args: args
+        outdated_casks(args:)
       else
-        outdated_formulae_casks(args: args).flatten
+        outdated_formulae_casks(args:).flatten
       end
 
-      print_outdated(outdated, args: args)
+      print_outdated(outdated, args:)
     end
 
     Homebrew.failed = args.named.present? && outdated.present?
@@ -137,7 +137,7 @@ module Homebrew
 
         { name:               f.full_name,
           installed_versions: outdated_versions.map(&:to_s),
-          current_version:    current_version,
+          current_version:,
           pinned:             f.pinned?,
           pinned_version:     f.pinned_version }
       else
@@ -166,14 +166,14 @@ module Homebrew
   end
 
   def self.outdated_formulae(args:)
-    select_outdated((args.named.to_resolved_formulae.presence || Formula.installed), args: args).sort
+    select_outdated((args.named.to_resolved_formulae.presence || Formula.installed), args:).sort
   end
 
   def self.outdated_casks(args:)
     if args.named.present?
-      select_outdated(args.named.to_casks, args: args)
+      select_outdated(args.named.to_casks, args:)
     else
-      select_outdated(Cask::Caskroom.casks, args: args)
+      select_outdated(Cask::Caskroom.casks, args:)
     end
   end
 
@@ -185,7 +185,7 @@ module Homebrew
       casks = Cask::Caskroom.casks
     end
 
-    [select_outdated(formulae, args: args).sort, select_outdated(casks, args: args)]
+    [select_outdated(formulae, args:).sort, select_outdated(casks, args:)]
   end
 
   def self.select_outdated(formulae_or_casks, args:)

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -59,7 +59,7 @@ module Homebrew
 
     Uninstall.uninstall_kegs(
       kegs_by_rack,
-      casks:               casks,
+      casks:,
       force:               args.force?,
       ignore_dependencies: args.ignore_dependencies?,
       named_args:          args.named,

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -714,7 +714,7 @@ class Reporter
       # Hack `git diff` output with regexes to look like `git diff-tree` output.
       # Yes, I know this is a bit filthy but it saves duplicating the #report logic.
       diff_output = Utils.popen_read("git", "diff", "--no-ext-diff", api_names_before_txt, api_names_txt)
-      header_regex = /^(---|\+\+\+) /.freeze
+      header_regex = /^(---|\+\+\+) /
       add_delete_characters = ["+", "-"].freeze
 
       diff_output.lines.map do |line|

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -109,7 +109,7 @@ module Homebrew
     odie "update-report should not be called directly!" if initial_revision.empty? || current_revision.empty?
 
     if initial_revision != current_revision
-      auto_update_header args: args
+      auto_update_header(args:)
 
       updated = true
 
@@ -219,7 +219,7 @@ module Homebrew
     end
 
     unless updated_taps.empty?
-      auto_update_header args: args
+      auto_update_header(args:)
       puts "Updated #{Utils.pluralize("tap", updated_taps.count, include_count: true)} (#{updated_taps.to_sentence})."
       updated = true
     end
@@ -696,7 +696,7 @@ class Reporter
       end
       next if oldnames_to_migrate.empty?
 
-      Migrator.migrate_if_needed(formula, force: force)
+      Migrator.migrate_if_needed(formula, force:)
     end
   end
 
@@ -750,7 +750,7 @@ class ReporterHub
 
   def add(reporter, auto_update: false)
     @reporters << reporter
-    report = reporter.report(auto_update: auto_update).delete_if { |_k, v| v.empty? }
+    report = reporter.report(auto_update:).delete_if { |_k, v| v.empty? }
     @hash.update(report) { |_key, oldval, newval| oldval.concat(newval) }
   end
 

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -137,8 +137,8 @@ module Homebrew
     only_upgrade_formulae = formulae.present? && casks.blank?
     only_upgrade_casks = casks.present? && formulae.blank?
 
-    upgrade_outdated_formulae(formulae, args: args) unless only_upgrade_casks
-    upgrade_outdated_casks(casks, args: args) unless only_upgrade_formulae
+    upgrade_outdated_formulae(formulae, args:) unless only_upgrade_casks
+    upgrade_outdated_casks(casks, args:) unless only_upgrade_formulae
 
     Cleanup.periodic_clean!(dry_run: args.dry_run?)
 
@@ -269,7 +269,7 @@ module Homebrew
       require_sha:         args.require_sha?,
       skip_cask_deps:      args.skip_cask_deps?,
       verbose:             args.verbose?,
-      args:                args,
+      args:,
     )
   end
 end

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -69,7 +69,7 @@ module Homebrew
       # If the formula doesn't exist: fake the needed formula object name.
       # This is a legacy use of OpenStruct that should be refactored.
       # rubocop:disable Style/OpenStructUse
-      args.named.map { |name| OpenStruct.new name: name, full_name: name }
+      args.named.map { |name| OpenStruct.new name:, full_name: name }
       # rubocop:enable Style/OpenStructUse
     end
 
@@ -80,7 +80,7 @@ module Homebrew
                              !args.include_optional? &&
                              !args.skip_recommended?
 
-    uses = intersection_of_dependents(use_runtime_dependents, used_formulae, args: args)
+    uses = intersection_of_dependents(use_runtime_dependents, used_formulae, args:)
 
     return if uses.empty?
 

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -116,7 +116,7 @@ module Commands
   def self.official_external_commands_paths(quiet:)
     OFFICIAL_CMD_TAPS.flat_map do |tap_name, cmds|
       tap = Tap.fetch(tap_name)
-      tap.install(quiet: quiet) unless tap.installed?
+      tap.install(quiet:) unless tap.installed?
       cmds.map(&method(:external_ruby_v2_cmd_path)).compact
     end
   end

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -35,7 +35,7 @@ module Commands
   # dot as a full stop if it is either followed by a whitespace or at the end of
   # the description. In this way we can prevent cutting off a sentence in the
   # middle due to dots in URLs or paths.
-  DESCRIPTION_SPLITTING_PATTERN = /\.(?>\s|$)/.freeze
+  DESCRIPTION_SPLITTING_PATTERN = /\.(?>\s|$)/
 
   def self.valid_internal_cmd?(cmd)
     require?(HOMEBREW_CMD_PATH/cmd)

--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -54,7 +54,7 @@ class CompilerFailure
       version = 9999
       exact_major_match = false
     end
-    new(type, version, exact_major_match: exact_major_match, &block)
+    new(type, version, exact_major_match:, &block)
   end
 
   def fails_with?(compiler)

--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -4,7 +4,7 @@
 # @private
 module CompilerConstants
   GNU_GCC_VERSIONS = %w[4.9 5 6 7 8 9 10 11 12 13].freeze
-  GNU_GCC_REGEXP = /^gcc-(4\.9|[5-9]|10|11|12|13)$/.freeze
+  GNU_GCC_REGEXP = /^gcc-(4\.9|[5-9]|10|11|12|13)$/
   COMPILER_SYMBOL_MAP = {
     "gcc"        => :gcc,
     "clang"      => :clang,

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -25,7 +25,7 @@ module DependenciesHelpers
 
     cache_key = "recursive_includes_#{includes}_#{ignores}"
 
-    klass.expand(root_dependent, cache_key: cache_key) do |dependent, dep|
+    klass.expand(root_dependent, cache_key:) do |dependent, dep|
       klass.prune if ignores.any? { |ignore| dep.public_send(ignore) }
       klass.prune if includes.none? do |include|
         # Ignore indirect test dependencies

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -77,7 +77,7 @@ class Dependency
   end
 
   def satisfied?(inherited_options = [], minimum_version: nil, minimum_revision: nil)
-    installed?(minimum_version: minimum_version, minimum_revision: minimum_revision) &&
+    installed?(minimum_version:, minimum_revision:) &&
       missing_options(inherited_options).empty?
   end
 
@@ -145,14 +145,14 @@ class Dependency
         when :skip
           next if @expand_stack.include? dep.name
 
-          expanded_deps.concat(expand(dep.to_formula, cache_key: cache_key, &block))
+          expanded_deps.concat(expand(dep.to_formula, cache_key:, &block))
         when :keep_but_prune_recursive_deps
           expanded_deps << dep
         else
           next if @expand_stack.include? dep.name
 
           dep_formula = dep.to_formula
-          expanded_deps.concat(expand(dep_formula, cache_key: cache_key, &block))
+          expanded_deps.concat(expand(dep_formula, cache_key:, &block))
 
           # Fixes names for renamed/aliased formulae.
           dep = dep.dup_with_formula_name(dep_formula)
@@ -266,7 +266,7 @@ class UsesFromMacOSDependency < Dependency
 
   sig { params(minimum_version: T.nilable(Version), minimum_revision: T.nilable(Integer)).returns(T::Boolean) }
   def installed?(minimum_version: nil, minimum_revision: nil)
-    use_macos_install? || super(minimum_version: minimum_version, minimum_revision: minimum_revision)
+    use_macos_install? || super(minimum_version:, minimum_revision:)
   end
 
   sig { returns(T::Boolean) }
@@ -293,7 +293,7 @@ class UsesFromMacOSDependency < Dependency
 
   sig { override.params(formula: Formula).returns(T.self_type) }
   def dup_with_formula_name(formula)
-    self.class.new(formula.full_name.to_s, tags, env_proc, option_names, bounds: bounds)
+    self.class.new(formula.full_name.to_s, tags, env_proc, option_names, bounds:)
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -34,7 +34,7 @@ class DescriptionCacheStore < CacheStore
     return unless eval_all
     return unless database.empty?
 
-    Formula.all(eval_all: eval_all).each { |f| update!(f.full_name, f.desc) }
+    Formula.all(eval_all:).each { |f| update!(f.full_name, f.desc) }
   end
 
   # Use an update report to update the {DescriptionCacheStore}.

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -11,7 +11,7 @@ require "search"
 class Descriptions
   # Given a regex, find all formulae whose specified fields contain a match.
   def self.search(string_or_regex, field, cache_store, eval_all = Homebrew::EnvConfig.eval_all?)
-    cache_store.populate_if_empty!(eval_all: eval_all)
+    cache_store.populate_if_empty!(eval_all:)
 
     results = case field
     when :name

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -209,20 +209,20 @@ module Homebrew
 
       only = only_cops ? ["style"] : args.only
       options = {
-        new_formula:         new_formula,
-        strict:              strict,
-        online:              online,
+        new_formula:,
+        strict:,
+        online:,
         git:                 args.git?,
-        only:                only,
+        only:,
         except:              args.except,
-        spdx_license_data:   spdx_license_data,
-        spdx_exception_data: spdx_exception_data,
+        spdx_license_data:,
+        spdx_exception_data:,
         style_offenses:      style_offenses&.for_path(f.path),
-        tap_audit:           tap_audit,
+        tap_audit:,
       }.compact
 
       errors = os_arch_combinations.flat_map do |os, arch|
-        SimulateSystem.with os: os, arch: arch do
+        SimulateSystem.with(os:, arch:) do
           odebug "Auditing Formula #{f} on os #{os} and arch #{arch}"
 
           Formulary.clear_cache if clear_formulary_cache
@@ -252,7 +252,7 @@ module Homebrew
       errors = os_arch_combinations.flat_map do |os, arch|
         next [] if os == :linux
 
-        SimulateSystem.with os: os, arch: arch do
+        SimulateSystem.with(os:, arch:) do
           odebug "Auditing Cask #{cask} on os #{os} and arch #{arch}"
 
           Cask::Auditor.audit(

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -12,7 +12,7 @@ require "erb"
 require "utils/gzip"
 require "api"
 
-BOTTLE_ERB = <<-EOS
+BOTTLE_ERB = <<-EOS.freeze
   bottle do
     <% if [HOMEBREW_BOTTLE_DEFAULT_DOMAIN.to_s,
            "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/bottles"].exclude?(root_url) %>

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -95,13 +95,13 @@ module Homebrew
 
     if args.merge?
       Homebrew.install_bundler_gems!(groups: ["ast"])
-      return merge(args: args)
+      return merge(args:)
     end
 
     gnu_tar_formula_ensure_installed_if_needed!(only_json_tab: args.only_json_tab?)
 
     args.named.to_resolved_formulae(uniq: false).each do |formula|
-      bottle_formula formula, args: args
+      bottle_formula formula, args:
     end
   end
 
@@ -152,7 +152,7 @@ module Homebrew
       end
     end
 
-    keg_contain_absolute_symlink_starting_with?(string, keg, args: args) || result
+    keg_contain_absolute_symlink_starting_with?(string, keg, args:) || result
   end
 
   def self.keg_contain_absolute_symlink_starting_with?(string, keg, args:)
@@ -481,7 +481,7 @@ module Homebrew
         else
           HOMEBREW_REPOSITORY
         end.to_s
-        if keg_contain?(repository_reference, keg, ignores + ALLOWABLE_HOMEBREW_REPOSITORY_LINKS, args: args)
+        if keg_contain?(repository_reference, keg, ignores + ALLOWABLE_HOMEBREW_REPOSITORY_LINKS, args:)
           odie "Bottle contains non-relocatable reference to #{repository_reference}!"
         end
 
@@ -489,16 +489,16 @@ module Homebrew
         if args.skip_relocation?
           skip_relocation = true
         else
-          relocatable = false if keg_contain?(prefix_check, keg, ignores, formula_and_runtime_deps_names, args: args)
-          relocatable = false if keg_contain?(cellar, keg, ignores, formula_and_runtime_deps_names, args: args)
-          if keg_contain?(HOMEBREW_LIBRARY.to_s, keg, ignores, formula_and_runtime_deps_names, args: args)
+          relocatable = false if keg_contain?(prefix_check, keg, ignores, formula_and_runtime_deps_names, args:)
+          relocatable = false if keg_contain?(cellar, keg, ignores, formula_and_runtime_deps_names, args:)
+          if keg_contain?(HOMEBREW_LIBRARY.to_s, keg, ignores, formula_and_runtime_deps_names, args:)
             relocatable = false
           end
           if prefix != prefix_check
-            relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg, args: args)
-            relocatable = false if keg_contain?("#{prefix}/etc", keg, ignores, args: args)
-            relocatable = false if keg_contain?("#{prefix}/var", keg, ignores, args: args)
-            relocatable = false if keg_contain?("#{prefix}/share/vim", keg, ignores, args: args)
+            relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg, args:)
+            relocatable = false if keg_contain?("#{prefix}/etc", keg, ignores, args:)
+            relocatable = false if keg_contain?("#{prefix}/var", keg, ignores, args:)
+            relocatable = false if keg_contain?("#{prefix}/share/vim", keg, ignores, args:)
           end
           skip_relocation = relocatable && !keg.require_relocation?
         end
@@ -660,7 +660,7 @@ module Homebrew
           tag.to_sym
         end
 
-        sha256_hash = { cellar: cellar, tag_sym => tag_hash["sha256"] }
+        sha256_hash = { cellar:, tag_sym => tag_hash["sha256"] }
         bottle.sha256 sha256_hash
 
         break if all_bottle
@@ -734,7 +734,7 @@ module Homebrew
 
       require "utils/ast"
       formula_ast = Utils::AST::FormulaAST.new(path.read)
-      checksums = old_checksums(formula, formula_ast, bottle_hash, args: args)
+      checksums = old_checksums(formula, formula_ast, bottle_hash, args:)
       update_or_add = checksums.nil? ? "add" : "update"
 
       checksums&.each(&bottle.method(:sha256))

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -114,7 +114,7 @@ module Homebrew
       raise UsageError, "No `--version`, `--url` or `--sha256` argument specified!"
     end
 
-    check_pull_requests(cask, args: args, new_version: new_version)
+    check_pull_requests(cask, args:, new_version:)
 
     replacement_pairs ||= []
     branch_name = "bump-#{cask.token}"
@@ -140,7 +140,7 @@ module Homebrew
       # For simplicity, our naming defers to the arm version if we multiple architectures are specified
       branch_version = new_version.arm || new_version.general
       if branch_version.is_a?(Cask::DSL::Version)
-        commit_version = shortened_version(branch_version, cask: cask)
+        commit_version = shortened_version(branch_version, cask:)
         branch_name = "bump-#{cask.token}-#{branch_version.tr(",:", "-")}"
         commit_message ||= "#{cask.token} #{commit_version}"
       end
@@ -157,18 +157,18 @@ module Homebrew
                                      read_only_run: args.dry_run?,
                                      silent:        args.quiet?)
 
-    run_cask_audit(cask, old_contents, args: args)
-    run_cask_style(cask, old_contents, args: args)
+    run_cask_audit(cask, old_contents, args:)
+    run_cask_style(cask, old_contents, args:)
 
     pr_info = {
-      branch_name:     branch_name,
-      commit_message:  commit_message,
-      old_contents:    old_contents,
+      branch_name:,
+      commit_message:,
+      old_contents:,
       pr_message:      "Created with `brew bump-cask-pr`.",
       sourcefile_path: cask.sourcefile_path,
       tap:             cask.tap,
     }
-    GitHub.create_bump_pr(pr_info, args: args)
+    GitHub.create_bump_pr(pr_info, args:)
   end
 
   sig { params(version: Cask::DSL::Version, cask: Cask::Cask).returns(Cask::DSL::Version) }
@@ -192,7 +192,7 @@ module Homebrew
     # When blocks are absent, arch is not relevant. For consistency, we simulate the arm architecture.
     arch_options = cask.on_system_blocks_exist? ? OnSystem::ARCH_OPTIONS : [:arm]
     arch_options.each do |arch|
-      SimulateSystem.with arch: arch do
+      SimulateSystem.with(arch:) do
         old_cask     = Cask::CaskLoader.load(cask.sourcefile_path)
         old_version  = old_cask.version
         bump_version = new_version.send(arch) || new_version.general
@@ -252,7 +252,7 @@ module Homebrew
                                              state:   "open",
                                              version: nil,
                                              file:    cask.sourcefile_path.relative_path_from(cask.tap.path).to_s,
-                                             args:    args)
+                                             args:)
 
     # if we haven't already found open requests, try for an exact match across closed requests
     new_version.instance_variables.each do |version_type|
@@ -263,9 +263,9 @@ module Homebrew
         cask.token,
         tap_remote_repo,
         state:   "closed",
-        version: shortened_version(version, cask: cask),
+        version: shortened_version(version, cask:),
         file:    cask.sourcefile_path.relative_path_from(cask.tap.path).to_s,
-        args:    args,
+        args:,
       )
     end
   end

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -124,10 +124,10 @@ module Homebrew
     remote_branch = formula.tap.git_repo.origin_branch_name
     previous_branch = "-"
 
-    check_open_pull_requests(formula, tap_remote_repo, args: args)
+    check_open_pull_requests(formula, tap_remote_repo, args:)
 
     new_version = args.version
-    check_new_version(formula, tap_remote_repo, version: new_version, args: args) if new_version.present?
+    check_new_version(formula, tap_remote_repo, version: new_version, args:) if new_version.present?
 
     opoo "This formula has patches that may be resolved upstream." if formula.patchlist.present?
     if formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") }
@@ -139,7 +139,7 @@ module Homebrew
     new_mirror ||= determine_mirror(new_url)
     new_mirrors ||= [new_mirror] if new_mirror.present?
 
-    check_for_mirrors(formula, old_mirrors, new_mirrors, args: args) if new_url.present?
+    check_for_mirrors(formula, old_mirrors, new_mirrors, args:) if new_url.present?
 
     old_hash = formula_spec.checksum&.hexdigest
     new_hash = args.sha256
@@ -151,10 +151,10 @@ module Homebrew
     old_version = old_formula_version.to_s
     forced_version = new_version.present?
     new_url_hash = if new_url.present? && new_hash.present?
-      check_new_version(formula, tap_remote_repo, url: new_url, args: args) if new_version.blank?
+      check_new_version(formula, tap_remote_repo, url: new_url, args:) if new_version.blank?
       true
     elsif new_tag.present? && new_revision.present?
-      check_new_version(formula, tap_remote_repo, url: old_url, tag: new_tag, args: args) if new_version.blank?
+      check_new_version(formula, tap_remote_repo, url: old_url, tag: new_tag, args:) if new_version.blank?
       false
     elsif old_hash.blank?
       if new_tag.blank? && new_version.blank? && new_revision.blank?
@@ -169,7 +169,7 @@ module Homebrew
             and old tag are both #{new_tag}.
           EOS
         end
-        check_new_version(formula, tap_remote_repo, url: old_url, tag: new_tag, args: args) if new_version.blank?
+        check_new_version(formula, tap_remote_repo, url: old_url, tag: new_tag, args:) if new_version.blank?
         resource_path, forced_version = fetch_resource_and_forced_version(formula, new_version, old_url, tag: new_tag)
         new_revision = Utils.popen_read("git", "-C", resource_path.to_s, "rev-parse", "-q", "--verify", "HEAD")
         new_revision = new_revision.strip
@@ -196,7 +196,7 @@ module Homebrew
             #{new_url}
         EOS
       end
-      check_new_version(formula, tap_remote_repo, url: new_url, args: args) if new_version.blank?
+      check_new_version(formula, tap_remote_repo, url: new_url, args:) if new_version.blank?
       resource_path, forced_version = fetch_resource_and_forced_version(formula, new_version, new_url)
       Utils::Tar.validate_file(resource_path)
       new_hash = resource_path.sha256
@@ -333,7 +333,7 @@ module Homebrew
                                                         ignore_non_pypi_packages: true
     end
 
-    run_audit(formula, alias_rename, old_contents, args: args)
+    run_audit(formula, alias_rename, old_contents, args:)
 
     pr_message = "Created with `brew bump-formula-pr`."
     if resources_checked.nil? && formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") }
@@ -368,18 +368,18 @@ module Homebrew
 
     pr_info = {
       sourcefile_path:  formula.path,
-      old_contents:     old_contents,
+      old_contents:,
       additional_files: alias_rename,
-      remote:           remote,
-      remote_branch:    remote_branch,
+      remote:,
+      remote_branch:,
       branch_name:      "bump-#{formula.name}-#{new_formula_version}",
       commit_message:   "#{formula.name} #{new_formula_version}",
-      previous_branch:  previous_branch,
+      previous_branch:,
       tap:              formula.tap,
-      tap_remote_repo:  tap_remote_repo,
-      pr_message:       pr_message,
+      tap_remote_repo:,
+      pr_message:,
     }
-    GitHub.create_bump_pr(pr_info, args: args)
+    GitHub.create_bump_pr(pr_info, args:)
   end
 
   def determine_mirror(url)
@@ -433,7 +433,7 @@ module Homebrew
     GitHub.check_for_duplicate_pull_requests(formula.name, tap_remote_repo,
                                              state: "open",
                                              file:  formula.path.relative_path_from(formula.tap.path).to_s,
-                                             args:  args)
+                                             args:)
   end
 
   def check_new_version(formula, tap_remote_repo, args:, version: nil, url: nil, tag: nil)
@@ -445,7 +445,7 @@ module Homebrew
     end
 
     check_throttle(formula, version)
-    check_closed_pull_requests(formula, tap_remote_repo, args: args, version: version)
+    check_closed_pull_requests(formula, tap_remote_repo, args:, version:)
   end
 
   def check_throttle(formula, new_version)
@@ -461,10 +461,10 @@ module Homebrew
   def check_closed_pull_requests(formula, tap_remote_repo, args:, version:)
     # if we haven't already found open requests, try for an exact match across closed requests
     GitHub.check_for_duplicate_pull_requests(formula.name, tap_remote_repo,
-                                             version: version,
+                                             version:,
                                              state:   "closed",
                                              file:    formula.path.relative_path_from(formula.tap.path).to_s,
-                                             args:    args)
+                                             args:)
   end
 
   def alias_update_pair(formula, new_formula_version)

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -138,14 +138,14 @@ module Homebrew
       package_data = if formula_or_cask.is_a?(Formula) && formula_or_cask.versioned_formula?
         nil
       else
-        Repology.single_package_query(name, repository: repository)
+        Repology.single_package_query(name, repository:)
       end
 
       retrieve_and_display_info_and_open_pr(
         formula_or_cask,
         name,
         package_data&.values&.first,
-        args:           args,
+        args:,
         ambiguous_cask: ambiguous_casks.include?(formula_or_cask),
       )
     end
@@ -206,8 +206,8 @@ module Homebrew
           formula_or_cask,
           name,
           repositories,
-          args:           args,
-          ambiguous_cask: ambiguous_cask,
+          args:,
+          ambiguous_cask:,
         )
       end
     end
@@ -258,7 +258,7 @@ module Homebrew
 
     version_info = Livecheck.latest_version(
       formula_or_cask,
-      referenced_formula_or_cask: referenced_formula_or_cask,
+      referenced_formula_or_cask:,
       json: true, full_name: false, verbose: true, debug: false
     )
     return "unable to get versions" if version_info.blank?
@@ -280,7 +280,7 @@ module Homebrew
   }
   def retrieve_pull_requests(formula_or_cask, name, state:, version: nil)
     tap_remote_repo = formula_or_cask.tap&.remote_repo || formula_or_cask.tap&.full_name
-    pull_requests = GitHub.fetch_pull_requests(name, tap_remote_repo, state: state, version: version)
+    pull_requests = GitHub.fetch_pull_requests(name, tap_remote_repo, state:, version:)
     if pull_requests&.any?
       pull_requests = pull_requests.map { |pr| "#{pr["title"]} (#{Formatter.url(pr["html_url"])})" }.join(", ")
     end
@@ -309,7 +309,7 @@ module Homebrew
     arch_options = is_cask_with_blocks ? OnSystem::ARCH_OPTIONS : [:arm]
 
     arch_options.each do |arch|
-      SimulateSystem.with arch: arch do
+      SimulateSystem.with(arch:) do
         version_key = is_cask_with_blocks ? arch : :general
 
         # We reload the formula/cask here to ensure we're getting the correct version for the current arch
@@ -382,14 +382,14 @@ module Homebrew
     end.presence
 
     VersionBumpInfo.new(
-      type:                 type,
-      multiple_versions:    multiple_versions,
-      version_name:         version_name,
-      current_version:      current_version,
-      repology_latest:      repology_latest,
-      new_version:          new_version,
-      open_pull_requests:   open_pull_requests,
-      closed_pull_requests: closed_pull_requests,
+      type:,
+      multiple_versions:,
+      version_name:,
+      current_version:,
+      repology_latest:,
+      new_version:,
+      open_pull_requests:,
+      closed_pull_requests:,
     )
   end
 
@@ -403,10 +403,10 @@ module Homebrew
     ).void
   }
   def retrieve_and_display_info_and_open_pr(formula_or_cask, name, repositories, args:, ambiguous_cask: false)
-    version_info = retrieve_versions_by_arch(formula_or_cask: formula_or_cask,
-                                             repositories:    repositories,
-                                             args:            args,
-                                             name:            name)
+    version_info = retrieve_versions_by_arch(formula_or_cask:,
+                                             repositories:,
+                                             args:,
+                                             name:)
 
     current_version = version_info.current_version
     new_version = version_info.new_version

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -71,7 +71,7 @@ module Homebrew
       # committer details to match the ones on GitHub.
       # TODO: Switch to using the GitHub APIs instead of `git log` if
       # they ever support trailers.
-      results[username] = scan_repositories(repos, username, args, from: from)
+      results[username] = scan_repositories(repos, username, args, from:)
       grand_totals[username] = total(results[username])
 
       contributions = contribution_types.map do |type|
@@ -85,7 +85,7 @@ module Homebrew
       puts [
         "#{username} contributed",
         *contributions.to_sentence,
-        "#{time_period(from: from, to: args.to)}.",
+        "#{time_period(from:, to: args.to)}.",
       ].join(" ")
     end
 
@@ -167,7 +167,7 @@ module Homebrew
       data[repo] = {
         author:       author_commits,
         committer:    committer_commits,
-        coauthorship: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", from: from, to: args.to),
+        coauthorship: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", from:, to: args.to),
         review:       count_reviews(repo_full_name, person, args),
       }
     end
@@ -203,7 +203,7 @@ module Homebrew
 
   sig { params(repo_full_name: String, person: String, args: Homebrew::CLI::Args).returns(Integer) }
   def count_reviews(repo_full_name, person, args)
-    GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, review: "approved", args: args)
+    GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, review: "approved", args:)
   rescue GitHub::API::ValidationFailedError
     if args.verbose?
       onoe "Couldn't search GitHub for PRs by #{person}. Their profile might be private. Defaulting to 0."

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -74,9 +74,9 @@ module Homebrew
     args = create_args.parse
 
     path = if args.cask?
-      create_cask(args: args)
+      create_cask(args:)
     else
-      create_formula(args: args)
+      create_formula(args:)
     end
 
     exec_editor path
@@ -167,7 +167,7 @@ module Homebrew
       args.set_version,
       tap:     args.tap,
       url:     args.named.first,
-      mode:    mode,
+      mode:,
       license: args.set_license,
       fetch:   !args.no_fetch?,
       head:    args.HEAD?,

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -69,7 +69,7 @@ ensure
 end
 
 module Homebrew
-  BOTTLE_BLOCK_REGEX = /  bottle (?:do.+?end|:[a-z]+)\n\n/m.freeze
+  BOTTLE_BLOCK_REGEX = /  bottle (?:do.+?end|:[a-z]+)\n\n/m
 
   sig { returns(CLI::Parser) }
   def self.extract_args

--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -36,6 +36,6 @@ module Homebrew
       Homebrew.forget_user_gem_groups!
     end
 
-    Homebrew.install_bundler_gems!(groups: groups)
+    Homebrew.install_bundler_gems!(groups:)
   end
 end

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -12,7 +12,7 @@ class String
   end
 
   def c(config: nil)
-    Cask::CaskLoader.load(self, config: config)
+    Cask::CaskLoader.load(self, config:)
   end
 end
 
@@ -22,7 +22,7 @@ class Symbol
   end
 
   def c(config: nil)
-    to_s.c(config: config)
+    to_s.c(config:)
   end
 end
 

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -161,12 +161,12 @@ module Homebrew
     package_name = package_file.basename.to_s.chomp(".rb")
 
     odebug "Cherry-picking #{package_file}: #{commit}"
-    Utils::Git.cherry_pick!(git_repo.to_s, commit, verbose: verbose, resolve: resolve)
+    Utils::Git.cherry_pick!(git_repo.to_s, commit, verbose:, resolve:)
 
     old_package = Utils::Git.file_at_commit(git_repo.to_s, file, "HEAD^")
     new_package = Utils::Git.file_at_commit(git_repo.to_s, file, "HEAD")
 
-    bump_subject = determine_bump_subject(old_package, new_package, package_file, reason: reason).strip
+    bump_subject = determine_bump_subject(old_package, new_package, package_file, reason:).strip
     subject, body, trailers = separate_commit_message(git_repo.commit_message)
 
     if subject != bump_subject && !subject.start_with?("#{package_name}:")
@@ -212,13 +212,13 @@ module Homebrew
     trailers = [trailers + co_author_trailers].flatten.uniq.compact
 
     # Apply the patch series but don't commit anything yet.
-    Utils::Git.cherry_pick!(git_repo.pathname, "--no-commit", *commits, verbose: verbose, resolve: resolve)
+    Utils::Git.cherry_pick!(git_repo.pathname, "--no-commit", *commits, verbose:, resolve:)
 
     # Determine the bump subject by comparing the original state of the tree to its current state.
     package_file = git_repo.pathname / file
     old_package = Utils::Git.file_at_commit(git_repo.pathname, file, "#{commits.first}^")
     new_package = package_file.read
-    bump_subject = determine_bump_subject(old_package, new_package, package_file, reason: reason)
+    bump_subject = determine_bump_subject(old_package, new_package, package_file, reason:)
 
     # Commit with the new subject, body, and trailers.
     safe_system("git", "-C", git_repo.pathname, "commit", "--quiet",
@@ -271,14 +271,14 @@ module Homebrew
       if files.length == 1 && files_to_commits[files.first].length == 1
         # If there's a 1:1 mapping of commits to files, just cherry pick and (maybe) reword.
         reword_package_commit(
-          commit, files.first, git_repo: git_repo, reason: reason, verbose: verbose, resolve: resolve
+          commit, files.first, git_repo:, reason:, verbose:, resolve:
         )
         processed_commits << commit
       elsif files.length == 1 && files_to_commits[files.first].length > 1
         # If multiple commits modify a single file, squash them down into a single commit.
         file = files.first
         commits = files_to_commits[file]
-        squash_package_commits(commits, file, git_repo: git_repo, reason: reason, verbose: verbose, resolve: resolve)
+        squash_package_commits(commits, file, git_repo:, reason:, verbose:, resolve:)
         processed_commits += commits
       else
         # We can't split commits (yet) so just raise an error.
@@ -360,7 +360,7 @@ module Homebrew
 
   def self.pr_check_conflicts(repo, pull_request)
     long_build_pr_files = GitHub.issues(
-      repo: repo, state: "open", labels: "no long build conflict",
+      repo:, state: "open", labels: "no long build conflict",
     ).each_with_object({}) do |long_build_pr, hash|
       next unless long_build_pr.key?("pull_request")
 
@@ -456,15 +456,15 @@ module Homebrew
           odebug "Pull request merge-base: #{original_commit}"
 
           unless args.no_commit?
-            cherry_pick_pr!(user, repo, pr, path: tap.path, args: args) unless args.no_cherry_pick?
+            cherry_pick_pr!(user, repo, pr, path: tap.path, args:) unless args.no_cherry_pick?
             if args.autosquash? && !args.dry_run?
-              autosquash!(original_commit, tap: tap, cherry_picked: !args.no_cherry_pick?,
+              autosquash!(original_commit, tap:, cherry_picked: !args.no_cherry_pick?,
                           verbose: args.verbose?, resolve: args.resolve?, reason: args.message)
             end
             signoff!(git_repo, pull_request: pr, dry_run: args.dry_run?) unless args.clean?
           end
 
-          unless formulae_need_bottles?(tap, original_commit, pr_labels, args: args)
+          unless formulae_need_bottles?(tap, original_commit, pr_labels, args:)
             ohai "Skipping artifacts for ##{pr} as the formulae don't need bottles"
             next
           end

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -103,7 +103,7 @@ module Homebrew
           end
         end
       rescue Exception => e # rubocop:disable Lint/RescueException
-        retry if retry_test?(f, args: args)
+        retry if retry_test?(f, args:)
         ofail "#{f.full_name}: failed"
         $stderr.puts e, Utils::Backtrace.clean(e)
       ensure

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -41,7 +41,7 @@ module Homebrew
 
     update = args.update? || args.update_all?
     groups = update ? Homebrew.valid_gem_groups : ["typecheck"]
-    Homebrew.install_bundler_gems!(groups: groups)
+    Homebrew.install_bundler_gems!(groups:)
 
     HOMEBREW_LIBRARY_PATH.cd do
       if update

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -65,7 +65,7 @@ module Homebrew
       raise "Unknown arch #{@bottle_tag.arch}."
     end
 
-    Homebrew::SimulateSystem.with os: os, arch: arch do
+    Homebrew::SimulateSystem.with(os:, arch:) do
       all = args.eval_all?
       if args.total?
         if !all && !Homebrew::EnvConfig.eval_all?

--- a/Library/Homebrew/dev-cmd/update-maintainers.rb
+++ b/Library/Homebrew/dev-cmd/update-maintainers.rb
@@ -32,7 +32,7 @@ module Homebrew
     members = {
       plc:         GitHub.members_by_team("Homebrew", "plc"),
       tsc:         GitHub.members_by_team("Homebrew", "tsc"),
-      maintainers: maintainers,
+      maintainers:,
     }
 
     sentences = {}

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -691,7 +691,7 @@ module Homebrew
         return unless coreutils.any_version_installed?
 
         gnubin = %W[#{coreutils.opt_libexec}/gnubin #{coreutils.libexec}/gnubin]
-        return if (paths & gnubin).empty?
+        return if !paths.intersect?(gnubin)
 
         <<~EOS
           Putting non-prefixed coreutils in your path can cause GMP builds to fail.

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -20,7 +20,7 @@ module Homebrew
     def self.missing_deps(formulae, hide = nil)
       missing = {}
       formulae.each do |f|
-        missing_dependencies = f.missing_dependencies(hide: hide)
+        missing_dependencies = f.missing_dependencies(hide:)
         next if missing_dependencies.empty?
 
         yield f.full_name, missing_dependencies if block_given?

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -107,7 +107,7 @@ class AbstractDownloadStrategy
     UnpackStrategy.detect(cached_location,
                           prioritize_extension: true,
                           ref_type: @ref_type, ref: @ref)
-                  .extract_nestedly(basename:             basename,
+                  .extract_nestedly(basename:,
                                     prioritize_extension: true,
                                     verbose:              verbose? && !quiet?)
     chdir(&block) if block
@@ -162,7 +162,7 @@ class AbstractDownloadStrategy
   end
 
   def silent_command(*args, **options)
-    system_command(*args, print_stderr: false, env: env, **options)
+    system_command(*args, print_stderr: false, env:, **options)
   end
 
   def command!(*args, **options)
@@ -442,7 +442,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         puts "Already downloaded: #{cached_location}"
       else
         begin
-          _fetch(url: url, resolved_url: resolved_url, timeout: end_time&.remaining!)
+          _fetch(url:, resolved_url:, timeout: end_time&.remaining!)
         rescue ErrorDuringExecution
           raise CurlDownloadStrategyError, url
         end
@@ -473,7 +473,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   end
 
   def resolved_time_file_size(timeout: nil)
-    _, _, time, file_size = resolve_url_basename_time_file_size(url, timeout: timeout)
+    _, _, time, file_size = resolve_url_basename_time_file_size(url, timeout:)
     [time, file_size]
   end
 
@@ -489,7 +489,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     return @resolved_info_cache[url] if @resolved_info_cache.include?(url)
 
     begin
-      parsed_output = curl_headers(url.to_s, wanted_headers: ["content-disposition"], timeout: timeout)
+      parsed_output = curl_headers(url.to_s, wanted_headers: ["content-disposition"], timeout:)
     rescue ErrorDuringExecution
       return [url, parse_basename(url), nil, nil, false]
     end
@@ -559,7 +559,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   end
 
   def _curl_download(resolved_url, to, timeout)
-    curl_download resolved_url, to: to, try_partial: @try_partial, timeout: timeout
+    curl_download resolved_url, to:, try_partial: @try_partial, timeout:
   end
 
   # Curl options to be always passed to curl,
@@ -611,7 +611,7 @@ class HomebrewCurlDownloadStrategy < CurlDownloadStrategy
   def _curl_download(resolved_url, to, timeout)
     raise HomebrewCurlDownloadStrategyError, url unless Formula["curl"].any_version_installed?
 
-    curl_download resolved_url, to: to, try_partial: @try_partial, timeout: timeout, use_homebrew_curl: true
+    curl_download resolved_url, to:, try_partial: @try_partial, timeout:, use_homebrew_curl: true
   end
 
   def curl_output(*args, **options)
@@ -666,7 +666,7 @@ class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy
 
   def resolve_url_basename_time_file_size(url, timeout: nil)
     if url == self.url
-      super("#{apache_mirrors["preferred"]}#{apache_mirrors["path_info"]}", timeout: timeout)
+      super("#{apache_mirrors["preferred"]}#{apache_mirrors["path_info"]}", timeout:)
     else
       super
     end
@@ -698,7 +698,7 @@ class CurlPostDownloadStrategy < CurlDownloadStrategy
       query.nil? ? [url, "-X", "POST"] : [url, "-d", query]
     end
 
-    curl_download(*args, to: temporary_path, try_partial: @try_partial, timeout: timeout)
+    curl_download(*args, to: temporary_path, try_partial: @try_partial, timeout:)
   end
 end
 
@@ -709,7 +709,7 @@ end
 class NoUnzipCurlDownloadStrategy < CurlDownloadStrategy
   def stage
     UnpackStrategy::Uncompressed.new(cached_location)
-                                .extract(basename: basename,
+                                .extract(basename:,
                                          verbose:  verbose? && !quiet?)
     yield if block_given?
   end
@@ -821,18 +821,18 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
   def clone_repo(timeout: nil)
     case @ref_type
     when :revision
-      fetch_repo cached_location, @url, @ref, timeout: timeout
+      fetch_repo cached_location, @url, @ref, timeout:
     when :revisions
       # nil is OK for main_revision, as fetch_repo will then get latest
       main_revision = @ref[:trunk]
-      fetch_repo cached_location, @url, main_revision, ignore_externals: true, timeout: timeout
+      fetch_repo(cached_location, @url, main_revision, ignore_externals: true, timeout:)
 
       externals do |external_name, external_url|
         fetch_repo cached_location/external_name, external_url, @ref[external_name], ignore_externals: true,
-                                                                                     timeout:          timeout
+                                                                                     timeout:
       end
     else
-      fetch_repo cached_location, @url, timeout: timeout
+      fetch_repo cached_location, @url, timeout:
     end
   end
   alias update clone_repo
@@ -893,10 +893,10 @@ class GitDownloadStrategy < VCSDownloadStrategy
   sig { params(timeout: T.nilable(Time)).void }
   def update(timeout: nil)
     config_repo
-    update_repo(timeout: timeout)
-    checkout(timeout: timeout)
+    update_repo(timeout:)
+    checkout(timeout:)
     reset
-    update_submodules(timeout: timeout) if submodules?
+    update_submodules(timeout:) if submodules?
   end
 
   def shallow_dir?
@@ -1018,8 +1018,8 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
     configure_sparse_checkout if partial_clone_sparse_checkout?
 
-    checkout(timeout: timeout)
-    update_submodules(timeout: timeout) if submodules?
+    checkout(timeout:)
+    update_submodules(timeout:) if submodules?
   end
 
   sig { params(timeout: T.nilable(Time)).void }

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -75,7 +75,7 @@ class Downloadable
       raise ArgumentError, "attempted to use a Downloadable without a URL!" if primary_url.blank?
 
       download_strategy.new(primary_url, download_name, version,
-                            mirrors: mirrors, cache: cache, **T.must(@url).specs)
+                            mirrors:, cache:, **T.must(@url).specs)
     end
   end
 
@@ -84,7 +84,7 @@ class Downloadable
     cache.mkpath
 
     begin
-      downloader.fetch(timeout: timeout)
+      downloader.fetch(timeout:)
     rescue ErrorDuringExecution, CurlDownloadStrategyError => e
       raise DownloadError.new(self, e)
     end

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -44,10 +44,10 @@ module EnvActivation
   def with_build_environment(env: nil, cc: nil, build_bottle: false, bottle_arch: nil, debug_symbols: false, &_block)
     old_env = to_hash.dup
     tmp_env = to_hash.dup.extend(EnvActivation)
-    T.cast(tmp_env, EnvActivation).activate_extensions!(env: env)
+    T.cast(tmp_env, EnvActivation).activate_extensions!(env:)
     T.cast(tmp_env, T.any(Superenv, Stdenv))
-     .setup_build_environment(cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch,
-                              debug_symbols: debug_symbols)
+     .setup_build_environment(cc:, build_bottle:, bottle_arch:,
+                              debug_symbols:)
     replace(tmp_env)
 
     begin

--- a/Library/Homebrew/extend/blank.rb
+++ b/Library/Homebrew/extend/blank.rb
@@ -132,7 +132,7 @@ class Symbol
 end
 
 class String
-  BLANK_RE = /\A[[:space:]]*\z/.freeze
+  BLANK_RE = /\A[[:space:]]*\z/
   # This is a cache that is intentionally mutable
   # rubocop:disable Style/MutableConstant
   ENCODED_BLANKS_ = T.let(Hash.new do |h, enc|

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -55,7 +55,7 @@ module Kernel
   end
 
   def oh1(title, truncate: :auto)
-    puts oh1_title(title, truncate: truncate)
+    puts oh1_title(title, truncate:)
   end
 
   # Print a message prefixed with "Warning" (do this rarely).
@@ -156,7 +156,7 @@ module Kernel
   end
 
   def odisabled(method, replacement = nil, **options)
-    options = { disable: true, caller: caller }.merge(options)
+    options = { disable: true, caller: }.merge(options)
     # This odeprecated should stick around indefinitely.
     odeprecated(method, replacement, **options)
   end
@@ -364,8 +364,8 @@ module Kernel
       end
       # Call this method itself with redirected stdout
       redirect_stdout(file) do
-        return ensure_formula_installed!(formula_or_name, latest: latest,
-                                         reason: reason, output_to_stderr: false)
+        return ensure_formula_installed!(formula_or_name, latest:,
+                                         reason:, output_to_stderr: false)
       end
     end
 
@@ -403,7 +403,7 @@ module Kernel
     ].compact.first
     return executable if executable.exist?
 
-    ensure_formula_installed!(formula_name, reason: reason).opt_bin/name
+    ensure_formula_installed!(formula_name, reason:).opt_bin/name
   end
 
   def paths
@@ -429,7 +429,7 @@ module Kernel
     if ((size * 10).to_i % 10).zero?
       "#{size.to_i}#{unit}"
     else
-      "#{format("%<size>.1f", size: size)}#{unit}"
+      "#{format("%<size>.1f", size:)}#{unit}"
     end
   end
 

--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -4,8 +4,8 @@
 module Stdenv
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false,
                               debug_symbols: false)
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch,
-                                    testing_formula: testing_formula, debug_symbols: debug_symbols)
+    generic_setup_build_environment(formula:, cc:, build_bottle:, bottle_arch:,
+                                    testing_formula:, debug_symbols:)
 
     prepend_path "CPATH", HOMEBREW_PREFIX/"include"
     prepend_path "LIBRARY_PATH", HOMEBREW_PREFIX/"lib"

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -15,8 +15,8 @@ module Superenv
   # @private
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false,
                               debug_symbols: false)
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch,
-                                    testing_formula: testing_formula, debug_symbols: debug_symbols)
+    generic_setup_build_environment(formula:, cc:, build_bottle:, bottle_arch:,
+                                    testing_formula:, debug_symbols:)
     self["HOMEBREW_OPTIMIZATION_LEVEL"] = "O2"
     self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path
     self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(@formula)

--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -31,7 +31,7 @@ module Homebrew
     private_constant :GCC_RUNTIME_LIBS
 
     def self.perform_preinstall_checks(all_fatal: false, cc: nil)
-      generic_perform_preinstall_checks(all_fatal: all_fatal, cc: cc)
+      generic_perform_preinstall_checks(all_fatal:, cc:)
       symlink_ld_so
       setup_preferred_gcc_libs
     end

--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -29,7 +29,7 @@ class LinkageChecker
   private
 
   def check_dylibs(rebuild_cache:)
-    generic_check_dylibs(rebuild_cache: rebuild_cache)
+    generic_check_dylibs(rebuild_cache:)
 
     # glibc and gcc are implicit dependencies.
     # No other linkage to system libraries is expected or desired.

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -96,7 +96,7 @@ module Homebrew
 
         gnubin = %W[#{findutils.opt_libexec}/gnubin #{findutils.libexec}/gnubin]
         default_names = Tab.for_name("findutils").with? "default-names"
-        return if !default_names && (paths & gnubin).empty?
+        return if !default_names && !paths.intersect?(gnubin)
 
         <<~EOS
           Putting non-prefixed findutils in your path can cause python builds to fail.

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -14,9 +14,9 @@ module SharedEnvExtension
   }
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false,
                               debug_symbols: false)
-    generic_shared_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle,
-                                           bottle_arch: bottle_arch, testing_formula: testing_formula,
-                                           debug_symbols: debug_symbols)
+    generic_shared_setup_build_environment(formula:, cc:, build_bottle:,
+                                           bottle_arch:, testing_formula:,
+                                           debug_symbols:)
 
     # Normalise the system Perl version used, where multiple may be available
     self["VERSIONER_PERL_VERSION"] = MacOS.preferred_perl_version

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -12,8 +12,8 @@ module Stdenv
 
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false,
                               debug_symbols: false)
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch,
-                                    testing_formula: testing_formula, debug_symbols: debug_symbols)
+    generic_setup_build_environment(formula:, cc:, build_bottle:, bottle_arch:,
+                                    testing_formula:, debug_symbols:)
 
     append "LDFLAGS", "-Wl,-headerpad_max_install_names"
 
@@ -23,7 +23,7 @@ module Stdenv
     self["LC_CTYPE"] = "C"
 
     # Add lib and include etc. from the current macosxsdk to compiler flags:
-    macosxsdk(formula: @formula, testing_formula: testing_formula)
+    macosxsdk(formula: @formula, testing_formula:)
 
     return unless MacOS::Xcode.without_clt?
 

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -99,8 +99,8 @@ module Superenv
       MacOS::CLT::PKG_PATH
     end
 
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch,
-                                    testing_formula: testing_formula, debug_symbols: debug_symbols)
+    generic_setup_build_environment(formula:, cc:, build_bottle:, bottle_arch:,
+                                    testing_formula:, debug_symbols:)
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/extend/os/mac/formula.rb
+++ b/Library/Homebrew/extend/os/mac/formula.rb
@@ -18,8 +18,8 @@ class Formula
     ).returns(T::Array[String])
   }
   def std_cmake_args(install_prefix: prefix, install_libdir: "lib", find_framework: "LAST")
-    args = generic_std_cmake_args(install_prefix: install_prefix, install_libdir: install_libdir,
-                                  find_framework: find_framework)
+    args = generic_std_cmake_args(install_prefix:, install_libdir:,
+                                  find_framework:)
 
     # Avoid false positives for clock_gettime support on 10.11.
     # CMake cache entries for other weak symbols may be added here as needed.

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -133,7 +133,7 @@ class Keg
   VARIABLE_REFERENCE_RX = /^@(loader_|executable_|r)path/.freeze
 
   def each_linkage_for(file, linkage_type, resolve_variable_references: false, &block)
-    file.public_send(linkage_type, resolve_variable_references: resolve_variable_references)
+    file.public_send(linkage_type, resolve_variable_references:)
         .grep_v(VARIABLE_REFERENCE_RX)
         .each(&block)
   end

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -130,7 +130,7 @@ class Keg
     end
   end
 
-  VARIABLE_REFERENCE_RX = /^@(loader_|executable_|r)path/.freeze
+  VARIABLE_REFERENCE_RX = /^@(loader_|executable_|r)path/
 
   def each_linkage_for(file, linkage_type, resolve_variable_references: false, &block)
     file.public_send(linkage_type, resolve_variable_references:)
@@ -159,7 +159,7 @@ class Keg
 
   # Matches framework references like `XXX.framework/Versions/YYY/XXX` and
   # `XXX.framework/XXX`, both with or without a slash-delimited prefix.
-  FRAMEWORK_RX = %r{(?:^|/)(([^/]+)\.framework/(?:Versions/[^/]+/)?\2)$}.freeze
+  FRAMEWORK_RX = %r{(?:^|/)(([^/]+)\.framework/(?:Versions/[^/]+/)?\2)$}
 
   def find_dylib_suffix_from(bad_name)
     if (framework = bad_name.match(FRAMEWORK_RX))
@@ -233,7 +233,7 @@ class Keg
 
   private
 
-  CELLAR_RX = %r{\A#{HOMEBREW_CELLAR}/(?<formula_name>[^/]+)/[^/]+}.freeze
+  CELLAR_RX = %r{\A#{HOMEBREW_CELLAR}/(?<formula_name>[^/]+)/[^/]+}
 
   # Replace HOMEBREW_CELLAR references with HOMEBREW_PREFIX/opt references
   # if the Cellar reference is to a different keg.

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
             # (Also, Homebrew's ZIP artifact automatically deletes this folder.)
             return system_command! "ditto",
                                    args:         ["-x", "-k", path, unpack_dir],
-                                   verbose:      verbose,
+                                   verbose:,
                                    print_stderr: false
           end
 
@@ -26,9 +26,9 @@ module UnpackStrategy
           rescue ErrorDuringExecution => e
             raise unless e.stderr.include?("End-of-central-directory signature not found.")
 
-            system_command! "ditto",
+            system_command!("ditto",
                             args:    ["-x", "-k", path, unpack_dir],
-                            verbose: verbose
+                            verbose:)
             nil
           end
 
@@ -46,12 +46,12 @@ module UnpackStrategy
 
             # `ditto` keeps Finder attributes intact and does not skip volume labels
             # like `unzip` does, which can prevent disk images from being unzipped.
-            system_command! "ditto",
+            system_command!("ditto",
                             args:    ["-x", "-k", path, tmp_unpack_dir],
-                            verbose: verbose
+                            verbose:)
 
             volumes.each do |volume|
-              FileUtils.mv tmp_unpack_dir/volume, unpack_dir/volume, verbose: verbose
+              FileUtils.mv tmp_unpack_dir/volume, unpack_dir/volume, verbose:
             end
           end
         end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1399,7 +1399,7 @@ class Formula
   def brew(fetch: true, keep_tmp: false, debug_symbols: false, interactive: false)
     @prefix_returns_versioned_prefix = true
     active_spec.fetch if fetch
-    stage(interactive: interactive, debug_symbols: debug_symbols) do |staging|
+    stage(interactive:, debug_symbols:) do |staging|
       staging.retain! if keep_tmp || debug_symbols
 
       prepare_patches
@@ -1496,7 +1496,7 @@ class Formula
       end
 
       if current_version ||
-         ((head_version = latest_head_version) && !head_version_outdated?(head_version, fetch_head: fetch_head))
+         ((head_version = latest_head_version) && !head_version_outdated?(head_version, fetch_head:))
         []
       else
         all_kegs += old_installed_formulae.flat_map(&:installed_kegs)
@@ -1555,7 +1555,7 @@ class Formula
   # @private
   sig { params(fetch_head: T::Boolean).returns(T::Boolean) }
   def outdated?(fetch_head: false)
-    !outdated_kegs(fetch_head: fetch_head).empty?
+    !outdated_kegs(fetch_head:).empty?
   rescue Migrator::MigrationNeededError
     true
   end
@@ -2074,14 +2074,14 @@ class Formula
   # @private
   def recursive_dependencies(&block)
     cache_key = "Formula#recursive_dependencies" unless block
-    Dependency.expand(self, cache_key: cache_key, &block)
+    Dependency.expand(self, cache_key:, &block)
   end
 
   # The full set of Requirements for this formula's dependency tree.
   # @private
   def recursive_requirements(&block)
     cache_key = "Formula#recursive_requirements" unless block
-    Requirement.expand(self, cache_key: cache_key, &block)
+    Requirement.expand(self, cache_key:, &block)
   end
 
   # Returns a Keg for the opt_prefix or installed_prefix if they exist.
@@ -2137,8 +2137,8 @@ class Formula
 
     Formula.cache[:runtime_formula_dependencies] ||= {}
     Formula.cache[:runtime_formula_dependencies][cache_key] ||= runtime_dependencies(
-      read_from_tab: read_from_tab,
-      undeclared:    undeclared,
+      read_from_tab:,
+      undeclared:,
     ).map do |d|
       d.to_formula
     rescue FormulaUnavailableError
@@ -2195,7 +2195,7 @@ class Formula
 
     all_dependables.map do |dependable|
       {
-        dependable: dependable,
+        dependable:,
         # Now find the list of specs each dependency was a part of.
         specs:      dependables.map { |spec, spec_deps| spec if spec_deps&.include?(dependable) }.compact,
       }
@@ -2400,15 +2400,15 @@ class Formula
     if path.exist? && on_system_blocks_exist?
       formula_contents = path.read
       OnSystem::ALL_OS_ARCH_COMBINATIONS.each do |os, arch|
-        bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
+        bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
         next unless bottle_tag.valid_combination?
 
-        Homebrew::SimulateSystem.with os: os, arch: arch do
+        Homebrew::SimulateSystem.with(os:, arch:) do
           variations_namespace = Formulary.class_s("Variations#{bottle_tag.to_sym.capitalize}")
           variations_formula_class = Formulary.load_formula(name, path, formula_contents, variations_namespace,
                                                             flags: self.class.build_flags, ignore_errors: true)
           variations_formula = variations_formula_class.new(name, path, :stable,
-                                                            alias_path: alias_path, force_bottle: force_bottle)
+                                                            alias_path:, force_bottle:)
 
           variations_formula.to_hash.each do |key, value|
             next if value.to_s == hash[key].to_s
@@ -2458,7 +2458,7 @@ class Formula
 
   # @private
   def fetch(verify_download_integrity: true)
-    active_spec.fetch(verify_download_integrity: verify_download_integrity)
+    active_spec.fetch(verify_download_integrity:)
   end
 
   # @private
@@ -2556,7 +2556,7 @@ class Formula
     ).void
   }
   def inreplace(paths, before = nil, after = nil, audit_result = true, &block) # rubocop:disable Style/OptionalBooleanParameter
-    Utils::Inreplace.inreplace(paths, before, after, audit_result: audit_result, &block)
+    Utils::Inreplace.inreplace(paths, before, after, audit_result:, &block)
   rescue Utils::Inreplace::Error => e
     onoe e.to_s
     raise BuildError.new(self, "inreplace", Array(paths), {})
@@ -2581,7 +2581,7 @@ class Formula
   # @private
   def declared_runtime_dependencies
     cache_key = "Formula#declared_runtime_dependencies" unless build.any_args_or_options?
-    Dependency.expand(self, cache_key: cache_key) do |_, dependency|
+    Dependency.expand(self, cache_key:) do |_, dependency|
       Dependency.prune if dependency.build?
       next if dependency.required?
 
@@ -2879,7 +2879,7 @@ class Formula
   end
 
   def stage(interactive: false, debug_symbols: false)
-    active_spec.stage(debug_symbols: debug_symbols) do |staging|
+    active_spec.stage(debug_symbols:) do |staging|
       @source_modified_time = active_spec.source_modified_time
       @buildpath = Pathname.pwd
       env_home = T.must(buildpath)/".brew_home"

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -572,7 +572,7 @@ module Homebrew
         user_agents:       [:browser, :default],
         check_content:     true,
         strict:            @strict,
-        use_homebrew_curl: use_homebrew_curl,
+        use_homebrew_curl:,
       ))
         problem http_content_problem
       end
@@ -672,7 +672,7 @@ module Homebrew
 
         ra = ResourceAuditor.new(
           spec, spec_name,
-          online: @online, strict: @strict, only: @only, except: except,
+          online: @online, strict: @strict, only: @only, except:,
           use_homebrew_curl: spec.using == :homebrew_curl
         ).audit
         ra.problems.each do |message|
@@ -761,7 +761,7 @@ module Homebrew
         tag ||= stable.version
 
         if @online
-          error = SharedAudits.gitlab_release(owner, repo, tag, formula: formula)
+          error = SharedAudits.gitlab_release(owner, repo, tag, formula:)
           problem error if error
         end
       when %r{^https://github.com/([\w-]+)/([\w-]+)}
@@ -771,7 +771,7 @@ module Homebrew
         tag ||= formula.stable.specs[:tag]
 
         if @online
-          error = SharedAudits.github_release(owner, repo, tag, formula: formula)
+          error = SharedAudits.github_release(owner, repo, tag, formula:)
           problem error if error
         end
       end
@@ -935,11 +935,11 @@ module Homebrew
     private
 
     def problem(message, location: nil, corrected: false)
-      @problems << ({ message: message, location: location, corrected: corrected })
+      @problems << ({ message:, location:, corrected: })
     end
 
     def new_formula_problem(message, location: nil, corrected: false)
-      @new_formula_problems << ({ message: message, location: location, corrected: corrected })
+      @new_formula_problems << ({ message:, location:, corrected: })
     end
 
     def head_only?(formula)
@@ -955,7 +955,7 @@ module Homebrew
       return false if variations.blank?
 
       MacOSVersion::SYMBOLS.keys.product(OnSystem::ARCH_OPTIONS).each do |os, arch|
-        bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
+        bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
         next unless bottle_tag.valid_combination?
 
         variation_dependencies = variations.dig(bottle_tag.to_sym, "dependencies")

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -426,7 +426,7 @@ class FormulaInstaller
 
     if (tap = formula.tap) && tap.should_report_analytics?
       Utils::Analytics.report_event(:formula_install, package_name: formula.name, tap_name: tap.name,
-on_request: installed_on_request?, options: options)
+on_request: installed_on_request?, options:)
     end
 
     self.class.attempted << formula
@@ -603,7 +603,7 @@ on_request: installed_on_request?, options: options)
   def expand_dependencies_for_formula(formula, inherited_options)
     # Cache for this expansion only. FormulaInstaller has a lot of inputs which can alter expansion.
     cache_key = "FormulaInstaller-#{formula.full_name}-#{Time.now.to_f}"
-    Dependency.expand(formula, cache_key: cache_key) do |dependent, dep|
+    Dependency.expand(formula, cache_key:) do |dependent, dep|
       inherited_options[dep.name] |= inherited_options_for(dep)
       build = effective_build_options_for(
         dependent,
@@ -738,7 +738,7 @@ on_request: installed_on_request?, options: options)
 
     fi = FormulaInstaller.new(
       df,
-      options:                    options,
+      options:,
       link_keg:                   keg_had_linked_keg ? keg_was_linked : nil,
       installed_as_dependency:    true,
       installed_on_request:       df.any_version_installed? && tab.present? && tab.installed_on_request,
@@ -1286,7 +1286,7 @@ on_request: installed_on_request?, options: options)
 
     keg = Keg.new(formula.prefix)
     skip_linkage = formula.bottle_specification.skip_relocation?
-    keg.replace_placeholders_with_locations tab.changed_files, skip_linkage: skip_linkage
+    keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:)
 
     cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)
     return if [:any, :any_skip_relocation].include?(cellar)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -17,7 +17,7 @@ require "active_support/core_ext/hash/deep_transform_values"
 module Formulary
   extend Cachable
 
-  URL_START_REGEX = %r{(https?|ftp|file)://}.freeze
+  URL_START_REGEX = %r{(https?|ftp|file)://}
 
   # :codesign and custom requirement classes are not supported
   API_SUPPORTED_REQUIREMENTS = [:arch, :linux, :macos, :maximum_macos, :xcode].freeze

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -38,14 +38,14 @@ class GitRepository
   # Gets the full commit hash of the HEAD commit.
   sig { params(safe: T::Boolean).returns(T.nilable(String)) }
   def head_ref(safe: false)
-    popen_git("rev-parse", "--verify", "--quiet", "HEAD", safe: safe)
+    popen_git("rev-parse", "--verify", "--quiet", "HEAD", safe:)
   end
 
   # Gets a short commit hash of the HEAD commit.
   sig { params(length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String)) }
   def short_head_ref(length: nil, safe: false)
     short_arg = length.present? ? "--short=#{length}" : "--short"
-    popen_git("rev-parse", short_arg, "--verify", "--quiet", "HEAD", safe: safe)
+    popen_git("rev-parse", short_arg, "--verify", "--quiet", "HEAD", safe:)
   end
 
   # Gets the relative date of the last commit, e.g. "1 hour ago"
@@ -57,7 +57,7 @@ class GitRepository
   # Gets the name of the currently checked-out branch, or HEAD if the repository is in a detached HEAD state.
   sig { params(safe: T::Boolean).returns(T.nilable(String)) }
   def branch_name(safe: false)
-    popen_git("rev-parse", "--abbrev-ref", "HEAD", safe: safe)
+    popen_git("rev-parse", "--abbrev-ref", "HEAD", safe:)
   end
 
   # Change the name of a local branch
@@ -104,7 +104,7 @@ class GitRepository
   # Gets the full commit message of the specified commit, or of the HEAD commit if unspecified.
   sig { params(commit: String, safe: T::Boolean).returns(T.nilable(String)) }
   def commit_message(commit = "HEAD", safe: false)
-    popen_git("log", "-1", "--pretty=%B", commit, "--", safe: safe, err: :out)&.strip
+    popen_git("log", "-1", "--pretty=%B", commit, "--", safe:, err: :out)&.strip
   end
 
   sig { returns(String) }
@@ -128,6 +128,6 @@ class GitRepository
       raise "Git is unavailable"
     end
 
-    Utils.popen_read(Utils::Git.git, *args, safe: safe, chdir: pathname, err: err).chomp.presence
+    Utils.popen_read(Utils::Git.git, *args, safe:, chdir: pathname, err:).chomp.presence
   end
 end

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -12,8 +12,8 @@ class GitHubPackages
   include Context
 
   URL_DOMAIN = "ghcr.io"
-  URL_PREFIX = "https://#{URL_DOMAIN}/v2/"
-  DOCKER_PREFIX = "docker://#{URL_DOMAIN}/"
+  URL_PREFIX = "https://#{URL_DOMAIN}/v2/".freeze
+  DOCKER_PREFIX = "docker://#{URL_DOMAIN}/".freeze
   public_constant :URL_DOMAIN
   private_constant :URL_PREFIX
   private_constant :DOCKER_PREFIX

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -18,12 +18,12 @@ class GitHubPackages
   private_constant :URL_PREFIX
   private_constant :DOCKER_PREFIX
 
-  URL_REGEX = %r{(?:#{Regexp.escape(URL_PREFIX)}|#{Regexp.escape(DOCKER_PREFIX)})([\w-]+)/([\w-]+)}.freeze
+  URL_REGEX = %r{(?:#{Regexp.escape(URL_PREFIX)}|#{Regexp.escape(DOCKER_PREFIX)})([\w-]+)/([\w-]+)}
 
   # Valid OCI tag characters
   # https://github.com/opencontainers/distribution-spec/blob/main/spec.md#workflow-categories
-  VALID_OCI_TAG_REGEX = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/.freeze
-  INVALID_OCI_TAG_CHARS_REGEX = /[^a-zA-Z0-9._-]/.freeze
+  VALID_OCI_TAG_REGEX = /^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/
+  INVALID_OCI_TAG_CHARS_REGEX = /[^a-zA-Z0-9._-]/
 
   GZIP_BUFFER_SIZE = 64 * 1024
   private_constant :GZIP_BUFFER_SIZE

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -64,7 +64,7 @@ class GitHubPackages
     bottles_hash.each do |formula_full_name, bottle_hash|
       # First, check that we won't encounter an error in the middle of uploading bottles.
       preupload_check(user, token, skopeo, formula_full_name, bottle_hash,
-                      keep_old: keep_old, dry_run: dry_run, warn_on_error: warn_on_error)
+                      keep_old:, dry_run:, warn_on_error:)
     end
 
     # We intentionally iterate over `bottles_hash` twice to
@@ -73,7 +73,7 @@ class GitHubPackages
     bottles_hash.each do |formula_full_name, bottle_hash|
       # Next, upload the bottles after checking them all.
       upload_bottle(user, token, skopeo, formula_full_name, bottle_hash,
-                    keep_old: keep_old, dry_run: dry_run, warn_on_error: warn_on_error)
+                    keep_old:, dry_run:, warn_on_error:)
     end
     # rubocop:enable Style/CombinableLoops
   end
@@ -204,7 +204,7 @@ class GitHubPackages
       puts "#{skopeo} #{args.join(" ")} --src-creds=#{user}:$HOMEBREW_GITHUB_PACKAGES_TOKEN"
     else
       args << "--src-creds=#{user}:#{token}"
-      system_command!(skopeo, verbose: true, print_stdout: true, args: args)
+      system_command!(skopeo, verbose: true, print_stdout: true, args:)
     end
   end
 
@@ -260,7 +260,7 @@ class GitHubPackages
   def upload_bottle(user, token, skopeo, formula_full_name, bottle_hash, keep_old:, dry_run:, warn_on_error:)
     # We run the preupload check twice to prevent TOCTOU bugs.
     result = preupload_check(user, token, skopeo, formula_full_name, bottle_hash,
-                             keep_old: keep_old, dry_run: dry_run, warn_on_error: warn_on_error)
+                             keep_old:, dry_run:, warn_on_error:)
 
     formula_name, org, repo, version, rebuild, version_rebuild, image_name, image_uri, keep_old = *result
 
@@ -269,7 +269,7 @@ class GitHubPackages
     root.mkpath
 
     if keep_old
-      download(user, token, skopeo, image_uri, root, dry_run: dry_run)
+      download(user, token, skopeo, image_uri, root, dry_run:)
     else
       write_image_layout(root)
     end
@@ -365,8 +365,8 @@ class GitHubPackages
       end
 
       platform_hash = {
-        architecture: architecture,
-        os: os,
+        architecture:,
+        os:,
         "os.version" => os_version,
       }.reject { |_, v| v.blank? }
 
@@ -443,7 +443,7 @@ class GitHubPackages
       args << "--dest-creds=#{user}:#{token}"
       retry_count = 0
       begin
-        system_command!(skopeo, verbose: true, print_stdout: true, args: args)
+        system_command!(skopeo, verbose: true, print_stdout: true, args:)
       rescue ErrorDuringExecution
         retry_count += 1
         odie "Cannot perform an upload to registry after retrying multiple times!" if retry_count >= 10
@@ -483,8 +483,8 @@ class GitHubPackages
   def write_image_index(manifests, blobs, annotations)
     image_index = {
       schemaVersion: 2,
-      manifests:     manifests,
-      annotations:   annotations,
+      manifests:,
+      annotations:,
     }
     validate_schema!(IMAGE_INDEX_SCHEMA_URI, image_index)
     write_hash(blobs, image_index)
@@ -497,7 +497,7 @@ class GitHubPackages
         mediaType:   "application/vnd.oci.image.index.v1+json",
         digest:      "sha256:#{index_json_sha256}",
         size:        index_json_size,
-        annotations: annotations,
+        annotations:,
       }],
     }
     validate_schema!(IMAGE_INDEX_SCHEMA_URI, index_json)

--- a/Library/Homebrew/github_releases.rb
+++ b/Library/Homebrew/github_releases.rb
@@ -34,7 +34,7 @@ class GitHubReleases
         remote_file = tag_hash["filename"]
         local_file = tag_hash["local_filename"]
         odebug "Uploading #{remote_file}"
-        GitHub.upload_release_asset user, repo, release["id"], local_file: local_file, remote_file: remote_file
+        GitHub.upload_release_asset user, repo, release["id"], local_file:, remote_file:
       end
     end
   end

--- a/Library/Homebrew/github_releases.rb
+++ b/Library/Homebrew/github_releases.rb
@@ -10,7 +10,7 @@ require "json"
 class GitHubReleases
   include Context
 
-  URL_REGEX = %r{https://github\.com/([\w-]+)/([\w-]+)?/releases/download/(.+)}.freeze
+  URL_REGEX = %r{https://github\.com/([\w-]+)/([\w-]+)?/releases/download/(.+)}
 
   sig { params(bottles_hash: T::Hash[String, T.untyped]).void }
   def upload_bottles(bottles_hash)

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -100,7 +100,7 @@ class GitHubRunnerMatrix
     raise "Unexpected platform: #{platform}" if VALID_PLATFORMS.exclude?(platform)
     raise "Unexpected arch: #{arch}" if VALID_ARCHES.exclude?(arch)
 
-    runner = GitHubRunner.new(platform: platform, arch: arch, spec: spec, macos_version: macos_version)
+    runner = GitHubRunner.new(platform:, arch:, spec:, macos_version:)
     runner.active = active_runner?(runner)
     runner.freeze
   end
@@ -147,7 +147,7 @@ class GitHubRunnerMatrix
 
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-x86_64",
-        runner:  runner,
+        runner:,
         timeout: runner_timeout,
         cleanup: !runner.end_with?(ephemeral_suffix),
       )
@@ -168,7 +168,7 @@ class GitHubRunnerMatrix
       runner_timeout /= 2 if runner_timeout < GITHUB_ACTIONS_LONG_TIMEOUT
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-arm64",
-        runner:  runner,
+        runner:,
         timeout: runner_timeout,
         cleanup: !runner.end_with?(ephemeral_suffix),
       )
@@ -215,7 +215,7 @@ class GitHubRunnerMatrix
       next false unless formula.public_send(:"#{arch}_compatible?")
       next false if macos_version.present? && !formula.compatible_with?(macos_version)
 
-      compatible_dependents = formula.dependents(platform: platform, arch: arch, macos_version: macos_version&.to_sym)
+      compatible_dependents = formula.dependents(platform:, arch:, macos_version: macos_version&.to_sym)
                                      .dup
 
       compatible_dependents.select! do |dependent_f|

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -42,7 +42,7 @@ HOMEBREW_PHYSICAL_PROCESSOR = ENV.fetch("HOMEBREW_PHYSICAL_PROCESSOR").freeze
 HOMEBREW_BREWED_CURL_PATH = Pathname(ENV.fetch("HOMEBREW_BREWED_CURL_PATH")).freeze
 HOMEBREW_USER_AGENT_CURL = ENV.fetch("HOMEBREW_USER_AGENT_CURL").freeze
 HOMEBREW_USER_AGENT_RUBY =
-  "#{ENV.fetch("HOMEBREW_USER_AGENT")} ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
+  "#{ENV.fetch("HOMEBREW_USER_AGENT")} ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}".freeze
 HOMEBREW_USER_AGENT_FAKE_SAFARI =
   # Don't update this beyond 10.15.7 until Safari actually updates their
   # user agent to be beyond 10.15.7 (not the case as-of macOS 14)
@@ -83,10 +83,10 @@ require "default_prefix"
 module Homebrew
   extend FileUtils
 
-  DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar"
-  DEFAULT_MACOS_CELLAR = "#{HOMEBREW_DEFAULT_PREFIX}/Cellar"
-  DEFAULT_MACOS_ARM_CELLAR = "#{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/Cellar"
-  DEFAULT_LINUX_CELLAR = "#{HOMEBREW_LINUX_DEFAULT_PREFIX}/Cellar"
+  DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar".freeze
+  DEFAULT_MACOS_CELLAR = "#{HOMEBREW_DEFAULT_PREFIX}/Cellar".freeze
+  DEFAULT_MACOS_ARM_CELLAR = "#{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/Cellar".freeze
+  DEFAULT_LINUX_CELLAR = "#{HOMEBREW_LINUX_DEFAULT_PREFIX}/Cellar".freeze
 
   class << self
     attr_writer :failed, :raise_deprecation_exceptions, :auditing

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -67,10 +67,10 @@ HOMEBREW_MACOS_OLDEST_SUPPORTED = ENV.fetch("HOMEBREW_MACOS_OLDEST_SUPPORTED").f
 HOMEBREW_MACOS_OLDEST_ALLOWED = ENV.fetch("HOMEBREW_MACOS_OLDEST_ALLOWED").freeze
 
 HOMEBREW_PULL_API_REGEX =
-  %r{https://api\.github\.com/repos/([\w-]+)/([\w-]+)?/pulls/(\d+)}.freeze
+  %r{https://api\.github\.com/repos/([\w-]+)/([\w-]+)?/pulls/(\d+)}
 HOMEBREW_PULL_OR_COMMIT_URL_REGEX =
-  %r[https://github\.com/([\w-]+)/([\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})].freeze
-HOMEBREW_BOTTLES_EXTNAME_REGEX = /\.([a-z0-9_]+)\.bottle\.(?:(\d+)\.)?tar\.gz$/.freeze
+  %r[https://github\.com/([\w-]+)/([\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})]
+HOMEBREW_BOTTLES_EXTNAME_REGEX = /\.([a-z0-9_]+)\.bottle\.(?:(\d+)\.)?tar\.gz$/
 
 require "extend/module"
 require "extend/blank"

--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -59,7 +59,7 @@ module Homebrew
 
       # Display command-specific (or generic) help in response to `UsageError`.
       if usage_error
-        $stderr.puts path ? command_help(cmd, path, remaining_args: remaining_args) : HOMEBREW_HELP
+        $stderr.puts path ? command_help(cmd, path, remaining_args:) : HOMEBREW_HELP
         $stderr.puts
         onoe usage_error
         exit 1
@@ -69,7 +69,7 @@ module Homebrew
       return if path.nil?
 
       # Display help for internal command (or generic help if undocumented).
-      puts command_help(cmd, path, remaining_args: remaining_args)
+      puts command_help(cmd, path, remaining_args:)
       exit 0
     end
 
@@ -78,7 +78,7 @@ module Homebrew
       output = if Commands.valid_internal_cmd?(cmd) ||
                   Commands.valid_internal_dev_cmd?(cmd) ||
                   Commands.external_ruby_v2_cmd_path(cmd)
-        parser_help(path, remaining_args: remaining_args)
+        parser_help(path, remaining_args:)
       end
 
       output ||= comment_help(path)

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -78,7 +78,7 @@ module Homebrew
 
         installed_head_version = formula.latest_head_version
         if installed_head_version &&
-           !formula.head_version_outdated?(installed_head_version, fetch_head: fetch_head)
+           !formula.head_version_outdated?(installed_head_version, fetch_head:)
           new_head_installed = true
         end
         prefix_installed = formula.prefix.exist? && !formula.prefix.children.empty?
@@ -245,30 +245,30 @@ module Homebrew
         skip_post_install: false
       )
         formula_installers = formulae_to_install.map do |formula|
-          Migrator.migrate_if_needed(formula, force: force, dry_run: dry_run)
+          Migrator.migrate_if_needed(formula, force:, dry_run:)
           build_options = formula.build
 
           formula_installer = FormulaInstaller.new(
             formula,
             options:                    build_options.used_options,
-            build_bottle:               build_bottle,
-            force_bottle:               force_bottle,
-            bottle_arch:                bottle_arch,
-            ignore_deps:                ignore_deps,
-            only_deps:                  only_deps,
-            include_test_formulae:      include_test_formulae,
-            build_from_source_formulae: build_from_source_formulae,
-            cc:                         cc,
-            git:                        git,
-            interactive:                interactive,
-            keep_tmp:                   keep_tmp,
-            debug_symbols:              debug_symbols,
-            force:                      force,
-            overwrite:                  overwrite,
-            debug:                      debug,
-            quiet:                      quiet,
-            verbose:                    verbose,
-            skip_post_install:          skip_post_install,
+            build_bottle:,
+            force_bottle:,
+            bottle_arch:,
+            ignore_deps:,
+            only_deps:,
+            include_test_formulae:,
+            build_from_source_formulae:,
+            cc:,
+            git:,
+            interactive:,
+            keep_tmp:,
+            debug_symbols:,
+            force:,
+            overwrite:,
+            debug:,
+            quiet:,
+            verbose:,
+            skip_post_install:,
           )
 
           begin
@@ -355,7 +355,7 @@ module Homebrew
 
         upgrade = formula.linked? && formula.outdated? && !formula.head? && !Homebrew::EnvConfig.no_install_upgrade?
 
-        Upgrade.install_formula(formula_installer, upgrade: upgrade)
+        Upgrade.install_formula(formula_installer, upgrade:)
       end
     end
   end

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -78,8 +78,8 @@ class Keg
   end
 
   # Locale-specific directories have the form `language[_territory][.codeset][@modifier]`
-  LOCALEDIR_RX = %r{(locale|man)/([a-z]{2}|C|POSIX)(_[A-Z]{2})?(\.[a-zA-Z\-0-9]+(@.+)?)?}.freeze
-  INFOFILE_RX = %r{info/([^.].*?\.info|dir)$}.freeze
+  LOCALEDIR_RX = %r{(locale|man)/([a-z]{2}|C|POSIX)(_[A-Z]{2})?(\.[a-zA-Z\-0-9]+(@.+)?)?}
+  INFOFILE_RX = %r{info/([^.].*?\.info|dir)$}
   KEG_LINK_DIRECTORIES = %w[
     bin etc include lib sbin share var
   ].freeze

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -408,16 +408,16 @@ class Keg
 
     ObserverPathnameExtension.reset_counts!
 
-    optlink(verbose: verbose, dry_run: dry_run, overwrite: overwrite) unless dry_run
+    optlink(verbose:, dry_run:, overwrite:) unless dry_run
 
     # yeah indeed, you have to force anything you need in the main tree into
     # these dirs REMEMBER that *NOT* everything needs to be in the main tree
-    link_dir("etc", verbose: verbose, dry_run: dry_run, overwrite: overwrite) { :mkpath }
-    link_dir("bin", verbose: verbose, dry_run: dry_run, overwrite: overwrite) { :skip_dir }
-    link_dir("sbin", verbose: verbose, dry_run: dry_run, overwrite: overwrite) { :skip_dir }
-    link_dir("include", verbose: verbose, dry_run: dry_run, overwrite: overwrite) { :link }
+    link_dir("etc", verbose:, dry_run:, overwrite:) { :mkpath }
+    link_dir("bin", verbose:, dry_run:, overwrite:) { :skip_dir }
+    link_dir("sbin", verbose:, dry_run:, overwrite:) { :skip_dir }
+    link_dir("include", verbose:, dry_run:, overwrite:) { :link }
 
-    link_dir("share", verbose: verbose, dry_run: dry_run, overwrite: overwrite) do |relative_path|
+    link_dir("share", verbose:, dry_run:, overwrite:) do |relative_path|
       case relative_path.to_s
       when INFOFILE_RX then :info
       when "locale/locale.alias",
@@ -436,7 +436,7 @@ class Keg
       end
     end
 
-    link_dir("lib", verbose: verbose, dry_run: dry_run, overwrite: overwrite) do |relative_path|
+    link_dir("lib", verbose:, dry_run:, overwrite:) do |relative_path|
       case relative_path.to_s
       when "charset.alias"
         :skip_file
@@ -462,7 +462,7 @@ class Keg
       end
     end
 
-    link_dir("Frameworks", verbose: verbose, dry_run: dry_run, overwrite: overwrite) do |relative_path|
+    link_dir("Frameworks", verbose:, dry_run:, overwrite:) do |relative_path|
       # Frameworks contain symlinks pointing into a subdir, so we have to use
       # the :link strategy. However, for Foo.framework and
       # Foo.framework/Versions we have to use :mkpath so that multiple formulae
@@ -474,10 +474,10 @@ class Keg
       end
     end
     unless dry_run
-      make_relative_symlink(linked_keg_record, path, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
+      make_relative_symlink(linked_keg_record, path, verbose:, dry_run:, overwrite:)
     end
   rescue LinkError
-    unlink(verbose: verbose)
+    unlink(verbose:)
     raise
   else
     ObserverPathnameExtension.n
@@ -512,16 +512,16 @@ class Keg
 
   def optlink(verbose: false, dry_run: false, overwrite: false)
     opt_record.delete if opt_record.symlink? || opt_record.exist?
-    make_relative_symlink(opt_record, path, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
+    make_relative_symlink(opt_record, path, verbose:, dry_run:, overwrite:)
     aliases.each do |a|
       alias_opt_record = opt_record.parent/a
       alias_opt_record.delete if alias_opt_record.symlink? || alias_opt_record.exist?
-      make_relative_symlink(alias_opt_record, path, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
+      make_relative_symlink(alias_opt_record, path, verbose:, dry_run:, overwrite:)
     end
 
     oldname_opt_records.each do |record|
       record.delete
-      make_relative_symlink(record, path, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
+      make_relative_symlink(record, path, verbose:, dry_run:, overwrite:)
     end
   end
 
@@ -641,10 +641,10 @@ class Keg
         when :info
           next if File.basename(src) == "dir" # skip historical local 'dir' files
 
-          make_relative_symlink dst, src, verbose: verbose, dry_run: dry_run, overwrite: overwrite
+          make_relative_symlink(dst, src, verbose:, dry_run:, overwrite:)
           dst.install_info
         else
-          make_relative_symlink dst, src, verbose: verbose, dry_run: dry_run, overwrite: overwrite
+          make_relative_symlink dst, src, verbose:, dry_run:, overwrite:
         end
       elsif src.directory?
         # if the dst dir already exists, then great! walk the rest of the tree tho
@@ -658,10 +658,10 @@ class Keg
         when :skip_dir
           Find.prune
         when :mkpath
-          dst.mkpath unless resolve_any_conflicts(dst, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
+          dst.mkpath unless resolve_any_conflicts(dst, verbose:, dry_run:, overwrite:)
         else
-          unless resolve_any_conflicts(dst, verbose: verbose, dry_run: dry_run, overwrite: overwrite)
-            make_relative_symlink dst, src, verbose: verbose, dry_run: dry_run, overwrite: overwrite
+          unless resolve_any_conflicts(dst, verbose:, dry_run:, overwrite:)
+            make_relative_symlink(dst, src, verbose:, dry_run:, overwrite:)
             Find.prune
           end
         end

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -128,7 +128,7 @@ class Keg
   def replace_placeholders_with_locations(files, skip_linkage: false)
     relocation = prepare_relocation_to_locations.freeze
     relocate_dynamic_linkage(relocation) unless skip_linkage
-    replace_text_in_files(relocation, files: files)
+    replace_text_in_files(relocation, files:)
   end
 
   def openjdk_dep_name_if_applicable

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -12,7 +12,7 @@ class Keg
   NULL_BYTE_STRING = "\\x00"
 
   class Relocation
-    RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))/.freeze
+    RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))/
 
     def initialize
       @replacement_map = {}
@@ -83,7 +83,7 @@ class Keg
     []
   end
 
-  JAVA_REGEX = %r{#{HOMEBREW_PREFIX}/opt/openjdk(@\d+(\.\d+)*)?/libexec(/openjdk\.jdk/Contents/Home)?}.freeze
+  JAVA_REGEX = %r{#{HOMEBREW_PREFIX}/opt/openjdk(@\d+(\.\d+)*)?/libexec(/openjdk\.jdk/Contents/Home)?}
 
   def prepare_relocation_to_placeholders
     relocation = Relocation.new

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -92,7 +92,7 @@ module Language
       module_function
 
       # A regex to match potential shebang permutations.
-      NODE_SHEBANG_REGEX = %r{^#! ?/usr/bin/(?:env )?node( |$)}.freeze
+      NODE_SHEBANG_REGEX = %r{^#! ?/usr/bin/(?:env )?node( |$)}
 
       # The length of the longest shebang matching `SHEBANG_REGEX`.
       NODE_SHEBANG_MAX_LENGTH = "#! /usr/bin/env node ".length

--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -11,7 +11,7 @@ module Language
       module_function
 
       # A regex to match potential shebang permutations.
-      PERL_SHEBANG_REGEX = %r{^#! ?/usr/bin/(?:env )?perl( |$)}.freeze
+      PERL_SHEBANG_REGEX = %r{^#! ?/usr/bin/(?:env )?perl( |$)}
 
       # The length of the longest shebang matching `SHEBANG_REGEX`.
       PERL_SHEBANG_MAX_LENGTH = "#! /usr/bin/env perl ".length

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -95,7 +95,7 @@ module Language
       module_function
 
       # A regex to match potential shebang permutations.
-      PYTHON_SHEBANG_REGEX = %r{^#! ?/usr/bin/(?:env )?python(?:[23](?:\.\d{1,2})?)?( |$)}.freeze
+      PYTHON_SHEBANG_REGEX = %r{^#! ?/usr/bin/(?:env )?python(?:[23](?:\.\d{1,2})?)?( |$)}
 
       # The length of the longest shebang matching `SHEBANG_REGEX`.
       PYTHON_SHEBANG_MAX_LENGTH = "#! /usr/bin/env pythonx.yyy ".length

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -154,7 +154,7 @@ module Language
 
         ENV.refurbish_args
         venv = Virtualenv.new formula, venv_root, python
-        venv.create(system_site_packages: system_site_packages, without_pip: without_pip)
+        venv.create(system_site_packages:, without_pip:)
 
         # Find any Python bindings provided by recursive dependencies
         formula_deps = formula.recursive_dependencies
@@ -208,10 +208,10 @@ module Language
           python = wanted.first
           python = "python3" if python == "python"
         end
-        venv = virtualenv_create(libexec, python.delete("@"), system_site_packages: system_site_packages,
-                                                              without_pip:          without_pip)
+        venv = virtualenv_create(libexec, python.delete("@"), system_site_packages:,
+                                                              without_pip:)
         venv.pip_install resources
-        venv.pip_install_and_link(buildpath, link_manpages: link_manpages)
+        venv.pip_install_and_link(buildpath, link_manpages:)
         venv
       end
 
@@ -289,10 +289,10 @@ module Language
           targets = Array(targets)
           targets.each do |t|
             if t.respond_to? :stage
-              t.stage { do_install(Pathname.pwd, build_isolation: build_isolation) }
+              t.stage { do_install(Pathname.pwd, build_isolation:) }
             else
               t = t.lines.map(&:strip) if t.respond_to?(:lines) && t.include?("\n")
-              do_install(t, build_isolation: build_isolation)
+              do_install(t, build_isolation:)
             end
           end
         end
@@ -306,7 +306,7 @@ module Language
           bin_before = Dir[@venv_root/"bin/*"].to_set
           man_before = Dir[@venv_root/"share/man/man*/*"].to_set if link_manpages
 
-          pip_install(targets, build_isolation: build_isolation)
+          pip_install(targets, build_isolation:)
 
           bin_after = Dir[@venv_root/"bin/*"].to_set
           bin_to_link = (bin_after - bin_before).to_a
@@ -324,7 +324,7 @@ module Language
 
         def do_install(targets, build_isolation: true)
           targets = Array(targets)
-          args = @formula.std_pip_args(prefix: false, build_isolation: build_isolation)
+          args = @formula.std_pip_args(prefix: false, build_isolation:)
           @formula.system @python, "-m", "pip", "--python=#{@venv_root}/bin/python", "install", *args, *targets
         end
       end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -31,7 +31,7 @@ class LinkageChecker
     @files_missing_rpaths = []
     @executable_path_dylibs = []
 
-    check_dylibs(rebuild_cache: rebuild_cache)
+    check_dylibs(rebuild_cache:)
   end
 
   def display_normal_output
@@ -63,15 +63,15 @@ class LinkageChecker
   end
 
   def display_test_output(puts_output: true, strict: false)
-    display_items "Missing libraries", @broken_dylibs, puts_output: puts_output
-    display_items "Broken dependencies", @broken_deps, puts_output: puts_output
-    display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
-    display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
+    display_items("Missing libraries", @broken_dylibs, puts_output:)
+    display_items("Broken dependencies", @broken_deps, puts_output:)
+    display_items("Unwanted system libraries", @unwanted_system_dylibs, puts_output:)
+    display_items("Conflicting libraries", @version_conflict_deps, puts_output:)
     return unless strict
 
-    display_items "Undeclared dependencies with linkage", @undeclared_deps, puts_output: puts_output
-    display_items "Files with missing rpath", @files_missing_rpaths, puts_output: puts_output
-    display_items "@executable_path references in libraries", @executable_path_dylibs, puts_output: puts_output
+    display_items("Undeclared dependencies with linkage", @undeclared_deps, puts_output:)
+    display_items("Files with missing rpath", @files_missing_rpaths, puts_output:)
+    display_items "@executable_path references in libraries", @executable_path_dylibs, puts_output:
   end
 
   sig { params(test: T::Boolean, strict: T::Boolean).returns(T::Boolean) }
@@ -179,7 +179,7 @@ class LinkageChecker
 
     return unless keg_files_dylibs_was_empty
 
-    store&.update!(keg_files_dylibs: keg_files_dylibs)
+    store&.update!(keg_files_dylibs:)
   end
   alias generic_check_dylibs check_dylibs
 

--- a/Library/Homebrew/linux_runner_spec.rb
+++ b/Library/Homebrew/linux_runner_spec.rb
@@ -21,12 +21,12 @@ class LinuxRunnerSpec < T::Struct
   }
   def to_h
     {
-      name:      name,
-      runner:    runner,
-      container: container,
-      workdir:   workdir,
-      timeout:   timeout,
-      cleanup:   cleanup,
+      name:,
+      runner:,
+      container:,
+      workdir:,
+      timeout:,
+      cleanup:,
     }
   end
 end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -128,11 +128,11 @@ module Homebrew
         if debug
           # Print the chain of references for debugging
           puts "Reference Chain:"
-          puts package_or_resource_name(first_formula_or_cask, full_name: full_name)
+          puts package_or_resource_name(first_formula_or_cask, full_name:)
 
           references << referenced_formula_or_cask
           references.each do |ref_formula_or_cask|
-            puts package_or_resource_name(ref_formula_or_cask, full_name: full_name)
+            puts package_or_resource_name(ref_formula_or_cask, full_name:)
           end
         end
 
@@ -145,8 +145,8 @@ module Homebrew
         referenced_formula_or_cask,
         first_formula_or_cask,
         references,
-        full_name: full_name,
-        debug:     debug,
+        full_name:,
+        debug:,
       )
 
       # Returning references along with the final referenced formula/cask
@@ -225,7 +225,7 @@ module Homebrew
         name = package_or_resource_name(formula_or_cask, full_name: use_full_name)
 
         referenced_formula_or_cask, livecheck_references =
-          resolve_livecheck_reference(formula_or_cask, full_name: use_full_name, debug: debug)
+          resolve_livecheck_reference(formula_or_cask, full_name: use_full_name, debug:)
 
         if debug && i.positive?
           puts <<~EOS
@@ -243,11 +243,11 @@ module Homebrew
             referenced_formula_or_cask,
             name,
             full_name: use_full_name,
-            verbose:   verbose,
+            verbose:,
           )
         end
 
-        skip_info ||= SkipConditions.skip_information(formula_or_cask, full_name: use_full_name, verbose: verbose)
+        skip_info ||= SkipConditions.skip_information(formula_or_cask, full_name: use_full_name, verbose:)
         if skip_info.present?
           next skip_info if json && !newer_only
 
@@ -279,9 +279,9 @@ module Homebrew
         else
           version_info = latest_version(
             formula_or_cask,
-            referenced_formula_or_cask: referenced_formula_or_cask,
-            livecheck_references: livecheck_references,
-            json: json, full_name: use_full_name, verbose: verbose, debug: debug
+            referenced_formula_or_cask:,
+            livecheck_references:,
+            json:, full_name: use_full_name, verbose:, debug:
           )
           version_info[:latest] if version_info.present?
         end
@@ -289,20 +289,20 @@ module Homebrew
         check_for_resources = check_resources && formula_or_cask.is_a?(Formula) && formula_or_cask.resources.present?
         if check_for_resources
           resource_version_info = formula_or_cask.resources.map do |resource|
-            res_skip_info ||= SkipConditions.skip_information(resource, verbose: verbose)
+            res_skip_info ||= SkipConditions.skip_information(resource, verbose:)
             if res_skip_info.present?
               res_skip_info
             else
               res_version_info = resource_version(
                 resource,
                 latest.to_s,
-                json:    json,
-                debug:   debug,
-                quiet:   quiet,
-                verbose: verbose,
+                json:,
+                debug:,
+                quiet:,
+                verbose:,
               )
               if res_version_info.empty?
-                status_hash(resource, "error", ["Unable to get versions"], verbose: verbose)
+                status_hash(resource, "error", ["Unable to get versions"], verbose:)
               else
                 res_version_info
               end
@@ -319,7 +319,7 @@ module Homebrew
           next version_info if version_info.is_a?(Hash) && version_info[:status] && version_info[:messages]
 
           latest_info = status_hash(formula_or_cask, "error", [no_versions_msg], full_name: use_full_name,
-                                                                                 verbose:   verbose)
+                                                                                 verbose:)
           if check_for_resources
             unless verbose
               resource_version_info.map! do |info|
@@ -383,8 +383,8 @@ module Homebrew
           next info
         end
         puts if debug
-        print_latest_version(info, verbose: verbose, ambiguous_cask: ambiguous_casks.include?(formula_or_cask))
-        print_resources_info(resource_version_info, verbose: verbose) if check_for_resources
+        print_latest_version(info, verbose:, ambiguous_cask: ambiguous_casks.include?(formula_or_cask))
+        print_resources_info(resource_version_info, verbose:) if check_for_resources
         nil
       rescue => e
         Homebrew.failed = true
@@ -394,7 +394,7 @@ module Homebrew
           progress&.increment
           unless quiet
             status_hash(formula_or_cask, "error", [e.to_s], full_name: use_full_name,
-                                                            verbose:   verbose)
+                                                            verbose:)
           end
         elsif !quiet
           name = package_or_resource_name(formula_or_cask, full_name: use_full_name)
@@ -402,7 +402,7 @@ module Homebrew
 
           onoe "#{Tty.blue}#{name}#{Tty.reset}: #{e}"
           $stderr.puts Utils::Backtrace.clean(e) if debug && !e.is_a?(Livecheck::Error)
-          print_resources_info(resource_version_info, verbose: verbose) if check_for_resources
+          print_resources_info(resource_version_info, verbose:) if check_for_resources
           nil
         end
       end
@@ -425,9 +425,9 @@ module Homebrew
     def package_or_resource_name(package_or_resource, full_name: false)
       case package_or_resource
       when Formula
-        formula_name(package_or_resource, full_name: full_name)
+        formula_name(package_or_resource, full_name:)
       when Cask::Cask
-        cask_name(package_or_resource, full_name: full_name)
+        cask_name(package_or_resource, full_name:)
       when Resource
         package_or_resource.name
       else
@@ -465,9 +465,9 @@ module Homebrew
 
       status_hash = {}
       if formula
-        status_hash[:formula] = formula_name(formula, full_name: full_name)
+        status_hash[:formula] = formula_name(formula, full_name:)
       elsif cask
-        status_hash[:cask] = cask_name(cask, full_name: full_name)
+        status_hash[:cask] = cask_name(cask, full_name:)
       elsif resource
         status_hash[:resource] = resource.name
       end
@@ -512,7 +512,7 @@ module Homebrew
         if r_info[:status] && r_info[:messages]
           SkipConditions.print_skip_information(r_info)
         else
-          print_latest_version(r_info, verbose: verbose)
+          print_latest_version(r_info, verbose:)
         end
       end
     end
@@ -673,19 +673,19 @@ module Homebrew
 
       if debug
         if formula
-          puts "Formula:          #{formula_name(formula, full_name: full_name)}"
+          puts "Formula:          #{formula_name(formula, full_name:)}"
           puts "Head only?:       true" if formula.head_only?
         elsif cask
-          puts "Cask:             #{cask_name(formula_or_cask, full_name: full_name)}"
+          puts "Cask:             #{cask_name(formula_or_cask, full_name:)}"
         end
         puts "Livecheckable?:   #{has_livecheckable ? "Yes" : "No"}"
 
         livecheck_references.each do |ref_formula_or_cask|
           case ref_formula_or_cask
           when Formula
-            puts "Formula Ref:      #{formula_name(ref_formula_or_cask, full_name: full_name)}"
+            puts "Formula Ref:      #{formula_name(ref_formula_or_cask, full_name:)}"
           when Cask::Cask
-            puts "Cask Ref:         #{cask_name(ref_formula_or_cask, full_name: full_name)}"
+            puts "Cask Ref:         #{cask_name(ref_formula_or_cask, full_name:)}"
           end
         end
       end
@@ -702,7 +702,7 @@ module Homebrew
 
         strategies = Strategy.from_url(
           url,
-          livecheck_strategy: livecheck_strategy,
+          livecheck_strategy:,
           url_provided:       livecheck_url.present?,
           regex_provided:     livecheck_regex.present?,
           block_provided:     livecheck_strategy_block.present?,
@@ -746,7 +746,7 @@ module Homebrew
 
         strategy_args = {
           regex:         livecheck_regex,
-          homebrew_curl: homebrew_curl,
+          homebrew_curl:,
         }
         # TODO: Set `cask`/`url` args based on the presence of the keyword arg
         # in the strategy's `#find_versions` method once we figure out why
@@ -769,7 +769,7 @@ module Homebrew
           puts messages unless json
           next if i + 1 < urls.length
 
-          return status_hash(formula_or_cask, "error", messages, full_name: full_name, verbose: verbose)
+          return status_hash(formula_or_cask, "error", messages, full_name:, verbose:)
         end
 
         if debug
@@ -817,9 +817,9 @@ module Homebrew
             version_info[:meta][:references] = livecheck_references.map do |ref_formula_or_cask|
               case ref_formula_or_cask
               when Formula
-                { formula: formula_name(ref_formula_or_cask, full_name: full_name) }
+                { formula: formula_name(ref_formula_or_cask, full_name:) }
               when Cask::Cask
-                { cask: cask_name(ref_formula_or_cask, full_name: full_name) }
+                { cask: cask_name(ref_formula_or_cask, full_name:) }
               end
             end
           end
@@ -897,7 +897,7 @@ module Homebrew
 
         strategies = Strategy.from_url(
           url,
-          livecheck_strategy: livecheck_strategy,
+          livecheck_strategy:,
           url_provided:       livecheck_url.present?,
           regex_provided:     livecheck_regex.present?,
           block_provided:     livecheck_strategy_block.present?,
@@ -934,7 +934,7 @@ module Homebrew
         next if strategy.blank?
 
         strategy_args = {
-          url:           url,
+          url:,
           regex:         livecheck_regex,
           homebrew_curl: false,
         }.compact
@@ -949,7 +949,7 @@ module Homebrew
           puts messages unless json
           next if i + 1 < urls.length
 
-          return status_hash(resource, "error", messages, verbose: verbose)
+          return status_hash(resource, "error", messages, verbose:)
         end
 
         if debug
@@ -989,7 +989,7 @@ module Homebrew
         res_current = T.must(resource.version)
         res_latest = Version.new(match_version_map.values.max_by { |v| LivecheckVersion.create(resource, v) })
 
-        return status_hash(resource, "error", ["Unable to get versions"], verbose: verbose) if res_latest.blank?
+        return status_hash(resource, "error", ["Unable to get versions"], verbose:) if res_latest.blank?
 
         is_outdated = res_current < res_latest
         is_newer_than_upstream = res_current > res_latest
@@ -1023,7 +1023,7 @@ module Homebrew
       rescue => e
         Homebrew.failed = true
         if json
-          status_hash(resource, "error", [e.to_s], verbose: verbose)
+          status_hash(resource, "error", [e.to_s], verbose:)
         elsif !quiet
           onoe "#{Tty.blue}#{resource.name}#{Tty.reset}: #{e}"
           $stderr.puts Utils::Backtrace.clean(e) if debug && !e.is_a?(Livecheck::Error)

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -46,7 +46,7 @@ module Homebrew
         return {} if !package_or_resource.livecheck.skip? && skip_message.blank?
 
         skip_messages = skip_message ? [skip_message] : nil
-        Livecheck.status_hash(package_or_resource, "skipped", skip_messages, full_name: full_name, verbose: verbose)
+        Livecheck.status_hash(package_or_resource, "skipped", skip_messages, full_name:, verbose:)
       end
 
       sig {
@@ -64,8 +64,8 @@ module Homebrew
           formula,
           "error",
           ["HEAD only formula must be installed to be livecheckable"],
-          full_name: full_name,
-          verbose:   verbose,
+          full_name:,
+          verbose:,
         )
       end
 
@@ -80,7 +80,7 @@ module Homebrew
       def formula_deprecated(formula, livecheckable, full_name: false, verbose: false)
         return {} if !formula.deprecated? || livecheckable
 
-        Livecheck.status_hash(formula, "deprecated", full_name: full_name, verbose: verbose)
+        Livecheck.status_hash(formula, "deprecated", full_name:, verbose:)
       end
 
       sig {
@@ -94,7 +94,7 @@ module Homebrew
       def formula_disabled(formula, livecheckable, full_name: false, verbose: false)
         return {} if !formula.disabled? || livecheckable
 
-        Livecheck.status_hash(formula, "disabled", full_name: full_name, verbose: verbose)
+        Livecheck.status_hash(formula, "disabled", full_name:, verbose:)
       end
 
       sig {
@@ -108,7 +108,7 @@ module Homebrew
       def formula_versioned(formula, livecheckable, full_name: false, verbose: false)
         return {} if !formula.versioned_formula? || livecheckable
 
-        Livecheck.status_hash(formula, "versioned", full_name: full_name, verbose: verbose)
+        Livecheck.status_hash(formula, "versioned", full_name:, verbose:)
       end
 
       sig {
@@ -122,7 +122,7 @@ module Homebrew
       def cask_discontinued(cask, livecheckable, full_name: false, verbose: false)
         return {} if !cask.discontinued? || livecheckable
 
-        Livecheck.status_hash(cask, "discontinued", full_name: full_name, verbose: verbose)
+        Livecheck.status_hash(cask, "discontinued", full_name:, verbose:)
       end
 
       sig {
@@ -136,7 +136,7 @@ module Homebrew
       def cask_version_latest(cask, livecheckable, full_name: false, verbose: false)
         return {} if !(cask.present? && cask.version&.latest?) || livecheckable
 
-        Livecheck.status_hash(cask, "latest", full_name: full_name, verbose: verbose)
+        Livecheck.status_hash(cask, "latest", full_name:, verbose:)
       end
 
       sig {
@@ -150,7 +150,7 @@ module Homebrew
       def cask_url_unversioned(cask, livecheckable, full_name: false, verbose: false)
         return {} if !(cask.present? && cask.url&.unversioned?) || livecheckable
 
-        Livecheck.status_hash(cask, "unversioned", full_name: full_name, verbose: verbose)
+        Livecheck.status_hash(cask, "unversioned", full_name:, verbose:)
       end
 
       # Skip conditions for formulae.
@@ -199,7 +199,7 @@ module Homebrew
         return {} unless checks
 
         checks.each do |method_name|
-          skip_hash = send(method_name, package_or_resource, livecheckable, full_name: full_name, verbose: verbose)
+          skip_hash = send(method_name, package_or_resource, livecheckable, full_name:, verbose:)
           return skip_hash if skip_hash.present?
         end
 
@@ -226,12 +226,12 @@ module Homebrew
       )
         skip_info = SkipConditions.skip_information(
           livecheck_package_or_resource,
-          full_name: full_name,
-          verbose:   verbose,
+          full_name:,
+          verbose:,
         )
         return if skip_info.blank?
 
-        referenced_name = Livecheck.package_or_resource_name(livecheck_package_or_resource, full_name: full_name)
+        referenced_name = Livecheck.package_or_resource_name(livecheck_package_or_resource, full_name:)
         referenced_type = case livecheck_package_or_resource
         when Formula
           :formula

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -81,7 +81,7 @@ module Homebrew
         (?:ar(?:\.(?:bz2|gz|lz|lzma|lzo|xz|Z|zst))?|
         b2|bz2?|z2|az|gz|lz|lzma|xz|Z|aZ|zst)
         $
-      /ix.freeze
+      /ix
 
       # An error message to use when a `strategy` block returns a value of
       # an inappropriate type.

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -189,7 +189,7 @@ module Homebrew
               url,
               wanted_headers:    ["location", "content-disposition"],
               use_homebrew_curl: homebrew_curl,
-              user_agent:        user_agent,
+              user_agent:,
               **DEFAULT_CURL_OPTIONS,
             )
           rescue ErrorDuringExecution
@@ -219,7 +219,7 @@ module Homebrew
             *PAGE_CONTENT_CURL_ARGS, url,
             **DEFAULT_CURL_OPTIONS,
             use_homebrew_curl: homebrew_curl,
-            user_agent:        user_agent
+            user_agent:
           )
           next unless status.success?
 

--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -37,7 +37,7 @@ module Homebrew
           (?<prefix>[^/]*?)  # Any text in filename or directory before version
           v?\d+(?:\.\d+)+    # The numeric version
           (?<suffix>/|[^/]*) # Any text in filename or directory after version
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -36,7 +36,7 @@ module Homebrew
           /(?<prefix>(?:[^/]+?[_-])?) # Filename text before the version
           v?\d+(?:\.\d+)+ # The numeric version
           (?<suffix>[^/]+) # Filename text after the version
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -27,7 +27,7 @@ module Homebrew
           (?<prefix>[^/]+) # Filename text before the version
           -v?\d+(?:\.\d+)* # The numeric version
           (?<suffix>[^/]+) # Filename text after the version
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -53,9 +53,9 @@ module Homebrew
           end
 
           Yaml.find_versions(
-            url:              url,
-            regex:            regex,
-            provided_content: provided_content,
+            url:,
+            regex:,
+            provided_content:,
             **unused,
             &block || proc { |yaml| yaml["version"] }
           )

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -19,7 +19,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://.+/[^/]+\.ya?ml(?:\?[^/?]+)?$}i.freeze
+        URL_MATCH_REGEX = %r{^https?://.+/[^/]+\.ya?ml(?:\?[^/?]+)?$}i
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -100,7 +100,7 @@ module Homebrew
             raise ArgumentError, "The #{Utils.demodulize(T.must(name))} strategy only supports casks."
           end
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
 
           unversioned_cask_checker = if url.present? && url != cask.url.to_s
             # Create a copy of the `cask` that uses the `livecheck` block URL

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -24,7 +24,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://}i.freeze
+        URL_MATCH_REGEX = %r{^https?://}i
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -30,7 +30,7 @@ module Homebrew
 
         # The default regex used to naively identify versions from tags when a
         # regex isn't provided.
-        DEFAULT_REGEX = /\D*(.+)/.freeze
+        DEFAULT_REGEX = /\D*(.+)/
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -127,7 +127,7 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, **_unused, &block)
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
 
           tags_data = tag_info(url, regex)
           tags = tags_data[:tags]

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -80,7 +80,7 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: GithubReleases::DEFAULT_REGEX, **_unused, &block)
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)
           return match_data if generated.blank?

--- a/Library/Homebrew/livecheck/strategy/github_releases.rb
+++ b/Library/Homebrew/livecheck/strategy/github_releases.rb
@@ -41,11 +41,11 @@ module Homebrew
           ^https?://github\.com
           /(?:downloads/)?(?<username>[^/]+) # The GitHub username
           /(?<repository>[^/]+)              # The GitHub repository name
-        }ix.freeze
+        }ix
 
         # The default regex used to identify a version from a tag when a regex
         # isn't provided.
-        DEFAULT_REGEX = /v?(\d+(?:\.\d+)+)/i.freeze
+        DEFAULT_REGEX = /v?(\d+(?:\.\d+)+)/i
 
         # Keys in the release JSON that could contain the version.
         # The tag name is checked first, to better align with the {Git}

--- a/Library/Homebrew/livecheck/strategy/github_releases.rb
+++ b/Library/Homebrew/livecheck/strategy/github_releases.rb
@@ -134,7 +134,7 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: DEFAULT_REGEX, **_unused, &block)
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)
           return match_data if generated.blank?

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -32,7 +32,7 @@ module Homebrew
           ^https?://download\.gnome\.org
           /sources
           /(?<package_name>[^/]+)/ # The GNOME package name
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -36,7 +36,7 @@ module Homebrew
           ^https?://
           (?:(?:[^/]+?\.)*gnu\.org/(?:gnu|software)/(?<project_name>[^/]+)/
           |(?<project_name>[^/]+)\.gnu\.org/?$)
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -19,17 +19,17 @@ module Homebrew
       class Hackage
         # A `Regexp` used in determining if the strategy applies to the URL and
         # also as part of extracting the package name from the URL basename.
-        PACKAGE_NAME_REGEX = /(?<package_name>.+?)-\d+/i.freeze
+        PACKAGE_NAME_REGEX = /(?<package_name>.+?)-\d+/i
 
         # A `Regexp` used to extract the package name from the URL basename.
-        FILENAME_REGEX = /^#{PACKAGE_NAME_REGEX.source.strip}/i.freeze
+        FILENAME_REGEX = /^#{PACKAGE_NAME_REGEX.source.strip}/i
 
         # A `Regexp` used in determining if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
           ^https?://(?:downloads|hackage)\.haskell\.org
           (?:/[^/]+)+ # Path before the filename
           #{PACKAGE_NAME_REGEX.source.strip}
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -81,9 +81,9 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, homebrew_curl: false, **_unused, &block)
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
 
-          headers = Strategy.page_headers(url, homebrew_curl: homebrew_curl)
+          headers = Strategy.page_headers(url, homebrew_curl:)
 
           # Merge the headers from all responses into one hash
           merged_headers = headers.reduce(&:merge)

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -19,7 +19,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://}i.freeze
+        URL_MATCH_REGEX = %r{^https?://}i
 
         # The header fields to check when a `strategy` block isn't provided.
         DEFAULT_HEADERS_TO_CHECK = ["content-disposition", "location"].freeze

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -109,14 +109,14 @@ module Homebrew
         def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
           return match_data if url.blank? || block.blank?
 
           content = if provided_content.is_a?(String)
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl: homebrew_curl))
+            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -31,7 +31,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://}i.freeze
+        URL_MATCH_REGEX = %r{^https?://}i
 
         # Whether the strategy can be applied to the provided URL.
         # {Json} will technically match any HTTP URL but is only usable with

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -79,7 +79,7 @@ module Homebrew
         def self.find_versions(url:, regex: DEFAULT_REGEX, **unused, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex, **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex:, **unused, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -27,11 +27,11 @@ module Homebrew
         URL_MATCH_REGEX = %r{
           ^https?://(?:[^/]+?\.)*launchpad\.net
           /(?<project_name>[^/]+) # The Launchpad project name
-        }ix.freeze
+        }ix
 
         # The default regex used to identify the latest version when a regex
         # isn't provided.
-        DEFAULT_REGEX = %r{class="[^"]*version[^"]*"[^>]*>\s*Latest version is (.+)\s*</}.freeze
+        DEFAULT_REGEX = %r{class="[^"]*version[^"]*"[^>]*>\s*Latest version is (.+)\s*</}
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -23,7 +23,7 @@ module Homebrew
         URL_MATCH_REGEX = %r{
           ^https?://registry\.npmjs\.org
           /(?<package_name>.+?)/-/ # The npm package name
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -24,7 +24,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://}i.freeze
+        URL_MATCH_REGEX = %r{^https?://}i
 
         # Whether the strategy can be applied to the provided URL.
         # {PageMatch} will technically match any HTTP URL but is only

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -94,14 +94,14 @@ module Homebrew
             raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a regex or `strategy` block"
           end
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
           return match_data if url.blank? || (regex.blank? && block.blank?)
 
           content = if provided_content.is_a?(String)
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl: homebrew_curl))
+            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -25,7 +25,7 @@ module Homebrew
           (?<package_name>.+)- # The package name followed by a hyphen
           .*? # The version string
           (?<suffix>\.tar\.[a-z0-9]+|\.[a-z0-9]+)$ # Filename extension
-        /ix.freeze
+        /ix
 
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
@@ -33,7 +33,7 @@ module Homebrew
           /packages
           (?:/[^/]+)+ # The hexadecimal paths before the filename
           /#{FILENAME_REGEX.source.strip} # The filename
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -39,7 +39,7 @@ module Homebrew
           (?:/projects?/(?<project_name>[^/]+)/
           |/p/(?<project_name>[^/]+)/
           |(?::/cvsroot)?/(?<project_name>[^/]+))
-        }ix.freeze
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -128,15 +128,15 @@ module Homebrew
             bundle_version = BundleVersion.new(short_version, version) if short_version || version
 
             data = {
-              title:                  title,
-              link:                   link,
-              channel:                channel,
-              release_notes_link:     release_notes_link,
-              pub_date:               pub_date,
-              os:                     os,
-              url:                    url,
-              bundle_version:         bundle_version,
-              minimum_system_version: minimum_system_version,
+              title:,
+              link:,
+              channel:,
+              release_notes_link:,
+              pub_date:,
+              os:,
+              url:,
+              bundle_version:,
+              minimum_system_version:,
             }.compact
             next if data.empty?
 
@@ -229,7 +229,7 @@ module Homebrew
                   "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
           end
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
 
           match_data.merge!(Strategy.page_content(url))
           content = match_data.delete(:content)

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -19,7 +19,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://}i.freeze
+        URL_MATCH_REGEX = %r{^https?://}i
 
         # Common `os` values used in appcasts to refer to macOS.
         APPCAST_MACOS_STRINGS = ["macos", "osx"].freeze

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -35,7 +35,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://}i.freeze
+        URL_MATCH_REGEX = %r{^https?://}i
 
         # Whether the strategy can be applied to the provided URL.
         # {Xml} will technically match any HTTP URL but is only usable with

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -149,14 +149,14 @@ module Homebrew
         def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
           return match_data if url.blank? || block.blank?
 
           content = if provided_content.is_a?(String)
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl: homebrew_curl))
+            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -42,17 +42,17 @@ module Homebrew
 
         # A `Regexp` used in determining if the strategy applies to the URL and
         # also as part of extracting the module name from the URL basename.
-        MODULE_REGEX = /(?<module_name>.+)-\d+/i.freeze
+        MODULE_REGEX = /(?<module_name>.+)-\d+/i
 
         # A `Regexp` used to extract the module name from the URL basename.
-        FILENAME_REGEX = /^#{MODULE_REGEX.source.strip}/i.freeze
+        FILENAME_REGEX = /^#{MODULE_REGEX.source.strip}/i
 
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
           ^https?://(?:[^/]+?\.)* # Scheme and any leading subdomains
           (?:x\.org/(?:[^/]+/)*individual/(?:[^/]+/)*#{MODULE_REGEX.source.strip}
           |freedesktop\.org/(?:archive|dist|software)/(?:[^/]+/)*#{MODULE_REGEX.source.strip})
-        }ix.freeze
+        }ix
 
         # Used to cache page content, so we don't fetch the same pages
         # repeatedly.

--- a/Library/Homebrew/livecheck/strategy/yaml.rb
+++ b/Library/Homebrew/livecheck/strategy/yaml.rb
@@ -31,7 +31,7 @@ module Homebrew
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = %r{^https?://}i.freeze
+        URL_MATCH_REGEX = %r{^https?://}i
 
         # Whether the strategy can be applied to the provided URL.
         # {Yaml} will technically match any HTTP URL but is only usable with

--- a/Library/Homebrew/livecheck/strategy/yaml.rb
+++ b/Library/Homebrew/livecheck/strategy/yaml.rb
@@ -109,14 +109,14 @@ module Homebrew
         def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
-          match_data = { matches: {}, regex: regex, url: url }
+          match_data = { matches: {}, regex:, url: }
           return match_data if url.blank? || block.blank?
 
           content = if provided_content.is_a?(String)
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl: homebrew_curl))
+            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -63,9 +63,9 @@ class Locale
     raise ArgumentError, "#{self.class} cannot be empty" if language.nil? && region.nil? && script.nil?
 
     {
-      language: language,
-      script:   script,
-      region:   region,
+      language:,
+      script:,
+      region:,
     }.each do |key, value|
       next if value.nil?
 

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -12,18 +12,18 @@ class Locale
   end
 
   # ISO 639-1 or ISO 639-2
-  LANGUAGE_REGEX = /(?:[a-z]{2,3})/.freeze
+  LANGUAGE_REGEX = /(?:[a-z]{2,3})/
   private_constant :LANGUAGE_REGEX
 
   # ISO 15924
-  SCRIPT_REGEX = /(?:[A-Z][a-z]{3})/.freeze
+  SCRIPT_REGEX = /(?:[A-Z][a-z]{3})/
   private_constant :SCRIPT_REGEX
 
   # ISO 3166-1 or UN M.49
-  REGION_REGEX = /(?:[A-Z]{2}|\d{3})/.freeze
+  REGION_REGEX = /(?:[A-Z]{2}|\d{3})/
   private_constant :REGION_REGEX
 
-  LOCALE_REGEX = /\A((?:#{LANGUAGE_REGEX}|#{REGION_REGEX}|#{SCRIPT_REGEX})(?:-|$)){1,3}\Z/.freeze
+  LOCALE_REGEX = /\A((?:#{LANGUAGE_REGEX}|#{REGION_REGEX}|#{SCRIPT_REGEX})(?:-|$)){1,3}\Z/
   private_constant :LOCALE_REGEX
 
   def self.parse(string)

--- a/Library/Homebrew/macos_runner_spec.rb
+++ b/Library/Homebrew/macos_runner_spec.rb
@@ -10,10 +10,10 @@ class MacOSRunnerSpec < T::Struct
   sig { returns({ name: String, runner: String, timeout: Integer, cleanup: T::Boolean }) }
   def to_h
     {
-      name:    name,
-      runner:  runner,
-      timeout: timeout,
-      cleanup: cleanup,
+      name:,
+      runner:,
+      timeout:,
+      cleanup:,
     }
   end
 end

--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -30,7 +30,7 @@ module Homebrew
     def self.regenerate_man_pages(quiet:)
       Homebrew.install_bundler_gems!(groups: ["man"])
 
-      markup = build_man_page(quiet: quiet)
+      markup = build_man_page(quiet:)
       convert_man_page(markup, TARGET_DOC_PATH/"Manpage.md")
       convert_man_page(markup, TARGET_MAN_PATH/"brew.1")
     end
@@ -41,7 +41,7 @@ module Homebrew
       variables = Variables.new(
         commands:                   generate_cmd_manpages(Commands.internal_commands_paths),
         developer_commands:         generate_cmd_manpages(Commands.internal_developer_commands_paths),
-        official_external_commands: generate_cmd_manpages(Commands.official_external_commands_paths(quiet: quiet)),
+        official_external_commands: generate_cmd_manpages(Commands.official_external_commands_paths(quiet:)),
         global_cask_options:        global_cask_options_manpage,
         global_options:             global_options_manpage,
         environment_variables:      env_vars_manpage,

--- a/Library/Homebrew/messages.rb
+++ b/Library/Homebrew/messages.rb
@@ -14,12 +14,12 @@ class Messages
   end
 
   def record_caveats(package, caveats)
-    @caveats.push(package: package, caveats: caveats)
+    @caveats.push(package:, caveats:)
   end
 
   def package_installed(package, elapsed_time)
     @package_count += 1
-    @install_times.push(package: package, time: elapsed_time)
+    @install_times.push(package:, time: elapsed_time)
   end
 
   def display_messages(force_caveats: false, display_times: false)

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -114,7 +114,7 @@ class Migrator
           next
         end
 
-        migrator = Migrator.new(formula, oldname, force: force)
+        migrator = Migrator.new(formula, oldname, force:)
         migrator.migrate
       end
     rescue => e

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -10,8 +10,8 @@ module Homebrew
   module MissingFormula
     class << self
       def reason(name, silent: false, show_info: false)
-        cask_reason(name, silent: silent, show_info: show_info) || disallowed_reason(name) ||
-          tap_migration_reason(name) || deleted_reason(name, silent: silent)
+        cask_reason(name, silent:, show_info:) || disallowed_reason(name) ||
+          tap_migration_reason(name) || deleted_reason(name, silent:)
       end
 
       def disallowed_reason(name)

--- a/Library/Homebrew/options.rb
+++ b/Library/Homebrew/options.rb
@@ -90,8 +90,8 @@ class Options
     super
   end
 
-  def each(*args, &block)
-    @options.each(*args, &block)
+  def each(...)
+    @options.each(...)
   end
 
   def <<(other)

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -40,7 +40,7 @@ module MachOShim
         else :dunno
         end
 
-        mach_data << { arch: arch, type: type }
+        mach_data << { arch:, type: }
       end
 
       mach_data

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -8,7 +8,7 @@ module OS
     # @api private
     class SDK
       # 11.x SDKs are explicitly excluded - we want the MacOSX11.sdk symlink instead.
-      VERSIONED_SDK_REGEX = /MacOSX(10\.\d+|\d+)\.sdk$/.freeze
+      VERSIONED_SDK_REGEX = /MacOSX(10\.\d+|\d+)\.sdk$/
 
       sig { returns(MacOSVersion) }
       attr_reader :version

--- a/Library/Homebrew/pkg_version.rb
+++ b/Library/Homebrew/pkg_version.rb
@@ -10,7 +10,7 @@ class PkgVersion
   include Comparable
   extend Forwardable
 
-  REGEX = /\A(.+?)(?:_(\d+))?\z/.freeze
+  REGEX = /\A(.+?)(?:_(\d+))?\z/
   private_constant :REGEX
 
   attr_reader :version, :revision

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -12,7 +12,7 @@ module Readall
     include Cachable
 
     # TODO: remove this once the `MacOS` module is undefined on Linux
-    MACOS_MODULE_REGEX = /\b(MacOS|OS::Mac)(\.|::)\b/.freeze
+    MACOS_MODULE_REGEX = /\b(MacOS|OS::Mac)(\.|::)\b/
     private_constant :MACOS_MODULE_REGEX
 
     private :cache

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -61,7 +61,7 @@ module Readall
         readall_namespace = "ReadallNamespace"
         readall_formula_class = Formulary.load_formula(formula_name, file, formula_contents, readall_namespace,
                                                        flags: [], ignore_errors: false)
-        readall_formula = readall_formula_class.new(formula_name, file, :stable, tap: tap)
+        readall_formula = readall_formula_class.new(formula_name, file, :stable, tap:)
         readall_formula.to_hash
         # TODO: Remove check for MACOS_MODULE_REGEX once the `MacOS` module is undefined on Linux
         cache[:valid_formulae][file] = if readall_formula.on_system_blocks_exist? ||
@@ -97,12 +97,12 @@ module Readall
         success = false unless valid_casks?(tap)
       else
         os_arch_combinations.each do |os, arch|
-          bottle_tag = Utils::Bottles::Tag.new(system: os, arch: arch)
+          bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
           next unless bottle_tag.valid_combination?
 
-          Homebrew::SimulateSystem.with os: os, arch: arch do
-            success = false unless valid_formulae?(tap, bottle_tag: bottle_tag)
-            success = false unless valid_casks?(tap, os_name: os, arch: arch)
+          Homebrew::SimulateSystem.with(os:, arch:) do
+            success = false unless valid_formulae?(tap, bottle_tag:)
+            success = false unless valid_casks?(tap, os_name: os, arch:)
           end
         end
       end

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -39,21 +39,21 @@ module Homebrew
     fi = FormulaInstaller.new(
       formula,
       **{
-        options:                    options,
+        options:,
         link_keg:                   keg_had_linked_opt ? keg_was_linked : nil,
         installed_as_dependency:    tab&.installed_as_dependency,
         installed_on_request:       installed_on_request || tab&.installed_on_request,
         build_bottle:               tab&.built_bottle?,
-        force_bottle:               force_bottle,
-        build_from_source_formulae: build_from_source_formulae,
-        git:                        git,
-        interactive:                interactive,
-        keep_tmp:                   keep_tmp,
-        debug_symbols:              debug_symbols,
-        force:                      force,
-        debug:                      debug,
-        quiet:                      quiet,
-        verbose:                    verbose,
+        force_bottle:,
+        build_from_source_formulae:,
+        git:,
+        interactive:,
+        keep_tmp:,
+        debug_symbols:,
+        force:,
+        debug:,
+        quiet:,
+        verbose:,
       }.compact,
     )
     fi.prelude
@@ -66,7 +66,7 @@ module Homebrew
   rescue FormulaInstallationAlreadyAttemptedError
     nil
   rescue Exception # rubocop:disable Lint/RescueException
-    ignore_interrupts { restore_backup(keg, keg_was_linked, verbose: verbose) }
+    ignore_interrupts { restore_backup(keg, keg_was_linked, verbose:) }
     raise
   else
     begin
@@ -99,7 +99,7 @@ module Homebrew
     Pathname.new(keg).rmtree if keg.exist?
 
     path.rename keg
-    keg.link(verbose: verbose) if keg_was_linked
+    keg.link(verbose:) if keg_was_linked
   end
 
   def backup_path(path)

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -67,7 +67,7 @@ class Requirement
     return true unless satisfy
 
     @satisfied_result =
-      satisfy.yielder(env: env, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch) do |p|
+      satisfy.yielder(env:, cc:, build_bottle:, bottle_arch:) do |p|
         instance_eval(&p)
       end
     return false unless @satisfied_result
@@ -94,7 +94,7 @@ class Requirement
   # Overriding {#modify_build_environment} is unsupported.
   # Pass a block to the env DSL method instead.
   def modify_build_environment(env: nil, cc: nil, build_bottle: false, bottle_arch: nil)
-    satisfied?(env: env, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
+    satisfied?(env:, cc:, build_bottle:, bottle_arch:)
     instance_eval(&env_proc) if env_proc
 
     # XXX If the satisfy block returns a Pathname, then make sure that it
@@ -203,7 +203,7 @@ class Requirement
       elsif @options[:build_env]
         require "extend/ENV"
         ENV.with_build_environment(
-          env: env, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch,
+          env:, cc:, build_bottle:, bottle_arch:,
         ) do
           yield @proc
         end

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -95,7 +95,7 @@ class Resource < Downloadable
     fetch_patches(skip_downloaded: true)
     fetch unless downloaded?
 
-    unpack(target, debug_symbols: debug_symbols, &block)
+    unpack(target, debug_symbols:, &block)
   end
 
   def prepare_patches
@@ -121,7 +121,7 @@ class Resource < Downloadable
   # A target or a block must be given, but not both.
   def unpack(target = nil, debug_symbols: false)
     current_working_directory = Pathname.pwd
-    stage_resource(download_name, debug_symbols: debug_symbols) do |staging|
+    stage_resource(download_name, debug_symbols:) do |staging|
       downloader.stage do
         @source_modified_time = downloader.source_modified_time
         apply_patches
@@ -145,7 +145,7 @@ class Resource < Downloadable
   def fetch(verify_download_integrity: true)
     fetch_patches
 
-    super(verify_download_integrity: verify_download_integrity)
+    super(verify_download_integrity:)
   end
 
   # @!attribute [w] livecheck

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -143,7 +143,7 @@ module Homebrew
           if (http_content_problem = curl_check_http_content(
             url,
             "source URL",
-            specs:             specs,
+            specs:,
             use_homebrew_curl: @use_homebrew_curl,
           ))
             problem http_content_problem

--- a/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
+++ b/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
@@ -35,7 +35,7 @@ module RuboCop
           # and 'https://example.org#path' into account.
           corrected_source = url_node.source.sub("://#{domain}", "://#{domain}/")
 
-          add_offense(url_node.loc.expression, message: format(MSG_NO_SLASH, url: url)) do |corrector|
+          add_offense(url_node.loc.expression, message: format(MSG_NO_SLASH, url:)) do |corrector|
             corrector.replace(url_node.source_range, corrected_source)
           end
         end

--- a/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
+++ b/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
@@ -55,7 +55,7 @@ module RuboCop
           nodes = {}
 
           sha256_on_arch_stanzas(cask_body) do |node, method, value|
-            nodes[method.to_s.delete_prefix("on_").to_sym] = { node: node, value: value }
+            nodes[method.to_s.delete_prefix("on_").to_sym] = { node:, value: }
           end
 
           return if !nodes.key?(:arm) || !nodes.key?(:intel)

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -91,7 +91,7 @@ module RuboCop
           line_length = [processed_source[line_index].size, 1].max
           @range = source_range(processed_source.buffer, line_index + 1, 0,
                                 line_length)
-          super(@range, message: message)
+          super(@range, message:)
         end
       end
     end

--- a/Library/Homebrew/rubocops/cask/url_legacy_comma_separators.rb
+++ b/Library/Homebrew/rubocops/cask/url_legacy_comma_separators.rb
@@ -25,7 +25,7 @@ module RuboCop
 
           corrected_url = url.sub("before_comma", "csv.first")&.sub("after_comma", "csv.second")
 
-          add_offense(url_node.loc.expression, message: format(MSG_CSV, url: url)) do |corrector|
+          add_offense(url_node.loc.expression, message: format(MSG_CSV, url:)) do |corrector|
             corrector.replace(url_node.source_range, corrected_url)
           end
         end

--- a/Library/Homebrew/rubocops/livecheck.rb
+++ b/Library/Homebrew/rubocops/livecheck.rb
@@ -153,7 +153,7 @@ module RuboCop
       class LivecheckRegexExtension < FormulaCop
         extend AutoCorrector
 
-        TAR_PATTERN = /\\?\.t(ar|(g|l|x)z$|[bz2]{2,4}$)(\\?\.((g|l|x)z)|[bz2]{2,4}|Z)?$/i.freeze
+        TAR_PATTERN = /\\?\.t(ar|(g|l|x)z$|[bz2]{2,4}$)(\\?\.((g|l|x)z)|[bz2]{2,4}|Z)?$/i
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           livecheck_node = find_block(body_node, :livecheck)

--- a/Library/Homebrew/rubocops/service.rb
+++ b/Library/Homebrew/rubocops/service.rb
@@ -33,7 +33,7 @@ module RuboCop
 
           # NOTE: Solving the first problem here might solve the second one too
           # so we don't show both of them at the same time.
-          if (method_calls.keys & REQUIRED_METHOD_CALLS).empty?
+          if !method_calls.keys.intersect?(REQUIRED_METHOD_CALLS)
             offending_node(service_node)
             problem "Service blocks require `run` or `name` to be defined."
           elsif !method_calls.key?(:run)

--- a/Library/Homebrew/rubocops/shared/desc_helper.rb
+++ b/Library/Homebrew/rubocops/shared/desc_helper.rb
@@ -86,7 +86,7 @@ module RuboCop
 
       # Auto correct desc problems. `regex_match_group` must be called before this to populate @offense_source_range.
       def desc_problem(message)
-        add_offense(@offensive_source_range, message: message) do |corrector|
+        add_offense(@offensive_source_range, message:) do |corrector|
           match_data = @offensive_node.source.match(/\A(?<quote>["'])(?<correction>.*)(?:\k<quote>)\Z/)
           correction = match_data[:correction]
           quote = match_data[:quote]

--- a/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
+++ b/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
@@ -83,18 +83,18 @@ module RuboCop
         ARCH_OPTIONS.each do |arch_option|
           else_method = (arch_option == :arm) ? :on_intel : :on_arm
           if_arch_node_search(body_node, arch: :"#{arch_option}?") do |if_node, else_node|
-            next if node_is_allowed?(if_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
+            next if node_is_allowed?(if_node, allowed_methods:, allowed_blocks:)
 
             if_statement_problem(if_node, "if Hardware::CPU.#{arch_option}?", "on_#{arch_option}",
-                                 else_method: else_method, else_node: else_node)
+                                 else_method:, else_node:)
           end
         end
 
         [:arch, :arm?, :intel?].each do |method|
-          hardware_cpu_search(body_node, method: method) do |method_node|
+          hardware_cpu_search(body_node, method:) do |method_node|
             # These should already be caught by `if_arch_node_search`
             next if method_node.parent.source.start_with? "if #{method_node.source}"
-            next if node_is_allowed?(method_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
+            next if node_is_allowed?(method_node, allowed_methods:, allowed_blocks:)
 
             offending_node(method_node)
             problem "Don't use `#{method_node.source}`, use `on_arm` and `on_intel` blocks instead."
@@ -110,10 +110,10 @@ module RuboCop
             [:linux?, :on_macos]
           end
           if_base_os_node_search(body_node, base_os: os_method) do |if_node, else_node|
-            next if node_is_allowed?(if_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
+            next if node_is_allowed?(if_node, allowed_methods:, allowed_blocks:)
 
             if_statement_problem(if_node, "if OS.#{os_method}", "on_#{base_os_option}",
-                                 else_method: else_method, else_node: else_node)
+                                 else_method:, else_node:)
           end
         end
       end
@@ -122,7 +122,7 @@ module RuboCop
                                            recommend_on_system: true)
         MACOS_VERSION_OPTIONS.each do |macos_version_option|
           if_macos_version_node_search(body_node, os_version: macos_version_option) do |if_node, operator, else_node|
-            next if node_is_allowed?(if_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
+            next if node_is_allowed?(if_node, allowed_methods:, allowed_blocks:)
 
             autocorrect = else_node.blank? && MACOS_VERSION_CONDITIONALS.key?(operator.to_s)
             on_system_method_string = if recommend_on_system && operator == :<
@@ -136,13 +136,13 @@ module RuboCop
             end
 
             if_statement_problem(if_node, "if MacOS.version #{operator} :#{macos_version_option}",
-                                 on_system_method_string, autocorrect: autocorrect)
+                                 on_system_method_string, autocorrect:)
           end
 
           macos_version_comparison_search(body_node, os_version: macos_version_option) do |method_node|
             # These should already be caught by `if_macos_version_node_search`
             next if method_node.parent.source.start_with? "if #{method_node.source}"
-            next if node_is_allowed?(method_node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
+            next if node_is_allowed?(method_node, allowed_methods:, allowed_blocks:)
 
             offending_node(method_node)
             problem "Don't use `#{method_node.source}`, use `on_{macos_version}` blocks instead."
@@ -153,7 +153,7 @@ module RuboCop
       def audit_macos_references(body_node, allowed_methods: [], allowed_blocks: [])
         MACOS_MODULE_NAMES.each do |macos_module_name|
           find_const(body_node, macos_module_name) do |node|
-            next if node_is_allowed?(node, allowed_methods: allowed_methods, allowed_blocks: allowed_blocks)
+            next if node_is_allowed?(node, allowed_methods:, allowed_blocks:)
 
             offending_node(node)
             problem "Don't use `#{macos_module_name}` where it could be called on Linux."

--- a/Library/Homebrew/rubocops/shell_commands.rb
+++ b/Library/Homebrew/rubocops/shell_commands.rb
@@ -101,7 +101,7 @@ module RuboCop
             else
               target_method.to_s
             end
-            add_offense(first_arg, message: format(MSG, method: method_string, good_args: good_args)) do |corrector|
+            add_offense(first_arg, message: format(MSG, method: method_string, good_args:)) do |corrector|
               corrector.replace(first_arg.source_range, good_args)
             end
           end

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -18,7 +18,7 @@ module RuboCop
           if (match = full_source_content.match(/^require ['"]formula['"]$/))
             range = source_range(source_buffer(node), match.pre_match.count("\n") + 1, 0, match[0].length)
             add_offense(range, message: "`#{match}` is now unnecessary") do |corrector|
-              corrector.remove(range_with_surrounding_space(range: range))
+              corrector.remove(range_with_surrounding_space(range:))
             end
           end
 

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -77,10 +77,10 @@ module Homebrew
       if command
         @run_params = command
       elsif macos || linux
-        @run_params = { macos: macos, linux: linux }.compact
+        @run_params = { macos:, linux: }.compact
       end
 
-      command ||= on_system_conditional(macos: macos, linux: linux)
+      command ||= on_system_conditional(macos:, linux:)
       case command
       when nil
         @run
@@ -214,7 +214,7 @@ module Homebrew
           raise TypeError, "Service#sockets expects a valid ipv4 or ipv6 host address"
         end
 
-        { host: host, port: port, type: type }
+        { host:, port:, type: }
       end
     end
 

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -188,7 +188,7 @@ module Homebrew
       end
     end
 
-    SOCKET_STRING_REGEX = %r{^([a-z]+)://(.+):([0-9]+)$}i.freeze
+    SOCKET_STRING_REGEX = %r{^([a-z]+)://(.+):([0-9]+)$}i
 
     sig {
       params(value: T.nilable(T.any(String, T::Hash[Symbol, String])))

--- a/Library/Homebrew/settings.rb
+++ b/Library/Homebrew/settings.rb
@@ -23,7 +23,7 @@ module Homebrew
 
       value = value.to_s
 
-      return if read(setting, repo: repo) == value
+      return if read(setting, repo:) == value
 
       Kernel.system("git", "-C", repo.to_s, "config", "--replace-all", "homebrew.#{setting}", value, exception: true)
     end
@@ -31,7 +31,7 @@ module Homebrew
     def self.delete(setting, repo: HOMEBREW_REPOSITORY)
       return unless (repo/".git/config").exist?
 
-      return if read(setting, repo: repo).nil?
+      return if read(setting, repo:).nil?
 
       Kernel.system("git", "-C", repo.to_s, "config", "--unset-all", "homebrew.#{setting}", exception: true)
     end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -199,7 +199,7 @@ class SoftwareSpec
 
     @uses_from_macos_elements << deps
 
-    depends_on UsesFromMacOSDependency.new(spec, Array(tags), bounds: bounds)
+    depends_on UsesFromMacOSDependency.new(spec, Array(tags), bounds:)
   end
 
   # @deprecated
@@ -359,7 +359,7 @@ class Bottle
   end
 
   def fetch(verify_download_integrity: true)
-    @resource.fetch(verify_download_integrity: verify_download_integrity)
+    @resource.fetch(verify_download_integrity:)
   rescue DownloadError
     raise unless fallback_on_error
 
@@ -579,7 +579,7 @@ class BottleSpecification
 
   sig { params(tag: T.any(Symbol, Utils::Bottles::Tag), no_older_versions: T::Boolean).returns(T::Boolean) }
   def tag?(tag, no_older_versions: false)
-    collector.tag?(tag, no_older_versions: no_older_versions)
+    collector.tag?(tag, no_older_versions:)
   end
 
   # Checksum methods in the DSL's bottle block take
@@ -603,7 +603,7 @@ class BottleSpecification
 
     cellar ||= tag.default_cellar
 
-    collector.add(tag, checksum: Checksum.new(digest), cellar: cellar)
+    collector.add(tag, checksum: Checksum.new(digest), cellar:)
   end
 
   sig {
@@ -611,7 +611,7 @@ class BottleSpecification
       .returns(T.nilable(Utils::Bottles::TagSpecification))
   }
   def tag_specification_for(tag, no_older_versions: false)
-    collector.specification_for(tag, no_older_versions: no_older_versions)
+    collector.specification_for(tag, no_older_versions:)
   end
 
   def checksums

--- a/Library/Homebrew/sorbet/parlour/attr.rb
+++ b/Library/Homebrew/sorbet/parlour/attr.rb
@@ -152,7 +152,7 @@ class Attr < Parlour::Plugin
             Parlour::RbiGenerator::Parameter.new("**options"),
             Parlour::RbiGenerator::Parameter.new("&block"),
           ],
-          return_type: return_type,
+          return_type:,
         )
       else
         raise "Malformed tree."

--- a/Library/Homebrew/standalone/sorbet.rb
+++ b/Library/Homebrew/standalone/sorbet.rb
@@ -12,19 +12,19 @@ unless ENV["HOMEBREW_SORBET_RUNTIME"]
   # @private
   module TNoChecks
     def cast(value, type, checked: false)
-      super(value, type, checked: checked)
+      super(value, type, checked:)
     end
 
     def let(value, type, checked: false)
-      super(value, type, checked: checked)
+      super(value, type, checked:)
     end
 
     def bind(value, type, checked: false)
-      super(value, type, checked: checked)
+      super(value, type, checked:)
     end
 
     def assert_type!(value, type, checked: false)
-      super(value, type, checked: checked)
+      super(value, type, checked:)
     end
   end
 

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -40,7 +40,7 @@ if homebrew_bootsnap_enabled
 
     Bootsnap.setup(
       cache_dir:          cache,
-      ignore_directories: ignore_directories,
+      ignore_directories:,
       load_path_cache:    true,
       compile_cache_iseq: true,
       compile_cache_yaml: true,

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -20,7 +20,7 @@ module Homebrew
             line = o.location.line
             column = o.location.line
 
-            annotation = GitHub::Actions::Annotation.new(:error, o.message, file: path, line: line, column: column)
+            annotation = GitHub::Actions::Annotation.new(:error, o.message, file: path, line:, column:)
             puts annotation if annotation.relevant?
           end
         end
@@ -51,23 +51,23 @@ module Homebrew
         (output_type == :json) ? [] : true
       else
         run_rubocop(ruby_files, output_type,
-                    fix: fix,
-                    except_cops: except_cops, only_cops: only_cops,
-                    display_cop_names: display_cop_names,
-                    reset_cache: reset_cache,
-                    debug: debug, verbose: verbose)
+                    fix:,
+                    except_cops:, only_cops:,
+                    display_cop_names:,
+                    reset_cache:,
+                    debug:, verbose:)
       end
 
       shellcheck_result = if ruby_files.any? && shell_files.none?
         (output_type == :json) ? [] : true
       else
-        run_shellcheck(shell_files, output_type, fix: fix)
+        run_shellcheck(shell_files, output_type, fix:)
       end
 
       shfmt_result = if ruby_files.any? && shell_files.none?
         true
       else
-        run_shfmt(shell_files, fix: fix)
+        run_shfmt(shell_files, fix:)
       end
 
       if output_type == :json

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -298,8 +298,8 @@ module Homebrew
         @offenses.fetch(Pathname(path), [])
       end
 
-      def each(*args, &block)
-        @offenses.each(*args, &block)
+      def each(...)
+        @offenses.each(...)
       end
     end
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -299,7 +299,7 @@ class Tap
 
     if installed?
       if requested_remote != remote # we are sure that clone_target is not nil and custom_remote is true here
-        fix_remote_configuration(requested_remote: requested_remote, quiet: quiet)
+        fix_remote_configuration(requested_remote:, quiet:)
       end
 
       unless force_auto_update.nil?
@@ -990,8 +990,8 @@ class CoreTap < AbstractCoreTap
       $stderr.puts "HOMEBREW_CORE_GIT_REMOTE set: using #{remote} as the Homebrew/homebrew-core Git remote."
     end
 
-    super(quiet: quiet, clone_target: remote, force_auto_update: force_auto_update,
-          custom_remote: custom_remote, force: force)
+    super(quiet:, clone_target: remote, force_auto_update:,
+          custom_remote:, force:)
   end
 
   # @private

--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -54,7 +54,7 @@ module Homebrew
 
     sig { params(message: String).void }
     def problem(message)
-      @problems << ({ message: message, location: nil, corrected: false })
+      @problems << ({ message:, location: nil, corrected: false })
     end
 
     private

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -2,19 +2,19 @@
 # frozen_string_literal: true
 
 # Match taps' formulae, e.g. `someuser/sometap/someformula`
-HOMEBREW_TAP_FORMULA_REGEX = T.let(%r{^([\w-]+)/([\w-]+)/([\w+-.@]+)$}.freeze, Regexp)
+HOMEBREW_TAP_FORMULA_REGEX = T.let(%r{^([\w-]+)/([\w-]+)/([\w+-.@]+)$}, Regexp)
 # Match taps' casks, e.g. `someuser/sometap/somecask`
-HOMEBREW_TAP_CASK_REGEX = T.let(%r{^([\w-]+)/([\w-]+)/([a-z0-9\-_]+)$}.freeze, Regexp)
+HOMEBREW_TAP_CASK_REGEX = T.let(%r{^([\w-]+)/([\w-]+)/([a-z0-9\-_]+)$}, Regexp)
 # Match main cask taps' casks, e.g. `homebrew/cask/somecask` or `somecask`
-HOMEBREW_MAIN_TAP_CASK_REGEX = T.let(%r{^([Hh]omebrew/(?:homebrew-)?cask/)?[a-z0-9\-_]+$}.freeze, Regexp)
+HOMEBREW_MAIN_TAP_CASK_REGEX = T.let(%r{^([Hh]omebrew/(?:homebrew-)?cask/)?[a-z0-9\-_]+$}, Regexp)
 # Match taps' directory paths, e.g. `HOMEBREW_LIBRARY/Taps/someuser/sometap`
 HOMEBREW_TAP_DIR_REGEX = T.let(
-  %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/(?<user>[\w-]+)/(?<repo>[\w-]+)}.freeze, Regexp
+  %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/(?<user>[\w-]+)/(?<repo>[\w-]+)}, Regexp
 )
 # Match taps' formula paths, e.g. `HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula`
 HOMEBREW_TAP_PATH_REGEX = T.let(Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{(?:/.*)?$}.source).freeze, Regexp)
 # Match official taps' casks, e.g. `homebrew/cask/somecask or homebrew/cask-versions/somecask`
 HOMEBREW_CASK_TAP_CASK_REGEX =
-  T.let(%r{^(?:([Cc]askroom)/(cask|versions)|([Hh]omebrew)/(?:homebrew-)?(cask|cask-[\w-]+))/([\w+-.]+)$}.freeze,
+  T.let(%r{^(?:([Cc]askroom)/(cask|versions)|([Hh]omebrew)/(?:homebrew-)?(cask|cask-[\w-]+))/([\w+-.]+)$},
         Regexp)
-HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX = T.let(/^(home|linux)brew-/.freeze, Regexp)
+HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX = T.let(/^(home|linux)brew-/, Regexp)

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -40,7 +40,7 @@ begin
   end
 
   ENV.extend(Stdenv)
-  ENV.setup_build_environment(formula: formula, testing_formula: true)
+  ENV.setup_build_environment(formula:, testing_formula: true)
 
   # tests can also return false to indicate failure
   run_test = proc { |_ = nil| raise "test returned false" if formula.run_test(keep_tmp: args.keep_tmp?) == false }

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -13,7 +13,7 @@ describe Homebrew::API do
   end
 
   def mock_curl_output(stdout: "", success: true)
-    curl_output = instance_double(SystemCommand::Result, stdout: stdout, success?: success)
+    curl_output = instance_double(SystemCommand::Result, stdout:, success?: success)
     allow(Utils::Curl).to receive(:curl_output).and_return curl_output
   end
 

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -10,8 +10,8 @@ describe Cask::Artifact::App, :cask do
   let(:source_path) { cask.staged_path.join("Caffeine.app") }
   let(:target_path) { cask.config.appdir.join("Caffeine.app") }
 
-  let(:install_phase) { app.install_phase(command: command, adopt: adopt, force: force) }
-  let(:uninstall_phase) { app.uninstall_phase(command: command, force: force) }
+  let(:install_phase) { app.install_phase(command:, adopt:, force:) }
+  let(:uninstall_phase) { app.uninstall_phase(command:, force:) }
 
   before do
     InstallHelper.install_without_artifacts(cask)
@@ -315,13 +315,13 @@ describe Cask::Artifact::App, :cask do
       inode = target_path.stat.ino
       expect(contents_path).to exist
 
-      app.uninstall_phase(command: command, force: force, successor: cask)
+      app.uninstall_phase(command:, force:, successor: cask)
 
       expect(target_path).to exist
       expect(target_path.children).to be_empty
       expect(contents_path).not_to exist
 
-      app.install_phase(command: command, adopt: adopt, force: force, predecessor: cask)
+      app.install_phase(command:, adopt:, force:, predecessor: cask)
       expect(target_path).to exist
       expect(target_path.stat.ino).to eq(inode)
 
@@ -335,10 +335,10 @@ describe Cask::Artifact::App, :cask do
         expect(File).to receive(:write).with(target_path / ".homebrew-write-test",
                                              instance_of(String)).and_raise(Errno::EACCES)
 
-        app.uninstall_phase(command: command, force: force, successor: cask)
+        app.uninstall_phase(command:, force:, successor: cask)
         expect(target_path).not_to exist
 
-        app.install_phase(command: command, adopt: adopt, force: force, predecessor: cask)
+        app.install_phase(command:, adopt:, force:, predecessor: cask)
         expect(target_contents_path).to exist
       end
     end
@@ -360,12 +360,12 @@ describe Cask::Artifact::App, :cask do
           .and_call_original
         expect(FileUtils).not_to receive(:move).with(source_contents_path, an_instance_of(Pathname))
 
-        app.uninstall_phase(command: command, force: force, successor: cask)
+        app.uninstall_phase(command:, force:, successor: cask)
         expect(target_contents_path).not_to exist
         expect(target_path).to exist
         expect(source_contents_path).to exist
 
-        app.install_phase(command: command, adopt: adopt, force: force, predecessor: cask)
+        app.install_phase(command:, adopt:, force:, predecessor: cask)
         expect(target_contents_path).to exist
       end
 
@@ -382,10 +382,10 @@ describe Cask::Artifact::App, :cask do
             .and_raise(ErrorDuringExecution.new([], status: 1,
 output: [[:stderr, "touch: #{target_path}/.homebrew-write-test: Operation not permitted\n"]], secrets: []))
 
-          app.uninstall_phase(command: command, force: force, successor: cask)
+          app.uninstall_phase(command:, force:, successor: cask)
           expect(target_path).not_to exist
 
-          app.install_phase(command: command, adopt: adopt, force: force, predecessor: cask)
+          app.install_phase(command:, adopt:, force:, predecessor: cask)
           expect(target_contents_path).to exist
         end
       end

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -4,7 +4,7 @@ describe Cask::Artifact::Installer, :cask do
   subject(:installer) { described_class.new(cask, **args) }
 
   let(:staged_path) { mktmpdir }
-  let(:cask) { instance_double(Cask::Cask, staged_path: staged_path) }
+  let(:cask) { instance_double(Cask::Cask, staged_path:) }
 
   let(:command) { SystemCommand }
 
@@ -16,7 +16,7 @@ describe Cask::Artifact::Installer, :cask do
 
       it "shows a message prompting to run the installer manually" do
         expect do
-          installer.install_phase(command: command)
+          installer.install_phase(command:)
         end.to output(%r{open #{staged_path}/installer}).to_stdout
       end
     end
@@ -37,7 +37,7 @@ describe Cask::Artifact::Installer, :cask do
           ),
         )
 
-        installer.install_phase(command: command)
+        installer.install_phase(command:)
       end
     end
   end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -52,13 +52,13 @@ describe Cask::Audit, :cask do
   let(:token_conflicts) { nil }
   let(:signing) { nil }
   let(:audit) do
-    described_class.new(cask, online:          online,
-                              strict:          strict,
-                              new_cask:        new_cask,
-                              token_conflicts: token_conflicts,
-                              signing:         signing,
-                              only:            only,
-                              except:          except)
+    described_class.new(cask, online:,
+                              strict:,
+                              new_cask:,
+                              token_conflicts:,
+                              signing:,
+                              only:,
+                              except:)
   end
 
   describe "#new" do

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -136,7 +136,7 @@ describe Cask::Cask, :cask do
           context "when versions #{installed_version} are installed and the " \
                   "tap version is #{tap_version}, #{"not " unless greedy}greedy " \
                   "and sha is #{"not " unless outdated_sha}outdated" do
-            subject { cask.outdated_version(greedy: greedy) }
+            subject { cask.outdated_version(greedy:) }
 
             it {
               allow(cask).to receive_messages(installed_version:      installed_version,

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -525,7 +525,7 @@ describe Cask::DSL, :cask do
         appdir: "/Applications/",
       })
 
-      cask = Cask::Cask.new("appdir-trailing-slash", config: config) do
+      cask = Cask::Cask.new("appdir-trailing-slash", config:) do
         binary "#{appdir}/some/path"
       end
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -54,7 +54,7 @@ describe Cask::Upgrade, :cask do
         expect(renamed_app_new_path).not_to be_a_directory
         expect(renamed_app.installed_version).to eq "1.0.0"
 
-        described_class.upgrade_casks(args: args)
+        described_class.upgrade_casks(args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -84,7 +84,7 @@ describe Cask::Upgrade, :cask do
         expect(renamed_app_new_path).not_to be_a_directory
         expect(renamed_app.installed_version).to eq "1.0.0"
 
-        described_class.upgrade_casks(local_caffeine, args: args)
+        described_class.upgrade_casks(local_caffeine, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -109,7 +109,7 @@ describe Cask::Upgrade, :cask do
         expect(auto_updates_path).to be_a_directory
         expect(auto_updates.installed_version).to eq "2.57"
 
-        described_class.upgrade_casks(local_caffeine, auto_updates, args: args)
+        described_class.upgrade_casks(local_caffeine, auto_updates, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -147,7 +147,7 @@ describe Cask::Upgrade, :cask do
         version_latest.download_sha_path.write("fake download sha")
         expect(version_latest.outdated_download_sha?).to be(true)
 
-        described_class.upgrade_casks(greedy: true, args: args)
+        described_class.upgrade_casks(greedy: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -177,13 +177,13 @@ describe Cask::Upgrade, :cask do
         expect(auto_updates_path).to be_a_directory
         expect(auto_updates.installed_version).to eq "2.57"
 
-        described_class.upgrade_casks(auto_updates, greedy: true, args: args)
+        described_class.upgrade_casks(auto_updates, greedy: true, args:)
 
         expect(auto_updates).to be_installed
         expect(auto_updates_path).to be_a_directory
         expect(auto_updates.installed_version).to eq "2.61"
 
-        described_class.upgrade_casks(auto_updates, greedy: true, args: args)
+        described_class.upgrade_casks(auto_updates, greedy: true, args:)
 
         expect(auto_updates).to be_installed
         expect(auto_updates_path).to be_a_directory
@@ -198,14 +198,14 @@ describe Cask::Upgrade, :cask do
         version_latest.download_sha_path.write("fake download sha")
         expect(version_latest.outdated_download_sha?).to be(true)
 
-        described_class.upgrade_casks(version_latest, greedy: true, args: args)
+        described_class.upgrade_casks(version_latest, greedy: true, args:)
 
         expect(version_latest).to be_installed
         expect(version_latest_paths).to all be_a_directory
         expect(version_latest.installed_version).to eq "latest"
         expect(version_latest.outdated_download_sha?).to be(false)
 
-        described_class.upgrade_casks(version_latest, greedy: true, args: args)
+        described_class.upgrade_casks(version_latest, greedy: true, args:)
 
         expect(version_latest).to be_installed
         expect(version_latest_paths).to all be_a_directory
@@ -250,7 +250,7 @@ describe Cask::Upgrade, :cask do
         expect(renamed_app_new_path).not_to be_a_directory
         expect(renamed_app.installed_version).to eq "1.0.0"
 
-        described_class.upgrade_casks(dry_run: true, args: args)
+        described_class.upgrade_casks(dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -277,7 +277,7 @@ describe Cask::Upgrade, :cask do
         expect(local_transmission_path).to be_a_directory
         expect(local_transmission.installed_version).to eq "2.60"
 
-        described_class.upgrade_casks(local_caffeine, dry_run: true, args: args)
+        described_class.upgrade_casks(local_caffeine, dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -304,7 +304,7 @@ describe Cask::Upgrade, :cask do
         expect(renamed_app_new_path).not_to be_a_directory
         expect(renamed_app.installed_version).to eq "1.0.0"
 
-        described_class.upgrade_casks(local_caffeine, auto_updates, dry_run: true, args: args)
+        described_class.upgrade_casks(local_caffeine, auto_updates, dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -347,7 +347,7 @@ describe Cask::Upgrade, :cask do
         version_latest.download_sha_path.write("fake download sha")
         expect(version_latest.outdated_download_sha?).to be(true)
 
-        described_class.upgrade_casks(greedy: true, dry_run: true, args: args)
+        described_class.upgrade_casks(greedy: true, dry_run: true, args:)
 
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
@@ -377,7 +377,7 @@ describe Cask::Upgrade, :cask do
         expect(auto_updates_path).to be_a_directory
         expect(auto_updates.installed_version).to eq "2.57"
 
-        described_class.upgrade_casks(auto_updates, dry_run: true, greedy: true, args: args)
+        described_class.upgrade_casks(auto_updates, dry_run: true, greedy: true, args:)
 
         expect(auto_updates).to be_installed
         expect(auto_updates_path).to be_a_directory
@@ -394,7 +394,7 @@ describe Cask::Upgrade, :cask do
         version_latest.download_sha_path.write("fake download sha")
         expect(version_latest.outdated_download_sha?).to be(true)
 
-        described_class.upgrade_casks(version_latest, dry_run: true, greedy: true, args: args)
+        described_class.upgrade_casks(version_latest, dry_run: true, greedy: true, args:)
 
         expect(version_latest).to be_installed
         expect(version_latest_paths).to all be_a_directory
@@ -432,7 +432,7 @@ describe Cask::Upgrade, :cask do
       expect(will_fail_if_upgraded.installed_version).to eq "1.2.2"
 
       expect do
-        described_class.upgrade_casks(will_fail_if_upgraded, args: args)
+        described_class.upgrade_casks(will_fail_if_upgraded, args:)
       end.to raise_error(Cask::CaskError).and output(output_reverted).to_stderr
 
       expect(will_fail_if_upgraded).to be_installed
@@ -450,7 +450,7 @@ describe Cask::Upgrade, :cask do
       expect(bad_checksum.installed_version).to eq "1.2.2"
 
       expect do
-        described_class.upgrade_casks(bad_checksum, args: args)
+        described_class.upgrade_casks(bad_checksum, args:)
       end.to raise_error(ChecksumMismatchError).and(not_to_output(output_reverted).to_stderr)
 
       expect(bad_checksum).to be_installed
@@ -496,7 +496,7 @@ describe Cask::Upgrade, :cask do
       expect(bad_checksum_2.installed_version).to eq "1.2.2"
 
       expect do
-        described_class.upgrade_casks(args: args)
+        described_class.upgrade_casks(args:)
       end.to raise_error(Cask::MultipleCaskErrors)
 
       expect(bad_checksum).to be_installed

--- a/Library/Homebrew/test/cask/utils_spec.rb
+++ b/Library/Homebrew/test/cask/utils_spec.rb
@@ -9,9 +9,9 @@ describe Cask::Utils do
   describe "::gain_permissions_mkpath" do
     it "creates a directory" do
       expect(path).not_to exist
-      described_class.gain_permissions_mkpath path, command: command
+      described_class.gain_permissions_mkpath(path, command:)
       expect(path).to be_a_directory
-      described_class.gain_permissions_mkpath path, command: command
+      described_class.gain_permissions_mkpath(path, command:)
       expect(path).to be_a_directory
     end
 
@@ -27,9 +27,9 @@ describe Cask::Utils do
         end
 
         expect(path).not_to exist
-        described_class.gain_permissions_mkpath path, command: command
+        described_class.gain_permissions_mkpath(path, command:)
         expect(path).to be_a_directory
-        described_class.gain_permissions_mkpath path, command: command
+        described_class.gain_permissions_mkpath(path, command:)
         expect(path).to be_a_directory
 
         expect(dir).not_to be_writable
@@ -48,12 +48,12 @@ describe Cask::Utils do
       expect(link).to be_a_symlink
       expect(link.realpath).to eq path
 
-      described_class.gain_permissions_remove link, command: command
+      described_class.gain_permissions_remove(link, command:)
 
       expect(path).to be_a_file
       expect(link).not_to exist
 
-      described_class.gain_permissions_remove path, command: command
+      described_class.gain_permissions_remove(path, command:)
 
       expect(path).not_to exist
     end
@@ -66,12 +66,12 @@ describe Cask::Utils do
       expect(link).to be_a_symlink
       expect(link.realpath).to eq path
 
-      described_class.gain_permissions_remove link, command: command
+      described_class.gain_permissions_remove(link, command:)
 
       expect(path).to be_a_directory
       expect(link).not_to exist
 
-      described_class.gain_permissions_remove path, command: command
+      described_class.gain_permissions_remove(path, command:)
 
       expect(path).not_to exist
     end

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -6,7 +6,7 @@ describe Dependency do
   def build_dep(name, tags = [], deps = [])
     dep = described_class.new(name.to_s, tags)
     allow(dep).to receive(:to_formula).and_return \
-      instance_double(Formula, deps: deps, name: name, full_name: name)
+      instance_double(Formula, deps:, name:, full_name: name)
     dep
   end
 
@@ -15,7 +15,7 @@ describe Dependency do
   let(:baz) { build_dep(:baz) }
   let(:qux) { build_dep(:qux) }
   let(:deps) { [foo, bar, baz, qux] }
-  let(:formula) { instance_double(Formula, deps: deps, name: "f") }
+  let(:formula) { instance_double(Formula, deps:, name: "f") }
 
   describe "::expand" do
     it "yields dependent and dependency pairs" do
@@ -52,13 +52,13 @@ describe Dependency do
 
   it "skips optionals by default" do
     deps = [build_dep(:foo, [:optional]), bar, baz, qux]
-    f = instance_double(Formula, deps: deps, build: instance_double(BuildOptions, with?: false), name: "f")
+    f = instance_double(Formula, deps:, build: instance_double(BuildOptions, with?: false), name: "f")
     expect(described_class.expand(f)).to eq([bar, baz, qux])
   end
 
   it "keeps recommended dependencies by default" do
     deps = [build_dep(:foo, [:recommended]), bar, baz, qux]
-    f = instance_double(Formula, deps: deps, build: instance_double(BuildOptions, with?: true), name: "f")
+    f = instance_double(Formula, deps:, build: instance_double(BuildOptions, with?: true), name: "f")
     expect(described_class.expand(f)).to eq(deps)
   end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -115,7 +115,7 @@ module Homebrew
       end
 
       it "detects no license info" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true, core_tap: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true, core_tap: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
           end
@@ -126,7 +126,7 @@ module Homebrew
       end
 
       it "detects if license is not a standard spdx-id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license "zzz"
@@ -141,7 +141,7 @@ module Homebrew
       end
 
       it "detects if license is a deprecated spdx-id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true, strict: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true, strict: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license "#{deprecated_spdx_id}"
@@ -157,7 +157,7 @@ module Homebrew
       end
 
       it "detects if license with AND contains a non-standard spdx-id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license #{license_all_custom_id}
@@ -172,7 +172,7 @@ module Homebrew
       end
 
       it "detects if license array contains a non-standard spdx-id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license #{license_any_nonstandard}
@@ -187,7 +187,7 @@ module Homebrew
       end
 
       it "detects if license array contains a deprecated spdx-id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true, strict: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true, strict: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license #{license_any_deprecated}
@@ -203,7 +203,7 @@ module Homebrew
       end
 
       it "verifies that a license info is a standard spdx id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license "0BSD"
@@ -215,7 +215,7 @@ module Homebrew
       end
 
       it "verifies that a license info with plus is a standard spdx id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license "0BSD+"
@@ -227,7 +227,7 @@ module Homebrew
       end
 
       it "allows :public_domain license" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license :public_domain
@@ -239,7 +239,7 @@ module Homebrew
       end
 
       it "verifies that a license info with multiple licenses are standard spdx ids" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license any_of: ["0BSD", "MIT"]
@@ -257,15 +257,15 @@ module Homebrew
             license "Apache-2.0" => { with: "LLVM-exception" }
           end
         RUBY
-        fa = formula_auditor "foo", formula_text, new_formula: true,
-                             spdx_license_data: spdx_license_data, spdx_exception_data: spdx_exception_data
+        fa = formula_auditor("foo", formula_text, new_formula: true,
+                             spdx_license_data:, spdx_exception_data:)
 
         fa.audit_license
         expect(fa.problems).to be_empty
       end
 
       it "verifies that a license array contains only standard spdx id" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license #{license_any}
@@ -277,7 +277,7 @@ module Homebrew
       end
 
       it "verifies that a license array contains only standard spdx id with plus" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license #{license_any_with_plus}
@@ -289,7 +289,7 @@ module Homebrew
       end
 
       it "verifies that a license array with AND contains only standard spdx ids" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_license_data: spdx_license_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_license_data:, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
             license #{license_nested_conditions}
@@ -309,7 +309,7 @@ module Homebrew
             license "GPL-3.0"
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, spdx_license_data: spdx_license_data,
+        fa = formula_auditor "cask", formula_text, spdx_license_data:,
                              online: true, core_tap: true, new_formula: true
 
         fa.audit_license
@@ -325,7 +325,7 @@ module Homebrew
             license all_of: ["GPL-3.0-or-later", "MIT"]
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, spdx_license_data: spdx_license_data,
+        fa = formula_auditor "cask", formula_text, spdx_license_data:,
                              online: true, core_tap: true, new_formula: true
 
         fa.audit_license
@@ -341,8 +341,8 @@ module Homebrew
             license "GPL-3.0-or-later" => { with: "LLVM-exception" }
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, online: true, core_tap: true, new_formula: true,
-                             spdx_license_data: spdx_license_data, spdx_exception_data: spdx_exception_data
+        fa = formula_auditor("cask", formula_text, online: true, core_tap: true, new_formula: true,
+                             spdx_license_data:, spdx_exception_data:)
 
         fa.audit_license
         expect(fa.problems).to be_empty
@@ -356,8 +356,8 @@ module Homebrew
             license "GPL-3.0-or-later" => { with: "zzz" }
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, core_tap: true, new_formula: true,
-                             spdx_license_data: spdx_license_data, spdx_exception_data: spdx_exception_data
+        fa = formula_auditor("cask", formula_text, core_tap: true, new_formula: true,
+                             spdx_license_data:, spdx_exception_data:)
 
         fa.audit_license
         expect(fa.problems.first[:message]).to match <<~EOS
@@ -375,8 +375,8 @@ module Homebrew
             license "GPL-3.0-or-later" => { with: "#{deprecated_spdx_exception}" }
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, core_tap: true, new_formula: true,
-                             spdx_license_data: spdx_license_data, spdx_exception_data: spdx_exception_data
+        fa = formula_auditor("cask", formula_text, core_tap: true, new_formula: true,
+                             spdx_license_data:, spdx_exception_data:)
 
         fa.audit_license
         expect(fa.problems.first[:message]).to match <<~EOS
@@ -388,7 +388,7 @@ module Homebrew
 
       it "checks online and verifies that a standard license id is in the same exempted license group" \
          "as what is indicated on its GitHub repo", :needs_network do
-        fa = formula_auditor "cask", <<~RUBY, spdx_license_data: spdx_license_data, online: true, new_formula: true
+        fa = formula_auditor "cask", <<~RUBY, spdx_license_data:, online: true, new_formula: true
           class Cask < Formula
             url "https://github.com/cask/cask/archive/v0.8.4.tar.gz"
             head "https://github.com/cask/cask.git"
@@ -402,7 +402,7 @@ module Homebrew
 
       it "checks online and verifies that a standard license array is in the same exempted license group" \
          "as what is indicated on its GitHub repo", :needs_network do
-        fa = formula_auditor "cask", <<~RUBY, spdx_license_data: spdx_license_data, online: true, new_formula: true
+        fa = formula_auditor "cask", <<~RUBY, spdx_license_data:, online: true, new_formula: true
           class Cask < Formula
             url "https://github.com/cask/cask/archive/v0.8.4.tar.gz"
             head "https://github.com/cask/cask.git"
@@ -423,7 +423,7 @@ module Homebrew
             license "0BSD"
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, spdx_license_data: spdx_license_data,
+        fa = formula_auditor "cask", formula_text, spdx_license_data:,
                              online: true, core_tap: true, new_formula: true
 
         fa.audit_license
@@ -440,7 +440,7 @@ module Homebrew
             license "0BSD"
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, spdx_license_data: spdx_license_data,
+        fa = formula_auditor "cask", formula_text, spdx_license_data:,
                              online: true, core_tap: true, new_formula: true,
                              tap_audit_exceptions: { permitted_formula_license_mismatches: ["cask"] }
 
@@ -457,7 +457,7 @@ module Homebrew
             license #{license_any_mismatch}
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, spdx_license_data: spdx_license_data,
+        fa = formula_auditor "cask", formula_text, spdx_license_data:,
                              online: true, core_tap: true, new_formula: true
 
         fa.audit_license
@@ -474,7 +474,7 @@ module Homebrew
             license #{license_any}
           end
         RUBY
-        fa = formula_auditor "cask", formula_text, spdx_license_data: spdx_license_data,
+        fa = formula_auditor "cask", formula_text, spdx_license_data:,
                              online: true, core_tap: true, new_formula: true
 
         fa.audit_license

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -30,7 +30,7 @@ describe "brew extract" do
         system "git", "add", "--all"
         system "git", "commit", "-m", "testball 0.2"
       end
-      { name: target.name, path: path }
+      { name: target.name, path: }
     end
 
     it "retrieves the most recent version of formula", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -96,7 +96,7 @@ describe "brew pr-pull" do
           safe_system Utils::Git.git, "commit", formula_file, "-m", "revision"
           File.write(formula_file, formula_version)
           safe_system Utils::Git.git, "commit", formula_file, "-m", "version", "--author=#{secondary_author}"
-          described_class.autosquash!(original_hash, tap: tap)
+          described_class.autosquash!(original_hash, tap:)
           expect(tap.git_repo.commit_message).to include("foo 2.0")
           expect(tap.git_repo.commit_message).to include("Co-authored-by: #{secondary_author}")
         end
@@ -111,7 +111,7 @@ describe "brew pr-pull" do
           safe_system Utils::Git.git, "commit", cask_file, "-m", "rebuild"
           File.write(cask_file, cask_version)
           safe_system Utils::Git.git, "commit", cask_file, "-m", "version", "--author=#{secondary_author}"
-          described_class.autosquash!(original_hash, tap: tap)
+          described_class.autosquash!(original_hash, tap:)
           git_repo = GitRepository.new(path)
           expect(git_repo.commit_message).to include("food 2.0")
           expect(git_repo.commit_message).to include("Co-authored-by: #{secondary_author}")

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -19,7 +19,7 @@ describe CurlDownloadStrategy do
 
   before do
     allow(strategy).to receive(:curl_headers).with(any_args)
-                                             .and_return({ responses: [{ headers: headers }] })
+                                             .and_return({ responses: [{ headers: }] })
   end
 
   it "parses the opts and sets the corresponding args" do

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 describe ErrorDuringExecution do
-  subject(:error) { described_class.new(command, status: status, output: output) }
+  subject(:error) { described_class.new(command, status:, output:) }
 
   let(:command) { ["false"] }
-  let(:status) { instance_double(Process::Status, exitstatus: exitstatus, termsig: nil) }
+  let(:status) { instance_double(Process::Status, exitstatus:, termsig: nil) }
   let(:exitstatus) { 1 }
   let(:output) { nil }
 
@@ -17,13 +17,13 @@ describe ErrorDuringExecution do
 
     it "fails when only given a status" do
       expect do
-        described_class.new(status: status)
+        described_class.new(status:)
       end.to raise_error(ArgumentError)
     end
 
     it "does not raise an error when given both a command and a status" do
       expect do
-        described_class.new(command, status: status)
+        described_class.new(command, status:)
       end.not_to raise_error
     end
   end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -194,7 +194,7 @@ describe "Exception" do
   end
 
   describe ErrorDuringExecution do
-    subject { described_class.new(["badprg", "arg1", "arg2"], status: status) }
+    subject { described_class.new(["badprg", "arg1", "arg2"], status:) }
 
     let(:status) { instance_double(Process::Status, exitstatus: 17, termsig: nil) }
 

--- a/Library/Homebrew/test/formula_pin_spec.rb
+++ b/Library/Homebrew/test/formula_pin_spec.rb
@@ -6,7 +6,7 @@ describe FormulaPin do
   subject(:formula_pin) { described_class.new(formula) }
 
   let(:name) { "double" }
-  let(:formula) { instance_double(Formula, name: name, rack: HOMEBREW_CELLAR/name) }
+  let(:formula) { instance_double(Formula, name:, rack: HOMEBREW_CELLAR/name) }
 
   before do
     formula.rack.mkpath

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -30,7 +30,7 @@ describe Formula do
     let(:alias_name) { "baz@1" }
     let(:alias_path) { (CoreTap.instance.alias_dir/alias_name).to_s }
     let(:f) { klass.new(name, path, spec) }
-    let(:f_alias) { klass.new(name, path, spec, alias_path: alias_path) }
+    let(:f_alias) { klass.new(name, path, spec, alias_path:) }
 
     specify "formula instantiation" do
       expect(f.name).to eq(name)
@@ -207,7 +207,7 @@ describe Formula do
     tap = Tap.new("user", "repo")
     name = "foo"
     path = tap.path/"Formula/#{name}.rb"
-    f = formula name, path: path do
+    f = formula(name, path:) do
       url "foo-1.0"
     end
 
@@ -417,7 +417,7 @@ describe Formula do
     example "alias paths with build options" do
       alias_path = (CoreTap.instance.alias_dir/"another_name")
 
-      f = formula alias_path: alias_path do
+      f = formula(alias_path:) do
         url "foo-1.0"
       end
       f.build = BuildOptions.new(Options.new, f.options)
@@ -430,7 +430,7 @@ describe Formula do
       alias_path = (CoreTap.instance.alias_dir/"another_name")
       source_path = CoreTap.instance.new_formula_path("another_other_name")
 
-      f = formula alias_path: alias_path do
+      f = formula(alias_path:) do
         url "foo-1.0"
       end
       f.build = Tab.new(source: { "path" => source_path.to_s })
@@ -443,7 +443,7 @@ describe Formula do
       alias_path = (CoreTap.instance.alias_dir/"another_name")
       source_path = (CoreTap.instance.alias_dir/"another_other_name")
 
-      f = formula alias_path: alias_path do
+      f = formula(alias_path:) do
         url "foo-1.0"
       end
       f.build = Tab.new(source: { "path" => source_path.to_s })
@@ -1227,13 +1227,13 @@ describe Formula do
 
   describe "alias changes" do
     let(:f) do
-      formula "formula_name", alias_path: alias_path do
+      formula("formula_name", alias_path:) do
         url "foo-1.0"
       end
     end
 
     let(:new_formula) do
-      formula "new_formula_name", alias_path: alias_path do
+      formula("new_formula_name", alias_path:) do
         url "foo-1.1"
       end
     end
@@ -1415,7 +1415,7 @@ describe Formula do
     end
 
     example "outdated old alias targets installed" do
-      f = formula alias_path: alias_path do
+      f = formula(alias_path:) do
         url "foo-1.0"
       end
 
@@ -1430,7 +1430,7 @@ describe Formula do
     end
 
     example "outdated old alias targets not installed" do
-      f = formula alias_path: alias_path do
+      f = formula(alias_path:) do
         url "foo-1.0"
       end
 

--- a/Library/Homebrew/test/github_runner_spec.rb
+++ b/Library/Homebrew/test/github_runner_spec.rb
@@ -6,7 +6,7 @@ describe GitHubRunner do
   let(:runner) do
     spec = MacOSRunnerSpec.new(name: "macOS 11-arm64", runner: "11-arm64", timeout: 90, cleanup: true)
     version = MacOSVersion.new("11")
-    described_class.new(platform: :macos, arch: :arm64, spec: spec, macos_version: version)
+    described_class.new(platform: :macos, arch: :arm64, spec:, macos_version: version)
   end
 
   it "has immutable attributes" do

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -11,7 +11,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
   let(:resource) { instance_double(Resource, "resource", stage: true) }
   let(:formula_bin) { dir/"formula_bin" }
   let(:formula_man) { dir/"formula_man" }
-  let(:formula) { instance_double(Formula, "formula", resource: resource, bin: formula_bin, man: formula_man) }
+  let(:formula) { instance_double(Formula, "formula", resource:, bin: formula_bin, man: formula_man) }
 
   describe "#create" do
     it "creates a venv" do

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -83,7 +83,7 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
       # block here simply to ensure this method works as expected when a
       # regex isn't provided.
       expect(electron_builder.find_versions(url: http_url, provided_content: content) do |yaml|
-        regex = /^v?(\d+(?:\.\d+)+)$/i.freeze
+        regex = /^v?(\d+(?:\.\d+)+)$/i
         yaml["version"][regex, 1]
       end).to eq(find_versions_cached_return_hash)
     end

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -66,17 +66,17 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
       expect(electron_builder.find_versions(url: http_url, provided_content: content))
         .to eq(find_versions_cached_return_hash)
 
-      expect(electron_builder.find_versions(url: http_url, regex: regex, provided_content: content) do |yaml, regex|
+      expect(electron_builder.find_versions(url: http_url, regex:, provided_content: content) do |yaml, regex|
         yaml["path"][regex, 1]
-      end).to eq(find_versions_cached_return_hash.merge({ regex: regex }))
+      end).to eq(find_versions_cached_return_hash.merge({ regex: }))
 
       expect(electron_builder.find_versions(
         url:              http_url,
-        regex:            regex,
+        regex:,
         provided_content: content_timestamp,
       ) do |yaml, regex|
         yaml["path"][regex, 1]
-      end).to eq(find_versions_cached_return_hash.merge({ regex: regex }))
+      end).to eq(find_versions_cached_return_hash.merge({ regex: }))
 
       # NOTE: A regex should be provided using the `#regex` method in a
       # `livecheck` block but we're using a regex literal in the `strategy`
@@ -89,7 +89,7 @@ describe Homebrew::Livecheck::Strategy::ElectronBuilder do
     end
 
     it "errors if a block is not provided" do
-      expect { electron_builder.find_versions(url: http_url, regex: regex, provided_content: content) }
+      expect { electron_builder.find_versions(url: http_url, regex:, provided_content: content) }
         .to raise_error(ArgumentError, "ElectronBuilder only supports a regex when using a `strategy` block")
     end
 

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -130,7 +130,7 @@ describe Homebrew::Livecheck::Strategy::Json do
       # block here simply to ensure this method works as expected when a
       # regex isn't provided.
       expect(json.find_versions(url: http_url, provided_content: content) do |json|
-        regex = /^v?(\d+(?:\.\d+)+)$/i.freeze
+        regex = /^v?(\d+(?:\.\d+)+)$/i
         json["versions"].select { |item| item["version"]&.match?(regex) }
                         .map { |item| item["version"][regex, 1] }
       end).to eq(find_versions_cached_return_hash.merge({ regex: nil }))

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -54,7 +54,7 @@ describe Homebrew::Livecheck::Strategy::Json do
         "1.0.1" => Version.new("1.0.1"),
         "1.0.0" => Version.new("1.0.0"),
       },
-      regex:   regex,
+      regex:,
       url:     http_url,
     }
   end
@@ -120,7 +120,7 @@ describe Homebrew::Livecheck::Strategy::Json do
 
   describe "::find_versions?" do
     it "finds versions in provided_content using a block" do
-      expect(json.find_versions(url: http_url, regex: regex, provided_content: content) do |json, regex|
+      expect(json.find_versions(url: http_url, regex:, provided_content: content) do |json, regex|
         json["versions"].select { |item| item["version"]&.match?(regex) }
                         .map { |item| item["version"][regex, 1] }
       end).to eq(find_versions_cached_return_hash)

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -50,7 +50,7 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
         "2.0.0" => Version.new("2.0.0"),
         "1.9.0" => Version.new("1.9.0"),
       },
-      regex:   regex,
+      regex:,
       url:     http_url,
     }
   end
@@ -105,7 +105,7 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
 
   describe "::find_versions?" do
     it "finds versions in provided_content" do
-      expect(page_match.find_versions(url: http_url, regex: regex, provided_content: content))
+      expect(page_match.find_versions(url: http_url, regex:, provided_content: content))
         .to eq(find_versions_cached_return_hash)
 
       # NOTE: Ideally, a regex should always be provided to `#find_versions`

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -174,13 +174,13 @@ describe Homebrew::Livecheck::Strategy::Sparkle do
     undefined_namespace = appcast.sub(/\s*xmlns:sparkle="[^"]+"/, "")
 
     {
-      appcast:             appcast,
-      omitted_items:       omitted_items,
-      bad_macos_version:   bad_macos_version,
-      beta_channel_item:   beta_channel_item,
-      no_versions_item:    no_versions_item,
-      no_items:            no_items,
-      undefined_namespace: undefined_namespace,
+      appcast:,
+      omitted_items:,
+      bad_macos_version:,
+      beta_channel_item:,
+      no_versions_item:,
+      no_items:,
+      undefined_namespace:,
     }
   end
 

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -222,7 +222,7 @@ describe Homebrew::Livecheck::Strategy::Xml do
       # block here simply to ensure this method works as expected when a
       # regex isn't provided.
       expect(xml.find_versions(url: http_url, provided_content: content_version_text) do |xml|
-        regex = /^v?(\d+(?:\.\d+)+)$/i.freeze
+        regex = /^v?(\d+(?:\.\d+)+)$/i
         xml.get_elements("/versions/version").map { |item| item.text[regex, 1] }
       end).to eq(find_versions_cached_return_hash.merge({ regex: nil }))
     end

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -111,7 +111,7 @@ describe Homebrew::Livecheck::Strategy::Xml do
         "1.0.1" => Version.new("1.0.1"),
         "1.0.0" => Version.new("1.0.0"),
       },
-      regex:   regex,
+      regex:,
       url:     http_url,
     }
   end
@@ -213,7 +213,7 @@ describe Homebrew::Livecheck::Strategy::Xml do
 
   describe "::find_versions?" do
     it "finds versions in provided_content using a block" do
-      expect(xml.find_versions(url: http_url, regex: regex, provided_content: content_version_text) do |xml, regex|
+      expect(xml.find_versions(url: http_url, regex:, provided_content: content_version_text) do |xml, regex|
         xml.get_elements("/versions/version").map { |item| item.text[regex, 1] }
       end).to eq(find_versions_cached_return_hash)
 

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -131,7 +131,7 @@ describe Homebrew::Livecheck::Strategy::Yaml do
       # block here simply to ensure this method works as expected when a
       # regex isn't provided.
       expect(yaml.find_versions(url: http_url, provided_content: content) do |yaml|
-        regex = /^v?(\d+(?:\.\d+)+)$/i.freeze
+        regex = /^v?(\d+(?:\.\d+)+)$/i
         yaml["versions"].select { |item| item["version"]&.match?(regex) }
                         .map { |item| item["version"][regex, 1] }
       end).to eq(find_versions_cached_return_hash.merge({ regex: nil }))

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -55,7 +55,7 @@ describe Homebrew::Livecheck::Strategy::Yaml do
         "1.0.1" => Version.new("1.0.1"),
         "1.0.0" => Version.new("1.0.0"),
       },
-      regex:   regex,
+      regex:,
       url:     http_url,
     }
   end
@@ -121,7 +121,7 @@ describe Homebrew::Livecheck::Strategy::Yaml do
 
   describe "::find_versions?" do
     it "finds versions in provided_content using a block" do
-      expect(yaml.find_versions(url: http_url, regex: regex, provided_content: content) do |yaml, regex|
+      expect(yaml.find_versions(url: http_url, regex:, provided_content: content) do |yaml, regex|
         yaml["versions"].select { |item| item["version"]&.match?(regex) }
                         .map { |item| item["version"][regex, 1] }
       end).to eq(find_versions_cached_return_hash)

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -99,7 +99,7 @@ describe Homebrew::MissingFormula do
   end
 
   describe "::cask_reason", :cask do
-    subject { described_class.cask_reason(formula, show_info: show_info) }
+    subject { described_class.cask_reason(formula, show_info:) }
 
     context "with a formula name that is a cask and show_info: false" do
       let(:formula) { "local-caffeine" }

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -53,7 +53,7 @@ describe Pathname do
       prefixes.each do |new_prefix|
         patch_elfs do |elf|
           interpreter = elf.interpreter.gsub(placeholder_prefix, new_prefix)
-          elf.patch!(interpreter: interpreter)
+          elf.patch!(interpreter:)
 
           modified_elf = elf.dirname/"mod.#{elf.basename}"
           FileUtils.cp(elf, modified_elf)
@@ -67,7 +67,7 @@ describe Pathname do
       prefixes.each do |new_prefix|
         patch_elfs do |elf|
           rpath = elf.rpath.gsub(placeholder_prefix, new_prefix)
-          elf.patch!(rpath: rpath)
+          elf.patch!(rpath:)
 
           modified_elf = elf.dirname/"mod.#{elf.basename}"
           FileUtils.cp(elf, modified_elf)
@@ -82,7 +82,7 @@ describe Pathname do
         patch_elfs do |elf|
           interpreter = elf.interpreter.gsub(placeholder_prefix, new_prefix)
           rpath = elf.rpath.gsub(placeholder_prefix, new_prefix)
-          elf.patch!(interpreter: interpreter, rpath: rpath)
+          elf.patch!(interpreter:, rpath:)
 
           modified_elf = elf.dirname/"mod.#{elf.basename}"
           FileUtils.cp(elf, modified_elf)

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -7,10 +7,10 @@ describe "patching" do
     Class.new(Formula) do
       # These are defined within an anonymous class to avoid polluting the global namespace.
       # rubocop:disable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
-      TESTBALL_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-      TESTBALL_PATCHES_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1-patches.tgz"
-      PATCH_URL_A = "file://#{TEST_FIXTURE_DIR}/patches/noop-a.diff"
-      PATCH_URL_B = "file://#{TEST_FIXTURE_DIR}/patches/noop-b.diff"
+      TESTBALL_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz".freeze
+      TESTBALL_PATCHES_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1-patches.tgz".freeze
+      PATCH_URL_A = "file://#{TEST_FIXTURE_DIR}/patches/noop-a.diff".freeze
+      PATCH_URL_B = "file://#{TEST_FIXTURE_DIR}/patches/noop-b.diff".freeze
       PATCH_A_CONTENTS = File.read("#{TEST_FIXTURE_DIR}/patches/noop-a.diff").freeze
       PATCH_B_CONTENTS = File.read("#{TEST_FIXTURE_DIR}/patches/noop-b.diff").freeze
       APPLY_A = "noop-a.diff"

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -25,7 +25,7 @@ describe "patching" do
 
   def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, &block)
     formula_subclass.class_eval(&block)
-    formula_subclass.new(name, path, spec, alias_path: alias_path)
+    formula_subclass.new(name, path, spec, alias_path:)
   end
 
   matcher :be_patched do

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -4,7 +4,7 @@ require "requirements/codesign_requirement"
 
 describe CodesignRequirement do
   subject(:requirement) do
-    described_class.new([{ identity: identity, with: with, url: url }])
+    described_class.new([{ identity:, with:, url: }])
   end
 
   let(:identity) { "lldb_codesign" }

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -163,7 +163,7 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
                                 severity: :convention,
                                 line:     2,
                                 column:   11,
-                                source:   source }]
+                                source: }]
 
         expected_offenses.zip([inspect_source(source).last]).each do |expected, actual|
           expect(actual.message).to eq(expected[:message])

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
   subject(:cop) { described_class.new }
 
   def expect_offense_hash(message:, severity:, line:, column:, source:)
-    [{ message: message, severity: severity, line: line, column: column, source: source }]
+    [{ message:, severity:, line:, column:, source: }]
   end
 
   context "when auditing legacy patches" do
@@ -52,29 +52,29 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         EOS
 
         expected_offense = if patch_url.include?("/raw.github.com/")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: GitHub/Gist patches should specify a revision: #{patch_url}
           EOS
         elsif patch_url.include?("macports/trunk")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: MacPorts patches should specify a revision instead of trunk: #{patch_url}
           EOS
         elsif patch_url.start_with?("http://trac.macports.org/")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: Patches from MacPorts Trac should be https://, not http: #{patch_url}
           EOS
         elsif patch_url.start_with?("http://bugs.debian.org/")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: Patches from Debian should be https://, not http: #{patch_url}
           EOS
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Layout/LineLength
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: Use a commit hash URL rather than patch-diff: #{patch_url}
           EOS
         elsif patch_url.match?(%r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)})
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: GitHub patches should use the full_index parameter: #{patch_url}?full_index=1
           EOS
         end
@@ -108,14 +108,14 @@ describe RuboCop::Cop::FormulaAudit::Patches do
           severity: :convention,
           line:     4,
           column:   2,
-          source:   source,
+          source:,
         }, {
           message:  "FormulaAudit/Patches: Patches from MacPorts Trac should be https://, not http: " \
                     "http://trac.macports.org/export/68507/trunk/dports/net/trafshow/files/",
           severity: :convention,
           line:     8,
           column:   25,
-          source:   source,
+          source:,
         }
       ]
 
@@ -201,41 +201,41 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         RUBY
 
         expected_offense = if patch_url.include?("/raw.github.com/")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: GitHub/Gist patches should specify a revision: #{patch_url}
           EOS
         elsif patch_url.include?("macports/trunk")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: MacPorts patches should specify a revision instead of trunk: #{patch_url}
           EOS
         elsif patch_url.start_with?("http://trac.macports.org/")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: Patches from MacPorts Trac should be https://, not http: #{patch_url}
           EOS
         elsif patch_url.start_with?("http://bugs.debian.org/")
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: Patches from Debian should be https://, not http: #{patch_url}
           EOS
         elsif patch_url.match?(%r{https://github.com/[^/]*/[^/]*/pull})
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: Use a commit hash URL rather than an unstable pull request URL: #{patch_url}
           EOS
         elsif patch_url.match?(%r{.*gitlab.*/merge_request.*})
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: Use a commit hash URL rather than an unstable merge request URL: #{patch_url}
           EOS
         elsif patch_url.match?(%r{https://github.com/[^/]*/[^/]*/commit/})
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: GitHub patches should end with .patch, not .diff: #{patch_url}
           EOS
         elsif patch_url.match?(%r{.*gitlab.*/commit/})
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: GitLab patches should end with .diff, not .patch: #{patch_url}
           EOS
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Layout/LineLength
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source:)
             FormulaAudit/Patches: Use a commit hash URL rather than patch-diff: #{patch_url}
           EOS
         end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -197,7 +197,7 @@ describe RuboCop::Cop::FormulaAudit::Urls do
                                severity: :convention,
                                line:     3,
                                column:   offense_info["col"],
-                               source:   source }]
+                               source: }]
 
         offenses = inspect_source(source)
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -217,7 +217,7 @@ RSpec.configure do |config|
     @__stdin = $stdin.clone
 
     begin
-      if (example.metadata.keys & [:focus, :byebug]).empty? && !ENV.key?("HOMEBREW_VERBOSE_TESTS")
+      if !example.metadata.keys.intersect?([:focus, :byebug]) && !ENV.key?("HOMEBREW_VERBOSE_TESTS")
         $stdout.reopen(File::NULL)
         $stderr.reopen(File::NULL)
       else

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -6,7 +6,7 @@ module Test
   module Helper
     module Formula
       def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, &block)
-        Class.new(::Formula, &block).new(name, path, spec, alias_path: alias_path)
+        Class.new(::Formula, &block).new(name, path, spec, alias_path:)
       end
 
       # Use a stubbed {Formulary::FormulaLoader} to make a given formula be found

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -187,7 +187,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
 
   def install_test_formula(name, content = nil, build_bottle: false)
     setup_test_formula(name, content)
-    fi = FormulaInstaller.new(Formula[name], build_bottle: build_bottle)
+    fi = FormulaInstaller.new(Formula[name], build_bottle:)
     fi.prelude
     fi.fetch
     fi.install

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -6,10 +6,10 @@ describe SystemCommand do
       described_class.new(
         "env",
         args:         env_args,
-        env:          env,
+        env:,
         must_succeed: true,
-        sudo:         sudo,
-        sudo_as_root: sudo_as_root,
+        sudo:,
+        sudo_as_root:,
       )
     end
 

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -279,7 +279,7 @@ describe Tab do
 
     it "can create a Tab from an alias" do
       alias_path = CoreTap.instance.alias_dir/"bar"
-      f = formula(alias_path: alias_path) { url "foo-1.0" }
+      f = formula(alias_path:) { url "foo-1.0" }
       compiler = DevelopmentTools.default_compiler
       stdlib = :libcxx
       tab = described_class.create(f, compiler, stdlib)
@@ -313,7 +313,7 @@ describe Tab do
 
     it "can create a Tab for for a Formula from an alias" do
       alias_path = CoreTap.instance.alias_dir/"bar"
-      f = formula(alias_path: alias_path) { url "foo-1.0" }
+      f = formula(alias_path:) { url "foo-1.0" }
 
       tab = described_class.for_formula(f)
       expect(tab.source["path"]).to eq(alias_path.to_s)

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -83,7 +83,7 @@ describe UnpackStrategy do
       end
 
       it "does not pass down the basename of the archive" do
-        strategy.extract_nestedly(to: unpack_dir, basename: basename)
+        strategy.extract_nestedly(to: unpack_dir, basename:)
         expect(unpack_dir/"file.txt").to be_a_file
       end
     end

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -59,15 +59,15 @@ describe Utils::Analytics do
       it "returns nil when HOMEBREW_NO_ANALYTICS is true" do
         ENV["HOMEBREW_NO_ANALYTICS"] = "true"
         expect(described_class).not_to receive(:report_influx)
-        described_class.report_event(:install, package_name: package_name, tap_name: tap_name,
-          on_request: on_request, options: options)
+        described_class.report_event(:install, package_name:, tap_name:,
+          on_request:, options:)
       end
 
       it "returns nil when HOMEBREW_NO_ANALYTICS_THIS_RUN is true" do
         ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "true"
         expect(described_class).not_to receive(:report_influx)
-        described_class.report_event(:install, package_name: package_name, tap_name: tap_name,
-          on_request: on_request, options: options)
+        described_class.report_event(:install, package_name:, tap_name:,
+          on_request:, options:)
       end
 
       it "returns nil when HOMEBREW_ANALYTICS_DEBUG is true" do
@@ -76,8 +76,8 @@ describe Utils::Analytics do
         ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
         expect(described_class).to receive(:report_influx)
 
-        described_class.report_event(:install, package_name: package_name, tap_name: tap_name,
-          on_request: on_request, options: options)
+        described_class.report_event(:install, package_name:, tap_name:,
+          on_request:, options:)
       end
     end
 
@@ -85,10 +85,10 @@ describe Utils::Analytics do
       ENV.delete("HOMEBREW_NO_ANALYTICS_THIS_RUN")
       ENV.delete("HOMEBREW_NO_ANALYTICS")
       ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
-      expect(described_class).to receive(:report_influx).with(:install, hash_including(package_name: package_name,
-                                                                                       on_request:   on_request)).once
-      described_class.report_event(:install, package_name: package_name, tap_name: tap_name,
-          on_request: on_request, options: options)
+      expect(described_class).to receive(:report_influx).with(:install, hash_including(package_name:,
+                                                                                       on_request:)).once
+      described_class.report_event(:install, package_name:, tap_name:,
+          on_request:, options:)
     end
   end
 
@@ -104,8 +104,8 @@ describe Utils::Analytics do
       ENV.delete("HOMEBREW_NO_ANALYTICS")
       ENV["HOMEBREW_ANALYTICS_DEBUG"] = "true"
       expect(described_class).to receive(:deferred_curl).once
-      described_class.report_influx(:install, package_name: package_name, tap_name: tap_name, on_request: on_request,
-options: options)
+      described_class.report_influx(:install, package_name:, tap_name:, on_request:,
+options:)
     end
   end
 

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -16,8 +16,8 @@ describe Utils::Gzip do
         File.write(somefile, file_content)
         mkdir path/"subdir"
 
-        expect(described_class.compress_with_options(somefile, mtime: mtime, orig_name: orig_name,
-output: output)).to eq(output)
+        expect(described_class.compress_with_options(somefile, mtime:, orig_name:,
+output:)).to eq(output)
         expect(Digest::SHA256.hexdigest(File.read(output))).to eq(expected_checksum)
       end
     end
@@ -63,7 +63,7 @@ output: output)).to eq(output)
         files = (0..2).map { |n| path/"somefile#{n}" }
         files.each { |f| File.write(f, "Hello world") }
 
-        results = described_class.compress(*files, mtime: mtime)
+        results = described_class.compress(*files, mtime:)
         3.times do |n|
           expect(results[n].to_s).to eq("#{files[n]}.gz")
           expect(Digest::SHA256.hexdigest(File.read(results[n]))).to eq(expected_checksums[n])

--- a/Library/Homebrew/test_runner_formula.rb
+++ b/Library/Homebrew/test_runner_formula.rb
@@ -102,10 +102,10 @@ class TestRunnerFormula
         os = macos_version || platform
         arch = SIMULATE_SYSTEM_SYMBOLS.fetch(arch)
 
-        Homebrew::SimulateSystem.with os: os, arch: arch do
+        Homebrew::SimulateSystem.with(os:, arch:) do
           Formula.public_send(formula_selector)
                  .select { |candidate_f| candidate_f.deps.map(&:name).include?(name) }
-                 .map { |f| TestRunnerFormula.new(f, eval_all: eval_all) }
+                 .map { |f| TestRunnerFormula.new(f, eval_all:) }
                  .freeze
         end
       end

--- a/Library/Homebrew/uninstall.rb
+++ b/Library/Homebrew/uninstall.rb
@@ -10,9 +10,9 @@ module Homebrew
   module Uninstall
     def self.uninstall_kegs(kegs_by_rack, casks: [], force: false, ignore_dependencies: false, named_args: [])
       handle_unsatisfied_dependents(kegs_by_rack,
-                                    casks:               casks,
-                                    ignore_dependencies: ignore_dependencies,
-                                    named_args:          named_args)
+                                    casks:,
+                                    ignore_dependencies:,
+                                    named_args:)
       return if Homebrew.failed?
 
       kegs_by_rack.each do |rack, kegs|
@@ -99,19 +99,19 @@ module Homebrew
       return if ignore_dependencies
 
       all_kegs = kegs_by_rack.values.flatten(1)
-      check_for_dependents(all_kegs, casks: casks, named_args: named_args)
+      check_for_dependents(all_kegs, casks:, named_args:)
     rescue MethodDeprecatedError
       # Silently ignore deprecations when uninstalling.
       nil
     end
 
     def self.check_for_dependents(kegs, casks: [], named_args: [])
-      return false unless (result = InstalledDependents.find_some_installed_dependents(kegs, casks: casks))
+      return false unless (result = InstalledDependents.find_some_installed_dependents(kegs, casks:))
 
       if Homebrew::EnvConfig.developer?
-        DeveloperDependentsMessage.new(*result, named_args: named_args).output
+        DeveloperDependentsMessage.new(*result, named_args:).output
       else
-        NondeveloperDependentsMessage.new(*result, named_args: named_args).output
+        NondeveloperDependentsMessage.new(*result, named_args:).output
       end
 
       true

--- a/Library/Homebrew/unlink.rb
+++ b/Library/Homebrew/unlink.rb
@@ -12,12 +12,12 @@ module Homebrew
              .compact
              .select(&:directory?)
              .each do |keg|
-        unlink(keg, verbose: verbose)
+        unlink(keg, verbose:)
       end
     end
 
     def self.unlink(keg, dry_run: false, verbose: false)
-      options = { dry_run: dry_run, verbose: verbose }
+      options = { dry_run:, verbose: }
 
       keg.lock do
         print "Unlinking #{keg}... "

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -87,7 +87,7 @@ module UnpackStrategy
 
     strategy ||= Uncompressed
 
-    strategy.new(path, ref_type: ref_type, ref: ref, merge_xattrs: merge_xattrs)
+    strategy.new(path, ref_type:, ref:, merge_xattrs:)
   end
 
   attr_reader :path, :merge_xattrs
@@ -113,7 +113,7 @@ module UnpackStrategy
     basename ||= path.basename
     unpack_dir = Pathname(to || Dir.pwd).expand_path
     unpack_dir.mkpath
-    extract_to_dir(unpack_dir, basename: Pathname(basename), verbose: verbose)
+    extract_to_dir(unpack_dir, basename: Pathname(basename), verbose:)
   end
 
   sig {
@@ -128,14 +128,14 @@ module UnpackStrategy
     Dir.mktmpdir do |tmp_unpack_dir|
       tmp_unpack_dir = Pathname(tmp_unpack_dir)
 
-      extract(to: tmp_unpack_dir, basename: basename, verbose: verbose)
+      extract(to: tmp_unpack_dir, basename:, verbose:)
 
       children = tmp_unpack_dir.children
 
       if children.size == 1 && !children.fetch(0).directory?
-        s = UnpackStrategy.detect(children.first, prioritize_extension: prioritize_extension)
+        s = UnpackStrategy.detect(children.first, prioritize_extension:)
 
-        s.extract_nestedly(to: to, verbose: verbose, prioritize_extension: prioritize_extension)
+        s.extract_nestedly(to:, verbose:, prioritize_extension:)
 
         next
       end
@@ -144,10 +144,10 @@ module UnpackStrategy
       each_directory(tmp_unpack_dir) do |path|
         next if path.writable?
 
-        FileUtils.chmod "u+w", path, verbose: verbose
+        FileUtils.chmod "u+w", path, verbose:
       end
 
-      Directory.new(tmp_unpack_dir).extract(to: to, verbose: verbose)
+      Directory.new(tmp_unpack_dir).extract(to:, verbose:)
     end
   end
 

--- a/Library/Homebrew/unpack_strategy/air.rb
+++ b/Library/Homebrew/unpack_strategy/air.rb
@@ -31,7 +31,7 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! AIR_APPLICATION_INSTALLER,
                       args:    ["-silent", "-location", unpack_dir, path],
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -23,7 +23,7 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "bunzip2",
                       args:    [*quiet_flags, unpack_dir/basename],
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -20,7 +20,7 @@ module UnpackStrategy
       system_command! "cabextract",
                       args:    ["-d", unpack_dir, "--", path],
                       env:     { "PATH" => PATH.new(Formula["cabextract"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
 
     def dependencies

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -23,7 +23,7 @@ module UnpackStrategy
         system_command! "cp",
                         args:    ["-pR", (child.directory? && !child.symlink?) ? "#{child}/." : child,
                                   unpack_dir/child.basename],
-                        verbose: verbose
+                        verbose:
       end
     end
   end

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -87,7 +87,7 @@ module UnpackStrategy
               "diskutil",
               args:         ["info", "-plist", path],
               print_stderr: false,
-              verbose:      verbose,
+              verbose:,
             )
 
             # For HFS, just use <mount-path>
@@ -102,13 +102,13 @@ module UnpackStrategy
               system_command! "diskutil",
                               args:         ["eject", eject_path],
                               print_stderr: false,
-                              verbose:      verbose
+                              verbose:
             end
           else
             system_command! "diskutil",
                             args:         ["unmount", "force", path],
                             print_stderr: false,
-                            verbose:      verbose
+                            verbose:
           end
         rescue ErrorDuringExecution => e
           raise e if (tries -= 1).zero?
@@ -141,12 +141,12 @@ module UnpackStrategy
 
             system_command! "mkbom",
                             args:    ["-s", "-i", filelist.path, "--", bomfile.path],
-                            verbose: verbose
+                            verbose:
           end
 
-          system_command! "ditto",
+          system_command!("ditto",
                           args:    ["--bom", bomfile.path, "--", path, unpack_dir],
-                          verbose: verbose
+                          verbose:)
 
           FileUtils.chmod "u+w", Pathname.glob(unpack_dir/"**/*", File::FNM_DOTMATCH).reject(&:symlink?)
         end
@@ -168,11 +168,11 @@ module UnpackStrategy
 
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      mount(verbose: verbose) do |mounts|
+      mount(verbose:) do |mounts|
         raise "No mounts found in '#{path}'; perhaps this is a bad disk image?" if mounts.empty?
 
         mounts.each do |mount|
-          mount.extract(to: unpack_dir, verbose: verbose)
+          mount.extract(to: unpack_dir, verbose:)
         end
       end
     end
@@ -189,7 +189,7 @@ module UnpackStrategy
           ],
           input:        "qn\n",
           print_stderr: false,
-          verbose:      verbose,
+          verbose:,
         )
 
         # If mounting without agreeing to EULA succeeded, there is none.
@@ -205,7 +205,7 @@ module UnpackStrategy
             args:    [
               "convert", *quiet_flag, "-format", "UDTO", "-o", cdr_path, path
             ],
-            verbose: verbose,
+            verbose:,
           )
 
           with_eula = system_command!(
@@ -214,7 +214,7 @@ module UnpackStrategy
               "attach", "-plist", "-nobrowse", "-readonly",
               "-mountrandom", mount_dir, cdr_path
             ],
-            verbose: verbose,
+            verbose:,
           )
 
           if verbose && !(eula_text = without_eula.stdout).empty?
@@ -237,7 +237,7 @@ module UnpackStrategy
           yield mounts
         ensure
           mounts.each do |mount|
-            mount.eject(verbose: verbose)
+            mount.eject(verbose:)
           end
         end
       end

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -36,7 +36,7 @@ module UnpackStrategy
                       args:    ["open", path, *args],
                       chdir:   unpack_dir,
                       env:     { "PATH" => PATH.new(Formula["fossil"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
                         "-output-directory", unpack_dir, "--", path
                       ],
                       env:     { "PATH" => PATH.new(Formula["unar"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/gzip.rb
+++ b/Library/Homebrew/unpack_strategy/gzip.rb
@@ -23,7 +23,7 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-q"]
       system_command! "gunzip",
                       args:    [*quiet_flags, "-N", "--", unpack_dir/basename],
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -26,7 +26,7 @@ module UnpackStrategy
       system_command! "lha",
                       args:    ["xq2w=#{unpack_dir}", path],
                       env:     { "PATH" => PATH.new(Formula["lha"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -28,7 +28,7 @@ module UnpackStrategy
       system_command! "lzip",
                       args:    ["-d", *quiet_flags, unpack_dir/basename],
                       env:     { "PATH" => PATH.new(Formula["lzip"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -28,7 +28,7 @@ module UnpackStrategy
       system_command! "unlzma",
                       args:    [*quiet_flags, "--", unpack_dir/basename],
                       env:     { "PATH" => PATH.new(Formula["xz"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/mercurial.rb
+++ b/Library/Homebrew/unpack_strategy/mercurial.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       system_command! "hg",
                       args:    ["--cwd", path, "archive", "--subrepos", "-y", "-t", "files", unpack_dir],
                       env:     { "PATH" => PATH.new(Formula["mercurial"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -26,7 +26,7 @@ module UnpackStrategy
       system_command! "7zr",
                       args:    ["x", "-y", "-bd", "-bso0", path, "-o#{unpack_dir}"],
                       env:     { "PATH" => PATH.new(Formula["p7zip"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/pax.rb
+++ b/Library/Homebrew/unpack_strategy/pax.rb
@@ -22,7 +22,7 @@ module UnpackStrategy
       system_command! "pax",
                       args:    ["-rf", path],
                       chdir:   unpack_dir,
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -26,7 +26,7 @@ module UnpackStrategy
       system_command! "bsdtar",
                       args:    ["x", "-f", path, "-C", unpack_dir],
                       env:     { "PATH" => PATH.new(Formula["libarchive"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       system_command! "svn",
                       args:    ["export", "--force", ".", unpack_dir],
                       chdir:   path.to_s,
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -48,7 +48,7 @@ module UnpackStrategy
                         args:    ["--extract", "--no-same-owner",
                                   "--file", tar_path,
                                   "--directory", unpack_dir],
-                        verbose: verbose
+                        verbose:
       end
     end
 
@@ -56,7 +56,7 @@ module UnpackStrategy
       params(extractor: T.any(T.class_of(Xz), T.class_of(Zstd)), dir: Pathname, verbose: T::Boolean).returns(Pathname)
     }
     def subextract(extractor, dir, verbose)
-      extractor.new(path).extract(to: dir, verbose: verbose)
+      extractor.new(path).extract(to: dir, verbose:)
       T.must(dir.children.first)
     end
   end

--- a/Library/Homebrew/unpack_strategy/uncompressed.rb
+++ b/Library/Homebrew/unpack_strategy/uncompressed.rb
@@ -15,14 +15,14 @@ module UnpackStrategy
       ).returns(T.untyped)
     }
     def extract_nestedly(to: nil, basename: nil, verbose: false, prioritize_extension: false)
-      extract(to: to, basename: basename, verbose: verbose)
+      extract(to:, basename:, verbose:)
     end
 
     private
 
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
     def extract_to_dir(unpack_dir, basename:, verbose: false)
-      FileUtils.cp path, unpack_dir/basename, preserve: true, verbose: verbose
+      FileUtils.cp path, unpack_dir/basename, preserve: true, verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/xar.rb
+++ b/Library/Homebrew/unpack_strategy/xar.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "xar",
                       args:    ["-x", "-f", path, "-C", unpack_dir],
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -28,7 +28,7 @@ module UnpackStrategy
       system_command! "unxz",
                       args:    [*quiet_flags, "-T0", "--", unpack_dir/basename],
                       env:     { "PATH" => PATH.new(Formula["xz"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -36,7 +36,7 @@ module UnpackStrategy
         result = system_command! "unzip",
                                  args:         [*quiet_flags, "-o", path, "-d", unpack_dir],
                                  env:          { "PATH" => PATH.new(unzip&.opt_bin, ENV.fetch("PATH")) },
-                                 verbose:      verbose,
+                                 verbose:,
                                  print_stderr: false
 
         FileUtils.rm_rf unpack_dir/"__MACOSX"

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -28,7 +28,7 @@ module UnpackStrategy
       system_command! "unzstd",
                       args:    [*quiet_flags, "-T0", "--rm", "--", unpack_dir/basename],
                       env:     { "PATH" => PATH.new(Formula["zstd"].opt_bin, ENV.fetch("PATH")) },
-                      verbose: verbose
+                      verbose:
     end
   end
 end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -53,21 +53,21 @@ module Homebrew
       end
 
       formula_installers = formulae_to_install.map do |formula|
-        Migrator.migrate_if_needed(formula, force: force, dry_run: dry_run)
+        Migrator.migrate_if_needed(formula, force:, dry_run:)
         begin
           fi = create_formula_installer(
             formula,
-            flags:                      flags,
-            installed_on_request:       installed_on_request,
-            force_bottle:               force_bottle,
-            build_from_source_formulae: build_from_source_formulae,
-            interactive:                interactive,
-            keep_tmp:                   keep_tmp,
-            debug_symbols:              debug_symbols,
-            force:                      force,
-            debug:                      debug,
-            quiet:                      quiet,
-            verbose:                    verbose,
+            flags:,
+            installed_on_request:,
+            force_bottle:,
+            build_from_source_formulae:,
+            interactive:,
+            keep_tmp:,
+            debug_symbols:,
+            force:,
+            debug:,
+            quiet:,
+            verbose:,
           )
           unless dry_run
             fi.prelude
@@ -117,8 +117,8 @@ module Homebrew
       end.compact
 
       formula_installers.each do |fi|
-        upgrade_formula(fi, dry_run: dry_run, verbose: verbose)
-        Cleanup.install_formula_clean!(fi.formula, dry_run: dry_run)
+        upgrade_formula(fi, dry_run:, verbose:)
+        Cleanup.install_formula_clean!(fi.formula, dry_run:)
       end
     end
 
@@ -173,20 +173,20 @@ module Homebrew
       FormulaInstaller.new(
         formula,
         **{
-          options:                    options,
+          options:,
           link_keg:                   keg_had_linked_opt ? keg_was_linked : nil,
           installed_as_dependency:    tab&.installed_as_dependency,
           installed_on_request:       installed_on_request || tab&.installed_on_request,
           build_bottle:               tab&.built_bottle?,
-          force_bottle:               force_bottle,
-          build_from_source_formulae: build_from_source_formulae,
-          interactive:                interactive,
-          keep_tmp:                   keep_tmp,
-          debug_symbols:              debug_symbols,
-          force:                      force,
-          debug:                      debug,
-          quiet:                      quiet,
-          verbose:                    verbose,
+          force_bottle:,
+          build_from_source_formulae:,
+          interactive:,
+          keep_tmp:,
+          debug_symbols:,
+          force:,
+          debug:,
+          quiet:,
+          verbose:,
         }.compact,
       )
     end
@@ -209,7 +209,7 @@ module Homebrew
 
       install_formula(formula_installer, upgrade: true)
     rescue BuildError => e
-      e.dump(verbose: verbose)
+      e.dump(verbose:)
       puts
       Homebrew.failed = true
     end
@@ -366,18 +366,18 @@ module Homebrew
       unless dry_run
         upgrade_formulae(
           upgradeable_dependents,
-          flags:                      flags,
-          installed_on_request:       installed_on_request,
-          force_bottle:               force_bottle,
-          build_from_source_formulae: build_from_source_formulae,
+          flags:,
+          installed_on_request:,
+          force_bottle:,
+          build_from_source_formulae:,
           dependents:                 true,
-          interactive:                interactive,
-          keep_tmp:                   keep_tmp,
-          debug_symbols:              debug_symbols,
-          force:                      force,
-          debug:                      debug,
-          quiet:                      quiet,
-          verbose:                    verbose,
+          interactive:,
+          keep_tmp:,
+          debug_symbols:,
+          force:,
+          debug:,
+          quiet:,
+          verbose:,
         )
       end
 
@@ -436,16 +436,16 @@ module Homebrew
       reinstallable_broken_dependents.each do |formula|
         Homebrew.reinstall_formula(
           formula,
-          flags:                      flags,
-          force_bottle:               force_bottle,
+          flags:,
+          force_bottle:,
           build_from_source_formulae: build_from_source_formulae + [formula.full_name],
-          interactive:                interactive,
-          keep_tmp:                   keep_tmp,
-          debug_symbols:              debug_symbols,
-          force:                      force,
-          debug:                      debug,
-          quiet:                      quiet,
-          verbose:                    verbose,
+          interactive:,
+          keep_tmp:,
+          debug_symbols:,
+          force:,
+          debug:,
+          quiet:,
+          verbose:,
         )
       rescue FormulaInstallationAlreadyAttemptedError
         # We already attempted to reinstall f as part of the dependency tree of
@@ -454,7 +454,7 @@ module Homebrew
       rescue CannotInstallFormulaError, DownloadError => e
         ofail e
       rescue BuildError => e
-        e.dump(verbose: verbose)
+        e.dump(verbose:)
         puts
         Homebrew.failed = true
       end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -80,7 +80,7 @@ module Homebrew
     at_exit do
       col_width = [$times.keys.map(&:size).max.to_i + 2, 15].max
       $times.sort_by { |_k, v| v }.each do |method, time|
-        puts format("%<method>-#{col_width}s %<time>0.4f sec", method: "#{method}:", time: time)
+        puts format("%<method>-#{col_width}s %<time>0.4f sec", method: "#{method}:", time:)
       end
     end
   end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -31,12 +31,12 @@ module Utils
         options = nil if options.blank?
 
         # Tags are always implicitly strings and must have low cardinality.
-        tags = default_tags_influx.merge(on_request: on_request)
+        tags = default_tags_influx.merge(on_request:)
                                   .map { |k, v| "#{k}=#{v}" }
                                   .join(",")
 
         # Fields need explicitly wrapped with quotes and can have high cardinality.
-        fields = default_fields_influx.merge(package: package_name, tap_name: tap_name, options: options)
+        fields = default_fields_influx.merge(package: package_name, tap_name:, options:)
                                       .compact
                                       .map { |k, v| %Q(#{k}="#{v}") }
                                       .join(",")
@@ -73,8 +73,8 @@ module Utils
                on_request: T::Boolean, options: String).void
       }
       def report_event(measurement, package_name:, tap_name:, on_request:, options: "")
-        report_influx_event(measurement, package_name: package_name, tap_name: tap_name, on_request: on_request,
-options: options)
+        report_influx_event(measurement, package_name:, tap_name:, on_request:,
+options:)
       end
 
       sig {
@@ -84,8 +84,8 @@ options: options)
       def report_influx_event(measurement, package_name:, tap_name:, on_request: false, options: "")
         return if not_this_run? || disabled?
 
-        report_influx(measurement, package_name: package_name, tap_name: tap_name, on_request: on_request,
-options: options)
+        report_influx(measurement, package_name:, tap_name:, on_request:,
+options:)
       end
 
       sig { params(exception: BuildError).void }
@@ -105,7 +105,7 @@ options: options)
         return unless tap.should_report_analytics?
 
         options = exception.options.to_a.map(&:to_s).join(" ")
-        report_influx_event(:build_error, package_name: formula.name, tap_name: tap.name, options: options)
+        report_influx_event(:build_error, package_name: formula.name, tap_name: tap.name, options:)
       end
 
       def influx_message_displayed?
@@ -186,7 +186,7 @@ options: options)
           return
         end
 
-        table_output(category, days, results, os_version: os_version, cask_install: cask_install)
+        table_output(category, days, results, os_version:, cask_install:)
       end
 
       def output_analytics(json, args:)
@@ -265,8 +265,8 @@ options: options)
         json = Homebrew::API::Formula.fetch formula.name
         return if json.blank? || json["analytics"].blank?
 
-        output_analytics(json, args: args)
-        output_github_packages_downloads(formula, args: args)
+        output_analytics(json, args:)
+        output_github_packages_downloads(formula, args:)
       rescue ArgumentError
         # Ignore failed API requests
         nil
@@ -278,7 +278,7 @@ options: options)
         json = Homebrew::API::Cask.fetch cask.token
         return if json.blank? || json["analytics"].blank?
 
-        output_analytics(json, args: args)
+        output_analytics(json, args:)
       rescue ArgumentError
         # Ignore failed API requests
         nil
@@ -298,7 +298,7 @@ options: options)
           # Tags are always strings and must have low cardinality.
           {
             ci:             ENV["CI"].present?,
-            prefix:         prefix,
+            prefix:,
             default_prefix: Homebrew.default_prefix?,
             developer:      Homebrew::EnvConfig.developer?,
             devcmdrun:      config_true?(:devcmdrun),
@@ -326,8 +326,8 @@ options: options)
           end
 
           {
-            version:             version,
-            os_name_and_version: os_name_and_version,
+            version:,
+            os_name_and_version:,
           }
         end
       end
@@ -428,7 +428,7 @@ options: options)
       end
 
       def format_percent(percent)
-        format("%<percent>.2f", percent: percent)
+        format("%<percent>.2f", percent:)
       end
     end
   end

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -98,7 +98,7 @@ module Utils
 
       sig { params(name: Symbol, type: T.nilable(Symbol)).returns(T.nilable(Node)) }
       def stanza(name, type: nil)
-        children.find { |child| call_node_match?(child, name: name, type: type) }
+        children.find { |child| call_node_match?(child, name:, type:) }
       end
 
       sig { params(bottle_output: String).void }
@@ -113,7 +113,7 @@ module Utils
 
       sig { params(name: Symbol, type: T.nilable(Symbol)).void }
       def remove_stanza(name, type: nil)
-        stanza_node = stanza(name, type: type)
+        stanza_node = stanza(name, type:)
         raise "Could not find '#{name}' stanza!" if stanza_node.blank?
 
         # stanza is probably followed by a newline character
@@ -146,7 +146,7 @@ module Utils
 
       sig { params(name: Symbol, replacement: T.any(Numeric, String, Symbol), type: T.nilable(Symbol)).void }
       def replace_stanza(name, replacement, type: nil)
-        stanza_node = stanza(name, type: type)
+        stanza_node = stanza(name, type:)
         raise "Could not find '#{name}' stanza!" if stanza_node.blank?
 
         tree_rewriter.replace(stanza_node.source_range, stanza_text(name, replacement, indent: 2).lstrip)
@@ -229,8 +229,8 @@ module Utils
           return false if components.any? do |component|
             component_match?(component_name: component[:name],
                              component_type: component[:type],
-                             target_name:    target_name,
-                             target_type:    target_type)
+                             target_name:,
+                             target_type:)
           end
           return true if components.any? do |component|
             call_node_match?(node, name: component[:name], type: component[:type])

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -150,7 +150,7 @@ module Utils
 
         system = match[:system].to_sym
         arch = match[:arch]&.to_sym || :x86_64
-        new(system: system, arch: arch)
+        new(system:, arch:)
       end
 
       sig { params(system: Symbol, arch: Symbol).void }
@@ -288,13 +288,13 @@ module Utils
 
       sig { params(tag: Utils::Bottles::Tag, checksum: Checksum, cellar: T.any(Symbol, String)).void }
       def add(tag, checksum:, cellar:)
-        spec = Utils::Bottles::TagSpecification.new(tag: tag, checksum: checksum, cellar: cellar)
+        spec = Utils::Bottles::TagSpecification.new(tag:, checksum:, cellar:)
         @tag_specs[tag] = spec
       end
 
       sig { params(tag: Utils::Bottles::Tag, no_older_versions: T::Boolean).returns(T::Boolean) }
       def tag?(tag, no_older_versions: false)
-        tag = find_matching_tag(tag, no_older_versions: no_older_versions)
+        tag = find_matching_tag(tag, no_older_versions:)
         tag.present?
       end
 
@@ -308,7 +308,7 @@ module Utils
           .returns(T.nilable(Utils::Bottles::TagSpecification))
       }
       def specification_for(tag, no_older_versions: false)
-        tag = find_matching_tag(tag, no_older_versions: no_older_versions)
+        tag = find_matching_tag(tag, no_older_versions:)
         @tag_specs[tag] if tag
       end
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -15,7 +15,7 @@ module Utils
     # This regex is used to extract the part of an ETag within quotation marks,
     # ignoring any leading weak validator indicator (`W/`). This simplifies
     # ETag comparison in `#curl_check_http_content`.
-    ETAG_VALUE_REGEX = %r{^(?:[wW]/)?"((?:[^"]|\\")*)"}.freeze
+    ETAG_VALUE_REGEX = %r{^(?:[wW]/)?"((?:[^"]|\\")*)"}
 
     # HTTP responses and body content are typically separated by a double
     # `CRLF` (whereas HTTP header lines are separated by a single `CRLF`).
@@ -24,7 +24,7 @@ module Utils
 
     # This regex is used to isolate the parts of an HTTP status line, namely
     # the status code and any following descriptive text (e.g. `Not Found`).
-    HTTP_STATUS_LINE_REGEX = %r{^HTTP/.* (?<code>\d+)(?: (?<text>[^\r\n]+))?}.freeze
+    HTTP_STATUS_LINE_REGEX = %r{^HTTP/.* (?<code>\d+)(?: (?<text>[^\r\n]+))?}
 
     private_constant :ETAG_VALUE_REGEX, :HTTP_RESPONSE_BODY_SEPARATOR, :HTTP_STATUS_LINE_REGEX
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -229,7 +229,7 @@ module Utils
           if request_args.empty?
             # If we didn't get any wanted header yet, retry using `GET`.
             next if wanted_headers.any? &&
-                    parsed_output.fetch(:responses).none? { |r| (r.fetch(:headers).keys & wanted_headers).any? }
+                    parsed_output.fetch(:responses).none? { |r| r.fetch(:headers).keys.intersect?(wanted_headers) }
 
             # Some CDNs respond with 400 codes for `HEAD` but resolve with `GET`.
             next if (400..499).cover?(parsed_output.fetch(:responses).last&.fetch(:status_code).to_i)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -130,16 +130,16 @@ module Utils
       end_time = Time.now + timeout if timeout
 
       command_options = {
-        secrets:      secrets,
-        print_stdout: print_stdout,
-        print_stderr: print_stderr,
-        debug:        debug,
-        verbose:      verbose,
+        secrets:,
+        print_stdout:,
+        print_stderr:,
+        debug:,
+        verbose:,
       }.compact
 
-      result = system_command curl_executable(use_homebrew_curl: use_homebrew_curl),
+      result = system_command curl_executable(use_homebrew_curl:),
                               args:    curl_args(*args, **options),
-                              env:     env,
+                              env:,
                               timeout: end_time&.remaining,
                               **command_options
 
@@ -173,7 +173,7 @@ module Utils
     end
 
     def curl(*args, print_stdout: true, **options)
-      result = curl_with_workarounds(*args, print_stdout: print_stdout, **options)
+      result = curl_with_workarounds(*args, print_stdout:, **options)
       result.assert_success!
       result
     end
@@ -279,11 +279,11 @@ module Utils
           secure_details = begin
             curl_http_content_headers_and_checksum(
               secure_url,
-              specs:             specs,
+              specs:,
               hash_needed:       true,
-              use_homebrew_curl: use_homebrew_curl,
-              user_agent:        user_agent,
-              referer:           referer,
+              use_homebrew_curl:,
+              user_agent:,
+              referer:,
             )
           rescue Timeout::Error
             next
@@ -303,11 +303,11 @@ module Utils
         loop do
           details = curl_http_content_headers_and_checksum(
             url,
-            specs:             specs,
-            hash_needed:       hash_needed,
-            use_homebrew_curl: use_homebrew_curl,
-            user_agent:        user_agent,
-            referer:           referer,
+            specs:,
+            hash_needed:,
+            use_homebrew_curl:,
+            user_agent:,
+            referer:,
           )
 
           # Retry on network issues
@@ -416,12 +416,12 @@ module Utils
       max_time = hash_needed ? 600 : 25
       output, _, status = curl_output(
         *specs, "--dump-header", "-", "--output", file.path, "--location", url,
-        use_homebrew_curl: use_homebrew_curl,
+        use_homebrew_curl:,
         connect_timeout:   15,
-        max_time:          max_time,
+        max_time:,
         retry_max_time:    max_time,
-        user_agent:        user_agent,
-        referer:           referer
+        user_agent:,
+        referer:
       )
 
       parsed_output = parse_curl_output(output)
@@ -455,16 +455,16 @@ module Utils
       end
 
       {
-        url:            url,
-        final_url:      final_url,
+        url:,
+        final_url:,
         exit_status:    status.exitstatus,
-        status_code:    status_code,
-        headers:        headers,
-        etag:           etag,
-        content_length: content_length,
+        status_code:,
+        headers:,
+        etag:,
+        content_length:,
         file:           file_contents,
-        file_hash:      file_hash,
-        responses:      responses,
+        file_hash:,
+        responses:,
       }
     ensure
       T.must(file).unlink
@@ -512,7 +512,7 @@ module Utils
         responses << response if response.present?
       end
 
-      { responses: responses, body: output }
+      { responses:, body: output }
     end
 
     # Returns the URL from the last location header found in cURL responses,

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -12,7 +12,7 @@ module Formatter
   end
 
   def self.headline(string, color: nil)
-    arrow("#{Tty.bold}#{string}#{Tty.reset}", color: color)
+    arrow("#{Tty.bold}#{string}#{Tty.reset}", color:)
   end
 
   def self.identifier(string)

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -143,7 +143,7 @@ module Homebrew
   end
 
   def install_gem_setup_path!(name, version: nil, executable: name, setup_gem_environment: true)
-    install_gem!(name, version: version, setup_gem_environment: setup_gem_environment)
+    install_gem!(name, version:, setup_gem_environment:)
     return if find_in_path(executable)
 
     odie_if_defined <<~EOS

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -80,7 +80,7 @@ module Utils
     }
     def self.last_revision_of_file(repo, file, before_commit: nil)
       relative_file = Pathname(file).relative_path_from(repo)
-      commit_hash = last_revision_commit_of_file(repo, relative_file, before_commit: before_commit)
+      commit_hash = last_revision_commit_of_file(repo, relative_file, before_commit:)
       file_at_commit(repo, file, commit_hash)
     end
 

--- a/Library/Homebrew/utils/git_repository.rb
+++ b/Library/Homebrew/utils/git_repository.rb
@@ -11,9 +11,9 @@ module Utils
     ).returns(T.nilable(String))
   }
   def self.git_head(repo = Pathname.pwd, length: nil, safe: true)
-    return git_short_head(repo, length: length) if length
+    return git_short_head(repo, length:) if length
 
-    GitRepository.new(Pathname(repo)).head_ref(safe: safe)
+    GitRepository.new(Pathname(repo)).head_ref(safe:)
   end
 
   # Gets a short commit hash of the HEAD commit.
@@ -25,7 +25,7 @@ module Utils
     ).returns(T.nilable(String))
   }
   def self.git_short_head(repo = Pathname.pwd, length: nil, safe: true)
-    GitRepository.new(Pathname(repo)).short_head_ref(length: length, safe: safe)
+    GitRepository.new(Pathname(repo)).short_head_ref(length:, safe:)
   end
 
   # Gets the name of the currently checked-out branch, or HEAD if the repository is in a detached HEAD state.
@@ -36,7 +36,7 @@ module Utils
     ).returns(T.nilable(String))
   }
   def self.git_branch(repo = Pathname.pwd, safe: true)
-    GitRepository.new(Pathname(repo)).branch_name(safe: safe)
+    GitRepository.new(Pathname(repo)).branch_name(safe:)
   end
 
   # Gets the full commit message of the specified commit, or of the HEAD commit if unspecified.
@@ -48,6 +48,6 @@ module Utils
     ).returns(T.nilable(String))
   }
   def self.git_commit_message(repo = Pathname.pwd, commit: "HEAD", safe: true)
-    GitRepository.new(Pathname(repo)).commit_message(commit, safe: safe)
+    GitRepository.new(Pathname(repo)).commit_message(commit, safe:)
   end
 end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -509,9 +509,9 @@ module GitHub
   end
 
   def self.pull_request_title_regex(name, version = nil)
-    return /(^|\s)#{Regexp.quote(name)}(:|,|\s|$)/i.freeze if version.blank?
+    return /(^|\s)#{Regexp.quote(name)}(:|,|\s|$)/i if version.blank?
 
-    /(^|\s)#{Regexp.quote(name)}(:|,|\s)(.*\s)?#{Regexp.quote(version)}(:|,|\s|$)/i.freeze
+    /(^|\s)#{Regexp.quote(name)}(:|,|\s)(.*\s)?#{Regexp.quote(version)}(:|,|\s|$)/i
   end
 
   def self.fetch_pull_requests(name, tap_remote_repo, state: nil, version: nil)

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -23,7 +23,7 @@ module GitHub
   end
 
   def self.create_check_run(repo:, data:)
-    API.open_rest(url_to("repos", repo, "check-runs"), data: data)
+    API.open_rest(url_to("repos", repo, "check-runs"), data:)
   end
 
   def self.issues(repo:, **filters)
@@ -43,13 +43,13 @@ module GitHub
   def self.create_gist(files, description, private:)
     url = "#{API_URL}/gists"
     data = { "public" => !private, "files" => files, "description" => description }
-    API.open_rest(url, data: data, scopes: CREATE_GIST_SCOPES)["html_url"]
+    API.open_rest(url, data:, scopes: CREATE_GIST_SCOPES)["html_url"]
   end
 
   def self.create_issue(repo, title, body)
     url = "#{API_URL}/repos/#{repo}/issues"
     data = { "title" => title, "body" => body }
-    API.open_rest(url, data: data, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)["html_url"]
+    API.open_rest(url, data:, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)["html_url"]
   end
 
   def self.repository(user, repo)
@@ -59,7 +59,7 @@ module GitHub
   def self.issues_for_formula(name, tap: CoreTap.instance, tap_remote_repo: tap&.full_name, state: nil, type: nil)
     return [] unless tap_remote_repo
 
-    search_issues(name, repo: tap_remote_repo, state: state, type: type, in: "title")
+    search_issues(name, repo: tap_remote_repo, state:, type:, in: "title")
   end
 
   def self.user
@@ -89,9 +89,9 @@ module GitHub
 
   def self.merge_pull_request(repo, number:, sha:, merge_method:, commit_message: nil)
     url = "#{API_URL}/repos/#{repo}/pulls/#{number}/merge"
-    data = { sha: sha, merge_method: merge_method }
+    data = { sha:, merge_method: }
     data[:commit_message] = commit_message if commit_message
-    API.open_rest(url, data: data, request_method: :PUT, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
+    API.open_rest(url, data:, request_method: :PUT, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
   end
 
   def self.print_pull_requests_matching(query, only = nil)
@@ -122,7 +122,7 @@ module GitHub
     data = {}
     data[:organization] = org if org
     scopes = CREATE_ISSUE_FORK_OR_PR_SCOPES
-    API.open_rest(url, data: data, scopes: scopes)
+    API.open_rest(url, data:, scopes:)
   end
 
   def self.fork_exists?(repo, org: nil)
@@ -138,9 +138,9 @@ module GitHub
 
   def self.create_pull_request(repo, title, head, base, body)
     url = "#{API_URL}/repos/#{repo}/pulls"
-    data = { title: title, head: head, base: base, body: body, maintainer_can_modify: true }
+    data = { title:, head:, base:, body:, maintainer_can_modify: true }
     scopes = CREATE_ISSUE_FORK_OR_PR_SCOPES
-    API.open_rest(url, data: data, scopes: scopes)
+    API.open_rest(url, data:, scopes:)
   end
 
   def self.private_repo?(full_name)
@@ -238,7 +238,7 @@ module GitHub
 
   def self.workflow_dispatch_event(user, repo, workflow, ref, **inputs)
     url = "#{API_URL}/repos/#{user}/#{repo}/actions/workflows/#{workflow}/dispatches"
-    API.open_rest(url, data:           { ref: ref, inputs: inputs },
+    API.open_rest(url, data:           { ref:, inputs: },
                        request_method: :POST,
                        scopes:         CREATE_ISSUE_FORK_OR_PR_SCOPES)
   end
@@ -257,7 +257,7 @@ module GitHub
     url = "#{API_URL}/repos/#{user}/#{repo}/releases/generate-notes"
     data = { tag_name: tag }
     data[:previous_tag_name] = previous_tag if previous_tag.present?
-    API.open_rest(url, data: data, request_method: :POST, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
+    API.open_rest(url, data:, request_method: :POST, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
   end
 
   def self.create_or_update_release(user, repo, tag, id: nil, name: nil, body: nil, draft: false)
@@ -271,10 +271,10 @@ module GitHub
     data = {
       tag_name: tag,
       name:     name || tag,
-      draft:    draft,
+      draft:,
     }
     data[:body] = body if body.present?
-    API.open_rest(url, data: data, request_method: method, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
+    API.open_rest(url, data:, request_method: method, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
   end
 
   def self.upload_release_asset(user, repo, id, local_file: nil, remote_file: nil)
@@ -288,7 +288,7 @@ module GitHub
 
     # GraphQL unfortunately has no way to get the workflow yml name, so we need an extra REST call.
     workflow_api_url = "#{API_URL}/repos/#{user}/#{repo}/actions/workflows/#{workflow_id}"
-    workflow_payload = API.open_rest(workflow_api_url, scopes: scopes)
+    workflow_payload = API.open_rest(workflow_api_url, scopes:)
     workflow_id_num = workflow_payload["id"]
 
     query = <<~EOS
@@ -318,11 +318,11 @@ module GitHub
       }
     EOS
     variables = {
-      user: user,
-      repo: repo,
+      user:,
+      repo:,
       pr:   pull_request.to_i,
     }
-    result = API.open_graphql(query, variables: variables, scopes: scopes)
+    result = API.open_graphql(query, variables:, scopes:)
 
     commit_node = result["repository"]["pullRequest"]["commits"]["nodes"].first
     check_suite = if commit_node.present?
@@ -355,7 +355,7 @@ module GitHub
     end
 
     run_id = check_suite.last["workflowRun"]["databaseId"]
-    artifacts = API.open_rest("#{API_URL}/repos/#{user}/#{repo}/actions/runs/#{run_id}/artifacts", scopes: scopes)
+    artifacts = API.open_rest("#{API_URL}/repos/#{user}/#{repo}/actions/runs/#{run_id}/artifacts", scopes:)
 
     artifact = artifacts["artifacts"].select do |art|
       art["name"] == artifact_name
@@ -375,7 +375,7 @@ module GitHub
     url = "#{API_URL}/orgs/#{org}/public_members"
     members = []
 
-    API.paginate_rest(url, per_page: per_page) do |result|
+    API.paginate_rest(url, per_page:) do |result|
       result = result.map { |member| member["login"] }
       members.concat(result)
 
@@ -491,8 +491,8 @@ module GitHub
       {
         name:                        sponsor["name"].presence || sponsor["login"],
         login:                       sponsor["login"],
-        monthly_amount:              monthly_amount,
-        closest_tier_monthly_amount: closest_tier_monthly_amount,
+        monthly_amount:,
+        closest_tier_monthly_amount:,
       }
     end
   end
@@ -518,7 +518,7 @@ module GitHub
     regex = pull_request_title_regex(name, version)
     query = "is:pr #{name} #{version}".strip
 
-    issues_for_formula(query, tap_remote_repo: tap_remote_repo, state: state).select do |pr|
+    issues_for_formula(query, tap_remote_repo:, state:).select do |pr|
       pr["html_url"].include?("/pull/") && regex.match?(pr["title"])
     end
   rescue API::RateLimitExceededError => e
@@ -556,9 +556,9 @@ module GitHub
   def self.check_for_duplicate_pull_requests(name, tap_remote_repo, state:, file:, args:, version: nil)
     # `fetch_open_pull_requests` is more reliable but *really* slow, so let's use it only in CI.
     pull_requests = if state == "open" && ENV["CI"].present?
-      fetch_open_pull_requests(name, tap_remote_repo, version: version)
+      fetch_open_pull_requests(name, tap_remote_repo, version:)
     else
-      fetch_pull_requests(name, tap_remote_repo, state: state, version: version)
+      fetch_pull_requests(name, tap_remote_repo, state:, version:)
     end
 
     pull_requests.select! do |pr|
@@ -590,9 +590,9 @@ module GitHub
   end
 
   def self.forked_repo_info!(tap_remote_repo, org: nil)
-    response = create_fork(tap_remote_repo, org: org)
+    response = create_fork(tap_remote_repo, org:)
     # GitHub API responds immediately but fork takes a few seconds to be ready.
-    sleep 1 until fork_exists?(tap_remote_repo, org: org)
+    sleep 1 until fork_exists?(tap_remote_repo, org:)
     remote_url = if system("git", "config", "--local", "--get-regexp", "remote..*.url", "git@github.com:.*")
       response.fetch("ssh_url")
     else
@@ -709,7 +709,7 @@ module GitHub
       raise API::Error, "Getting #{commit_count} commits would exceed limit of #{API_MAX_ITEMS} API items!"
     end
 
-    API.paginate_rest(commits_api, per_page: per_page) do |result, page|
+    API.paginate_rest(commits_api, per_page:) do |result, page|
       commits.concat(result.map { |c| c["sha"] })
 
       return commits if commits.length == commit_count

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -65,7 +65,7 @@ module GitHub
                                            "the `(.+)` organization has an IP allow list enabled, " \
                                            "and your IP address is not permitted to access this resource").freeze
 
-    NO_CREDENTIALS_MESSAGE = <<~MESSAGE
+    NO_CREDENTIALS_MESSAGE = <<~MESSAGE.freeze
       No GitHub credentials found in macOS Keychain, GitHub CLI or the environment.
       #{GitHub.pat_blurb}
     MESSAGE

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -26,7 +26,7 @@ module GitHub
   CREATE_ISSUE_FORK_OR_PR_SCOPES = ["repo"].freeze
   CREATE_WORKFLOW_SCOPES = ["workflow"].freeze
   ALL_SCOPES = (CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES + CREATE_WORKFLOW_SCOPES).freeze
-  GITHUB_PERSONAL_ACCESS_TOKEN_REGEX = /^(?:[a-f0-9]{40}|gh[po]_\w{36,251})$/.freeze
+  GITHUB_PERSONAL_ACCESS_TOKEN_REGEX = /^(?:[a-f0-9]{40}|gh[po]_\w{36,251})$/
 
   # Helper functions to access the GitHub API.
   #

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -135,7 +135,7 @@ module GitHub
       env = { "PATH" => PATH.new(HOMEBREW_PREFIX/"opt/gh/bin", ENV.fetch("PATH")) }
       gh_out, _, result = system_command "gh",
                                          args:         ["auth", "token", "--hostname", "github.com"],
-                                         env:          env,
+                                         env:,
                                          print_stderr: false
       return unless result.success?
 
@@ -300,8 +300,8 @@ module GitHub
     end
 
     def self.open_graphql(query, variables: nil, scopes: [].freeze, raise_errors: true)
-      data = { query: query, variables: variables }
-      result = open_rest("#{API_URL}/graphql", scopes: scopes, data: data, request_method: "POST")
+      data = { query:, variables: }
+      result = open_rest("#{API_URL}/graphql", scopes:, data:, request_method: "POST")
 
       if raise_errors
         if result["errors"].present?

--- a/Library/Homebrew/utils/github/artifacts.rb
+++ b/Library/Homebrew/utils/github/artifacts.rb
@@ -18,7 +18,7 @@ module GitHub
     # We use a download strategy here to leverage the Homebrew cache
     # to avoid repeated downloads of (possibly large) bottles.
     token = API.credentials
-    downloader = GitHubArtifactDownloadStrategy.new(url, artifact_id, token: token)
+    downloader = GitHubArtifactDownloadStrategy.new(url, artifact_id, token:)
     downloader.fetch
     downloader.stage
   end
@@ -40,10 +40,10 @@ class GitHubArtifactDownloadStrategy < AbstractFileDownloadStrategy
       puts "Already downloaded: #{cached_location}"
     else
       begin
-        Utils::Curl.curl "--location", "--create-dirs", "--output", temporary_path, url,
+        Utils::Curl.curl("--location", "--create-dirs", "--output", temporary_path, url,
                          "--header", "Authorization: token #{@token}",
                          secrets: [@token],
-                         timeout: timeout
+                         timeout:)
       rescue ErrorDuringExecution
         raise CurlDownloadStrategyError, url
       end

--- a/Library/Homebrew/utils/gzip.rb
+++ b/Library/Homebrew/utils/gzip.rb
@@ -54,7 +54,7 @@ module Utils
     def self.compress(*paths, reproducible: true, mtime: ENV["SOURCE_DATE_EPOCH"].to_i)
       if reproducible
         paths.map do |path|
-          compress_with_options(path, mtime: mtime)
+          compress_with_options(path, mtime:)
         end
       else
         paths.map do |path|

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -66,7 +66,7 @@ module Repology
     while page_no <= MAX_PAGINATION
       odebug "Paginating Repology API page: #{page_no}"
 
-      response = query_api(last_package, repository: repository)
+      response = query_api(last_package, repository:)
       outdated_packages.merge!(response)
       last_package = response.keys.max
 

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -106,7 +106,7 @@ module Utils
       zsh:  "~/.zshrc",
     }.freeze
 
-    UNSAFE_SHELL_CHAR = %r{([^A-Za-z0-9_\-.,:/@~\n])}.freeze
+    UNSAFE_SHELL_CHAR = %r{([^A-Za-z0-9_\-.,:/@~\n])}
 
     sig { params(str: String).returns(String) }
     def csh_quote(str)

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -102,7 +102,7 @@ module SPDX
           expressions.push "#{hash_type} with #{license_expression[hash_type][:with]}"
         else
           expressions += license_expression[hash_type].map do |license|
-            license_expression_to_string license, bracket: true, hash_type: hash_type
+            license_expression_to_string license, bracket: true, hash_type:
           end
         end
       else

--- a/Library/Homebrew/utils/svn.rb
+++ b/Library/Homebrew/utils/svn.rb
@@ -29,7 +29,7 @@ module Utils
         return true unless available?
 
         args = ["ls", url, "--depth", "empty"]
-        _, stderr, status = system_command("svn", args: args, print_stderr: false)
+        _, stderr, status = system_command("svn", args:, print_stderr: false)
         return status.success? unless stderr.include?("certificate verification failed")
 
         # OK to unconditionally trust here because we're just checking if a URL exists.

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -139,7 +139,7 @@ class Version
 
   # A token string.
   class StringToken < Token
-    PATTERN = /[a-z]+/i.freeze
+    PATTERN = /[a-z]+/i
 
     sig { override.returns(String) }
     attr_reader :value
@@ -164,7 +164,7 @@ class Version
 
   # A token consisting of only numbers.
   class NumericToken < Token
-    PATTERN = /[0-9]+/i.freeze
+    PATTERN = /[0-9]+/i
 
     sig { override.returns(Integer) }
     attr_reader :value
@@ -204,7 +204,7 @@ class Version
 
   # A token representing the part of a version designating it as an alpha release.
   class AlphaToken < CompositeToken
-    PATTERN = /alpha[0-9]*|a[0-9]+/i.freeze
+    PATTERN = /alpha[0-9]*|a[0-9]+/i
 
     sig { override.params(other: T.untyped).returns(T.nilable(Integer)) }
     def <=>(other)
@@ -223,7 +223,7 @@ class Version
 
   # A token representing the part of a version designating it as a beta release.
   class BetaToken < CompositeToken
-    PATTERN = /beta[0-9]*|b[0-9]+/i.freeze
+    PATTERN = /beta[0-9]*|b[0-9]+/i
 
     sig { override.params(other: T.untyped).returns(T.nilable(Integer)) }
     def <=>(other)
@@ -244,7 +244,7 @@ class Version
 
   # A token representing the part of a version designating it as a pre-release.
   class PreToken < CompositeToken
-    PATTERN = /pre[0-9]*/i.freeze
+    PATTERN = /pre[0-9]*/i
 
     sig { override.params(other: T.untyped).returns(T.nilable(Integer)) }
     def <=>(other)
@@ -265,7 +265,7 @@ class Version
 
   # A token representing the part of a version designating it as a release candidate.
   class RCToken < CompositeToken
-    PATTERN = /rc[0-9]*/i.freeze
+    PATTERN = /rc[0-9]*/i
 
     sig { override.params(other: T.untyped).returns(T.nilable(Integer)) }
     def <=>(other)
@@ -286,7 +286,7 @@ class Version
 
   # A token representing the part of a version designating it as a patch release.
   class PatchToken < CompositeToken
-    PATTERN = /p[0-9]*/i.freeze
+    PATTERN = /p[0-9]*/i
 
     sig { override.params(other: T.untyped).returns(T.nilable(Integer)) }
     def <=>(other)
@@ -305,7 +305,7 @@ class Version
 
   # A token representing the part of a version designating it as a post release.
   class PostToken < CompositeToken
-    PATTERN = /.post[0-9]+/i.freeze
+    PATTERN = /.post[0-9]+/i
 
     sig { override.params(other: T.untyped).returns(T.nilable(Integer)) }
     def <=>(other)
@@ -503,7 +503,7 @@ class Version
     @detected_from_url
   end
 
-  HEAD_VERSION_REGEX = /\AHEAD(?:-(?<commit>.*))?\Z/.freeze
+  HEAD_VERSION_REGEX = /\AHEAD(?:-(?<commit>.*))?\Z/
   private_constant :HEAD_VERSION_REGEX
 
   # Check if this is a HEAD version.

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -353,7 +353,7 @@ class Version
 
     VERSION_PARSERS.each do |parser|
       version = parser.parse(spec)
-      return new(version, detected_from_url: detected_from_url) if version.present?
+      return new(version, detected_from_url:) if version.present?
     end
 
     NULL

--- a/Library/Homebrew/version/parser.rb
+++ b/Library/Homebrew/version/parser.rb
@@ -49,8 +49,8 @@ class Version
 
   # @api private
   class StemParser < RegexParser
-    SOURCEFORGE_DOWNLOAD_REGEX = %r{(?:sourceforge\.net|sf\.net)/.*/download$}.freeze
-    NO_FILE_EXTENSION_REGEX = /\.[^a-zA-Z]+$/.freeze
+    SOURCEFORGE_DOWNLOAD_REGEX = %r{(?:sourceforge\.net|sf\.net)/.*/download$}
+    NO_FILE_EXTENSION_REGEX = /\.[^a-zA-Z]+$/
 
     sig { override.params(spec: Pathname).returns(String) }
     def self.process_spec(spec)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- As noted in Slack, bumping RuboCop's target Ruby version to the one we actually use now reveals a bunch of improvements, all autofixable.
- This is draft because I have to change trains now - I'll return to this later.