### PR TITLE
tap: revert caching `Tap.reverse_tap_migrations_renames`

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -820,7 +820,7 @@ class Tap
 
   sig { returns(T::Hash[String, T::Array[String]]) }
   def self.reverse_tap_migrations_renames
-    cache[:reverse_tap_migrations_renames] ||= Tap.each_with_object({}) do |tap, hash|
+    Tap.each_with_object({}) do |tap, hash|
       tap.tap_migrations.each do |old_name, new_name|
         new_tap_user, new_tap_repo, new_name = new_name.split("/", 3)
         next unless new_name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This could cause problems if a tap is installed during the lifetime of the program which happens occasionally with `Tap#ensure_installed!`.

It also seems to be slow mainly because of intermediate arrays and Pathname objects that get created in `Tap.each`. Maybe that should be optimized instead.

As discussed in https://github.com/Homebrew/brew/pull/16791#discussion_r1509963530