### PR TITLE
fix(tap): handle unset git config vars in taps

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1347,7 +1347,7 @@ class TapConfig
     Homebrew::Settings.read key, repo: tap.path
   end
 
-  sig { params(key: T.any(Symbol, String), value: T.any(T::Boolean, String)).void }
+  sig { params(key: T.any(Symbol, String), value: T.any(T::Boolean, String, NilClass)).void }
   def []=(key, value)
     return unless tap.git?
     return unless Utils::Git.available?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

cc/ @reitermarkus 

#### Commits _(oldest to newest)_

3479d70296 fix(tap): handle unset git config vars in taps

I'm not sure how/when this happened, but I have this in the
`.git/config` for some of my taps.

```text
[homebrew]
	private =
```

And this breaks `brew upgrade` and `brew tap-info <tap>` since
<https://github.com/Homebrew/brew/pull/16811>.

<br/>