### PR TITLE
Add support for the `--overwrite` flag to `brew upgrade` to govern the keg-linking step

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -75,6 +75,9 @@ module Homebrew
           env:         :display_install_times,
           description: "Print install times for each package at the end of the run.",
         }],
+        [:switch, "--overwrite", {
+          description: "Delete files that already exist in the prefix while linking.",
+        }],
       ].each do |args|
         options = args.pop
         send(*args, **options)
@@ -229,6 +232,7 @@ module Homebrew
       keep_tmp:                   args.keep_tmp?,
       debug_symbols:              args.debug_symbols?,
       force:                      args.force?,
+      overwrite:                  args.overwrite?,
       debug:                      args.debug?,
       quiet:                      args.quiet?,
       verbose:                    args.verbose?,

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -27,6 +27,7 @@ module Homebrew
       keep_tmp: false,
       debug_symbols: false,
       force: false,
+      overwrite: false,
       debug: false,
       quiet: false,
       verbose: false
@@ -65,6 +66,7 @@ module Homebrew
             keep_tmp:                   keep_tmp,
             debug_symbols:              debug_symbols,
             force:                      force,
+            overwrite:                  overwrite,
             debug:                      debug,
             quiet:                      quiet,
             verbose:                    verbose,
@@ -150,6 +152,7 @@ module Homebrew
       keep_tmp: false,
       debug_symbols: false,
       force: false,
+      overwrite: false,
       debug: false,
       quiet: false,
       verbose: false
@@ -184,6 +187,7 @@ module Homebrew
           keep_tmp:                   keep_tmp,
           debug_symbols:              debug_symbols,
           force:                      force,
+          overwrite:                  overwrite,
           debug:                      debug,
           quiet:                      quiet,
           verbose:                    verbose,


### PR DESCRIPTION
`FormulaInstaller` already supports this (https://github.com/Homebrew/brew/pull/12691) but I didn't wire it up via `brew upgrade` and the two can be used largely interchangeably

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
