### PR TITLE
tap: fix performance regression in *_files_by_name

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -820,7 +820,7 @@ class Tap
 
   sig { returns(T::Hash[String, T::Array[String]]) }
   def self.reverse_tap_migrations_renames
-    Tap.each_with_object({}) do |tap, hash|
+    cache[:reverse_tap_migrations_renames] ||= Tap.each_with_object({}) do |tap, hash|
       tap.tap_migrations.each do |old_name, new_name|
         new_tap_user, new_tap_repo, new_name = new_name.split("/", 3)
         next unless new_name

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1211,14 +1211,16 @@ class CoreTap < AbstractCoreTap
   def formula_files_by_name
     return super if Homebrew::EnvConfig.no_install_from_api?
 
-    tap_path = path.to_s
-    Homebrew::API::Formula.all_formulae.each_with_object({}) do |item, hash|
-      name, formula_hash = item
-      # If there's more than one item with the same path: use the longer one to prioritise more specific results.
-      existing_path = hash[name]
-      # Pathname equivalent is slow in a tight loop
-      new_path = File.join(tap_path, formula_hash.fetch("ruby_source_path"))
-      hash[name] = Pathname(new_path) if existing_path.nil? || existing_path.to_s.length < new_path.length
+    @formula_files_by_name ||= begin
+      tap_path = path.to_s
+      Homebrew::API::Formula.all_formulae.each_with_object({}) do |item, hash|
+        name, formula_hash = item
+        # If there's more than one item with the same path: use the longer one to prioritise more specific results.
+        existing_path = hash[name]
+        # Pathname equivalent is slow in a tight loop
+        new_path = File.join(tap_path, formula_hash.fetch("ruby_source_path"))
+        hash[name] = Pathname(new_path) if existing_path.nil? || existing_path.to_s.length < new_path.length
+      end
     end
   end
 
@@ -1279,7 +1281,7 @@ class CoreCaskTap < AbstractCoreTap
   def cask_files_by_name
     return super if Homebrew::EnvConfig.no_install_from_api?
 
-    Homebrew::API::Cask.all_casks.each_with_object({}) do |item, hash|
+    @cask_files_by_name ||= Homebrew::API::Cask.all_casks.each_with_object({}) do |item, hash|
       name, cask_hash = item
       # If there's more than one item with the same path: use the longer one to prioritise more specific results.
       existing_path = hash[name]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We essentially stopped caching these accidentally and they get called every time we try to load a cask or formula from the API. It gets really, really, really slow.

I ran `brew deps --casks --eval-all` before and after the changes.

### Before

I let it run for 3 minutes before killing it. No output had been printed to the screen.

### After

It finished printing all output (pages and pages of it) in less than a minute.

---

This should match the caching behavior we had before the recent changes in these two PRs.

- https://github.com/Homebrew/brew/pull/16777
- https://github.com/Homebrew/brew/pull/16775