### PR TITLE
Fix cask migration warnings.

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -445,10 +445,10 @@ module Cask
       }
       def self.try_new(ref, warn: false)
         return unless ref.is_a?(String)
-        return if ref.include?("/")
+        return unless (token = ref[HOMEBREW_DEFAULT_TAP_CASK_REGEX, :token])
         return unless (tap = CoreCaskTap.instance).installed?
 
-        return unless (loader = super("#{tap}/#{ref}", warn: warn))
+        return unless (loader = super("#{tap}/#{token}", warn: warn))
 
         loader if loader.path.exist?
       end

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -66,5 +66,45 @@ describe Cask::CaskLoader, :cask do
         end
       end
     end
+
+    context "when not using the API" do
+      before do
+        ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+      end
+
+      context "when a cask is migrated to the default tap" do
+        let(:token) { "local-caffeine" }
+        let(:tap_migrations) do
+          {
+            token => default_tap.name,
+          }
+        end
+        let(:old_tap) { CoreTap.instance }
+        let(:default_tap) { CoreCaskTap.instance }
+
+        before do
+          (old_tap.path/"tap_migrations.json").write tap_migrations.to_json
+          old_tap.clear_cache
+        end
+
+        it "does not warn when loading the short token" do
+          expect do
+            described_class.for(token)
+          end.not_to output.to_stderr
+        end
+
+        it "does not warn when loading the full token in the default tap" do
+          expect do
+            described_class.for("#{default_tap}/#{token}")
+          end.not_to output.to_stderr
+        end
+
+        it "warns when loading the full token in the old tap" do
+          expect do
+            described_class.for("#{old_tap}/#{token}")
+          end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{token}\.}).to_stderr
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Readd a separate loader for the default tap to avoid showing a warning when a cask was migrated to it when trying to load a cask using the short token.

Fixes https://github.com/Homebrew/brew/issues/16653.