### PR TITLE
Prefer numbered block params over proc conversion

### DIFF
--- a/Library/Homebrew/PATH.rb
+++ b/Library/Homebrew/PATH.rb
@@ -77,7 +77,7 @@ class PATH
 
   sig { returns(T.nilable(T.self_type)) }
   def existing
-    existing_path = select(&File.method(:directory?))
+    existing_path = select { File.directory?(_1) }
     # return nil instead of empty PATH, to unset environment variables
     existing_path unless existing_path.empty?
   end

--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -135,7 +135,7 @@ module Cask
       # @api public
       sig { returns(T::Array[Version]) } # Only top-level T.self_type is supported https://sorbet.org/docs/self-type
       def csv
-        split(",").map(&self.class.method(:new))
+        split(",").map { self.class.new(_1) }
       end
 
       # @api public

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -90,7 +90,7 @@ module Cask
                                    .stdout
                                    .split("\n")
                                    .map { |path| root.join(path) }
-                                   .reject(&MacOS.public_method(:undeletable?))
+                                   .reject { MacOS.undeletable?(_1) }
     end
 
     sig { returns(Pathname) }

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -679,7 +679,7 @@ module Homebrew
 
     class OptionConflictError < UsageError
       def initialize(args)
-        args_list = args.map(&Formatter.public_method(:option))
+        args_list = args.map { Formatter.option(_1) }
                         .join(" and ")
         super "Options #{args_list} are mutually exclusive."
       end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -664,7 +664,7 @@ on_request: installed_on_request?, options: options)
       puts "All dependencies for #{formula.full_name} are satisfied."
     elsif !deps.empty?
       oh1 "Installing dependencies for #{formula.full_name}: " \
-          "#{deps.map(&:first).map(&Formatter.method(:identifier)).to_sentence}",
+          "#{deps.map(&:first).map { Formatter.identifier(_1) }.to_sentence}",
           truncate: false
       deps.each { |dep, options| install_dependency(dep, options) }
     end
@@ -1184,7 +1184,7 @@ on_request: installed_on_request?, options: options)
     return if deps.empty?
 
     oh1 "Fetching dependencies for #{formula.full_name}: " \
-        "#{deps.map(&:first).map(&Formatter.method(:identifier)).to_sentence}",
+        "#{deps.map(&:first).map { Formatter.identifier(_1) }.to_sentence}",
         truncate: false
 
     deps.each { |(dep, _options)| fetch_dependency(dep) }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -143,7 +143,7 @@ class Keg
     files ||= text_files | libtool_files
 
     changed_files = T.let([], Array)
-    files.map(&path.method(:join)).group_by { |f| f.stat.ino }.each_value do |first, *rest|
+    files.map { path.join(_1) }.group_by { |f| f.stat.ino }.each_value do |first, *rest|
       s = first.open("rb", &:read)
 
       next unless relocation.replace_text(s)

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -276,7 +276,7 @@ class SystemCommand
 
   sig { params(raw_stdin: IO).void }
   def write_input_to(raw_stdin)
-    input.each(&raw_stdin.method(:write))
+    input.each { raw_stdin.write(_1) }
   end
 
   sig { params(sources: T::Array[IO], _block: T.proc.params(type: Symbol, line: String).void).void }

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -322,11 +322,11 @@ class Tab
   end
 
   def stable_version
-    versions["stable"]&.then(&Version.method(:new))
+    versions["stable"]&.then { Version.new(_1) }
   end
 
   def head_version
-    versions["head"]&.then(&Version.method(:new))
+    versions["head"]&.then { Version.new(_1) }
   end
 
   def version_scheme

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Cask::List, :cask do
     let(:casks) { [caffeine, transmission] }
 
     it "lists the installed files for those Casks" do
-      casks.each(&InstallHelper.method(:install_without_artifacts_with_caskfile))
+      casks.each { InstallHelper.install_without_artifacts_with_caskfile(_1) }
 
       transmission.artifacts.select { |a| a.is_a?(Cask::Artifact::App) }.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)

--- a/Library/Homebrew/test/cask/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/uninstall_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Cask::Uninstall, :cask do
     before do
       app.tap(&:mkpath)
          .join("Contents").tap(&:mkpath)
-         .join("Info.plist").tap(&FileUtils.method(:touch))
+         .join("Info.plist").tap { FileUtils.touch(_1) }
 
       caskroom_path.mkpath
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The occasional style of converting a method to a proc for use as a block argument isn't one I've seen elsewhere. I propose replacing it with something more idiomatic (assuming the conversions below are correct, it's honestly a bit confusing to me). This also has the advantage of providing type checking.

(I realize numbered block params have a mixed reception, though I think they're strictly clearer in the cases in this PR. I won't be upset if folks feel otherwise though).