### PR TITLE
mac/keg_relocate: use relocatable install names by default

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -98,7 +98,7 @@ class Keg
 
   def loader_name_for(file, target)
     # Use @loader_path-relative install names for other Homebrew-installed binaries.
-    if ENV["HOMEBREW_RELOCATABLE_INSTALL_NAMES"] && target.start_with?(HOMEBREW_PREFIX)
+    if !ENV["HOMEBREW_NO_RELOCATABLE_INSTALL_NAMES"] && target.start_with?(HOMEBREW_PREFIX)
       dylib_suffix = find_dylib_suffix_from(target)
       target_dir = Pathname.new(target.delete_suffix(dylib_suffix)).cleanpath
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

#15571 added relocatable (i.e. `@loader_path`-relative) install names for binaries. This functionality is currently gated behind a `HOMEBREW_RELOCATABLE_INSTALL_NAMES` flag, which has now been [enabled in core CI](https://github.com/Homebrew/homebrew-core/commit/83ef417a20290fe027f7e6b36e68c4976e313ad5) for over 5 months, with no current or major issues that I'm aware of. I've also been testing the feature locally with no problems to report.

**I propose enabling this feature by default in Homebrew**, as was the original plan that we discussed in that PR. I can see no disadvantages in doing so now (but of course I'll take the maintainers' opinions on this).

This PR enables relocatable names by default, with an opt-out via a new `HOMEBREW_NO_RELOCATABLE_INSTALL_NAMES` flag. No other changes are made.

When/if this is merged, the current `HOMEBREW_RELOCATABLE_INSTALL_NAMES` opt-in can be removed from CI at core.