### PR TITLE
dev-cmd/bump: add `--tap=` flag

### DIFF
--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -20,4 +20,11 @@ RSpec.describe "brew bump" do
         .and be_a_success
     end
   end
+
+  it "gives an error for `--tap` with official taps", :integration_test do
+    expect { brew "bump", "--tap", "Homebrew/core" }
+      .to output(/Invalid usage/).to_stderr
+      .and not_to_output.to_stdout
+      .and be_a_failure
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Allow tap maintainers to run `brew bump --tap <user>/<repo>` to keep their formulae and casks up-to-date.

(Note: this is the same exact behavior as `brew livecheck --tap <user/<repo>`)