### PR TITLE
Remove irrelevant Rails cops

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -208,25 +208,11 @@ Rails:
     - "Homebrew/rubocops/**/*"
 
 # These relate to ActiveSupport and not other parts of Rails.
-Rails/ActiveSupportAliases:
-  Enabled: true
 Rails/Blank:
   Enabled: true
 Rails/CompactBlank:
   Enabled: true
-Rails/Delegate:
-  Enabled: false # TODO
-Rails/DelegateAllowBlank:
-  Enabled: true
-Rails/DurationArithmetic:
-  Enabled: true
-Rails/ExpandedDateRange:
-  Enabled: true
-Rails/Inquiry:
-  Enabled: true
 Rails/NegateInclude:
-  Enabled: true
-Rails/PluralizationGrammar:
   Enabled: true
 Rails/Presence:
   Enabled: true
@@ -235,15 +221,7 @@ Rails/Present:
   Exclude:
     # `present?` is defined as `!blank?` wihin this file
     - "Homebrew/extend/blank.rb"
-Rails/RelativeDateConstant:
-  Enabled: true
-Rails/SafeNavigation:
-  Enabled: true
 Rails/SafeNavigationWithBlank:
-  Enabled: true
-Rails/StripHeredoc:
-  Enabled: true
-Rails/ToFormattedS:
   Enabled: true
 
 # Intentionally disabled as it doesn't fit with our code style.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
relates to https://github.com/Homebrew/brew/issues/16190 and https://github.com/Homebrew/brew/issues/16190#issuecomment-1854255498 in particular

This removes Rails cops that can't trigger (or be resolved, in the case of `Rails/Delegate`), bc we aren't requiring the components of ActiveSupport that they pertain to. This reduces our surface ActiveSupport dependency surface area a tiny bit, and saves us a few flops on builds.