### PR TITLE
Fix "an artifact with this name already exists on the workflow run"

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -96,7 +96,7 @@ module Homebrew
 
             - name: Upload bottles as artifact
               if: always() && github.event_name == 'pull_request'
-              uses: actions/upload-artifact@main
+              uses: actions/upload-artifact@v3
               with:
                 name: bottles
                 path: '*.bottle.*'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Two days ago my tap started failing because the upstream `actions/upload-artifact@main` was bumped to v4. This version no longer allows to upload artifacts with the same `name` for multiple jobs.

Example: https://github.com/autobrew/homebrew-cran/actions/runs/7232216444

So we either need to make the `name` parameter unique or stick with v3 for now.
