### PR TITLE
audit: cleanup easy-install check

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -131,13 +131,13 @@ module FormulaCellarChecks
   end
 
   def check_easy_install_pth(lib)
-    pth_found = Dir["#{lib}/python{2.7,3}*/site-packages/easy-install.pth"].map { |f| File.dirname(f) }
+    pth_found = Dir["#{lib}/python3*/site-packages/easy-install.pth"].map { |f| File.dirname(f) }
     return if pth_found.empty?
 
     <<~EOS
       'easy-install.pth' files were found.
       These '.pth' files are likely to cause link conflicts.
-      Please invoke `setup.py` using 'Language::Python.setup_install_args'.
+      Easy install is now deprecated, do not use it.
       The offending files are:
         #{pth_found * "\n  "}
     EOS


### PR DESCRIPTION
- Python 2 is long gone
- Do not allow to use easy_install at all: it is now long deprecated

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
