### PR TITLE
completions: improve list of available services and outdated checks

### DIFF
--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -81,14 +81,14 @@ __brew_complete_installed_casks() {
 __brew_complete_outdated_formulae() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local outdated_formulae
-  outdated_formulae="$(brew outdated --formula --quiet)"
+  outdated_formulae="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_formulae}" -- "${cur}")
 }
 
 __brew_complete_outdated_casks() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local outdated_casks
-  outdated_casks="$(brew outdated --cask --quiet 2>/dev/null)"
+  outdated_casks="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --quiet 2>/dev/null)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_casks}" -- "${cur}")
 }
 

--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -108,7 +108,7 @@ end
 
 
 function __fish_brew_suggest_formulae_outdated -d "List of outdated formulae with the information about potential upgrade"
-    brew outdated --formula --verbose \
+    HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --verbose 2>/dev/null \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end
@@ -134,7 +134,7 @@ function __fish_brew_suggest_casks_installed -d "Lists installed casks"
 end
 
 function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the information about potential upgrade"
-    brew outdated --cask --verbose 2>/dev/null \
+    HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --verbose 2>/dev/null \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end
@@ -157,13 +157,10 @@ function __fish_brew_suggest_diagnostic_checks -d "List available diagnostic che
     brew doctor --list-checks
 end
 
-# TODO: any better way to list available services?
 function __fish_brew_suggest_services -d "Lists available services"
-    set -l list (brew services list)
-    set -e list[1] # Header
-    for line in $list
-        echo (string split ' ' $line)[1]
-    end
+    command find (brew --cellar) -mindepth 3 -maxdepth 3 -name '*.service' \
+      | awk -F'homebrew.|.service' '{print $3}' \
+      | sort -d
 end
 
 

--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -74,7 +74,7 @@ __brew_outdated_formulae() {
   [[ -prefix '-' ]] && return 0
 
   local -a formulae
-  formulae=($(brew outdated --formula))
+  formulae=($(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula))
   _describe -t formulae 'outdated formulae' formulae
 }
 
@@ -106,7 +106,7 @@ __brew_outdated_casks() {
   [[ -prefix '-' ]] && return 0
 
   local -a casks
-  casks=($(brew outdated --cask 2>/dev/null))
+  casks=($(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask 2>/dev/null))
   _describe -t casks 'outdated casks' casks
 }
 

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -68,14 +68,14 @@ __brew_complete_installed_casks() {
 __brew_complete_outdated_formulae() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local outdated_formulae
-  outdated_formulae="$(brew outdated --formula --quiet)"
+  outdated_formulae="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --quiet)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_formulae}" -- "${cur}")
 }
 
 __brew_complete_outdated_casks() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local outdated_casks
-  outdated_casks="$(brew outdated --cask --quiet 2>/dev/null)"
+  outdated_casks="$(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --quiet 2>/dev/null)"
   while read -r line; do COMPREPLY+=("${line}"); done < <(compgen -W "${outdated_casks}" -- "${cur}")
 }
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -95,7 +95,7 @@ end
 
 
 function __fish_brew_suggest_formulae_outdated -d "List of outdated formulae with the information about potential upgrade"
-    brew outdated --formula --verbose \
+    HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --verbose 2>/dev/null \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end
@@ -121,7 +121,7 @@ function __fish_brew_suggest_casks_installed -d "Lists installed casks"
 end
 
 function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the information about potential upgrade"
-    brew outdated --cask --verbose 2>/dev/null \
+    HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --verbose 2>/dev/null \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end
@@ -144,13 +144,10 @@ function __fish_brew_suggest_diagnostic_checks -d "List available diagnostic che
     brew doctor --list-checks
 end
 
-# TODO: any better way to list available services?
 function __fish_brew_suggest_services -d "Lists available services"
