### PR TITLE
Enable Style/TopLevelMethodDefinition

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -432,6 +432,9 @@ Style/SymbolArray:
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
 
+Style/TopLevelMethodDefinition:
+  Enabled: true
+
 # Trailing commas make diffs nicer.
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -434,6 +434,8 @@ Style/TernaryParentheses:
 
 Style/TopLevelMethodDefinition:
   Enabled: true
+  Exclude:
+    - "Taps/**/*.rb"
 
 # Trailing commas make diffs nicer.
 Style/TrailingCommaInArguments:

--- a/Library/Homebrew/.yardopts
+++ b/Library/Homebrew/.yardopts
@@ -7,6 +7,7 @@
 --template-path yard/templates
 --exclude test/
 --exclude vendor/
+--exclude yard/
 extend/os/**/*.rb
 **/*.rb
 -

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -7,67 +7,6 @@ require "formulary"
 require "software_spec"
 require "tap"
 
-def with_monkey_patch
-  # Since `method_defined?` is not a supported type guard, the use of `alias_method` below is not typesafe:
-  BottleSpecification.class_eval do
-    T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
-    define_method(:method_missing) do |*|
-      # do nothing
-    end
-  end
-
-  Module.class_eval do
-    T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
-    define_method(:method_missing) do |*|
-      # do nothing
-    end
-  end
-
-  Resource.class_eval do
-    T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
-    define_method(:method_missing) do |*|
-      # do nothing
-    end
-  end
-
-  DependencyCollector.class_eval do
-    T.unsafe(self).alias_method :old_parse_symbol_spec, :parse_symbol_spec if method_defined?(:parse_symbol_spec)
-    define_method(:parse_symbol_spec) do |*|
-      # do nothing
-    end
-  end
-
-  yield
-ensure
-  BottleSpecification.class_eval do
-    if method_defined?(:old_method_missing)
-      T.unsafe(self).alias_method :method_missing, :old_method_missing
-      undef :old_method_missing
-    end
-  end
-
-  Module.class_eval do
-    if method_defined?(:old_method_missing)
-      T.unsafe(self).alias_method :method_missing, :old_method_missing
-      undef :old_method_missing
-    end
-  end
-
-  Resource.class_eval do
-    if method_defined?(:old_method_missing)
-      T.unsafe(self).alias_method :method_missing, :old_method_missing
-      undef :old_method_missing
-    end
-  end
-
-  DependencyCollector.class_eval do
-    if method_defined?(:old_parse_symbol_spec)
-      T.unsafe(self).alias_method :parse_symbol_spec, :old_parse_symbol_spec
-      undef :old_parse_symbol_spec
-    end
-  end
-end
-
 module Homebrew
   BOTTLE_BLOCK_REGEX = /  bottle (?:do.+?end|:[a-z]+)\n\n/m
 
@@ -221,5 +160,66 @@ module Homebrew
     contents.gsub!("require 'brewkit'", "require 'formula'")
     contents.sub!(BOTTLE_BLOCK_REGEX, "")
     with_monkey_patch { Formulary.from_contents(name, file, contents, ignore_errors: true) }
+  end
+
+  private_class_method def self.with_monkey_patch
+    # Since `method_defined?` is not a supported type guard, the use of `alias_method` below is not typesafe:
+    BottleSpecification.class_eval do
+      T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
+      define_method(:method_missing) do |*|
+        # do nothing
+      end
+    end
+
+    Module.class_eval do
+      T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
+      define_method(:method_missing) do |*|
+        # do nothing
+      end
+    end
+
+    Resource.class_eval do
+      T.unsafe(self).alias_method :old_method_missing, :method_missing if method_defined?(:method_missing)
+      define_method(:method_missing) do |*|
+        # do nothing
+      end
+    end
+
+    DependencyCollector.class_eval do
+      T.unsafe(self).alias_method :old_parse_symbol_spec, :parse_symbol_spec if method_defined?(:parse_symbol_spec)
+      define_method(:parse_symbol_spec) do |*|
+        # do nothing
+      end
+    end
+
+    yield
+  ensure
+    BottleSpecification.class_eval do
+      if method_defined?(:old_method_missing)
+        T.unsafe(self).alias_method :method_missing, :old_method_missing
+        undef :old_method_missing
+      end
+    end
+
+    Module.class_eval do
+      if method_defined?(:old_method_missing)
+        T.unsafe(self).alias_method :method_missing, :old_method_missing
+        undef :old_method_missing
+      end
+    end
+
+    Resource.class_eval do
+      if method_defined?(:old_method_missing)
+        T.unsafe(self).alias_method :method_missing, :old_method_missing
+        undef :old_method_missing
+      end
+    end
+
+    DependencyCollector.class_eval do
+      if method_defined?(:old_parse_symbol_spec)
+        T.unsafe(self).alias_method :parse_symbol_spec, :old_parse_symbol_spec
+        undef :old_parse_symbol_spec
+      end
+    end
   end
 end

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -2,20 +2,20 @@
 
 require "cli/named_args"
 
-def setup_unredable_formula(name)
-  error = FormulaUnreadableError.new(name, RuntimeError.new("testing"))
-  allow(Formulary).to receive(:factory).with(name, any_args).and_raise(error)
-end
-
-def setup_unredable_cask(name)
-  error = Cask::CaskUnreadableError.new(name, "testing")
-  allow(Cask::CaskLoader).to receive(:load).with(name, any_args).and_raise(error)
-
-  config = instance_double(Cask::Config)
-  allow(Cask::Config).to receive(:from_args).and_return(config)
-end
-
 describe Homebrew::CLI::NamedArgs do
+  def setup_unredable_formula(name)
+    error = FormulaUnreadableError.new(name, RuntimeError.new("testing"))
+    allow(Formulary).to receive(:factory).with(name, any_args).and_raise(error)
+  end
+
+  def setup_unredable_cask(name)
+    error = Cask::CaskUnreadableError.new(name, "testing")
+    allow(Cask::CaskLoader).to receive(:load).with(name, any_args).and_raise(error)
+
+    config = instance_double(Cask::Config)
+    allow(Cask::Config).to receive(:from_args).and_return(config)
+  end
+
   let(:foo) do
     formula "foo" do
       url "https://brew.sh"

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -4,6 +4,32 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/bottle"
 
 describe "brew bottle" do
+  def stub_hash(parameters)
+    <<~EOS
+      {
+        "#{parameters[:name]}":{
+           "formula":{
+              "pkg_version":"#{parameters[:version]}",
+              "path":"#{parameters[:path]}"
+           },
+           "bottle":{
+              "root_url":"#{parameters[:root_url] || HOMEBREW_BOTTLE_DEFAULT_DOMAIN}",
+              "prefix":"/usr/local",
+              "cellar":"#{parameters[:cellar]}",
+              "rebuild":0,
+              "tags":{
+                 "#{parameters[:os]}":{
+                    "filename":"#{parameters[:filename]}",
+                    "local_filename":"#{parameters[:local_filename]}",
+                    "sha256":"#{parameters[:sha256]}"
+                 }
+              }
+           }
+        }
+      }
+    EOS
+  end
+
   it_behaves_like "parseable arguments"
 
   it "builds a bottle for the given Formula", :integration_test do
@@ -537,30 +563,4 @@ describe "brew bottle" do
       end
     end
   end
-end
-
-def stub_hash(parameters)
-  <<~EOS
-    {
-      "#{parameters[:name]}":{
-         "formula":{
-            "pkg_version":"#{parameters[:version]}",
-            "path":"#{parameters[:path]}"
-         },
-         "bottle":{
-            "root_url":"#{parameters[:root_url] || HOMEBREW_BOTTLE_DEFAULT_DOMAIN}",
-            "prefix":"/usr/local",
-            "cellar":"#{parameters[:cellar]}",
-            "rebuild":0,
-            "tags":{
-               "#{parameters[:os]}":{
-                  "filename":"#{parameters[:filename]}",
-                  "local_filename":"#{parameters[:local_filename]}",
-                  "sha256":"#{parameters[:sha256]}"
-               }
-            }
-         }
-      }
-    }
-  EOS
 end

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -4,6 +4,14 @@ require "dev-cmd/determine-test-runners"
 require "cmd/shared_examples/args_parse"
 
 describe "brew determine-test-runners" do
+  def get_runners(file)
+    runner_line = File.open(file).first
+    json_text = runner_line[/runners=(.*)/, 1]
+    runner_hash = JSON.parse(json_text)
+    runner_hash.map { |item| item["runner"].delete_suffix(ephemeral_suffix) }
+               .sort
+  end
+
   after do
     FileUtils.rm_f github_output
   end
@@ -46,14 +54,6 @@ describe "brew determine-test-runners" do
     expect(File.read(github_output)).not_to be_empty
     expect(get_runners(github_output).sort).to eq(all_runners.sort)
   end
-end
-
-def get_runners(file)
-  runner_line = File.open(file).first
-  json_text = runner_line[/runners=(.*)/, 1]
-  runner_hash = JSON.parse(json_text)
-  runner_hash.map { |item| item["runner"].delete_suffix(ephemeral_suffix) }
-             .sort
 end
 
 class DetermineRunnerTestHelper

--- a/Library/Homebrew/yard/templates/default/docstring/html/setup.rb
+++ b/Library/Homebrew/yard/templates/default/docstring/html/setup.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+# This follows the docs at https://github.com/lsegal/yard/blob/main/docs/Templates.md#setuprb
+# rubocop:disable Style/TopLevelMethodDefinition
 def init
   # `sorbet` is available transitively through the `yard-sorbet` plugin, but we're
   # outside of the standalone sorbet config, so `checked` is enabled by default
@@ -16,3 +18,4 @@ def internal
   T.bind(self, YARD::Templates::Template, checked: false)
   erb(:internal) if object.has_tag?(:api) && object.tag(:api).text == "internal"
 end
+# rubocop:enable Style/TopLevelMethodDefinition


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This cop is disabled by default, per [docs](https://docs.rubocop.org/rubocop/cops_style.html#styletoplevelmethoddefinition) because "for ruby scripts it is perfectly fine to use top-level methods", which doesn't apply in the cases below. 
These methods also pollute the Top Level Namespace in the [docs](https://rubydoc.brew.sh/top-level-namespace.html#instance_method_details):

<img width="661" alt="image" src="https://github.com/Homebrew/brew/assets/697964/550dcea7-08a9-482e-8019-02f650f6f39a">

(The top-level `SystemCommand::Mixin` will have to wait for a future PR)