### PR TITLE
utils/github: use GraphQL PR searching

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -312,11 +312,7 @@ module Homebrew
       nil
     end
 
-    if pull_requests&.any?
-      pull_requests = pull_requests.map { |pr| "#{pr["title"]} (#{Formatter.url(pr["html_url"])})" }.join(", ")
-    end
-
-    pull_requests
+    pull_requests&.map { |pr| "#{pr["title"]} (#{Formatter.url(pr["html_url"])})" }&.join(", ")
   end
 
   sig {


### PR DESCRIPTION
The search API is restricted to 30/minute, which is too little for our autobump workflow: https://github.com/Homebrew/homebrew-core/actions/runs/8273488630/job/22637346680

However GraphQL searching seems to be higher - it's unclear exactly how high until we try it out. So let's try use it and see if it improves things.

I've also tried to fold the `fetch_open_pull_requests` CI workaround into this, because it's slow (3 seconds), the cache doesn't work in autobump workflows since it's distinct `brew` processes and will be inferior if the new method works. However I do have yet another implementation of `fetch_open_pull_requests` that's still significantly faster than the old one that I can add if we find even the GraphQL search API is not good enough.