### PR TITLE
Enable Sorbet/ImplicitConversionMethod cop

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -264,6 +264,24 @@ Sorbet/ConstantsFromStrings:
 Sorbet/FalseSigil:
   Enabled: false
 
+# Implicit conversions have been a frequent source of runtime errors
+Sorbet/ImplicitConversionMethod:
+  Enabled: true
+  # TODO: These are pre-existing violations and should be corrected
+  Exclude:
+    - Homebrew/PATH.rb
+    - Homebrew/extend/pathname.rb
+    - Homebrew/formula.rb
+    - Homebrew/formula_support.rb
+    - Homebrew/livecheck.rb
+    - Homebrew/options.rb
+    - Homebrew/pkg_version.rb
+    - Homebrew/software_spec.rb
+    - Homebrew/system_command.rb
+    - Homebrew/tap.rb
+    - Homebrew/version.rb
+    - Taps/homebrew/homebrew-services/lib/service/formula_wrapper.rb
+
 # T::Sig is monkey-patched into Module
 Sorbet/RedundantExtendTSig:
   Enabled: true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Ruby supports a few methods that allow implicit type [conversions](https://docs.ruby-lang.org/en/3.2/implicit_conversion_rdoc.html).

Since Sorbet is a nominal (not [structural](https://sorbet.org/docs/faq#can-i-use-sorbet-for-duck-typed-code)) type system, implicit conversion is currently [unsupported](https://sorbet.run/#%23%20typed%3A%20true%0A%0Aclass%20Pathname%0A%20%20extend%20T%3A%3ASig%0A%20%20sig%20%7B%20returns%28String%29%20%7D%0A%20%20def%20to_str%0A%20%20%20%20to_s%0A%20%20end%0Aend%0A%0A''%20%2B%20Pathname%28'%2F'%29%20%23%20%3D%3E%20%22%2F%22).

Thus, implicit type conversions have historically been a factory for runtime type errors. A selection I found with a quick search includes:

https://github.com/Homebrew/brew/pull/15805
https://github.com/Homebrew/brew/pull/15741
https://github.com/Homebrew/brew/pull/15739
https://github.com/Homebrew/brew/pull/15738
https://github.com/Homebrew/brew/pull/15733
https://github.com/Homebrew/brew/pull/15729
https://github.com/Homebrew/brew/pull/13841

For this reason, I wrote this cop [upstream](https://github.com/Shopify/rubocop-sorbet/pull/165), largely with brew in mind. Existing violations are grandfathered in, for now (I can look into fixing these, but the primary goal of this PR is to contain this antipattern).