### PR TITLE
formulary: allow for more keyless fields when loading from API

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -165,7 +165,7 @@ module Formulary
 
     json_formula = Homebrew::API.merge_variations(json_formula)
 
-    uses_from_macos_names = json_formula["uses_from_macos"]&.map do |dep|
+    uses_from_macos_names = json_formula.fetch("uses_from_macos", []).map do |dep|
       next dep unless dep.is_a? Hash
 
       dep.keys.first
@@ -382,12 +382,12 @@ module Formulary
         self.class.instance_variable_get(:@oldnames_array)
       end
 
-      @aliases_array = json_formula["aliases"]
+      @aliases_array = json_formula.fetch("aliases", [])
       def aliases
         self.class.instance_variable_get(:@aliases_array)
       end
 
-      @versioned_formulae_array = json_formula["versioned_formulae"]
+      @versioned_formulae_array = json_formula.fetch("versioned_formulae", [])
       def versioned_formulae_names
         self.class.instance_variable_get(:@versioned_formulae_array)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These were fields I missed the first time around in https://github.com/Homebrew/brew/pull/16420. Now the values should line up with the expected values.

I checked it with https://github.com/apainintheneck/homebrew-dev-utils/pull/36 and a new branch I'm working on locally based on https://github.com/Homebrew/brew/pull/16433#issuecomment-1882564053.