### PR TITLE
formula: add slimmer api json v3 representation

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -55,8 +55,7 @@ module Homebrew
       tap_migrations_json = JSON.dump(tap.tap_migrations)
       File.write("api/formula_tap_migrations.json", tap_migrations_json) unless args.dry_run?
 
-      internal_formula_v3_hash = {
-        "tap_name"       => tap.name,
+      homebrew_core_tap_hash = {
         "tap_git_head"   => tap.git_head,
         "aliases"        => tap.alias_table,
         "renames"        => tap.formula_renames,
@@ -79,14 +78,14 @@ module Homebrew
           File.write("formula/#{name}.html", html_template_name)
         end
 
-        internal_formula_v3_hash["formulae"][formula.name] = formula.to_api_hash.except("name")
+        homebrew_core_tap_hash["formulae"][formula.name] = formula.to_api_hash.except("name")
       rescue
         onoe "Error while generating data for formula '#{name}'."
         raise
       end
 
-      internal_formula_v3_json = JSON.generate(internal_formula_v3_hash)
-      File.write("api/internal_formula_v3.json", internal_formula_v3_json) unless args.dry_run?
+      homebrew_core_tap_json = JSON.generate(homebrew_core_tap_hash)
+      File.write("api/homebrew-core.json", homebrew_core_tap_json) unless args.dry_run?
       canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
       File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
     end

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -56,10 +56,12 @@ module Homebrew
       File.write("api/formula_tap_migrations.json", tap_migrations_json) unless args.dry_run?
 
       internal_formula_v3_hash = {
+        "tap_name"       => tap.name,
+        "tap_git_head"   => tap.git_head,
         "aliases"        => tap.alias_table,
-        "formulae"       => {},
         "renames"        => tap.formula_renames,
         "tap_migrations" => tap.tap_migrations,
+        "formulae"       => {},
       }
 
       Formulary.enable_factory_cache!

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -77,7 +77,7 @@ module Homebrew
       end
 
       internal_formula_json = JSON.generate(internal_formula_hashes)
-      File.write("internal_formula.json", internal_formula_json) unless args.dry_run?
+      File.write("api/internal_formula.json", internal_formula_json) unless args.dry_run?
       canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
       File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
     end

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -58,10 +58,12 @@ module Homebrew
       Formulary.enable_factory_cache!
       Formula.generating_hash!
 
+      internal_formula_hashes = []
       tap.formula_names.each do |name|
         formula = Formulary.factory(name)
         name = formula.name
         json = JSON.pretty_generate(formula.to_hash_with_variations)
+        internal_formula_hashes << formula.to_api_hash
         html_template_name = html_template(name)
 
         unless args.dry_run?
@@ -74,6 +76,8 @@ module Homebrew
         raise
       end
 
+      internal_formula_json = JSON.generate(internal_formula_hashes)
+      File.write("internal_formula.json", internal_formula_json) unless args.dry_run?
       canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
       File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
     end

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -55,15 +55,20 @@ module Homebrew
       tap_migrations_json = JSON.dump(tap.tap_migrations)
       File.write("api/formula_tap_migrations.json", tap_migrations_json) unless args.dry_run?
 
+      internal_formula_v3_hash = {
+        "aliases"        => tap.alias_table,
+        "formulae"       => {},
+        "renames"        => tap.formula_renames,
+        "tap_migrations" => tap.tap_migrations,
+      }
+
       Formulary.enable_factory_cache!
       Formula.generating_hash!
 
-      internal_formula_hashes = []
       tap.formula_names.each do |name|
         formula = Formulary.factory(name)
         name = formula.name
         json = JSON.pretty_generate(formula.to_hash_with_variations)
-        internal_formula_hashes << formula.to_api_hash
         html_template_name = html_template(name)
 
         unless args.dry_run?
@@ -71,13 +76,15 @@ module Homebrew
           File.write("api/formula/#{name}.json", FORMULA_JSON_TEMPLATE)
           File.write("formula/#{name}.html", html_template_name)
         end
+
+        internal_formula_v3_hash["formulae"][formula.name] = formula.to_api_hash.except("name")
       rescue
         onoe "Error while generating data for formula '#{name}'."
         raise
       end
 
-      internal_formula_json = JSON.generate(internal_formula_hashes)
-      File.write("api/internal_formula.json", internal_formula_json) unless args.dry_run?
+      internal_formula_v3_json = JSON.generate(internal_formula_v3_hash)
+      File.write("api/internal_formula_v3.json", internal_formula_v3_json) unless args.dry_run?
       canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
       File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2446,17 +2446,25 @@ class Formula
       "oldnames",
       "tap",
       "tap_git_head",
+      # Not used at all and identical to "name" anyway.
+      "full_name",
     )
 
     # Remove keys that default to zero.
     %w[revision version_scheme].each do |key|
-      next unless api_hash[key].zero?
+      next unless api_hash.fetch(key).zero?
 
       api_hash.delete(key)
     end
 
+    # Remove unused url options.
+    api_hash["urls"] = api_hash.fetch("urls").transform_values(&:compact)
+
     if (stable_bottle = api_hash.dig("bottle", "stable"))
-      stable_bottle["files"] = stable_bottle["files"].transform_values do |file|
+      stable_bottle.delete("rebuild") if stable_bottle.fetch("rebuild").zero? # default value
+      stable_bottle.delete("root_url") # not used at all
+
+      stable_bottle["files"] = stable_bottle.fetch("files").transform_values do |file|
         # The "url" is not used here and takes up a lot of space.
         file.slice("cellar", "sha256")
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2434,9 +2434,26 @@ class Formula
     hash
   end
 
+  # Builds internal json v3 hash.
+  #
   # @private
   def to_api_hash
-    api_hash = to_hash_with_variations
+    api_hash = to_hash_with_variations.except(
+      # Included in the top-level of the `internal_formula_v3.json` file
+      # created by the `brew generate-formula-api` command.
+      "aliases",
+      "oldname",
+      "oldnames",
+      "tap",
+      "tap_git_head",
+    )
+
+    # Remove keys that default to zero.
+    %w[revision version_scheme].each do |key|
+      next unless api_hash[key].zero?
+
+      api_hash.delete(key)
+    end
 
     if (stable_bottle = api_hash.dig("bottle", "stable"))
       stable_bottle["files"] = stable_bottle["files"].transform_values do |file|

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2439,7 +2439,7 @@ class Formula
   # @private
   def to_api_hash
     api_hash = to_hash_with_variations.except(
-      # Included in the top-level of the `internal_formula_v3.json` file
+      # Included in the top-level of the `homebrew-core.json` file
       # created by the `brew generate-formula-api` command.
       "aliases",
       "oldname",

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2436,16 +2436,20 @@ class Formula
 
   # @private
   def to_api_hash
-    hash = to_hash_with_variations
+    api_hash = to_hash_with_variations
 
-    if (stable_bottle = hash.dig("bottle", "stable"))
+    if (stable_bottle = api_hash.dig("bottle", "stable"))
       stable_bottle["files"] = stable_bottle["files"].transform_values do |file|
         # The "url" is not used here and takes up a lot of space.
         file.slice("cellar", "sha256")
       end
     end
 
-    hash.reject { |_, value| value.blank? }.to_h
+    api_hash.reject { |_, value| value.blank? }.to_h.tap do |hash|
+      # We use nil here to mean that post install is defined for backwards compatibility
+      # in `Formulary.load_formula_from_api` so we need to preserve the boolean value.
+      hash["post_install_defined"] = post_install_defined?
+    end
   end
 
   # Returns the bottle information for a formula.

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -376,6 +376,9 @@ describe Formulary do
           "oldnames"                 => [],
           "aliases"                  => [],
           "versioned_formulae"       => [],
+          "revision"                 => 0,
+          "version_scheme"           => 0,
+          "key_only"                 => false,
           "keg_only_reason"          => nil,
           "options"                  => [],
           "build_dependencies"       => [],
@@ -502,7 +505,7 @@ describe Formulary do
         expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be true
       end
 
-      it "returns a Formula from a hash with missing keys" do
+      it "returns a Formula from a json v3 hash with missing keys" do
         # Use a hash with blank fields to load the first formula.
         all_formulae = formula_json_contents(blank_fields)
         allow(Homebrew::API::Formula).to receive(:all_formulae).and_return(all_formulae)
@@ -514,6 +517,7 @@ describe Formulary do
         api_json = formula.to_api_hash
         expect(api_json).not_to have_key("dependencies")
         expect(api_json).not_to have_key("caveats")
+        expect(api_json).not_to have_key("revision")
         # This needs to be included when false because nil implies true for backwards compatibility.
         expect(api_json).to have_key("post_install_defined")
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -396,6 +396,7 @@ describe Formulary do
           "deprecation_reason"       => [],
           "disable_date"             => [],
           "disable_reason"           => [],
+          "post_install_defined"     => false,
           "service"                  => nil,
           "variations"               => {},
         }
@@ -513,6 +514,8 @@ describe Formulary do
         api_json = formula.to_api_hash
         expect(api_json).not_to have_key("dependencies")
         expect(api_json).not_to have_key("caveats")
+        # This needs to be included when false because nil implies true for backwards compatibility.
+        expect(api_json).to have_key("post_install_defined")
 
         described_class.clear_cache
         all_formulae = { formula_name => api_json.except("name") }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Alternative approach to https://github.com/Homebrew/brew/pull/16433 based on discussion there and in the original issue https://github.com/Homebrew/brew/issues/16410.

This is a second go at this after the recursive compacting approach in the earlier PR ended up not yielding big gains beyond what's in this PR. IMO this is the simplest approach to reducing the JSON size by omitting the bottle url field that we don't use anywhere and also removing blank fields at the top-level of the resulting hash.

I decided to memoize the variations generation since that takes a while but shouldn't change once a formula is loaded. This reduces time in the `brew generate-formula-api` command.

TODO:
- [x] Merge in https://github.com/Homebrew/brew/pull/16459
- [x] Add tests