### PR TITLE
Load internal cask json v3

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -297,11 +297,8 @@ module Cask
       @tap_git_head = json_cask.fetch(:tap_git_head, "HEAD")
 
       @ruby_source_path = json_cask[:ruby_source_path]
-      @ruby_source_checksum = if Homebrew::API.internal_json_v3?
-        { "sha256" => json_cask.fetch(:ruby_source_sha256) }
-      else
-        json_cask[:ruby_source_checksum]
-      end
+      @ruby_source_checksum = json_cask[:ruby_source_checksum] || # public JSON v2
+                              json_cask[:ruby_source_sha256]&.then { { "sha256" => _1 } } # internal JSON v3
     end
 
     def to_s

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -362,7 +362,6 @@ module Cask
     # @private
     def to_internal_api_hash
       api_hash = {
-        "token"              => token,
         "name"               => name,
         "desc"               => desc,
         "homepage"           => homepage,

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -299,7 +299,12 @@ module Cask
 
         json_cask = Homebrew::API.merge_variations(json_cask).deep_symbolize_keys.freeze
 
-        cask_options[:tap] = Tap.fetch(json_cask[:tap]) if json_cask[:tap].to_s.include?("/")
+        # We could probably just default to the core cask tap in all cases without problems.
+        cask_options[:tap] = if Homebrew::API.internal_json_v3?
+          CoreCaskTap.instance
+        elsif json_cask[:tap].to_s.include?("/")
+          Tap.fetch(json_cask[:tap])
+        end
 
         user_agent = json_cask.dig(:url_specs, :user_agent)
         json_cask[:url_specs][:user_agent] = user_agent[1..].to_sym if user_agent && user_agent[0] == ":"

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -299,11 +299,11 @@ module Cask
 
         json_cask = Homebrew::API.merge_variations(json_cask).deep_symbolize_keys.freeze
 
-        # We could probably just default to the core cask tap in all cases without problems.
-        cask_options[:tap] = if Homebrew::API.internal_json_v3?
+        cask_options[:tap] = if json_cask.key?(:tap) # public JSON v2
+          tap_value = json_cask.fetch(:tap)
+          Tap.fetch(tap_value) if tap_value.to_s.include?("/")
+        else # internal JSON v3
           CoreCaskTap.instance
-        elsif json_cask[:tap].to_s.include?("/")
-          Tap.fetch(json_cask[:tap])
         end
 
         user_agent = json_cask.dig(:url_specs, :user_agent)

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1380,6 +1380,8 @@ class CoreCaskTap < AbstractCoreTap
   def tap_migrations
     @tap_migrations ||= if Homebrew::EnvConfig.no_install_from_api?
       super
+    elsif Homebrew::API.internal_json_v3?
+      Homebrew::API::Cask.tap_migrations
     else
       migrations, = Homebrew::API.fetch_json_api_file "cask_tap_migrations.jws.json",
                                                       stale_seconds: TAP_MIGRATIONS_STALE_SECONDS

--- a/Library/Homebrew/test/api/internal_tap_json/cask_spec.rb
+++ b/Library/Homebrew/test/api/internal_tap_json/cask_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Internal Tap JSON -- Cask" do
         "ankerslicer"        => "ankermake",
         "autodesk-fusion360" => "autodesk-fusion",
         "betterdummy"        => "betterdisplay",
-        "julia-lang"         => "julia",
+        "factor-lang"        => "factor",
         "smlnj-lang"         => "smlnj",
       })
     end
@@ -67,16 +67,16 @@ RSpec.describe "Internal Tap JSON -- Cask" do
     end
 
     context "when loading formulae" do
