### PR TITLE
Work around recent Akamai/Microsoft issues

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -785,8 +785,14 @@ module Cask
 
       return unless cask.homepage
 
+      user_agents = if cask.tap&.audit_exception(:simple_user_agent_for_homepage, cask.token)
+        ["curl"]
+      else
+        [:browser, :default]
+      end
+
       validate_url_for_https_availability(cask.homepage, SharedAudits::URL_TYPE_HOMEPAGE, cask.token, cask.tap,
-                                          user_agents:   [:browser, :default],
+                                          user_agents:   user_agents,
                                           check_content: true,
                                           strict:        strict?)
     end


### PR DESCRIPTION
At the moment, Microsoft Office and related casks fail audit due to failure to fetch a product homepage from the main Microsoft site (https://www.microsoft.com/) served by Akamai CDN. The failure is severe and weird: no status code is received as the connection is reset.
The analysis revealed the issue is linked to `User-Agent` and `Accept-Language` headers parsing. Homebrew uses involved user agent strings and has language hardcoded as `en`.
The simplest workaround is to use a simple user agent string when checking homepage availability if the cask is in an audit exceptions list.

Merging this would fix Microsoft Office updates (including https://github.com/Homebrew/homebrew-cask/pull/162671)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
