### PR TITLE
Fix "OS is not a class" crash on Ubuntu 23.10

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -202,8 +202,10 @@ Performance/MethodObjectAsBlock:
 Rails:
   # Selectively enable what we want.
   Enabled: false
-  # Do not use ActiveSupport in RuboCops.
   Exclude:
+    # This file is loaded before any extra methods are defined.
+    - "Homebrew/standalone/init.rb"
+    # Do not use ActiveSupport in RuboCops.
     - "Homebrew/rubocops/**/*"
 
 # These relate to ActiveSupport and not other parts of Rails.

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -39,7 +39,13 @@ if !gems_vendored && !ENV["HOMEBREW_SKIP_INITIAL_GEM_INSTALL"]
   ENV["HOMEBREW_SKIP_INITIAL_GEM_INSTALL"] = "1"
 end
 
-$LOAD_PATH.unshift HOMEBREW_LIBRARY_PATH.to_s unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
+unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
+  # Insert the path after any existing Homebrew paths (e.g. those inserted by tests and parent processes)
+  last_homebrew_path_idx = $LOAD_PATH.rindex do |path|
+    path.start_with?(HOMEBREW_LIBRARY_PATH.to_s) && !path.include?("vendor/portable-ruby")
+  end || -1
+  $LOAD_PATH.insert(last_homebrew_path_idx + 1, HOMEBREW_LIBRARY_PATH.to_s)
+end
 require_relative "../vendor/bundle/bundler/setup"
 $LOAD_PATH.unshift "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/" \
                    "bundler-#{Homebrew::HOMEBREW_BUNDLER_VERSION}/lib"

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -39,7 +39,7 @@ if !gems_vendored && !ENV["HOMEBREW_SKIP_INITIAL_GEM_INSTALL"]
   ENV["HOMEBREW_SKIP_INITIAL_GEM_INSTALL"] = "1"
 end
 
-$LOAD_PATH.push HOMEBREW_LIBRARY_PATH.to_s unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
+$LOAD_PATH.unshift HOMEBREW_LIBRARY_PATH.to_s unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
 require_relative "../vendor/bundle/bundler/setup"
 $LOAD_PATH.unshift "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/" \
                    "bundler-#{Homebrew::HOMEBREW_BUNDLER_VERSION}/lib"

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -33,7 +33,7 @@ require "find"
 require "byebug"
 require "timeout"
 
-$LOAD_PATH.push(File.expand_path("#{ENV.fetch("HOMEBREW_LIBRARY")}/Homebrew/test/support/lib"))
+$LOAD_PATH.unshift(File.expand_path("#{ENV.fetch("HOMEBREW_LIBRARY")}/Homebrew/test/support/lib"))
 
 require_relative "../global"
 


### PR DESCRIPTION
This seems to resolve the issue raised at [discussion #5050](https://github.com/orgs/Homebrew/discussions/5050). I have not added new tests, but this seems like something that should have tests associated with it!

Without this patch, on Ubuntu 23.10, you experience the following:

```bash
$ brew
/usr/lib/ruby/vendor_ruby/os.rb:7:in `<top (required)>': OS is not a class (TypeError)
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/macos_version.rb:168: previous definition of OS was here
        from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/global.rb:77:in `require'
        from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/global.rb:77:in `<top (required)>'
        from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:18:in `require_relative'
        from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:18:in `<main>'

```


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
