### PR TITLE
dependency: add `until` bound to `uses_from_macos`

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -279,7 +279,8 @@ class UsesFromMacOSDependency < Dependency
       if Homebrew::SimulateSystem.current_os != :macos
         current_os = MacOSVersion.from_symbol(Homebrew::SimulateSystem.current_os)
         since_os = MacOSVersion.from_symbol(bounds[:since]) if bounds.key?(:since)
-        return true if current_os >= since_os
+        until_os = MacOSVersion.from_symbol(bounds[:until]) if bounds.key?(:until)
+        return true if current_os >= since_os && (until_os.nil? || current_os <= until_os)
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think we were discussing something like this back in Ventura due to missing `texinfo` and `groff`.

Interpreting `until` as inclusive of bound (Probably need to document whether inclusive/exclusive as can be ambiguous).

Probably need some tests/docs and will need to check if anything else is needed to support this.