### PR TITLE
cask/artifact: check the bundle version when using `--adopt`.

### DIFF
--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -43,7 +43,7 @@ module Cask
 
       private
 
-      def link(force: false, command: nil, **_options)
+      def link(force: false, adopt: false, command: nil, **_options)
         unless source.exist?
           raise CaskError,
                 "It seems the #{self.class.link_type_english_name.downcase} " \
@@ -54,7 +54,7 @@ module Cask
           message = "It seems there is already #{self.class.english_article} " \
                     "#{self.class.english_name} at '#{target}'"
 
-          if force && target.symlink? &&
+          if (force || adopt) && target.symlink? &&
              (target.realpath == source.realpath || target.realpath.to_s.start_with?("#{cask.caskroom_path}/"))
             opoo "#{message}; overwriting."
             Utils.gain_permissions_remove(target, command:)


### PR DESCRIPTION
This makes `--adopt` considerably faster and more useful for application bundles by checking the bundle version before failing to adopt the bundle.

This could be further extended by e.g. checking if auto-updates are enabled.

While we're here, also allow `adopt` to act a bit more like `force` in a few other places assuming this initial check passes.

Can test with e.g. `brew install fork; sudo rm -rf /opt/homebrew/Caskroom/fork; brew install --adopt fork`