### PR TITLE
Fix new `Style/MutableConstant` RuboCop offenses for Ruby 3.1

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -386,10 +386,9 @@ Style/InvertibleUnlessCondition:
     # Don't require non-standard `exclude?` (for now at least) - it's not available in every file
     :include?:
 
-# TODO: Enable this cop again once https://github.com/Homebrew/brew/pull/16337#issuecomment-1855668516 is done.
-# From the RuboCop docs: "NOTE: Regexp and Range literals are frozen objects since Ruby 3.0."
 Style/MutableConstant:
-  Enabled: false
+  # would rather freeze too much than too little
+  EnforcedStyle: strict
 
 # Zero-prefixed octal literals are widely used and understood.
 Style/NumericLiteralPrefix:

--- a/Library/Homebrew/PATH.rb
+++ b/Library/Homebrew/PATH.rb
@@ -10,10 +10,13 @@ class PATH
 
   delegate each: :@paths
 
+  # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
+  # rubocop:disable Style/MutableConstant
   Element = T.type_alias { T.nilable(T.any(Pathname, String, PATH)) }
   private_constant :Element
   Elements = T.type_alias { T.any(Element, T::Array[Element]) }
   private_constant :Elements
+  # rubocop:enable Style/MutableConstant
 
   sig { params(paths: Elements).void }
   def initialize(*paths)

--- a/Library/Homebrew/cask/staged.rb
+++ b/Library/Homebrew/cask/staged.rb
@@ -8,7 +8,10 @@ module Cask
   #
   # @api private
   module Staged
+    # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
+    # rubocop:disable Style/MutableConstant
     Paths = T.type_alias { T.any(String, Pathname, T::Array[T.any(String, Pathname)]) }
+    # rubocop:enable Style/MutableConstant
 
     sig { params(paths: Paths, permissions_str: String).void }
     def set_permissions(paths, permissions_str)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -12,7 +12,7 @@ require "erb"
 require "utils/gzip"
 require "api"
 
-BOTTLE_ERB = <<-EOS
+BOTTLE_ERB = <<-EOS.freeze
   bottle do
     <% if [HOMEBREW_BOTTLE_DEFAULT_DOMAIN.to_s,
            "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/bottles"].exclude?(root_url) %>

--- a/Library/Homebrew/extend/blank.rb
+++ b/Library/Homebrew/extend/blank.rb
@@ -133,9 +133,12 @@ end
 
 class String
   BLANK_RE = /\A[[:space:]]*\z/.freeze
+  # This is a cache that is intentionally mutable
+  # rubocop:disable Style/MutableConstant
   ENCODED_BLANKS_ = T.let(Hash.new do |h, enc|
     h[enc] = Regexp.new(BLANK_RE.source.encode(enc), BLANK_RE.options | Regexp::FIXEDENCODING)
   end, T::Hash[Encoding, Regexp])
+  # rubocop:enable Style/MutableConstant
 
   # A string is blank if it's empty or contains whitespaces only:
   #

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -12,8 +12,8 @@ class GitHubPackages
   include Context
 
   URL_DOMAIN = "ghcr.io"
-  URL_PREFIX = "https://#{URL_DOMAIN}/v2/"
-  DOCKER_PREFIX = "docker://#{URL_DOMAIN}/"
+  URL_PREFIX = "https://#{URL_DOMAIN}/v2/".freeze
+  DOCKER_PREFIX = "docker://#{URL_DOMAIN}/".freeze
   public_constant :URL_DOMAIN
   private_constant :URL_PREFIX
   private_constant :DOCKER_PREFIX

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -5,6 +5,8 @@ require "test_runner_formula"
 require "github_runner"
 
 class GitHubRunnerMatrix
+  # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
+  # rubocop:disable Style/MutableConstant
   RunnerSpec = T.type_alias { T.any(LinuxRunnerSpec, MacOSRunnerSpec) }
   private_constant :RunnerSpec
 
@@ -25,6 +27,7 @@ class GitHubRunnerMatrix
 
   RunnerSpecHash = T.type_alias { T.any(LinuxRunnerSpecHash, MacOSRunnerSpecHash) }
   private_constant :RunnerSpecHash
