### PR TITLE
Modernize RSpec configuration

### DIFF
--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -2,17 +2,21 @@
 # frozen_string_literal: true
 
 module Homebrew
-  sig { returns(T::Array[String]) }
-  def self.tar_args
-    if MacOS.version >= :catalina
-      ["--no-mac-metadata", "--no-acls", "--no-xattrs"].freeze
-    else
-      [].freeze
+  class << self
+    undef tar_args
+    sig { returns(T::Array[String]) }
+    def tar_args
+      if MacOS.version >= :catalina
+        ["--no-mac-metadata", "--no-acls", "--no-xattrs"].freeze
+      else
+        [].freeze
+      end
     end
-  end
 
-  sig { params(gnu_tar_formula: Formula).returns(String) }
-  def self.gnu_tar(gnu_tar_formula)
-    "#{gnu_tar_formula.opt_bin}/gtar"
+    undef gnu_tar
+    sig { params(gnu_tar_formula: Formula).returns(String) }
+    def gnu_tar(gnu_tar_formula)
+      "#{gnu_tar_formula.opt_bin}/gtar"
+    end
   end
 end

--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -4,6 +4,7 @@
 module Homebrew
   class << self
     undef tar_args
+
     sig { returns(T::Array[String]) }
     def tar_args
       if MacOS.version >= :catalina
@@ -14,6 +15,7 @@ module Homebrew
     end
 
     undef gnu_tar
+
     sig { params(gnu_tar_formula: Formula).returns(String) }
     def gnu_tar(gnu_tar_formula)
       "#{gnu_tar_formula.opt_bin}/gtar"

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "livecheck/livecheck"
-
 module Homebrew
   module Livecheck
     # The `Livecheck::SkipConditions` module primarily contains methods that

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -2,7 +2,7 @@
 
 require "extend/ENV"
 
-describe "ENV" do
+RSpec.describe "ENV" do
   shared_examples EnvActivation do
     subject(:env) { env_activation.extend(described_class) }
 

--- a/Library/Homebrew/test/PATH_spec.rb
+++ b/Library/Homebrew/test/PATH_spec.rb
@@ -2,7 +2,7 @@
 
 require "PATH"
 
-describe PATH do
+RSpec.describe PATH do
   describe "#initialize" do
     it "can take multiple arguments" do
       expect(described_class.new("/path1", "/path2")).to eq("/path1:/path2")

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -2,7 +2,7 @@
 
 require "api"
 
-describe Homebrew::API::Cask do
+RSpec.describe Homebrew::API::Cask do
   let(:cache_dir) { mktmpdir }
 
   before do

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -2,7 +2,7 @@
 
 require "api"
 
-describe Homebrew::API::Formula do
+RSpec.describe Homebrew::API::Formula do
   let(:cache_dir) { mktmpdir }
 
   before do

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -2,7 +2,7 @@
 
 require "api"
 
-describe Homebrew::API do
+RSpec.describe Homebrew::API do
   let(:text) { "foo" }
   let(:json) { '{"foo":"bar"}' }
   let(:json_hash) { JSON.parse(json) }

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -2,7 +2,7 @@
 
 require "open3"
 
-describe "Bash" do
+RSpec.describe "Bash" do
   matcher :have_valid_bash_syntax do
     match do |file|
       stdout, stderr, status = Open3.capture3("/bin/bash", "-n", file)

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -3,7 +3,7 @@
 require "formula"
 require "software_spec"
 
-describe Bottle::Filename do
+RSpec.describe Bottle::Filename do
   subject { described_class.new(name, version, tag, rebuild) }
 
   let(:name) { "user/repo/foo" }

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -2,7 +2,7 @@
 
 require "build_environment"
 
-describe BuildEnvironment do
+RSpec.describe BuildEnvironment do
   let(:env) { described_class.new }
 
   describe "#<<" do

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -3,7 +3,7 @@
 require "build_options"
 require "options"
 
-describe BuildOptions do
+RSpec.describe BuildOptions do
   alias_matcher :be_built_with, :be_with
   alias_matcher :be_built_without, :be_without
 

--- a/Library/Homebrew/test/bump_version_parser_spec.rb
+++ b/Library/Homebrew/test/bump_version_parser_spec.rb
@@ -2,7 +2,7 @@
 
 require "bump_version_parser"
 
-describe Homebrew::BumpVersionParser do
+RSpec.describe Homebrew::BumpVersionParser do
   let(:general_version) { "1.2.3" }
   let(:intel_version) { "2.3.4" }
   let(:arm_version) { "3.4.5" }

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -2,7 +2,7 @@
 
 require "bundle_version"
 
-describe Homebrew::BundleVersion do
+RSpec.describe Homebrew::BundleVersion do
   describe "#<=>" do
     it "compares both the `short_version` and `version`" do
       expect(described_class.new("1.2.3", "3000")).to be < described_class.new("1.2.3", "4000")

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -2,7 +2,7 @@
 
 require "cache_store"
 
-describe CacheStoreDatabase do
+RSpec.describe CacheStoreDatabase do
   subject(:sample_db) { described_class.new(:sample) }
 
   describe "self.use" do

--- a/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/abstract_artifact_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::AbstractArtifact, :cask do
+RSpec.describe Cask::Artifact::AbstractArtifact, :cask do
   describe ".read_script_arguments" do
     let(:stanza) { :installer }
 

--- a/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::App, :cask do
+RSpec.describe Cask::Artifact::App, :cask do
   describe "activate to alternate target" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-alt-target")) }
 

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::App, :cask do
+RSpec.describe Cask::Artifact::App, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("local-caffeine")) }
   let(:command) { NeverSudoSystemCommand }
   let(:adopt) { false }

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::Binary, :cask do
+RSpec.describe Cask::Artifact::Binary, :cask do
   let(:cask) do
     Cask::CaskLoader.load(cask_path("with-binary")).tap do |cask|
       InstallHelper.install_without_artifacts(cask)

--- a/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/generic_artifact_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::Artifact, :cask do
+RSpec.describe Cask::Artifact::Artifact, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("with-generic-artifact")) }
 
   let(:install_phase) do

--- a/Library/Homebrew/test/cask/artifact/installer_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/installer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::Installer, :cask do
+RSpec.describe Cask::Artifact::Installer, :cask do
   subject(:installer) { described_class.new(cask, **args) }
 
   let(:staged_path) { mktmpdir }

--- a/Library/Homebrew/test/cask/artifact/manpage_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/manpage_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::Manpage, :cask do
+RSpec.describe Cask::Artifact::Manpage, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_token) }
 
   context "without section" do

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::Pkg, :cask do
+RSpec.describe Cask::Artifact::Pkg, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("with-installable")) }
   let(:fake_system_command) { class_double(SystemCommand) }
 

--- a/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/postflight_block_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::PostflightBlock, :cask do
+RSpec.describe Cask::Artifact::PostflightBlock, :cask do
   describe "install_phase" do
     it "calls the specified block after installing, passing a Cask mini-dsl" do
       called = false

--- a/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/preflight_block_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::PreflightBlock, :cask do
+RSpec.describe Cask::Artifact::PreflightBlock, :cask do
   describe "install_phase" do
     it "calls the specified block before installing, passing a Cask mini-dsl" do
       called = false

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -2,7 +2,7 @@
 
 require "benchmark"
 
-shared_examples "#uninstall_phase or #zap_phase" do
+RSpec.shared_examples "#uninstall_phase or #zap_phase" do
   subject { artifact }
 
   let(:artifact_dsl_key) { described_class.dsl_key }

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::Suite, :cask do
+RSpec.describe Cask::Artifact::Suite, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("with-suite")) }
 
   let(:install_phase) do

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::App, :cask do
+RSpec.describe Cask::Artifact::App, :cask do
   describe "multiple apps" do
     let(:cask) { Cask::CaskLoader.load(cask_path("with-two-apps-correct")) }
 

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Artifact::Zap, :cask do
+RSpec.describe Cask::Artifact::Zap, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("with-installable")) }
 
   let(:zap_artifact) do

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples/uninstall_zap"
 
-describe Cask::Artifact::Uninstall, :cask do
+RSpec.describe Cask::Artifact::Uninstall, :cask do
   describe "#uninstall_phase" do
     include_examples "#uninstall_phase or #zap_phase"
   end

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples/uninstall_zap"
 
-describe Cask::Artifact::Zap, :cask do
+RSpec.describe Cask::Artifact::Zap, :cask do
   describe "#zap_phase" do
     include_examples "#uninstall_phase or #zap_phase"
 

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -472,7 +472,6 @@ describe Cask::Audit, :cask do
 
       before do
         allow(audit).to receive_messages(download: download_double, signing?: true)
-        allow(audit).to receive(:check_https_availability)
       end
 
       context "when cask is not using a signed artifact" do
@@ -1024,7 +1023,6 @@ describe Cask::Audit, :cask do
 
       before do
         allow(audit).to receive(:download).and_return(download_double)
-        allow(audit).to receive(:check_https_availability)
         allow(UnpackStrategy).to receive(:detect).and_return(nil)
       end
 

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -2,7 +2,7 @@
 
 require "cask/audit"
 
-describe Cask::Audit, :cask do
+RSpec.describe Cask::Audit, :cask do
   def include_msg?(problems, msg)
     if msg.is_a?(Regexp)
       Array(problems).any? { |problem| msg.match?(problem[:message]) }

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::CaskLoader::FromAPILoader, :cask do
+RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
   shared_context "with API setup" do |new_token|
     let(:token) { new_token }
     let(:cask_from_source) { Cask::CaskLoader.load(token) }

--- a/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_content_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::CaskLoader::FromContentLoader do
+RSpec.describe Cask::CaskLoader::FromContentLoader do
   describe "::try_new" do
     it "returns a loader for Casks specified with `cask \"token\" do … end`" do
       expect(described_class.try_new(<<~RUBY)).not_to be_nil

--- a/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_path_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::CaskLoader::FromPathLoader do
+RSpec.describe Cask::CaskLoader::FromPathLoader do
   describe "#load" do
     context "when the file does not contain a cask" do
       let(:path) do

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::CaskLoader::FromTapLoader do
+RSpec.describe Cask::CaskLoader::FromTapLoader do
   let(:cask_name) { "testball" }
   let(:cask_full_name) { "homebrew/cask/#{cask_name}" }
   let(:cask_path) { CoreCaskTap.instance.cask_dir/"#{cask_name}.rb" }

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::CaskLoader::FromURILoader do
+RSpec.describe Cask::CaskLoader::FromURILoader do
   describe "::try_new" do
     it "returns a loader when given an URI" do
       expect(described_class.try_new(URI("https://brew.sh/"))).not_to be_nil

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::CaskLoader, :cask do
+RSpec.describe Cask::CaskLoader, :cask do
   describe "::for" do
     let(:tap) { CoreCaskTap.instance }
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Cask, :cask do
+RSpec.describe Cask::Cask, :cask do
   let(:cask) { described_class.new("versioned-cask") }
 
   context "when multiple versions are installed" do

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Config, :cask do
+RSpec.describe Cask::Config, :cask do
   subject(:config) { described_class.new }
 
   describe "::from_json" do

--- a/Library/Homebrew/test/cask/conflicts_with_spec.rb
+++ b/Library/Homebrew/test/cask/conflicts_with_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "conflicts_with", :cask do
+RSpec.describe "conflicts_with", :cask do
   describe "conflicts_with cask" do
     let(:local_caffeine) do
       Cask::CaskLoader.load(cask_path("local-caffeine"))

--- a/Library/Homebrew/test/cask/denylist_spec.rb
+++ b/Library/Homebrew/test/cask/denylist_spec.rb
@@ -2,7 +2,7 @@
 
 require "cask/denylist"
 
-describe Cask::Denylist, :cask do
+RSpec.describe Cask::Denylist, :cask do
   describe "::reason" do
     matcher :disallow do |name|
       match do |expected|

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -2,7 +2,7 @@
 
 # TODO: this test should be named after the corresponding class, once
 #       that class is abstracted from installer.rb
-describe "Satisfy Dependencies and Requirements", :cask do
+RSpec.describe "Satisfy Dependencies and Requirements", :cask do
   subject(:install) do
     Cask::Installer.new(cask).install
   end

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Cask
-  describe Download, :cask do
+  RSpec.describe Download, :cask do
     describe "#verify_download_integrity" do
       subject(:verification) { described_class.new(cask).verify_download_integrity(downloaded_path) }
 

--- a/Library/Homebrew/test/cask/dsl/caveats_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/caveats_spec.rb
@@ -2,7 +2,7 @@
 
 require "test/cask/dsl/shared_examples/base"
 
-describe Cask::DSL::Caveats, :cask do
+RSpec.describe Cask::DSL::Caveats, :cask do
   subject(:caveats) { described_class.new(cask) }
 
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }

--- a/Library/Homebrew/test/cask/dsl/container_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/container_spec.rb
@@ -2,7 +2,7 @@
 
 require "test/cask/dsl/shared_examples/base"
 
-describe Cask::DSL::Container do
+RSpec.describe Cask::DSL::Container do
   subject(:container) { described_class.new(**params) }
 
   describe "#pairs" do

--- a/Library/Homebrew/test/cask/dsl/postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/postflight_spec.rb
@@ -3,7 +3,7 @@
 require "test/cask/dsl/shared_examples/base"
 require "test/cask/dsl/shared_examples/staged"
 
-describe Cask::DSL::Postflight, :cask do
+RSpec.describe Cask::DSL::Postflight, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:fake_system_command) { class_double(SystemCommand) }
   let(:dsl) { described_class.new(cask, fake_system_command) }

--- a/Library/Homebrew/test/cask/dsl/preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/preflight_spec.rb
@@ -3,7 +3,7 @@
 require "test/cask/dsl/shared_examples/base"
 require "test/cask/dsl/shared_examples/staged"
 
-describe Cask::DSL::Preflight, :cask do
+RSpec.describe Cask::DSL::Preflight, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:fake_system_command) { class_double(SystemCommand) }
   let(:dsl) { described_class.new(cask, fake_system_command) }

--- a/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/base.rb
@@ -2,7 +2,7 @@
 
 require "cask/dsl/base"
 
-shared_examples Cask::DSL::Base do
+RSpec.shared_examples Cask::DSL::Base do
   it "supports the token method" do
     expect(dsl.token).to eq(cask.token)
   end

--- a/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
+++ b/Library/Homebrew/test/cask/dsl/shared_examples/staged.rb
@@ -2,7 +2,7 @@
 
 require "cask/staged"
 
