### PR TITLE
rubocop: Set TargetRubyVersion to 3.1 & disable all cops that fail

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -12,7 +12,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
   ActiveSupportExtensionsEnabled: true
   NewCops: enable
   Include:
@@ -386,9 +386,10 @@ Style/InvertibleUnlessCondition:
     # Don't require non-standard `exclude?` (for now at least) - it's not available in every file
     # :include?:
 
-# would rather freeze too much than too little
+# TODO: Enable this cop again once https://github.com/Homebrew/brew/pull/16337#issuecomment-1855668516 is done.
+# From the RuboCop docs: "NOTE: Regexp and Range literals are frozen objects since Ruby 3.0."
 Style/MutableConstant:
-  EnforcedStyle: strict
+  Enabled: false
 
 # Zero-prefixed octal literals are widely used and understood.
 Style/NumericLiteralPrefix:
@@ -469,3 +470,21 @@ Style/UnlessLogicalOperators:
 # a bit confusing to non-Rubyists but useful for longer arrays
 Style/WordArray:
   MinSize: 4
+
+# TODO: Enable these cops once https://github.com/Homebrew/brew/pull/16337#issuecomment-1855668516 is done.
+Lint/RedundantDirGlobSort:
+  Enabled: false
+Naming/BlockForwarding:
+  Enabled: false
+Performance/BindCall:
+  Enabled: false
+Performance/MapCompact:
+  Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/ArrayIntersect:
+  Enabled: false
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either
+Style/RedundantFreeze:
+  Enabled: false

--- a/Library/Homebrew/PATH.rb
+++ b/Library/Homebrew/PATH.rb
@@ -10,13 +10,10 @@ class PATH
 
   delegate each: :@paths
 
-  # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
-  # rubocop:disable Style/MutableConstant
   Element = T.type_alias { T.nilable(T.any(Pathname, String, PATH)) }
   private_constant :Element
   Elements = T.type_alias { T.any(Element, T::Array[Element]) }
   private_constant :Elements
-  # rubocop:enable Style/MutableConstant
 
   sig { params(paths: Elements).void }
   def initialize(*paths)

--- a/Library/Homebrew/cask/staged.rb
+++ b/Library/Homebrew/cask/staged.rb
@@ -8,10 +8,7 @@ module Cask
   #
   # @api private
   module Staged
-    # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
-    # rubocop:disable Style/MutableConstant
     Paths = T.type_alias { T.any(String, Pathname, T::Array[T.any(String, Pathname)]) }
-    # rubocop:enable Style/MutableConstant
 
     sig { params(paths: Paths, permissions_str: String).void }
     def set_permissions(paths, permissions_str)

--- a/Library/Homebrew/extend/blank.rb
+++ b/Library/Homebrew/extend/blank.rb
@@ -133,12 +133,9 @@ end
 
 class String
   BLANK_RE = /\A[[:space:]]*\z/.freeze
-  # This is a cache that is intentionally mutable
-  # rubocop:disable Style/MutableConstant
   ENCODED_BLANKS_ = T.let(Hash.new do |h, enc|
     h[enc] = Regexp.new(BLANK_RE.source.encode(enc), BLANK_RE.options | Regexp::FIXEDENCODING)
   end, T::Hash[Encoding, Regexp])
-  # rubocop:enable Style/MutableConstant
 
   # A string is blank if it's empty or contains whitespaces only:
   #

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -5,8 +5,6 @@ require "test_runner_formula"
 require "github_runner"
 
 class GitHubRunnerMatrix
-  # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
-  # rubocop:disable Style/MutableConstant
   RunnerSpec = T.type_alias { T.any(LinuxRunnerSpec, MacOSRunnerSpec) }
   private_constant :RunnerSpec
 
@@ -27,7 +25,6 @@ class GitHubRunnerMatrix
 
   RunnerSpecHash = T.type_alias { T.any(LinuxRunnerSpecHash, MacOSRunnerSpecHash) }
   private_constant :RunnerSpecHash
-  # rubocop:enable Style/MutableConstant
 
   sig { returns(T::Array[GitHubRunner]) }
   attr_reader :runners

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -159,7 +159,7 @@ class Object
 end
 
 module MacOSVersions
-  SYMBOLS = LazyObject.new do # rubocop:disable Style/MutableConstant
+  SYMBOLS = LazyObject.new do
     odisabled "MacOSVersions::SYMBOLS", "MacOSVersion::SYMBOLS"
     MacOSVersion::SYMBOLS
   end
@@ -168,7 +168,7 @@ end
 module OS
   module Mac
     # TODO: Replace `::Version` with `Version` when this is removed.
-    Version = LazyObject.new do # rubocop:disable Style/MutableConstant
+    Version = LazyObject.new do
       odisabled "OS::Mac::Version", "MacOSVersion"
       MacOSVersion
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Supersedes #16337 (for now).
- As discussed in https://github.com/Homebrew/brew/pull/16337#issuecomment-1855668516, then we won't have the chicken/egg problem.