### PR TITLE
ci/codeql: In-line the `paths-ignore` config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,2 +1,0 @@
-paths-ignore:
-  - Library/Homebrew/vendor/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,33 +1,33 @@
 name: "CodeQL"
 
 on:
- push:
-   branches:
-     - master
- pull_request:
-   branches:
-     - master
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
- analyze:
-   name: Analyze
-   runs-on: ubuntu-22.04
-   permissions:
-     actions: read
-     contents: read
-     security-events: write
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
-   steps:
-   - name: Checkout repository
-     uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-   - name: Initialize CodeQL
-     uses: github/codeql-action/init@v3
-     with:
-       languages: ruby
-       config: |
-        paths-ignore:
-          - Library/Homebrew/vendor
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ruby
+          config: |
+            paths-ignore:
+              - Library/Homebrew/vendor
 
-   - name: Perform CodeQL Analysis
-     uses: github/codeql-action/analyze@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,9 @@ jobs:
      uses: github/codeql-action/init@v3
      with:
        languages: ruby
-       config-file: ./.github/codeql/codeql-config.yml
+       config: |
+        paths-ignore:
+          - Library/Homebrew/vendor
 
    - name: Perform CodeQL Analysis
      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-configuration-details-using-the-config-input
- And I noticed the indentation of the workflow YAML was weird. (Probably worth a `?w=1` on this review to ignore whitespace.)