### PR TITLE
Fix untap cmd bugs

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -1,7 +1,8 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "cli/parser"
+require "untap"
 
 module Homebrew
   sig { returns(CLI::Parser) }
@@ -25,8 +26,8 @@ module Homebrew
       odie "Untapping #{tap} is not allowed" if tap.core_tap? && Homebrew::EnvConfig.no_install_from_api?
 
       if Homebrew::EnvConfig.no_install_from_api? || (!tap.core_tap? && !tap.core_cask_tap?)
-        installed_tap_formulae = installed_formulae_for(tap: tap)
-        installed_tap_casks = installed_casks_for(tap: tap)
+        installed_tap_formulae = Untap.installed_formulae_for(tap:)
+        installed_tap_casks = Untap.installed_casks_for(tap:)
 
         if installed_tap_formulae.present? || installed_tap_casks.present?
           installed_names = (installed_tap_formulae + installed_tap_casks.map(&:token)).join("\n")
@@ -46,49 +47,5 @@ module Homebrew
 
       tap.uninstall manual: true
     end
-  end
-
-  sig { params(tap: Tap).returns(T::Array[Formula]) }
-  def self.installed_formulae_for(tap:)
-    tap.formula_names.filter_map do |formula_name|
-      next unless installed_formulae_names.include?(T.must(formula_name.split("/").last))
-
-      formula = begin
-        Formulary.factory(formula_name)
-      rescue
-        # Don't blow up because of a single unavailable formula.
-        next
-      end
-
-      # Can't use Formula#any_version_installed? because it doesn't consider
-      # taps correctly.
-      formula if formula.installed_kegs.any? { |keg| keg.tab.tap == tap }
-    end
-  end
-
-  sig { returns(T::Set[String]) }
-  def self.installed_formulae_names
-    @installed_formulae_names ||= Formula.installed_formula_names.to_set
-  end
-
-  sig { params(tap: Tap).returns(T::Array[Cask::Cask]) }
-  def self.installed_casks_for(tap:)
-    tap.cask_tokens.filter_map do |cask_token|
-      next unless installed_cask_tokens.include?(T.must(cask_token.split("/").last))
-
-      cask = begin
-        Cask::CaskLoader.load(cask_token)
-      rescue
-        # Don't blow up because of a single unavailable cask.
-        next
-      end
-
-      cask if cask.installed?
-    end
-  end
-
-  sig { returns(T::Set[String]) }
-  def self.installed_cask_tokens
-    @installed_cask_tokens ||= Cask::Caskroom.tokens.to_set
   end
 end

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -31,10 +31,10 @@ module Homebrew
         installed_tap_formulae = tap.formula_names.filter_map do |formula_name|
           # initialise lazily in case there's no formulae in this tap
           installed_formula_names ||= Set.new(Formula.installed_formula_names)
-          next unless installed_formula_names.include?(formula_name)
+          next unless installed_formula_names.include?(formula_name.split("/").last)
 
           formula = begin
-            Formulary.factory("#{tap.name}/#{formula_name}")
+            Formulary.factory(formula_name)
           rescue
             # Don't blow up because of a single unavailable formula.
             next
@@ -49,10 +49,10 @@ module Homebrew
         installed_tap_casks = tap.cask_tokens.filter_map do |cask_token|
           # initialise lazily in case there's no casks in this tap
           installed_cask_tokens ||= Set.new(Cask::Caskroom.tokens)
-          next unless installed_cask_tokens.include?(cask_token)
+          next unless installed_cask_tokens.include?(cask_token.split("/").last)
 
           cask = begin
-            Cask::CaskLoader.load("#{tap.name}/#{cask_token}")
+            Cask::CaskLoader.load(cask_token)
           rescue
             # Don't blow up because of a single unavailable cask.
             next

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -5,8 +5,9 @@ require "formulary"
 module Test
   module Helper
     module Formula
-      def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, &block)
-        Class.new(::Formula, &block).new(name, path, spec, alias_path:)
+      def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, tap: nil,
+                  &block)
+        Class.new(::Formula, &block).new(name, path, spec, alias_path:, tap:)
       end
 
       # Use a stubbed {Formulary::FormulaLoader} to make a given formula be found

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -129,7 +129,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
     end
   end
 
-  def setup_test_formula(name, content = nil, bottle_block: nil)
+  def setup_test_formula(name, content = nil, tap: CoreTap.instance, bottle_block: nil)
     case name
     when /^testball/
       tarball = if OS.linux?
@@ -174,14 +174,14 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
       RUBY
     end
 
-    Formulary.core_path(name).tap do |formula_path|
+    Formulary.find_formula_in_tap(name.downcase, tap).tap do |formula_path|
       formula_path.write <<~RUBY
         class #{Formulary.class_s(name)} < Formula
         #{content.gsub(/^(?!$)/, "  ")}
         end
       RUBY
 
