### PR TITLE
Make `Tap::new` private.

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -58,7 +58,7 @@ class Tap
     return CoreCaskTap.instance if user == "Homebrew" && repo == "cask"
 
     cache_key = "#{user}/#{repo}".downcase
-    cache.fetch(cache_key) { |key| cache[key] = Tap.new(user, repo) }
+    cache.fetch(cache_key) { |key| cache[key] = new(user, repo) }
   end
 
   def self.from_path(path)
@@ -141,6 +141,9 @@ class Tap
   # The git repository of this {Tap}.
   sig { returns(GitRepository) }
   attr_reader :git_repo
+
+  # Always use `Tap.fetch` instead of `Tap.new`.
+  private_class_method :new
 
   # @private
   def initialize(user, repo)
@@ -1004,6 +1007,8 @@ class AbstractCoreTap < Tap
   extend T::Helpers
 
   abstract!
+
+  private_class_method :fetch
 
   sig { returns(T.attached_class) }
   def self.instance

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "brew log" do
   it "shows the Git log for a given Formula", :integration_test do
     setup_test_formula "testball"
 
-    core_tap = CoreTap.new
+    core_tap = CoreTap.instance
     core_tap.path.cd do
       system "git", "init"
       system "git", "add", "--all"

--- a/Library/Homebrew/test/cmd/readall_spec.rb
+++ b/Library/Homebrew/test/cmd/readall_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "brew readall" do
   it "imports all Formulae for a given Tap", :integration_test do
     formula_file = setup_test_formula "testball"
 
-    alias_file = CoreTap.new.alias_dir/"foobar"
+    alias_file = CoreTap.instance.alias_dir/"foobar"
     alias_file.parent.mkpath
 
     FileUtils.ln_s formula_file, alias_file

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "brew update-report" do
   it_behaves_like "parseable arguments"
 
   describe Reporter do
-    let(:tap) { CoreTap.new }
+    let(:tap) { CoreTap.instance }
     let(:reporter_class) do
       Class.new(described_class) do
         def initialize(tap)
@@ -87,7 +87,7 @@ RSpec.describe "brew update-report" do
     end
 
     context "when updating a Tap other than the core Tap" do
-      let(:tap) { Tap.new("foo", "bar") }
+      let(:tap) { Tap.fetch("foo", "bar") }
 
       before do
         (tap.path/"Formula").mkpath

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Dependency do
   describe "#tap" do
     it "returns a tap passed a fully-qualified name" do
       dependency = described_class.new("foo/bar/dog")
-      expect(dependency.tap).to eq(Tap.new("foo", "bar"))
+      expect(dependency.tap).to eq(Tap.fetch("foo", "bar"))
     end
 
     it "returns no tap passed a simple name" do

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "brew bottle" do
   end
 
   describe "--merge", :integration_test do
-    let(:core_tap) { CoreTap.new }
+    let(:core_tap) { CoreTap.instance }
     let(:tarball) do
       if OS.linux?
         TEST_FIXTURE_DIR/"tarballs/testball-0.1-linux.tbz"

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -4,7 +4,7 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe "brew create" do
   let(:url) { "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz" }
-  let(:formula_file) { CoreTap.new.new_formula_path("testball") }
+  let(:formula_file) { CoreTap.instance.new_formula_path("testball") }
 
   it_behaves_like "parseable arguments"
 

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "brew extract" do
       path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
       (path/"Formula").mkpath
       target = Tap.from_path(path)
-      core_tap = CoreTap.new
+      core_tap = CoreTap.instance
       core_tap.path.cd do
         system "git", "init"
         # Start with deprecated bottle syntax

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe FormulaInstaller do
       ENV["HOMEBREW_DEVELOPER"] = "1"
 
       dep_name = "homebrew-test-cyclic"
-      dep_path = CoreTap.new.new_formula_path(dep_name)
+      dep_path = CoreTap.instance.new_formula_path(dep_name)
       dep_path.write <<~RUBY
         class #{Formulary.class_s(dep_name)} < Formula
           url "foo"
@@ -105,7 +105,7 @@ RSpec.describe FormulaInstaller do
 
       formula1_name = "homebrew-test-formula1"
       formula2_name = "homebrew-test-formula2"
-      formula1_path = CoreTap.new.new_formula_path(formula1_name)
+      formula1_path = CoreTap.instance.new_formula_path(formula1_name)
       formula1_path.write <<~RUBY
         class #{Formulary.class_s(formula1_name)} < Formula
           url "foo"
