### PR TITLE
Include all test paths in RSpec cops

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -215,6 +215,10 @@ Performance/CaseWhenSplat:
 Performance/MethodObjectAsBlock:
   Enabled: false
 
+RSpec:
+  Include:
+    - 'Homebrew/test/**/*'
+
 # Intentionally disabled as it doesn't fit with our code style.
 RSpec/AnyInstance:
   Enabled: false

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -9,7 +9,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
   let(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
   let(:fake_system_command) { class_double(SystemCommand) }
 
-  context "using :launchctl" do
+  context "when using :launchctl" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-launchctl")) }
     let(:launchctl_list_cmd) { %w[/bin/launchctl list my.fancy.package.service] }
     let(:launchctl_remove_cmd) { %w[/bin/launchctl remove my.fancy.package.service] }
@@ -84,7 +84,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using :launchctl with regex wildcard" do
+  context "when using :launchctl with regex wildcard" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-launchctl-wildcard")) }
     let(:launchctl_regex) { "my.fancy.package.service.*" }
     let(:unknown_response) { "launchctl list returned unknown response\n" }
@@ -154,7 +154,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using :pkgutil" do
+  context "when using :pkgutil" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-pkgutil")) }
 
     let(:main_pkg_id) { "my.fancy.package.main" }
@@ -178,7 +178,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using :kext" do
+  context "when using :kext" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-kext")) }
     let(:kext_id) { "my.fancy.package.kernelextension" }
 
@@ -202,7 +202,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using :quit" do
+  context "when using :quit" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-quit")) }
     let(:bundle_id) { "my.fancy.package.app" }
 
@@ -236,10 +236,8 @@ shared_examples "#uninstall_phase or #zap_phase" do
       expect(subject).not_to receive(:running?)
       expect(subject).not_to receive(:quit)
 
-      expect do
-        subject.public_send(:"#{artifact_dsl_key}_phase", upgrade: true, command: fake_system_command)
-        subject.public_send(:"#{artifact_dsl_key}_phase", reinstall: true, command: fake_system_command)
-      end
+      subject.public_send(:"#{artifact_dsl_key}_phase", upgrade: true, command: fake_system_command)
+      subject.public_send(:"#{artifact_dsl_key}_phase", reinstall: true, command: fake_system_command)
     end
 
     it "tries to quit the application for 10 seconds" do
@@ -259,7 +257,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using :signal" do
+  context "when using :signal" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-signal")) }
     let(:bundle_id) { "my.fancy.package.app" }
     let(:signals) { %w[TERM KILL] }
@@ -294,13 +292,13 @@ shared_examples "#uninstall_phase or #zap_phase" do
   [:delete, :trash].each do |directive|
     next if directive == :trash && ENV["HOMEBREW_TESTS_COVERAGE"].nil?
 
-    context "using :#{directive}" do
+    context "when using :#{directive}" do
       let(:dir) { TEST_TMPDIR }
       let(:absolute_path) { Pathname.new("#{dir}/absolute_path") }
       let(:path_with_tilde) { Pathname.new("#{dir}/path_with_tilde") }
-      let(:glob_path1) { Pathname.new("#{dir}/glob_path1") }
-      let(:glob_path2) { Pathname.new("#{dir}/glob_path2") }
-      let(:paths) { [absolute_path, path_with_tilde, glob_path1, glob_path2] }
+      let(:glob_path) { Pathname.new("#{dir}/glob_path") }
+      let(:glob_path_alt) { Pathname.new("#{dir}/glob_path_alt") }
+      let(:paths) { [absolute_path, path_with_tilde, glob_path, glob_path_alt] }
       let(:fake_system_command) { NeverSudoSystemCommand }
       let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-#{directive}")) }
 
@@ -336,7 +334,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
   end
 
   [:script, :early_script].each do |script_type|
-    context "using #{script_type.inspect}" do
+    context "when using #{script_type.inspect}" do
       let(:fake_system_command) { NeverSudoSystemCommand }
       let(:token) { "with-#{artifact_dsl_key}-#{script_type}".tr("_", "-") }
       let(:cask) { Cask::CaskLoader.load(cask_path(token.to_s)) }
@@ -360,7 +358,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using :login_item" do
+  context "when using :login_item" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-login-item")) }
 
     it "is supported" do

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -185,15 +185,15 @@ shared_examples "#uninstall_phase or #zap_phase" do
     it "is supported" do
       allow(subject).to receive(:system_command!)
         .with("/usr/sbin/kextstat", args: ["-l", "-b", kext_id], sudo: true, sudo_as_root: true)
-        .and_return(instance_double("SystemCommand::Result", stdout: "loaded"))
+        .and_return(instance_double(SystemCommand::Result, stdout: "loaded"))
 
       expect(subject).to receive(:system_command!)
         .with("/sbin/kextunload", args: ["-b", kext_id], sudo: true, sudo_as_root: true)
-        .and_return(instance_double("SystemCommand::Result"))
+        .and_return(instance_double(SystemCommand::Result))
 
       expect(subject).to receive(:system_command!)
         .with("/usr/sbin/kextfind", args: ["-b", kext_id], sudo: true, sudo_as_root: true)
-        .and_return(instance_double("SystemCommand::Result", stdout: "/Library/Extensions/FancyPackage.kext\n"))
+        .and_return(instance_double(SystemCommand::Result, stdout: "/Library/Extensions/FancyPackage.kext\n"))
 
       expect(subject).to receive(:system_command!)
         .with("/bin/rm", args: ["-rf", "/Library/Extensions/FancyPackage.kext"], sudo: true, sudo_as_root: true)
@@ -220,7 +220,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
 
       expect(subject).to receive(:running?).with(bundle_id).ordered.and_return(true)
       expect(subject).to receive(:quit).with(bundle_id)
-                                       .and_return(instance_double("SystemCommand::Result", success?: true))
+                                       .and_return(instance_double(SystemCommand::Result, success?: true))
       expect(subject).to receive(:running?).with(bundle_id).ordered.and_return(false)
 
       expect do
@@ -247,7 +247,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
 
       allow(subject).to receive(:running?).with(bundle_id).and_return(true)
       allow(subject).to receive(:quit).with(bundle_id)
-                                      .and_return(instance_double("SystemCommand::Result", success?: false))
+                                      .and_return(instance_double(SystemCommand::Result, success?: false))
 
       time = Benchmark.measure do
         expect do
@@ -369,7 +369,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
           "osascript",
           args: ["-e", 'tell application "System Events" to delete every login item whose name is "Fancy"'],
         )
