### PR TITLE
cask/artifact/moved: fix permission handling when removing directories

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -181,14 +181,8 @@ module Cask
           # If an app folder is deleted, macOS considers the app uninstalled and removes some data.
           # Remove only the contents to handle this case.
           target.children.each do |child|
-            if target.writable? && !force
-              child.rmtree
-            else
-              Utils.gain_permissions_remove(child, command:)
-            end
+            Utils.gain_permissions_remove(child, command:)
           end
-        elsif target.parent.writable? && !force
-          target.rmtree
         else
           Utils.gain_permissions_remove(target, command:)
         end

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Cask::Artifact::App, :cask do
 
       FileUtils.chmod 0544, target_path
 
-      expect { uninstall_phase }.to raise_error(Errno::ENOTEMPTY)
+      uninstall_phase
 
       expect(source_path).to be_a_directory
     end


### PR DESCRIPTION
While `target.parent.writable?` is a sufficient check if we can remove a file or an empty directory, it is insufficient to test whether we can remove the entire directory tree as the directory itself and all non-empty recursive subdirectories will need write permissions. `Utils.gain_permissions_remove` already handles this for us so use it unconditionally.

Note that using `Utils.gain_permissions_remove` doesn't mean that sudo will always be used - it will still try to remove without sudo if possible.