### PR TITLE
Clean up `Tap#ensure_installed!` usage.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -304,9 +304,11 @@ module Homebrew
 
     if Homebrew::EnvConfig.no_install_from_api?
       return if Homebrew::EnvConfig.automatically_set_no_install_from_api?
-      return if CoreTap.instance.installed?
 
-      CoreTap.ensure_installed!
+      core_tap = CoreTap.instance
+      return if core_tap.installed?
+
+      core_tap.ensure_installed!
       revision = CoreTap.instance.git_head
       ENV["HOMEBREW_UPDATE_BEFORE_HOMEBREW_HOMEBREW_CORE"] = revision
       ENV["HOMEBREW_UPDATE_AFTER_HOMEBREW_HOMEBREW_CORE"] = revision

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -523,21 +523,21 @@ module Homebrew
       end
 
       def check_coretap_integrity
-        coretap = CoreTap.instance
-        unless coretap.installed?
+        core_tap = CoreTap.instance
+        unless core_tap.installed?
           return unless EnvConfig.no_install_from_api?
 
-          CoreTap.ensure_installed!
+          core_tap.ensure_installed!
         end
 
-        broken_tap(coretap) || examine_git_origin(coretap.git_repo, Homebrew::EnvConfig.core_git_remote)
+        broken_tap(core_tap) || examine_git_origin(core_tap.git_repo, Homebrew::EnvConfig.core_git_remote)
       end
 
       def check_casktap_integrity
-        default_cask_tap = CoreCaskTap.instance
-        return unless default_cask_tap.installed?
+        core_cask_tap = CoreCaskTap.instance
+        return unless core_cask_tap.installed?
 
-        broken_tap(default_cask_tap) || examine_git_origin(default_cask_tap.git_repo, default_cask_tap.remote)
+        broken_tap(core_cask_tap) || examine_git_origin(core_cask_tap.git_repo, core_cask_tap.remote)
       end
 
       sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -67,14 +67,14 @@ class Tap
 
   sig { returns(CoreCaskTap) }
   def self.default_cask_tap
-    odisabled "Tap.default_cask_tap", "CoreCaskTap.instance"
+    odisabled "`Tap.default_cask_tap`", "`CoreCaskTap.instance`"
 
     CoreCaskTap.instance
   end
 
   sig { params(force: T::Boolean).returns(T::Boolean) }
   def self.install_default_cask_tap_if_necessary(force: false)
-    odisabled "Tap.install_default_cask_tap_if_necessary", "CoreCaskTap.ensure_installed!"
+    odisabled "`Tap.install_default_cask_tap_if_necessary`", "`CoreCaskTap.instance.ensure_installed!`"
 
     false
   end
@@ -968,6 +968,8 @@ class AbstractCoreTap < Tap
 
   sig { void }
   def self.ensure_installed!
+    # odeprecated "`#{self}.ensure_installed!`", "`#{self}.instance.ensure_installed!`"
+
     instance.ensure_installed!
   end
 
@@ -1043,7 +1045,7 @@ class CoreTap < AbstractCoreTap
   sig { returns(Pathname) }
   def formula_dir
     @formula_dir ||= begin
-      self.class.ensure_installed!
+      ensure_installed!
       super
     end
   end
@@ -1065,7 +1067,7 @@ class CoreTap < AbstractCoreTap
   sig { returns(Pathname) }
   def alias_dir
     @alias_dir ||= begin
-      self.class.ensure_installed!
+      ensure_installed!
       super
     end
   end
@@ -1074,7 +1076,7 @@ class CoreTap < AbstractCoreTap
   sig { returns(T::Hash[String, String]) }
   def formula_renames
     @formula_renames ||= if Homebrew::EnvConfig.no_install_from_api?
-      self.class.ensure_installed!
+      ensure_installed!
       super
     else
       Homebrew::API::Formula.all_renames
@@ -1085,7 +1087,7 @@ class CoreTap < AbstractCoreTap
   sig { returns(Hash) }
   def tap_migrations
     @tap_migrations ||= if Homebrew::EnvConfig.no_install_from_api?
-      self.class.ensure_installed!
+      ensure_installed!
       super
     else
       migrations, = Homebrew::API.fetch_json_api_file "formula_tap_migrations.jws.json",
@@ -1098,7 +1100,7 @@ class CoreTap < AbstractCoreTap
   sig { returns(Hash) }
   def audit_exceptions
     @audit_exceptions ||= begin
-      self.class.ensure_installed!
+      ensure_installed!
       super
     end
   end
@@ -1107,7 +1109,7 @@ class CoreTap < AbstractCoreTap
   sig { returns(Hash) }
   def style_exceptions
     @style_exceptions ||= begin
-      self.class.ensure_installed!
+      ensure_installed!
       super
     end
   end
@@ -1116,7 +1118,7 @@ class CoreTap < AbstractCoreTap
   sig { returns(Hash) }
   def pypi_formula_mappings
     @pypi_formula_mappings ||= begin
-      self.class.ensure_installed!
+      ensure_installed!
       super
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Get rid of inconsistent `CoreTap.instance.ensure_installed!` vs. `CoreTap.ensure_installed!` usage.

There is still one usage of `CoreTap.ensure_installed!` [in `test-bot`](https://github.com/Homebrew/homebrew-test-bot/blob/8cd7bcb87b27075a731ac1e6a4c0b2ab61c9e7a3/lib/tests/formulae_detect.rb#L51).