### PR TITLE
Ask to use HOMEBREW_NO_INSTALL_FROM_API=1 for audit

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -225,7 +225,7 @@ module Homebrew
     end
     PyPI.update_python_resources! formula, ignore_non_pypi_packages: true if args.python?
 
-    puts "Please run `brew audit --new #{fc.name}` before submitting, thanks."
+    puts "Please run `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --new #{fc.name}` before submitting, thanks."
     path
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew audit` on newly created formula fails without `HOMEBREW_NO_INSTALL_FROM_API=1`.
```
✗ brew audit --new observable 
Error: No available formula with the name "observable". Did you mean observerward?
```
The PR fixes user instructions.