### PR TITLE
Prevent unexpected network calls in tests

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -256,11 +256,15 @@ module Homebrew
               paths = []
 
               if formula_path.exist? ||
-                 (!CoreTap.instance.installed? && Homebrew::API::Formula.all_formulae.key?(path.basename.to_s))
+                 (!Homebrew::EnvConfig.no_install_from_api? &&
+                 !CoreTap.instance.installed? &&
+                 Homebrew::API::Formula.all_formulae.key?(path.basename.to_s))
                 paths << formula_path
               end
               if cask_path.exist? ||
-                 (!CoreCaskTap.instance.installed? && Homebrew::API::Cask.all_casks.key?(path.basename.to_s))
+                 (!Homebrew::EnvConfig.no_install_from_api? &&
+                 !CoreCaskTap.instance.installed? &&
+                 Homebrew::API::Cask.all_casks.key?(path.basename.to_s))
                 paths << cask_path
               end
 

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -22,11 +22,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
   describe ".can_load?" do
     include_context "with API setup", "test-opera"
 
-    context "when not using the API" do
-      before do
-        ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
-      end
-
+    context "when not using the API", :no_api do
       it "returns false" do
         expect(described_class.try_new(token)).to be_nil
       end

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -30,11 +30,7 @@ RSpec.describe Cask::CaskLoader, :cask do
           .and_return(cask_renames)
       end
 
-      context "when not using the API" do
-        before do
-          ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
-        end
-
+      context "when not using the API", :no_api do
         it "warns when using the short token" do
           expect do
             expect(described_class.for("version-newest")).to be_a Cask::CaskLoader::FromPathLoader
@@ -67,11 +63,7 @@ RSpec.describe Cask::CaskLoader, :cask do
       end
     end
 
-    context "when not using the API" do
-      before do
-        ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
-      end
-
+    context "when not using the API", :no_api do
       context "when a cask is migrated" do
         let(:token) { "local-caffeine" }
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -46,13 +46,15 @@ RSpec.describe Cask::Cask, :cask do
       expect(c.token).to eq("caffeine")
     end
 
-    it "returns an instance of the Cask from a URL" do
+    it "returns an instance of the Cask from a URL", :needs_utils_curl do
+      expect(Homebrew::API).not_to receive(:fetch_json_api_file)
       c = Cask::CaskLoader.load("file://#{tap_path}/Casks/local-caffeine.rb")
       expect(c).to be_a(described_class)
       expect(c.token).to eq("local-caffeine")
     end
 
-    it "raises an error when failing to download a Cask from a URL" do
+    it "raises an error when failing to download a Cask from a URL", :needs_utils_curl do
+      expect(Homebrew::API).not_to receive(:fetch_json_api_file)
       expect do
         Cask::CaskLoader.load("file://#{tap_path}/Casks/notacask.rb")
       end.to raise_error(Cask::CaskUnavailableError)

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -46,15 +46,13 @@ RSpec.describe Cask::Cask, :cask do
       expect(c.token).to eq("caffeine")
     end
 
-    it "returns an instance of the Cask from a URL", :needs_utils_curl do
-      expect(Homebrew::API).not_to receive(:fetch_json_api_file)
+    it "returns an instance of the Cask from a URL", :needs_utils_curl, :no_api do
       c = Cask::CaskLoader.load("file://#{tap_path}/Casks/local-caffeine.rb")
       expect(c).to be_a(described_class)
       expect(c.token).to eq("local-caffeine")
     end
 
-    it "raises an error when failing to download a Cask from a URL", :needs_utils_curl do
-      expect(Homebrew::API).not_to receive(:fetch_json_api_file)
+    it "raises an error when failing to download a Cask from a URL", :needs_utils_curl, :no_api do
       expect do
         Cask::CaskLoader.load("file://#{tap_path}/Casks/notacask.rb")
       end.to raise_error(Cask::CaskUnavailableError)

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -3,6 +3,11 @@
 require "utils"
 
 RSpec.describe Cask::Info, :cask do
+  before do
+    # Prevent unnecessary network requests in `Utils::Analytics.cask_output`
+    ENV["HOMEBREW_NO_ANALYTICS"] = "1"
+  end
+
   it "displays some nice info about the specified Cask" do
     expect do
       described_class.info(Cask::CaskLoader.load("local-transmission"))

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -119,7 +119,8 @@ RSpec.describe Formulary do
       expect(described_class.factory(formula_path)).to be_a(Formula)
     end
 
