### PR TITLE
Require SystemCommand only where needed

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -7,6 +7,7 @@ require "utils/user"
 require "cask/artifact/abstract_artifact"
 require "cask/pkg"
 require "extend/hash/keys"
+require "system_command"
 
 module Cask
   module Artifact
@@ -14,6 +15,8 @@ module Cask
     #
     # @api private
     class AbstractUninstall < AbstractArtifact
+      include SystemCommand::Mixin
+
       ORDERED_DIRECTIVES = [
         :early_script,
         :launchctl,

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -17,6 +17,7 @@ module Cask
   #
   # @api private
   class Audit
+    include SystemCommand::Mixin
     include ::Utils::Curl
     extend Attrable
 

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -3,12 +3,15 @@
 
 require "development_tools"
 require "cask/exceptions"
+require "system_command"
 
 module Cask
   # Helper module for quarantining files.
   #
   # @api private
   module Quarantine
+    extend SystemCommand::Mixin
+
     QUARANTINE_ATTRIBUTE = "com.apple.quarantine"
 
     QUARANTINE_SCRIPT = (HOMEBREW_LIBRARY_PATH/"cask/utils/quarantine.swift").freeze

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -11,6 +11,7 @@ require "utils/shell"
 require "system_config"
 require "cask/caskroom"
 require "cask/quarantine"
+require "system_command"
 
 module Homebrew
   # Module containing diagnostic checks.
@@ -48,6 +49,8 @@ module Homebrew
 
     # Diagnostic checks.
     class Checks
+      include SystemCommand::Mixin
+
       def initialize(verbose: true)
         @verbose = verbose
       end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -7,6 +7,7 @@ require "unpack_strategy"
 require "lazy_object"
 require "cgi"
 require "lock_file"
+require "system_command"
 
 # Need to define this before requiring Mechanize to avoid:
 #   uninitialized constant Mechanize
@@ -28,6 +29,7 @@ class AbstractDownloadStrategy
   extend Forwardable
   include FileUtils
   include Context
+  include SystemCommand::Mixin
 
   # Extension for bottle downloads.
   #

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -1,7 +1,11 @@
 # typed: true
 # frozen_string_literal: true
 
+require "system_command"
+
 class Keg
+  include SystemCommand::Mixin
+
   GENERIC_KEG_LINK_DIRECTORIES = (remove_const :KEG_LINK_DIRECTORIES).freeze
   KEG_LINK_DIRECTORIES = (GENERIC_KEG_LINK_DIRECTORIES + ["Frameworks"]).freeze
   GENERIC_MUST_EXIST_SUBDIRECTORIES = (remove_const :MUST_EXIST_SUBDIRECTORIES).freeze

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -5,6 +5,7 @@ require "context"
 require "resource"
 require "metafiles"
 require "extend/file/atomic"
+require "system_command"
 
 module DiskUsageExtension
   sig { returns(Integer) }
@@ -77,6 +78,7 @@ end
 # Homebrew extends Ruby's `Pathname` to make our code more readable.
 # @see https://ruby-doc.org/stdlib-2.6.3/libdoc/pathname/rdoc/Pathname.html Ruby's Pathname API
 class Pathname
+  include SystemCommand::Mixin
   include DiskUsageExtension
 
   # Moves a file from the original location to the {Pathname}'s.

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -5,12 +5,14 @@ require "utils/curl"
 require "json"
 require "zlib"
 require "extend/hash/keys"
+require "system_command"
 
 # GitHub Packages client.
 #
 # @api private
 class GitHubPackages
   include Context
+  include SystemCommand::Mixin
 
   URL_DOMAIN = "ghcr.io"
   URL_PREFIX = "https://#{URL_DOMAIN}/v2/".freeze

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -137,7 +137,6 @@ rescue
   nil
 end.compact.freeze
 
-require "system_command"
 require "exceptions"
 require "utils"
 

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "open3"
+require "system_command"
 
 module Homebrew
   module Livecheck
@@ -24,6 +25,8 @@ module Homebrew
       #
       # @api public
       class Git
+        extend SystemCommand::Mixin
+
         # The priority of the strategy on an informal scale of 1 to 10 (from
         # lowest to highest).
         PRIORITY = 8

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "system_command"
+
 module OS
   module Mac
     # Class representing a macOS SDK.
@@ -32,6 +34,7 @@ module OS
     # @api private
     class BaseSDKLocator
       extend T::Helpers
+      include SystemCommand::Mixin
 
       abstract!
 

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -3,6 +3,7 @@
 
 require "formula"
 require "cask/cask_loader"
+require "system_command"
 
 # Helper module for validating syntax in taps.
 #
@@ -10,6 +11,7 @@ require "cask/cask_loader"
 module Readall
   class << self
     include Cachable
+    include SystemCommand::Mixin
 
     # TODO: remove this once the `MacOS` module is undefined on Linux
     MACOS_MODULE_REGEX = /\b(MacOS|OS::Mac)(\.|::)\b/

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -3,12 +3,15 @@
 
 require "shellwords"
 require "source_location"
+require "system_command"
 
 module Homebrew
   # Helper module for running RuboCop.
   #
   # @api private
   module Style
+    extend SystemCommand::Mixin
+
     # Checks style for a list of files, printing simple RuboCop output.
     # Returns true if violations were found, false otherwise.
     def self.check_style_and_print(files, **options)

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -6,6 +6,7 @@ require "open3"
 require "plist"
 require "shellwords"
 
+require "context"
 require "extend/io"
 require "utils/timer"
 
@@ -405,7 +406,3 @@ class SystemCommand
     private :warn_plist_garbage
   end
 end
-
-# Make `system_command` available everywhere.
-# FIXME: Include this explicitly only where it is needed.
-include SystemCommand::Mixin # rubocop:disable Style/MixinUsage

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "system_command"
+
 describe SystemCommand do
   describe "#initialize" do
     subject(:command) do
@@ -284,7 +286,7 @@ describe SystemCommand do
 
     it 'does not format `stderr` when it starts with \r' do
       expect do
-        system_command \
+        Class.new.extend(SystemCommand::Mixin).system_command \
           "bash",
           args: [
             "-c",
@@ -308,7 +310,7 @@ describe SystemCommand do
       end
 
       it "does not interpret the executable as a shell line" do
-        expect(system_command(executable)).to be_a_success
+        expect(Class.new.extend(SystemCommand::Mixin).system_command(executable)).to be_a_success
       end
     end
 

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -2,14 +2,18 @@
 # frozen_string_literal: true
 
 require "tempfile"
+require "system_command"
 
 module UnpackStrategy
   # Strategy for unpacking disk images.
   class Dmg
+    extend SystemCommand::Mixin
     include UnpackStrategy
 
     # Helper module for listing the contents of a volume mounted from a disk image.
     module Bom
+      extend SystemCommand::Mixin
+
       DMG_METADATA = Set.new(%w[
         .background
         .com.apple.timemachine.donotpresent

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -4,6 +4,7 @@
 require "bundle_version"
 require "cask/cask"
 require "cask/installer"
+require "system_command"
 
 module Homebrew
   # Check unversioned casks for updates by extracting their
@@ -11,6 +12,8 @@ module Homebrew
   #
   # @api private
   class UnversionedCaskChecker
+    include SystemCommand::Mixin
+
     sig { returns(Cask::Cask) }
     attr_reader :cask
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -4,12 +4,16 @@
 require "open3"
 
 require "utils/timer"
+require "system_command"
 
 module Utils
   # Helper function for interacting with `curl`.
   #
   # @api private
   module Curl
+    include SystemCommand::Mixin
+    extend SystemCommand::Mixin
+
     # This regex is used to extract the part of an ETag within quotation marks,
     # ignoring any leading weak validator indicator (`W/`). This simplifies
     # ETag comparison in `#curl_check_http_content`.

--- a/Library/Homebrew/utils/curl.rbi
+++ b/Library/Homebrew/utils/curl.rbi
@@ -2,5 +2,4 @@
 
 module Utils::Curl
   include Kernel
-  requires_ancestor { SystemCommand::Mixin }
 end

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -1,12 +1,16 @@
 # typed: true
 # frozen_string_literal: true
 
+require "system_command"
+
 module Utils
   # Helper functions for querying Git information.
   #
   # @see GitRepository
   # @api private
   module Git
+    extend SystemCommand::Mixin
+
     def self.available?
       version.present?
     end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -11,7 +11,7 @@ require "system_command"
 #
 # @api private
 module GitHub
-  include SystemCommand::Mixin
+  extend SystemCommand::Mixin
 
   def self.check_runs(repo: nil, commit: nil, pull_request: nil)
     if pull_request

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "system_command"
 require "tempfile"
 require "utils/shell"
 require "utils/formatter"
@@ -32,6 +33,8 @@ module GitHub
   #
   # @api private
   module API
+    extend SystemCommand::Mixin
+
     # Generic API error.
     class Error < RuntimeError
       attr_reader :github_message

--- a/Library/Homebrew/utils/tar.rb
+++ b/Library/Homebrew/utils/tar.rb
@@ -9,6 +9,8 @@ module Utils
   # @api private
   module Tar
     class << self
+      include SystemCommand::Mixin
+
       TAR_FILE_EXTENSIONS = %w[.tar .tb2 .tbz .tbz2 .tgz .tlz .txz .tZ].freeze
 
       def available?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Continuation of https://github.com/Homebrew/brew/pull/16538

This removes `SystemCommand::Mixin` from the top-level namespace, and instead includes it only in the needed namespaces.