### PR TITLE
WIP: Slim down formula API JSON

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -58,10 +58,14 @@ module Homebrew
       Formulary.enable_factory_cache!
       Formula.generating_hash!
 
+      api_json = []
+
       tap.formula_names.each do |name|
         formula = Formulary.factory(name)
         name = formula.name
-        json = JSON.pretty_generate(formula.to_hash_with_variations)
+        formula_hash = formula.to_hash_with_variations
+        json = JSON.pretty_generate(formula_hash)
+        api_json << API::Formula.slim_hash(formula_hash)
         html_template_name = html_template(name)
 
         unless args.dry_run?
@@ -74,6 +78,7 @@ module Homebrew
         raise
       end
 
+      File.write("formula.json", JSON.generate(api_json))
       canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
       File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
     end

--- a/Library/Homebrew/utils/collection.rb
+++ b/Library/Homebrew/utils/collection.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+module Utils
+  module Collection
+    def self.recursive_compact(value)
+      case value
+      when Array
+        recursive_compact_array(value)
+      when Hash
+        recursive_compact_hash(value)
+      else
+        value
+      end
+    end
+
+    sig { params(array: Array).returns(T.nilable(Array)) }
+    def self.recursive_compact_array(array)
+      array.map do |value|
+        recursive_compact(value)
+      end.compact.presence
+    end
+
+    sig { params(hash: Hash).returns(T.nilable(Hash)) }
+    def self.recursive_compact_hash(hash)
+      hash.transform_values do |value|
+        recursive_compact(value)
+      end.compact.presence
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related to https://github.com/Homebrew/brew/issues/16410

The idea here is to create a file with the slimmed down formula JSON that omits certain fields and removes nil values, empty hashes and empty arrays. It looks like the resulting file is around half the size.