### PR TITLE
Fix flaky `Formulary` test.

### DIFF
--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -104,6 +104,21 @@ describe Cask::CaskLoader, :cask do
             described_class.for("#{old_tap}/#{token}")
           end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{token}\.}).to_stderr
         end
+
+        context "when there is an infinite tap migration loop" do
+          before do
+            (default_tap.path/"tap_migrations.json").write({
+              token => old_tap.name,
+            }.to_json)
+            default_tap.clear_cache
+          end
+
+          it "stops recursing" do
+            expect do
+              described_class.for("#{default_tap}/#{token}")
+            end.not_to output.to_stderr
+          end
+        end
       end
     end
   end

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -85,6 +85,7 @@ describe Cask::CaskLoader, :cask do
         before do
           (old_tap.path/"tap_migrations.json").write tap_migrations.to_json
           old_tap.clear_cache
+          default_tap.clear_cache
         end
 
         it "does not warn when loading the short token" do
@@ -105,20 +106,21 @@ describe Cask::CaskLoader, :cask do
           end.to output(%r{Cask #{old_tap}/#{token} was renamed to #{token}\.}).to_stderr
         end
 
-        context "when there is an infinite tap migration loop" do
-          before do
-            (default_tap.path/"tap_migrations.json").write({
-              token => old_tap.name,
-            }.to_json)
-            default_tap.clear_cache
-          end
-
-          it "stops recursing" do
-            expect do
-              described_class.for("#{default_tap}/#{token}")
-            end.not_to output.to_stderr
-          end
-        end
+        # FIXME
+        # context "when there is an infinite tap migration loop" do
+        #   before do
+        #     (default_tap.path/"tap_migrations.json").write({
+        #       token => old_tap.name,
+        #     }.to_json)
+        #     default_tap.clear_cache
+        #   end
+        #
+        #   it "stops recursing" do
+        #     expect do
+        #       described_class.for("#{default_tap}/#{token}")
+        #     end.not_to output.to_stderr
+        #   end
+        # end
       end
     end
   end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -540,7 +540,7 @@ describe Formulary do
       end
 
       context "when a formula is migrated to the default tap" do
-        let(:token) { "local-caffeine" }
+        let(:token) { "foo" }
         let(:tap_migrations) do
           {
             token => default_tap.name,
@@ -553,6 +553,7 @@ describe Formulary do
           old_tap.path.mkpath
           (old_tap.path/"tap_migrations.json").write tap_migrations.to_json
           old_tap.clear_cache
+          default_tap.clear_cache
         end
 
         it "does not warn when loading the short token" do
@@ -573,20 +574,21 @@ describe Formulary do
           end.to output(%r{Formula #{old_tap}/#{token} was renamed to #{token}\.}).to_stderr
         end
 
-        context "when there is an infinite tap migration loop" do
-          before do
-            (default_tap.path/"tap_migrations.json").write({
-              token => old_tap.name,
-            }.to_json)
-            default_tap.clear_cache
-          end
-
-          it "stops recursing" do
-            expect do
-              described_class.loader_for("#{default_tap}/#{token}")
-            end.not_to output.to_stderr
-          end
-        end
+        # FIXME
+        # context "when there is an infinite tap migration loop" do
+        #   before do
+        #     (default_tap.path/"tap_migrations.json").write({
+        #       token => old_tap.name,
+        #     }.to_json)
+        #     default_tap.clear_cache
+        #   end
+        #
+        #   it "stops recursing" do
+        #     expect do
+        #       described_class.loader_for("#{default_tap}/#{token}")
+        #     end.not_to output.to_stderr
+        #   end
+        # end
       end
     end
   end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -572,6 +572,21 @@ describe Formulary do
             described_class.loader_for("#{old_tap}/#{token}")
           end.to output(%r{Formula #{old_tap}/#{token} was renamed to #{token}\.}).to_stderr
         end
+
+        context "when there is an infinite tap migration loop" do
+          before do
+            (default_tap.path/"tap_migrations.json").write({
+              token => old_tap.name,
+            }.to_json)
+            default_tap.clear_cache
+          end
+
+          it "stops recursing" do
+            expect do
+              described_class.loader_for("#{default_tap}/#{token}")
+            end.not_to output.to_stderr
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `CaskLoader` and `Formulary` tests use the same tap migrations, but in opposite directions. I assume there is a small possibility that both migrations exist at the same time, resulting in an infinite loop between the two taps.

I added two tests to reproduce the flaky test. Will have a look later at how to best fix this. Simplest solution for now is to not use the same formula/cask name, but that doesn't really scale.