### PR TITLE
rubocop: The `sorbet/rbi/todo.rbi` file doesn't exist

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -20,7 +20,6 @@ AllCops:
   Exclude:
     - "Homebrew/sorbet/rbi/gems/**/*.rbi"
     - "Homebrew/sorbet/rbi/hidden-definitions/*.rbi"
-    - "Homebrew/sorbet/rbi/todo.rbi"
     - "Homebrew/bin/*"
     - "Homebrew/vendor/**/*"
     - "Taps/*/*/vendor/**/*"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- It got deleted in 89531e9ff36b84a47a078065e5d2ac9674dfbd2d.
- The first cleanup from a tool I'm working on to check that all the paths in `rubocop.yml` Includes and Excludes do actually exist.
