### PR TITLE
Include .rbi shims in yard docs

### DIFF
--- a/Library/Homebrew/.yardopts
+++ b/Library/Homebrew/.yardopts
@@ -5,10 +5,12 @@
 --plugin sorbet
 --load yard/ignore_directives.rb
 --template-path yard/templates
+--exclude sorbet/rbi/gems/
 --exclude test/
 --exclude vendor/
 --exclude yard/
 extend/os/**/*.rb
 **/*.rb
+**/*.rbi
 -
 *.md

--- a/Library/Homebrew/extend/hash/deep_transform_values.rb
+++ b/Library/Homebrew/extend/hash/deep_transform_values.rb
@@ -6,6 +6,7 @@ class Hash
   # This includes the values from the root hash and from all
   # nested hashes and arrays.
   #
+  # @example
   #  hash = { person: { name: 'Rob', age: '28' } }
   #
   #  hash.deep_transform_values{ |value| value.to_s.upcase }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Per https://github.com/dduugg/yard-sorbet/blob/main/README.md we can merge the RBI sigs with source code documentation. The add'l time is ~negligible (27s now, 24s before). This also bumps the documentation level from 60.3% to 63.5%.

Before:
<img width="630" alt="image" src="https://github.com/Homebrew/brew/assets/697964/4a72c2b2-2786-4268-af17-8118059bd39d">

`Homebrew::CLI::Args` instance methods after:
<img width="359" alt="image" src="https://github.com/Homebrew/brew/assets/697964/2eb1eaff-ddfa-4286-9cc9-a0c22bc79719">

