### PR TITLE
Fixes `openjdk_dep_name_if_applicable` when not using `CurlGitHubPackagesDownloadStrategy`

### DIFF
--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -13,4 +13,44 @@ describe Utils::Bottles do
       end
     end
   end
+
+  describe ".load_tab" do
+    context "when tab_attributes and tabfile are missing" do
+      before do
+        # setup a testball1
+        dep_name = "testball1"
+        dep_path = CoreTap.new.new_formula_path(dep_name)
+        dep_path.write <<~RUBY
+          class #{Formulary.class_s(dep_name)} < Formula
+            url "testball1"
+            version "0.1"
+          end
+        RUBY
+        Formulary.cache.delete(dep_path)
+
+        # setup a testball2, that depends on testball1
+        formula_name = "testball2"
+        formula_path = CoreTap.new.new_formula_path(formula_name)
+        formula_path.write <<~RUBY
+          class #{Formulary.class_s(formula_name)} < Formula
+            url "testball2"
+            version "0.1"
+            depends_on "testball1"
+          end
+        RUBY
+        Formulary.cache.delete(formula_path)
+      end
+
+      it "includes runtime_dependencies" do
+        formula = Formula["testball2"]
+        formula.prefix.mkpath
+
+        runtime_dependencies = described_class.load_tab(formula).runtime_dependencies
+
+        expect(runtime_dependencies).not_to be_nil
+        expect(runtime_dependencies.size).to eq(1)
+        expect(runtime_dependencies.first).to include("full_name" => "testball1")
+      end
+    end
+  end
 end

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -118,9 +118,9 @@ module Utils
         else
           tab = Tab.for_keg(keg)
 
-          if tab.runtime_dependencies.nil?
+          tab.runtime_dependencies = begin
             f_runtime_deps = formula.runtime_dependencies(read_from_tab: false)
-            tab.runtime_dependencies = Tab.runtime_deps_hash(formula, f_runtime_deps)
+            Tab.runtime_deps_hash(formula, f_runtime_deps)
           end
 
           tab

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -116,7 +116,14 @@ module Utils
           tab_json = bottle_hash[formula.full_name]["bottle"]["tags"][tag]["tab"].to_json
           Tab.from_file_content(tab_json, tabfile)
         else
-          Tab.for_keg(keg)
+          tab = Tab.for_keg(keg)
+
+          if tab.runtime_dependencies.nil?
+            f_runtime_deps = formula.runtime_dependencies(read_from_tab: false)
+            tab.runtime_dependencies = Tab.runtime_deps_hash(formula, f_runtime_deps)
+          end
+
+          tab
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes `openjdk_dep_name_if_applicable` when not using `CurlGitHubPackagesDownloadStrategy`

When installing a formula, `FormulaInstaller` calls `#pour`, which in turn calls:

https://github.com/Homebrew/brew/blob/6f20c0300aee2ab0feae3132d13f859d91cf295b/Library/Homebrew/formula_installer.rb#L1260

This `tab` is expected to have `#runtime_dependencies`, and it typically will because most packages come from http://ghcr.io

https://github.com/Homebrew/brew/blob/6f20c0300aee2ab0feae3132d13f859d91cf295b/Library/Homebrew/utils/bottles.rb#L111

Any `DownloadStrategy` that does not match `CurlGitHubPackagesDownloadStrategy` will lead here: https://github.com/Homebrew/brew/blob/6f20c0300aee2ab0feae3132d13f859d91cf295b/Library/Homebrew/software_spec.rb#L463

Causing this branch to be executed for creating the `tab`, without `#runtime_dependencies`: https://github.com/Homebrew/brew/blob/6f20c0300aee2ab0feae3132d13f859d91cf295b/Library/Homebrew/utils/bottles.rb#L119

This causes a slight issue because `openjdk_dep_name_if_applicable` calls `keg.runtime_dependencies` when it's still `nil`.

https://github.com/Homebrew/brew/blob/6f20c0300aee2ab0feae3132d13f859d91cf295b/Library/Homebrew/keg_relocate.rb#L134-L140

And if it's blank, it won't do the regex replacement on `@@HOMEBREW_JAVA@@`, resulting in the following error when running `Kafka`:

```console
$ tail -f /opt/homebrew/var/log/kafka/kafka_output.log
/opt/homebrew/Cellar/kafka/3.6.0/libexec/bin/kafka-run-class.sh: line 346: /opt/homebrew/@@HOMEBREW_JAVA@@/bin/java: No such file or directory
/opt/homebrew/Cellar/kafka/3.6.0/libexec/bin/kafka-run-class.sh: line 346: exec: /opt/homebrew/@@HOMEBREW_JAVA@@/bin/java: cannot execute: No such file or directory
```

As mentioned by: https://github.com/orgs/Homebrew/discussions/2530#discussioncomment-2002374

> Installing Java-dependent formulae from bottle mirrors doesn't work properly at the moment. The issue is that brew needs the manifest in order to correctly replace @@HOMEBREW_JAVA@@ but brew only knows how to fetch manifests from ghcr.io.
> Pull requests to fix this welcome.

This should fix this issue, by getting the `runtime_dependencies` directly from the formula for those cases that it can't get it from https://ghcr.io or tabfile

```ruby
f_runtime_deps = formula.runtime_dependencies(read_from_tab: false)
tab.runtime_dependencies = Tab.runtime_deps_hash(formula, f_runtime_deps)
```