### PR TITLE
Make `Tap::each` respect the API and clear all tap caches before each test.

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -55,8 +55,10 @@ module Homebrew
     args = tap_args.parse
 
     if args.repair?
-      Tap.each(&:link_completions_and_manpages)
-      Tap.each(&:fix_remote_configuration)
+      Tap.select(&:installed?).each do |tap|
+        tap.link_completions_and_manpages
+        tap.fix_remote_configuration
+      end
     elsif args.no_named?
       puts Tap.names
     else

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -146,7 +146,7 @@ module Homebrew
     hub = ReporterHub.new
 
     updated_taps = []
-    Tap.each do |tap|
+    Tap.select(&:installed?).each do |tap|
       next if !tap.git? || tap.git_repo.origin_url.nil?
       next if (tap.core_tap? || tap.core_cask_tap?) && !Homebrew::EnvConfig.no_install_from_api?
 
@@ -254,7 +254,7 @@ module Homebrew
 
     Commands.rebuild_commands_completion_list
     link_completions_manpages_and_docs
-    Tap.each(&:link_completions_and_manpages)
+    Tap.select(&:installed?).each(&:link_completions_and_manpages)
 
     failed_fetch_dirs = ENV["HOMEBREW_MISSING_REMOTE_REF_DIRS"]&.split("\n")
     if failed_fetch_dirs.present?

--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -72,7 +72,7 @@ module Homebrew
     sig { void }
     def self.link!
       Settings.write :linkcompletions, true
-      Tap.each do |tap|
+      Tap.select(&:installed?).each do |tap|
         Utils::Link.link_completions tap.path, "brew completions link"
       end
     end
@@ -80,7 +80,7 @@ module Homebrew
     sig { void }
     def self.unlink!
       Settings.write :linkcompletions, false
-      Tap.each do |tap|
+      Tap.select(&:installed?).each do |tap|
         next if tap.official?
 
         Utils::Link.unlink_completions tap.path
@@ -94,7 +94,7 @@ module Homebrew
 
     sig { returns(T::Boolean) }
     def self.completions_to_link?
-      Tap.each do |tap|
+      Tap.select(&:installed?).each do |tap|
         next if tap.official?
 
         SHELLS.each do |shell|

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -189,7 +189,7 @@ module Homebrew
 
     # Run tap audits first
     named_arg_taps = [*audit_formulae, *audit_casks].map(&:tap).uniq if !args.tap && !no_named_args
-    tap_problems = Tap.each_with_object({}) do |tap, problems|
+    tap_problems = Tap.select(&:installed?).each_with_object({}) do |tap, problems|
       next if args.tap && tap != args.tap
       next if named_arg_taps&.exclude?(tap)
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -545,7 +545,7 @@ module Homebrew
         return if ENV["CI"]
         return unless Utils::Git.available?
 
-        commands = Tap.map do |tap|
+        commands = Tap.select(&:installed?).map do |tap|
           next if tap.git_repo.default_origin_branch?
 
           "git -C $(brew --repo #{tap.name}) checkout #{tap.git_repo.origin_branch_name}"
@@ -795,7 +795,7 @@ module Homebrew
 
       def check_for_tap_ruby_files_locations
         bad_tap_files = {}
-        Tap.each do |tap|
+        Tap.select(&:installed?).each do |tap|
           unused_formula_dirs = tap.potential_formula_dirs - [tap.formula_dir]
           unused_formula_dirs.each do |dir|
             next unless dir.exist?

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1025,7 +1025,7 @@ module Formulary
 
   def self.tap_paths(name)
     name = name.to_s.downcase
-    Tap.map do |tap|
+    Tap.select(&:installed?).map do |tap|
       formula_path = find_formula_in_tap(name, tap)
 
       alias_path = tap.alias_dir/name

--- a/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_tap_loader_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Cask::CaskLoader::FromTapLoader do
+  let(:tap) { CoreCaskTap.instance }
   let(:cask_name) { "testball" }
   let(:cask_full_name) { "homebrew/cask/#{cask_name}" }
-  let(:cask_path) { CoreCaskTap.instance.cask_dir/"#{cask_name}.rb" }
+  let(:cask_path) { tap.cask_dir/"#{cask_name}.rb" }
 
   describe "#load" do
     before do
-      CoreCaskTap.instance.clear_cache
       cask_path.parent.mkpath
       cask_path.write <<~RUBY
         cask '#{cask_name}' do
@@ -25,7 +25,7 @@ RSpec.describe Cask::CaskLoader::FromTapLoader do
     end
 
     context "with sharded Cask directory" do
-      let(:cask_path) { CoreCaskTap.instance.cask_dir/cask_name[0]/"#{cask_name}.rb" }
+      let(:cask_path) { tap.cask_dir/cask_name[0]/"#{cask_name}.rb" }
 
       it "returns a Cask" do
         expect(described_class.new(cask_full_name).load(config: nil)).to be_a(Cask::Cask)

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -84,8 +84,6 @@ RSpec.describe Cask::CaskLoader, :cask do
 
         before do
           (old_tap.path/"tap_migrations.json").write tap_migrations.to_json
-          old_tap.clear_cache
-          default_tap.clear_cache
         end
 
         it "does not warn when loading the short token" do
@@ -112,7 +110,6 @@ RSpec.describe Cask::CaskLoader, :cask do
         #     (default_tap.path/"tap_migrations.json").write({
         #       token => old_tap.name,
         #     }.to_json)
-        #     default_tap.clear_cache
         #   end
         #
         #   it "stops recursing" do

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -547,8 +547,6 @@ RSpec.describe Formulary do
         before do
           old_tap.path.mkpath
           (old_tap.path/"tap_migrations.json").write tap_migrations.to_json
-          old_tap.clear_cache
-          default_tap.clear_cache
         end
 
         it "does not warn when loading the short token" do
@@ -575,7 +573,6 @@ RSpec.describe Formulary do
         #     (default_tap.path/"tap_migrations.json").write({
         #       token => old_tap.name,
         #     }.to_json)
-        #     default_tap.clear_cache
         #   end
         #
         #   it "stops recursing" do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -203,6 +203,7 @@ RSpec.configure do |config|
     Homebrew.raise_deprecation_exceptions = true
 
     Formulary.clear_cache
+    Tap.each(&:clear_cache)
     Tap.clear_cache
     DependencyCollector.clear_cache
     Formula.clear_cache
@@ -249,6 +250,9 @@ RSpec.configure do |config|
     rescue SystemExit => e
       example.example.set_exception(e)
     ensure
+      # This depends on `HOMEBREW_NO_INSTALL_FROM_API`.
+      Tap.each(&:clear_cache)
+
       ENV.replace(@__env)
       Context.current = Context::ContextStruct.new
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Ensure that `Tap::each` includes `CoreTap` and `CoreCaskTap` when using the API. This ensures all caches can be cleared and `Tap::reverse_tap_migrations_renames` works correctly when these taps are not installed locally.

More general solution than https://github.com/Homebrew/brew/pull/16680, which added this before one specific test.