-      let(:julia_metadata) do
+      let(:factor_metadata) do
         {
-          "token"                => "julia",
-          "name"                 => %w[Julia],
-          "desc"                 => "Programming language for technical computing",
-          "homepage"             => "https://julialang.org/",
-          "version"              => "1.10.2",
-          "ruby_source_path"     => "Casks/j/julia.rb",
+          "token"                => "factor",
+          "name"                 => %w[Factor],
+          "desc"                 => "Programming language",
+          "homepage"             => "https://factorcode.org/",
+          "version"              => "0.99",
+          "ruby_source_path"     => "Casks/f/factor.rb",
           "ruby_source_checksum" => {
-            "sha256" => "7fbf6c98c0a3b75ca8636c141f38512a899565a58518fc714e5f73c210e24449",
+            "sha256" => "a0dabe24c67269e5310b47639cf32e74f49959ba1be454b2c072805b1f04c7e5",
           },
         }
       end
@@ -95,16 +95,16 @@ RSpec.describe "Internal Tap JSON -- Cask" do
         }
       end
 
-      it "loads julia" do
-        julia = Cask::CaskLoader.load("julia")
-        expect(julia.to_h).to include(julia_metadata)
-        expect(julia.sha256).to eq("26b822154ae05f2c2b66d2b1538e1df86f1bb39967cbc9380a7f2271f5a677ce")
-        expect(julia.url.to_s).to eq("https://julialang-s3.julialang.org/bin/mac/x64/1.10/julia-1.10.2-mac64.dmg")
+      it "loads factor" do
+        factor = Cask::CaskLoader.load("factor")
+        expect(factor.to_h).to include(factor_metadata)
+        expect(factor.sha256).to eq("8a7968b873b5e87c83b5d0f5ddb4d3d76a2460f5e5c14edac6b18fe5957bd7d6")
+        expect(factor.url.to_s).to eq("https://downloads.factorcode.org/releases/0.99/factor-macosx-x86-64-0.99.dmg")
       end
 
-      it "loads julia from rename" do
-        julia = Cask::CaskLoader.load("julia-lang")
-        expect(julia.to_h).to include(**julia_metadata)
+      it "loads factor from rename" do
+        factor = Cask::CaskLoader.load("factor-lang")
+        expect(factor.to_h).to include(**factor_metadata)
       end
 
       it "loads smlnj" do

