### PR TITLE
docs: remove some system Python notes

### DIFF
--- a/docs/Gems,-Eggs-and-Perl-Modules.md
+++ b/docs/Gems,-Eggs-and-Perl-Modules.md
@@ -1,14 +1,13 @@
 # Gems, Eggs and Perl Modules
 
-On a fresh macOS installation there are three empty directories for
+On a fresh macOS installation there are two empty directories for
 add-ons available to all users:
 
 * `/Library/Ruby`
-* `/Library/Python`
 * `/Library/Perl`
 
-You need sudo to install to these like so: `sudo gem install`,
-`sudo easy_install` or `sudo cpan -i`.
+You need sudo to install to these like so: `sudo gem install`
+or `sudo cpan -i`.
 
 ## Python packages (eggs) without sudo using system Python
 

--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -6,7 +6,7 @@ Homebrew will install the necessary Python 3 version that is needed to make your
 
 ## Python 3
 
-Homebrew provides formulae for the newest and maintained releases of Python 3 (`python@3.y`) (https://devguide.python.org/versions/).
+Homebrew provides formulae for the newest and maintained releases of Python 3 (`python@3.y`) (<https://devguide.python.org/versions/>).
 We keep older `python@3.y` versions according to our [versioned formulae guidelines](https://docs.brew.sh/Versions).
 
 **Important:** Python may be upgraded to a newer version at any time. Consider using a version
@@ -68,15 +68,11 @@ The reasoning for this location is to preserve your modules between (minor) upgr
 
 Some formulae provide Python bindings.
 
-**Warning!** Python may crash (see [Common Issues](Common-Issues.md)) when you `import <module>` from a brewed Python if you ran `brew install <formula_with_python_bindings>` against the system Python. If you decide to switch to the brewed Python, then reinstall all formulae with Python bindings (e.g. `pyside`, `wxwidgets`, `pyqt`, `pygobject3`, `opencv`, `vtk` and `boost-python`).
-
 ## Policy for non-brewed Python bindings
 
 These should be installed via `pip install <package>`. To discover, you can use <https://pypi.org/search>.
 
 Starting with Python 3.12, we highly recommend you to use a separate virtualenv for this (see the section about [PEP 668](https://peps.python.org/pep-0668/#marking-an-interpreter-as-using-an-external-package-manager) below).
-
-**Note:** macOS's system Python does not provide `pip`. Follow the [pip documentation](https://pip.pypa.io/en/stable/installation/) to install it for your system Python if you would like it.
 
 ## Brewed Python modules
 
@@ -88,11 +84,7 @@ Since the system Python may not know which compiler flags to set when building b
 CFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib" pip install <package>
 ```
 
-**Warning!** When you `brew install` formulae that provide Python bindings, you should **not be in an active virtual environment.**
-
-Activate the virtualenv *after* you have installed your package with brew, or install brew's packages in a fresh terminal window. This will ensure Python modules are installed into Homebrew's `site-packages` and *not* into that of the virtual environment.
-
-## PEP 668 (Python@3.12) and virtualenvs
+## PEP 668 (Python@3.12) and virtual environments
 
 Starting with Python@3.12, Homebrew follows [PEP 668](https://peps.python.org/pep-0668/#marking-an-interpreter-as-using-an-external-package-manager).
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Last system Python was Monterey 12.2. For last 3 supported macOS, it is possible to still have system Python if user is on Monterey and never upgraded to 12.3+, but I think we can phase out these comments.