### PR TITLE
update-python-resources: show pip install failure when `--verbose`

### DIFF
--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -45,6 +45,7 @@ module Homebrew
                                     exclude_packages:         args.exclude_packages,
                                     print_only:               args.print_only?,
                                     silent:                   args.silent?,
+                                    verbose:                  args.verbose?,
                                     ignore_non_pypi_packages: args.ignore_non_pypi_packages?
     end
   end


### PR DESCRIPTION
Also use `--disable-pip-version-check` to remove pip update notices

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Right now, `brew update-python-resources` will just give a generic:
```
Error: Unable to determine dependencies for "..." because of a failure when running ...
Please update the resources manually.
```

When trying to figure out reason, I found it useful to see the actual failure (which is currently hidden behind the `HOMEBREW_STDERR` variable, but setting that can lead to unwanted errors due to Sorbet).

---

Also worth setting `--disable-pip-version-check` to avoid some spam when showing stderr:
```
[notice] A new release of pip is available: 23.3.1 -> 23.3.2
[notice] To update, run: /opt/homebrew/opt/python@3.11/bin/python3.11 -m pip install --upgrade pip
```