### PR TITLE
Don't store tap config when value is unknown.

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -963,7 +963,10 @@ class Tap
         if custom_remote?
           true
         else
-          GitHub.private_repo?(full_name)
+          # Don't store config if we don't know for sure.
+          return false if (value = GitHub.private_repo?(full_name)).nil?
+
+          value
         end
       rescue GitHub::API::HTTPNotFoundError
         true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Closes https://github.com/Homebrew/brew/pull/16825.

This only happens if `HOMEBREW_NO_GITHUB_API` is set. Storing the config in that case has no benefit anyways since the whole point of it is to avoid API calls.