### PR TITLE
actionlint.yaml: remove workaround for `macos-14`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,9 +1,6 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
-  labels:
-    # TODO: technically not a self-hosted runner but avoids errors until a new
-    # version of actionlint is released.
-    - macos-14
+  labels: []
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is no longer needed after actionlint [1.6.27](https://github.com/rhysd/actionlint/releases/tag/v1.6.27) was released on 24 Feb 2024 with the fix in https://github.com/rhysd/actionlint/pull/392. The formula in homebrew-core and its bottles were updated to 1.6.27 on 24 Feb 2024.

This partially reverts commit https://github.com/Homebrew/brew/commit/3c32efaad95fb0efb8f2986b11e0724383e741a5:
> - Pretend `macos-14` is a self-hosted runner until a new version of `actionlint` is released which doesn't error on `macos-14`.