@@ -116,7 +116,7 @@ RSpec.describe FormulaInstaller do
       Formulary.cache.delete(formula1_path)
       formula1 = Formulary.factory(formula1_name)
 
-      formula2_path = CoreTap.new.new_formula_path(formula2_name)
+      formula2_path = CoreTap.instance.new_formula_path(formula2_name)
       formula2_path.write <<~RUBY
         class #{Formulary.class_s(formula2_name)} < Formula
           url "foo"
@@ -135,7 +135,7 @@ RSpec.describe FormulaInstaller do
 
     it "raises on pinned dependency" do
       dep_name = "homebrew-test-dependency"
-      dep_path = CoreTap.new.new_formula_path(dep_name)
+      dep_path = CoreTap.instance.new_formula_path(dep_name)
       dep_path.write <<~RUBY
         class #{Formulary.class_s(dep_name)} < Formula
           url "foo"

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Formula do
     end
 
     context "when in a Tap" do
-      let(:tap) { Tap.new("foo", "bar") }
+      let(:tap) { Tap.fetch("foo", "bar") }
       let(:path) { (tap.path/"Formula/#{name}.rb") }
       let(:full_name) { "#{tap.user}/#{tap.repo}/#{name}" }
       let(:full_alias_name) { "#{tap.user}/#{tap.repo}/#{alias_name}" }
@@ -204,7 +204,7 @@ RSpec.describe Formula do
   end
 
   example "installed alias with tap" do
-    tap = Tap.new("user", "repo")
+    tap = Tap.fetch("user", "repo")
     name = "foo"
     path = tap.path/"Formula/#{name}.rb"
     f = formula name, path: path do
@@ -847,7 +847,7 @@ RSpec.describe Formula do
       allow(tap_loader).to receive(:get_formula).and_raise(RuntimeError, "tried resolving tap formula")
       allow(Formulary).to receive(:loader_for).with("foo/bar/f1", from: nil).and_return(tap_loader)
 
-      f2_path = Tap.new("baz", "qux").path/"Formula/f2.rb"
+      f2_path = Tap.fetch("baz", "qux").path/"Formula/f2.rb"
       stub_formula_loader(formula("f2", path: f2_path) { url("f2-1.0") }, "baz/qux/f2")
 
       f3 = formula "f3" do
@@ -859,7 +859,7 @@ RSpec.describe Formula do
 
       expect(f3.runtime_dependencies.map(&:name)).to eq(["baz/qux/f2"])
 
-      f1_path = Tap.new("foo", "bar").path/"Formula/f1.rb"
+      f1_path = Tap.fetch("foo", "bar").path/"Formula/f1.rb"
       stub_formula_loader(formula("f1", path: f1_path) { url("f1-1.0") }, "foo/bar/f1")
 
       f3.build = BuildOptions.new(Options.create(["--with-f1"]), f3.options)
@@ -956,7 +956,7 @@ RSpec.describe Formula do
   end
 
   describe "#to_hash_with_variations", :needs_macos do
-    let(:formula_path) { CoreTap.new.new_formula_path("foo-variations") }
+    let(:formula_path) { CoreTap.instance.new_formula_path("foo-variations") }
     let(:formula_content) do
       <<~RUBY
         class FooVariations < Formula

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -6,7 +6,7 @@ require "utils/bottles"
 
 RSpec.describe Formulary do
   let(:formula_name) { "testball_bottle" }
-  let(:formula_path) { CoreTap.new.new_formula_path(formula_name) }
+  let(:formula_path) { CoreTap.instance.new_formula_path(formula_name) }
   let(:formula_content) do
     <<~RUBY
       class #{described_class.class_s(formula_name)} < Formula
@@ -85,7 +85,7 @@ RSpec.describe Formulary do
 
       let(:formula_name) { "testball_sharded" }
       let(:formula_path) do
-        core_tap = CoreTap.new
+        core_tap = CoreTap.instance
         (core_tap.formula_dir/formula_name[0]).mkpath
         core_tap.new_formula_path(formula_name)
       end
@@ -184,8 +184,8 @@ RSpec.describe Formulary do
     end
 
     context "when migrating from a Tap" do
-      let(:tap) { Tap.new("homebrew", "foo") }
-      let(:another_tap) { Tap.new("homebrew", "bar") }
+      let(:tap) { Tap.fetch("homebrew", "foo") }
+      let(:another_tap) { Tap.fetch("homebrew", "bar") }
       let(:tap_migrations_path) { tap.path/"tap_migrations.json" }
       let(:another_tap_formula_path) { another_tap.path/"Formula/#{formula_name}.rb" }
 
