### PR TITLE
brew: clarify which user needs to be able to read the working directory.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -425,7 +425,7 @@ then
 fi
 if ! [[ -r "$(pwd)" ]]
 then
-  odie "The current working directory must be readable to run brew."
+  odie "The current working directory must be readable to ${USER} to run brew."
 fi
 
 #####

--- a/bin/brew
+++ b/bin/brew
@@ -25,7 +25,7 @@ then
 fi
 if ! [[ -r "${PWD}" ]]
 then
-  echo "Error: The current working directory must be readable to run brew." >&2
+  echo "Error: The current working directory must be readable to ${USER} to run brew." >&2
   exit 1
 fi
 


### PR DESCRIPTION
Otherwise, in multi-user environments, it can be ambiguous.