### PR TITLE
Fix loading aliases from API.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -937,7 +937,8 @@ module Formulary
 
     if tap.core_tap? && !Homebrew::EnvConfig.no_install_from_api?
       if type == :alias
-        return AliasAPILoader.new(name)
+        alias_name = tapped_name[HOMEBREW_TAP_FORMULA_REGEX, 3]
+        return AliasAPILoader.new(alias_name)
       elsif Homebrew::API::Formula.all_formulae.key?(name)
         return FormulaAPILoader.new(name)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes bug introduced in https://github.com/Homebrew/brew/pull/16595 when loading aliases form API using the long name, e.g. `homebrew/core/tiv`. 