-    set -l list (brew services list)
-    set -e list[1] # Header
-    for line in $list
-        echo (string split ' ' $line)[1]
-    end
+    command find (brew --cellar) -mindepth 3 -maxdepth 3 -name '*.service' \
+      | awk -F'homebrew.|.service' '{print $3}' \
+      | sort -d
 end
 
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -78,7 +78,7 @@ __brew_outdated_formulae() {
   [[ -prefix '-' ]] && return 0
 
   local -a formulae
-  formulae=($(brew outdated --formula))
+  formulae=($(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula))
   _describe -t formulae 'outdated formulae' formulae
 }
 
@@ -110,7 +110,7 @@ __brew_outdated_casks() {
   [[ -prefix '-' ]] && return 0
 
   local -a casks
-  casks=($(brew outdated --cask 2>/dev/null))
+  casks=($(HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask 2>/dev/null))
   _describe -t casks 'outdated casks' casks
 }
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR makes some improvements to the completions.
1. It improves the logic for finding services
2. It passes HOMEBREW_NO_AUTO_UPDATE=1 to all `brew outdated` calls in the completions. While this change prevents the completion from fetching outdated casks/formulas by itself, it represents a substantial improvement in a completion that is otherwise input-blocking. 


```fish
❯ hyperfine "brew outdated --formula --verbose  | string replace -r '\s' '\t'" "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --verbose 2>/dev/null | string replace -r '\s' '\t'" --shell fish
Benchmark 1: brew outdated --formula --verbose  | string replace -r '\s' '\t'
  Time (mean ± σ):      3.686 s ±  0.879 s    [User: 0.845 s, System: 0.238 s]
  Range (min … max):    3.183 s …  6.048 s    10 runs

Benchmark 2: HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --verbose 2>/dev/null | string replace -r '\s' '\t'
  Time (mean ± σ):      1.462 s ±  0.045 s    [User: 0.836 s, System: 0.223 s]
  Range (min … max):    1.399 s …  1.548 s    10 runs

Summary
  HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --formula --verbose 2>/dev/null | string replace -r '\s' '\t' ran
    3.52 ± 0.61 times faster than brew outdated --formula --verbose  | string replace -r '\s' '\t'
```

```fish
❯ hyperfine "brew outdated --cask --verbose 2>/dev/null | string replace -r '\s' '\t'" "HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --verbose 2>/dev/null | string replace -r '\s' '\t'" --shell fish
Benchmark 1: brew outdated --cask --verbose 2>/dev/null | string replace -r '\s' '\t'
  Time (mean ± σ):      3.211 s ±  0.013 s    [User: 0.454 s, System: 0.140 s]
  Range (min … max):    3.190 s …  3.232 s    10 runs

Benchmark 2: HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --verbose 2>/dev/null | string replace -r '\s' '\t'
  Time (mean ± σ):     886.5 ms ±  68.7 ms    [User: 433.1 ms, System: 125.2 ms]
  Range (min … max):   812.5 ms … 1018.8 ms    10 runs

Summary
  HOMEBREW_NO_AUTO_UPDATE=1 brew outdated --cask --verbose 2>/dev/null | string replace -r '\s' '\t' ran
    3.62 ± 0.28 times faster than brew outdated --cask --verbose 2>/dev/null | string replace -r '\s' '\t'
```

```fish
Benchmark 1:     command find (brew --cellar) -mindepth 3 -maxdepth 3 -name '*.service'       | awk -F'homebrew.|.service' '{print }'       | sort -d
  Time (mean ± σ):      59.2 ms ±   3.3 ms    [User: 8.4 ms, System: 43.4 ms]
  Range (min … max):    56.1 ms …  73.2 ms    27 runs

Benchmark 2:     set -l list (brew services list)
    set -e list[1] # Header
    for line in
        echo (string split ' ' )[1]
    end
  Time (mean ± σ):      1.687 s ±  0.097 s    [User: 0.861 s, System: 0.305 s]
  Range (min … max):    1.589 s …  1.933 s    10 runs

Summary
      command find (brew --cellar) -mindepth 3 -maxdepth 3 -name '*.service'       | awk -F'homebrew.|.service' '{print }'       | sort -d ran
   28.48 ± 2.29 times faster than     set -l list (brew services list)
    set -e list[1] # Header
    for line in
        echo (string split ' ' )[1]
    end
```