### PR TITLE
Replace “QuickLook” with “Quick Look”

### DIFF
--- a/Library/Homebrew/cask/artifact/qlplugin.rb
+++ b/Library/Homebrew/cask/artifact/qlplugin.rb
@@ -11,7 +11,7 @@ module Cask
     class Qlplugin < Moved
       sig { returns(String) }
       def self.english_name
-        "QuickLook Plugin"
+        "Quick Look Plugin"
       end
 
       def install_phase(**options)

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -48,7 +48,7 @@ module Homebrew
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:prefpanedir]}`).",
           }],
           [:flag, "--qlplugindir=", {
-            description: "Target location for QuickLook Plugins " \
+            description: "Target location for Quick Look Plugins " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:qlplugindir]}`).",
           }],
           [:flag, "--mdimporterdir=", {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the Quick Look stylization, [Apple](https://developer.apple.com/documentation/quicklook) seems to only use "QuickLook" for the framework (and the `Library` path).


Apple uses [Quick Look](https://support.apple.com/en-gb/guide/mac-help/mh14119/14.0/mac/14.0) consistently (even for [developer documentation](https://developer.apple.com/documentation/arkit/arkit_in_ios/previewing_a_model_with_ar_quick_look)), as does [Wikipedia](https://en.wikipedia.org/wiki/Quick_Look).







