### PR TITLE
audit: fix formula path

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -943,7 +943,7 @@ module Cask
       formula_path = Formulary.core_path(cask.token)
                               .to_s
                               .delete_prefix(core_tap.path.to_s)
-      "#{core_tap.default_remote}/blob/HEAD/Formula/#{formula_path}"
+      "#{core_tap.default_remote}/blob/HEAD#{formula_path}"
     end
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
This PR addresses a small issue regarding error messages for cask token conflicts. Presently, when a token conflict arises, an error message is displayed with an incorrect path. For example (highlights mine):

```
possible duplicate, cask token conflicts with Homebrew core formula:
https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula//Formula/o/ollama.rb
                                                   ^^^^^^^^^^^^^^^^^
```

This PR corrects the path in the error message to ensure it reflects the correct location.