### PR TITLE
dev-cmd/bump: Don't fall over when retrieving PRs 404s

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -288,10 +288,11 @@ module Homebrew
   }
   def retrieve_pull_requests(formula_or_cask, name, state:, version: nil)
     tap_remote_repo = formula_or_cask.tap&.remote_repo || formula_or_cask.tap&.full_name
-    begin
-      pull_requests = GitHub.fetch_pull_requests(name, tap_remote_repo, state: state, version: version)
+    pull_requests = begin
+      GitHub.fetch_pull_requests(name, tap_remote_repo, state: state, version: version)
     rescue GitHub::API::ValidationFailedError => e
       odebug "Error fetching pull requests for #{formula_or_cask} #{name}: #{e}"
+      nil
     end
 
     if pull_requests&.any?

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -288,7 +288,12 @@ module Homebrew
   }
   def retrieve_pull_requests(formula_or_cask, name, state:, version: nil)
     tap_remote_repo = formula_or_cask.tap&.remote_repo || formula_or_cask.tap&.full_name
-    pull_requests = GitHub.fetch_pull_requests(name, tap_remote_repo, state: state, version: version)
+    begin
+      pull_requests = GitHub.fetch_pull_requests(name, tap_remote_repo, state: state, version: version)
+    rescue GitHub::API::ValidationFailedError => e
+      odebug "Error fetching pull requests for #{formula_or_cask} #{name}: #{e}"
+    end
+
     if pull_requests&.any?
       pull_requests = pull_requests.map { |pr| "#{pr["title"]} (#{Formatter.url(pr["html_url"])})" }.join(", ")
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Instead, let the `pull_requests&.any?` check do its job and not show PRs that we couldn't find or fetch.
- In the `--debug` output, show the error message that we got from GitHub.
- Fixes https://github.com/Homebrew/brew/issues/16504.