### PR TITLE
Don't require "branch: main" for resources with revisions set

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -171,6 +171,7 @@ module Homebrew
       return if spec_name != :head
       return unless Utils::Git.remote_exists?(url)
       return if specs[:tag].present?
+      return if specs[:revision].present?
 
       branch = Utils.popen_read("git", "ls-remote", "--symref", url, "HEAD")
                     .match(%r{ref: refs/heads/(.*?)\s+HEAD})&.to_a&.second


### PR DESCRIPTION
Just like when a tag is set, when a revision is set for a resource it shouldn't _also_ specify that it comes from the main branch.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
