### PR TITLE
Remove canonical_segments check

### DIFF
--- a/Library/Homebrew/utils/ruby_check_version_script.rb
+++ b/Library/Homebrew/utils/ruby_check_version_script.rb
@@ -8,9 +8,6 @@ raise "No Ruby version passed!" if HOMEBREW_REQUIRED_RUBY_VERSION.to_s.empty?
 require "rubygems"
 
 ruby_version = Gem::Version.new(RUBY_VERSION)
-# This will only happen if the Ruby is too old anyway.
-abort unless ruby_version.respond_to?(:canonical_segments)
-
 homebrew_required_ruby_version = Gem::Version.new(HOMEBREW_REQUIRED_RUBY_VERSION)
 
 ruby_version_major, ruby_version_minor, = ruby_version.canonical_segments


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Ruby 3.1 [ships](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/#:~:text=Standard%20libraries%20updates) with rubygems 3.3.3, which was [released](https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#333--2021-12-24) 2021-12-24. `Gem::Version#canonical_segments` was [introduced](https://github.com/rubygems/rubygems/pull/1659) in 2016.