--- a/Library/Homebrew/test/api/internal_tap_json/cask_spec.rb
+++ b/Library/Homebrew/test/api/internal_tap_json/cask_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+RSpec.describe "Internal Tap JSON -- Cask" do
+  let(:internal_tap_json) { File.read(TEST_FIXTURE_DIR/"internal_tap_json/homebrew-cask.json").chomp }
+  let(:tap_git_head) { "b26c1e550a8b7eed2dcd5306ea8f3da3848258b3" }
+
+  context "when generating JSON", :needs_macos do
+    before do
+      FileUtils.rm_rf CoreCaskTap.instance.path
+      cp_r(TEST_FIXTURE_DIR/"internal_tap_json/homebrew-cask", Tap::TAP_DIRECTORY/"homebrew")
+      allow(Cask::Cask).to receive(:generating_hash?).and_return(true)
+    end
+
+    it "creates the expected hash" do
+      api_hash = CoreCaskTap.instance.to_internal_api_hash
+      api_hash["tap_git_head"] = tap_git_head # tricky to mock
+
+      expect(JSON.pretty_generate(api_hash)).to eq(internal_tap_json)
+    end
+  end
+
+  context "when loading JSON" do
+    before do
+      ENV["HOMEBREW_INTERNAL_JSON_V3"] = "1"
+      ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
+
+      allow(Homebrew::API).to receive(:fetch_json_api_file)
+        .with("internal/v3/homebrew-cask.jws.json")
+        .and_return([JSON.parse(internal_tap_json), false])
+
+      # `Tap.tap_migration_oldnames` looks for renames in every
+      # tap so `CoreTap.tap_migrations` gets called and tries to
+      # fetch stuff from the API. This just avoids errors.
+      allow(Homebrew::API).to receive(:fetch_json_api_file)
+        .with("internal/v3/homebrew-core.jws.json")
+        .and_return([{ "tap_migrations" => {}, "formulae" => {}, "aliases" => {} }, false])
+
+      # To allow `cask_names.txt` to be written to the cache.
+      (HOMEBREW_CACHE/"api").mkdir
+
+      Homebrew::API::Cask.clear_cache
+    end
+
+    it "loads cask renames" do
+      expect(CoreCaskTap.instance.cask_renames).to eq({
+        "ankerslicer"        => "ankermake",
+        "autodesk-fusion360" => "autodesk-fusion",
+        "betterdummy"        => "betterdisplay",
+        "julia-lang"         => "julia",
+        "smlnj-lang"         => "smlnj",
+      })
+    end
+
+    it "loads tap migrations" do
+      expect(CoreCaskTap.instance.tap_migrations).to eq({
+        "azure-cli"  => "homebrew/core",
+        "basex"      => "homebrew/core",
+        "borgbackup" => "homebrew/core",
+        "chronograf" => "homebrew/core",
+        "consul"     => "homebrew/core",
+      })
+    end
+
+    it "loads tap git head" do
+      expect(Homebrew::API::Cask.tap_git_head)
+        .to eq(tap_git_head)
+    end
+
+    context "when loading formulae" do
+      let(:julia_metadata) do
+        {
+          "token"                => "julia",
+          "name"                 => %w[Julia],
+          "desc"                 => "Programming language for technical computing",
+          "homepage"             => "https://julialang.org/",
+          "version"              => "1.10.2",
+          "ruby_source_path"     => "Casks/j/julia.rb",
+          "ruby_source_checksum" => {
+            "sha256" => "7fbf6c98c0a3b75ca8636c141f38512a899565a58518fc714e5f73c210e24449",
+          },
+        }
+      end
+
+      let(:smlnj_metadata) do
+        {
+          "token"                => "smlnj",
+          "name"                 => ["Standard ML of New Jersey"],
+          "desc"                 => "Compiler for the Standard ML '97 programming language",
+          "homepage"             => "https://www.smlnj.org/",
+          "version"              => "110.99.4",
+          "ruby_source_path"     => "Casks/s/smlnj.rb",
+          "ruby_source_checksum" => {
+            "sha256" => "d47f46a88248272314a501741460d42a8c731030912a83ef58d3c7fd1e90034d",
+          },
+        }
+      end
+
+      it "loads julia" do
+        julia = Cask::CaskLoader.load("julia")
+        expect(julia.to_h).to include(julia_metadata)
+        expect(julia.sha256).to eq("26b822154ae05f2c2b66d2b1538e1df86f1bb39967cbc9380a7f2271f5a677ce")
+        expect(julia.url.to_s).to eq("https://julialang-s3.julialang.org/bin/mac/x64/1.10/julia-1.10.2-mac64.dmg")
+      end
+
+      it "loads julia from rename" do
+        julia = Cask::CaskLoader.load("julia-lang")
+        expect(julia.to_h).to include(**julia_metadata)
+      end
+
+      it "loads smlnj" do
+        smlnj = Cask::CaskLoader.load("smlnj")
+        expect(smlnj.to_h).to include(**smlnj_metadata)
+        expect(smlnj.sha256).to eq("2bf858017b8ba43a70b30527290ed9fbbc81d9eaac1abeba62469d95392019a3")
+        expect(smlnj.url.to_s).to eq("http://smlnj.cs.uchicago.edu/dist/working/110.99.4/smlnj-amd64-110.99.4.pkg")
+      end
+
+      it "loads smlnj from rename" do
+        smlnj = Cask::CaskLoader.load("smlnj-lang")
+        expect(smlnj.to_h).to include(**smlnj_metadata)
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
+++ b/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "Internal Tap JSON -- Formula" do
       cp_r(TEST_FIXTURE_DIR/"internal_tap_json/homebrew-core", Tap::TAP_DIRECTORY/"homebrew")
 
       # NOTE: Symlinks can't be copied recursively so we create them manually here.
