### PR TITLE
rubocop: exclude more tap files from the top-level method cop

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -373,7 +373,7 @@ Style/NumericLiterals:
 
 Style/OpenStructUse:
   Exclude:
-    - "Taps/**/*.rb"
+    - "Taps/**/*"
     # TODO: This is a pre-existing violation and should be corrected
     #   to define methods so that call sites can be type-checked.
     - "Homebrew/cli/args.rb"
@@ -426,7 +426,7 @@ Style/TernaryParentheses:
 Style/TopLevelMethodDefinition:
   Enabled: true
   Exclude:
-    - "Taps/**/*.rb"
+    - "Taps/**/*"
 
 # Trailing commas make diffs nicer.
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Basically, this started failing for me on my personal tap because there are some methods defined at the top-level in my Rakefile. That seems acceptable to me and since we're already ignoring all other Ruby files in the tap I figured we might as well just ignore all of them.

I tested it locally and the errors I was getting with my personal tap went away.

Errors: https://github.com/apainintheneck/homebrew-dev-utils/actions/runs/7769885195/job/21189430063?pr=38