### PR TITLE
Improved the GitHub link that is generated when the required scope of the token has mismatched with the present scope

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -197,11 +197,11 @@ module GitHub
 
       scopes = response_headers["x-accepted-oauth-scopes"].to_s.split(", ")
       needed_scopes = Set.new(scopes || needed_scopes)
-      github_permission_link = GitHub.pat_blurb(needed_scopes)
 
       credentials_scopes = response_headers["x-oauth-scopes"]
       return if needed_scopes.subset?(Set.new(credentials_scopes.to_s.split(", ")))
 
+      github_permission_link = GitHub.pat_blurb(needed_scopes.to_a)
       needed_scopes = needed_scopes.to_a.join(", ").presence || "none"
       credentials_scopes = "none" if credentials_scopes.blank?
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -197,7 +197,6 @@ module GitHub
 
       scopes = response_headers["x-accepted-oauth-scopes"].to_s.split(", ")
       needed_scopes = Set.new(scopes || needed_scopes)
-
       credentials_scopes = response_headers["x-oauth-scopes"]
       return if needed_scopes.subset?(Set.new(credentials_scopes.to_s.split(", ")))
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -208,7 +208,7 @@ module GitHub
         Your #{what} credentials do not have sufficient scope!
         Scopes required: #{needed_scopes}
         Scopes present:  #{credentials_scopes}
-        #{GitHub.pat_blurb}
+        #{GitHub.pat_blurb(needed_scopes.split(", "))}
       EOS
     end
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -197,6 +197,8 @@ module GitHub
 
       scopes = response_headers["x-accepted-oauth-scopes"].to_s.split(", ")
       needed_scopes = Set.new(scopes || needed_scopes)
+      github_permission_link = GitHub.pat_blurb(needed_scopes)
+
       credentials_scopes = response_headers["x-oauth-scopes"]
       return if needed_scopes.subset?(Set.new(credentials_scopes.to_s.split(", ")))
 
@@ -208,7 +210,7 @@ module GitHub
         Your #{what} credentials do not have sufficient scope!
         Scopes required: #{needed_scopes}
         Scopes present:  #{credentials_scopes}
-        #{GitHub.pat_blurb(needed_scopes.split(", "))}
+        #{github_permission_link}
       EOS
     end
 


### PR DESCRIPTION
Improved the GitHub link that is generated when the required scope of the token has mismatched with the present scope


- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