-shared_examples Cask::Staged do
+RSpec.shared_examples Cask::Staged do
   let(:existing_path) { Pathname("/path/to/file/that/exists") }
   let(:non_existent_path) { Pathname("/path/to/file/that/does/not/exist") }
 

--- a/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_postflight_spec.rb
@@ -2,7 +2,7 @@
 
 require "test/cask/dsl/shared_examples/base"
 
-describe Cask::DSL::UninstallPostflight, :cask do
+RSpec.describe Cask::DSL::UninstallPostflight, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:dsl) { described_class.new(cask, class_double(SystemCommand)) }
 

--- a/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/uninstall_preflight_spec.rb
@@ -3,7 +3,7 @@
 require "test/cask/dsl/shared_examples/base"
 require "test/cask/dsl/shared_examples/staged"
 
-describe Cask::DSL::UninstallPreflight, :cask do
+RSpec.describe Cask::DSL::UninstallPreflight, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path("basic-cask")) }
   let(:fake_system_command) { class_double(SystemCommand) }
   let(:dsl) { described_class.new(cask, fake_system_command) }

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::DSL::Version, :cask do
+RSpec.describe Cask::DSL::Version, :cask do
   shared_examples "expectations hash" do |input_name, expectations|
     expectations.each do |input_value, expected_output|
       context "when #{input_name} is #{input_value.inspect}" do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::DSL, :cask do
+RSpec.describe Cask::DSL, :cask do
   let(:cask) { Cask::CaskLoader.load(token) }
   let(:token) { "basic-cask" }
 

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils"
 
-describe Cask::Info, :cask do
+RSpec.describe Cask::Info, :cask do
   it "displays some nice info about the specified Cask" do
     expect do
       described_class.info(Cask::CaskLoader.load("local-transmission"))

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Installer, :cask do
+RSpec.describe Cask::Installer, :cask do
   describe "install" do
     it "downloads and installs a nice fresh Cask" do
       caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -2,7 +2,7 @@
 
 require "cask/list"
 
-describe Cask::List, :cask do
+RSpec.describe Cask::List, :cask do
   it "lists the installed Casks in a pretty fashion" do
     casks = %w[local-caffeine local-transmission].map { |c| Cask::CaskLoader.load(c) }
 

