### PR TITLE
docs: use `--eval-all` with `brew info`

### DIFF
--- a/docs/Querying-Brew.md
+++ b/docs/Querying-Brew.md
@@ -33,7 +33,7 @@ brew info --json=v1 tig | jq .
 To show full JSON information about all installed formulae:
 
 ```sh
-brew info --json=v1 --all | jq "map(select(.installed != []))"
+brew info --json=v1 --eval-all | jq "map(select(.installed != []))"
 ```
 
 You'll note that processing all formulae can be slow; it's quicker to let `brew` do this:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`--all` is not a valid option for `brew info`