### PR TITLE
`strategy#page_content`: allow cURL to `--fail-with-body`

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -58,8 +58,8 @@ module Homebrew
       # `curl` arguments used in `Strategy#page_content` method.
       PAGE_CONTENT_CURL_ARGS = ([
         "--compressed",
-        # Allow the return of an error code on exit, so that we can retry
-        # with a fake UA string (e.g. for Cloudflare-protected sites)
+        # Return an error when the HTTP response code is 400 or greater but
+        # continue to return body content
         "--fail-with-body",
         # Include HTTP response headers in output, so we can identify the
         # final URL after any redirections

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -58,6 +58,9 @@ module Homebrew
       # `curl` arguments used in `Strategy#page_content` method.
       PAGE_CONTENT_CURL_ARGS = ([
         "--compressed",
+        # Allow the return of an error code on exit, so that we can retry
+        # with a fake UA string (e.g. for Cloudflare-protected sites)
+        "--fail-with-body",
         # Include HTTP response headers in output, so we can identify the
         # final URL after any redirections
         "--include",


### PR DESCRIPTION
### TL;DR
`livecheck` for sites behind DDoS protection is broken. We need an error code from cURL for #11517 to work; #15351 seems to have broken that. This explicitly adds `--fail-with-body` to the `PAGE_CONTENT_CURL_ARGS` so that `strategy#page_content` calls return an error code, but sidestep potentially misguiding HTTP codes from… confused servers (see [this part](https://arc.net/l/quote/alapgexm) of @samford’s comment on #15437).

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~ <sub>No. Should I? 😅 (I’d need help coming up with them)</sub>
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

### Huh?
- #11517 addressed the issue of `livecheck` failing for some sites that are protected by e.g. Cloudflare, by having us try the URL again with a fake Safari-like UA string. (`[:default, :browser].each do`)
- At the time, `strategy#page_content` and `strategy#page_headers` used the (relatively) raw `curl_with_workarounds` function, and not `curl_output` (introduced in #15351).
- `curl_output` by default doesn’t pass `--fail` unlike its incumbent `curl_with_workarounds`: I’m guessing this is since `--fail` omits printing any body received at all — I’m led to believe from [the struck-out portion](https://arc.net/l/quote/alapgexm) of @samford’s comments on #15437 that this is undesirable for some servers, which may provide useful content despite a 400+ HTTP status code. (While the struck-out portion was, in fact, inapplicable to `page_headers` — which the PR is all about, it seems like it might have an impact on `page_content`?)*  
`strategy#page_headers` doesn’t face this issue at all, since `curl_headers` doesn’t set `show_output`, and in turn, the `—-fail` flag is passed to cURL.
- Not passing any variant of `--fail[...]` means that 400+ error codes don’t trigger non-zero exit codes. From `curl(1)`,
> 22: HTTP page not retrieved. The requested URL was not found or returned another error with the HTTP error code being 400 or above. This return code only appears if -f, --fail is used.

- `--fail-with-body` allows cURL to exit with an error code, while still printing whatever body it received; the servers that don’t play nice that @samford spoke of should still be fetched from, while `livecheck` **will at least try again on error, which it doesn’t do right now.**

### 🧪?
I’ve tested this with `vitalsource-bookshelf` (which brought me to it in the first place). On forcing `verbose: true` in the `curl_output` call, I noticed that only a single cURL call was made, despite a 403: `status.success?` was returning `true` when it shouldn’t! Unfortunately, I couldn’t test this elsewhere, as none of the original examples in #11517 hold good anymore; e.g., `camo-studio`’s URL seems perfectly happy responding to cURL with Homebrew’s `:default` UA (e.g. `Homebrew/4.2.9-92-gd0a3f09-dirty...`), `keycue` doesn’t seem to mind receiving no UA at all, and the other two casks were removed.  
I also ran `grep -r ':fake' <cask-tap>` and tried a few random samples, but everything I tried fell under the above two categories. **TL;DR** I’m unsure how to properly test this out 🥲

*If that isn’t the case, we could probably consider simply adding `--fail`

<sub>I feel silly, like I’m literally making a huge deal of a single line of code, so if you’ve reached here, thanks for bearing with my rant xD. I want to help, not be a burden, so I did as much digging as I could to compensate for me being new and my lack of Ruby skill. I hope this is, indeed, helpful like I intended it to be</sub>