### PR TITLE
test: prune test deps of dependencies

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -60,12 +60,11 @@ module Homebrew
       end
 
       # Don't test formulae missing test dependencies
-      missing_test_deps = f.recursive_dependencies do |_, dependency|
+      missing_test_deps = f.recursive_dependencies do |dependent, dependency|
         Dependency.prune if dependency.installed?
-        next if dependency.test?
+        next if dependency.test? && dependent == f
 
-        Dependency.prune if dependency.optional?
-        Dependency.prune if dependency.build?
+        Dependency.prune unless dependency.required?
       end.map(&:to_s)
       unless missing_test_deps.empty?
         ofail "#{f.full_name} is missing test dependencies: #{missing_test_deps.join(" ")}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Test dependencies of test dependencies are added to missing dependencies list, e.g. In following, `python@3.11` is not needed to test:
```console
❯ brew install zurl
==> Downloading https://ghcr.io/v2/homebrew/core/zurl/manifests/1.12.0
...

❯ brew test zurl
Error: zurl is missing test dependencies: python-setuptools python@3.11 libcython python-packaging
```

Need to make sure this isn't accidentally removing wanted dependencies as not familiar with recursive dependency logic.