### PR TITLE
deprecate_disable: add cask deprecate/disable reasons

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -23,9 +23,9 @@ module DeprecateDisable
   }.freeze
 
   CASK_DEPRECATE_DISABLE_REASONS = {
-    discontinued: "is discontinued upstream",
+    discontinued:        "is discontinued upstream",
     no_longer_available: "is no longer available upstream",
-    unmaintained: "is not maintained upstream",
+    unmaintained:        "is not maintained upstream",
   }.freeze
 
   def type(formula_or_cask)

--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -24,6 +24,8 @@ module DeprecateDisable
 
   CASK_DEPRECATE_DISABLE_REASONS = {
     discontinued: "is discontinued upstream",
+    no_longer_available: "is no longer available upstream",
+    unmaintained: "is not maintained upstream",
   }.freeze
 
   def type(formula_or_cask)

--- a/docs/Deprecating-Disabling-and-Removing-Casks.md
+++ b/docs/Deprecating-Disabling-and-Removing-Casks.md
@@ -75,6 +75,8 @@ When a cask is deprecated or disabled, a reason explaining the action must be pr
 There are two ways to indicate the reason. The preferred way is to use a pre-existing symbol to indicate the reason. The available symbols are listed below and can be found in the [`DeprecateDisable` module](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/deprecate_disable.rb):
 
 - `:discontinued`: the cask is discontinued upstream
+- `:no_longer_available`: the cask is no longer available upstream
+- `:unmaintained`: the cask is not maintained upstream
 
 These reasons can be specified by their symbols (the comments show the message that will be displayed to users):
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds some additional reasons for deprecate/disable in casks.

I would expect that `discontinued` would be used when a software is officially discontinued upstream, `unmaintained` used when a software has not received updates for a long time and may not work as expected on modern hardware, and `no_longer_available` when the software can longer be sourced from upstream.

It could be worth considering a `no_longer_works` style option, however this likely overlaps with `unmaintained`.