### PR TITLE
Improve user ergonomics of `brew link --overwrite` help

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -60,7 +60,7 @@ class Keg
           brew link --overwrite #{keg.name}
 
         To list all files that would be deleted:
-          brew link --overwrite --dry-run #{keg.name}
+          brew link --overwrite #{keg.name} --dry-run
       EOS
       s.join("\n")
     end


### PR DESCRIPTION
This PR makes the two-step: `link --overwrite --dry-run` followed by `link --overwrite` easier/faster for users. (Easy to leverage shell history to re-run the command without the `--dry-run` flag.)

## Background

When a Keg is unlinked, brew-link gives a very helpful message for how to proceed: add the `--overwrite` flag.

For safety, it also recommends running in `--dry-run` mode first to see what would be deleted.

So a user's common flow would be:

1. run `brew link foo`
2. get error message with guidance
3. run `brew link --overwrite --dry-run foo`
4. inspect output
5. run `brew link --overwrite foo`

In this flow, steps 3-5 are likely very common to run back-to-back. Common enough that a user may use their shell history (up arrow) to re-populate their prompt with step 3's command, delete the `--dry-run` flag, and re-run.

The `--dry-run` flag needs to be removed from the command, of course. If it had been at the _end_ of the command, it would make the subsequent modification easier.

Instead of "up arrow, left-arrow a bunch, then backspace over --dry-run, hopefully not backspacing over the formula name", it would be easier for the user if the dry-run flag were already at the end of the command. Then the user can "up arrow, backspace a few times and hit enter".

What's more, if the last arg were `--dry-run`, a more advanced bash user could even use `!:-` to re-run the link command with all-but-the-last-arg.

This change is admittedly quite trivial, and unlikely to heavily impact anyone's life. However, I find myself running these commands often enough in quick succession that it would be a nice improvement to make the "re-run for reals" step easier.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). This doesn't seem worth a test?
- [ ] Have you successfully run `brew style` with your changes locally? (this errored while installing gems 😬 ) 
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

<details>
<summary>brew-style error</summary>
<pre><code>
$ brew style
Fetching gem metadata from https://rubygems.org/.......
Fetching sorbet-runtime 0.5.11247
Fetching rubocop-sorbet 0.7.7
Installing rubocop-sorbet 0.7.7
Installing sorbet-runtime 0.5.11247
Bundle complete! 35 Gemfile dependencies, 29 gems now installed.
Bundled gems are installed into `./Library/Homebrew/vendor/bundle`
Removing rubocop-sorbet (0.7.6)
cannot load such file -- standard/cop/semantic_blocks
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/feature_loader.rb:46:in `rescue in rescue in load'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/feature_loader.rb:39:in `rescue in load'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/feature_loader.rb:32:in `load'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/feature_loader.rb:21:in `load'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_loader_resolver.rb:14:in `block (2 levels) in resolve_requires'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_loader_resolver.rb:13:in `each'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_loader_resolver.rb:13:in `block in resolve_requires'
<internal:kernel>:90:in `tap'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_loader_resolver.rb:12:in `resolve_requires'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_loader.rb:52:in `load_file'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_loader.rb:111:in `configuration_from_file'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_store.rb:68:in `for_dir'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/config_store.rb:47:in `for_pwd'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/cli.rb:134:in `validate_options_vs_config'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/cli.rb:48:in `block in run'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/cli.rb:77:in `profile_if_needed'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/rubocop-1.60.2/lib/rubocop/cli.rb:43:in `run'
/usr/local/Homebrew/Library/Homebrew/utils/rubocop.rb:12:in `<main>'
</code></pre>
</details>
-----
