### PR TITLE
formula_auditor: also use `tag` when checking GitHub license

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -242,6 +242,7 @@ module Homebrew
         return if user.blank?
 
         tag = SharedAudits.github_tag_from_url(formula.stable.url)
+        tag ||= formula.stable.specs[:tag]
         github_license = GitHub.get_repo_license(user, repo, ref: tag)
         return unless github_license
         return if (licenses + ["NOASSERTION"]).include?(github_license)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Also check `tag` info to work when URL is a git tag, e.g. current `influxdb`
```console
❯ git checkout -q master

❯ brew audit --online --git --only license influxdb; echo $?
influxdb
  * Formula license ["MIT"] does not match GitHub license ["Apache-2.0"].
Error: 1 problem in 1 formula detected.
1

❯ git checkout -q formula_auditor-also-check-tag

❯ brew audit --online --git --only license influxdb; echo $?
0

❯ gh api 'repos/influxdata/influxdb/license?ref=v2.7.5' | jq .license
{
  "key": "mit",
  "name": "MIT License",
  "spdx_id": "MIT",
  "url": "https://api.github.com/licenses/mit",
  "node_id": "MDc6TGljZW5zZTEz"
}
```