### PR TITLE
internal json v3: parse ruby source checksum correctly

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -240,6 +240,7 @@ module Homebrew
 
     # TODO: remove this and fix tests when possible.
     ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+    ENV.delete("HOMEBREW_INTERNAL_JSON_V3")
 
     ENV["USER"] ||= system_command!("id", args: ["-nu"]).stdout.chomp
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -411,10 +411,11 @@ module Formulary
         self.class.instance_variable_get(:@ruby_source_path_string)
       end
 
-      @ruby_source_checksum_hash = json_formula["ruby_source_checksum"]
+      @ruby_source_checksum_string = json_formula.dig("ruby_source_checksum", "sha256")
+      @ruby_source_checksum_string ||= json_formula["ruby_source_sha256"]
       def ruby_source_checksum
-        checksum_hash = self.class.instance_variable_get(:@ruby_source_checksum_hash)
-        Checksum.new(checksum_hash["sha256"]) if checksum_hash&.key?("sha256")
+        checksum = self.class.instance_variable_get(:@ruby_source_checksum_string)
+        Checksum.new(checksum) if checksum
       end
     end
 

--- a/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
+++ b/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
@@ -85,16 +85,19 @@ RSpec.describe "Internal Tap JSON -- Formula" do
     context "when loading formulae" do
       let(:fennel_metadata) do
         {
-          "dependencies"     => ["lua"],
-          "desc"             => "Lua Lisp Language",
-          "full_name"        => "fennel",
-          "homepage"         => "https://fennel-lang.org",
-          "license"          => "MIT",
-          "name"             => "fennel",
-          "ruby_source_path" => "Formula/f/fennel.rb",
-          "tap"              => "homebrew/core",
-          "tap_git_head"     => tap_git_head,
-          "versions"         => { "bottle"=>true, "head"=>nil, "stable"=>"1.4.0" },
+          "dependencies"         => ["lua"],
+          "desc"                 => "Lua Lisp Language",
+          "full_name"            => "fennel",
+          "homepage"             => "https://fennel-lang.org",
+          "license"              => "MIT",
+          "name"                 => "fennel",
+          "ruby_source_path"     => "Formula/f/fennel.rb",
+          "tap"                  => "homebrew/core",
+          "tap_git_head"         => tap_git_head,
+          "versions"             => { "bottle"=>true, "head"=>nil, "stable"=>"1.4.0" },
+          "ruby_source_checksum" => {
+            "sha256" => "5856e655fd1cea11496d67bc27fb14fee5cfbdea63c697c3773c7f247581197d",
+          },
         }
       end
 
@@ -112,6 +115,9 @@ RSpec.describe "Internal Tap JSON -- Formula" do
           "uses_from_macos"        => [{ "llvm"=>[:build, :test] }, "zlib"],
           "uses_from_macos_bounds" => [{}, {}],
           "versions"               => { "bottle"=>true, "head"=>nil, "stable"=>"0.58.1" },
+          "ruby_source_checksum"   => {
+            "sha256" => "81d51c25d18710191beb62f9f380bae3d878aad815a65ec1ee2a3b132c1fadb3",
+          },
         }
       end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -331,6 +331,7 @@ RSpec.describe Formulary do
               "working_dir" => "/$HOME",
             },
             "ruby_source_path"         => "Formula/#{formula_name}.rb",
+            "ruby_source_checksum"     => { "sha256" => "ABCDEFGHIJKLMNOPQRSTUVWXYZ" },
           }.merge(extra_items),
         }
       end
@@ -418,6 +419,8 @@ RSpec.describe Formulary do
         expect(formula.service.working_dir).to eq(Dir.home)
         expect(formula.plist_name).to eq("custom.launchd.name")
         expect(formula.service_name).to eq("custom.systemd.name")
+
+        expect(formula.ruby_source_checksum.hexdigest).to eq("abcdefghijklmnopqrstuvwxyz")
 
         expect do
           formula.install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently we are including this in the API but not actually parsing and loading it correctly from the JSON. I think this was an oversight when addressing feedback and refactoring the JSON shape. Not a big deal, of course, because I'm the only person using it right now.

I found this out while testing installs using the API and I got this error while running `brew reinstall tree`.

```
Warning: Cannot verify integrity of '60fc4212023d3fef00e6de4b9f3f0d63402cf3eca00778d09f4f2d3481b524a1--tree.rb'.
No checksum was provided.
```

I also am excluding the `HOMEBREW_INTERNAL_JSON_V3` environment variable from tests because it was causing some API loading tests to fail.