### PR TITLE
os/mac/xcode: support Xcode 15.1

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -17,10 +17,9 @@ module OS
       # This may be a beta version for a beta macOS.
       sig { params(macos: MacOSVersion).returns(String) }
       def self.latest_version(macos: MacOS.version)
-        latest_stable = "14.3"
+        latest_stable = "15.1"
         case macos
-        when "14" then "15.0"
-        when "13" then latest_stable
+        when "14", "13" then latest_stable
         when "12" then "14.2"
         when "11" then "13.2.1"
         when "10.15" then "12.4"
@@ -243,7 +242,7 @@ module OS
         when "13.0.0" then "13.2.1"
         when "13.1.6" then "13.4.1"
         when "14.0.0" then "14.2"
-        when "15.0.0" then "15.0"
+        when "15.0.0" then "15.1"
         else               "14.3"
         end
       end
@@ -339,8 +338,7 @@ module OS
       sig { returns(String) }
       def self.latest_clang_version
         case MacOS.version
-        when "14"    then "1500.0.28.1.1"
-        when "13"    then "1403.0.22.14.1"
+        when "14", "13" then "1500.1.0.2.5"
         when "12"    then "1400.0.29.202"
         when "11"    then "1300.0.29.30"
         when "10.15" then "1200.0.32.29"


### PR DESCRIPTION
I think this is sufficiently stable to recommend for all. Most linker bugs have been fixed.