-      CoreTap.instance.clear_cache
+      tap.clear_cache
     end
   end
 

--- a/Library/Homebrew/test/untap_spec.rb
+++ b/Library/Homebrew/test/untap_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "untap"
+
+RSpec.describe Homebrew::Untap do
+  describe ".installed_formulae_for" do
+    shared_examples "finds installed formulae in tap" do
+      def load_formula(name:, with_formula_file: false, mock_install: false)
+        formula = formula(name, tap:) do
+          url "https://brew.sh/foo-1.0.tgz"
+        end
+
+        if with_formula_file
+          class_name = name.split("_").map(&:capitalize).join
+          tap.formula_dir.mkpath
+          (tap.formula_dir/"#{name}.rb").write <<~RUBY
+            class #{class_name} < Formula
+              url "https://brew.sh/foo-1.0.tgz"
+            end
+          RUBY
+        end
+
+        if mock_install
+          keg_path = HOMEBREW_CELLAR/name/"1.2.3"
+          keg_path.mkpath
+
+          tab_path = keg_path/Tab::FILENAME
+          tab_path.write <<~JSON
+            {
+              "source": {
+                "tap": "#{tap}"
+              }
+            }
+          JSON
+        end
+
+        formula
+      end
+
+      let!(:currently_installed_formula) do
+        load_formula(name: "current_install", with_formula_file: true, mock_install: true)
+      end
+
+      before do
+        # Formula that is available from a tap but not installed.
+        load_formula(name: "no_install", with_formula_file: true)
+
+        # Formula that was installed from a tap but is no longer available from that tap.
+        load_formula(name: "legacy_install", mock_install: true)
+
+        tap.clear_cache
+      end
+
+      it "returns the expected formulae" do
+        expect(described_class.installed_formulae_for(tap:).map(&:full_name))
+          .to eq([currently_installed_formula.full_name])
+      end
+    end
+
+    context "with core tap" do
+      let(:tap) { CoreTap.instance }
+
+      include_examples "finds installed formulae in tap"
+    end
+
+    context "with non-core tap" do
+      let(:tap) { Tap.fetch("homebrew", "foo") }
+
+      include_examples "finds installed formulae in tap"
+    end
+  end
+
+  describe ".installed_casks_for" do
+    shared_examples "finds installed casks in tap" do
+      def load_cask(token:, with_cask_file: false, mock_install: false)
+        cask_loader = Cask::CaskLoader::FromContentLoader.new(<<~RUBY, tap:)
+          cask '#{token}' do
+            version "1.2.3"
+            sha256 :no_check
+
+            url 'https://brew.sh/'
+          end
+        RUBY
+
+        cask = cask_loader.load(config: nil)
+
+        if with_cask_file
+          cask_path = tap.cask_dir/"#{token}.rb"
+          cask_path.parent.mkpath
+          cask_path.write cask.source
+        end
+
+        if mock_install
+          metadata_subdirectory = cask.metadata_subdir("Casks", timestamp: :now, create: true)
+          (metadata_subdirectory/"#{token}.rb").write cask.source
+        end
+
+        cask
+      end
+
+      let!(:currently_installed_cask) do
+        load_cask(token: "current_install", with_cask_file: true, mock_install: true)
+      end
+
+      before do
+        # Cask that is available from a tap but not installed.
+        load_cask(token: "no_install", with_cask_file: true)
+
+        # Cask that was installed from a tap but is no longer available from that tap.
+        load_cask(token: "legacy_install", mock_install: true)
+      end
+
+      it "returns the expected casks" do
+        expect(described_class.installed_casks_for(tap:)).to eq([currently_installed_cask])
+      end
+    end
+
+    context "with core cask tap" do
+      let(:tap) { CoreCaskTap.instance }
+
+      include_examples "finds installed casks in tap"
+    end
+
+    context "with non-core cask tap" do
+      let(:tap) { Tap.fetch("homebrew", "foo") }
+
+      include_examples "finds installed casks in tap"
+    end
+  end
+end

--- a/Library/Homebrew/untap.rb
+++ b/Library/Homebrew/untap.rb
@@ -1,10 +1,14 @@
 # typed: true
 # frozen_string_literal: true
 
+require "extend/cachable"
+
 module Homebrew
   # Helpers for the `brew untap` command.
   # @api private
   module Untap
+    extend Cachable
+
     # All installed formulae currently available in a tap by formula full name.
     sig { params(tap: Tap).returns(T::Array[Formula]) }
     def self.installed_formulae_for(tap:)
@@ -26,7 +30,7 @@ module Homebrew
 
     sig { returns(T::Set[String]) }
     def self.installed_formulae_names
-      @installed_formulae_names ||= Formula.installed_formula_names.to_set.freeze
+      cache[:installed_formulae_names] ||= Formula.installed_formula_names.to_set.freeze
     end
     private_class_method :installed_formulae_names
 
