### PR TITLE
cmd/config: Add core cask tap to output

### DIFF
--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -29,6 +29,11 @@ module SystemConfig
       @clt ||= MacOS::CLT.version if MacOS::CLT.installed?
     end
 
+    def core_tap_config(out = $stdout)
+      dump_tap_config(CoreTap.instance, out)
+      dump_tap_config(CoreCaskTap.instance, out)
+    end
+
     def dump_verbose_config(out = $stdout)
       dump_generic_verbose_config(out)
       out.puts "macOS: #{MacOS.full_version}-#{kernel}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This information is occasionally useful when debugging so we should include it by default to make our lives easier.

```console
$ brew config
HOMEBREW_VERSION: 4.2.0-50-g536b37c
ORIGIN: https://github.com/Homebrew/brew
HEAD: 536b37c7665763d30819919a532996d593ef0aa0
Last commit: 4 minutes ago
Core tap origin: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 58c547f2a50e995baf7279f47c1190cab8bcb1f2
Core tap last commit: 6 hours ago
Core tap branch: master
Core tap JSON: 22 Dec 05:08 UTC
Core cask tap origin: https://github.com/Homebrew/homebrew-cask
Core cask tap HEAD: 3c6b6215ed536a26d2cbe18b2e03de0f2ed3c0af
Core cask tap last commit: 3 hours ago
Core cask tap branch: master
Core cask tap JSON: 22 Dec 05:08 UTC
HOMEBREW_PREFIX: /usr/local
HOMEBREW_AUTOREMOVE: set
HOMEBREW_CASK_OPTS: []
HOMEBREW_DEVELOPER: set
HOMEBREW_DISPLAY: /private/tmp/com.apple.launchd.4yAKvlGURn/org.macosforge.xquartz:0
HOMEBREW_EDITOR: code
HOMEBREW_MAKE_JOBS: 4
HOMEBREW_SORBET_RUNTIME: set
Homebrew Ruby: 3.1.4 => /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/3.1.4/bin/ruby
CPU: quad-core 64-bit ivybridge
Clang: 12.0.0 build 1200
Git: 2.24.3 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 10.15.7-x86_64
CLT: 12.0.0.32.29
Xcode: 12.4
```