### PR TITLE
Fix flaky `CaskDependent` tests.

### DIFF
--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -180,6 +180,8 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
         #{content.gsub(/^(?!$)/, "  ")}
         end
       RUBY
+
+      CoreTap.instance.clear_cache
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This tries to fix the flaky `CaskDependent#recursive_dependencies` test by clearing the tap cache after setting up a new test formula.