### PR TITLE
dev-cmd/bump: Point out if formulae should be kept in sync with others

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -463,9 +463,9 @@ module Homebrew
     if formula_or_cask.is_a?(Formula)
       require "formula_auditor"
       auditor = FormulaAuditor.new(formula_or_cask)
-      puts <<~EOS if T.must(auditor).synced_with_other_formulae?
+      puts <<~EOS if auditor.synced_with_other_formulae?
         Version syncing:          #{title_name} version should be kept in sync with
-                                  #{synced_with(T.must(auditor), formula_or_cask, new_version.general).join(", ")}.
+                                  #{synced_with(auditor, formula_or_cask, new_version.general).join(", ")}.
       EOS
     end
     puts <<~EOS unless args.no_pull_requests?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Related to #16383.
- This will give some information to users of `brew bump` that they should keep the version of the formula in sync with other formulae.
- A future enhancement is actually making the bumping of the "related" formulae automatic with `--open-pr`. But for now, telling people so that they don't have to wait until `brew audit` fails either locally or in CI at a later stage is a good start.