### PR TITLE
extend/ENV/shared: effective_arch as public API

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -271,7 +271,6 @@ module SharedEnvExtension
     set_cpu_flags(flags)
   end
 
-  # @private
   sig { returns(Symbol) }
   def effective_arch
     if @build_bottle && @bottle_arch

--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 module SharedEnvExtension
-  # @private
   def effective_arch
     if @build_bottle && @bottle_arch
       @bottle_arch.to_sym


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Opening this to discuss possibility of exposing `effective_arch` information.

Main reason is that we currently use `Hardware.oldest_cpu` in formulae but this may not be accurate if user wants to target different arch.

Would need some input if anything else needs to change to get this information available to be used by formulae that are not capable of relying on existing shim arch selection.