+  # rubocop:enable Style/MutableConstant
 
   sig { returns(T::Array[GitHubRunner]) }
   attr_reader :runners

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -42,7 +42,7 @@ HOMEBREW_PHYSICAL_PROCESSOR = ENV.fetch("HOMEBREW_PHYSICAL_PROCESSOR").freeze
 HOMEBREW_BREWED_CURL_PATH = Pathname(ENV.fetch("HOMEBREW_BREWED_CURL_PATH")).freeze
 HOMEBREW_USER_AGENT_CURL = ENV.fetch("HOMEBREW_USER_AGENT_CURL").freeze
 HOMEBREW_USER_AGENT_RUBY =
-  "#{ENV.fetch("HOMEBREW_USER_AGENT")} ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}"
+  "#{ENV.fetch("HOMEBREW_USER_AGENT")} ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}".freeze
 HOMEBREW_USER_AGENT_FAKE_SAFARI =
   # Don't update this beyond 10.15.7 until Safari actually updates their
   # user agent to be beyond 10.15.7 (not the case as-of macOS 14)
@@ -83,10 +83,10 @@ require "default_prefix"
 module Homebrew
   extend FileUtils
 
-  DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar"
-  DEFAULT_MACOS_CELLAR = "#{HOMEBREW_DEFAULT_PREFIX}/Cellar"
-  DEFAULT_MACOS_ARM_CELLAR = "#{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/Cellar"
-  DEFAULT_LINUX_CELLAR = "#{HOMEBREW_LINUX_DEFAULT_PREFIX}/Cellar"
+  DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar".freeze
+  DEFAULT_MACOS_CELLAR = "#{HOMEBREW_DEFAULT_PREFIX}/Cellar".freeze
+  DEFAULT_MACOS_ARM_CELLAR = "#{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/Cellar".freeze
+  DEFAULT_LINUX_CELLAR = "#{HOMEBREW_LINUX_DEFAULT_PREFIX}/Cellar".freeze
 
   class << self
     attr_writer :failed, :raise_deprecation_exceptions, :auditing

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -159,7 +159,7 @@ class Object
 end
 
 module MacOSVersions
-  SYMBOLS = LazyObject.new do
+  SYMBOLS = LazyObject.new do # rubocop:disable Style/MutableConstant
     odisabled "MacOSVersions::SYMBOLS", "MacOSVersion::SYMBOLS"
     MacOSVersion::SYMBOLS
   end
@@ -168,7 +168,7 @@ end
 module OS
   module Mac
     # TODO: Replace `::Version` with `Version` when this is removed.
-    Version = LazyObject.new do
+    Version = LazyObject.new do # rubocop:disable Style/MutableConstant
       odisabled "OS::Mac::Version", "MacOSVersion"
       MacOSVersion
     end

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -7,10 +7,10 @@ describe "patching" do
     Class.new(Formula) do
       # These are defined within an anonymous class to avoid polluting the global namespace.
       # rubocop:disable RSpec/LeakyConstantDeclaration,Lint/ConstantDefinitionInBlock
-      TESTBALL_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-      TESTBALL_PATCHES_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1-patches.tgz"
-      PATCH_URL_A = "file://#{TEST_FIXTURE_DIR}/patches/noop-a.diff"
-      PATCH_URL_B = "file://#{TEST_FIXTURE_DIR}/patches/noop-b.diff"
+      TESTBALL_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz".freeze
+      TESTBALL_PATCHES_URL = "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1-patches.tgz".freeze
+      PATCH_URL_A = "file://#{TEST_FIXTURE_DIR}/patches/noop-a.diff".freeze
+      PATCH_URL_B = "file://#{TEST_FIXTURE_DIR}/patches/noop-b.diff".freeze
       PATCH_A_CONTENTS = File.read("#{TEST_FIXTURE_DIR}/patches/noop-a.diff").freeze
       PATCH_B_CONTENTS = File.read("#{TEST_FIXTURE_DIR}/patches/noop-b.diff").freeze
       APPLY_A = "noop-a.diff"

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -65,7 +65,7 @@ module GitHub
                                            "the `(.+)` organization has an IP allow list enabled, " \
                                            "and your IP address is not permitted to access this resource").freeze
 
-    NO_CREDENTIALS_MESSAGE = <<~MESSAGE
+    NO_CREDENTIALS_MESSAGE = <<~MESSAGE.freeze
       No GitHub credentials found in macOS Keychain, GitHub CLI or the environment.
       #{GitHub.pat_blurb}
     MESSAGE


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- A follow-up to de592af20bbff5bcb548d2474f0722e59ff1129a, resetting the previous disabled comments too (from https://github.com/Homebrew/brew/pull/16341#discussion_r1427695062).