### PR TITLE
sudo: Prioritize sudo_as_root over HOMEBREW_SUDO_THROUGH_SUDO_USER.

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -183,15 +183,15 @@ class SystemCommand
   def sudo_prefix
     askpass_flags = ENV.key?("SUDO_ASKPASS") ? ["-A"] : []
     user_flags = []
-    if sudo_as_root?
-      user_flags += ["-u", "root"]
-    elsif Homebrew::EnvConfig.sudo_through_sudo_user?
+    if Homebrew::EnvConfig.sudo_through_sudo_user?
       raise ArgumentError, "HOMEBREW_SUDO_THROUGH_SUDO_USER set but SUDO_USER unset!" if homebrew_sudo_user.blank?
 
       user_flags += ["--prompt", "Password for %p:", "-u", homebrew_sudo_user,
                      *askpass_flags,
                      "-E", *env_args,
                      "--", "/usr/bin/sudo"]
+    elsif sudo_as_root?
+      user_flags += ["-u", "root"]
     end
     ["/usr/bin/sudo", *user_flags, *askpass_flags, "-E", *env_args, "--"]
   end

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -191,7 +191,7 @@ class SystemCommand
                      "-E", *env_args,
                      "--", "/usr/bin/sudo"]
     end
-    user_flags += sudo_as_root? ? ["-u", "root"] : []
+    user_flags += ["-u", "root"] if sudo_as_root?
     ["/usr/bin/sudo", *user_flags, *askpass_flags, "-E", *env_args, "--"]
   end
 

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -183,15 +183,15 @@ class SystemCommand
   def sudo_prefix
     askpass_flags = ENV.key?("SUDO_ASKPASS") ? ["-A"] : []
     user_flags = []
-    if Homebrew::EnvConfig.sudo_through_sudo_user?
+    if sudo_as_root?
+      user_flags += ["-u", "root"]
+    elsif Homebrew::EnvConfig.sudo_through_sudo_user?
       raise ArgumentError, "HOMEBREW_SUDO_THROUGH_SUDO_USER set but SUDO_USER unset!" if homebrew_sudo_user.blank?
 
       user_flags += ["--prompt", "Password for %p:", "-u", homebrew_sudo_user,
                      *askpass_flags,
                      "-E", *env_args,
                      "--", "/usr/bin/sudo"]
-    elsif sudo_as_root?
-      user_flags += ["-u", "root"]
     end
     ["/usr/bin/sudo", *user_flags, *askpass_flags, "-E", *env_args, "--"]
   end

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -191,9 +191,7 @@ class SystemCommand
                      "-E", *env_args,
                      "--", "/usr/bin/sudo"]
     end
-    if sudo_as_root?
-      user_flags += ["-u", "root"]
-    end
+    user_flags += sudo_as_root? ? ["-u", "root"] : []
     ["/usr/bin/sudo", *user_flags, *askpass_flags, "-E", *env_args, "--"]
   end
 

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -190,7 +190,8 @@ class SystemCommand
                      *askpass_flags,
                      "-E", *env_args,
                      "--", "/usr/bin/sudo"]
-    elsif sudo_as_root?
+    end
+    if sudo_as_root?
       user_flags += ["-u", "root"]
     end
     ["/usr/bin/sudo", *user_flags, *askpass_flags, "-E", *env_args, "--"]


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`sudo_as_root` is reserved for cases where a command must be run as root and root only. No other user can suffice regardless of group and/or ACLs. Therefore it should be preferred over `HOMEBREW_SUDO_THROUGH_SUDO_USER`.