### PR TITLE
homebrew/autoupdate is no longer official.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,7 +108,6 @@ jobs:
       - name: Set up all Homebrew taps
         run: |
           brew tap homebrew/aliases
-          brew tap homebrew/autoupdate
           brew tap homebrew/bundle
           brew tap homebrew/cask-fonts
           brew tap homebrew/cask-versions
@@ -127,7 +126,6 @@ jobs:
                      homebrew/test-bot
 
           brew style homebrew/aliases \
-                     homebrew/autoupdate\
                      homebrew/command-not-found \
                      homebrew/formula-analytics \
                      homebrew/portable-ruby

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -9,7 +9,6 @@ OFFICIAL_CASK_TAPS = %w[
 
 OFFICIAL_CMD_TAPS = {
   "homebrew/aliases"           => ["alias", "unalias"],
-  "homebrew/autoupdate"        => ["autoupdate"],
   "homebrew/bundle"            => ["bundle"],
   "homebrew/command-not-found" => ["command-not-found-init", "which-formula", "which-update"],
   "homebrew/test-bot"          => ["test-bot"],

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -531,7 +531,7 @@ __fish_brew_complete_arg 'contributions' -l debug -d 'Display any debugging info
 __fish_brew_complete_arg 'contributions' -l from -d 'Date (ISO-8601 format) to start searching contributions. Omitting this flag searches the last year'
 __fish_brew_complete_arg 'contributions' -l help -d 'Show this message'
 __fish_brew_complete_arg 'contributions' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'contributions' -l repositories -d 'Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `autoupdate`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. '
+__fish_brew_complete_arg 'contributions' -l repositories -d 'Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. '
 __fish_brew_complete_arg 'contributions' -l to -d 'Date (ISO-8601 format) to stop searching contributions'
 __fish_brew_complete_arg 'contributions' -l user -d 'Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches maintainers'
 __fish_brew_complete_arg 'contributions' -l verbose -d 'Make some output more verbose'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -681,7 +681,7 @@ _brew_contributions() {
     '--from[Date (ISO-8601 format) to start searching contributions. Omitting this flag searches the last year]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
-    '--repositories[Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `autoupdate`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. ]' \
+    '--repositories[Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. ]' \
     '--to[Date (ISO-8601 format) to stop searching contributions]' \
     '--user[Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches maintainers]' \
     '--verbose[Make some output more verbose]'

--- a/docs/Interesting-Taps-and-Forks.md
+++ b/docs/Interesting-Taps-and-Forks.md
@@ -8,6 +8,8 @@ Your taps are Git repositories located at `$(brew --repository)/Library/Taps`.
 
 ## Unsupported interesting taps
 
+* [DomT4/autoupdate](https://github.com/DomT4/homebrew-autoupdate): An external command to automatically run `brew update` (and optionally `brew upgrade` or `brew cleanup`) in the background with `launchd`.
+
 * [homebrew-ffmpeg/ffmpeg](https://github.com/homebrew-ffmpeg/homebrew-ffmpeg): A tap for FFmpeg with additional options, including nonfree additions.
 
 * [denji/nginx](https://github.com/denji/homebrew-nginx): A tap for NGINX modules, intended for its `nginx-full` formula which includes more module options.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1181,7 +1181,7 @@ Display the path to the file being used when invoking `brew` *`cmd`*.
 Summarise contributions to Homebrew repositories.
 
 * `--repositories`:
-  Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `autoupdate`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. 
+  Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. 
 * `--from`:
   Date (ISO-8601 format) to start searching contributions. Omitting this flag searches the last year.
 * `--to`:
@@ -1782,47 +1782,6 @@ Show existing aliases. If no aliases are given, print the whole list.
 
 * `--edit`:
   Edit aliases in a text editor. Either one or all aliases may be opened at once. If the given alias doesn't exist it'll be pre-populated with a template.
-
-### `autoupdate` *`subcommand`* [*`interval`*] [*`options`*]
-
-An easy, convenient way to automatically update Homebrew.
-
-This script will run `brew update` in the background once every 24 hours (by default)
-until explicitly told to stop, utilising `launchd`.
-
-`brew autoupdate start` [*``interval``*] [*``options``*]
-<br>Start autoupdating either once every `interval` hours or once every 24 hours.
-Please note the interval has to be passed in seconds, so 12 hours would be
-`brew autoupdate start 43200`. If you want to start the autoupdate immediately
-and on system boot, pass `--immediate`. Pass `--upgrade` or `--cleanup`
-to automatically run `brew upgrade` and/or `brew cleanup` respectively.
-Pass `--enable-notification` to send a notification when the autoupdate
-process has finished successfully.
-
-`brew autoupdate stop`
-<br>Stop autoupdating, but retain plist and logs.
-
-`brew autoupdate delete`
-<br>Cancel the autoupdate, delete the plist and logs.
-
-`brew autoupdate status`
-<br>Print the current status of this tool.
-
-`brew autoupdate version`
-<br>Output this tool's current version, and a short changelog.
-
-* `--upgrade`:
-  Automatically upgrade your installed formulae. If the Caskroom exists locally then casks will be upgraded as well. Must be passed with `start`.
-* `--greedy`:
-  Upgrade casks with `--greedy` (include auto-updating casks). Must be passed with `start`.
-* `--cleanup`:
-  Automatically clean Homebrew's cache and logs. Must be passed with `start`.
-* `--enable-notification`:
-  Send a notification when the autoupdate process has finished successfully, if `terminal-notifier` is installed and found. Must be passed with `start`. Note: notifications are enabled by default on macOS Catalina and newer.
-* `--immediate`:
-  Starts the autoupdate command immediately and on system boot, instead of waiting for one interval (24 hours by default) to pass first. Must be passed with `start`.
-* `--sudo`:
-  If a cask requires `sudo`, autoupdate will open a GUI to ask for the password. Requires https://formulae.brew.sh/formula/pinentry-mac to be installed.
 
 ### `bundle` [*`subcommand`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1690,7 +1690,7 @@ Summarise contributions to Homebrew repositories\.
 .
 .TP
 \fB\-\-repositories\fR
-Specify a comma\-separated list of repositories to search\. Supported repositories: \fBbrew\fR, \fBcore\fR, \fBcask\fR, \fBaliases\fR, \fBautoupdate\fR, \fBbundle\fR, \fBcommand\-not\-found\fR, \fBtest\-bot\fR, \fBservices\fR, \fBcask\-fonts\fR and \fBcask\-versions\fR\. Omitting this flag, or specifying \fB\-\-repositories=primary\fR, searches only the main repositories: brew,core,cask\. Specifying \fB\-\-repositories=all\fR, searches all repositories\.
+Specify a comma\-separated list of repositories to search\. Supported repositories: \fBbrew\fR, \fBcore\fR, \fBcask\fR, \fBaliases\fR, \fBbundle\fR, \fBcommand\-not\-found\fR, \fBtest\-bot\fR, \fBservices\fR, \fBcask\-fonts\fR and \fBcask\-versions\fR\. Omitting this flag, or specifying \fB\-\-repositories=primary\fR, searches only the main repositories: brew,core,cask\. Specifying \fB\-\-repositories=all\fR, searches all repositories\.
 .
 .TP
 \fB\-\-from\fR
@@ -2535,56 +2535,6 @@ Show existing aliases\. If no aliases are given, print the whole list\.
 .TP
 \fB\-\-edit\fR
 Edit aliases in a text editor\. Either one or all aliases may be opened at once\. If the given alias doesn\'t exist it\'ll be pre\-populated with a template\.
-.
-.SS "\fBautoupdate\fR \fIsubcommand\fR [\fIinterval\fR] [\fIoptions\fR]"
-An easy, convenient way to automatically update Homebrew\.
-.
-.P
-This script will run \fBbrew update\fR in the background once every 24 hours (by default) until explicitly told to stop, utilising \fBlaunchd\fR\.
-.
-.P
-\fBbrew autoupdate start\fR [\fI\fBinterval\fR\fR] [\fI\fBoptions\fR\fR]
-    Start autoupdating either once every \fBinterval\fR hours or once every 24 hours\. Please note the interval has to be passed in seconds, so 12 hours would be \fBbrew autoupdate start 43200\fR\. If you want to start the autoupdate immediately and on system boot, pass \fB\-\-immediate\fR\. Pass \fB\-\-upgrade\fR or \fB\-\-cleanup\fR to automatically run \fBbrew upgrade\fR and/or \fBbrew cleanup\fR respectively\. Pass \fB\-\-enable\-notification\fR to send a notification when the autoupdate process has finished successfully\.
-.
-.P
-\fBbrew autoupdate stop\fR
-    Stop autoupdating, but retain plist and logs\.
-.
-.P
-\fBbrew autoupdate delete\fR
-    Cancel the autoupdate, delete the plist and logs\.
-.
-.P
-\fBbrew autoupdate status\fR
-    Print the current status of this tool\.
-.
-.P
-\fBbrew autoupdate version\fR
-    Output this tool\'s current version, and a short changelog\.
-.
-.TP
-\fB\-\-upgrade\fR
-Automatically upgrade your installed formulae\. If the Caskroom exists locally then casks will be upgraded as well\. Must be passed with \fBstart\fR\.
-.
-.TP
-\fB\-\-greedy\fR
-Upgrade casks with \fB\-\-greedy\fR (include auto\-updating casks)\. Must be passed with \fBstart\fR\.
-.
-.TP
-\fB\-\-cleanup\fR
-Automatically clean Homebrew\'s cache and logs\. Must be passed with \fBstart\fR\.
-.
-.TP
-\fB\-\-enable\-notification\fR
-Send a notification when the autoupdate process has finished successfully, if \fBterminal\-notifier\fR is installed and found\. Must be passed with \fBstart\fR\. Note: notifications are enabled by default on macOS Catalina and newer\.
-.
-.TP
-\fB\-\-immediate\fR
-Starts the autoupdate command immediately and on system boot, instead of waiting for one interval (24 hours by default) to pass first\. Must be passed with \fBstart\fR\.
-.
-.TP
-\fB\-\-sudo\fR
-If a cask requires \fBsudo\fR, autoupdate will open a GUI to ask for the password\. Requires https://formulae\.brew\.sh/formula/pinentry\-mac to be installed\.
 .
 .SS "\fBbundle\fR [\fIsubcommand\fR]"
 Bundler for non\-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store, Whalebrew and Visual Studio Code\.


### PR DESCRIPTION
DomT4 and the Homebrew maintainers have agreed that homebrew/autoupdate is a better fit for not being an official tap and has been moved back to his user account.

Documentation and code has been adjusted accordingly and it was added to the list of interesting taps.