### PR TITLE
test: clear tap instance caches between test runs again

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -204,6 +204,7 @@ RSpec.configure do |config|
   config.around do |example|
     Homebrew.raise_deprecation_exceptions = true
 
+    Tap.each(&:clear_cache)
     Cachable::Registry.clear_all_caches
     FormulaInstaller.clear_attempted
     FormulaInstaller.clear_installed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/Homebrew/brew/pull/16746#discussion_r1503903349

The core taps exist outside of the normal cache busting cycle so they need to clear explicitly at the instance level. In theory all the other tap instances should get cleared by the class level purge of the `Tap#fetch` cache. Just to be sure we should clear all of them each time.

This essentially reverts a small regression in this PR.
- https://github.com/Homebrew/brew/pull/16746

CC: @reitermarkus 