### PR TITLE
workflows/tests: fix codecov reporting after v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -392,10 +392,11 @@ jobs:
           HOMEBREW_BUILDPULSE_ACCOUNT_ID: 1503512
           HOMEBREW_BUILDPULSE_REPOSITORY_ID: 53238813
 
-      - uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044
+      - uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           root_dir: ${{ steps.set-up-homebrew.outputs.repository-path }}
           files: Library/Homebrew/test/coverage/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-default-formula:
     name: ${{ matrix.name }}


### PR DESCRIPTION
Was a documented breaking change

The lack of token in PRs is still OK as it does still support tokenless uploading for only those scenarios.