### PR TITLE
cask/uninstall: skip quit/signal directives when upgrading or reinstalling

### DIFF
--- a/Library/Homebrew/cask/artifact/uninstall.rb
+++ b/Library/Homebrew/cask/artifact/uninstall.rb
@@ -3,17 +3,26 @@
 
 require "cask/artifact/abstract_uninstall"
 
+UPGRADE_REINSTALL_SKIP_DIRECTIVES = [:quit, :signal].freeze
+
 module Cask
   module Artifact
     # Artifact corresponding to the `uninstall` stanza.
     #
     # @api private
     class Uninstall < AbstractUninstall
-      def uninstall_phase(**options)
-        ORDERED_DIRECTIVES.reject { |directive_sym| directive_sym == :rmdir }
-                          .each do |directive_sym|
-                            dispatch_uninstall_directive(directive_sym, **options)
-                          end
+      def uninstall_phase(upgrade: false, reinstall: false, **options)
+        filtered_directives = ORDERED_DIRECTIVES.filter do |directive_sym|
+          next false if directive_sym == :rmdir
+
+          next false if (upgrade || reinstall) && UPGRADE_REINSTALL_SKIP_DIRECTIVES.include?(directive_sym)
+
+          true
+        end
+
+        filtered_directives.each do |directive_sym|
+          dispatch_uninstall_directive(directive_sym, **options)
+        end
       end
 
       def post_uninstall_phase(**options)

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -472,6 +472,8 @@ on_request: true)
             skip:      clear,
             force:     force?,
             successor: successor,
+            upgrade:   upgrade?,
+            reinstall: reinstall?,
           )
         end
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -761,8 +761,8 @@ Since `pkg` installers can do arbitrary things, different techniques are needed 
 
 * **`early_script:`** (string or hash) - like [`script:`](#uninstall-script), but runs early (for special cases, best avoided)
 * [`launchctl:`](#uninstall-launchctl) (string or array) - IDs of `launchd` jobs to remove
-* [`quit:`](#uninstall-quit) (string or array) - bundle IDs of running applications to quit
-* [`signal:`](#uninstall-signal) (array of arrays) - signal numbers and bundle IDs of running applications to send a Unix signal to (for when `quit:` does not work)
+* [`quit:`](#uninstall-quit) (string or array) - bundle IDs of running applications to quit (does not run when uninstall is initiated by `brew upgrade` or `brew reinstall`)
+* [`signal:`](#uninstall-signal) (array of arrays) - signal numbers and bundle IDs of running applications to send a Unix signal to - for when `quit:` does not work (does not run when uninstall is initiated by `brew upgrade` or `brew reinstall`)
 * [`login_item:`](#uninstall-login_item) (string or array) - names of login items to remove
 * [`kext:`](#uninstall-kext) (string or array) - bundle IDs of kexts to unload from the system
 * [`script:`](#uninstall-script) (string or hash) - relative path to an uninstall script to be run via sudo; use hash if args are needed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

To ensure that a fresh copy of an application is installed correctly, and that the previous copy is removed entirely, when `brew upgrade` or `brew reinstall` is called, we first uninstall the prior version of the application. 

This can have a side-effect of being destructive in that a running application can be closed using SIGTERM (or similar commands) in a forceful manner without an user confirmation. This is the reasonably expected behaviour when running `brew uninstall` as the user is explicitly asking for the application to be removed.

However, in cases where the user is running `brew upgrade` it may not be anticipated that the application will be forcefully terminated, potentially resulting in the loss of unsaved work.