### PR TITLE
Sort printed package list in `brew upgrade`

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -215,6 +215,7 @@ module Homebrew
           "#{f.full_specified_name} #{f.pkg_version}"
         end
       end
+      formulae_upgrades.sort!
       puts formulae_upgrades.join("\n")
     end
 


### PR DESCRIPTION
At the beginning of a `brew upgrade` run, brew prints the list of packages to be upgraded e.g. as

    ncdu 2.2.2 -> 2.3
    nmap 7.94 -> 7.94_1
    jq 1.6 -> 1.7.1
    sdl2 2.26.5 -> 2.30.0
    libusb 1.0.26 -> 1.0.27
    python@3.11 3.11.3 -> 3.11.7_1
    file-formula 5.44 -> 5.45

The order is apparently arbitrary (I think maybe FS readdir order?) which makes it difficult to easily eyeball the list to see if some specific package of interest is included. Instead, sort it.



- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [not yet!] Have you successfully run `brew tests` with your changes locally?

-----
