### PR TITLE
Next gen api formula json v3

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2255,7 +2255,7 @@ class Formula
       "disable_date"           => disable_date,
       "disable_reason"         => disable_reason,
       "post_install_defined"   => post_install_defined?,
-      "service"                => (service.serialize if service?),
+      "service"                => (service.to_hash if service?),
       "tap_git_head"           => tap_git_head,
       "ruby_source_path"       => ruby_source_path,
       "ruby_source_checksum"   => {},
@@ -2318,7 +2318,7 @@ class Formula
     api_hash["pour_bottle_only_if"] = self.class.pour_bottle_only_if.to_s if self.class.pour_bottle_only_if
     api_hash["link_overwrite"] = self.class.link_overwrite_paths.to_a if self.class.link_overwrite_paths.present?
     api_hash["caveats"] = caveats_with_placeholders if caveats
-    api_hash["service"] = service.serialize if service?
+    api_hash["service"] = service.to_hash if service?
 
     if stable
       api_hash["version"] = stable&.version&.to_s

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2407,7 +2407,7 @@ class Formula
       end
     end
 
-    hash["variations"] = variations
+    hash["variations"] = variations if hash_method != :to_api_hash || variations.present?
     hash
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2215,50 +2215,56 @@ class Formula
   # @private
   def to_hash
     hsh = {
-      "name"                   => name,
-      "full_name"              => full_name,
-      "tap"                    => tap&.name,
-      "oldname"                => oldnames.first, # deprecated
-      "oldnames"               => oldnames,
-      "aliases"                => aliases.sort,
-      "versioned_formulae"     => versioned_formulae.map(&:name),
-      "desc"                   => desc,
-      "license"                => SPDX.license_expression_to_string(license),
-      "homepage"               => homepage,
-      "versions"               => {
+      "name"                     => name,
+      "full_name"                => full_name,
+      "tap"                      => tap&.name,
+      "oldname"                  => oldnames.first, # deprecated
+      "oldnames"                 => oldnames,
+      "aliases"                  => aliases.sort,
+      "versioned_formulae"       => versioned_formulae.map(&:name),
+      "desc"                     => desc,
+      "license"                  => SPDX.license_expression_to_string(license),
+      "homepage"                 => homepage,
+      "versions"                 => {
         "stable" => stable&.version&.to_s,
         "head"   => head&.version&.to_s,
         "bottle" => bottle_defined?,
       },
-      "urls"                   => urls_hash,
-      "revision"               => revision,
-      "version_scheme"         => version_scheme,
-      "bottle"                 => {},
-      "pour_bottle_only_if"    => self.class.pour_bottle_only_if&.to_s,
-      "keg_only"               => keg_only?,
-      "keg_only_reason"        => keg_only_reason&.to_hash,
-      "options"                => [],
-      **dependencies_hash,
-      "requirements"           => serialized_requirements,
-      "conflicts_with"         => conflicts.map(&:name),
-      "conflicts_with_reasons" => conflicts.map(&:reason),
-      "link_overwrite"         => self.class.link_overwrite_paths.to_a,
-      "caveats"                => caveats_with_placeholders,
-      "installed"              => [],
-      "linked_keg"             => linked_version&.to_s,
-      "pinned"                 => pinned?,
-      "outdated"               => outdated?,
-      "deprecated"             => deprecated?,
-      "deprecation_date"       => deprecation_date,
-      "deprecation_reason"     => deprecation_reason,
-      "disabled"               => disabled?,
-      "disable_date"           => disable_date,
-      "disable_reason"         => disable_reason,
-      "post_install_defined"   => post_install_defined?,
-      "service"                => (service.to_hash if service?),
-      "tap_git_head"           => tap_git_head,
-      "ruby_source_path"       => ruby_source_path,
-      "ruby_source_checksum"   => {},
+      "urls"                     => urls_hash,
+      "revision"                 => revision,
+      "version_scheme"           => version_scheme,
+      "bottle"                   => {},
+      "pour_bottle_only_if"      => self.class.pour_bottle_only_if&.to_s,
+      "keg_only"                 => keg_only?,
+      "keg_only_reason"          => keg_only_reason&.to_hash,
+      "options"                  => [],
+      "build_dependencies"       => [],
+      "dependencies"             => [],
+      "test_dependencies"        => [],
+      "recommended_dependencies" => [],
+      "optional_dependencies"    => [],
+      "uses_from_macos"          => [],
+      "uses_from_macos_bounds"   => [],
+      "requirements"             => serialized_requirements,
+      "conflicts_with"           => conflicts.map(&:name),
+      "conflicts_with_reasons"   => conflicts.map(&:reason),
+      "link_overwrite"           => self.class.link_overwrite_paths.to_a,
+      "caveats"                  => caveats_with_placeholders,
+      "installed"                => [],
+      "linked_keg"               => linked_version&.to_s,
+      "pinned"                   => pinned?,
+      "outdated"                 => outdated?,
+      "deprecated"               => deprecated?,
+      "deprecation_date"         => deprecation_date,
+      "deprecation_reason"       => deprecation_reason,
+      "disabled"                 => disabled?,
+      "disable_date"             => disable_date,
+      "disable_reason"           => disable_reason,
+      "post_install_defined"     => post_install_defined?,
+      "service"                  => (service.to_hash if service?),
+      "tap_git_head"             => tap_git_head,
+      "ruby_source_path"         => ruby_source_path,
+      "ruby_source_checksum"     => {},
     }
 
     hsh["bottle"]["stable"] = bottle_hash if stable && bottle_defined?
@@ -2266,6 +2272,8 @@ class Formula
     hsh["options"] = options.map do |opt|
       { "option" => opt.flag, "description" => opt.description }
     end
+
+    hsh.merge!(dependencies_hash)
 
     hsh["installed"] = installed_kegs.sort_by(&:version).map do |keg|
       tab = Tab.for_keg keg
@@ -2307,7 +2315,7 @@ class Formula
                .transform_values(&:presence)
                .compact
 
-    api_hash.merge(dep_hash)
+    api_hash.merge!(dep_hash)
 
     # Exclude default values.
     api_hash["revision"] = revision unless revision.zero?

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -341,7 +341,7 @@ module Formulary
       end
 
       if (service_hash = json_formula["service"].presence)
-        service_hash = Homebrew::Service.deserialize(service_hash)
+        service_hash = Homebrew::Service.from_hash(service_hash)
         service do
           T.bind(self, Homebrew::Service)
 

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -515,7 +515,7 @@ module Homebrew
 
     # Prepare the service hash for inclusion in the formula API JSON.
     sig { returns(Hash) }
-    def serialize
+    def to_hash
       name_params = {
         macos: (plist_name if plist_name != default_plist_name),
         linux: (service_name if service_name != default_service_name),
@@ -568,7 +568,7 @@ module Homebrew
 
     # Turn the service API hash values back into what is expected by the formula DSL.
     sig { params(api_hash: Hash).returns(Hash) }
-    def self.deserialize(api_hash)
+    def self.from_hash(api_hash)
       hash = {}
       hash[:name] = api_hash["name"].transform_keys(&:to_sym) if api_hash.key?("name")
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -738,7 +738,7 @@ describe Formula do
         url "https://brew.sh/test-1.0.tbz"
       end
 
-      expect(f.service.serialize).to eq({})
+      expect(f.service.to_hash).to eq({})
     end
 
     specify "service complicated" do
@@ -754,7 +754,7 @@ describe Formula do
           keep_alive true
         end
       end
-      expect(f.service.serialize.keys)
+      expect(f.service.to_hash.keys)
         .to contain_exactly(:run, :run_type, :error_log_path, :log_path, :working_dir, :keep_alive)
     end
 
@@ -766,7 +766,7 @@ describe Formula do
         end
       end
 
-      expect(f.service.serialize.keys).to contain_exactly(:run, :run_type)
+      expect(f.service.to_hash.keys).to contain_exactly(:run, :run_type)
     end
 
     specify "service with only custom names" do
@@ -779,7 +779,7 @@ describe Formula do
 
       expect(f.plist_name).to eq("custom.macos.beanstalkd")
       expect(f.service_name).to eq("custom.linux.beanstalkd")
-      expect(f.service.serialize.keys).to contain_exactly(:name)
+      expect(f.service.to_hash.keys).to contain_exactly(:name)
     end
 
     specify "service helpers return data" do

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -1044,7 +1044,7 @@ describe Homebrew::Service do
     end
   end
 
-  describe "#serialize" do
+  describe "#to_hash" do
     let(:serialized_hash) do
       {
         environment_variables: {
@@ -1072,12 +1072,12 @@ describe Homebrew::Service do
       end
 
       Formula.generating_hash!
-      expect(f.service.serialize).to eq(serialized_hash)
+      expect(f.service.to_hash).to eq(serialized_hash)
       Formula.generated_hash!
     end
   end
 
-  describe ".deserialize" do
+  describe ".from_hash" do
     let(:serialized_hash) do
       {
         "name"                  => {
@@ -1111,12 +1111,12 @@ describe Homebrew::Service do
     end
 
     it "replaces placeholders with local paths" do
-      expect(described_class.deserialize(serialized_hash)).to eq(deserialized_hash)
+      expect(described_class.from_hash(serialized_hash)).to eq(deserialized_hash)
     end
 
     describe "run command" do
       it "handles String argument correctly" do
-        expect(described_class.deserialize({
+        expect(described_class.from_hash({
           "run" => "$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd",
         })).to eq({
           run: "#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd",
@@ -1124,7 +1124,7 @@ describe Homebrew::Service do
       end
 
       it "handles Array argument correctly" do
-        expect(described_class.deserialize({
+        expect(described_class.from_hash({
           "run" => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "--option"],
         })).to eq({
           run: ["#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd", "--option"],
@@ -1132,7 +1132,7 @@ describe Homebrew::Service do
       end
 
       it "handles Hash argument correctly" do
-        expect(described_class.deserialize({
+        expect(described_class.from_hash({
           "run" => {
             "linux" => "$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd",
             "macos" => ["$HOMEBREW_PREFIX/opt/formula_name/bin/beanstalkd", "--option"],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is my third attempt at this PR. The goal here is to add a new JSON representation for formulae that is more compact so that there is less data that has to go over the network and less data that has to be loaded at runtime.

The thing is that we wanted to be more explicit about which fields should be included or not. This means that we shouldn't base the JSON representation on the internal `#to_hash` method because that can be changed independently.

As a result of these changes, we expect the `brew generate-formula-api` command to be significantly slower (probably 2x slower) than before because we're not able to memoize as much information as we did in https://github.com/Homebrew/brew/pull/16460. I'll explore if there are any easy wins in this area.

Update: There were none. It's mostly just slow `Formula` loading which is unsurprising.

Code Changes:
- Add `#to_api_hash` method
- Modify `#to_hash_with_variations` to work with both hash methods
- Modify `#bottle_hash` to have an optional compact version
- Add `#urls_hash` method to share urls serialization logic
- Add `#serialized_requirements` to share serialization logic
- Add `#dependencies_hash` to share serialization logic

API Changes:
I've tested the current API hash generation for backwards compatibility and the only difference now is that the optional `head_dependencies` key is right after the other dependency keys instead of at the end each resulting hash after variations. Not sure if we care about that but it should be functionally equivalent.

## Related links
- Issue: https://github.com/Homebrew/brew/issues/16410
- v1: https://github.com/Homebrew/brew/pull/16433
- v2: https://github.com/Homebrew/brew/pull/16460