### PR TITLE
Fix Sorbet/TrueSigil exclusion

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -301,7 +301,6 @@ Sorbet/StrictSigil:
 Sorbet/TrueSigil:
   Enabled: true
   Exclude:
-    - "Homebrew/standalone/init.rb" # loaded before sorbet-runtime
     - "Taps/**/*"
     - "/**/{Formula,Casks}/**/*.rb"
     - "**/{Formula,Casks}/**/*.rb"

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 # This file is included before any other files. It intentionally has typing disabled and has minimal use of `require`.
@@ -9,6 +9,8 @@ gems_vendored = if required_ruby_minor.nil?
   true
 else
   ruby_major, ruby_minor, = RUBY_VERSION.split(".").map(&:to_i)
+  raise "Could not parse Ruby requirements" if !ruby_major || !ruby_minor || !required_ruby_major
+
   if ruby_major < required_ruby_major || (ruby_major == required_ruby_major && ruby_minor < required_ruby_minor)
     raise "Homebrew must be run under Ruby #{required_ruby_major}.#{required_ruby_minor}! " \
           "You're running #{RUBY_VERSION}."
@@ -25,7 +27,8 @@ require "rbconfig"
 $LOAD_PATH.reject! { |path| path.start_with?(RbConfig::CONFIG["sitedir"]) }
 
 require "pathname"
-HOMEBREW_LIBRARY_PATH = Pathname(__dir__).parent.realpath.freeze
+dir = __dir__ || raise("__dir__ is not defined")
+HOMEBREW_LIBRARY_PATH = Pathname(dir).parent.realpath.freeze
 
 require_relative "../utils/gems"
 Homebrew.setup_gem_environment!(setup_path: false)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This is minor (and arguably over-verbose), but resolves the one non-test file we have excluded from type-checking.