### PR TITLE
rubocops/components_redundancy: stable/head block removal

### DIFF
--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -72,5 +72,47 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
         end
       RUBY
     end
+
+    it "reports an offense if `stable do` or `head do` is present with only `url`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          stable do
+          ^^^^^^^^^ FormulaAudit/ComponentsRedundancy: `stable do` should not be present with only url/sha256/mirror/version
+            url "https://brew.sh/foo-1.0.tgz"
+          end
+
+          head do
+          ^^^^^^^ FormulaAudit/ComponentsRedundancy: `head do` should not be present with only `url`
+            url "https://brew.sh/foo.git"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses if `stable do` is present with `url` and `depends_on`" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          head "https://brew.sh/foo.git"
+
+          stable do
+            url "https://brew.sh/foo-1.0.tgz"
+            depends_on "bar"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses if `head do` is present with `url` and `depends_on`" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+          head do
+            url "https://brew.sh/foo.git"
+            depends_on "bar"
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
When a `stable do` or `head do` block only contains `url`, `sha256`, `mirror`, and/or `version`, then the block should be removed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
