### PR TITLE
utils/pypi: allow overwriting resource patches

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -370,7 +370,18 @@ module PyPI
       new_resource_blocks += "  def install"
     else
       # Replace existing resource blocks with new resource blocks
-      inreplace_regex = /  (resource .* do\s+url .*\s+sha256 .*\s+ end\s*)+/
+      inreplace_regex = /
+        \ \ (
+        resource\ .*\ do\s+
+          url\ .*\s+
+          sha256\ .*\s+
+          ((\#.*\s+)*
+          patch\ (.*\ )?do\s+
+            url\ .*\s+
+            sha256\ .*\s+
+          end\s+)*
+        end\s+)+
+      /x
       new_resource_blocks += "  "
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Mainly to prevent autobump from failing whenever we have patched resources. This allows PR to be created and then a maintainer may need to restore patch. Not too different than what we might manually do (i.e. remove patch, `brew update-python-resources ...`, re-apply patch).

Can consider carrying over patches on identical versions later on.

---

One example usage is `dvc` after https://github.com/Homebrew/homebrew-core/pull/166343

Before:
```console
❯ brew update-python-resources dvc
==> Retrieving PyPI dependencies for "dvc[all]==3.48.4"...
==> Retrieving PyPI dependencies for excluded "certifi cryptography numpy"...
==> Getting PyPI info for "adlfs==2024.2.0"
==> Getting PyPI info for "aiobotocore==2.12.1"
...
==> Getting PyPI info for "zc-lockfile==3.0.post1"
==> Updating resource blocks
Error: Unable to update resource blocks for "dvc" automatically. Please update them manually.
```

After:
```console
❯ brew update-python-resources dvc
==> Retrieving PyPI dependencies for "dvc[all]==3.48.4"...
==> Retrieving PyPI dependencies for excluded "certifi cryptography numpy"...
==> Getting PyPI info for "adlfs==2024.2.0"
==> Getting PyPI info for "aiobotocore==2.12.1"
...
==> Getting PyPI info for "zc-lockfile==3.0.post1"
==> Updating resource blocks

❯ git diff
diff --git a/Formula/d/dvc.rb b/Formula/d/dvc.rb
index 0af6302e9a3..14ec4b11b2e 100644
--- a/Formula/d/dvc.rb
+++ b/Formula/d/dvc.rb
@@ -581,12 +581,6 @@ class Dvc < Formula
   resource "pyarrow" do
     url "https://files.pythonhosted.org/packages/ac/f8/38a8498b294a6d3c74cd81bb411c510d52dfdd40d082651ded761fa7a964/pyarrow-15.0.1.tar.gz"
     sha256 "21d812548d39d490e0c6928a7c663f37b96bf764034123d4b4ab4530ecc757a9"
-
-    # Backport fix for Cython 3.0.9+
-    patch :p2 do
-      url "https://github.com/apache/arrow/commit/1d966e98e41ce817d1f8c5159c0b9caa4de75816.patch?full_index=1"
-      sha256 "3272126cb6726744cfeb770513eb2b8b105b7926a38477a6bbd4aa0352beb6d5"
-    end
   end

   resource "pyasn1" do
```