### PR TITLE
rubocops/uses_from_macos: audit when `depends_on :linux`

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -98,7 +98,12 @@ module RuboCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           return if body_node.nil?
 
+          depends_on_linux = depends_on?(:linux)
+
           find_method_with_args(body_node, :uses_from_macos, /^"(.+)"/).each do |method|
+            @offensive_node = method
+            problem "`uses_from_macos` should not be used when Linux is required." if depends_on_linux
+
             dep = if parameters(method).first.instance_of?(RuboCop::AST::StrNode)
               parameters(method).first
             elsif parameters(method).first.instance_of?(RuboCop::AST::HashNode)

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -5,16 +5,47 @@ require "rubocops/uses_from_macos"
 describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
   subject(:cop) { described_class.new }
 
-  it "when auditing uses_from_macos dependencies" do
-    expect_offense(<<~RUBY)
-      class Foo < Formula
-        url "https://brew.sh/foo-1.0.tgz"
-        homepage "https://brew.sh"
+  context "when auditing `uses_from_macos` dependencies" do
+    it "reports an offense when used on non-macOS dependency" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
-        uses_from_macos "postgresql"
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not postgresql.
-      end
-    RUBY
+          uses_from_macos "postgresql"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not postgresql.
+        end
+      RUBY
+    end
+
+    it "reports offenses for multiple non-macOS dependencies and none for valid macOS dependencies" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          uses_from_macos "boost"
+          ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not boost.
+          uses_from_macos "bzip2"
+          uses_from_macos "postgresql"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not postgresql.
+          uses_from_macos "zlib"
+        end
+      RUBY
+    end
+
+    it "reports an offense when used in `depends_on :linux` formula" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          depends_on :linux
+          uses_from_macos "zlib"
+          ^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should not be used when Linux is required.
+        end
+      RUBY
+    end
   end
 
   include_examples "formulae exist", described_class::ALLOWED_USES_FROM_MACOS_DEPS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `uses_from_macos` DSL is a bit confusing when a formula is `depends_on :linux` as the formula isn't using anything on macOS.

We've typically have used `depends_on "<builtin-macos>"` for these formulae which sounds more accurate.