### PR TITLE
Add GitHub Actions warning/error annotations for deprecations/disables.

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -130,11 +130,16 @@ on_request: true)
       deprecate_disable_type = DeprecateDisable.type(@cask)
       return if deprecate_disable_type.nil?
 
+      message = DeprecateDisable.message(@cask)
+      message_full = "#{@cask.token} has been #{message}"
+
       case deprecate_disable_type
       when :deprecated
-        opoo "#{@cask.token} has been #{DeprecateDisable.message(@cask)}"
+        puts "::warning #{message_full}" if ENV["GITHUB_ACTIONS"]
+        opoo message_full
       when :disabled
-        raise CaskCannotBeInstalledError.new(@cask, DeprecateDisable.message(@cask))
+        puts "::error #{message_full}" if ENV["GITHUB_ACTIONS"]
+        raise CaskCannotBeInstalledError.new(@cask, message)
       end
     end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -135,10 +135,10 @@ on_request: true)
 
       case deprecate_disable_type
       when :deprecated
-        puts "::warning #{message_full}" if ENV["GITHUB_ACTIONS"]
+        puts "::warning::#{message_full}" if ENV["GITHUB_ACTIONS"]
         opoo message_full
       when :disabled
-        puts "::error #{message_full}" if ENV["GITHUB_ACTIONS"]
+        puts "::error::#{message_full}" if ENV["GITHUB_ACTIONS"]
         raise CaskCannotBeInstalledError.new(@cask, message)
       end
     end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -147,10 +147,12 @@ module Kernel
 
     disable = true if disable_for_developers && Homebrew::EnvConfig.developer?
     if disable || Homebrew.raise_deprecation_exceptions?
+      puts "::error #{message}" if ENV["GITHUB_ACTIONS"]
       exception = MethodDeprecatedError.new(message)
       exception.set_backtrace(backtrace)
       raise exception
     elsif !Homebrew.auditing?
+      puts "::warning #{message}" if ENV["GITHUB_ACTIONS"]
       opoo message
     end
   end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -147,12 +147,12 @@ module Kernel
 
     disable = true if disable_for_developers && Homebrew::EnvConfig.developer?
     if disable || Homebrew.raise_deprecation_exceptions?
-      puts "::error #{message}" if ENV["GITHUB_ACTIONS"]
+      puts "::error::#{message}" if ENV["GITHUB_ACTIONS"]
       exception = MethodDeprecatedError.new(message)
       exception.set_backtrace(backtrace)
       raise exception
     elsif !Homebrew.auditing?
-      puts "::warning #{message}" if ENV["GITHUB_ACTIONS"]
+      puts "::warning::#{message}" if ENV["GITHUB_ACTIONS"]
       opoo message
     end
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -206,8 +206,10 @@ class FormulaInstaller
 
       case deprecate_disable_type
       when :deprecated
+        puts "::warning #{message}" if ENV["GITHUB_ACTIONS"]
         opoo message
       when :disabled
+        puts "::error #{message}" if ENV["GITHUB_ACTIONS"]
         raise CannotInstallFormulaError, message
       end
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -206,10 +206,10 @@ class FormulaInstaller
 
       case deprecate_disable_type
       when :deprecated
-        puts "::warning #{message}" if ENV["GITHUB_ACTIONS"]
+        puts "::warning::#{message}" if ENV["GITHUB_ACTIONS"]
         opoo message
       when :disabled
-        puts "::error #{message}" if ENV["GITHUB_ACTIONS"]
+        puts "::error::#{message}" if ENV["GITHUB_ACTIONS"]
         raise CannotInstallFormulaError, message
       end
     end


### PR DESCRIPTION
This should make these messages, particular warnings, more obvious to GitHub Actions users.

There's an argument perhaps we should do this more broadly for all warning/error messages but: this feels like a good start.

CC @Bo98 as this came out one of our discussions.