-      (Tap::TAP_DIRECTORY/"homebrew/homebrew-core").tap do |core_tap|
-        mkdir(core_tap/"Aliases")
-        ln_s(core_tap/"Formula/f/fennel.rb", core_tap/"Aliases/fennel-lang")
-        ln_s(core_tap/"Formula/p/ponyc.rb", core_tap/"Aliases/ponyc-lang")
+      CoreTap.instance.path.tap do |core_tap_path|
+        mkdir(core_tap_path/"Aliases")
+        ln_s(core_tap_path/"Formula/f/fennel.rb", core_tap_path/"Aliases/fennel-lang")
+        ln_s(core_tap_path/"Formula/p/ponyc.rb", core_tap_path/"Aliases/ponyc-lang")
       end
     end
 
@@ -37,16 +37,12 @@ RSpec.describe "Internal Tap JSON -- Formula" do
       # tap so `CoreCaskTap.tap_migrations` gets called and tries to
       # fetch stuff from the API. This just avoids errors.
       allow(Homebrew::API).to receive(:fetch_json_api_file)
-        .with("cask_tap_migrations.jws.json", anything)
-        .and_return([{}, false])
+        .with("internal/v3/homebrew-cask.jws.json")
+        .and_return([{ "tap_migrations" => {}, "casks" => {} }, false])
 
       # To allow `formula_names.txt` to be written to the cache.
       (HOMEBREW_CACHE/"api").mkdir
 
-      Homebrew::API::Formula.clear_cache
-    end
-
-    after do
       Homebrew::API::Formula.clear_cache
     end
 

--- a/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask.json
+++ b/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask.json
@@ -1,0 +1,76 @@
+{
+  "tap_git_head": "b26c1e550a8b7eed2dcd5306ea8f3da3848258b3",
+  "renames": {
+    "ankerslicer": "ankermake",
+    "autodesk-fusion360": "autodesk-fusion",
+    "betterdummy": "betterdisplay",
+    "factor-lang": "factor",
+    "smlnj-lang": "smlnj"
+  },
+  "tap_migrations": {
+    "azure-cli": "homebrew/core",
+    "basex": "homebrew/core",
+    "borgbackup": "homebrew/core",
+    "chronograf": "homebrew/core",
+    "consul": "homebrew/core"
+  },
+  "casks": {
+    "factor": {
+      "name": [
+        "Factor"
+      ],
+      "desc": "Programming language",
+      "homepage": "https://factorcode.org/",
+      "url": "https://downloads.factorcode.org/releases/0.99/factor-macosx-x86-64-0.99.dmg",
+      "version": "0.99",
+      "sha256": "8a7968b873b5e87c83b5d0f5ddb4d3d76a2460f5e5c14edac6b18fe5957bd7d6",
+      "artifacts": [
+        {
+          "suite": [
+            "factor"
+          ]
+        }
+      ],
+      "ruby_source_path": "Casks/f/factor.rb",
+      "ruby_source_sha256": "a0dabe24c67269e5310b47639cf32e74f49959ba1be454b2c072805b1f04c7e5",
+      "caveats": "To use factor, you may need to add the $APPDIR/factor directory\nto your PATH environment variable, e.g. (for Bash shell):\n  export PATH=$APPDIR/factor:\"$PATH\"\n"
+    },
+    "smlnj": {
+      "name": [
+        "Standard ML of New Jersey"
+      ],
+      "desc": "Compiler for the Standard ML '97 programming language",
+      "homepage": "https://www.smlnj.org/",
+      "url": "http://smlnj.cs.uchicago.edu/dist/working/110.99.4/smlnj-amd64-110.99.4.pkg",
+      "version": "110.99.4",
+      "sha256": "2bf858017b8ba43a70b30527290ed9fbbc81d9eaac1abeba62469d95392019a3",
+      "artifacts": [
+        {
+          "uninstall": [
+            {
+              "pkgutil": "org.smlnj.amd64.pkg"
+            }
+          ]
+        },
+        {
+          "pkg": [
+            "smlnj-amd64-110.99.4.pkg"
+          ]
+        },
+        {
+          "zap": [
+            {
+              "delete": "/usr/local/smlnj"
+            }
+          ]
+        }
+      ],
+      "ruby_source_path": "Casks/s/smlnj.rb",
+      "ruby_source_sha256": "d47f46a88248272314a501741460d42a8c731030912a83ef58d3c7fd1e90034d",
+      "url_specs": {
+        "verified": "smlnj.cs.uchicago.edu/"
+      },
+      "caveats": "To use smlnj, you may need to add the /usr/local/smlnj/bin directory\nto your PATH environment variable, e.g. (for Bash shell):\n  export PATH=/usr/local/smlnj/bin:\"$PATH\"\n"
+    }
+  }
+}

