### PR TITLE
Fix syntax of `brew audit` call

### DIFF
--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -28,7 +28,7 @@ If you're stuck, ask for help on GitHub or the [Homebrew discussion forum](https
 
 ### Testing and auditing the formula
 
-1. Run `brew audit --strict --new-formula --online <formula>` with your formula. If any errors occur, correct your formula and run the audit again. The audit should finish without any errors by the end of this step.
+1. Run `brew audit --strict --new --online <formula>` with your formula. If any errors occur, correct your formula and run the audit again. The audit should finish without any errors by the end of this step.
 
 1. Run your formula's test using `brew test <formula>`. The test should finish without any errors.
 


### PR DESCRIPTION
`--new-formula` is now simply `--new` (according to `brew audit` itself).

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- (n/a) Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- (n/a) Have you successfully run `brew style` with your changes locally?
- (n/a) Have you successfully run `brew typecheck` with your changes locally?
- (n/a) Have you successfully run `brew tests` with your changes locally?

-----
