### PR TITLE
formula_cellar_checks: detect cpuid in static libs

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -324,6 +324,14 @@ module FormulaCellarChecks
       cpuid_instruction?(file, objdump)
     end
 
+    hardlinks = Set.new
+    return if formula.lib.directory? && formula.lib.find.any? do |pn|
+      next false if pn.symlink? || pn.directory? || pn.extname != ".a"
+      next false unless hardlinks.add? [pn.stat.dev, pn.stat.ino]
+
+      cpuid_instruction?(pn, objdump)
+    end
+
     "No `cpuid` instruction detected. #{formula} should not use `ENV.runtime_cpu_detection`."
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related to https://github.com/Homebrew/homebrew-core/pull/157146 where runtime CPU detection is done inside static library.

Here I am only looking for static libraries directly installed inside `lib` so will skip any installed into `libexec` or symlinks whose realpath is outside `lib`. Also not as accurate as dynamic library detection since only looking for file extension rather than contents.