### PR TITLE
diagnostic: use FromTapLoader to check 3rd-party formula

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -835,7 +835,7 @@ module Homebrew
 
         deleted_formulae = kegs.filter_map do |keg|
           tap = Tab.for_keg(keg).tap
-          keg_name = tap ? "#{tap}/#{keg.name}" : keg.name
+          tap_keg_name = tap ? "#{tap}/#{keg.name}" : keg.name
 
           loadable = [
             Formulary::FromAPILoader,
@@ -843,7 +843,7 @@ module Homebrew
             Formulary::FromNameLoader,
           ].any? do |loader_class|
             loader = begin
-              loader_class.try_new(keg_name, warn: false)
+              loader_class.try_new(tap_keg_name, warn: false)
             rescue TapFormulaAmbiguityError => e
               e.loaders.first
             end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -835,25 +835,20 @@ module Homebrew
 
         deleted_formulae = kegs.filter_map do |keg|
           tap = Tab.for_keg(keg).tap
+          keg_name = tap ? "#{tap}/#{keg.name}" : keg.name
 
           loadable = [
             Formulary::FromAPILoader,
+            Formulary::FromTapLoader,
             Formulary::FromNameLoader,
           ].any? do |loader_class|
             loader = begin
-              loader_class.try_new(keg.name, warn: false)
+              loader_class.try_new(keg_name, warn: false)
             rescue TapFormulaAmbiguityError => e
               e.loaders.first
             end
 
-            if loader
-              # If we know the tap, ignore all other taps.
-              next false if tap && loader.tap != tap
-
-              next true
-            end
-
-            false
+            loader.instance_of?(Formulary::FromTapLoader) ? loader.path.exist? : loader.present?
           end
 
           keg.name unless loadable


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Might help with https://github.com/Homebrew/brew/issues/16878 when name collision between existing core formula and 3rd party tap.

Seems to work locally for specific example.
```console
❯ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Some installed kegs have no formulae!
This means they were either deleted or installed manually.
You should find replacements for the following formulae:
  packer
```
```console
❯ brew doctor
Your system is ready to brew.
```