### PR TITLE
tap: memoize loading installed taps

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -60,7 +60,7 @@ module Homebrew
         tap.fix_remote_configuration
       end
     elsif args.no_named?
-      puts Tap.select(&:installed?)
+      puts Tap.select(&:installed?).sort_by(&:name)
     else
       tap = Tap.fetch(args.named.first)
       begin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See https://github.com/Homebrew/brew/pull/16791#discussion_r1509963530

This adds a new `Tap.tap_registry` method that will load all installed and core taps only once instead of doing it every time on the fly. We only expect this list to change when a tap is installed or uninstalled in the lifetime of the program. The only places where that can happen are in the `Tap#install` and `Tap#uninstall` methods so we make sure to update the tap registry when those methods are called.

This increases the performance of `Tap#reverse_tap_migrations_renames` since most of that time was spent in `Tap.each` loading the installed taps from the tap directory.

On my local computer, the performance goes from 3+ seconds to around 0.2 when calling `Tap.each(&:to_s)` in a loop 6k times. 6k is around the number of formulae in the core tap so this is not unheard of.

Before:

```rb
==> Interactive Homebrew Shell              
Example commands available with: `brew irb --examples`
brew(main):001:0> require "benchmark"
=> true
brew(main):002:1* Benchmark.realtime do
brew(main):003:1*   6_000.times { Tap.each(&:to_s) }
brew(main):004:0> end
=> 3.4574323009983345
brew(main):005:0> Tap.clear_cache
=> T::Private::Types::Void::VOID
brew(main):006:1* Benchmark.realtime do
brew(main):007:1*   6_000.times { Tap.reverse_tap_migrations_renames }
brew(main):008:0> end
=> 4.388525905000279
brew(main):009:0> exit
```

After:

```rb
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
brew(main):001:0> require "benchmark"
=> true
brew(main):002:1* Benchmark.realtime do
brew(main):003:1*   6_000.times { Tap.each(&:to_s) }
brew(main):004:0> end
=> 0.027163652001036098
brew(main):005:0> Tap.clear_cache
brew(main):006:1* Benchmark.realtime do
brew(main):007:1*   6_000.times { Tap.reverse_tap_migrations_renames }
brew(main):008:0> end
=> 1.0597649259980244
```

---

There might be additional improvements that can be made to `Tap.reverse_tap_migrations_renames` but there will be diminishing returns. We can consider doing that work in a separate PR.