### PR TITLE
cmd/audit: fix type error in cask livecheck url audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -806,10 +806,11 @@ module Cask
     def audit_livecheck_https_availability
       return unless online?
       return unless cask.livecheckable?
-      return if cask.livecheck.url.is_a?(Symbol)
+      return unless (url = cask.livecheck.url)
+      return if url.is_a?(Symbol)
 
       validate_url_for_https_availability(
-        cask.livecheck.url, "livecheck URL",
+        url, "livecheck URL",
         check_content: true
       )
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This got updated recently in 42a42c96acc5193dbb6e321ff2aaecceb00e48a4 to split out the livecheck audits and as a result of that the type signature for the #validate_url_for_https_availablity method got updated.

This did not account for the possibility that the livecheck url was nil. I've added a nil check here since it makes no sense to try and validate a nil url and we have nil checks for the other two http availability audits already. Plus, the livecheck blocks are audited thoroughly already for syntax.

This should fix the audit error mentioned in https://github.com/Homebrew/brew/pull/16438#issuecomment-1880200011.

CC: @reitermarkus @bevanjkay