### PR TITLE
Use `HOMEBREW_TEMP` more universally

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -514,7 +514,7 @@ module Cask
 
       return if artifacts.empty?
 
-      @tmpdir ||= Pathname(Dir.mktmpdir)
+      @tmpdir ||= Pathname(Dir.mktmpdir("cask-audit", HOMEBREW_TEMP))
 
       ohai "Downloading and extracting artifacts"
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -207,7 +207,7 @@ on_request: true)
       basename = downloader.basename
 
       if (nested_container = @cask.container&.nested)
-        Dir.mktmpdir do |tmpdir|
+        Dir.mktmpdir("cask-installer", HOMEBREW_TEMP) do |tmpdir|
           tmpdir = Pathname(tmpdir)
           primary_container.extract(to: tmpdir, basename: basename, verbose: verbose?)
 

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -446,7 +446,7 @@ module Homebrew
       pr_check_conflicts("#{user}/#{repo}", pr)
 
       ohai "Fetching #{tap} pull request ##{pr}"
-      dir = Dir.mktmpdir pr
+      dir = Dir.mktmpdir("pr-pull-#{pr}-", HOMEBREW_TEMP)
       begin
         cd dir do
           current_branch_head = ENV["GITHUB_SHA"] || tap.git_head

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -40,7 +40,7 @@ module UnpackStrategy
 
           return if volumes.empty?
 
-          Dir.mktmpdir do |tmp_unpack_dir|
+          Dir.mktmpdir("homebrew-zip", HOMEBREW_TEMP) do |tmp_unpack_dir|
             tmp_unpack_dir = Pathname(tmp_unpack_dir)
 
             # `ditto` keeps Finder attributes intact and does not skip volume labels

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -125,7 +125,7 @@ module UnpackStrategy
     ).returns(T.untyped)
   }
   def extract_nestedly(to: nil, basename: nil, verbose: false, prioritize_extension: false)
-    Dir.mktmpdir do |tmp_unpack_dir|
+    Dir.mktmpdir("homebrew-unpack", HOMEBREW_TEMP) do |tmp_unpack_dir|
       tmp_unpack_dir = Pathname(tmp_unpack_dir)
 
       extract(to: tmp_unpack_dir, basename: basename, verbose: verbose)

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -181,7 +181,7 @@ module UnpackStrategy
     end
 
     def mount(verbose: false)
-      Dir.mktmpdir do |mount_dir|
+      Dir.mktmpdir("homebrew-dmg", HOMEBREW_TEMP) do |mount_dir|
         mount_dir = Pathname(mount_dir)
 
         without_eula = system_command(

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -35,7 +35,7 @@ module UnpackStrategy
 
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      Dir.mktmpdir do |tmpdir|
+      Dir.mktmpdir("homebrew-tar", HOMEBREW_TEMP) do |tmpdir|
         tar_path = if DependencyCollector.tar_needs_xz_dependency? && Xz.can_extract?(path)
           subextract(Xz, Pathname(tmpdir), verbose)
         elsif Zstd.can_extract?(path)

--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -114,7 +114,7 @@ module Homebrew
         versions[id] = version if id && version
       end
 
-      Dir.mktmpdir do |dir|
+      Dir.mktmpdir("cask-checker", HOMEBREW_TEMP) do |dir|
         dir = Pathname(dir)
 
         installer.extract_primary_container(to: dir)
@@ -150,7 +150,7 @@ module Homebrew
         pkg_paths = Pathname.glob(dir/"**"/"*.pkg").sort if pkg_paths.empty?
 
         pkg_paths.each do |pkg_path|
-          Dir.mktmpdir do |extract_dir|
+          Dir.mktmpdir("cask-checker", HOMEBREW_TEMP) do |extract_dir|
             extract_dir = Pathname(extract_dir)
             FileUtils.rmdir extract_dir
 
@@ -178,7 +178,7 @@ module Homebrew
         return
       end
 
-      Dir.mktmpdir do |dir|
+      Dir.mktmpdir("cask-checker", HOMEBREW_TEMP) do |dir|
         dir = Pathname(dir)
 
         installer.then do |i|
@@ -208,7 +208,7 @@ module Homebrew
             .plist
             .map { |package| package.fetch("Package") }
 
-          Dir.mktmpdir do |extract_dir|
+          Dir.mktmpdir("cask-checker", HOMEBREW_TEMP) do |extract_dir|
             extract_dir = Pathname(extract_dir)
             FileUtils.rmdir extract_dir
 


### PR DESCRIPTION
We might be able to point bottle uploads to use `HOMEBREW_TEMP` on an alternative drive with more space...

Homebrew/homebrew-core#164263