### PR TITLE
Dockerfile: drop libz-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update \
   git \
   gpg \
   less \
-  libz-dev \
   locales \
   make \
   netbase \


### PR DESCRIPTION
This causes formulae to build against with system zlib which we don't want.

The original need for it is also no longer valid: https://github.com/Homebrew/brew/commit/5e42f6778357f9509f2335c7fe34c5fd5bf5c43a