### PR TITLE
fix: fail if superfluous packages are excluded

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -307,6 +307,7 @@ module PyPI
     found_packages.sort.each do |package|
       if exclude_packages.include? package
         ohai "Excluding \"#{package}\"" if show_info
+        exclude_packages.delete package
         next
       end
 
@@ -330,6 +331,10 @@ module PyPI
   end
 
       EOS
+    end
+
+    unless exclude_packages.empty?
+      odie "Excluded superfluous packages: #{", ".join(exclude_packages)}"
     end
 
     if print_only

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -333,7 +333,7 @@ module PyPI
       EOS
     end
 
-    unless exclude_packages.empty?
+    if exclude_packages.any?
       odie "Excluded superfluous packages: #{", ".join(exclude_packages)}"
     end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -333,7 +333,7 @@ module PyPI
       EOS
     end
 
-    odie "Excluded superfluous packages: #{", ".join(exclude_packages)}" if exclude_packages.any?
+    odie "Excluded superfluous packages: #{exclude_packages.join(", ")}" if exclude_packages.any?
 
     if print_only
       puts new_resource_blocks.chomp

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -333,9 +333,7 @@ module PyPI
       EOS
     end
 
-    if exclude_packages.any?
-      odie "Excluded superfluous packages: #{", ".join(exclude_packages)}"
-    end
+    odie "Excluded superfluous packages: #{", ".join(exclude_packages)}" if exclude_packages.any?
 
     if print_only
       puts new_resource_blocks.chomp


### PR DESCRIPTION
Fixes issue where:
- you add a package and depend on the `six` formula so you add it to the exclude list
- upstream removes the dependency on six in a new release
- everything keeps depending on `six` since currently we have no way to know if the excludes list has superfluous entries.