### PR TITLE
API: Load casks/formula from JSON with missing keys

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -124,11 +124,12 @@ module Homebrew
 
     sig { params(json: Hash).returns(Hash) }
     def self.merge_variations(json)
+      return json unless json.key?("variations")
+
       bottle_tag = ::Utils::Bottles::Tag.new(system: Homebrew::SimulateSystem.current_os,
                                              arch:   Homebrew::SimulateSystem.current_arch)
 
-      if (variations = json["variations"].presence) &&
-         (variation = variations[bottle_tag.to_s].presence)
+      if (variation = json.dig("variations", bottle_tag.to_s).presence)
         json = json.merge(variation)
       end
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -279,7 +279,7 @@ module Cask
     def populate_from_api!(json_cask)
       raise ArgumentError, "Expected cask to be loaded from the API" unless loaded_from_api?
 
-      @languages = json_cask[:languages]
+      @languages = json_cask.fetch(:languages, [])
       @tap_git_head = json_cask.fetch(:tap_git_head, "HEAD")
 
       @ruby_source_path = json_cask[:ruby_source_path]

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -280,7 +280,7 @@ module Cask
 
           url json_cask[:url], **json_cask.fetch(:url_specs, {}) if json_cask[:url].present?
           appcast json_cask[:appcast] if json_cask[:appcast].present?
-          json_cask[:name].each do |cask_name|
+          json_cask[:name]&.each do |cask_name|
             name cask_name
           end
           desc json_cask[:desc]

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -154,14 +154,14 @@ module Formulary
 
     json_formula = Homebrew::API.merge_variations(json_formula)
 
-    uses_from_macos_names = json_formula["uses_from_macos"].map do |dep|
+    uses_from_macos_names = json_formula["uses_from_macos"]&.map do |dep|
       next dep unless dep.is_a? Hash
 
       dep.keys.first
     end
 
     requirements = {}
-    json_formula["requirements"].map do |req|
+    json_formula["requirements"]&.map do |req|
       req_name = req["name"].to_sym
       next if API_SUPPORTED_REQUIREMENTS.exclude?(req_name)
 
@@ -176,7 +176,7 @@ module Formulary
 
       req_tags = []
       req_tags << req_version if req_version.present?
-      req_tags += req["contexts"].map do |tag|
+      req_tags += req["contexts"]&.map do |tag|
         case tag
         when String
           tag.to_sym
@@ -202,7 +202,7 @@ module Formulary
 
       dep_json = json_formula.fetch("#{spec}_dependencies", json_formula)
 
-      dep_json["dependencies"].each do |dep|
+      dep_json["dependencies"]&.each do |dep|
         # Backwards compatibility check - uses_from_macos used to be a part of dependencies on Linux
         next if !json_formula.key?("uses_from_macos_bounds") && uses_from_macos_names.include?(dep) &&
                 !Homebrew::SimulateSystem.simulating_or_running_on_macos?
@@ -211,7 +211,7 @@ module Formulary
       end
 
       [:build, :test, :recommended, :optional].each do |type|
-        dep_json["#{type}_dependencies"].each do |dep|
+        dep_json["#{type}_dependencies"]&.each do |dep|
           # Backwards compatibility check - uses_from_macos used to be a part of dependencies on Linux
           next if !json_formula.key?("uses_from_macos_bounds") && uses_from_macos_names.include?(dep) &&
                   !Homebrew::SimulateSystem.simulating_or_running_on_macos?
@@ -220,7 +220,7 @@ module Formulary
         end
       end
 
-      dep_json["uses_from_macos"].each_with_index do |dep, index|
+      dep_json["uses_from_macos"]&.each_with_index do |dep, index|
         bounds = dep_json.fetch("uses_from_macos_bounds", [])[index] || {}
         bounds.deep_transform_keys!(&:to_sym)
         bounds.deep_transform_values! { |val| val.is_a?(String) ? val.to_sym : val }
@@ -311,7 +311,7 @@ module Formulary
         disable! date: disable_date, because: reason
       end
 
-      json_formula["conflicts_with"].each_with_index do |conflict, index|
+      json_formula["conflicts_with"]&.each_with_index do |conflict, index|
         conflicts_with conflict, because: json_formula.dig("conflicts_with_reasons", index)
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related to the discussion in https://github.com/Homebrew/brew/issues/16410 and the first bullet point in https://github.com/Homebrew/brew/issues/16410#issuecomment-1873432513.

We'd like to reduce the size of the API JSON and to do that we are going to remove unused and/or blank elements from the cask/formula definition. This will reduce the amount of data that has to go over the wire and make it easier to load this data into memory.

Beyond the code I've changed here, there are a few other spots that I've decided not to update to handle null values because they should always be present anyway and if they're missing, we'll have bigger problems to deal with.

https://github.com/Homebrew/brew/blob/080e61f9bc0aa36c246a5377e42657c75e04c9d3/Library/Homebrew/formulary.rb#L288

https://github.com/Homebrew/brew/blob/080e61f9bc0aa36c246a5377e42657c75e04c9d3/Library/Homebrew/cask/cask_loader.rb#L338