### PR TITLE
Scope sponsors-maintainers-man-completions.yml to master branch

### DIFF
--- a/.github/workflows/sponsors-maintainers-man-completions.yml
+++ b/.github/workflows/sponsors-maintainers-man-completions.yml
@@ -3,7 +3,7 @@ name: Update sponsors, maintainers, manpage and completions
 on:
   push:
     branches:
-      - "**"
+      - master
     paths:
       - .github/workflows/sponsors-maintainers-man-completions.yml
       - README.md


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This came up when I started pushing some branches directly to the brew repo instead of using a fork (probably a bad idea in hindsight).

As a result of that, the ever friendly brew test bot took it upon itself to update the maintainers on each of the branches I'd updated recently. This was not actually very helpful. We really only need to run this workflow when there are pushes to the master branch.

- https://github.com/Homebrew/brew/pull/16798/commits/c6c5fcdf99abe6e8a4eb3a41c68a49e87f2dfe55
- https://github.com/Homebrew/brew/pull/16806/commits/5515248be77b3a2384cb60fe82f6ba531b32f55f