### PR TITLE
formula_creator: Fix GitHub parsing when name doesn't match URL

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -56,10 +56,8 @@ module Homebrew
       when %r{github\.com/(\S+)/(\S+)\.git}
         @user = Regexp.last_match(1)
         @head = true
-        @github = true
       when %r{github\.com/(\S+)/(\S+)/(archive|releases)/}
         @user = Regexp.last_match(1)
-        @github = true
       end
     end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #16675.