### PR TITLE
formulary_spec: update API tests to avoid mocking

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1169,7 +1169,8 @@ class CoreTap < AbstractCoreTap
       name, formula_hash = item
       # If there's more than one item with the same path: use the longer one to prioritise more specific results.
       existing_path = hash[name]
-      new_path = File.join(tap_path, formula_hash["ruby_source_path"]) # Pathname equivalent is slow in a tight loop
+      # Pathname equivalent is slow in a tight loop
+      new_path = File.join(tap_path, formula_hash.fetch("ruby_source_path"))
       hash[name] = Pathname(new_path) if existing_path.nil? || existing_path.to_s.length < new_path.length
     end
   end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -158,8 +158,6 @@ describe Formulary do
 
     context "with installed Formula" do
       before do
-        allow(described_class).to receive(:loader_for).and_call_original
-
         # don't try to load/fetch gcc/glibc
         allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
       end
@@ -329,6 +327,7 @@ describe Formulary do
               "run_type"    => "immediate",
               "working_dir" => "/$HOME",
             },
+            "ruby_source_path"         => "Formula/#{formula_name}.rb",
           }.merge(extra_items),
         }
       end
@@ -378,7 +377,7 @@ describe Formulary do
       end
 
       before do
-        allow(described_class).to receive(:loader_for).and_return(described_class::FormulaAPILoader.new(formula_name))
+        ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
 
         # don't try to load/fetch gcc/glibc
         allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Stop mocking the formulary loader method. We just need to set the environment variable so that it knows to load things from the API.

Fix spec that doesn't work with the `CoreTap#formula_names`. That method assumes that we always have a valid `ruby_source_path` in the API JSON even though that was optional for a while after launching the API if my memory serves me. It's probably fine to assume this should always be set though and I changed it to use `Hash#fetch` to give use better error messages if something goes wrong in the future.

Remove unnecessary `allow(x).to receive(y).and_call_original` in tap spec.

Extracted from https://github.com/Homebrew/brew/pull/16460#discussion_r1451389544
