### PR TITLE
Add `~/Library/Containers` to the list of `Layout/LineLength` exclusions

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -112,6 +112,7 @@ Layout/LineLength:
       '"/Library/PreferencePanes/',
       ' "~/Library/Application Support/',
       '"~/Library/Caches/',
+      '"~/Library/Containers',
       '"~/Application Support',
       " was verified as official when first introduced to the cask",
     ]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This was found in https://github.com/Homebrew/homebrew-cask/pull/164915/files#r1460533604.
