### PR TITLE
github_runner_matrix: discontinue non-ephemeral runners

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -158,8 +158,7 @@ class GitHubRunnerMatrix
       runner = +"#{version}-arm64"
       runner_timeout = timeout
 
-      # Use bare metal runner when testing dependents on ARM64 Monterey.
-      use_ephemeral = macos_version >= (@dependent_matrix ? :ventura : :monterey)
+      use_ephemeral = macos_version >= :monterey
       runner << ephemeral_suffix if use_ephemeral
 
       runner.freeze


### PR DESCRIPTION
Non-ephemeral machines need regular restarts and we'd like to tell MacStadium they can be decommissioned.

For portable Ruby, I will be working on a 11-arm64-cross soon that will support ephemeral by having it run on macOS 12 (or later) instead. Was hoping pre-AGM but I can't guarantee that yet.