### PR TITLE
workflows/tests: remove `brew cleanup --prune-prefix`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -424,8 +424,6 @@ jobs:
 
       - run: brew test-bot --only-cleanup-before
 
-      - run: brew cleanup --prune-prefix
-
       - run: brew test-bot --only-setup
 
       - run: brew install gnu-tar


### PR DESCRIPTION
This is no longer needed after https://github.com/Homebrew/homebrew-test-bot/pull/1015