--- a/Library/Homebrew/test/cask/macos_spec.rb
+++ b/Library/Homebrew/test/cask/macos_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe MacOS, :cask do
+RSpec.describe MacOS, :cask do
   it "says '/' is undeletable" do
     expect(described_class).to be_undeletable(
       "/",

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Pkg, :cask do
+RSpec.describe Cask::Pkg, :cask do
   describe "#uninstall" do
     let(:fake_system_command) { NeverSudoSystemCommand }
     let(:empty_response) do

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -3,7 +3,7 @@
 require "cask/installer"
 require "cask/reinstall"
 
-describe Cask::Reinstall, :cask do
+RSpec.describe Cask::Reinstall, :cask do
   it "displays the reinstallation progress" do
     caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -2,7 +2,7 @@
 
 require "cask/uninstall"
 
-describe Cask::Uninstall, :cask do
+RSpec.describe Cask::Uninstall, :cask do
   it "displays the uninstallation progress" do
     caffeine = Cask::CaskLoader.load(cask_path("local-caffeine"))
 

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -25,8 +25,6 @@ describe Cask::Upgrade, :cask do
     installed.each do |cask|
       Cask::Installer.new(Cask::CaskLoader.load(cask_path(cask))).install
     end
-
-    allow_any_instance_of(described_class).to receive(:verbose?).and_return(true)
   end
 
   context "when the upgrade is a dry run" do

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -2,7 +2,7 @@
 
 require "cask/upgrade"
 
-describe Cask::Upgrade, :cask do
+RSpec.describe Cask::Upgrade, :cask do
   let(:version_latest_paths) do
     [
       version_latest.config.appdir.join("Caffeine Mini.app"),

--- a/Library/Homebrew/test/cask/utils_spec.rb
+++ b/Library/Homebrew/test/cask/utils_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Cask::Utils do
+RSpec.describe Cask::Utils do
   let(:command) { NeverSudoSystemCommand }
   let(:dir) { mktmpdir }
   let(:path) { dir/"a/b/c" }

--- a/Library/Homebrew/test/cask_dependent_spec.rb
+++ b/Library/Homebrew/test/cask_dependent_spec.rb
@@ -3,7 +3,7 @@
 require "cask/cask_loader"
 require "cask_dependent"
 
-describe CaskDependent, :needs_macos do
+RSpec.describe CaskDependent, :needs_macos do
   subject(:dependent) { described_class.new test_cask }
 
   let :test_cask do

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -3,7 +3,7 @@
 require "formula"
 require "caveats"
 
-describe Caveats do
+RSpec.describe Caveats do
   subject(:caveats) { described_class.new(f) }
 
   let(:f) { formula { url "foo-1.0" } }

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -2,7 +2,7 @@
 
 require "checksum"
 
-describe Checksum do
+RSpec.describe Checksum do
   describe "#empty?" do
     subject { described_class.new("") }
 

--- a/Library/Homebrew/test/checksum_verification_spec.rb
+++ b/Library/Homebrew/test/checksum_verification_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula"
 
-describe Formula do
+RSpec.describe Formula do
   def formula(&block)
     super do
       url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -3,7 +3,7 @@
 require "cleaner"
 require "formula"
 
-describe Cleaner do
+RSpec.describe Cleaner do
   include FileUtils
 
   describe "#clean" do

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -5,7 +5,7 @@ require "cleanup"
 require "cask/cache"
 require "fileutils"
 
-describe Homebrew::Cleanup do
+RSpec.describe Homebrew::Cleanup do
   subject(:cleanup) { described_class.new }
 
   let(:ds_store) { Pathname.new("#{HOMEBREW_CELLAR}/.DS_Store") }

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -2,7 +2,7 @@
 
 require "cli/named_args"
 
-describe Homebrew::CLI::NamedArgs do
+RSpec.describe Homebrew::CLI::NamedArgs do
   def setup_unredable_formula(name)
     error = FormulaUnreadableError.new(name, RuntimeError.new("testing"))
     allow(Formulary).to receive(:factory).with(name, any_args).and_raise(error)

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -235,14 +235,18 @@ describe Homebrew::CLI::Parser do
     end
 
     it "prioritizes cli arguments over env vars when they conflict" do
-      allow(Homebrew::EnvConfig).to receive_messages(switch_a?: true, switch_b?: false)
+      without_partial_double_verification do
+        allow(Homebrew::EnvConfig).to receive_messages(switch_a?: true, switch_b?: false)
+      end
       args = parser.parse(["--switch-b"])
       expect(args.switch_a?).to be false
       expect(args).to be_switch_b
     end
 
     it "raises an exception on constraint violation when both are env vars" do
-      allow(Homebrew::EnvConfig).to receive_messages(switch_a?: true, switch_b?: true)
+      without_partial_double_verification do
+        allow(Homebrew::EnvConfig).to receive_messages(switch_a?: true, switch_b?: true)
+      end
       expect { parser.parse([]) }.to raise_error(Homebrew::CLI::OptionConflictError)
     end
   end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "../../cli/parser"
 
-describe Homebrew::CLI::Parser do
+RSpec.describe Homebrew::CLI::Parser do
   describe "test switch options" do
     subject(:parser) do
       described_class.new do

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew --cache" do
+RSpec.describe "brew --cache" do
   it_behaves_like "parseable arguments"
 
   it "prints all cache files for a given Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/--caskroom_spec.rb
+++ b/Library/Homebrew/test/cmd/--caskroom_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew --caskroom" do
+RSpec.describe "brew --caskroom" do
   it_behaves_like "parseable arguments"
 
   it "prints Homebrew's Caskroom", :integration_test do

--- a/Library/Homebrew/test/cmd/--cellar_spec.rb
+++ b/Library/Homebrew/test/cmd/--cellar_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew --cellar" do
+RSpec.describe "brew --cellar" do
   it_behaves_like "parseable arguments"
 
   it "prints Homebrew's Cellar", :integration_test do

--- a/Library/Homebrew/test/cmd/--env_spec.rb
+++ b/Library/Homebrew/test/cmd/--env_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew --env" do
+RSpec.describe "brew --env" do
   it_behaves_like "parseable arguments"
 
   describe "--shell=bash", :integration_test do

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew --prefix" do
+RSpec.describe "brew --prefix" do
   it_behaves_like "parseable arguments"
 
   it "prints Homebrew's prefix", :integration_test do

--- a/Library/Homebrew/test/cmd/--repository_spec.rb
+++ b/Library/Homebrew/test/cmd/--repository_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew --repository" do
+RSpec.describe "brew --repository" do
   it_behaves_like "parseable arguments"
 
   it "prints Homebrew's repository", :integration_test do

--- a/Library/Homebrew/test/cmd/--version_spec.rb
+++ b/Library/Homebrew/test/cmd/--version_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew --version" do
+RSpec.describe "brew --version" do
   it "prints the Homebrew's version", :integration_test do
     expect { brew_sh "--version" }
       .to output(/^Homebrew #{Regexp.escape(HOMEBREW_VERSION)}\n/o).to_stdout

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew analytics" do
+RSpec.describe "brew analytics" do
   it_behaves_like "parseable arguments"
 
   it "when HOMEBREW_NO_ANALYTICS is unset is disabled after running `brew analytics off`", :integration_test do

--- a/Library/Homebrew/test/cmd/autoremove_spec.rb
+++ b/Library/Homebrew/test/cmd/autoremove_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew autoremove" do
+RSpec.describe "brew autoremove" do
   it_behaves_like "parseable arguments"
 
   describe "integration test" do

--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "brew bundle", :integration_test do
+RSpec.describe "brew bundle", :integration_test do
   describe "check" do
     it "checks if a Brewfile's dependencies are satisfied", :needs_network do
       setup_remote_tap "homebrew/bundle"

--- a/Library/Homebrew/test/cmd/cleanup_spec.rb
+++ b/Library/Homebrew/test/cmd/cleanup_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew cleanup" do
+RSpec.describe "brew cleanup" do
   before do
     FileUtils.mkdir_p HOMEBREW_LIBRARY/"Homebrew/vendor/"
     FileUtils.touch HOMEBREW_LIBRARY/"Homebrew/vendor/portable-ruby-version"

--- a/Library/Homebrew/test/cmd/commands_spec.rb
+++ b/Library/Homebrew/test/cmd/commands_spec.rb
@@ -5,7 +5,7 @@ require "fileutils"
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew commands" do
+RSpec.describe "brew commands" do
   it_behaves_like "parseable arguments"
 
   it "prints a list of all available commands", :integration_test do

--- a/Library/Homebrew/test/cmd/completions_spec.rb
+++ b/Library/Homebrew/test/cmd/completions_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew completions" do
+RSpec.describe "brew completions" do
   it_behaves_like "parseable arguments"
 
   it "runs the status subcommand correctly", :integration_test do

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew config" do
+RSpec.describe "brew config" do
   it_behaves_like "parseable arguments"
 
   it "prints information about the current Homebrew configuration", :integration_test do

--- a/Library/Homebrew/test/cmd/custom-external-command_spec.rb
+++ b/Library/Homebrew/test/cmd/custom-external-command_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "brew custom-external-command", :integration_test do
+RSpec.describe "brew custom-external-command", :integration_test do
   it "is supported" do
     mktmpdir do |path|
       cmd = "custom-external-command-#{rand}"

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew deps" do
+RSpec.describe "brew deps" do
   it_behaves_like "parseable arguments"
 
   it "outputs all of a Formula's dependencies and their dependencies on separate lines", :integration_test do

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew desc" do
+RSpec.describe "brew desc" do
   it_behaves_like "parseable arguments"
 
   it "shows a given Formula's description", :integration_test do

--- a/Library/Homebrew/test/cmd/developer_spec.rb
+++ b/Library/Homebrew/test/cmd/developer_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew developer" do
+RSpec.describe "brew developer" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/cmd/docs_spec.rb
+++ b/Library/Homebrew/test/cmd/docs_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "brew docs" do
+RSpec.describe "brew docs" do
   it "opens the docs page", :integration_test do
     expect { brew "docs", "HOMEBREW_BROWSER" => "echo" }
       .to output("https://docs.brew.sh\n").to_stdout

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew doctor" do
+RSpec.describe "brew doctor" do
   it_behaves_like "parseable arguments"
 
   specify "check_integration_test", :integration_test do

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew fetch" do
+RSpec.describe "brew fetch" do
   it_behaves_like "parseable arguments"
 
   it "downloads the Formula's URL", :integration_test do

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew gist-logs" do
+RSpec.describe "brew gist-logs" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "brew", :integration_test do
+RSpec.describe "brew", :integration_test do
   describe "help" do
     it "prints help for a documented Ruby command" do
       expect { brew "help", "cat" }

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew home" do
+RSpec.describe "brew home" do
   let(:testballhome_homepage) do
     Formula["testballhome"].homepage
   end

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -4,7 +4,7 @@ require "cmd/info"
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew info" do
+RSpec.describe "brew info" do
   it_behaves_like "parseable arguments"
 
   it "prints as json with the --json=v1 flag", :integration_test do

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew install" do
+RSpec.describe "brew install" do
   it_behaves_like "parseable arguments"
 
   it "installs formulae", :integration_test do

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew leaves" do
+RSpec.describe "brew leaves" do
   it_behaves_like "parseable arguments"
 
   context "when there are no installed Formulae", :integration_test do

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew link" do
+RSpec.describe "brew link" do
   it_behaves_like "parseable arguments"
 
   it "links a given Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew list" do
+RSpec.describe "brew list" do
   let(:formulae) { %w[bar foo qux] }
 
   it_behaves_like "parseable arguments"

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew log" do
+RSpec.describe "brew log" do
   it_behaves_like "parseable arguments"
 
   it "shows the Git log for a given Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew migrate" do
+RSpec.describe "brew migrate" do
   it_behaves_like "parseable arguments"
 
   it "migrates a renamed Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew missing" do
+RSpec.describe "brew missing" do
   it_behaves_like "parseable arguments"
 
   it "prints missing dependencies", :integration_test do

--- a/Library/Homebrew/test/cmd/options_spec.rb
+++ b/Library/Homebrew/test/cmd/options_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew options" do
+RSpec.describe "brew options" do
   it_behaves_like "parseable arguments"
 
   it "prints a given Formula's options", :integration_test do

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew outdated" do
+RSpec.describe "brew outdated" do
   it_behaves_like "parseable arguments"
 
   it "outputs JSON", :integration_test do

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew pin" do
+RSpec.describe "brew pin" do
   it_behaves_like "parseable arguments"
 
   it "pins a Formula's version", :integration_test do

--- a/Library/Homebrew/test/cmd/postinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/postinstall_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew postinstall" do
+RSpec.describe "brew postinstall" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/cmd/readall_spec.rb
+++ b/Library/Homebrew/test/cmd/readall_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew readall" do
+RSpec.describe "brew readall" do
   it_behaves_like "parseable arguments"
 
   it "imports all Formulae for a given Tap", :integration_test do

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -3,7 +3,7 @@
 require "extend/ENV"
 require "cmd/shared_examples/args_parse"
 
-describe "brew reinstall" do
+RSpec.describe "brew reinstall" do
   it_behaves_like "parseable arguments"
 
   it "reinstalls a Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -3,7 +3,7 @@
 require "cmd/search"
 require "cmd/shared_examples/args_parse"
 
-describe "brew search" do
+RSpec.describe "brew search" do
   it_behaves_like "parseable arguments"
 
   it "finds formula in search", :integration_test do

--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "brew services", :integration_test, :needs_network do
+RSpec.describe "brew services", :integration_test, :needs_network do
   it "allows controlling services" do
     setup_remote_tap "homebrew/services"
 

--- a/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples "parseable arguments" do
+RSpec.shared_examples "parseable arguments" do
   subject(:method_name) { "#{command_name.tr("-", "_")}_args" }
 
   let(:command_name) do |example|

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew tap-info" do
+RSpec.describe "brew tap-info" do
   it_behaves_like "parseable arguments"
 
   it "gets information for a given Tap", :integration_test, :needs_network do

--- a/Library/Homebrew/test/cmd/tap_spec.rb
+++ b/Library/Homebrew/test/cmd/tap_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew tap" do
+RSpec.describe "brew tap" do
   it_behaves_like "parseable arguments"
 
   it "taps a given Tap", :integration_test do

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -4,7 +4,7 @@ require "cmd/uninstall"
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew uninstall" do
+RSpec.describe "brew uninstall" do
   it_behaves_like "parseable arguments"
 
   it "uninstalls a given Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/unlink_spec.rb
+++ b/Library/Homebrew/test/cmd/unlink_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew unlink" do
+RSpec.describe "brew unlink" do
   it_behaves_like "parseable arguments"
 
   it "unlinks a Formula", :integration_test do

--- a/Library/Homebrew/test/cmd/unpin_spec.rb
+++ b/Library/Homebrew/test/cmd/unpin_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew unpin" do
+RSpec.describe "brew unpin" do
   it_behaves_like "parseable arguments"
 
   it "unpins a Formula's version", :integration_test do

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew untap" do
+RSpec.describe "brew untap" do
   it_behaves_like "parseable arguments"
 
   it "untaps a given Tap", :integration_test do

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -5,7 +5,7 @@ require "formula_versions"
 require "yaml"
 require "cmd/shared_examples/args_parse"
 
-describe "brew update-report" do
+RSpec.describe "brew update-report" do
   it_behaves_like "parseable arguments"
 
   describe Reporter do

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew upgrade" do
+RSpec.describe "brew upgrade" do
   it_behaves_like "parseable arguments"
 
   it "upgrades a Formula and cleans up old versions", :integration_test do

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew uses" do
+RSpec.describe "brew uses" do
   it_behaves_like "parseable arguments"
 
   it "prints the Formulae a given Formula is used by", :integration_test do

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -26,7 +26,7 @@ RSpec.shared_context "custom internal commands" do # rubocop:disable RSpec/Conte
   end
 end
 
-describe Commands do
+RSpec.describe Commands do
   include_context "custom internal commands"
 
   specify "::internal_commands" do

--- a/Library/Homebrew/test/compiler_failure_spec.rb
+++ b/Library/Homebrew/test/compiler_failure_spec.rb
@@ -2,7 +2,7 @@
 
 require "compilers"
 
-describe CompilerFailure do
+RSpec.describe CompilerFailure do
   alias_matcher :fail_with, :be_fails_with
 
   describe "::create" do

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -3,7 +3,7 @@
 require "compilers"
 require "software_spec"
 
-describe CompilerSelector do
+RSpec.describe CompilerSelector do
   subject(:selector) { described_class.new(software_spec, versions, compilers) }
 
   let(:compilers) { [:clang, :gnu] }

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -2,7 +2,7 @@
 
 require "completions"
 
-describe Homebrew::Completions do
+RSpec.describe Homebrew::Completions do
   let(:completions_dir) { HOMEBREW_REPOSITORY/"completions" }
   let(:internal_path) { HOMEBREW_REPOSITORY/"Library/Taps/homebrew/homebrew-bar" }
   let(:external_path) { HOMEBREW_REPOSITORY/"Library/Taps/foo/homebrew-bar" }

--- a/Library/Homebrew/test/cxxstdlib_spec.rb
+++ b/Library/Homebrew/test/cxxstdlib_spec.rb
@@ -3,7 +3,7 @@
 require "formula"
 require "cxxstdlib"
 
-describe CxxStdlib do
+RSpec.describe CxxStdlib do
   let(:clang) { described_class.create(:libstdcxx, :clang) }
   let(:lcxx) { described_class.create(:libcxx, :clang) }
 

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -2,7 +2,7 @@
 
 require "dependable"
 
-describe Dependable do
+RSpec.describe Dependable do
   alias_matcher :be_a_build_dependency, :be_build
 
   subject(:dependable) do

--- a/Library/Homebrew/test/dependencies_helpers_spec.rb
+++ b/Library/Homebrew/test/dependencies_helpers_spec.rb
@@ -2,7 +2,7 @@
 
 require "dependencies_helpers"
 
-describe DependenciesHelpers do
+RSpec.describe DependenciesHelpers do
   specify "#dependents" do
     foo = formula "foo" do
       url "foo"

--- a/Library/Homebrew/test/dependencies_spec.rb
+++ b/Library/Homebrew/test/dependencies_spec.rb
@@ -3,7 +3,7 @@
 require "dependencies"
 require "dependency"
 
-describe Dependencies do
+RSpec.describe Dependencies do
   subject(:dependencies) { described_class.new }
 
   describe "#<<" do

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "dependency_collector"
 
-describe DependencyCollector do
+RSpec.describe DependencyCollector do
   alias_matcher :be_a_build_requirement, :be_build
 
   subject(:collector) { described_class.new }

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -2,7 +2,7 @@
 
 require "dependency"
 
-describe Dependency do
+RSpec.describe Dependency do
   def build_dep(name, tags = [], deps = [])
     dep = described_class.new(name.to_s, tags)
     allow(dep).to receive(:to_formula).and_return \

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -2,7 +2,7 @@
 
 require "dependency"
 
-describe Dependency do
+RSpec.describe Dependency do
   alias_matcher :be_a_build_dependency, :be_build
 
   describe "::new" do

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -2,7 +2,7 @@
 
 require "deprecate_disable"
 
-describe DeprecateDisable do
+RSpec.describe DeprecateDisable do
   let(:deprecated_formula) do
     instance_double(Formula, deprecated?: true, disabled?: false, deprecation_reason: :does_not_build)
   end

--- a/Library/Homebrew/test/description_cache_store_spec.rb
+++ b/Library/Homebrew/test/description_cache_store_spec.rb
@@ -3,7 +3,7 @@
 require "cmd/update-report"
 require "description_cache_store"
 
-describe DescriptionCacheStore do
+RSpec.describe DescriptionCacheStore do
   subject(:cache_store) { described_class.new(database) }
 
   let(:database) { instance_double(CacheStoreDatabase, "database") }

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -2,7 +2,7 @@
 
 require "descriptions"
 
-describe Descriptions do
+RSpec.describe Descriptions do
   subject(:descriptions) { described_class.new(descriptions_hash) }
 
   let(:descriptions_hash) { {} }

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -5,7 +5,7 @@ require "formulary"
 require "cmd/shared_examples/args_parse"
 require "utils/spdx"
 
-describe "brew audit" do
+RSpec.describe "brew audit" do
   it_behaves_like "parseable arguments"
 end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -17,7 +17,7 @@ module Count
 end
 
 module Homebrew
-  describe FormulaTextAuditor do
+  RSpec.describe FormulaTextAuditor do
     alias_matcher :have_data, :be_data
     alias_matcher :have_end, :be_end
     alias_matcher :have_trailing_newline, :be_trailing_newline
@@ -56,7 +56,7 @@ module Homebrew
     end
   end
 
-  describe FormulaAuditor do
+  RSpec.describe FormulaAuditor do
     let(:dir) { mktmpdir }
     let(:foo_version) { Count.increment }
     let(:formula_subpath) { "Formula/foo#{foo_version}.rb" }

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -3,7 +3,7 @@
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/bottle"
 
-describe "brew bottle" do
+RSpec.describe "brew bottle" do
   def stub_hash(parameters)
     <<~EOS
       {

--- a/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-cask-pr_spec.rb
@@ -3,6 +3,6 @@
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/bump-cask-pr"
 
-describe "brew bump-cask-pr" do
+RSpec.describe "brew bump-cask-pr" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-formula-pr_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew bump-formula-pr" do
+RSpec.describe "brew bump-formula-pr" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew bump-revision" do
+RSpec.describe "brew bump-revision" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-unversioned-casks_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew bump-unversioned-casks" do
+RSpec.describe "brew bump-unversioned-casks" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew bump" do
+RSpec.describe "brew bump" do
   it_behaves_like "parseable arguments"
 
   describe "formula", :integration_test, :needs_homebrew_curl, :needs_network do

--- a/Library/Homebrew/test/dev-cmd/cat_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/cat_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew cat" do
+RSpec.describe "brew cat" do
   it_behaves_like "parseable arguments"
 
   it "prints the content of a given Formula", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/command_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/command_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew command" do
+RSpec.describe "brew command" do
   it_behaves_like "parseable arguments"
 
   it "returns the file for a given command", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/contributions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/contributions_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew contributions" do
+RSpec.describe "brew contributions" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew create" do
+RSpec.describe "brew create" do
   let(:url) { "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz" }
   let(:formula_file) { CoreTap.new.new_formula_path("testball") }
 

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -3,7 +3,7 @@
 require "dev-cmd/determine-test-runners"
 require "cmd/shared_examples/args_parse"
 
-describe "brew determine-test-runners" do
+RSpec.describe "brew determine-test-runners" do
   def get_runners(file)
     runner_line = File.open(file).first
     json_text = runner_line[/runners=(.*)/, 1]

--- a/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/dispatch-build-bottle_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew dispatch-build-bottle" do
+RSpec.describe "brew dispatch-build-bottle" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/edit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/edit_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew edit" do
+RSpec.describe "brew edit" do
   it_behaves_like "parseable arguments"
 
   it "opens a given Formula in an editor", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew extract" do
+RSpec.describe "brew extract" do
   it_behaves_like "parseable arguments"
 
   context "when extracting a formula" do

--- a/Library/Homebrew/test/dev-cmd/formula_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/formula_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew formula" do
+RSpec.describe "brew formula" do
   it_behaves_like "parseable arguments"
 
   it "prints a given Formula's path", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-cask-api_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew generate-cask-api" do
+RSpec.describe "brew generate-cask-api" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-formula-api_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew generate-formula-api" do
+RSpec.describe "brew generate-formula-api" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/generate-man-completions_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew generate-man-completions" do
+RSpec.describe "brew generate-man-completions" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew irb" do
+RSpec.describe "brew irb" do
   it_behaves_like "parseable arguments"
 
   describe "integration test" do

--- a/Library/Homebrew/test/dev-cmd/linkage_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/linkage_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew linkage" do
+RSpec.describe "brew linkage" do
   it_behaves_like "parseable arguments"
 
   it "works when no arguments are provided", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew livecheck" do
+RSpec.describe "brew livecheck" do
   it_behaves_like "parseable arguments"
 
   it "reports the latest version of a Formula", :integration_test, :needs_network do

--- a/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew pr-automerge" do
+RSpec.describe "brew pr-automerge" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew pr-publish" do
+RSpec.describe "brew pr-publish" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -5,7 +5,7 @@ require "utils/git"
 require "tap"
 require "cmd/shared_examples/args_parse"
 
-describe "brew pr-pull" do
+RSpec.describe "brew pr-pull" do
   it_behaves_like "parseable arguments"
 
   describe Homebrew do

--- a/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-upload_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew pr-upload" do
+RSpec.describe "brew pr-upload" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew prof" do
+RSpec.describe "brew prof" do
   it_behaves_like "parseable arguments"
 
   describe "integration tests", :integration_test, :needs_network do

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew release" do
+RSpec.describe "brew release" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew ruby" do
+RSpec.describe "brew ruby" do
   it_behaves_like "parseable arguments"
 
   it "executes ruby code with Homebrew's libraries loaded", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/sh_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/sh_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew sh" do
+RSpec.describe "brew sh" do
   it_behaves_like "parseable arguments"
 
   it "runs a shell with the Homebrew environment", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/style_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/style_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew style" do
+RSpec.describe "brew style" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew tap-new" do
+RSpec.describe "brew tap-new" do
   it_behaves_like "parseable arguments"
 
   it "initializes a new tap with a README file and GitHub Actions CI", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew test" do
+RSpec.describe "brew test" do
   it_behaves_like "parseable arguments"
 
   it "tests a given Formula", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/typecheck_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew typecheck" do
+RSpec.describe "brew typecheck" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unbottled_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew unbottled" do
+RSpec.describe "brew unbottled" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/unpack_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/unpack_spec.rb
@@ -2,7 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew unpack" do
+RSpec.describe "brew unpack" do
   it_behaves_like "parseable arguments"
 
   it "unpacks a given Formula's archive", :integration_test do

--- a/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-license-data_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew update-license-data" do
+RSpec.describe "brew update-license-data" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-maintainers_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew update-maintainers" do
+RSpec.describe "brew update-maintainers" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-python-resources_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew update-python-resources" do
+RSpec.describe "brew update-python-resources" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/update-sponsors_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew update-sponsors" do
+RSpec.describe "brew update-sponsors" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/vendor-gems_spec.rb
@@ -2,6 +2,6 @@
 
 require "cmd/shared_examples/args_parse"
 
-describe "brew vendor-gems" do
+RSpec.describe "brew vendor-gems" do
   it_behaves_like "parseable arguments"
 end

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -2,7 +2,7 @@
 
 require "diagnostic"
 
-describe Homebrew::Diagnostic::Checks do
+RSpec.describe Homebrew::Diagnostic::Checks do
   subject(:checks) { described_class.new }
 
   specify "#inject_file_list" do

--- a/Library/Homebrew/test/download_strategies/abstract_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe AbstractDownloadStrategy do
+RSpec.describe AbstractDownloadStrategy do
   subject(:strategy) { described_class.new(url, name, version, **specs) }
 
   let(:specs) { {} }

--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe CurlGitHubPackagesDownloadStrategy do
+RSpec.describe CurlGitHubPackagesDownloadStrategy do
   subject(:strategy) { described_class.new(url, name, version, **specs) }
 
   let(:name) { "foo" }

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe CurlPostDownloadStrategy do
+RSpec.describe CurlPostDownloadStrategy do
   subject(:strategy) { described_class.new(url, name, version, **specs) }
 
   let(:name) { "foo" }

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe CurlDownloadStrategy do
+RSpec.describe CurlDownloadStrategy do
   subject(:strategy) { described_class.new(url, name, version, **specs) }
 
   let(:name) { "foo" }

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe DownloadStrategyDetector do
+RSpec.describe DownloadStrategyDetector do
   describe "::detect" do
     subject(:strategy_detector) { described_class.detect(url, strategy) }
 

--- a/Library/Homebrew/test/download_strategies/git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/git_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe GitDownloadStrategy do
+RSpec.describe GitDownloadStrategy do
   subject(:strategy) { described_class.new(url, name, version) }
 
   let(:name) { "baz" }

--- a/Library/Homebrew/test/download_strategies/github_git_spec.rb
+++ b/Library/Homebrew/test/download_strategies/github_git_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe GitHubGitDownloadStrategy do
+RSpec.describe GitHubGitDownloadStrategy do
   subject(:strategy) { described_class.new(url, name, version) }
 
   let(:name) { "brew" }

--- a/Library/Homebrew/test/download_strategies/subversion_spec.rb
+++ b/Library/Homebrew/test/download_strategies/subversion_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe SubversionDownloadStrategy do
+RSpec.describe SubversionDownloadStrategy do
   subject(:strategy) { described_class.new(url, name, version, **specs) }
 
   let(:name) { "foo" }

--- a/Library/Homebrew/test/download_strategies/vcs_spec.rb
+++ b/Library/Homebrew/test/download_strategies/vcs_spec.rb
@@ -2,7 +2,7 @@
 
 require "download_strategy"
 
-describe VCSDownloadStrategy do
+RSpec.describe VCSDownloadStrategy do
   let(:url) { "https://example.com/bar" }
   let(:version) { nil }
 

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -2,7 +2,7 @@
 
 require "diagnostic"
 
-describe Homebrew::EnvConfig do
+RSpec.describe Homebrew::EnvConfig do
   subject(:env_config) { described_class }
 
   describe ".env_method_name" do

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe ErrorDuringExecution do
+RSpec.describe ErrorDuringExecution do
   subject(:error) { described_class.new(command, status: status, output: output) }
 
   let(:command) { ["false"] }

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -2,7 +2,7 @@
 
 require "exceptions"
 
-describe "Exception" do
+RSpec.describe "Exception" do
   describe MultipleVersionsInstalledError do
     subject do
       described_class.new <<~EOS

--- a/Library/Homebrew/test/extend/array_spec.rb
+++ b/Library/Homebrew/test/extend/array_spec.rb
@@ -2,7 +2,7 @@
 
 require "extend/array"
 
-describe Array do
+RSpec.describe Array do
   describe ".to_sentence" do
     it "converts a plain array to a sentence" do
       expect([].to_sentence).to eq("")

--- a/Library/Homebrew/test/extend/blank_spec.rb
+++ b/Library/Homebrew/test/extend/blank_spec.rb
@@ -2,7 +2,7 @@
 
 require "extend/blank"
 
-describe Object do
+RSpec.describe Object do
   let(:empty_true) do
     Class.new(described_class) do
       def empty?

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "globally-scoped helper methods" do
+RSpec.describe "globally-scoped helper methods" do
   let(:dir) { mktmpdir }
 
   def esc(code)

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -3,7 +3,7 @@
 require "utils/formatter"
 require "utils/tty"
 
-describe Formatter do
+RSpec.describe Formatter do
   describe "::columns" do
     subject(:columns) { described_class.columns(input) }
 

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula_creator"
 
-describe Homebrew::FormulaCreator do
+RSpec.describe Homebrew::FormulaCreator do
   it "gets name from GitHub archive URL" do
     t = described_class.name_from_url("https://github.com/abitrolly/lapce/archive/v0.3.0.tar.gz")
     expect(t).to eq("lapce")

--- a/Library/Homebrew/test/formula_free_port_spec.rb
+++ b/Library/Homebrew/test/formula_free_port_spec.rb
@@ -4,7 +4,7 @@ require "socket"
 require "formula_free_port"
 
 module Homebrew
-  describe FreePort do
+  RSpec.describe FreePort do
     include described_class
 
     describe "#free_port" do

--- a/Library/Homebrew/test/formula_info_spec.rb
+++ b/Library/Homebrew/test/formula_info_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula_info"
 
-describe FormulaInfo, :integration_test do
+RSpec.describe FormulaInfo, :integration_test do
   it "tests the FormulaInfo class" do
     install_test_formula "testball"
 

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -9,7 +9,7 @@ require "test/support/fixtures/testball"
 require "test/support/fixtures/testball_bottle"
 require "test/support/fixtures/testball_bottle_cellar"
 
-describe FormulaInstaller do
+RSpec.describe FormulaInstaller do
   alias_matcher :pour_bottle, :be_pour_bottle
 
   matcher :be_poured_from_bottle do

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -9,7 +9,7 @@ require "test/support/fixtures/testball"
 require "test/support/fixtures/testball_bottle"
 require "test/support/fixtures/failball"
 
-describe FormulaInstaller do
+RSpec.describe FormulaInstaller do
   matcher :be_poured_from_bottle do
     match(&:poured_from_bottle)
   end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -282,7 +282,6 @@ describe FormulaInstaller do
       expect(formula).to receive(:plist).and_return(nil)
       expect(formula).to receive(:service?).exactly(3).and_return(nil)
       expect(formula).not_to receive(:launchd_service_path)
-      expect(formula).not_to receive(:to_systemd_unit)
 
       installer = described_class.new(formula)
       expect do

--- a/Library/Homebrew/test/formula_pin_spec.rb
+++ b/Library/Homebrew/test/formula_pin_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula_pin"
 
-describe FormulaPin do
+RSpec.describe FormulaPin do
   subject(:formula_pin) { described_class.new(formula) }
 
   let(:name) { "double" }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -3,7 +3,7 @@
 require "test/support/fixtures/testball"
 require "formula"
 
-describe Formula do
+RSpec.describe Formula do
   alias_matcher :follow_installed_alias, :be_follow_installed_alias
   alias_matcher :have_any_version_installed, :be_any_version_installed
   alias_matcher :need_migration, :be_migration_needed

--- a/Library/Homebrew/test/formula_spec_selection_spec.rb
+++ b/Library/Homebrew/test/formula_spec_selection_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula"
 
-describe Formula do
+RSpec.describe Formula do
   describe "::new" do
     it "selects stable by default" do
       f = formula do

--- a/Library/Homebrew/test/formula_support/keg_only_reason_spec.rb
+++ b/Library/Homebrew/test/formula_support/keg_only_reason_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula_support"
 
-describe KegOnlyReason do
+RSpec.describe KegOnlyReason do
   describe "#to_s" do
     it "returns the reason provided" do
       r = described_class.new :provided_by_macos, "test"

--- a/Library/Homebrew/test/formula_validation_spec.rb
+++ b/Library/Homebrew/test/formula_validation_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula"
 
-describe Formula do
+RSpec.describe Formula do
   describe "::new" do
     matcher :fail_with_invalid do |attr|
       match do |actual|

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -4,7 +4,7 @@ require "formula"
 require "formula_installer"
 require "utils/bottles"
 
-describe Formulary do
+RSpec.describe Formulary do
   let(:formula_name) { "testball_bottle" }
   let(:formula_path) { CoreTap.new.new_formula_path(formula_name) }
   let(:formula_content) do

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -3,7 +3,7 @@
 require "github_runner_matrix"
 require "test/support/fixtures/testball"
 
-describe GitHubRunnerMatrix do
+RSpec.describe GitHubRunnerMatrix do
   before do
     allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_RUNNER").and_return("ubuntu-latest")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_TIMEOUT").and_return("90")

--- a/Library/Homebrew/test/github_runner_spec.rb
+++ b/Library/Homebrew/test/github_runner_spec.rb
@@ -2,7 +2,7 @@
 
 require "github_runner"
 
-describe GitHubRunner do
+RSpec.describe GitHubRunner do
   let(:runner) do
     spec = MacOSRunnerSpec.new(name: "macOS 11-arm64", runner: "11-arm64", timeout: 90, cleanup: true)
     version = MacOSVersion.new("11")

--- a/Library/Homebrew/test/global_spec.rb
+++ b/Library/Homebrew/test/global_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "brew", :integration_test do
+RSpec.describe "brew", :integration_test do
   it "does not invoke `require \"formula\"` at startup" do
     expect { brew "verify-formula-undefined" }
       .to not_to_output.to_stdout

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -2,7 +2,7 @@
 
 require "hardware"
 
-describe Hardware::CPU do
+RSpec.describe Hardware::CPU do
   describe "::type" do
     let(:cpu_types) do
       [

--- a/Library/Homebrew/test/installed_dependents_spec.rb
+++ b/Library/Homebrew/test/installed_dependents_spec.rb
@@ -2,7 +2,7 @@
 
 require "installed_dependents"
 
-describe InstalledDependents do
+RSpec.describe InstalledDependents do
   include FileUtils
 
   def stub_formula(name, version = "1.0", &block)

--- a/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/binary_relocation_spec.rb
@@ -2,7 +2,7 @@
 
 require "keg_relocate"
 
-describe Keg do
+RSpec.describe Keg do
   subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
 
   let(:dir) { HOMEBREW_CELLAR/"foo/1.0.0" }

--- a/Library/Homebrew/test/keg_relocate/grep_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/grep_spec.rb
@@ -2,7 +2,7 @@
 
 require "keg_relocate"
 
-describe Keg do
+RSpec.describe Keg do
   subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
 
   let(:dir) { HOMEBREW_CELLAR/"foo/1.0.0" }

--- a/Library/Homebrew/test/keg_relocate/relocation_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/relocation_spec.rb
@@ -2,7 +2,7 @@
 
 require "keg_relocate"
 
-describe Keg::Relocation do
+RSpec.describe Keg::Relocation do
   let(:prefix) { HOMEBREW_PREFIX.to_s }
   let(:cellar) { HOMEBREW_CELLAR.to_s }
   let(:repository) { HOMEBREW_REPOSITORY.to_s }

--- a/Library/Homebrew/test/keg_relocate/text_spec.rb
+++ b/Library/Homebrew/test/keg_relocate/text_spec.rb
@@ -2,7 +2,7 @@
 
 require "keg_relocate"
 
-describe Keg do
+RSpec.describe Keg do
   subject(:keg) { described_class.new(HOMEBREW_CELLAR/"foo/1.0.0") }
 
   let(:dir) { mktmpdir }

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -3,7 +3,7 @@
 require "keg"
 require "stringio"
 
-describe Keg do
+RSpec.describe Keg do
   def setup_test_keg(name, version)
     path = HOMEBREW_CELLAR/name/version
     (path/"bin").mkpath

--- a/Library/Homebrew/test/language/go_spec.rb
+++ b/Library/Homebrew/test/language/go_spec.rb
@@ -2,7 +2,7 @@
 
 require "language/go"
 
-describe Language::Go do
+RSpec.describe Language::Go do
   specify "#stage_deps" do
     ENV.delete("HOMEBREW_DEVELOPER")
 

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -2,7 +2,7 @@
 
 require "language/java"
 
-describe Language::Java do
+RSpec.describe Language::Java do
   let(:f) do
     formula("openjdk") do
       url "openjdk"

--- a/Library/Homebrew/test/language/node/shebang_spec.rb
+++ b/Library/Homebrew/test/language/node/shebang_spec.rb
@@ -3,7 +3,7 @@
 require "language/node"
 require "utils/shebang"
 
-describe Language::Node::Shebang do
+RSpec.describe Language::Node::Shebang do
   let(:file) { Tempfile.new("node-shebang") }
   let(:f) do
     f = {}

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -2,7 +2,7 @@
 
 require "language/node"
 
-describe Language::Node do
+RSpec.describe Language::Node do
   let(:npm_pack_cmd) { ["npm", "pack", "--ignore-scripts"] }
 
   describe "#setup_npm_environment" do

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -11,12 +11,16 @@ describe Language::Node do
         url "node-test-v1.0"
       end
       stub_formula_loader(node)
-      expect(ENV).to receive(:prepend_path)
+      without_partial_double_verification do
+        expect(ENV).to receive(:prepend_path)
+      end
       described_class.instance_variable_set(:@env_set, false)
       expect(described_class.setup_npm_environment).to be_nil
 
       expect(described_class.instance_variable_get(:@env_set)).to be(true)
-      expect(ENV).not_to receive(:prepend_path)
+      without_partial_double_verification do
+        expect(ENV).not_to receive(:prepend_path)
+      end
       expect(described_class.setup_npm_environment).to be_nil
     end
 

--- a/Library/Homebrew/test/language/perl/shebang_spec.rb
+++ b/Library/Homebrew/test/language/perl/shebang_spec.rb
@@ -3,7 +3,7 @@
 require "language/perl"
 require "utils/shebang"
 
-describe Language::Perl::Shebang do
+RSpec.describe Language::Perl::Shebang do
   let(:file) { Tempfile.new("perl-shebang") }
   let(:f) do
     f = {}

--- a/Library/Homebrew/test/language/python/shebang_spec.rb
+++ b/Library/Homebrew/test/language/python/shebang_spec.rb
@@ -3,7 +3,7 @@
 require "language/python"
 require "utils/shebang"
 
-describe Language::Python::Shebang do
+RSpec.describe Language::Python::Shebang do
   let(:file) { Tempfile.new("python-shebang") }
   let(:f) do
     f = {}

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -3,7 +3,7 @@
 require "language/python"
 require "resource"
 
-describe Language::Python::Virtualenv::Virtualenv, :needs_python do
+RSpec.describe Language::Python::Virtualenv::Virtualenv, :needs_python do
   subject(:virtualenv) { described_class.new(formula, dir, "python") }
 
   let(:dir) { mktmpdir }

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -2,7 +2,7 @@
 
 require "language/python"
 
-describe Language::Python, :needs_python do
+RSpec.describe Language::Python, :needs_python do
   describe "#major_minor_version" do
     it "returns a Version for Python 2" do
       expect(described_class).to receive(:major_minor_version).and_return(Version)

--- a/Library/Homebrew/test/lazy_object_spec.rb
+++ b/Library/Homebrew/test/lazy_object_spec.rb
@@ -2,7 +2,7 @@
 
 require "lazy_object"
 
-describe LazyObject do
+RSpec.describe LazyObject do
   describe "#initialize" do
     it "does not evaluate the block" do
       expect do |block|

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -2,7 +2,7 @@
 
 require "linkage_cache_store"
 
-describe LinkageCacheStore do
+RSpec.describe LinkageCacheStore do
   subject(:linkage_cache) { described_class.new(keg_name, database) }
 
   let(:keg_name) { "keg_name" }

--- a/Library/Homebrew/test/linux_runner_spec_spec.rb
+++ b/Library/Homebrew/test/linux_runner_spec_spec.rb
@@ -2,7 +2,7 @@
 
 require "linux_runner_spec"
 
-describe LinuxRunnerSpec do
+RSpec.describe LinuxRunnerSpec do
   let(:spec) do
     described_class.new(
       name:      "Linux",

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/livecheck"
 
-describe Homebrew::Livecheck do
+RSpec.describe Homebrew::Livecheck do
   subject(:livecheck) { described_class }
 
   let(:cask_url) { "https://brew.sh/test-0.0.1.dmg" }

--- a/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_version_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/livecheck_version"
 
-describe Homebrew::Livecheck::LivecheckVersion do
+RSpec.describe Homebrew::Livecheck::LivecheckVersion do
   let(:formula) { instance_double(Formula) }
   let(:cask) { instance_double(Cask::Cask) }
   let(:resource) { instance_double(Resource) }

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "livecheck/livecheck"
 require "livecheck/skip_conditions"
 
 describe Homebrew::Livecheck::SkipConditions do

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -3,7 +3,7 @@
 require "livecheck/livecheck"
 require "livecheck/skip_conditions"
 
-describe Homebrew::Livecheck::SkipConditions do
+RSpec.describe Homebrew::Livecheck::SkipConditions do
   subject(:skip_conditions) { described_class }
 
   let(:formulae) do

--- a/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/apache_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Apache do
+RSpec.describe Homebrew::Livecheck::Strategy::Apache do
   subject(:apache) { described_class }
 
   let(:apache_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Bitbucket do
+RSpec.describe Homebrew::Livecheck::Strategy::Bitbucket do
   subject(:bitbucket) { described_class }
 
   let(:bitbucket_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Cpan do
+RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
   subject(:cpan) { described_class }
 
   let(:cpan_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/crate_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Crate do
+RSpec.describe Homebrew::Livecheck::Strategy::Crate do
   subject(:crate) { described_class }
 
   let(:crate_url) { "https://static.crates.io/crates/example/example-0.1.0.crate" }

--- a/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/electron_builder_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::ElectronBuilder do
+RSpec.describe Homebrew::Livecheck::Strategy::ElectronBuilder do
   subject(:electron_builder) { described_class }
 
   let(:http_url) { "https://www.example.com/example/latest-mac.yml" }

--- a/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/extract_plist_spec.rb
@@ -3,7 +3,7 @@
 require "livecheck/strategy"
 require "bundle_version"
 
-describe Homebrew::Livecheck::Strategy::ExtractPlist do
+RSpec.describe Homebrew::Livecheck::Strategy::ExtractPlist do
   subject(:extract_plist) { described_class }
 
   let(:http_url) { "https://brew.sh/blog/" }

--- a/Library/Homebrew/test/livecheck/strategy/git_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/git_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Git do
+RSpec.describe Homebrew::Livecheck::Strategy::Git do
   subject(:git) { described_class }
 
   let(:git_url) { "https://github.com/Homebrew/brew.git" }

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -3,7 +3,7 @@
 require "livecheck/strategy/github_releases"
 require "livecheck/strategy/github_latest"
 
-describe Homebrew::Livecheck::Strategy::GithubLatest do
+RSpec.describe Homebrew::Livecheck::Strategy::GithubLatest do
   subject(:github_latest) { described_class }
 
   let(:github_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::GithubReleases do
+RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
   subject(:github_releases) { described_class }
 
   let(:github_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnome_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy/gnome"
 
-describe Homebrew::Livecheck::Strategy::Gnome do
+RSpec.describe Homebrew::Livecheck::Strategy::Gnome do
   subject(:gnome) { described_class }
 
   let(:gnome_url) { "https://download.gnome.org/sources/abc/1.2/abc-1.2.3.tar.xz" }

--- a/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/gnu_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy/gnu"
 
-describe Homebrew::Livecheck::Strategy::Gnu do
+RSpec.describe Homebrew::Livecheck::Strategy::Gnu do
   subject(:gnu) { described_class }
 
   let(:gnu_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/hackage_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy/hackage"
 
-describe Homebrew::Livecheck::Strategy::Hackage do
+RSpec.describe Homebrew::Livecheck::Strategy::Hackage do
   subject(:hackage) { described_class }
 
   let(:hackage_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::HeaderMatch do
+RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
   subject(:header_match) { described_class }
 
   let(:http_url) { "https://brew.sh/blog/" }

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Json do
+RSpec.describe Homebrew::Livecheck::Strategy::Json do
   subject(:json) { described_class }
 
   let(:http_url) { "https://brew.sh/blog/" }

--- a/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/launchpad_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy/launchpad"
 
-describe Homebrew::Livecheck::Strategy::Launchpad do
+RSpec.describe Homebrew::Livecheck::Strategy::Launchpad do
   subject(:launchpad) { described_class }
 
   let(:launchpad_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/npm_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy/npm"
 
-describe Homebrew::Livecheck::Strategy::Npm do
+RSpec.describe Homebrew::Livecheck::Strategy::Npm do
   subject(:npm) { described_class }
 
   let(:npm_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::PageMatch do
+RSpec.describe Homebrew::Livecheck::Strategy::PageMatch do
   subject(:page_match) { described_class }
 
   let(:http_url) { "https://brew.sh/blog/" }

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Pypi do
+RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
   subject(:pypi) { described_class }
 
   let(:pypi_url) { "https://files.pythonhosted.org/packages/ab/cd/efg/example-1.2.3.tar.gz" }

--- a/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sourceforge_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy/sourceforge"
 
-describe Homebrew::Livecheck::Strategy::Sourceforge do
+RSpec.describe Homebrew::Livecheck::Strategy::Sourceforge do
   subject(:sourceforge) { described_class }
 
   let(:sourceforge_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/sparkle_spec.rb
@@ -3,7 +3,7 @@
 require "livecheck/strategy"
 require "bundle_version"
 
-describe Homebrew::Livecheck::Strategy::Sparkle do
+RSpec.describe Homebrew::Livecheck::Strategy::Sparkle do
   subject(:sparkle) { described_class }
 
   def create_appcast_xml(items_str = "")

--- a/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xml_spec.rb
@@ -3,7 +3,7 @@
 require "livecheck/strategy"
 require "rexml/document"
 
-describe Homebrew::Livecheck::Strategy::Xml do
+RSpec.describe Homebrew::Livecheck::Strategy::Xml do
   subject(:xml) { described_class }
 
   let(:http_url) { "https://brew.sh/blog/" }

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy/xorg"
 
-describe Homebrew::Livecheck::Strategy::Xorg do
+RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
   subject(:xorg) { described_class }
 
   let(:xorg_urls) do

--- a/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/yaml_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy::Yaml do
+RSpec.describe Homebrew::Livecheck::Strategy::Yaml do
   subject(:yaml) { described_class }
 
   let(:http_url) { "https://brew.sh/blog/" }

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -2,7 +2,7 @@
 
 require "livecheck/strategy"
 
-describe Homebrew::Livecheck::Strategy do
+RSpec.describe Homebrew::Livecheck::Strategy do
   subject(:strategy) { described_class }
 
   describe "::from_symbol" do

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -3,7 +3,7 @@
 require "formula"
 require "livecheck"
 
-describe Livecheck do
+RSpec.describe Livecheck do
   let(:f) do
     formula do
       homepage "https://brew.sh"

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -2,7 +2,7 @@
 
 require "locale"
 
-describe Locale do
+RSpec.describe Locale do
   describe "::parse" do
     it "parses a string in the correct format" do
       expect(described_class.parse("zh")).to eql(described_class.new("zh", nil, nil))

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -2,7 +2,7 @@
 
 require "lock_file"
 
-describe LockFile do
+RSpec.describe LockFile do
   subject(:lock_file) { described_class.new("foo") }
 
   describe "#lock" do

--- a/Library/Homebrew/test/macos_runner_spec_spec.rb
+++ b/Library/Homebrew/test/macos_runner_spec_spec.rb
@@ -2,7 +2,7 @@
 
 require "macos_runner_spec"
 
-describe MacOSRunnerSpec do
+RSpec.describe MacOSRunnerSpec do
   let(:spec) { described_class.new(name: "macOS 11-arm64", runner: "11-arm64", timeout: 90, cleanup: true) }
 
   it "has immutable attributes" do

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -2,7 +2,7 @@
 
 require "macos_version"
 
-describe MacOSVersion do
+RSpec.describe MacOSVersion do
   let(:version) { described_class.new("10.14") }
   let(:big_sur_major) { described_class.new("11.0") }
   let(:big_sur_update) { described_class.new("11.1") }

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -3,7 +3,7 @@
 require "messages"
 require "spec_helper"
 
-describe Messages do
+RSpec.describe Messages do
   let(:messages) { described_class.new }
   let(:test_formula) { formula("foo") { url("https://brew.sh/foo-0.1.tgz") } }
   let(:elapsed_time) { 1.1 }

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -5,7 +5,7 @@ require "test/support/fixtures/testball"
 require "tab"
 require "keg"
 
-describe Migrator do
+RSpec.describe Migrator do
   subject(:migrator) { described_class.new(new_formula, old_formula.name) }
 
   let(:new_formula) { Testball.new("newname") }

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -2,7 +2,7 @@
 
 require "missing_formula"
 
-describe Homebrew::MissingFormula do
+RSpec.describe Homebrew::MissingFormula do
   describe "::reason" do
     subject { described_class.reason("gem") }
 

--- a/Library/Homebrew/test/options/deprecated_option_spec.rb
+++ b/Library/Homebrew/test/options/deprecated_option_spec.rb
@@ -2,7 +2,7 @@
 
 require "options"
 
-describe DeprecatedOption do
+RSpec.describe DeprecatedOption do
   subject(:option) { described_class.new("foo", "bar") }
 
   specify "#old" do

--- a/Library/Homebrew/test/options/option_spec.rb
+++ b/Library/Homebrew/test/options/option_spec.rb
@@ -2,7 +2,7 @@
 
 require "options"
 
-describe Option do
+RSpec.describe Option do
   subject(:option) { described_class.new("foo") }
 
   specify "#to_s" do

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -2,7 +2,7 @@
 
 require "options"
 
-describe Options do
+RSpec.describe Options do
   subject(:options) { described_class.new }
 
   it "removes duplicate options" do

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "dependency_collector"
 
-describe DependencyCollector do
+RSpec.describe DependencyCollector do
   alias_matcher :be_a_build_requirement, :be_build
 
   subject(:collector) { described_class.new }

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -2,7 +2,7 @@
 
 require "diagnostic"
 
-describe Homebrew::Diagnostic::Checks do
+RSpec.describe Homebrew::Diagnostic::Checks do
   subject(:checks) { described_class.new }
 
   specify "#check_supported_architecture" do

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -3,7 +3,7 @@
 require "test/support/fixtures/testball"
 require "formula"
 
-describe Formula do
+RSpec.describe Formula do
   describe "#uses_from_macos" do
     before do
       allow(OS).to receive(:mac?).and_return(false)

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -2,7 +2,7 @@
 
 require "extend/pathname"
 
-describe Pathname do
+RSpec.describe Pathname do
   let(:elf_dir) { described_class.new "#{TEST_FIXTURE_DIR}/elf" }
   let(:sho) { elf_dir/"libforty.so.0" }
   let(:sho_without_runpath_rpath) { elf_dir/"libhello.so.0" }

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "dependency_collector"
 
-describe DependencyCollector do
+RSpec.describe DependencyCollector do
   alias_matcher :need_tar_xz_dependency, :be_tar_needs_xz_dependency
 
   subject(:collector) { described_class.new }

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -2,7 +2,7 @@
 
 require "diagnostic"
 
-describe Homebrew::Diagnostic::Checks do
+RSpec.describe Homebrew::Diagnostic::Checks do
   subject(:checks) { described_class.new }
 
   specify "#check_for_unsupported_macos" do

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -3,7 +3,7 @@
 require "test/support/fixtures/testball"
 require "formula"
 
-describe Formula do
+RSpec.describe Formula do
   describe "#uses_from_macos" do
     before do
       allow(OS).to receive(:mac?).and_return(true)

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -2,7 +2,7 @@
 
 require "keg"
 
-describe Keg do
+RSpec.describe Keg do
   include FileUtils
 
   subject(:keg) { described_class.new(keg_path) }

--- a/Library/Homebrew/test/os/mac/mach_spec.rb
+++ b/Library/Homebrew/test/os/mac/mach_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "Mach-O" do
+RSpec.describe "Mach-O" do
   describe "Pathname tests" do
     specify "fat dylib" do
       pn = dylib_path("fat")

--- a/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
+++ b/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
@@ -12,7 +12,7 @@
 # Additionally, libffi version detection cannot be performed on systems running Mojave or earlier.
 #
 # For indeterminable cases, consult https://opensource.apple.com for the version used.
-describe "pkg-config", :needs_ci do
+RSpec.describe "pkg-config", :needs_ci do
   def pc_version(library)
     path = HOMEBREW_LIBRARY_PATH/"os/mac/pkgconfig/#{MacOS.version}/#{library}.pc"
     version = File.foreach(path)

--- a/Library/Homebrew/test/os/mac/sdk_spec.rb
+++ b/Library/Homebrew/test/os/mac/sdk_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe OS::Mac::CLTSDKLocator do
+RSpec.describe OS::Mac::CLTSDKLocator do
   subject(:locator) { described_class.new }
 
   let(:big_sur_sdk) { OS::Mac::SDK.new(MacOSVersion.new("11"), "/some/path/MacOSX.sdk", :clt) }

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -3,7 +3,7 @@
 require "locale"
 require "os/mac"
 
-describe OS::Mac do
+RSpec.describe OS::Mac do
   describe "::languages" do
     it "returns a list of all languages" do
       expect(described_class.languages).not_to be_empty

--- a/Library/Homebrew/test/os/os_spec.rb
+++ b/Library/Homebrew/test/os/os_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe OS do
+RSpec.describe OS do
   describe "::kernel_version" do
     it "is not NULL" do
       expect(described_class.kernel_version).not_to be_null

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -2,7 +2,7 @@
 
 require "patch"
 
-describe Patch do
+RSpec.describe Patch do
   describe "#create" do
     context "with a simple patch" do
       subject { described_class.create(:p2, nil) }

--- a/Library/Homebrew/test/patching_spec.rb
+++ b/Library/Homebrew/test/patching_spec.rb
@@ -2,7 +2,7 @@
 
 require "formula"
 
-describe "patching" do
+RSpec.describe "patching" do
   let(:formula_subclass) do
     Class.new(Formula) do
       # These are defined within an anonymous class to avoid polluting the global namespace.

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -3,7 +3,7 @@
 require "extend/pathname"
 require "install_renamed"
 
-describe Pathname do
+RSpec.describe Pathname do
   include FileUtils
 
   let(:src) { mktmpdir }

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -2,7 +2,7 @@
 
 require "pkg_version"
 
-describe PkgVersion do
+RSpec.describe PkgVersion do
   describe "::parse" do
     it "parses versions from a string" do
       expect(described_class.parse("1.0_1")).to eq(described_class.new(Version.new("1.0"), 1))

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -139,7 +139,9 @@ describe Requirement do
       end
 
       it "infers path from #satisfy result" do
-        expect(ENV).to receive(:prepend_path).with("PATH", Pathname.new("/foo/bar"))
+        without_partial_double_verification do
+          expect(ENV).to receive(:prepend_path).with("PATH", Pathname.new("/foo/bar"))
+        end
         requirement.satisfied?
         requirement.modify_build_environment
       end

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -3,7 +3,7 @@
 require "extend/ENV"
 require "requirement"
 
-describe Requirement do
+RSpec.describe Requirement do
   alias_matcher :be_a_build_requirement, :be_a_build
 
   subject(:requirement) { klass.new }

--- a/Library/Homebrew/test/requirements/arch_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/arch_requirement_spec.rb
@@ -2,7 +2,7 @@
 
 require "requirements/arch_requirement"
 
-describe ArchRequirement do
+RSpec.describe ArchRequirement do
   subject(:requirement) { described_class.new([Hardware::CPU.type]) }
 
   describe "#satisfied?" do

--- a/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/codesign_requirement_spec.rb
@@ -2,7 +2,7 @@
 
 require "requirements/codesign_requirement"
 
-describe CodesignRequirement do
+RSpec.describe CodesignRequirement do
   subject(:requirement) do
     described_class.new([{ identity: identity, with: with, url: url }])
   end

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -2,7 +2,7 @@
 
 require "requirements/linux_requirement"
 
-describe LinuxRequirement do
+RSpec.describe LinuxRequirement do
   subject(:requirement) { described_class.new }
 
   describe "#satisfied?" do

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -2,7 +2,7 @@
 
 require "requirements/macos_requirement"
 
-describe MacOSRequirement do
+RSpec.describe MacOSRequirement do
   subject(:requirement) { described_class.new }
 
   describe "#satisfied?" do

--- a/Library/Homebrew/test/requirements_spec.rb
+++ b/Library/Homebrew/test/requirements_spec.rb
@@ -2,7 +2,7 @@
 
 require "requirements"
 
-describe Requirements do
+RSpec.describe Requirements do
   subject(:requirements) { described_class.new }
 
   describe "#<<" do

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -3,7 +3,7 @@
 require "resource"
 require "livecheck"
 
-describe Resource do
+RSpec.describe Resource do
   subject(:resource) { described_class.new("test") }
 
   let(:livecheck_resource) do

--- a/Library/Homebrew/test/rubocop_spec.rb
+++ b/Library/Homebrew/test/rubocop_spec.rb
@@ -2,7 +2,7 @@
 
 require "open3"
 
-describe "RuboCop" do
+RSpec.describe "RuboCop" do
   context "when calling `rubocop` outside of the Homebrew environment" do
     before do
       ENV.each_key do |key|

--- a/Library/Homebrew/test/rubocops/blank_spec.rb
+++ b/Library/Homebrew/test/rubocops/blank_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/blank"
 
-describe RuboCop::Cop::Homebrew::Blank, :config do
+RSpec.describe RuboCop::Cop::Homebrew::Blank, :config do
   shared_examples "offense" do |source, correction, message|
     it "registers an offense and corrects" do
       expect_offense(<<~RUBY, source: source, message: message)

--- a/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_digest_indentation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/bottle"
 
-describe RuboCop::Cop::FormulaAudit::BottleDigestIndentation do
+RSpec.describe RuboCop::Cop::FormulaAudit::BottleDigestIndentation do
   subject(:cop) { described_class.new }
 
   it "reports no offenses for `bottle :unneeded`" do

--- a/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/bottle"
 
-describe RuboCop::Cop::FormulaAudit::BottleFormat do
+RSpec.describe RuboCop::Cop::FormulaAudit::BottleFormat do
   subject(:cop) { described_class.new }
 
   it "reports no offenses for `bottle :unneeded`" do

--- a/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/bottle"
 
-describe RuboCop::Cop::FormulaAudit::BottleOrder do
+RSpec.describe RuboCop::Cop::FormulaAudit::BottleOrder do
   subject(:cop) { described_class.new }
 
   it "reports no offenses for `bottle :unneeded`" do

--- a/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_tag_indentation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/bottle"
 
-describe RuboCop::Cop::FormulaAudit::BottleTagIndentation do
+RSpec.describe RuboCop::Cop::FormulaAudit::BottleTagIndentation do
   subject(:cop) { described_class.new }
 
   it "reports no offenses for `bottle :unneeded`" do

--- a/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::ArrayAlphabetization, :config do
+RSpec.describe RuboCop::Cop::Cask::ArrayAlphabetization, :config do
   it "reports an offense when a single `zap trash` path is specified in an array" do
     expect_offense(<<~CASK)
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/cask/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/desc_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::Desc, :config do
+RSpec.describe RuboCop::Cop::Cask::Desc, :config do
   it "does not start with an article" do
     expect_no_offenses <<~RUBY
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/cask/discontinued_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/discontinued_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::Discontinued, :config do
+RSpec.describe RuboCop::Cop::Cask::Discontinued, :config do
   it "reports no offenses when there is no `caveats` stanza" do
     expect_no_offenses <<~CASK
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::HomepageUrlTrailingSlash, :config do
+RSpec.describe RuboCop::Cop::Cask::HomepageUrlTrailingSlash, :config do
   it "accepts a homepage URL ending with a slash" do
     expect_no_offenses <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::NoOverrides, :config do
+RSpec.describe RuboCop::Cop::Cask::NoOverrides, :config do
   it "accepts when there are no `on_*` blocks" do
     expect_no_offenses <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
+RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
   context "when auditing `postflight` stanzas" do
     it "accepts when there are no `on_*` blocks" do
       expect_no_offenses <<~CASK

--- a/Library/Homebrew/test/rubocops/cask/shared_filelist_glob_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/shared_filelist_glob_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::SharedFilelistGlob, :config do
+RSpec.describe RuboCop::Cop::Cask::SharedFilelistGlob, :config do
   it "reports an offense when a zap trash array includes an .sfl2 or .sfl3 file" do
     expect_offense(<<~CASK)
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::StanzaGrouping, :config do
+RSpec.describe RuboCop::Cop::Cask::StanzaGrouping, :config do
   it "accepts a sole stanza" do
     expect_no_offenses <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::StanzaOrder, :config do
+RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
   it "accepts a sole stanza" do
     expect_no_offenses <<~CASK
       cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/uninstall_methods_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/uninstall_methods_order_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rubocops/rubocop-cask"
-describe RuboCop::Cop::Cask::UninstallMethodsOrder, :config do
+RSpec.describe RuboCop::Cop::Cask::UninstallMethodsOrder, :config do
   context "with uninstall blocks" do
     context "when methods are incorrectly ordered" do
       it "detects and corrects ordering offenses in the uninstall block when each method contains a single item" do

--- a/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_legacy_comma_separators_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::UrlLegacyCommaSeparators, :config do
+RSpec.describe RuboCop::Cop::Cask::UrlLegacyCommaSeparators, :config do
   it "accepts a simple `version` interpolation" do
     expect_no_offenses <<~'CASK'
       cask 'foo' do

--- a/Library/Homebrew/test/rubocops/cask/url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/url_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::Url, :config do
+RSpec.describe RuboCop::Cop::Cask::Url, :config do
   it "accepts a `verified` value that does not start with a protocol" do
     expect_no_offenses <<~CASK
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/cask/variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/variables_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/rubocop-cask"
 
-describe RuboCop::Cop::Cask::Variables, :config do
+RSpec.describe RuboCop::Cop::Cask::Variables, :config do
   it "accepts when there are no variables" do
     expect_no_offenses <<~CASK
       cask "foo" do

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/caveats"
 
-describe RuboCop::Cop::FormulaAudit::Caveats do
+RSpec.describe RuboCop::Cop::FormulaAudit::Caveats do
   subject(:cop) { described_class.new }
 
   context "when auditing `caveats`" do

--- a/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/checksum"
 
-describe RuboCop::Cop::FormulaAudit::ChecksumCase do
+RSpec.describe RuboCop::Cop::FormulaAudit::ChecksumCase do
   subject(:cop) { described_class.new }
 
   context "when auditing spec checksums" do

--- a/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/checksum"
 
-describe RuboCop::Cop::FormulaAudit::Checksum do
+RSpec.describe RuboCop::Cop::FormulaAudit::Checksum do
   subject(:cop) { described_class.new }
 
   context "when auditing spec checksums" do

--- a/Library/Homebrew/test/rubocops/class/class_name_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/class_name_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/class"
 
-describe RuboCop::Cop::FormulaAudit::ClassName do
+RSpec.describe RuboCop::Cop::FormulaAudit::ClassName do
   subject(:cop) { described_class.new }
 
   corrected_source = <<~RUBY

--- a/Library/Homebrew/test/rubocops/class/test_present.rb
+++ b/Library/Homebrew/test/rubocops/class/test_present.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/class"
 
-describe RuboCop::Cop::FormulaAuditStrict::TestPresent do
+RSpec.describe RuboCop::Cop::FormulaAuditStrict::TestPresent do
   subject(:cop) { described_class.new }
 
   it "reports an offense when there is no test block" do

--- a/Library/Homebrew/test/rubocops/class/test_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/test_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/class"
 
-describe RuboCop::Cop::FormulaAudit::Test do
+RSpec.describe RuboCop::Cop::FormulaAudit::Test do
   subject(:cop) { described_class.new }
 
   it "reports and corrects an offense when /usr/local/bin is found in test calls" do

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/components_order"
 
-describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
+RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
   subject(:cop) { described_class.new }
 
   context "when auditing formula components order" do

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/components_redundancy"
 
-describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
+RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
   subject(:cop) { described_class.new }
 
   context "when auditing formula components" do

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/conflicts"
 
-describe RuboCop::Cop::FormulaAudit::Conflicts do
+RSpec.describe RuboCop::Cop::FormulaAudit::Conflicts do
   subject(:cop) { described_class.new }
 
   context "when auditing `conflicts_with`" do

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/dependency_order"
 
-describe RuboCop::Cop::FormulaAudit::DependencyOrder do
+RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
   subject(:cop) { described_class.new }
 
   context "when auditing `uses_from_macos`" do

--- a/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/date_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/deprecate_disable"
 
-describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
+RSpec.describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
   subject(:cop) { described_class.new }
 
   context "when auditing `deprecate!`" do

--- a/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable/reason_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/deprecate_disable"
 
-describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
+RSpec.describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
   subject(:cop) { described_class.new }
 
   context "when auditing `deprecate!`" do

--- a/Library/Homebrew/test/rubocops/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/desc_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/desc"
 
-describe RuboCop::Cop::FormulaAudit::Desc do
+RSpec.describe RuboCop::Cop::FormulaAudit::Desc do
   subject(:cop) { described_class.new }
 
   context "when auditing formula `desc` methods" do

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/files"
 
-describe RuboCop::Cop::FormulaAudit::Files do
+RSpec.describe RuboCop::Cop::FormulaAudit::Files do
   subject(:cop) { described_class.new }
 
   context "when auditing files" do

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/homepage"
 
-describe RuboCop::Cop::FormulaAudit::Homepage do
+RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
   subject(:cop) { described_class.new }
 
   context "when auditing homepage" do

--- a/Library/Homebrew/test/rubocops/io_read_spec.rb
+++ b/Library/Homebrew/test/rubocops/io_read_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/io_read"
 
-describe RuboCop::Cop::Homebrew::IORead do
+RSpec.describe RuboCop::Cop::Homebrew::IORead do
   subject(:cop) { described_class.new }
 
   it "reports an offense when `IO.read` is used with a pipe character" do

--- a/Library/Homebrew/test/rubocops/keg_only_spec.rb
+++ b/Library/Homebrew/test/rubocops/keg_only_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/keg_only"
 
-describe RuboCop::Cop::FormulaAudit::KegOnly do
+RSpec.describe RuboCop::Cop::FormulaAudit::KegOnly do
   subject(:cop) { described_class.new }
 
   it "reports and corrects an offense when the `keg_only` reason is capitalized" do

--- a/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/class_inheritance_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::ClassInheritance do
+RSpec.describe RuboCop::Cop::FormulaAudit::ClassInheritance do
   subject(:cop) { described_class.new }
 
   context "when auditing formula class inheritance" do

--- a/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/generate_completions_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit do
+RSpec.describe RuboCop::Cop::FormulaAudit do
   describe RuboCop::Cop::FormulaAudit::GenerateCompletionsDSL do
     subject(:cop) { described_class.new }
 

--- a/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::QuicTLSCheck do
+RSpec.describe RuboCop::Cop::FormulaAudit::QuicTLSCheck do
   subject(:cop) { described_class.new }
 
   context "when auditing formula dependencies" do

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::Lines do
+RSpec.describe RuboCop::Cop::FormulaAudit::Lines do
   subject(:cop) { described_class.new }
 
   context "when auditing deprecated special dependencies" do

--- a/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_case_insensitive_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/livecheck"
 
-describe RuboCop::Cop::FormulaAudit::LivecheckRegexCaseInsensitive do
+RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexCaseInsensitive do
   subject(:cop) { described_class.new }
 
   it "reports an offense when the `regex` is not case-insensitive" do

--- a/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_extension_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/livecheck"
 
-describe RuboCop::Cop::FormulaAudit::LivecheckRegexExtension do
+RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexExtension do
   subject(:cop) { described_class.new }
 
   it "reports an offense when the `regex` does not use `\\.t` for archive file extensions" do

--- a/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_if_page_match_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/livecheck"
 
-describe RuboCop::Cop::FormulaAudit::LivecheckRegexIfPageMatch do
+RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexIfPageMatch do
   subject(:cop) { described_class.new }
 
   it "reports an offense when there is no `regex` for `strategy :page_match`" do

--- a/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/livecheck"
 
-describe RuboCop::Cop::FormulaAudit::LivecheckRegexParentheses do
+RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexParentheses do
   subject(:cop) { described_class.new }
 
   it "reports an offense when the `regex` call in the livecheck block does not use parentheses" do

--- a/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/livecheck"
 
-describe RuboCop::Cop::FormulaAudit::LivecheckSkip do
+RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckSkip do
   subject(:cop) { described_class.new }
 
   it "reports an offense when a skipped formula's livecheck block contains other information" do

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/livecheck"
 
-describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
+RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
   subject(:cop) { described_class.new }
 
   it "reports an offense when a `url` is not specified in the livecheck block" do

--- a/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/livecheck"
 
-describe RuboCop::Cop::FormulaAudit::LivecheckUrlSymbol do
+RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlSymbol do
   subject(:cop) { described_class.new }
 
   it "reports an offense when the `url` specified in the livecheck block is identical to a formula URL" do

--- a/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
+++ b/Library/Homebrew/test/rubocops/move_to_extend_os_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/move_to_extend_os"
 
-describe RuboCop::Cop::Homebrew::MoveToExtendOS do
+RSpec.describe RuboCop::Cop::Homebrew::MoveToExtendOS do
   subject(:cop) { described_class.new }
 
   it "registers an offense when using `OS.linux?`" do

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/options"
 
-describe RuboCop::Cop::FormulaAudit::Options do
+RSpec.describe RuboCop::Cop::FormulaAudit::Options do
   subject(:cop) { described_class.new }
 
   context "when auditing options" do

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/patches"
 
-describe RuboCop::Cop::FormulaAudit::Patches do
+RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
   subject(:cop) { described_class.new }
 
   def expect_offense_hash(message:, severity:, line:, column:, source:)

--- a/Library/Homebrew/test/rubocops/present_spec.rb
+++ b/Library/Homebrew/test/rubocops/present_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/present"
 
-describe RuboCop::Cop::Homebrew::Present, :config do
+RSpec.describe RuboCop::Cop::Homebrew::Present, :config do
   shared_examples "offense" do |source, correction, message|
     it "registers an offense and corrects" do
       expect_offense(<<~RUBY, source: source, message: message)

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/uses_from_macos"
 
-describe RuboCop::Cop::FormulaAudit::ProvidedByMacos do
+RSpec.describe RuboCop::Cop::FormulaAudit::ProvidedByMacos do
   subject(:cop) { described_class.new }
 
   it "fails for formulae not in PROVIDED_BY_MACOS_FORMULAE list" do

--- a/Library/Homebrew/test/rubocops/service_spec.rb
+++ b/Library/Homebrew/test/rubocops/service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/service"
 
-describe RuboCop::Cop::FormulaAudit::Service do
+RSpec.describe RuboCop::Cop::FormulaAudit::Service do
   subject(:cop) { described_class.new }
 
   it "reports offenses when a service block is missing a required command" do

--- a/Library/Homebrew/test/rubocops/shell_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/shell_commands_spec.rb
@@ -5,7 +5,7 @@ require "rubocops/shell_commands"
 module RuboCop
   module Cop
     module Homebrew
-      describe ShellCommands do
+      ::RSpec.describe ShellCommands do
         subject(:cop) { described_class.new }
 
         context "when auditing shell commands" do
@@ -213,7 +213,7 @@ module RuboCop
         end
       end
 
-      describe ExecShellMetacharacters do
+      ::RSpec.describe ExecShellMetacharacters do
         subject(:cop) { described_class.new }
 
         context "when auditing exec calls" do

--- a/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/assert_statements_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::AssertStatements do
+RSpec.describe RuboCop::Cop::FormulaAudit::AssertStatements do
   subject(:cop) { described_class.new }
 
   context "when auditing formula assertions" do

--- a/Library/Homebrew/test/rubocops/text/comments_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/comments_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::Comments do
+RSpec.describe RuboCop::Cop::FormulaAudit::Comments do
   subject(:cop) { described_class.new }
 
   context "when auditing comment text" do

--- a/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/license_arrays_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::LicenseArrays do
+RSpec.describe RuboCop::Cop::FormulaAudit::LicenseArrays do
   subject(:cop) { described_class.new }
 
   context "when auditing license arrays" do

--- a/Library/Homebrew/test/rubocops/text/licenses_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/licenses_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::Licenses do
+RSpec.describe RuboCop::Cop::FormulaAudit::Licenses do
   subject(:cop) { described_class.new }
 
   context "when auditing licenses" do

--- a/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/macos_on_linux_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::MacOSOnLinux do
+RSpec.describe RuboCop::Cop::FormulaAudit::MacOSOnLinux do
   subject(:cop) { described_class.new }
 
   it "reports an offense when `MacOS` is used in the `Formula` class" do

--- a/Library/Homebrew/test/rubocops/text/make_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/make_check_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAuditStrict::MakeCheck do
+RSpec.describe RuboCop::Cop::FormulaAuditStrict::MakeCheck do
   subject(:cop) { described_class.new }
 
   let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-core" }

--- a/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::Miscellaneous do
+RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
   subject(:cop) { described_class.new }
 
   context "when auditing formula miscellany" do

--- a/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::MpiCheck do
+RSpec.describe RuboCop::Cop::FormulaAudit::MpiCheck do
   subject(:cop) { described_class.new }
 
   context "when auditing MPI dependencies" do

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
+RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
   subject(:cop) { described_class.new }
 
   context "when auditing OS conditionals" do

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
+RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
   subject(:cop) { described_class.new }
 
   context "when auditing options" do

--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::PythonVersions do
+RSpec.describe RuboCop::Cop::FormulaAudit::PythonVersions do
   subject(:cop) { described_class.new }
 
   context "when auditing Python versions" do

--- a/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/safe_popen_commands_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::SafePopenCommands do
+RSpec.describe RuboCop::Cop::FormulaAudit::SafePopenCommands do
   subject(:cop) { described_class.new }
 
   context "when auditing popen commands" do

--- a/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/lines"
 
-describe RuboCop::Cop::FormulaAudit::ShellVariables do
+RSpec.describe RuboCop::Cop::FormulaAudit::ShellVariables do
   subject(:cop) { described_class.new }
 
   context "when auditing shell variables" do

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/text"
 
-describe RuboCop::Cop::FormulaAuditStrict::Text do
+RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
   subject(:cop) { described_class.new }
 
   context "when auditing formula text in homebrew/core" do

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/text"
 
-describe RuboCop::Cop::FormulaAudit::Text do
+RSpec.describe RuboCop::Cop::FormulaAudit::Text do
   subject(:cop) { described_class.new }
 
   context "when auditing formula text" do

--- a/Library/Homebrew/test/rubocops/urls/git_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/urls"
 
-describe RuboCop::Cop::FormulaAudit::GitUrls do
+RSpec.describe RuboCop::Cop::FormulaAudit::GitUrls do
   subject(:cop) { described_class.new }
 
   context "when a git URL is used" do

--- a/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/urls"
 
-describe RuboCop::Cop::FormulaAuditStrict::GitUrls do
+RSpec.describe RuboCop::Cop::FormulaAuditStrict::GitUrls do
   subject(:cop) { described_class.new }
 
   context "when a git URL is used" do

--- a/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/urls"
 
-describe RuboCop::Cop::FormulaAudit::PyPiUrls do
+RSpec.describe RuboCop::Cop::FormulaAudit::PyPiUrls do
   subject(:cop) { described_class.new }
 
   context "when a pypi URL is used" do

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/urls"
 
-describe RuboCop::Cop::FormulaAudit::Urls do
+RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
   subject(:cop) { described_class.new }
 
   let(:offense_list) do

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/uses_from_macos"
 
-describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
+RSpec.describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
   subject(:cop) { described_class.new }
 
   context "when auditing `uses_from_macos` dependencies" do

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/version"
 
-describe RuboCop::Cop::FormulaAudit::Version do
+RSpec.describe RuboCop::Cop::FormulaAudit::Version do
   subject(:cop) { described_class.new }
 
   context "when auditing version" do

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -2,7 +2,7 @@
 
 require "sandbox"
 
-describe Sandbox, :needs_macos do
+RSpec.describe Sandbox, :needs_macos do
   define_negated_matcher :not_matching, :matching
 
   subject(:sandbox) { described_class.new }

--- a/Library/Homebrew/test/search_spec.rb
+++ b/Library/Homebrew/test/search_spec.rb
@@ -2,7 +2,7 @@
 
 require "search"
 
-describe Homebrew::Search do
+RSpec.describe Homebrew::Search do
   describe "#query_regexp" do
     it "correctly parses a regex query" do
       expect(described_class.query_regexp("/^query$/")).to eq(/^query$/)

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -3,7 +3,7 @@
 require "formula"
 require "service"
 
-describe Homebrew::Service do
+RSpec.describe Homebrew::Service do
   let(:name) { "formula_name" }
 
   def stub_formula(&block)

--- a/Library/Homebrew/test/settings_spec.rb
+++ b/Library/Homebrew/test/settings_spec.rb
@@ -2,7 +2,7 @@
 
 require "settings"
 
-describe Homebrew::Settings do
+RSpec.describe Homebrew::Settings do
   before do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"

--- a/Library/Homebrew/test/simulate_system_spec.rb
+++ b/Library/Homebrew/test/simulate_system_spec.rb
@@ -2,7 +2,7 @@
 
 require "settings"
 
-describe Homebrew::SimulateSystem do
+RSpec.describe Homebrew::SimulateSystem do
   after do
     described_class.clear
   end

--- a/Library/Homebrew/test/software_spec/bottle_spec.rb
+++ b/Library/Homebrew/test/software_spec/bottle_spec.rb
@@ -2,7 +2,7 @@
 
 require "software_spec"
 
-describe BottleSpecification do
+RSpec.describe BottleSpecification do
   subject(:bottle_spec) { described_class.new }
 
   describe "#sha256" do

--- a/Library/Homebrew/test/software_spec/head_spec.rb
+++ b/Library/Homebrew/test/software_spec/head_spec.rb
@@ -2,7 +2,7 @@
 
 require "software_spec"
 
-describe HeadSoftwareSpec do
+RSpec.describe HeadSoftwareSpec do
   subject(:head_spec) { described_class.new }
 
   specify "#version" do

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -2,7 +2,7 @@
 
 require "software_spec"
 
-describe SoftwareSpec do
+RSpec.describe SoftwareSpec do
   alias_matcher :have_defined_resource, :be_resource_defined
   alias_matcher :have_defined_option, :be_option_defined
 

--- a/Library/Homebrew/test/sorbet/tapioca/config_spec.rb
+++ b/Library/Homebrew/test/sorbet/tapioca/config_spec.rb
@@ -3,7 +3,7 @@
 require "rubygems"
 require "yaml"
 
-describe "Tapioca Config" do
+RSpec.describe "Tapioca Config" do
   let(:config) { YAML.load_file(File.join(__dir__, "../../../sorbet/tapioca/config.yml")) }
 
   it "only excludes dependencies" do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
 
   config.raise_errors_for_deprecations!
   config.warnings = true
+  config.disable_monkey_patching!
 
   config.filter_run_when_matching :focus
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -87,6 +87,24 @@ RSpec.configure do |config|
   # identify flaky tests.
   config.default_retry_count = 2 unless ENV["BUILDPULSE"]
 
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
   # Increase timeouts for integration tests (as we expect them to take longer).
   config.around(:each, :integration_test) do |example|
     example.metadata[:timeout] ||= 120

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -66,6 +66,7 @@ RSpec.configure do |config|
   config.order = :random
 
   config.raise_errors_for_deprecations!
+  config.warnings = true
 
   config.filter_run_when_matching :focus
 
@@ -179,6 +180,7 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
+    undef find_files if defined? find_files
     def find_files
       return [] unless File.exist?(TEST_TMPDIR)
 

--- a/Library/Homebrew/test/style_spec.rb
+++ b/Library/Homebrew/test/style_spec.rb
@@ -2,7 +2,7 @@
 
 require "style"
 
-describe Homebrew::Style do
+RSpec.describe Homebrew::Style do
   around do |example|
     FileUtils.ln_s HOMEBREW_LIBRARY_PATH, HOMEBREW_LIBRARY/"Homebrew"
     FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".rubocop.yml"

--- a/Library/Homebrew/test/support/helper/files.rb
+++ b/Library/Homebrew/test/support/helper/files.rb
@@ -1,0 +1,17 @@
+# typed: true
+# frozen_string_literal: true
+
+module Test
+  module Helper
+    module Files
+      def self.find_files
+        return [] unless File.exist?(TEST_TMPDIR)
+
+        Find.find(TEST_TMPDIR)
+            .reject { |f| File.basename(f) == ".DS_Store" }
+            .reject { |f| TEST_DIRECTORIES.include?(Pathname(f)) }
+            .map { |f| f.sub(TEST_TMPDIR, "") }
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-shared_examples "formulae exist" do |array|
+RSpec.shared_examples "formulae exist" do |array|
   array.each do |f|
     it "#{f} formula exists" do
       core_tap = Pathname("#{HOMEBREW_LIBRARY_PATH}/../Taps/homebrew/homebrew-core")

--- a/Library/Homebrew/test/system_command_result_spec.rb
+++ b/Library/Homebrew/test/system_command_result_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_command"
 
-describe SystemCommand::Result do
+RSpec.describe SystemCommand::Result do
   subject(:result) do
     described_class.new([], output_array, instance_double(Process::Status, exitstatus: 0, success?: true),
                         secrets: [])

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -2,7 +2,7 @@
 
 require "system_command"
 
-describe SystemCommand do
+RSpec.describe SystemCommand do
   describe "#initialize" do
     subject(:command) do
       described_class.new(

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -3,7 +3,7 @@
 require "tab"
 require "formula"
 
-describe Tab do
+RSpec.describe Tab do
   alias_matcher :be_built_with, :be_with
 
   matcher :be_poured_from_bottle do

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Tap do
+RSpec.describe Tap do
   alias_matcher :have_formula_file, :be_formula_file
   alias_matcher :have_custom_remote, :be_custom_remote
 

--- a/Library/Homebrew/test/test_runner_formula_spec.rb
+++ b/Library/Homebrew/test/test_runner_formula_spec.rb
@@ -3,7 +3,7 @@
 require "test_runner_formula"
 require "test/support/fixtures/testball"
 
-describe TestRunnerFormula do
+RSpec.describe TestRunnerFormula do
   let(:testball) { Testball.new }
   let(:xcode_helper) { setup_test_formula("xcode-helper", [:macos]) }
   let(:linux_kernel_requirer) { setup_test_formula("linux-kernel-requirer", [:linux]) }

--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -2,7 +2,7 @@
 
 require "uninstall"
 
-describe Homebrew::Uninstall do
+RSpec.describe Homebrew::Uninstall do
   let(:dependency) { formula("dependency") { url "f-1" } }
 
   let(:dependent_formula) do

--- a/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bazaar_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Bazaar do
+RSpec.describe UnpackStrategy::Bazaar do
   let(:repo) do
     mktmpdir.tap do |repo|
       FileUtils.touch repo/"test"

--- a/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/bzip2_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Bzip2 do
+RSpec.describe UnpackStrategy::Bzip2 do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.bz2" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/cvs_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Cvs do
+RSpec.describe UnpackStrategy::Cvs do
   let(:repo) do
     mktmpdir.tap do |repo|
       FileUtils.touch repo/"test"

--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Directory do
+RSpec.describe UnpackStrategy::Directory do
   subject(:strategy) { described_class.new(path) }
 
   let(:path) do

--- a/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/dmg_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Dmg, :needs_macos do
+RSpec.describe UnpackStrategy::Dmg, :needs_macos do
   describe "#mount" do
     let(:path) { TEST_FIXTURE_DIR/"cask/container.dmg" }
 

--- a/Library/Homebrew/test/unpack_strategy/git_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/git_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Git do
+RSpec.describe UnpackStrategy::Git do
   let(:repo) do
     mktmpdir.tap do |repo|
       system "git", "-C", repo, "init"

--- a/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/gzip_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Gzip do
+RSpec.describe UnpackStrategy::Gzip do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.gz" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/jar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/jar_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Jar, :needs_unzip do
+RSpec.describe UnpackStrategy::Jar, :needs_unzip do
   let(:path) { TEST_FIXTURE_DIR/"test.jar" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/lha_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lha_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Lha do
+RSpec.describe UnpackStrategy::Lha do
   let(:path) { TEST_FIXTURE_DIR/"test.lha" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/lzip_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Lzip do
+RSpec.describe UnpackStrategy::Lzip do
   let(:path) { TEST_FIXTURE_DIR/"test.lz" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/mercurial_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Mercurial do
+RSpec.describe UnpackStrategy::Mercurial do
   let(:repo) do
     mktmpdir.tap do |repo|
       (repo/".hg").mkpath

--- a/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/p7zip_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::P7Zip do
+RSpec.describe UnpackStrategy::P7Zip do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.7z" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/rar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/rar_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Rar do
+RSpec.describe UnpackStrategy::Rar do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.rar" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/shared_examples.rb
+++ b/Library/Homebrew/test/unpack_strategy/shared_examples.rb
@@ -2,13 +2,13 @@
 
 require "unpack_strategy"
 
-shared_examples "UnpackStrategy::detect" do
+RSpec.shared_examples "UnpackStrategy::detect" do
   it "is correctly detected" do
     expect(UnpackStrategy.detect(path)).to be_a described_class
   end
 end
 
-shared_examples "#extract" do |children: []|
+RSpec.shared_examples "#extract" do |children: []|
   specify "#extract" do
     mktmpdir do |unpack_dir|
       described_class.new(path).extract(to: unpack_dir)

--- a/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Subversion, :needs_svn do
+RSpec.describe UnpackStrategy::Subversion, :needs_svn do
   let(:repo) { mktmpdir }
   let(:working_copy) { mktmpdir }
   let(:path) { working_copy }

--- a/Library/Homebrew/test/unpack_strategy/tar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/tar_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Tar do
+RSpec.describe UnpackStrategy::Tar do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.tar.gz" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/uncompressed_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Uncompressed do
+RSpec.describe UnpackStrategy::Uncompressed do
   let(:path) do
     (mktmpdir/"test").tap do |path|
       FileUtils.touch path

--- a/Library/Homebrew/test/unpack_strategy/xar_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xar_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Xar, :needs_macos do
+RSpec.describe UnpackStrategy::Xar, :needs_macos do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.xar" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/xz_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/xz_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Xz do
+RSpec.describe UnpackStrategy::Xz do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.xz" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/zip_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zip_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Zip do
+RSpec.describe UnpackStrategy::Zip do
   let(:path) { TEST_FIXTURE_DIR/"cask/MyFancyApp.zip" }
 
   include_examples "UnpackStrategy::detect"

--- a/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/zstd_spec.rb
@@ -2,7 +2,7 @@
 
 require_relative "shared_examples"
 
-describe UnpackStrategy::Zstd do
+RSpec.describe UnpackStrategy::Zstd do
   let(:path) { TEST_FIXTURE_DIR/"cask/container.tar.zst" }
 
   it "is correctly detected" do

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe UnpackStrategy do
+RSpec.describe UnpackStrategy do
   describe "#extract_nestedly" do
     subject(:strategy) { described_class.detect(path) }
 

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -3,7 +3,7 @@
 require "utils/analytics"
 require "formula_installer"
 
-describe Utils::Analytics do
+RSpec.describe Utils::Analytics do
   before do
     described_class.clear_cache
   end

--- a/Library/Homebrew/test/utils/ast/ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/ast_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/ast"
 
-describe Utils::AST do
+RSpec.describe Utils::AST do
   describe ".stanza_text" do
     let(:compound_license) do
       <<-RUBY

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/ast"
 
-describe Utils::AST::FormulaAST do
+RSpec.describe Utils::AST::FormulaAST do
   subject(:formula_ast) do
     described_class.new <<~RUBY
       class Foo < Formula

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/autoremove"
 
-describe Utils::Autoremove do
+RSpec.describe Utils::Autoremove do
   shared_context "with formulae for dependency testing" do
     let(:formula_with_deps) do
       formula "zero" do

--- a/Library/Homebrew/test/utils/backtrace_spec.rb
+++ b/Library/Homebrew/test/utils/backtrace_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/backtrace"
 
-describe Utils::Backtrace do
+RSpec.describe Utils::Backtrace do
   let(:backtrace_no_sorbet_paths) do
     [
       "/Library/Homebrew/downloadable.rb:75:in",

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/bottles"
 
-describe Utils::Bottles do
+RSpec.describe Utils::Bottles do
   describe "#tag", :needs_macos do
     it "returns :big_sur or :arm64_big_sur on Big Sur" do
       allow(MacOS).to receive(:version).and_return(MacOSVersion.new("11.0"))

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/bottles"
 
-describe Utils::Bottles::Collector do
+RSpec.describe Utils::Bottles::Collector do
   subject(:collector) { described_class.new }
 
   let(:catalina) { Utils::Bottles::Tag.from_symbol(:catalina) }

--- a/Library/Homebrew/test/utils/bottles/tag_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/tag_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/bottles"
 
-describe Utils::Bottles::Tag do
+RSpec.describe Utils::Bottles::Tag do
   it "can parse macOS symbols with archs" do
     symbol = :arm64_big_sur
     tag = described_class.from_symbol(symbol)

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/curl"
 
-describe "Utils::Curl" do
+RSpec.describe "Utils::Curl" do
   include Utils::Curl
 
   let(:details) do

--- a/Library/Homebrew/test/utils/fork_spec.rb
+++ b/Library/Homebrew/test/utils/fork_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/fork"
 
-describe Utils do
+RSpec.describe Utils do
   describe "#safe_fork" do
     it "raises a RuntimeError on an error that isn't ErrorDuringExecution" do
       expect do

--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/git_repository"
 
-describe Utils do
+RSpec.describe Utils do
   shared_examples "git_repository helper function" do |method_name|
     context "when directory is not a Git repository" do
       it "returns nil if `safe` parameter is `false`" do

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/git"
 
-describe Utils::Git do
+RSpec.describe Utils::Git do
   around do |example|
     described_class.clear_available_cache
     example.run

--- a/Library/Homebrew/test/utils/github/actions_spec.rb
+++ b/Library/Homebrew/test/utils/github/actions_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/github/actions"
 
-describe GitHub::Actions::Annotation do
+RSpec.describe GitHub::Actions::Annotation do
   let(:message) { "lorem ipsum" }
 
   describe "#new" do

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/github"
 
-describe GitHub do
+RSpec.describe GitHub do
   describe "::search_query_string" do
     it "builds a query with the given hash parameters formatted as key:value" do
       query = described_class.search_query_string(user: "Homebrew", repo: "brew")

--- a/Library/Homebrew/test/utils/gzip_spec.rb
+++ b/Library/Homebrew/test/utils/gzip_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/gzip"
 
-describe Utils::Gzip do
+RSpec.describe Utils::Gzip do
   describe "compress_with_options" do
     it "uses the explicitly specified mtime, orig_name, and output path when passed" do
       mktmpdir do |path|

--- a/Library/Homebrew/test/utils/inreplace_spec.rb
+++ b/Library/Homebrew/test/utils/inreplace_spec.rb
@@ -3,7 +3,7 @@
 require "tempfile"
 require "utils/inreplace"
 
-describe Utils::Inreplace do
+RSpec.describe Utils::Inreplace do
   let(:file) { Tempfile.new("test") }
 
   before do

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/popen"
 
-describe Utils do
+RSpec.describe Utils do
   describe "::popen_read" do
     it "reads the standard output of a given command" do
       expect(described_class.popen_read("sh", "-c", "echo success").chomp).to eq("success")

--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/pypi"
 
-describe PyPI do
+RSpec.describe PyPI do
   let(:pypi_package_url) do
     "https://files.pythonhosted.org/packages/b0/3f/2e1dad67eb172b6443b5eb37eb885a054a55cfd733393071499514140282/" \
       "snakemake-5.29.0.tar.gz"

--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Utils do
+RSpec.describe Utils do
   describe "ruby_check_version_script" do
     subject do
       homebrew_env = ENV.select { |key, _| key.start_with?("HOMEBREW_") }

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/shell"
 
-describe Utils::Shell do
+RSpec.describe Utils::Shell do
   describe "::profile" do
     it "returns ~/.profile by default" do
       ENV["SHELL"] = "/bin/another_shell"

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/spdx"
 
-describe SPDX do
+RSpec.describe SPDX do
   describe ".license_data" do
     it "has the license list version" do
       expect(described_class.license_data["licenseListVersion"]).not_to be_nil

--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/string_inreplace_extension"
 
-describe StringInreplaceExtension do
+RSpec.describe StringInreplaceExtension do
   subject(:string_extension) { described_class.new(string.dup) }
 
   describe "#change_make_var!" do

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/svn"
 
-describe Utils::Svn do
+RSpec.describe Utils::Svn do
   before do
     described_class.clear_version_cache
   end

--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/tar"
 
-describe Utils::Tar do
+RSpec.describe Utils::Tar do
   before do
     described_class.clear_executable_cache
   end

--- a/Library/Homebrew/test/utils/timer_spec.rb
+++ b/Library/Homebrew/test/utils/timer_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/timer"
 
-describe Utils::Timer do
+RSpec.describe Utils::Timer do
   describe "#remaining" do
     it "returns nil when nil" do
       expect(described_class.remaining(nil)).to be_nil

--- a/Library/Homebrew/test/utils/topological_hash_spec.rb
+++ b/Library/Homebrew/test/utils/topological_hash_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/topological_hash"
 
-describe Utils::TopologicalHash do
+RSpec.describe Utils::TopologicalHash do
   describe "#tsort" do
     it "returns a topologically sorted array" do
       hash = described_class.new

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Tty do
+RSpec.describe Tty do
   describe "::strip_ansi" do
     it "removes ANSI escape codes from a string" do
       expect(described_class.strip_ansi("\033[36;7mhello\033[0m")).to eq("hello")

--- a/Library/Homebrew/test/utils/user_spec.rb
+++ b/Library/Homebrew/test/utils/user_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils/user"
 
-describe User do
+RSpec.describe User do
   subject { described_class.current }
 
   it { is_expected.to eq ENV.fetch("USER") }

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -2,7 +2,7 @@
 
 require "utils"
 
-describe Utils do
+RSpec.describe Utils do
   describe ".deconstantize" do
     it "removes the rightmost segment from the constant expression in the string" do
       expect(described_class.deconstantize("Net::HTTP")).to eq("Net")

--- a/Library/Homebrew/test/version/parser_spec.rb
+++ b/Library/Homebrew/test/version/parser_spec.rb
@@ -2,7 +2,7 @@
 
 require "version/parser"
 
-describe Version::Parser do
+RSpec.describe Version::Parser do
   specify "::new" do
     expect { described_class.new }
       .to raise_error("Version::Parser is declared as abstract; it cannot be instantiated")

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -2,7 +2,7 @@
 
 require "version"
 
-describe Version do
+RSpec.describe Version do
   subject(:version) { described_class.new("1.2.3") }
 
   specify ".formula_optionally_versioned_regex" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR enables some best-practice RSpec options (for reference, see the project initializer [boilerplate](https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/project_initializer/spec/spec_helper.rb) in `rspec-core`). Specifically, it:

- Enables and fixes warnings (first commit). These involved a circular `require` and re-defining methods without undefining them first. (The latter can seem a bit silly, but I've found to be very useful in understanding code on occasion.)
- Enables and fixes `verify_partial_double` (second commit). This checks that the underlying object actually defines the doubled methods. This uncovered some cruft, though I had to use the escape hatch of `without_partial_double_verification` around ENV code that I couldn't make immediate sense of.
- Enables and fixes `disable_monkey_patching` (remaining commits). This [setting](https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/) removes RSpec methods from the top-level scope.