@@ -49,7 +53,7 @@ module Homebrew
 
     sig { returns(T::Set[String]) }
     def self.installed_cask_tokens
-      @installed_cask_tokens ||= Cask::Caskroom.tokens.to_set.freeze
+      cache[:installed_cask_tokens] ||= Cask::Caskroom.tokens.to_set.freeze
     end
     private_class_method :installed_cask_tokens
   end

--- a/Library/Homebrew/untap.rb
+++ b/Library/Homebrew/untap.rb
@@ -1,0 +1,56 @@
+# typed: true
+# frozen_string_literal: true
+
+module Homebrew
+  # Helpers for the `brew untap` command.
+  # @api private
+  module Untap
+    # All installed formulae currently available in a tap by formula full name.
+    sig { params(tap: Tap).returns(T::Array[Formula]) }
+    def self.installed_formulae_for(tap:)
+      tap.formula_names.filter_map do |formula_name|
+        next unless installed_formulae_names.include?(T.must(formula_name.split("/").last))
+
+        formula = begin
+          Formulary.factory(formula_name)
+        rescue
+          # Don't blow up because of a single unavailable formula.
+          next
+        end
+
+        # Can't use Formula#any_version_installed? because it doesn't consider
+        # taps correctly.
+        formula if formula.installed_kegs.any? { |keg| keg.tab.tap == tap }
+      end
+    end
+
+    sig { returns(T::Set[String]) }
+    def self.installed_formulae_names
+      @installed_formulae_names ||= Formula.installed_formula_names.to_set.freeze
+    end
+    private_class_method :installed_formulae_names
+
+    # All installed casks currently available in a tap by cask full name.
+    sig { params(tap: Tap).returns(T::Array[Cask::Cask]) }
+    def self.installed_casks_for(tap:)
+      tap.cask_tokens.filter_map do |cask_token|
+        next unless installed_cask_tokens.include?(T.must(cask_token.split("/").last))
+
+        cask = begin
+          Cask::CaskLoader.load(cask_token)
+        rescue
+          # Don't blow up because of a single unavailable cask.
+          next
+        end
+
+        cask if cask.installed?
+      end
+    end
+
+    sig { returns(T::Set[String]) }
+    def self.installed_cask_tokens
+      @installed_cask_tokens ||= Cask::Caskroom.tokens.to_set.freeze
+    end
+    private_class_method :installed_cask_tokens
+  end
+end

--- a/Library/Homebrew/untap.rb
+++ b/Library/Homebrew/untap.rb
@@ -17,7 +17,7 @@ module Homebrew
 
         formula = begin
           Formulary.factory(formula_name)
-        rescue
+        rescue FormulaUnavailableError
           # Don't blow up because of a single unavailable formula.
           next
         end
@@ -42,7 +42,7 @@ module Homebrew
 
         cask = begin
           Cask::CaskLoader.load(cask_token)
-        rescue
+        rescue Cask::CaskUnavailableError
           # Don't blow up because of a single unavailable cask.
           next
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This bug was found when reviewing https://github.com/Homebrew/brew/pull/16867.

The warning for installed formulae or casks in `brew untap` wasn't working before for a few reasons.

1. It never got past the installed name check because the
installed name sets had short names and the tap names were
long names including the tap namespace too. Now we just trim the
long name before comparing it to the installed name set.

Before:

```
["name"].include?("tap/full/name") # always false
```

After:

```
["name"].include("tap/full/name".split("/").last) # sometimes true
```

2. The names we were trying to load formulae and casks with
were incorrect.

Before:

```
tap = Tap.fetch("homebrew/cask-versions")
token = "homebrew/cask-versions/token"

cask = Cask::CaskLoader.load("#{tap}/#{token}")
```

After:

```
token = "homebrew/cask-versions/token"
cask = CaskCaskLoader.load(token)
```

---

I tried to keep the commits organized so they're probably best to review in order. The change itself is pretty simple (see the first commit) but adding tests is quite a feat. Let me know if there's some way to simplify the tests without turning them into a bunch of integration tests.

It is not that tough to test that things are working correctly now.

If you have any casks installed, the following line should fail for you.

```console
$ HOMEBREW_NO_INSTALL_FROM_API=1 HOMEBREW_DEVELOPER= brew untap homebrew/cask
Error: Refusing to untap homebrew/cask because it contains the following installed formulae or casks:
discord
iterm2
visual-studio-code
```

Beyond that I installed the candy formula from a third-party tap and made sure that it gave me the appropriate warning when trying to untap the tap with that formula.

```console
$ HOMEBREW_DEVELOPER= brew untap owenthereal/candy
Error: Refusing to untap owenthereal/candy because it contains the following installed formulae or casks:
candy
$ brew uninstall candy
...
$ HOMEBREW_DEVELOPER= brew untap owenthereal/candy
Untapping owenthereal/candy...
Untapped 1 formula (107 files, 60.9KB).
```