### PR TITLE
Various `brew update` behaviour improvements

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -262,22 +262,6 @@ check-array-membership() {
   fi
 }
 
-# Let user know we're still updating Homebrew if brew update --auto-update
-# exceeds 3 seconds.
-auto-update-timer() {
-  sleep 3
-  # Outputting a command but don't want to run it, hence single quotes.
-  # shellcheck disable=SC2016
-  echo 'Running `brew update --auto-update`...' >&2
-  if [[ -z "${HOMEBREW_NO_ENV_HINTS}" && -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
-  then
-    # shellcheck disable=SC2016
-    echo 'Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with' >&2
-    # shellcheck disable=SC2016
-    echo 'HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).' >&2
-  fi
-}
-
 # These variables are set from various Homebrew scripts.
 # shellcheck disable=SC2154
 auto-update() {
@@ -339,19 +323,7 @@ auto-update() {
       return
     fi
 
-    if [[ -z "${HOMEBREW_VERBOSE}" ]]
-    then
-      auto-update-timer &
-      timer_pid=$!
-    fi
-
     brew update --auto-update
-
-    if [[ -n "${timer_pid}" ]]
-    then
-      kill "${timer_pid}" 2>/dev/null
-      wait "${timer_pid}" 2>/dev/null
-    fi
 
     unset HOMEBREW_AUTO_UPDATING
 

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -34,8 +34,7 @@ module Homebrew
              replacement: false,
              disable:     true
       switch "--[no-]force-auto-update",
-             description: "Auto-update tap even if it is not hosted on GitHub. By default, only taps " \
-                          "hosted on GitHub are auto-updated (for performance reasons)."
+             hidden: true
       switch "--custom-remote",
              description: "Install or change a tap with a custom remote. Useful for mirrors."
       switch "--repair",
@@ -64,12 +63,11 @@ module Homebrew
     else
       tap = Tap.fetch(args.named.first)
       begin
-        tap.install clone_target:      args.named.second,
-                    force_auto_update: args.force_auto_update?,
-                    custom_remote:     args.custom_remote?,
-                    quiet:             args.quiet?,
-                    verify:            args.eval_all? || Homebrew::EnvConfig.eval_all?,
-                    force:             args.force?
+        tap.install clone_target:  args.named.second,
+                    custom_remote: args.custom_remote?,
+                    quiet:         args.quiet?,
+                    verify:        args.eval_all? || Homebrew::EnvConfig.eval_all?,
+                    force:         args.force?
       rescue TapRemoteMismatchError, TapNoCustomRemoteError => e
         odie e
       rescue TapAlreadyTappedError

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -622,6 +622,26 @@ EOS
       [[ -n "${SKIP_FETCH_CORE_REPOSITORY}" && "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" ]] && continue
     fi
 
+    if [[ -z "${UPDATING_MESSAGE_SHOWN}" ]]
+    then
+      if [[ -n "${HOMEBREW_UPDATE_AUTO}" ]]
+      then
+        # Outputting a command but don't want to run it, hence single quotes.
+        # shellcheck disable=SC2016
+        ohai 'Auto-updating Homebrew...' >&2
+        if [[ -z "${HOMEBREW_NO_ENV_HINTS}" && -z "${HOMEBREW_AUTO_UPDATE_SECS}" ]]
+        then
+          # shellcheck disable=SC2016
+          echo 'Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with' >&2
+          # shellcheck disable=SC2016
+          echo 'HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).' >&2
+        fi
+      else
+        ohai 'Updating Homebrew...' >&2
+      fi
+      UPDATING_MESSAGE_SHOWN=1
+    fi
+
     # The upstream repository's default branch may not be master;
     # check refs/remotes/origin/HEAD to see what the default
     # origin branch name is, and use that. If not set, fall back to "master".
@@ -693,14 +713,6 @@ EOS
         # Touch FETCH_HEAD to confirm we've checked for an update.
         [[ -f "${DIR}/.git/FETCH_HEAD" ]] && touch "${DIR}/.git/FETCH_HEAD"
         [[ -z "${HOMEBREW_UPDATE_FORCE}" ]] && [[ "${UPSTREAM_SHA_HTTP_CODE}" == "304" ]] && exit
-      elif [[ -n "${HOMEBREW_UPDATE_AUTO}" ]]
-      then
-        FORCE_AUTO_UPDATE="$(git config homebrew.forceautoupdate 2>/dev/null || echo "false")"
-        if [[ "${FORCE_AUTO_UPDATE}" != "true" ]]
-        then
-          # Don't try to do a `git fetch` that may take longer than expected.
-          exit
-        fi
       fi
 
       # HOMEBREW_VERBOSE isn't modified here so ignore subshell warning.

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -354,31 +354,6 @@ RSpec.describe Tap do
       end.to raise_error(TapNoCustomRemoteError)
     end
 
-    describe "force_auto_update" do
-      before do
-        setup_git_repo
-      end
-
-      let(:already_tapped_tap) { described_class.fetch("Homebrew", "foo") }
-
-      it "defaults to nil" do
-        expect(already_tapped_tap).to be_installed
-        expect(already_tapped_tap.config[:forceautoupdate]).to be_nil
-      end
-
-      it "enables forced auto-updates when true" do
-        expect(already_tapped_tap).to be_installed
-        already_tapped_tap.install force_auto_update: true
-        expect(already_tapped_tap.config[:forceautoupdate]).to be true
-      end
-
-      it "disables forced auto-updates when false" do
-        expect(already_tapped_tap).to be_installed
-        already_tapped_tap.install force_auto_update: false
-        expect(already_tapped_tap.config[:forceautoupdate]).to be_nil
-      end
-    end
-
     specify "Git error" do
       tap = described_class.fetch("user", "repo")
 


### PR DESCRIPTION
- Output a message every time auto-update is run rather than a 3 second timer. This makes it more obvious that Homebrew isn't just sitting doing nothing for 2.9 seconds.
- Output a message when running `brew update` so Homebrew doesn't just sit there silently doing nothing.
- Update all taps when `brew update` is run, not just those hosted on GitHub. This makes it more obvious that people don't need to explictly run `brew update` "just in case".
- As a result of this, remove `brew tap --force-auto-update` as it's no longer necessary.
