### PR TITLE
cleaner: remove RECORD and modify INSTALLER

### DIFF
--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -155,6 +155,52 @@ RSpec.describe Cleaner do
       expect(arch_file).not_to exist
       expect(name_file).to exist
     end
+
+    it "removes '*.dist-info/direct_url.json' files" do
+      dir = f.lib/"python3.12/site-packages/test.dist-info"
+      file = dir/"direct_url.json"
+      unrelated_file = dir/"METADATA"
+      unrelated_dir_file = f.lib/"direct_url.json"
+
+      dir.mkpath
+      touch file
+      touch unrelated_file
+      touch unrelated_dir_file
+
+      cleaner.clean
+
+      expect(file).not_to exist
+      expect(unrelated_file).to exist
+      expect(unrelated_dir_file).to exist
+    end
+
+    it "removes '*.dist-info/RECORD' files" do
+      dir = f.lib/"python3.12/site-packages/test.dist-info"
+      file = dir/"RECORD"
+      unrelated_file = dir/"METADATA"
+      unrelated_dir_file = f.lib/"RECORD"
+
+      dir.mkpath
+      touch file
+      touch unrelated_file
+      touch unrelated_dir_file
+
+      cleaner.clean
+
+      expect(file).not_to exist
+      expect(unrelated_file).to exist
+      expect(unrelated_dir_file).to exist
+    end
+
+    it "modifies '*.dist-info/INSTALLER' files" do
+      file = f.lib/"python3.12/site-packages/test.dist-info/INSTALLER"
+      file.dirname.mkpath
+      file.write "pip\n"
+
+      cleaner.clean
+
+      expect(file.read).to eq "brew\n"
+    end
   end
 
   describe "::skip_clean" do


### PR DESCRIPTION
EDIT: Updated contents to match latest commit

According to [Python specification][1], we should remove `RECORD` file
to prevent changes to installed formula files via other tools, e.g. pip.
This also improves chances of generating an `all` bottle as it avoids
diff due to checksums of HOMEBREW_PREFIX present files. Also modify
`INSTALLER` file to indicate that brew is managing the Python package.

[1]: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#intentionally-preventing-changes-to-installed-packages

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

```console
❯ brew bottle --json --only-json-tab asciidoc
==> Determining asciidoc bottle rebuild...
==> Bottling asciidoc--10.2.0.arm64_sonoma.bottle.7.tar.gz...
./asciidoc--10.2.0.arm64_sonoma.bottle.7.tar.gz
  bottle do
    rebuild 7
    sha256 cellar: :any_skip_relocation, arm64_sonoma: "397fc8b36e3079d3f387c91a9df61d0314f34c26f98c4dcebf44b13a0498d648"
  end

❯ brew fetch -q asciidoc
SHA256: 215cdd544ce3046f58f868347c476c8fa83b3391b2a700e6ddd1f9b65b0e9c4f

❯ diffoscope $(brew --cache -q asciidoc) asciidoc--10.2.0.arm64_sonoma.bottle.7.tar.gz
--- /Users/cho-m/Library/Caches/Homebrew/downloads/0dc87f8a307fb752c8a06de20d603793dcd2d4a2aab76dcbf6085012327a2507--asciidoc--10.2.0.arm64_sonoma.bottle.6.tar.gz
+++ asciidoc--10.2.0.arm64_sonoma.bottle.7.tar.gz
│   --- 0dc87f8a307fb752c8a06de20d603793dcd2d4a2aab76dcbf6085012327a2507--asciidoc--10.2.0.arm64_sonoma.bottle.6.tar
├── +++ asciidoc--10.2.0.arm64_sonoma.bottle.7.tar
│ ├── file list
│ │ @@ -142,15 +142,14 @@
│ │  -rw-r--r--   0        0        0    11241 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc/resources/themes/flask/flask.css
│ │  drwxr-xr-x   0        0        0        0 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc/resources/themes/volnitsky/
│ │  -rw-r--r--   0        0        0     8043 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc/resources/themes/volnitsky/volnitsky.css
│ │  -rw-r--r--   0        0        0     1954 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc/resources/xhtml11-quirks.conf
│ │  -rw-r--r--   0        0        0    23017 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc/resources/xhtml11.conf
│ │  -rw-r--r--   0        0        0     5810 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc/utils.py
│ │  drwxr-xr-x   0        0        0        0 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/
│ │ --rw-r--r--   0        0        0        4 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/INSTALLER
│ │ +-rw-r--r--   0        0        0        5 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/INSTALLER
│ │  -rw-r--r--   0        0        0     3103 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/METADATA
│ │ --rw-r--r--   0        0        0    11135 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/RECORD
│ │  -rw-r--r--   0        0        0        0 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/REQUESTED
│ │  -rw-r--r--   0        0        0       92 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/WHEEL
│ │  -rw-r--r--   0        0        0       74 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/entry_points.txt
│ │  -rw-r--r--   0        0        0        9 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/top_level.txt
│ │  -rw-r--r--   0        0        0      361 2022-05-22 17:07:31.000000 asciidoc/10.2.0/libexec/pyvenv.cfg
│ ├── asciidoc/10.2.0/libexec/lib/python3.12/site-packages/asciidoc-10.2.0.dist-info/INSTALLER
│ │ @@ -1 +1 @@
│ │ -pip
│ │ +brew

❯
```
