### PR TITLE
.gitignore: Be more lenient with the unignore of Library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .DS_Store
 
 # Unignore the contents of `Library` as that's where our code lives.
-!/Library/
+!/Library
 
 # Ignore files within `Library` (again).
 /Library/Homebrew/.npmignore


### PR DESCRIPTION
vscode for example has a issue in that it won't unignore Library if the unignore line ends with a slash. As `/Library` will never be confused with a normal file this change won't have any adverse issues.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
