### PR TITLE
dev-cmd/bump: add `--no-fork` switch

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -37,6 +37,8 @@ module Homebrew
              description: "Check only casks."
       switch "--installed",
              description: "Check formulae and casks that are currently installed."
+      switch "--no-fork",
+             description: "Don't try to fork the repository."
       switch "--open-pr",
              description: "Open a pull request for the new version if none have been opened yet."
       flag   "--limit=",
@@ -508,6 +510,8 @@ module Homebrew
       "--no-browse",
       "--message=Created by `brew bump`",
     ]
+
+    bump_cask_pr_args << "--no-fork" if args.no_fork?
 
     system HOMEBREW_BREW_FILE, *bump_cask_pr_args
   end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -443,6 +443,7 @@ _brew_bump() {
       --help
       --installed
       --limit
+      --no-fork
       --no-pull-requests
       --open-pr
       --quiet

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -383,6 +383,7 @@ __fish_brew_complete_arg 'bump' -l full-name -d 'Print formulae/casks with fully
 __fish_brew_complete_arg 'bump' -l help -d 'Show this message'
 __fish_brew_complete_arg 'bump' -l installed -d 'Check formulae and casks that are currently installed'
 __fish_brew_complete_arg 'bump' -l limit -d 'Limit number of package results returned'
+__fish_brew_complete_arg 'bump' -l no-fork -d 'Don\'t try to fork the repository'
 __fish_brew_complete_arg 'bump' -l no-pull-requests -d 'Do not retrieve pull requests from GitHub'
 __fish_brew_complete_arg 'bump' -l open-pr -d 'Open a pull request for the new version if none have been opened yet'
 __fish_brew_complete_arg 'bump' -l quiet -d 'Make some output more quiet'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -498,6 +498,7 @@ _brew_bump() {
     '--help[Show this message]' \
     '--installed[Check formulae and casks that are currently installed]' \
     '--limit[Limit number of package results returned]' \
+    '--no-fork[Don'\''t try to fork the repository]' \
     '(--open-pr)--no-pull-requests[Do not retrieve pull requests from GitHub]' \
     '(--no-pull-requests)--open-pr[Open a pull request for the new version if none have been opened yet]' \
     '--quiet[Make some output more quiet]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1031,6 +1031,8 @@ formulae, also displays whether a pull request has been opened with the URL.
   Check only casks.
 * `--installed`:
   Check formulae and casks that are currently installed.
+* `--no-fork`:
+  Don't try to fork the repository.
 * `--open-pr`:
   Open a pull request for the new version if none have been opened yet.
 * `--limit`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1461,6 +1461,10 @@ Check only casks\.
 Check formulae and casks that are currently installed\.
 .
 .TP
+\fB\-\-no\-fork\fR
+Don\'t try to fork the repository\.
+.
+.TP
 \fB\-\-open\-pr\fR
 Open a pull request for the new version if none have been opened yet\.
 .


### PR DESCRIPTION
Signed-off-by: Patrick Linnane <patrick@linnane.io>- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR brings the `--no-fork` switch in `bump-cask-pr` and `bump-formula-pr` to `brew bump`. Given that maintainers are now using branches within the main repo, this will make things easier in two ways:

1. Maintainers can make manual changes to formulae or casks, save them, and then run `brew bump --open-pr --no-fork foo` to handle the rest of the PR process with their local changes incorporated.
2. We can use this for BrewTestBot's autobump PR's. This will reduce the thousands of stale branches in the BrewTestBot forks (which I still plan to deal with).

Example PR opened using this branch: https://github.com/Homebrew/homebrew-core/pull/163948

As usual, thanks to @Bo98 for his guidance so I could put this together.