### PR TITLE
Patch new cask documentation

### DIFF
--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -251,6 +251,7 @@ Give it a shot with:
 
 ```bash
 export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_FROM_API=1
 brew install my-new-cask
 ```
 
@@ -386,8 +387,9 @@ cd "$(brew --repository)"/Library/Taps/homebrew/homebrew-cask
 git checkout master
 ```
 
-If earlier you set the variable `HOMEBREW_NO_AUTO_UPDATE` then clean it up with:
+If earlier you set the variable `HOMEBREW_NO_AUTO_UPDATE` and `HOMEBREW_NO_INSTALL_FROM_API` then clean it up with:
 
 ```bash
 unset HOMEBREW_NO_AUTO_UPDATE
+unset HOMEBREW_NO_INSTALL_FROM_API
 ```


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

While adding a new cask (Homebrew/homebrew-cask#164152), the testing command failed when `HOMEBREW_NO_INSTALL_FROM_API` env is not set. This is documented in the section for adding new formulae but not in the section for new casks.

This PR patches the commands.
