### PR TITLE
Re-add some `discontinued?` checks for casks

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -289,7 +289,7 @@ module Cask
 
     sig { params(livecheck_result: T.any(NilClass, T::Boolean, Symbol)).void }
     def audit_hosting_with_livecheck(livecheck_result: audit_livecheck_version)
-      return if cask.deprecated? || cask.disabled?
+      return if cask.discontinued? || cask.deprecated? || cask.disabled?
       return if cask.version&.latest?
       return unless cask.url
       return if block_url_offline?
@@ -683,7 +683,7 @@ module Cask
     sig { void }
     def audit_github_repository_archived
       # Deprecated/disabled casks may have an archived repo.
-      return if cask.deprecated? || cask.disabled?
+      return if cask.discontinued? || cask.deprecated? || cask.disabled?
 
       user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*}) if online?
       return if user.nil?
@@ -697,7 +697,7 @@ module Cask
     sig { void }
     def audit_gitlab_repository_archived
       # Deprecated/disabled casks may have an archived repo.
-      return if cask.deprecated? || cask.disabled?
+      return if cask.discontinued? || cask.deprecated? || cask.disabled?
 
       user, repo = get_repo_data(%r{https?://gitlab\.com/([^/]+)/([^/]+)/?.*}) if online?
       return if user.nil?

--- a/Library/Homebrew/cask/cask.rbi
+++ b/Library/Homebrew/cask/cask.rbi
@@ -20,6 +20,8 @@ module Cask
 
     def desc; end
 
+    def discontinued?; end
+
     def deprecated?; end
 
     def deprecation_date; end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -92,7 +92,7 @@ module Cask
       :disabled?,
       :disable_date,
       :disable_reason,
-      :discontinued?,
+      :discontinued?, # TODO: remove once discontinued? is removed (4.5.0)
       :livecheck,
       :livecheckable?,
       :on_system_blocks_exist?,
@@ -106,7 +106,7 @@ module Cask
 
     attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :disable_date, :disable_reason
 
-    attr_predicate :on_system_blocks_exist?, :disabled?, :livecheckable?
+    attr_predicate :on_system_blocks_exist?, :deprecated?, :disabled?, :livecheckable?
 
     def initialize(cask)
       @cask = cask
@@ -326,11 +326,6 @@ module Cask
     def discontinued?
       # odeprecated "`discontinued?`", "`deprecated?` or `disabled?`"
       @caveats&.discontinued? == true
-    end
-
-    # TODO: replace with with attr_predicate once discontinued? is disabled
-    def deprecated?
-      @deprecated == true || @caveats&.discontinued? == true
     end
 
     # @api public

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -119,6 +119,20 @@ module Homebrew
           verbose:       T::Boolean,
         ).returns(Hash)
       }
+      def cask_discontinued(cask, livecheckable, full_name: false, verbose: false)
+        return {} if !cask.discontinued? || livecheckable
+
+        Livecheck.status_hash(cask, "discontinued", full_name: full_name, verbose: verbose)
+      end
+
+      sig {
+        params(
+          cask:          Cask::Cask,
+          livecheckable: T::Boolean,
+          full_name:     T::Boolean,
+          verbose:       T::Boolean,
+        ).returns(Hash)
+      }
       def cask_deprecated(cask, livecheckable, full_name: false, verbose: false)
         return {} if !cask.deprecated? || livecheckable
 
@@ -179,6 +193,7 @@ module Homebrew
       # Skip conditions for casks.
       CASK_CHECKS = [
         :package_or_resource_skip,
+        :cask_discontinued,
         :cask_deprecated,
         :cask_disabled,
         :cask_version_latest,

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -247,7 +247,7 @@ describe Homebrew::Livecheck::SkipConditions do
       cask:    {
         discontinued:      {
           cask:   "test_discontinued",
-          status: "deprecated",
+          status: "discontinued",
           meta:   {
             livecheckable: false,
           },
@@ -478,7 +478,7 @@ describe Homebrew::Livecheck::SkipConditions do
     context "when a cask without a livecheckable is discontinued" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(casks[:discontinued], original_name) }
-          .to raise_error(RuntimeError, "Referenced cask (test_discontinued) is skipped as deprecated")
+          .to raise_error(RuntimeError, "Referenced cask (test_discontinued) is skipped as discontinued")
       end
     end
 
@@ -601,7 +601,7 @@ describe Homebrew::Livecheck::SkipConditions do
     context "when the cask is discontinued without a livecheckable" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:discontinued]) }
-          .to output("test_discontinued: deprecated\n").to_stdout
+          .to output("test_discontinued: discontinued\n").to_stdout
           .and not_to_output.to_stderr
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/16292

Since `discontinued` will be around an un-deprecated until 4.3.0, let's continue to check for it in `brew audit` and `brew livecheck` for now.