### PR TITLE
formula_creator: keep `std_configure_args`

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -167,9 +167,9 @@ module Homebrew
             system "cmake", "--build", "build"
             system "cmake", "--install", "build"
         <% elsif @mode == :autotools %>
-            # Remove unrecognized options if warned by configure
+            # Remove unrecognized options if they cause configure to fail
             # https://rubydoc.brew.sh/Formula.html#std_configure_args-instance_method
-            system "./configure", *std_configure_args, "--disable-silent-rules"
+            system "./configure", "--disable-silent-rules", *std_configure_args
             system "make", "install" # if this fails, try separate make/make install steps
         <% elsif @mode == :crystal %>
             system "shards", "build", "--release"
@@ -214,9 +214,9 @@ module Homebrew
         <% elsif @mode == :rust %>
             system "cargo", "install", *std_cargo_args
         <% else %>
-            # Remove unrecognized options if warned by configure
+            # Remove unrecognized options if they cause configure to fail
             # https://rubydoc.brew.sh/Formula.html#std_configure_args-instance_method
-            system "./configure", *std_configure_args, "--disable-silent-rules"
+            system "./configure", "--disable-silent-rules", *std_configure_args
             # system "cmake", "-S", ".", "-B", "build", *std_cmake_args
         <% end %>
           end


### PR DESCRIPTION
Match `homebrew-core` preferences where we usually keep `std_configure_args` even if some args are unrecognized and where we pass any additional args before `std_configure_args`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think we usually only need to remove these options if upstream is using a non-autotools `configure` script which has strict failures on undefined options.