### PR TITLE
Generalise internal cross-image handling

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -575,7 +575,14 @@ then
     HOMEBREW_FORCE_BREWED_CA_CERTIFICATES="1"
   fi
 
+  # TEMP: backwards compatiblity with existing 10.11-cross image
+  # Can (probably) be removed in March 2024.
   if [[ -n "${HOMEBREW_FAKE_EL_CAPITAN}" ]]
+  then
+    export HOMEBREW_FAKE_MACOS="10.11.6"
+  fi
+
+  if [[ "${HOMEBREW_FAKE_MACOS}" =~ ^10\.11(\.|$) ]]
   then
     # We only need this to work enough to update brew and build the set portable formulae, so relax the requirement.
     HOMEBREW_MINIMUM_GIT_VERSION="2.7.4"

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -138,7 +138,7 @@ module Homebrew
 
         # With fake El Capitan for Portable Ruby, we are intentionally not using Xcode 8.
         # This is because we are not using the CLT and Xcode 8 has the 10.12 SDK.
-        return if ENV["HOMEBREW_FAKE_EL_CAPITAN"]
+        return if ENV["HOMEBREW_FAKE_MACOS"]
 
         message = <<~EOS
           Your Xcode (#{MacOS::Xcode.version}) is outdated.

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -33,8 +33,8 @@ module OS
     sig { returns(MacOSVersion) }
     def self.full_version
       odeprecated "`MacOS.full_version` on Linux" if Homebrew::SimulateSystem.simulating_or_running_on_linux?
-      @full_version ||= if ENV["HOMEBREW_FAKE_EL_CAPITAN"] # for Portable Ruby building
-        MacOSVersion.new("10.11.6")
+      @full_version ||= if (fake_macos = ENV.fetch("HOMEBREW_FAKE_MACOS", nil)) # for Portable Ruby building
+        MacOSVersion.new(fake_macos)
       else
         MacOSVersion.new(VERSION)
       end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -73,7 +73,7 @@ module OS
         # With fake El Capitan for Portable Ruby, we want the full 10.11 SDK so that we can link
         # against the correct set of libraries in the SDK sysroot rather than the system's copies.
         # We therefore do not use the CLT under this setup, which installs to /usr/include.
-        return false if ENV["HOMEBREW_FAKE_EL_CAPITAN"]
+        return false if ENV["HOMEBREW_FAKE_MACOS"]
 
         without_clt?
       end


### PR DESCRIPTION
We are planning to add a macOS 11 arm64 cross-build to the mix so need to make the existing cross-build logic apply to multiple macOS versions. x86_64 will probably stay on 10.11 but this is TBC depending on subsequent testing and I may try various combinations here.

Once this change is in place, I plan to build new cross-build images for Portable Ruby which I'll then test against Portable Ruby CI.