### PR TITLE
rubocop: Formulae with the "lxml" resource have required dependencies

### DIFF
--- a/Library/Homebrew/rubocops/resource_requires_dependencies.rb
+++ b/Library/Homebrew/rubocops/resource_requires_dependencies.rb
@@ -1,0 +1,32 @@
+# typed: true
+# frozen_string_literal: true
+
+require "rubocops/extend/formula_cop"
+
+module RuboCop
+  module Cop
+    module FormulaAudit
+      # This cop audits Python formulae that include the "lxml" resource
+      # to ensure that they also have the correct `uses_from_macos`
+      # dependencies.
+      #
+      # @api private
+      class ResourceRequiresDependencies < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          return if body_node.nil?
+
+          resource_nodes = find_every_method_call_by_name(body_node, :resource)
+          lxml = resource_nodes.find { |node| node.arguments.first.str_content == "lxml" }
+          return unless lxml
+
+          uses_from_macos_nodes = find_every_method_call_by_name(body_node, :uses_from_macos)
+          dependencies = uses_from_macos_nodes.map { |node| node.arguments.first.str_content }
+          return if dependencies.include?("libxml2") && dependencies.include?("libxslt")
+
+          offending_node(lxml)
+          problem "Add `uses_from_macos` lines above for \"libxml2\"` and \"libxslt\"."
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/rubocops/resource_requires_dependencies.rb
+++ b/Library/Homebrew/rubocops/resource_requires_dependencies.rb
@@ -24,7 +24,7 @@ module RuboCop
           return if dependencies.include?("libxml2") && dependencies.include?("libxslt")
 
           offending_node(lxml)
-          problem "Add `uses_from_macos` lines above for \"libxml2\"` and \"libxslt\"."
+          problem "Add `uses_from_macos` lines above for `\"libxml2\"` and `\"libxslt\"`."
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
+++ b/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
@@ -2,7 +2,7 @@
 
 require "rubocops/resource_requires_dependencies"
 
-describe RuboCop::Cop::FormulaAudit::ResourceRequiresDependencies do
+RSpec.describe RuboCop::Cop::FormulaAudit::ResourceRequiresDependencies do
   subject(:cop) { described_class.new }
 
   context "when a formula does not have the lxml resource" do
@@ -51,7 +51,7 @@ describe RuboCop::Cop::FormulaAudit::ResourceRequiresDependencies do
           uses_from_macos "not_libxml2"
 
           resource "lxml" do
-          ^^^^^^^^^^^^^^^ FormulaAudit/ResourceRequiresDependencies: Add `uses_from_macos` lines above for "libxml2"` and "libxslt".
+          ^^^^^^^^^^^^^^^ FormulaAudit/ResourceRequiresDependencies: Add `uses_from_macos` lines above for `"libxml2"` and `"libxslt"`.
             url "blah"
             sha256 "blah"
           end

--- a/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
+++ b/Library/Homebrew/test/rubocops/resource_requires_dependencies_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rubocops/resource_requires_dependencies"
+
+describe RuboCop::Cop::FormulaAudit::ResourceRequiresDependencies do
+  subject(:cop) { described_class.new }
+
+  context "when a formula does not have the lxml resource" do
+    it "does not report offenses" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          uses_from_macos "libxml2"
+
+          resource "not-lxml" do
+            url "blah"
+            sha256 "blah"
+          end
+        end
+      RUBY
+    end
+  end
+
+  context "when a formula has the lxml resource" do
+    it "does not report offenses if the dependencies are present" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          uses_from_macos "libxml2"
+          uses_from_macos "libxslt"
+
+          resource "lxml" do
+            url "blah"
+            sha256 "blah"
+          end
+        end
+      RUBY
+    end
+
+    it "reports offenses if missing a dependency" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+
+          uses_from_macos "libsomethingelse"
+          uses_from_macos "not_libxml2"
+
+          resource "lxml" do
+          ^^^^^^^^^^^^^^^ FormulaAudit/ResourceRequiresDependencies: Add `uses_from_macos` lines above for "libxml2"` and "libxslt".
+            url "blah"
+            sha256 "blah"
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- We're moving from `depends_on "python-lxml"` to `resource "lxml" ...` as part of the new Python vendoring plan.
- For `resource "lxml"` to work, `uses_from_macos "libxml2"` and `uses_from_macos "libxslt"` are needed in the formulae.
- This new RuboCop rule enforces that a formula including the "lxml" resource also include those dependencies.

-----

TODO:

- [ ] An autocorrect, probably useful when we start switching these over (right now everything still uses `depends_on "python-lxml"`). Separate PR?