### PR TITLE
docs: update language on commit messages & notability

### DIFF
--- a/docs/Acceptable-Formulae.md
+++ b/docs/Acceptable-Formulae.md
@@ -56,7 +56,7 @@ The software in question must:
 
 * be maintained (i.e. the last release wasn't ages ago, it works without patching on all Homebrew-supported OS versions and has no outstanding, unpatched security vulnerabilities)
 * be stable (e.g. not declared "unstable" or "beta" by upstream)
-* be known
+* be known (e.g. GitHub repositories should have >30 forks, >30 watchers and >75 stars)
 * be used
 * have a homepage
 

--- a/docs/Acceptable-Formulae.md
+++ b/docs/Acceptable-Formulae.md
@@ -56,7 +56,7 @@ The software in question must:
 
 * be maintained (i.e. the last release wasn't ages ago, it works without patching on all Homebrew-supported OS versions and has no outstanding, unpatched security vulnerabilities)
 * be stable (e.g. not declared "unstable" or "beta" by upstream)
-* be known (e.g. GitHub repositories should have >30 forks, >30 watchers and >75 stars)
+* be known (e.g. GitHub repositories should have >=30 forks, >=30 watchers or >=75 stars)
 * be used
 * have a homepage
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -401,11 +401,11 @@ The established standard for Git commit messages is:
 * two (2) newlines, then
 * explain the commit thoroughly.
 
-At Homebrew, we like to put the name of the formula up front like so: `foobar 7.3 (new formula)`.
+At Homebrew, we require the name of the formula up front like so: `foobar 7.3 (new formula)`.
 
 This may seem crazy short, but you’ll find that forcing yourself to summarise the commit encourages you to be atomic and concise. If you can’t summarise it in 50 to 80 characters, you’re probably trying to commit two commits as one. For a more thorough explanation, please read Tim Pope’s excellent blog post, [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
-The preferred commit message format for simple version updates is `foobar 7.3` and for fixes is `foobar: fix flibble matrix.`. Please squash your commits into one with this message format, otherwise your PR will be replaced by our autosquash workflow.
+The required commit message format for simple version updates is `foobar 7.3` and for fixes is `foobar: fix flibble matrix.`. Please squash your commits into one with this message format, otherwise your PR will be replaced by our autosquash workflow.
 
 Ensure you reference any relevant GitHub issue, e.g. `Closes #12345` in the commit message. Homebrew’s history is the first thing future contributors will look to when trying to understand the current state of formulae they’re interested in.
 

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -113,8 +113,8 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
    brew audit --strict --online <CHANGED_FORMULA|CHANGED_CASK>
    ```
 
-6. [Make a separate commit](Formula-Cookbook.md#commit) for each changed formula with `git add` and `git commit`.
-   * Please note that our preferred commit message format for simple version updates is "`<FORMULA_NAME> <NEW_VERSION>`", e.g. "`source-highlight 3.1.8`".
+6. [Make a separate commit](Formula-Cookbook.md#commit) for each changed formula with `git add` and `git commit`. Each formula's commits must be squashed.
+   * Please note that our required commit message format for simple version updates is "`<FORMULA_NAME> <NEW_VERSION>`", e.g. "`source-highlight 3.1.8`".
 7. Upload your branch of new commits to your fork:
 
    ```sh


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Updating the language to explain that our commit style is a requirement, instead of a preference. This will allow us to reduce the amount of autosquashed PR's.

Also putting an example for our notability check, which I haven't found documented anywhere. It seems to only be in:
https://github.com/Homebrew/brew/blob/6e7e56fdecdc861d9c75c632cc2257dcca8eb390/Library/Homebrew/utils/shared_audits.rb#L112-L115