### PR TITLE
cleanup: remove broken symlink for uninstalled migrated Casks

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -634,6 +634,20 @@ module Homebrew
         end
       end
 
+      require "cask/caskroom"
+      if Cask::Caskroom.path.directory?
+        Cask::Caskroom.path.each_child do |path|
+          path.extend(ObserverPathnameExtension)
+          next if !path.symlink? || path.resolved_path_exists?
+
+          if dry_run?
+            puts "Would remove (broken link): #{path}"
+          else
+            path.unlink
+          end
+        end
+      end
+
       return if dry_run?
 
       return if ObserverPathnameExtension.total.zero?

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -163,6 +163,20 @@ RSpec.describe Homebrew::Cleanup do
         expect(grandchild_dir).to exist
       end
     end
+
+    it "removes broken symlinks for uninstalled migrated Casks" do
+      caskroom = Cask::Caskroom.path
+      old_cask_dir = caskroom/"old"
+      new_cask_dir = caskroom/"new"
+      unrelated_cask_dir = caskroom/"other"
+      unrelated_cask_dir.mkpath
+      FileUtils.ln_s new_cask_dir, old_cask_dir
+
+      cleanup.prune_prefix_symlinks_and_directories
+      expect(unrelated_cask_dir).to exist
+      expect(old_cask_dir).not_to be_a_symlink
+      expect(old_cask_dir).not_to exist
+    end
   end
 
   specify "::cleanup_formula" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Draft to rebase after #16871

Currently, if there is a cask_rename and user does `brew migrate <cask>` then `brew uninstall <cask>`, we leave behind a broken symlink in the Caskroom.

As far as I can tell, this requires a manual deletion. `--prune=all` / `--prune-prefix` doesn't handle Caskroom.

Not sure if possible to handle during `brew uninstall` so just went with adding additional symlink check in `brew cleanup`. I didn't do any empty directory removal and only left logic as direct symlinks inside Caskroom.