### PR TITLE
completions: ignore errors on cask list generation.

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -22,7 +22,7 @@ then
 fi
 
 __brewcomp_words_include() {
-  local element idx 
+  local element idx
   for (( idx = 1; idx < COMP_CWORD; idx++ ))
   do
     element=${COMP_WORDS[idx]}
@@ -88,7 +88,7 @@ __brew_complete_outdated_formulae() {
 __brew_complete_outdated_casks() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local outdated_casks
-  outdated_casks="$(brew outdated --cask --quiet)"
+  outdated_casks="$(brew outdated --cask --quiet 2>/dev/null)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_casks}" -- "${cur}")
 }
 

--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -98,7 +98,7 @@ __brew_installed_casks() {
 
   local -a list
   local expl
-  list=( $(brew list --cask) )
+  list=( $(brew list --cask 2>/dev/null) )
   _wanted list expl 'installed casks' compadd -a list
 }
 
@@ -106,7 +106,7 @@ __brew_outdated_casks() {
   [[ -prefix '-' ]] && return 0
 
   local -a casks
-  casks=($(brew outdated --cask))
+  casks=($(brew outdated --cask 2>/dev/null))
   _describe -t casks 'outdated casks' casks
 }
 


### PR DESCRIPTION
These will always error on Linux.

Fixes #16424