### PR TITLE
cask: read bundle version from `Info.plist` when sensible.

### DIFF
--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -21,6 +21,8 @@
   "version": "1.2.3",
   "installed": null,
   "installed_time": null,
+  "bundle_version": null,
+  "bundle_short_version": null,
   "outdated": false,
   "sha256": "c64c05bdc0be845505d6e55e69e696a7f50d40846e76155f0c85d5ff5e7bbb84",
   "artifacts": [

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -94,6 +94,9 @@ class Version
     def null?
       false
     end
+
+    sig { returns(T::Boolean) }
+    def blank? = null?
   end
 
   # A pseudo-token representing the absence of a token.
@@ -126,6 +129,9 @@ class Version
     def null?
       true
     end
+
+    sig { returns(T::Boolean) }
+    def blank? = true
 
     sig { override.returns(String) }
     def inspect


### PR DESCRIPTION
If you're trying to use `brew info --json=v2` to get an installed version and figure out if it is outdated: you're going to have a bad time with `auto_updates` casks because `installed_version` alone is not enough to get the actually currently installed version of the app.

Instead, in these cases, try to read from `Info.plist` if there is one and use that version.

While we're here, add a `blank?` method to `Version` so we can use it for `present?` checks (making a `null?` `Version` object `blank?`).