### PR TITLE
rubocops/lines: consistency with single non-runtime Python

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -375,9 +375,17 @@ module RuboCop
             string_content(parameters(dep).first).start_with? "python@"
           end
 
-          return if python_formula_node.blank?
+          python_version = if python_formula_node.blank?
+            other_python_nodes = find_every_method_call_by_name(body_node, :depends_on).select do |dep|
+              parameters(dep).first.instance_of?(RuboCop::AST::HashNode) &&
+                string_content(parameters(dep).first.keys.first).start_with?("python@")
+            end
+            return if other_python_nodes.size != 1
 
-          python_version = string_content(parameters(python_formula_node).first).split("@").last
+            string_content(parameters(other_python_nodes.first).first.keys.first).split("@").last
+          else
+            string_content(parameters(python_formula_node).first).split("@").last
+          end
 
           find_strings(body_node).each do |str|
             content = string_content(str)

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -179,5 +179,45 @@ describe RuboCop::Cop::FormulaAudit::PythonVersions do
         end
       RUBY
     end
+
+    it "reports no offenses for multiple non-runtime Python dependencies" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.9" => :build
+          depends_on "python@3.10" => :test
+
+          def install
+            puts "python3.9"
+          end
+
+          test do
+            puts "python3.10"
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects Python references that mismatch single non-runtime Python dependency" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.9" => :build
+
+          def install
+            puts "python@3.8"
+                 ^^^^^^^^^^^^ FormulaAudit/PythonVersions: References to `python@3.8` should match the specified python dependency (`python@3.9`)
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.9" => :build
+
+          def install
+            puts "python@3.9"
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A couple PRs in `homebrew-core` were merged for modifying `python@3.11 --> python@3.12` but the actual build/test was still using `python3.11` since the corresponding reference was not updated.