-        .and_return(instance_double("SystemCommand::Result", success?: true))
+        .and_return(instance_double(SystemCommand::Result, success?: true))
 
       subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
     end

--- a/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
@@ -7,12 +7,8 @@ shared_examples Cask::Staged do
   let(:non_existent_path) { Pathname("/path/to/file/that/does/not/exist") }
 
   before do
-    allow(existing_path).to receive(:exist?).and_return(true)
-    allow(existing_path).to receive(:expand_path)
-      .and_return(existing_path)
-    allow(non_existent_path).to receive(:exist?).and_return(false)
-    allow(non_existent_path).to receive(:expand_path)
-      .and_return(non_existent_path)
+    allow(existing_path).to receive_messages(exist?: true, expand_path: existing_path)
+    allow(non_existent_path).to receive_messages(exist?: false, expand_path: non_existent_path)
   end
 
   it "can run system commands with list-form arguments" do

--- a/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
@@ -41,6 +41,7 @@ shared_examples Cask::Staged do
   it "cannot set the permissions of a file that does not exist" do
     fake_pathname = non_existent_path
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
+    expect(fake_system_command).not_to receive(:run!)
     staged.set_permissions(fake_pathname.to_s, "777")
   end
 
@@ -91,7 +92,7 @@ shared_examples Cask::Staged do
     allow(User).to receive(:current).and_return(User.new("fake_user"))
     fake_pathname = non_existent_path
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
-
+    expect(fake_system_command).not_to receive(:run!)
     staged.set_ownership(fake_pathname.to_s)
   end
 end

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -14,7 +14,7 @@ module Test
       def stub_formula_loader(formula, ref = formula.full_name, call_original: false)
         allow(Formulary).to receive(:loader_for).and_call_original if call_original
 
-        loader = double(get_formula: formula)
+        loader = instance_double(Formulary::FormulaLoader, get_formula: formula)
         allow(Formulary).to receive(:loader_for).with(ref, any_args).and_return(loader)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Per [docs](https://docs.rubocop.org/rubocop-rspec/usage.html#inspecting-files-that-dont-end-with-_spec-rb):

> By default, rubocop-rspec only inspects code within paths ending in _spec.rb or including spec/.

(Possibly, we want to follow convention and rename the `test` dir to `spec`, but we'd still have to apply the fixes here)