### PR TITLE
dev-cmd/bump: hide version syncing when empty list

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -472,10 +472,13 @@ module Homebrew
     if formula_or_cask.is_a?(Formula)
       require "formula_auditor"
       auditor = FormulaAuditor.new(formula_or_cask)
-      puts <<~EOS if auditor.synced_with_other_formulae?
-        Version syncing:          #{title_name} version should be kept in sync with
-                                  #{synced_with(auditor, formula_or_cask, new_version.general).join(", ")}.
-      EOS
+      if auditor.synced_with_other_formulae?
+        outdated_synced_formulae = synced_with(auditor, formula_or_cask, new_version.general)
+        puts <<~EOS if outdated_synced_formulae.present?
+          Version syncing:          #{title_name} version should be kept in sync with
+                                    #{outdated_synced_formulae.join(", ")}.
+        EOS
+      end
     end
     puts <<~EOS unless args.no_pull_requests?
       Open pull requests:       #{open_pull_requests || "none"}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Mainly to clean up output when up-to-date. Current output with up-to-date and outdated formulae:
```console
❯ brew bump boost petsc
==> boost is up to date!
Current formula version:  1.84.0
Latest livecheck version: 1.84.0
Latest Repology version:  1.84.0
Version syncing:          boost version should be kept in sync with
                          .
Open pull requests:       none
Closed pull requests:     none

==> petsc
Current formula version:  3.20.4
Latest livecheck version: 3.20.5
Latest Repology version:  3.20.5
Version syncing:          petsc version should be kept in sync with
                          petsc, petsc-complex.
Open pull requests:       none
Closed pull requests:     none
``` 

Afterward:
```console
❯ brew bump boost petsc
==> boost is up to date!
Current formula version:  1.84.0
Latest livecheck version: 1.84.0
Latest Repology version:  1.84.0
Open pull requests:       none
Closed pull requests:     none

==> petsc
Current formula version:  3.20.4
Latest livecheck version: 3.20.5
Latest Repology version:  3.20.5
Version syncing:          petsc version should be kept in sync with
                          petsc, petsc-complex.
Open pull requests:       none
Closed pull requests:     none
```