### PR TITLE
utils/pypi: default to formula version when using package_name

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -239,7 +239,9 @@ module PyPI
     end
 
     main_package = if package_name.present?
-      Package.new(package_name, python_name: python_name)
+      package_string = package_name
+      package_string += "==#{formula.version}" if version.blank? && formula.version.present?
+      Package.new(package_string, python_name: python_name)
     elsif package_name == ""
       nil
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When using `package_name`, we currently end up dropping the version information. For example,
```console
❯ brew update-python-resources black
==> Retrieving PyPI dependencies for "black[d]"...
==> Retrieving PyPI dependencies for excluded ""...
...
```
vs. removing `package_name`:
```console
❯ brew update-python-resources black
==> Retrieving PyPI dependencies for "black==24.2.0"...
==> Retrieving PyPI dependencies for excluded ""...
```

This can potentially lead to incorrect resolution if the formula version is not the latest version.

---

With change, the default version is obtained from the formula:
```console
❯ brew update-python-resources black
==> Retrieving PyPI dependencies for "black[d]==24.2.0"...
==> Retrieving PyPI dependencies for excluded ""...
```

---

One potential issue is if the formula version scheme is different from PyPI formula scheme.

If we hit this and there is no other solution, then I think we could add a way of bypassing this inside `pypi_formula_mappings.json` (e.g. an extra field like `unversioned: true` or `without_version: true` or some other name)