### PR TITLE
cask: always return short cask tokens from core cask tap

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1060,6 +1060,12 @@ class AbstractCoreTap < Tap
   end
 
   # @private
+  sig { params(file: Pathname).returns(String) }
+  def formula_file_to_name(file)
+    file.basename(".rb").to_s
+  end
+
+  # @private
   sig { override.returns(T::Boolean) }
   def should_report_analytics?
     return super if Homebrew::EnvConfig.no_install_from_api?
@@ -1227,12 +1233,6 @@ class CoreTap < AbstractCoreTap
       ensure_installed!
       super
     end
-  end
-
-  # @private
-  sig { params(file: Pathname).returns(String) }
-  def formula_file_to_name(file)
-    file.basename(".rb").to_s
   end
 
   # @private

--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -14,12 +14,14 @@ module Homebrew
       Homebrew.with_no_api_env do
         @name                      = tap.name
         @path                      = tap.path
-        @cask_tokens               = tap.cask_tokens
         @tap_audit_exceptions      = tap.audit_exceptions
         @tap_style_exceptions      = tap.style_exceptions
         @tap_pypi_formula_mappings = tap.pypi_formula_mappings
         @problems                  = []
 
+        @cask_tokens = tap.cask_tokens.map do |cask_token|
+          cask_token.split("/").last
+        end
         @formula_aliases = tap.aliases.map do |formula_alias|
           formula_alias.split("/").last
         end
@@ -83,7 +85,7 @@ module Homebrew
       invalid_formulae_casks = list.select do |formula_or_cask_name|
         formula_names.exclude?(formula_or_cask_name) &&
           formula_aliases.exclude?(formula_or_cask_name) &&
-          cask_tokens.exclude?("#{@name}/#{formula_or_cask_name}")
+          cask_tokens.exclude?(formula_or_cask_name)
       end
 
       return if invalid_formulae_casks.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For some reason `Tap#formula_names` returns the short name while `Tap#cask_tokens` returns the full name for some reason. I'd overlooked that when generating the internal JSON. ~This just gets the short name for casks from the casks themselves.~

```rb
brew(main):004:0> ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
=> "1"
brew(main):005:0> CoreCaskTap.instance.cask_tokens.sample(5)
=> ["homebrew/cask/ssh-config-editor", "homebrew/cask/deskpad", "homebrew/cask/zoom-for-it-admins", "homebrew/cask/ukelele", "homebrew/cask/baiduinput"]
brew(main):006:0> CoreTap.instance.formula_names.sample(5)
=> ["lilv", "libccd", "chmlib", "mpfrcx", "cgit"]
brew(main):007:0> :deskpad.c.token
=> "deskpad"
```

Edit: Based on code review we've decided to change the behavior of `CoreCaskTap.instance.cask_tokens` to always return the short tokens. This matches the behavior when the core cask tap is loaded from the API. The other bug with `brew untap` is being handled in a separate PR: https://github.com/Homebrew/brew/pull/16875