@@ -226,8 +226,8 @@ RSpec.describe Formulary do
     end
 
     context "when loading from Tap" do
-      let(:tap) { Tap.new("homebrew", "foo") }
-      let(:another_tap) { Tap.new("homebrew", "bar") }
+      let(:tap) { Tap.fetch("homebrew", "foo") }
+      let(:another_tap) { Tap.fetch("homebrew", "bar") }
       let(:formula_path) { tap.path/"Formula/#{formula_name}.rb" }
       let(:alias_name) { "bar" }
       let(:alias_dir) { tap.alias_dir }

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe Tab do
         depends_on "baz" => :build
       end
 
-      tap = Tap.new("user", "repo")
+      tap = Tap.fetch("user", "repo")
       from_tap = formula("from_tap", path: tap.path/"Formula/from_tap.rb") do
         url "from_tap-1.0"
         revision 1

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Tap do
   alias_matcher :have_formula_file, :be_formula_file
   alias_matcher :have_custom_remote, :be_custom_remote
 
-  subject(:homebrew_foo_tap) { described_class.new("Homebrew", "foo") }
+  subject(:homebrew_foo_tap) { described_class.fetch("Homebrew", "foo") }
 
   let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-foo" }
   let(:formula_file) { path/"Formula/foo.rb" }
@@ -155,7 +155,7 @@ RSpec.describe Tap do
   end
 
   specify "#issues_url" do
-    t = described_class.new("someone", "foo")
+    t = described_class.fetch("someone", "foo")
     path = Tap::TAP_DIRECTORY/"someone/homebrew-foo"
     path.mkpath
     cd path do
