### PR TITLE
Add option to retain tmpdir on pr-pull

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -506,7 +506,12 @@ module Homebrew
         end
       ensure
         if args.retain_bottle_dir?
-          puts "::set-output name=bottle_path::#{dir}"
+          ohai "Bottle files retained at:", dir
+          return unless ENV["GITHUB_ACTIONS"]
+
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
+            f.puts "bottle_path=#{dir}"
+          end
         else
           FileUtils.remove_entry dir
         end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -505,10 +505,8 @@ module Homebrew
           safe_system HOMEBREW_BREW_FILE, *upload_args
         end
       ensure
-        if args.retain_bottle_dir?
+        if args.retain_bottle_dir? && ENV["GITHUB_ACTIONS"]
           ohai "Bottle files retained at:", dir
-          return unless ENV["GITHUB_ACTIONS"]
-
           File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
             f.puts "bottle_path=#{dir}"
           end


### PR DESCRIPTION
This option will be used to generate build provenance in the `publish-commit-bottles.yml` workflow in `Homebrew/homebrew-core`. It adds a single flag that controls whether or not the temporary directory where bottles are downloaded is retained.

Necessary for [adding build provenance](https://github.com/Homebrew/homebrew-core/pull/160941) to `Homebrew/homebrew-core`. This must be merged first.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
