### PR TITLE
dependabot.yml: group actions/*-artifact

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     ignore:
       - dependency-name: actions/stale
       - dependency-name: dessant/lock-threads
+    groups:
+      artifacts:
+        patterns:
+          - actions/*-artifact
 
   - package-ecosystem: bundler
     directory: /Library/Homebrew


### PR DESCRIPTION
50:50 whether dependabot.yml changes work in Homebrew/brew, but this at least shows what how we can do this across some of our other repos like Homebrew/formulae.brew.sh.