@@ -167,7 +167,7 @@ RSpec.describe Tap do
     expect(homebrew_foo_tap.issues_url).to eq("https://github.com/Homebrew/homebrew-foo/issues")
 
     (Tap::TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
-    expect(described_class.new("someone", "no-git").issues_url).to be_nil
+    expect(described_class.fetch("someone", "no-git").issues_url).to be_nil
   ensure
     path.parent.rmtree
   end
@@ -198,7 +198,7 @@ RSpec.describe Tap do
       expect(homebrew_foo_tap.remote).to eq("https://github.com/Homebrew/homebrew-foo")
       expect(homebrew_foo_tap).not_to have_custom_remote
 
-      services_tap = described_class.new("Homebrew", "services")
+      services_tap = described_class.fetch("Homebrew", "services")
       services_tap.path.mkpath
       services_tap.path.cd do
         system "git", "init"
@@ -224,7 +224,7 @@ RSpec.describe Tap do
 
       expect(homebrew_foo_tap.remote_repo).to eq("Homebrew/homebrew-foo")
 
-      services_tap = described_class.new("Homebrew", "services")
+      services_tap = described_class.fetch("Homebrew", "services")
       services_tap.path.mkpath
       services_tap.path.cd do
         system "git", "init"
@@ -238,7 +238,7 @@ RSpec.describe Tap do
 
       expect(homebrew_foo_tap.remote_repo).to eq("Homebrew/homebrew-foo")
 
-      services_tap = described_class.new("Homebrew", "services")
+      services_tap = described_class.fetch("Homebrew", "services")
       services_tap.path.mkpath
       services_tap.path.cd do
         system "git", "init"
@@ -259,7 +259,7 @@ RSpec.describe Tap do
   end
 
   describe "#custom_remote?" do
-    subject(:tap) { described_class.new("Homebrew", "services") }
+    subject(:tap) { described_class.fetch("Homebrew", "services") }
 
     let(:remote) { nil }
 
@@ -304,14 +304,14 @@ RSpec.describe Tap do
   describe "#install" do
     it "raises an error when the Tap is already tapped" do
       setup_git_repo
-      already_tapped_tap = described_class.new("Homebrew", "foo")
+      already_tapped_tap = described_class.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
       expect { already_tapped_tap.install }.to raise_error(TapAlreadyTappedError)
     end
 
     it "raises an error when the Tap is already tapped with the right remote" do
       setup_git_repo
-      already_tapped_tap = described_class.new("Homebrew", "foo")
+      already_tapped_tap = described_class.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
       right_remote = homebrew_foo_tap.remote
       expect { already_tapped_tap.install clone_target: right_remote }.to raise_error(TapAlreadyTappedError)
@@ -319,7 +319,7 @@ RSpec.describe Tap do
 
     it "raises an error when the remote doesn't match" do
       setup_git_repo
-      already_tapped_tap = described_class.new("Homebrew", "foo")
+      already_tapped_tap = described_class.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
       wrong_remote = "#{homebrew_foo_tap.remote}-oops"
       expect do
@@ -337,7 +337,7 @@ RSpec.describe Tap do
 
     it "raises an error when run `brew tap --custom-remote` without a custom remote (already installed)" do
       setup_git_repo
-      already_tapped_tap = described_class.new("Homebrew", "foo")
+      already_tapped_tap = described_class.fetch("Homebrew", "foo")
       expect(already_tapped_tap).to be_installed
 
       expect do
@@ -346,7 +346,7 @@ RSpec.describe Tap do
     end
 
     it "raises an error when run `brew tap --custom-remote` without a custom remote (not installed)" do
-      not_tapped_tap = described_class.new("Homebrew", "bar")
+      not_tapped_tap = described_class.fetch("Homebrew", "bar")
       expect(not_tapped_tap).not_to be_installed
 
       expect do
@@ -359,7 +359,7 @@ RSpec.describe Tap do
         setup_git_repo
       end
 
-      let(:already_tapped_tap) { described_class.new("Homebrew", "foo") }
+      let(:already_tapped_tap) { described_class.fetch("Homebrew", "foo") }
 
       it "defaults to nil" do
         expect(already_tapped_tap).to be_installed
@@ -380,7 +380,7 @@ RSpec.describe Tap do
     end
 
     specify "Git error" do
-      tap = described_class.new("user", "repo")
+      tap = described_class.fetch("user", "repo")
 
       expect do
         tap.install clone_target: "file:///not/existed/remote/url"
@@ -393,7 +393,7 @@ RSpec.describe Tap do
 
   describe "#uninstall" do
     it "raises an error if the Tap is not available" do
-      tap = described_class.new("Homebrew", "bar")
+      tap = described_class.fetch("Homebrew", "bar")
       expect { tap.uninstall }.to raise_error(TapUnavailableError)
     end
   end
@@ -403,7 +403,7 @@ RSpec.describe Tap do
     setup_git_repo
     setup_completion link: true
 
-    tap = described_class.new("Homebrew", "bar")
+    tap = described_class.fetch("Homebrew", "bar")
 
     tap.install clone_target: homebrew_foo_tap.path/".git"
 
@@ -429,7 +429,7 @@ RSpec.describe Tap do
     setup_tap_files
     setup_git_repo
     setup_completion link: true
-    tap = described_class.new("NotHomebrew", "baz")
+    tap = described_class.fetch("NotHomebrew", "baz")
     tap.install clone_target: homebrew_foo_tap.path/".git"
     (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
     (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete
@@ -450,7 +450,7 @@ RSpec.describe Tap do
     setup_tap_files
     setup_git_repo
     setup_completion link: false
-    tap = described_class.new("NotHomebrew", "baz")
+    tap = described_class.fetch("NotHomebrew", "baz")
     tap.install clone_target: homebrew_foo_tap.path/".git"
     (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
     tap.link_completions_and_manpages
@@ -468,7 +468,7 @@ RSpec.describe Tap do
     setup_tap_files
     setup_git_repo
     setup_completion link: false
-    tap = described_class.new("Homebrew", "baz")
+    tap = described_class.fetch("Homebrew", "baz")
     tap.install clone_target: homebrew_foo_tap.path/".git"
     (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
     (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete
@@ -562,7 +562,7 @@ RSpec.describe Tap do
   end
 
   describe CoreTap do
-    subject(:core_tap) { described_class.new }
+    subject(:core_tap) { described_class.instance }
 
     specify "attributes" do
       expect(core_tap.user).to eq("Homebrew")

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Utils::Bottles do
       before do
         # setup a testball1
         dep_name = "testball1"
-        dep_path = CoreTap.new.new_formula_path(dep_name)
+        dep_path = CoreTap.instance.new_formula_path(dep_name)
         dep_path.write <<~RUBY
           class #{Formulary.class_s(dep_name)} < Formula
             url "testball1"
@@ -30,7 +30,7 @@ RSpec.describe Utils::Bottles do
 
         # setup a testball2, that depends on testball1
         formula_name = "testball2"
-        formula_path = CoreTap.new.new_formula_path(formula_name)
+        formula_path = CoreTap.instance.new_formula_path(formula_name)
         formula_path.write <<~RUBY
           class #{Formulary.class_s(formula_name)} < Formula
             url "testball2"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As mentioned in https://github.com/Homebrew/brew/pull/16832#discussion_r1514544435. This ensures there is no way to get a `Tap.new("Homebrew", "core")` instead of a `CoreTap.instance`.