### PR TITLE
Rename `Tap#repo_var` to `Tap#repo_var_suffix`.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -428,11 +428,11 @@ class Reporter
       @api_names_before_txt = api_names_before_txt
       @api_dir_prefix = api_dir_prefix
     else
-      initial_revision_var = "HOMEBREW_UPDATE_BEFORE#{tap.repo_var}"
+      initial_revision_var = "HOMEBREW_UPDATE_BEFORE#{tap.repo_var_suffix}"
       @initial_revision = ENV[initial_revision_var].to_s
       raise ReporterRevisionUnsetError, initial_revision_var if @initial_revision.empty?
 
-      current_revision_var = "HOMEBREW_UPDATE_AFTER#{tap.repo_var}"
+      current_revision_var = "HOMEBREW_UPDATE_AFTER#{tap.repo_var_suffix}"
       @current_revision = ENV[current_revision_var].to_s
       raise ReporterRevisionUnsetError, current_revision_var if @current_revision.empty?
     end

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -94,6 +94,7 @@ git_init_if_necessary() {
 
 repo_var_suffix() {
   local repo_dir="${1}"
+  local repo_var_suffix
 
   if [[ "${repo_dir}" == "${HOMEBREW_REPOSITORY}" ]]
   then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -92,18 +92,17 @@ git_init_if_necessary() {
   fi
 }
 
-repo_var() {
-  local repo_var
+repo_var_suffix() {
+  local repo_dir="${1}"
 
-  repo_var="$1"
-  if [[ "${repo_var}" == "${HOMEBREW_REPOSITORY}" ]]
+  if [[ "${repo_dir}" == "${HOMEBREW_REPOSITORY}" ]]
   then
-    repo_var=""
+    repo_var_suffix=""
   else
-    repo_var="${repo_var#"${HOMEBREW_LIBRARY}/Taps"}"
-    repo_var="$(echo -n "${repo_var}" | tr -C "A-Za-z0-9" "_" | tr "[:lower:]" "[:upper:]")"
+    repo_var_suffix="${repo_dir#"${HOMEBREW_LIBRARY}/Taps"}"
+    repo_var_suffix="$(echo -n "${repo_var_suffix}" | tr -C "A-Za-z0-9" "_" | tr "[:lower:]" "[:upper:]")"
   fi
-  echo "${repo_var}"
+  echo "${repo_var_suffix}"
 }
 
 upstream_branch() {
@@ -600,7 +599,7 @@ EOS
       echo "Checking if we need to fetch ${DIR}..."
     fi
 
-    TAP_VAR="$(repo_var "${DIR}")"
+    TAP_VAR="$(repo_var_suffix "${DIR}")"
     UPSTREAM_BRANCH_DIR="$(upstream_branch)"
     declare UPSTREAM_BRANCH"${TAP_VAR}"="${UPSTREAM_BRANCH_DIR}"
     declare PREFETCH_REVISION"${TAP_VAR}"="$(git rev-parse -q --verify refs/remotes/origin/"${UPSTREAM_BRANCH_DIR}")"
@@ -774,7 +773,7 @@ EOS
       continue
     fi
 
-    TAP_VAR="$(repo_var "${DIR}")"
+    TAP_VAR="$(repo_var_suffix "${DIR}")"
     UPSTREAM_BRANCH_VAR="UPSTREAM_BRANCH${TAP_VAR}"
     UPSTREAM_BRANCH="${!UPSTREAM_BRANCH_VAR}"
     CURRENT_REVISION="$(read_current_revision)"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -122,7 +122,7 @@ class Tap
   # Clear internal cache.
   def clear_cache
     @remote = nil
-    @repo_var = nil
+    @repo_var_suffix = nil
     @formula_dir = nil
     @cask_dir = nil
     @command_dir = nil
@@ -175,11 +175,13 @@ class Tap
     "https://github.com/#{full_name}"
   end
 
-  def repo_var
-    @repo_var ||= path.to_s
-                      .delete_prefix(TAP_DIRECTORY.to_s)
-                      .tr("^A-Za-z0-9", "_")
-                      .upcase
+  # @private
+  sig { returns(String) }
+  def repo_var_suffix
+    @repo_var_suffix ||= path.to_s
+                             .delete_prefix(TAP_DIRECTORY.to_s)
+                             .tr("^A-Za-z0-9", "_")
+                             .upcase
   end
 
   # True if this {Tap} is a Git repository.

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe "brew update-report" do
         def initialize(tap)
           @tap = tap
 
-          ENV["HOMEBREW_UPDATE_BEFORE#{tap.repo_var}"] = "12345678"
-          ENV["HOMEBREW_UPDATE_AFTER#{tap.repo_var}"] = "abcdef00"
+          ENV["HOMEBREW_UPDATE_BEFORE#{tap.repo_var_suffix}"] = "12345678"
+          ENV["HOMEBREW_UPDATE_AFTER#{tap.repo_var_suffix}"] = "abcdef00"
 
           super(tap)
         end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -588,4 +588,15 @@ RSpec.describe Tap do
       expect(core_tap.pypi_formula_mappings).to eq formula_list_file_contents
     end
   end
+
+  describe "#repo_var_suffix" do
+    it "converts the repo directory to an environment variable suffix" do
+      expect(CoreTap.instance.repo_var_suffix).to eq "_HOMEBREW_HOMEBREW_CORE"
+    end
+
+    it "converts non-alphanumeric characters to underscores" do
+      expect(described_class.fetch("my", "tap-with-dashes").repo_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH_DASHES"
+      expect(described_class.fetch("my", "tap-with-@-symbol").repo_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH___SYMBOL"
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As mentioned in https://github.com/Homebrew/brew/pull/16730#discussion_r1500769678, it think it makes sense to rename this given this is not used as a variable name directly.