### PR TITLE
api: use freeze option for JSON parsing

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -30,7 +30,7 @@ module Homebrew
       end
       raise ArgumentError, "No file found at #{Tty.underline}#{api_url}#{Tty.reset}" unless output.success?
 
-      cache[endpoint] = JSON.parse(output.stdout)
+      cache[endpoint] = JSON.parse(output.stdout, freeze: true)
     rescue JSON::ParserError
       raise ArgumentError, "Invalid JSON file: #{Tty.underline}#{api_url}#{Tty.reset}"
     end
@@ -96,7 +96,7 @@ module Homebrew
 
         mtime = insecure_download ? Time.new(1970, 1, 1) : Time.now
         FileUtils.touch(target, mtime: mtime) unless skip_download
-        JSON.parse(target.read)
+        JSON.parse(target.read, freeze: true)
       rescue JSON::ParserError
         target.unlink
         retry_count += 1
@@ -170,7 +170,7 @@ module Homebrew
         return false, "signature mismatch"
       end
 
-      [true, JSON.parse(json_data["payload"])]
+      [true, JSON.parse(json_data["payload"], freeze: true)]
     end
 
     sig { params(path: Pathname).returns(T.nilable(Tap)) }

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -47,13 +47,13 @@ module Homebrew
 
           cache["renames"] = {}
           cache["casks"] = json_casks.to_h do |json_cask|
-            token = json_cask.delete("token")
+            token = json_cask["token"]
 
             json_cask.fetch("old_tokens", []).each do |old_token|
               cache["renames"][old_token] = token
             end
 
-            [token, json_cask]
+            [token, json_cask.except("token")]
           end
 
           updated

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -349,7 +349,7 @@ module Cask
 
     def to_hash_with_variations
       if loaded_from_api? && !Homebrew::EnvConfig.no_install_from_api?
-        return api_to_local_hash(Homebrew::API::Cask.all_casks[token])
+        return api_to_local_hash(Homebrew::API::Cask.all_casks[token].dup)
       end
 
       hash = to_h

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -232,7 +232,7 @@ module Formulary
       end
 
       dep_json["uses_from_macos"]&.each_with_index do |dep, index|
-        bounds = dep_json.fetch("uses_from_macos_bounds", [])[index] || {}
+        bounds = dep_json.fetch("uses_from_macos_bounds", [])[index].dup || {}
         bounds.deep_transform_keys!(&:to_sym)
         bounds.deep_transform_values! { |val| val.is_a?(String) ? val.to_sym : val }
 


### PR DESCRIPTION
This undocumented option seems to reduce total objects by ~185k.