### PR TITLE
dependency: cleanup unused code

### DIFF
--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -73,15 +73,6 @@ describe Dependency do
     end
   end
 
-  it "merges dependencies and preserves env_proc" do
-    env_proc = double
-    dep = described_class.new("foo", [], env_proc)
-    allow(dep).to receive(:to_formula).and_return \
-      instance_double(Formula, deps: [], name: "foo", full_name: "foo")
-    deps.replace([dep])
-    expect(described_class.expand(formula).first.env_proc).to eq(env_proc)
-  end
-
   it "merges tags without duplicating them" do
     foo2 = build_dep(:foo, ["option"])
     foo3 = build_dep(:foo, ["option"])

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -33,22 +33,18 @@ describe Dependency do
 
   describe "::merge_repeats" do
     it "merges duplicate dependencies" do
-      dep = described_class.new("foo", [:build], nil, "foo")
-      dep2 = described_class.new("foo", ["bar"], nil, "foo2")
-      dep3 = described_class.new("xyz", ["abc"], nil, "foo")
+      dep = described_class.new("foo", [:build])
+      dep2 = described_class.new("foo", ["bar"])
+      dep3 = described_class.new("xyz", ["abc"])
       merged = described_class.merge_repeats([dep, dep2, dep3])
       expect(merged.count).to eq(2)
       expect(merged.first).to be_a described_class
 
       foo_named_dep = merged.find { |d| d.name == "foo" }
       expect(foo_named_dep.tags).to eq(["bar"])
-      expect(foo_named_dep.option_names).to include("foo")
-      expect(foo_named_dep.option_names).to include("foo2")
 
       xyz_named_dep = merged.find { |d| d.name == "xyz" }
       expect(xyz_named_dep.tags).to eq(["abc"])
-      expect(xyz_named_dep.option_names).to include("foo")
-      expect(xyz_named_dep.option_names).not_to include("foo2")
     end
 
     it "merges necessity tags" do


### PR DESCRIPTION
Most of this wasn't used since the removal of default_formula from Requirements.