### PR TITLE
Introduce Formulary platform cache

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -64,7 +64,6 @@ module Homebrew
 
         os_arch_combinations.each do |os, arch|
           SimulateSystem.with os: os, arch: arch do
-            Formulary.clear_cache
             formula = Formulary.factory(ref)
             print_formula_cache(formula, os: os, arch: arch, args: args)
           end

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -99,7 +99,6 @@ module Homebrew
 
         os_arch_combinations.each do |os, arch|
           SimulateSystem.with os: os, arch: arch do
-            Formulary.clear_cache
             formula = Formulary.factory(ref, args.HEAD? ? :head : :stable)
 
             formula.print_tap_action verb: "Fetching"

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -205,8 +205,6 @@ module Homebrew
     spdx_license_data = SPDX.license_data
     spdx_exception_data = SPDX.exception_data
 
-    clear_formulary_cache = [args.os, args.arch].any?
-
     formula_problems = audit_formulae.sort.each_with_object({}) do |f, problems|
       path = f.path
 
@@ -227,8 +225,6 @@ module Homebrew
       errors = os_arch_combinations.flat_map do |os, arch|
         SimulateSystem.with os: os, arch: arch do
           odebug "Auditing Formula #{f} on os #{os} and arch #{arch}"
-
-          Formulary.clear_cache if clear_formulary_cache
 
           audit_proc = proc { FormulaAuditor.new(Formulary.factory(path), **options).tap(&:audit) }
 

--- a/Library/Homebrew/test_runner_formula.rb
+++ b/Library/Homebrew/test_runner_formula.rb
@@ -97,8 +97,6 @@ class TestRunnerFormula
       end
 
       with_env(HOMEBREW_EVAL_ALL: eval_all_env) do
-        Formulary.clear_cache
-
         os = macos_version || platform
         arch = SIMULATE_SYSTEM_SYMBOLS.fetch(arch)
 


### PR DESCRIPTION
Haven't really tested this properly but aim here is to get rid of `Formulary.clear_cache` calls whenever we use `Homebrew::SimulateSystem`...