### PR TITLE
chore: add audit to check if an EOL is known

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -12,6 +12,16 @@ module SharedAudits
 
   module_function
 
+  def eol_data(product, cycle)
+    @eol_data ||= {}
+    @eol_data["#{product}/#{cycle}"] ||= begin
+      out, _, status = Utils::Curl.curl_output("--location", "https://endoflife.date/api/#{product}/#{cycle}.json")
+      json = JSON.parse(out) if status.success?
+      json = nil if json&.dig("message")&.include?("Product not found")
+      json
+    end
+  end
+
   def github_repo_data(user, repo)
     @github_repo_data ||= {}
     @github_repo_data["#{user}/#{repo}"] ||= GitHub.repository(user, repo)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This should give us some warning if software has a known EOL date