### PR TITLE
utils/pypi: allow only updating `extra_packages`

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -274,7 +274,7 @@ module PyPI
     # remove packages from the exclude list if we've explicitly requested them as an extra package
     exclude_packages.delete_if { |package| extra_packages.include?(package) }
 
-    input_packages = main_package.nil? ? [] : [main_package]
+    input_packages = Array(main_package)
     extra_packages.each do |extra_package|
       if !extra_package.valid_pypi_package? && !ignore_non_pypi_packages
         odie "\"#{extra_package}\" is not available on PyPI."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Goal of PR is to allow easier updating of Python resources for formulae that aren't Python packages. In future, may allow `brew bump` to automatically run this (currently not done for non-PyPI URLs).

To give an example, the resources within the `python` formula
- Current state:
    ```console
    ❯ brew update-python-resources python@3.12
    Error: Unable to determine metadata for "https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz" because of a failure when running
    `/opt/homebrew/opt/python@3.12/libexec/bin/python -m pip install -q --no-deps --dry-run --ignore-installed --report /dev/stdout https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz`.
    Please report this issue:
      https://docs.brew.sh/Troubleshooting
    ```

- With PR, need to add diff to get subsequent output:
    ```diff
    diff --git a/pypi_formula_mappings.json b/pypi_formula_mappings.json
    index 9718573087a..619c6da0d48 100644
    --- a/pypi_formula_mappings.json
    +++ b/pypi_formula_mappings.json
    @@ -588,6 +588,7 @@
         "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
       },
       "python@3.12": {
    +    "package_name": "",
         "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
       },
       "python-build": {
    ```
    ```console
    ❯ brew update-python-resources python@3.12
    ==> Retrieving PyPI dependencies for "flit-core setuptools pip wheel"...
    ==> Retrieving PyPI dependencies for excluded ""...
    ==> Getting PyPI info for "flit-core==3.9.0"
    ==> Getting PyPI info for "pip==24.0"
    ==> Getting PyPI info for "setuptools==69.1.1"
    ==> Getting PyPI info for "wheel==0.42.0"
    ==> Updating resource blocks
    ```