-    it "returns a Formula when given a URL" do
+    it "returns a Formula when given a URL", :needs_utils_curl do
+      expect(Homebrew::API).not_to receive(:fetch_json_api_file)
       formula = described_class.factory("file://#{formula_path}")
       expect(formula).to be_a(Formula)
     end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -119,8 +119,7 @@ RSpec.describe Formulary do
       expect(described_class.factory(formula_path)).to be_a(Formula)
     end
 
-    it "returns a Formula when given a URL", :needs_utils_curl do
-      expect(Homebrew::API).not_to receive(:fetch_json_api_file)
+    it "returns a Formula when given a URL", :needs_utils_curl, :no_api do
       formula = described_class.factory("file://#{formula_path}")
       expect(formula).to be_a(Formula)
     end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -384,6 +384,10 @@ RSpec.describe Formulary do
       before do
         ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
 
+        # avoid unnecessary network calls
+        allow(Homebrew::API::Formula).to receive_messages(all_aliases: {}, all_renames: {})
+        allow(CoreTap.instance).to receive(:tap_migrations).and_return({})
+
         # don't try to load/fetch gcc/glibc
         allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
       end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -165,6 +165,15 @@ RSpec.configure do |config|
     skip "Requires network connection." unless ENV["HOMEBREW_TEST_ONLINE"]
   end
 
+  config.before do |example|
+    next if example.metadata.key?(:needs_network)
+    next if example.metadata.key?(:needs_utils_curl)
+
+    allow(Utils::Curl).to receive(:curl_executable).and_raise(<<~ERROR)
+      Unexpected call to Utils::Curl.curl_executable without setting :needs_network or :needs_utils_curl.
+    ERROR
+  end
+
   config.before(:each, :needs_svn) do
     svn_shim = HOMEBREW_SHIMS_PATH/"shared/svn"
     skip "Subversion is not installed." unless quiet_system svn_shim, "--version"

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -174,6 +174,10 @@ RSpec.configure do |config|
     ERROR
   end
 
+  config.before(:each, :no_api) do
+    ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+  end
+
   config.before(:each, :needs_svn) do
     svn_shim = HOMEBREW_SHIMS_PATH/"shared/svn"
     skip "Subversion is not installed." unless quiet_system svn_shim, "--version"

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -488,8 +488,7 @@ RSpec.describe Tap do
         expect(described_class.to_a).to include(CoreTap.instance)
       end
 
-      it "omits the core tap without the api" do
-        ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
+      it "omits the core tap without the api", :no_api do
         expect(described_class.to_a).not_to include(CoreTap.instance)
       end
     end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Tap do
   end
 
   describe "#remote" do
-    it "returns the remote URL" do
+    it "returns the remote URL", :needs_network do
       setup_git_repo
 
       expect(homebrew_foo_tap.remote).to eq("https://github.com/Homebrew/homebrew-foo")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This implemented a crude check for unexpected network calls in tests that are not tagged `:needs_network`. Basically, it raise an error if ~any method~ the `.curl_executable` method in the `Utils::Curl` module is referenced and is not stubbed. This works most of the time and it did help me uncover a few tests that were making network calls when they shouldn't have been. Of course, sometimes we know that the network calls we're going to make are all to the local filesystem and in that case there is an escape hatch you can use with the ~`:allow_utils_curl`~ `:needs_utils_curl` tag.

As written this works well with the current codebase but does clash a bit with the API mocking ideas found in https://github.com/Homebrew/brew/issues/16895. It should be possible to override the checks in the test suite when we add some sort of mock API helper though.

I'm marking this as discussion to see if people think this is a good general idea and are okay with the implementation.

CC: @Bo98 @reitermarkus 

---

Changes:

- b66097fa3d3a7927eb13771786c3832ae5621b17
  - Add check for unexpected network calls to spec_helper.rb
  - Fix acceptable tests that use curl to download local files 
- ad35db4b24997c7999e9c1c0a37ff66d2e985ccd
  - Fix tests with unexpected network calls
  - IMO these should be merged in whether or not we decide to include unexpected network call check