### PR TITLE
cmd/upgrade: rename arg to installed_formula/cask

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -119,7 +119,7 @@ module Homebrew
 
       conflicts "--build-from-source", "--force-bottle"
 
-      named_args [:outdated_formula, :outdated_cask]
+      named_args [:installed_formula, :installed_cask]
     end
   end
 

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -294,7 +294,7 @@ describe Homebrew::Completions do
 
       it "returns appropriate completion for a command with multiple named arg types" do
         completion = described_class.generate_bash_subcommand_completion("upgrade")
-        expect(completion).to match(/__brew_complete_outdated_formulae\n  __brew_complete_outdated_casks\n}$/)
+        expect(completion).to match(/__brew_complete_installed_formulae\n  __brew_complete_installed_casks\n}$/)
       end
     end
 
@@ -415,10 +415,10 @@ describe Homebrew::Completions do
         completion = described_class.generate_fish_subcommand_completion("upgrade")
         expected_line_start = "__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument"
         expect(completion).to match(
-          /#{expected_line_start} -l cask -l casks' -a '\(__fish_brew_suggest_formulae_outdated\)'/,
+          /#{expected_line_start} -l cask -l casks' -a '\(__fish_brew_suggest_formulae_installed\)'/,
         )
         expect(completion).to match(
-          /#{expected_line_start} -l formula -l formulae' -a '\(__fish_brew_suggest_casks_outdated\)'/,
+          /#{expected_line_start} -l formula -l formulae' -a '\(__fish_brew_suggest_casks_installed\)'/,
         )
       end
     end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -2588,8 +2588,8 @@ _brew_upgrade() {
       ;;
     *) ;;
   esac
-  __brew_complete_outdated_formulae
-  __brew_complete_outdated_casks
+  __brew_complete_installed_formulae
+  __brew_complete_installed_casks
 }
 
 _brew_uses() {

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1690,8 +1690,8 @@ __fish_brew_complete_arg 'upgrade' -l skip-cask-deps -d 'Skip installing cask de
 __fish_brew_complete_arg 'upgrade' -l verbose -d 'Print the verification and post-install steps'
 __fish_brew_complete_arg 'upgrade' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'upgrade' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_outdated)'
-__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_outdated)'
+__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'uses' 'Show formulae and casks that specify formula as a dependency; that is, show dependents of formula'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -2078,12 +2078,12 @@ _brew_upgrade() {
     '--verbose[Print the verification and post-install steps]' \
     '(--formula)--vst-plugindir[Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)]' \
     '(--formula)--vst3-plugindir[Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)]' \
-    - outdated_formula \
+    - installed_formula \
     '(--casks --skip-cask-deps --greedy --greedy-latest --greedy-auto-updates --binaries --require-sha --quarantine --appdir --keyboard-layoutdir --colorpickerdir --prefpanedir --qlplugindir --mdimporterdir --dictionarydir --fontdir --servicedir --input-methoddir --internet-plugindir --audio-unit-plugindir --vst-plugindir --vst3-plugindir --screen-saverdir --language)--formula[Treat all named arguments as formulae. If no named arguments are specified, upgrade only outdated formulae]' \
-    '*::outdated_formula:__brew_outdated_formulae' \
-    - outdated_cask \
+    '*::installed_formula:__brew_installed_formulae' \
+    - installed_cask \
     '(--formulae --build-from-source --interactive --force-bottle --fetch-HEAD --ignore-pinned --keep-tmp --debug-symbols --display-times)--cask[Treat all named arguments as casks. If no named arguments are specified, upgrade only outdated casks]' \
-    '*::outdated_cask:__brew_outdated_casks'
+    '*::installed_cask:__brew_installed_casks'
 }
 
 # brew uses

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -770,7 +770,7 @@ Fetch and reset Homebrew and all tap repositories (or any specified *`repository
 
 *Note:* this will destroy all your uncommitted or committed changes.
 
-### `upgrade` [*`options`*] [*`outdated_formula`*|*`outdated_cask`* ...]
+### `upgrade` [*`options`*] [*`installed_formula`*|*`installed_cask`* ...]
 
 Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally
 installed with, plus any appended brew formula options. If *`cask`* or *`formula`* are specified,

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1060,7 +1060,7 @@ Fetch and reset Homebrew and all tap repositories (or any specified \fIrepositor
 .P
 \fINote:\fR this will destroy all your uncommitted or committed changes\.
 .
-.SS "\fBupgrade\fR [\fIoptions\fR] [\fIoutdated_formula\fR|\fIoutdated_cask\fR \.\.\.]"
+.SS "\fBupgrade\fR [\fIoptions\fR] [\fIinstalled_formula\fR|\fIinstalled_cask\fR \.\.\.]"
 Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally installed with, plus any appended brew formula options\. If \fIcask\fR or \fIformula\fR are specified, upgrade only the given \fIcask\fR or \fIformula\fR kegs (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.
 .
 .P


### PR DESCRIPTION
This avoids running `brew outdated` in shell completions, which is noticeably slow.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
