### PR TITLE
os/mac/hardware/cpu: update M3 value

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -109,8 +109,12 @@ module Hardware
           :arm_firestorm_icestorm
         when 0xda33d83d             # ARMv8.5-A (Blizzard, Avalanche)
           :arm_blizzard_avalanche
-        when 0x8765edea             # ARMv8.6-A (Everest, Sawtooth)
-          :arm_everest_sawtooth
+        when 0xfa33415e             # ARMv8.6-A (M3, Ibiza)
+          :arm_ibiza
+        when 0x5f4dea93             # ARMv8.6-A (M3 Pro, Lobos)
+          :arm_lobos
+        when 0x72015832             # ARMv8.6-A (M3 Max, Palma)
+          :arm_palma
         else
           :dunno
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I ran `brew config` locally on an M3 processor and received this value: `CPU: 14-core 64-bit dunno`. I checked my `hw.cpufamily` using `sysctl -a`: `hw.cpufamily: 1912690738`. Converting this to hex results in the change I've pushed here. This change returns the correct value: `CPU: 14-core 64-bit arm_everest_sawtooth`