### PR TITLE
Fix Cask::Cask.all bug

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -30,8 +30,11 @@ module Cask
         raise ArgumentError, "Cask::Cask#all cannot be used without --eval-all or HOMEBREW_EVAL_ALL"
       end
 
-      Tap.flat_map(&:cask_files).map do |f|
-        CaskLoader::FromTapPathLoader.new(f).load(config: nil)
+      # Load core casks from tokens so they load from the API when the core cask is not tapped.
+      tokens_and_files = CoreCaskTap.instance.cask_tokens
+      tokens_and_files += Tap.reject(&:core_cask_tap?).flat_map(&:cask_files)
+      tokens_and_files.map do |token_or_file|
+        CaskLoader.load(token_or_file)
       rescue CaskUnreadableError => e
         opoo e.message
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -24,9 +24,8 @@ module Cask
     attr_predicate :loaded_from_api?
 
     # @api private
-    def self.all
-      # TODO: replace this ARGV and ENV logic with an argument, like how we do with formulae
-      if ARGV.exclude?("--eval-all") && !Homebrew::EnvConfig.eval_all?
+    def self.all(eval_all: false)
+      if !eval_all && !Homebrew::EnvConfig.eval_all?
         raise ArgumentError, "Cask::Cask#all cannot be used without --eval-all or HOMEBREW_EVAL_ALL"
       end
 

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -131,8 +131,9 @@ module Homebrew
       puts_deps_tree dependents, recursive: recursive, args: args
       return
     elsif all
-      puts_deps sorted_dependents(Formula.all(eval_all: args.eval_all?) + Cask::Cask.all), recursive: recursive,
-                                                                                           args:      args
+      puts_deps sorted_dependents(
+        Formula.all(eval_all: args.eval_all?) + Cask::Cask.all(eval_all: args.eval_all?),
+      ), recursive: recursive, args: args
       return
     elsif !args.no_named? && args.for_each?
       puts_deps sorted_dependents(args.named.to_formulae_and_casks), recursive: recursive, args: args

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -207,7 +207,10 @@ module Homebrew
       end
     when :v2
       formulae, casks = if all
-        [Formula.all(eval_all: args.eval_all?).sort, Cask::Cask.all.sort_by(&:full_name)]
+        [
+          Formula.all(eval_all: args.eval_all?).sort,
+          Cask::Cask.all(eval_all: args.eval_all?).sort_by(&:full_name),
+        ]
       elsif args.installed?
         [Formula.installed.sort, Cask::Caskroom.casks.sort_by(&:full_name)]
       else

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -119,7 +119,7 @@ module Homebrew
         deps += args.installed? ? Formula.installed : Formula.all(eval_all: args.eval_all?)
       end
       if show_formulae_and_casks || args.cask?
-        deps += args.installed? ? Cask::Caskroom.casks : Cask::Cask.all
+        deps += args.installed? ? Cask::Caskroom.casks : Cask::Cask.all(eval_all: args.eval_all?)
       end
 
       if args.missing?

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -100,7 +100,8 @@ class CaskDescriptionCacheStore < DescriptionCacheStore
     return unless eval_all
     return unless database.empty?
 
-    Cask::Cask.all.each { |c| update!(c.full_name, [c.name.join(", "), c.desc.presence]) }
+    Cask::Cask.all(eval_all: eval_all)
+              .each { |c| update!(c.full_name, [c.name.join(", "), c.desc.presence]) }
   end
 
   # Use an update report to update the {CaskDescriptionCacheStore}.

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -145,7 +145,10 @@ module Homebrew
                     "brew audit --eval-all or HOMEBREW_EVAL_ALL"
         end
         no_named_args = true
-        [Formula.all(eval_all: args.eval_all?), Cask::Cask.all]
+        [
+          Formula.all(eval_all: args.eval_all?),
+          Cask::Cask.all(eval_all: args.eval_all?),
+        ]
       else
         if args.named.any? { |named_arg| named_arg.end_with?(".rb") }
           # This odisabled should probably stick around indefinitely,

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -87,7 +87,7 @@ module Homebrew
         formulae + casks
       elsif all
         formulae = args.cask? ? [] : Formula.all(eval_all: args.eval_all?)
-        casks = args.formula? ? [] : Cask::Cask.all
+        casks = args.formula? ? [] : Cask::Cask.all(eval_all: args.eval_all?)
         formulae + casks
       elsif args.named.present?
         if args.formula?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #16378

1. 5a674c232f156ff6a66e78594b8c1167c45c817a

Fix bug in Cask::Cask.all where we'd only read cask files and not attempt to load casks from the API JSON.

I ran a quick benchmark to make sure this isn't going to slow things down more than usual and it seems in the neighborhood so nothing to worry about from a performance perspective.

```shell
$ hyperfine \
  --parameter-list branch master,fix-cask-all \
  --warmup 2 \
  --setup 'git switch {branch}' \
  'HOMEBREW_EVAL_ALL=1 brew ruby -rformula -e \'Cask::Cask.all\''
Benchmark 1: HOMEBREW_EVAL_ALL=1 brew ruby -rformula -e 'Cask::Cask.all' (branch = master)
  Time (mean ± σ):     10.360 s ±  0.039 s    [User: 7.026 s, System: 2.639 s]
  Range (min … max):   10.291 s … 10.435 s    10 runs
 
Benchmark 2: HOMEBREW_EVAL_ALL=1 brew ruby -rformula -e 'Cask::Cask.all' (branch = fix-cask-all)
  Time (mean ± σ):      9.124 s ±  0.120 s    [User: 6.689 s, System: 2.043 s]
  Range (min … max):    9.015 s …  9.346 s    10 runs
 
Summary
  HOMEBREW_EVAL_ALL=1 brew ruby -rformula -e 'Cask::Cask.all' (branch = fix-cask-all) ran
    1.14 ± 0.02 times faster than HOMEBREW_EVAL_ALL=1 brew ruby -rformula -e 'Cask::Cask.all' (branch = master)
```

2. b79778229cce05e362629d6d4d0b2fe7161fc115

Resolve todo to remove ARGV references in Cask::Cask.all by adding the :eval_all parameter. I figured I'd just do this while I was in the area.
