### PR TITLE
bump-formula-pr: update Python resources for non-PyPI formulae

### DIFF
--- a/Library/Homebrew/:w
+++ b/Library/Homebrew/:w
@@ -283,8 +283,9 @@ module PyPI
       elsif url.blank?
         odie "The main package is not a PyPI package, meaning that version-only " \
              "updates cannot be performed. Please update its URL manually."
-      elsif ["", version].exclude? Version.detect(url).to_s
-        odie "`#{__method__}` version=#{version} argument does not match version detected from url=#{url}."
+      elsif (url_version = Version.detect(url)) && ["", version].exclude?(url_version.to_s)
+        odie "`#{__method__}` version=#{version} argument does not match version " \
+             "detected from url=#{url} argument."
       end
     end
 


### PR DESCRIPTION
This extends previous logic to include non-PyPI formulae that are specified within pypi_formula_mappings.json.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Draft as I need to test behavior some more (particularly for any existing `homebrew-core` formulae that this will impact) and don't want to conflict with some of my other PRs.

Continuing some work from my other PRs to enable more formulae to automatically update Python resources.

For some non-PyPI formulae, this may require adding a line in JSON like `  "awscli": {},` to enable this behavior.