### PR TITLE
Replace Time refinement with Timer Util

### DIFF
--- a/Library/Homebrew/extend/time.rb
+++ b/Library/Homebrew/extend/time.rb
@@ -1,22 +1,7 @@
-# typed: true
+# typed: strong
 # frozen_string_literal: true
 
-module TimeRemaining
-  refine Time do
-    def remaining
-      T.bind(self, Time)
-      [0, self - Time.now].max
-    end
-
-    def remaining!
-      r = remaining
-
-      Kernel.raise Timeout::Error if r <= 0
-
-      r
-    end
-  end
-end
+require "time"
 
 class Time
   # Backwards compatibility for formulae that used this ActiveSupport extension

--- a/Library/Homebrew/extend/time.rbi
+++ b/Library/Homebrew/extend/time.rbi
@@ -1,9 +1,0 @@
-# typed: strict
-
-class Time
-  sig { returns(T.any(Integer, Float)) }
-  def remaining; end
-
-  sig { returns(T.any(Integer, Float)) }
-  def remaining!; end
-end

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -7,14 +7,12 @@ require "plist"
 require "shellwords"
 
 require "extend/io"
-require "extend/time"
+require "utils/timer"
 
 # Class for running sub-processes and capturing their output and exit status.
 #
 # @api private
 class SystemCommand
-  using TimeRemaining
-
   # Helper functions for calling {SystemCommand.run}.
   module Mixin
     def system_command(executable, **options)
@@ -259,7 +257,7 @@ class SystemCommand
     end
 
     end_time = Time.now + @timeout if @timeout
-    raise Timeout::Error if raw_wait_thr.join(end_time&.remaining).nil?
+    raise Timeout::Error if raw_wait_thr.join(Utils::Timer.remaining(end_time)).nil?
 
     @status = raw_wait_thr.value
 

--- a/Library/Homebrew/test/utils/timer_spec.rb
+++ b/Library/Homebrew/test/utils/timer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "utils/timer"
+
+describe Utils::Timer do
+  describe "#remaining" do
+    it "returns nil when nil" do
+      expect(described_class.remaining(nil)).to be_nil
+    end
+
+    it "returns time remaining when there is time remaining" do
+      expect(described_class.remaining(Time.now + 10)).to be > 1
+    end
+
+    it "returns 0 when there is no time remaining" do
+      expect(described_class.remaining(Time.now - 10)).to be 0
+    end
+  end
+
+  describe "#remaining!" do
+    it "returns nil when nil" do
+      expect(described_class.remaining!(nil)).to be_nil
+    end
+
+    it "returns time remaining when there is time remaining" do
+      expect(described_class.remaining!(Time.now + 10)).to be > 1
+    end
+
+    it "returns 0 when there is no time remaining" do
+      expect { described_class.remaining!(Time.now - 10) }.to raise_error(Timeout::Error)
+    end
+  end
+end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -3,15 +3,13 @@
 
 require "open3"
 
-require "extend/time"
+require "utils/timer"
 
 module Utils
   # Helper function for interacting with `curl`.
   #
   # @api private
   module Curl
-    using TimeRemaining
-
     # This regex is used to extract the part of an ETag within quotation marks,
     # ignoring any leading weak validator indicator (`W/`). This simplifies
     # ETag comparison in `#curl_check_http_content`.
@@ -140,7 +138,7 @@ module Utils
       result = system_command curl_executable(use_homebrew_curl: use_homebrew_curl),
                               args:    curl_args(*args, **options),
                               env:     env,
-                              timeout: end_time&.remaining,
+                              timeout: Utils::Timer.remaining(end_time),
                               **command_options
 
       return result if result.success? || args.include?("--http1.1")
@@ -151,7 +149,7 @@ module Utils
       if result.exit_status == 16
         return curl_with_workarounds(
           *args, "--http1.1",
-          timeout: end_time&.remaining, **command_options, **options
+          timeout: Utils::Timer.remaining(end_time), **command_options, **options
         )
       end
 

--- a/Library/Homebrew/utils/timer.rb
+++ b/Library/Homebrew/utils/timer.rb
@@ -1,0 +1,21 @@
+# typed: strong
+# frozen_string_literal: true
+
+module Utils
+  module Timer
+    sig { params(time: T.nilable(Time)).returns(T.any(Float, Integer, NilClass)) }
+    def self.remaining(time)
+      return unless time
+
+      [0, time - Time.now].max
+    end
+
+    sig { params(time: T.nilable(Time)).returns(T.any(Float, Integer, NilClass)) }
+    def self.remaining!(time)
+      r = remaining(time)
+      raise Timeout::Error if r && r <= 0
+
+      r
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Refinements are problematic for reasons covered in [past](https://github.com/Homebrew/brew/pull/15018) PRs. This PR removes one of the two remaining refinements (`Time`) in favor of static Utils methods.