### PR TITLE
Implement `conflicts_with :formula` for casks

### DIFF
--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -88,6 +88,34 @@ module Cask
     end
   end
 
+  # Error when a cask conflicts with formulae.
+  #
+  # @api private
+  class CaskConflictWithFormulaError < AbstractCaskErrorWithToken
+    attr_reader :conflicting_formulae
+
+    def initialize(token, conflicting_formulae)
+      super(token)
+      @conflicting_formulae = conflicting_formulae
+    end
+
+    sig { returns(String) }
+    def to_s
+      message = []
+      message << "Cask '#{token}' conflicts with the following formulae that are installed:"
+      message.concat conflicting_formulae.map(&:conflict_message) << ""
+      message << <<~EOS
+        Please `brew unlink #{conflicting_formulae.map(&:name) * " "}` before continuing.
+
+        Unlinking removes a formula's symlinks from #{HOMEBREW_PREFIX}. You can
+        link the formula again after the install finishes. You can --force this
+        install, but the build may fail or cause obscure side effects in the
+        resulting software.
+      EOS
+      message.join("\n")
+    end
+  end
+
   # Error when a cask is not available.
   #
   # @api private

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -420,18 +420,11 @@ class FormulaConflictError < RuntimeError
     super message
   end
 
-  def conflict_message(conflict)
-    message = []
-    message << "  #{conflict.name}"
-    message << ": because #{conflict.reason}" if conflict.reason
-    message.join
-  end
-
   sig { returns(String) }
   def message
     message = []
     message << "Cannot install #{formula.full_name} because conflicting formulae are installed."
-    message.concat conflicts.map { |c| conflict_message(c) } << ""
+    message.concat conflicts.map(&:conflict_message) << ""
     message << <<~EOS
       Please `brew unlink #{conflicts.map(&:name) * " "}` before continuing.
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4,6 +4,7 @@
 require "cache_store"
 require "did_you_mean"
 require "formula_support"
+require "formula_conflict"
 require "lock_file"
 require "formula_pin"
 require "hardware"

--- a/Library/Homebrew/formula_conflict.rb
+++ b/Library/Homebrew/formula_conflict.rb
@@ -1,0 +1,41 @@
+# typed: true
+# frozen_string_literal: true
+
+# Used to track formulae that cannot be installed at the same time.
+FormulaConflict = Struct.new(:name, :reason) do
+  def conflict_message
+    message = []
+    message << "  #{name}"
+    message << ": because #{reason}" if reason
+    message.join
+  end
+
+  def conflicts?(formula_or_cask)
+    f = Formulary.factory(name)
+  rescue TapFormulaUnavailableError
+    # If the formula name is a fully-qualified name let's silently
+    # ignore it as we don't care about things used in taps that aren't
+    # currently tapped.
+    false
+  rescue FormulaUnavailableError => e
+    # If the formula name doesn't exist any more then complain but don't
+    # stop installation from continuing.
+    official_tap, filename = if formula_or_cask.is_a?(Formula)
+      ["homebrew-core", formula_or_cask.path.basename]
+    else
+      ["homebrew-cask", formula_or_cask.sourcefile_path.basename]
+    end
+    opoo <<~EOS
+      #{formula_or_cask}: #{e.message}
+      'conflicts_with "#{name}"' should be removed from #{filename}.
+    EOS
+
+    raise if Homebrew::EnvConfig.developer?
+
+    $stderr.puts "Please report this issue to the #{formula_or_cask.tap} tap " \
+                 "(not Homebrew/brew or Homebrew/#{official_tap})!"
+    false
+  else
+    f.linked_keg.exist? && f.opt_prefix.exist?
+  end
+end

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -1,9 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-# Used to track formulae that cannot be installed at the same time.
-FormulaConflict = Struct.new(:name, :reason)
-
 # Used to annotate formulae that duplicate macOS-provided software
 # or cause conflicts when linked in.
 class KegOnlyReason

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -166,7 +166,10 @@ describe "Exception" do
     subject { described_class.new(formula, [conflict]) }
 
     let(:formula) { instance_double(Formula, full_name: "foo/qux") }
-    let(:conflict) { instance_double(FormulaConflict, name: "bar", reason: "I decided to") }
+    let(:conflict) do
+      instance_double(FormulaConflict, name: "bar", reason: "I decided to", conflicts?: true,
+                      conflict_message: "  bar: because I decided to")
+    end
 
     its(:to_s) { is_expected.to match(/Please `brew unlink bar` before continuing\./) }
   end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -154,7 +154,7 @@ Each cask must declare one or more *artifacts* (i.e. something to install).
 | name                                       | multiple occurrences allowed? | value |
 | ------------------------------------------ | :---------------------------: | ----- |
 | [`uninstall`](#stanza-uninstall)           | yes                           | Procedures to uninstall a cask. Optional unless the `pkg` stanza is used. |
-| [`conflicts_with`](#stanza-conflicts_with) | yes                           | List of conflicts with this cask (*not yet functional*). |
+| [`conflicts_with`](#stanza-conflicts_with) | yes                           | List of conflicts with this cask. |
 | [`caveats`](#stanza-caveats)               | yes                           | String or Ruby block providing the user with cask-specific information at install time. |
 | [`deprecate!`](#stanza-deprecate--disable) | no                            | Date as a String in `YYYY-MM-DD` format and a String or Symbol providing a reason. |
 | [`disable!`](#stanza-deprecate--disable)   | no                            | Date as a String in `YYYY-MM-DD` format and a String or Symbol providing a reason. |
@@ -350,8 +350,6 @@ conflicts_with cask: "macfuse-dev"
 ```
 
 #### `conflicts_with` *formula*
-
-**Note:** `conflicts_with formula:` is a stub and is not yet functional.
 
 The value should be another formula name.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Closes https://github.com/Homebrew/homebrew-cask/issues/12822

This PR implements the `conflicts_with formula: "..."` DSL for casks by extracting the logic for handling formula conflicts and applying it to casks as well.

Interestingly, after I started working on this, I noticed some discussion in https://github.com/Homebrew/brew/issues/16309 about this kind of thing. My reading of that conversation was that there might be interest in a more advanced type of conflict where instead of refusing to install, we simply don't link the conflicting files. For now, my implementation works the same way inter-casks and inter-formulae conflicts work (meaning it simply refuses to install). I figured I'd open this PR so we can discuss what the best way to handle this is.

CC @MikeMcQuaid, @cho-m, and @Homebrew/cask
