### PR TITLE
rubocops/cask/on_system_conditionals: allow blocks.

### DIFF
--- a/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
+++ b/Library/Homebrew/rubocops/cask/on_system_conditionals.rb
@@ -40,7 +40,7 @@ module RuboCop
             audit_on_system_blocks(stanza.stanza_node, stanza.stanza_name)
           end
 
-          audit_arch_conditionals(cask_body)
+          audit_arch_conditionals(cask_body, allowed_blocks: FLIGHT_STANZA_NAMES)
           audit_macos_version_conditionals(cask_body, recommend_on_system: false)
           simplify_sha256_stanzas
         end


### PR DESCRIPTION
Without this, there's an infinite loop on `brew style --fix` if you have a `if Hardware::CPU.arm?` in a `postflight` block where it will change back and forward between `if` and `on_os` syntax forever.