### PR TITLE
Remove `FromDefaultNameLoader` to avoid warning twice.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -838,7 +838,6 @@ module Homebrew
 
           loadable = [
             Formulary::FromAPILoader,
-            Formulary::FromDefaultNameLoader,
             Formulary::FromNameLoader,
           ].any? do |loader_class|
             loader = begin

--- a/Library/Homebrew/test/.rubocop.yml
+++ b/Library/Homebrew/test/.rubocop.yml
@@ -14,3 +14,4 @@ RSpec/ContextWording:
     - unless
     - for
     - which
+    - to


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the duplicate warning when trying to load a migrated formula/cask using a short token.

Note: This does not yet fix the warning being shown when loading both formulae/casks at the same time, despite the migrated-to formula/cask existing.
