### PR TITLE
pypi: stop excluding setuptools

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -258,7 +258,7 @@ module PyPI
     extra_packages = (extra_packages || []).map { |p| Package.new p }
     exclude_packages = (exclude_packages || []).map { |p| Package.new p }
     exclude_packages += %w[argparse pip wsgiref].map { |p| Package.new p }
-    if python_deps.first && python_deps.first.version < Version.new("3.12")
+    if (newest_python = python_deps.first) && newest_python.version < Version.new("3.12")
       exclude_packages.append(Package.new("setuptools"))
     end
     # remove packages from the exclude list if we've explicitly requested them as an extra package

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -249,9 +249,18 @@ module PyPI
       end
     end
 
+    python_deps = formula.deps
+                         .select { |d| d.name.match?(/^python(@.+)?$/) }
+                         .map(&:to_formula)
+                         .sort_by(&:version)
+                         .reverse
+
     extra_packages = (extra_packages || []).map { |p| Package.new p }
     exclude_packages = (exclude_packages || []).map { |p| Package.new p }
-    exclude_packages += %w[argparse pip setuptools wsgiref].map { |p| Package.new p }
+    exclude_packages += %w[argparse pip wsgiref].map { |p| Package.new p }
+    if python_deps.first && python_deps.first.version < Version.new("3.12")
+      exclude_packages.append(Package.new("setuptools"))
+    end
     # remove packages from the exclude list if we've explicitly requested them as an extra package
     exclude_packages.delete_if { |package| extra_packages.include?(package) }
 
@@ -277,11 +286,6 @@ module PyPI
       end
     end
 
-    python_deps = formula.deps
-                         .map(&:to_formula)
-                         .select { |f| f.name.start_with?("python@") }
-                         .sort_by(&:version)
-                         .reverse
     python_name = if python_deps.empty?
       "python"
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

Python 3.12 no longer bundles setuptools (see https://docs.python.org/3/whatsnew/3.12.html#ensurepip), so `brew update-python-resources` shouldn't exclude it anymore for those versions

See also https://github.com/orgs/Homebrew/discussions/5028, https://github.com/Homebrew/homebrew-core/pull/159180
