### PR TITLE
dev-cmd/bump: change `args` type to `CLI::Args`

### DIFF
--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -207,6 +207,15 @@ module Homebrew
       sig { returns(T::Boolean) }
       def fail_if_not_changed?; end
 
+      sig { returns(T::Boolean) }
+      def no_pull_requests?; end
+
+      sig { returns(T::Boolean) }
+      def no_fork?; end
+
+      sig { returns(T::Boolean) }
+      def open_pr?; end
+
       sig { returns(T.nilable(String)) }
       def limit; end
 

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -309,7 +309,7 @@ module Homebrew
     params(
       formula_or_cask: T.any(Formula, Cask::Cask),
       repositories:    T::Array[T.untyped],
-      args:            T.untyped,
+      args:            CLI::Args,
       name:            String,
     ).returns(VersionBumpInfo)
   }
@@ -417,7 +417,7 @@ module Homebrew
       formula_or_cask: T.any(Formula, Cask::Cask),
       name:            String,
       repositories:    T::Array[T.untyped],
-      args:            T.untyped,
+      args:            CLI::Args,
       ambiguous_cask:  T::Boolean,
     ).void
   }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Typing changes split out from #16833 as that PR should no longer add extra options.