### PR TITLE
Remove redirection for default prefixes

### DIFF
--- a/Library/Homebrew/default_prefix.rb
+++ b/Library/Homebrew/default_prefix.rb
@@ -1,7 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-module Homebrew
-  DEFAULT_PREFIX = T.let(ENV.fetch("HOMEBREW_DEFAULT_PREFIX").freeze, String)
-  DEFAULT_REPOSITORY = T.let(ENV.fetch("HOMEBREW_DEFAULT_REPOSITORY").freeze, String)
-end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -70,11 +70,12 @@ require "env_config"
 require "macos_version"
 require "os"
 require "messages"
-require "default_prefix"
 
 module Homebrew
   extend FileUtils
 
+  DEFAULT_PREFIX = T.let(ENV.fetch("HOMEBREW_DEFAULT_PREFIX").freeze, String)
+  DEFAULT_REPOSITORY = T.let(ENV.fetch("HOMEBREW_DEFAULT_REPOSITORY").freeze, String)
   DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar".freeze
   DEFAULT_MACOS_CELLAR = "#{HOMEBREW_DEFAULT_PREFIX}/Cellar".freeze
   DEFAULT_MACOS_ARM_CELLAR = "#{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/Cellar".freeze

--- a/Library/Homebrew/test/support/lib/default_prefix.rb
+++ b/Library/Homebrew/test/support/lib/default_prefix.rb
@@ -1,8 +1,0 @@
-# typed: strict
-# frozen_string_literal: true
-
-module Homebrew
-  # For testing's sake always assume the default prefix
-  DEFAULT_PREFIX = T.let(HOMEBREW_PREFIX.to_s.freeze, String)
-  DEFAULT_REPOSITORY = T.let(HOMEBREW_REPOSITORY.to_s.freeze, String)
-end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This felt like unnecessary redirection to define a pair of constants