--- a/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/Casks/f/factor.rb
+++ b/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/Casks/f/factor.rb
@@ -1,0 +1,20 @@
+cask "factor" do
+  version "0.99"
+  sha256 "8a7968b873b5e87c83b5d0f5ddb4d3d76a2460f5e5c14edac6b18fe5957bd7d6"
+
+  url "https://downloads.factorcode.org/releases/#{version}/factor-macosx-x86-64-#{version}.dmg"
+  name "Factor"
+  desc "Programming language"
+  homepage "https://factorcode.org/"
+
+  livecheck do
+    url "https://downloads.factorcode.org/releases/"
+    regex(%r{href=.*?(\d+(?:\.\d+)+)/}i)
+  end
+
+  suite "factor"
+
+  caveats do
+    path_environment_variable "#{appdir}/factor"
+  end
+end

--- a/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/Casks/s/smlnj.rb
+++ b/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/Casks/s/smlnj.rb
@@ -1,0 +1,25 @@
+cask "smlnj" do
+  version "110.99.4"
+  sha256 "2bf858017b8ba43a70b30527290ed9fbbc81d9eaac1abeba62469d95392019a3"
+
+  url "http://smlnj.cs.uchicago.edu/dist/working/#{version}/smlnj-amd64-#{version}.pkg",
+      verified: "smlnj.cs.uchicago.edu/"
+  name "Standard ML of New Jersey"
+  desc "Compiler for the Standard ML '97 programming language"
+  homepage "https://www.smlnj.org/"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=.*?/smlnj-amd64-(\d+(?:\.\d+)*)\.pkg}i)
+  end
+
+  pkg "smlnj-amd64-#{version}.pkg"
+
+  uninstall pkgutil: "org.smlnj.amd64.pkg"
+
+  zap delete: "/usr/local/smlnj"
+
+  caveats do
+    path_environment_variable "/usr/local/smlnj/bin"
+  end
+end

--- a/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/cask_renames.json
+++ b/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/cask_renames.json
@@ -1,0 +1,7 @@
+{
+  "ankerslicer": "ankermake",
+  "autodesk-fusion360": "autodesk-fusion",
+  "betterdummy": "betterdisplay",
+  "factor-lang": "factor",
+  "smlnj-lang": "smlnj"
+}

--- a/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/tap_migrations.json
+++ b/Library/Homebrew/test/support/fixtures/internal_tap_json/homebrew-cask/tap_migrations.json
@@ -1,0 +1,7 @@
+{
+  "azure-cli": "homebrew/core",
+  "basex": "homebrew/core",
+  "borgbackup": "homebrew/core",
+  "chronograf": "homebrew/core",
+  "consul": "homebrew/core"
+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is the follow-up to https://github.com/Homebrew/brew/pull/16798 where we start loading the cask from the new JSON API. It ended up being quite similar in to what I did in https://github.com/Homebrew/brew/pull/16638 a few weeks ago.