### PR TITLE
Homebrew-on-Linux.md: switch to `pacman -S`

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -69,7 +69,7 @@ To install build tools, paste at a terminal prompt:
 - **Arch Linux**
 
   ```sh
-  sudo pacman -Syu base-devel procps-ng curl file git
+  sudo pacman -S base-devel procps-ng curl file git
   ```
 
 ### ARM (unsupported)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] ~Have you successfully run `brew typecheck` with your changes locally?~
- [ ] ~Have you successfully run `brew tests` with your changes locally?~

-----

I realized the convention in documentations is to recommend `-S`, not `-Syu`, as a system upgrade is usually an overkill. This change also makes Homebrew's documentation more consistent.