### PR TITLE
[brew audit] fix "Incorrect file permissions" message

### DIFF
--- a/Library/Homebrew/rubocops/files.rb
+++ b/Library/Homebrew/rubocops/files.rb
@@ -22,7 +22,7 @@ module RuboCop
           if actual_mode & 0444 != 0444
             problem format("Incorrect file permissions (%03<actual>o): chmod %<wanted>s %<path>s",
                            actual: actual_mode & 0777,
-                           wanted: "+r",
+                           wanted: "a+r",
                            path:   file_path)
           end
           # Check that the file is user-writeable.

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Files do
 
         expect_offense(<<~RUBY, file)
           class Foo < Formula
-          ^^^^^^^^^^^^^^^^^^^ FormulaAudit/Files: Incorrect file permissions (000): chmod +r #{filename}
+          ^^^^^^^^^^^^^^^^^^^ FormulaAudit/Files: Incorrect file permissions (000): chmod a+r #{filename}
             url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY


### PR DESCRIPTION
When the file isn't world-readable, `brew audit` prints a failure message including a suggestion to `chmod +r` the file. Unfortunately, this isn't quite right: with both macOS and coreutils, leaving out the "who" in a chmod only affects bits which would be set in the umask. So, if the umask doesn't allow world-readable (which might be why the file wasn't world-readable in the first place), the suggested chmod command does nothing.

Change to print `chmod a+r` instead; that does have the intended effect.

No other `chmod` suggestions in this file have the same problem.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [existing test updated] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
