### PR TITLE
cmd/config: limit tap info output

### DIFF
--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -121,10 +121,10 @@ module SystemConfig
       end
 
       if tap.installed?
-        out.puts "#{tap_name} origin: #{tap.remote}"
+        out.puts "#{tap_name} origin: #{tap.remote}" if tap.remote != tap.default_remote
         out.puts "#{tap_name} HEAD: #{tap.git_head || "(none)"}"
         out.puts "#{tap_name} last commit: #{tap.git_last_commit || "never"}"
-        out.puts "#{tap_name} branch: #{tap.git_branch || "(none)"}"
+        out.puts "#{tap_name} branch: #{tap.git_branch || "(none)"}" if tap.git_branch != "master"
       end
 
       if (json_file = Homebrew::API::HOMEBREW_CACHE_API/json_file_name) && json_file.exist?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/Homebrew/brew/pull/16385#pullrequestreview-1794162825

We really only need to see info that is surprising or out of the norm. For that reason, we can skip showing the tap remote and the tap branch if they are what we expect them to be.

```
$ brew config
HOMEBREW_VERSION: 4.2.0-55-g857ab13
ORIGIN: https://github.com/Homebrew/brew
HEAD: 857ab132a2942c6519e8016b63c1d458ca2e90bf
Last commit: 3 minutes ago
Core tap HEAD: 2d28e828ac78151a5076fe1060beb53dabdaa02f
Core tap last commit: 63 minutes ago
Core tap JSON: 22 Dec 18:22 UTC
Core cask tap HEAD: 30d910ada9cd36305e6110130a8d6ee2e74e61f9
Core cask tap last commit: 59 minutes ago
Core cask tap JSON: 22 Dec 18:22 UTC
HOMEBREW_PREFIX: /usr/local
HOMEBREW_AUTOREMOVE: set
HOMEBREW_CASK_OPTS: []
HOMEBREW_DEVELOPER: set
HOMEBREW_DISPLAY: /private/tmp/com.apple.launchd.F4lxiBJvUl/org.macosforge.xquartz:0
HOMEBREW_EDITOR: code
HOMEBREW_MAKE_JOBS: 4
HOMEBREW_SORBET_RUNTIME: set
Homebrew Ruby: 3.1.4 => /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/3.1.4/bin/ruby
CPU: quad-core 64-bit ivybridge
Clang: 12.0.0 build 1200
Git: 2.24.3 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 10.15.7-x86_64
CLT: 12.0.0.32.29
Xcode: 12.4
```

Compare to the output in https://github.com/Homebrew/brew/pull/16385.