### PR TITLE
Remove ability to skip the duplicate PR check in autobump

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -570,7 +570,6 @@ module GitHub
     end
     return if pull_requests.blank?
 
-    force = ENV.fetch("HOMEBREW_TEST_BOT_AUTOBUMP", nil).present?
     duplicates_message = <<~EOS
       These #{state} pull requests may be duplicates:
       #{pull_requests.map { |pr| "#{pr["title"]} #{pr["html_url"]}" }.join("\n")}
@@ -579,11 +578,10 @@ module GitHub
       Duplicate PRs should not be opened.
       Manually open these PRs if you are sure that they are not duplicates.
     EOS
-    if force && !quiet
-      opoo duplicates_message
-    elsif !force && quiet
+
+    if quiet
       odie error_message
-    elsif !force
+    else
       odie <<~EOS
         #{duplicates_message.chomp}
         #{error_message}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This simply removes the environment variable check. The code was disabled in core around two weeks ago in https://github.com/Homebrew/homebrew-core/pull/163023. We need this PR to land first as explained in https://github.com/Homebrew/actions/pull/506#issuecomment-1972489707 to unblock other PRs.