### PR TITLE
Fix loading casks/formulae from relative paths.

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -142,8 +142,8 @@ on_request: true)
       return unless @cask.conflicts_with
 
       @cask.conflicts_with[:cask].each do |conflicting_cask|
-        if (match = conflicting_cask.match(HOMEBREW_TAP_CASK_REGEX))
-          conflicting_cask_tap = Tap.fetch(match[1], match[2])
+        if (conflicting_cask_tap_with_token = Tap.with_cask_token(conflicting_cask))
+          conflicting_cask_tap, = conflicting_cask_tap_with_token
           next unless conflicting_cask_tap.installed?
         end
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -175,11 +175,13 @@ module Homebrew
     end
 
     args.named.each do |name|
-      next if File.exist?(name)
-      next unless name =~ HOMEBREW_TAP_FORMULA_REGEX
+      if (tap_with_name = Tap.with_formula_name(name))
+        tap, = tap_with_name
+      elsif (tap_with_token = Tap.with_cask_token(name))
+        tap, = tap_with_token
+      end
 
-      tap = Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))
-      tap.ensure_installed!
+      tap&.ensure_installed!
     end
 
     if args.ignore_dependencies?

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -19,7 +19,9 @@ class Dependency
     @name = name
     @tags = tags
 
-    @tap = Tap.fetch(Regexp.last_match(1), Regexp.last_match(2)) if name =~ HOMEBREW_TAP_FORMULA_REGEX
+    return unless (tap_with_name = Tap.with_formula_name(name))
+
+    @tap, = tap_with_name
   end
 
   def to_s

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -34,9 +34,8 @@ module Homebrew
   def self.extract
     args = extract_args.parse
 
-    if (match = args.named.first.match(HOMEBREW_TAP_FORMULA_REGEX))
-      name = match[3].downcase
-      source_tap = Tap.fetch(match[1], match[2])
+    if (tap_with_name = args.named.first&.then { Tap.with_formula_name(_1) })
+      source_tap, name = tap_with_name
     else
       name = args.named.first.downcase
       source_tap = CoreTap.instance

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -65,6 +65,38 @@ class Tap
     fetch(match[:user], match[:repo])
   end
 
+  # @private
+  sig { params(name: String).returns(T.nilable([T.attached_class, String])) }
+  def self.with_formula_name(name)
+    return unless (match = name.match(HOMEBREW_TAP_FORMULA_REGEX))
+
+    user = T.must(match[:user])
+    repo = T.must(match[:repo])
+    name = T.must(match[:name])
+
+    # Relative paths are not taps.
+    return if [user, repo].intersect?([".", ".."])
+
+    tap = fetch(user, repo)
+    [tap, name.downcase]
+  end
+
+  # @private
+  sig { params(token: String).returns(T.nilable([T.attached_class, String])) }
+  def self.with_cask_token(token)
+    return unless (match = token.match(HOMEBREW_TAP_CASK_REGEX))
+
+    user = T.must(match[:user])
+    repo = T.must(match[:repo])
+    token = T.must(match[:token])
+
+    # Relative paths are not taps.
+    return if [user, repo].intersect?([".", ".."])
+
+    tap = fetch(user, repo)
+    [tap, token.downcase]
+  end
+
   sig { returns(CoreCaskTap) }
   def self.default_cask_tap
     odisabled "`Tap.default_cask_tap`", "`CoreCaskTap.instance`"

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -535,6 +535,22 @@ RSpec.describe Formulary do
   end
 
   describe "::loader_for" do
+    context "when given a relative path with two slashes" do
+      it "returns a `FromPathLoader`" do
+        mktmpdir.cd do
+          FileUtils.mkdir "Formula"
+          FileUtils.touch "Formula/gcc.rb"
+          expect(described_class.loader_for("./Formula/gcc.rb")).to be_a Formulary::FromPathLoader
+        end
+      end
+    end
+
+    context "when given a tapped name" do
+      it "returns a `FromTapLoader`" do
+        expect(described_class.loader_for("homebrew/core/gcc")).to be_a Formulary::FromTapLoader
+      end
+    end
+
     context "when not using the API" do
       before do
         ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -599,4 +599,24 @@ RSpec.describe Tap do
       expect(described_class.fetch("my", "tap-with-@-symbol").repo_var_suffix).to eq "_MY_HOMEBREW_TAP_WITH___SYMBOL"
     end
   end
+
+  describe "::with_formula_name" do
+    it "returns the tap and formula name when given a full name" do
+      expect(described_class.with_formula_name("homebrew/core/gcc")).to eq [CoreTap.instance, "gcc"]
+    end
+
+    it "returns nil when given a relative path" do
+      expect(described_class.with_formula_name("./Formula/gcc.rb")).to be_nil
+    end
+  end
+
+  describe "::with_cask_token" do
+    it "returns the tap and cask token when given a full token" do
+      expect(described_class.with_cask_token("homebrew/cask/alfred")).to eq [CoreCaskTap.instance, "alfred"]
+    end
+
+    it "returns nil when given a relative path" do
+      expect(described_class.with_cask_token("./Casks/alfred.rb")).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I don't think there is a way to match everything except `.`/`..` using a regex, so this adds two new methods to convert a tapped name (e.g. `homebrew/core/gcc`) into a pair of tap and name, matching all tapped names except those that look like relative paths, e.g. `./Formula/gcc.rb`.

Fixes https://github.com/Homebrew/brew/issues/16773.
