### PR TITLE
workflows: use macos-14 runner.

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,9 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
-  labels: []
+  labels:
+    # TODO: technically not a self-hosted runner but avoids errors until a new
+    # version of actionlint is released.
+    - macos-14
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   tapioca:
     if: github.repository == 'Homebrew/brew'
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
     name: cask audit
     needs: syntax
     if: github.repository_owner == 'Homebrew'
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -270,7 +270,7 @@ jobs:
           - name: update-test (Ubuntu 22.04)
             runs-on: ubuntu-22.04
           - name: update-test (macOS 13)
-            runs-on: macos-13
+            runs-on: macos-14
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -305,9 +305,12 @@ jobs:
           - name: tests (Ubuntu 20.04)
             test-flags: --coverage
             runs-on: ubuntu-20.04
-          - name: tests (macOS 13)
+          - name: tests (macOS 13 x86_64)
             test-flags: --coverage
             runs-on: macos-13
+          - name: tests (macOS 14 arm64)
+            test-flags: --coverage
+            runs-on: macos-14
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -406,8 +409,10 @@ jobs:
             runs-on: ubuntu-22.04
           - name: test default formula (Ubuntu 20.04)
             runs-on: ubuntu-20.04
-          - name: test default formula (macOS 13)
+          - name: test default formula (macOS 13 x86_64)
             runs-on: macos-13
+          - name: test default formula (macOS 14 arm64)
+            runs-on: macos-14
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -418,6 +423,8 @@ jobs:
           test-bot: true
 
       - run: brew test-bot --only-cleanup-before
+
+      - run: brew cleanup --prune-prefix
 
       - run: brew test-bot --only-setup
 

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -32,7 +32,7 @@ jobs:
           contains(github.event.pull_request.title, '/Library/Homebrew')
         )
       )
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
- Use `macos-14` instead of `macos-13` most of the time.
- For `tests` and `test default formula` builds: run on both macOS 13 x86_64 and macOS 14 arm64
- Pretend `macos-14` is a self-hosted runner until a new version of `actionlint` is released which doesn't error on `macos-14`.