### PR TITLE
formula_audit: Check the license(s) of the specific release

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -255,7 +255,8 @@ module Homebrew
         user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*})
         return if user.blank?
 
-        github_license = GitHub.get_repo_license(user, repo)
+        tag = SharedAudits.github_tag_from_url(formula.stable.url)
+        github_license = GitHub.get_repo_license(user, repo, ref: tag)
         return unless github_license
         return if (licenses + ["NOASSERTION"]).include?(github_license)
         return if PERMITTED_LICENSE_MISMATCHES[github_license]&.any? { |license| licenses.include? license }

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -497,8 +497,10 @@ module GitHub
     end
   end
 
-  def self.get_repo_license(user, repo)
-    response = API.open_rest("#{API_URL}/repos/#{user}/#{repo}/license")
+  def self.get_repo_license(user, repo, ref: nil)
+    url = "#{API_URL}/repos/#{user}/#{repo}/license"
+    url += "?ref=#{ref}" if ref.present?
+    response = API.open_rest(url)
     return unless response.key?("license")
 
     response["license"]["spdx_id"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes https://github.com/Homebrew/brew/issues/16711.
- Some repositories occasionally change their licenses. For example they release a version of the software with one license and then decide to change the license later.
- Now that `?ref=` is a parameter to the GitHub Repositories License API (the docs updates will process soon - I shipped the actual feature though), we can use that in the license audit to check if the license of the specific release matches the one declared in the formula.

Having removed the formula from the audit exceptions file, here's the previous behaviour:

```
❯ brew audit --online --git --skip-style manticoresearch
manticoresearch
  * Formula license ["GPL-2.0-only"] does not match GitHub license ["GPL-3.0"].
Error: 1 problem in 1 formula detected.
```

And now:

```
❯ brew audit --online --git --skip-style manticoresearch
```
