### PR TITLE
os/mac/hardware: use Westmere on >= Ventura

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -11,9 +11,11 @@ module Hardware
     end
     if CPU.arch == :arm64
       :arm_vortex_tempest
-    # This cannot use a newer CPU e.g. ivybridge because Rosetta 2 does not
+    # This cannot use a newer CPU e.g. haswell because Rosetta 2 does not
     # support AVX instructions in bottles:
     #   https://github.com/Homebrew/homebrew-core/issues/67713
+    elsif version >= :ventura
+      :westmere
     elsif version >= :mojave
       :nehalem
     else

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -29,10 +29,11 @@ module Hardware
           native:             arch_flag("native"),
           ivybridge:          "-march=ivybridge",
           sandybridge:        "-march=sandybridge",
+          westmere:           "-march=westmere",
           nehalem:            "-march=nehalem",
           core2:              "-march=core2",
           core:               "-march=prescott",
-          arm_vortex_tempest: "",
+          arm_vortex_tempest: "", # TODO: -mcpu=apple-m1 when we've patched all our GCCs to support it
           armv6:              "-march=armv6",
           armv8:              "-march=armv8-a",
           ppc64:              "-mcpu=powerpc64",
@@ -225,7 +226,7 @@ module Hardware
       @target_cpu ||= case (cpu = oldest_cpu)
       when :core
         :prescott
-      when :native, :ivybridge, :sandybridge, :nehalem, :core2
+      when :native, :ivybridge, :sandybridge, :westmere, :nehalem, :core2
         cpu
       end
       return if @target_cpu.blank?


### PR DESCRIPTION
Although we can't use anything with AVX in order to support Rosetta (similar to how Apple also avoid AVX in their own tools), we can do a minor bump to Westmere which adds `CLMUL` instructions that Rosetta 2 supports.

Not much of a difference to Nehalem, but it's something.