### PR TITLE
Fix flaky Tapioca::Compilers::Args test

### DIFF
--- a/Library/Homebrew/test/sorbet/tapioca/compilers/args_spec.rb
+++ b/Library/Homebrew/test/sorbet/tapioca/compilers/args_spec.rb
@@ -17,28 +17,10 @@ RSpec.describe Tapioca::Compilers::Args do
 
   describe "#args_table" do
     it "returns a mapping of list args to default values" do
-      expect(compiler.args_table(list_parser)).to eq({
-        "1?":       false,
-        cask?:      false,
-        casks?:     false,
-        d?:         false,
-        debug?:     false,
-        formula?:   false,
-        formulae?:  false,
-        full_name?: false,
-        h?:         false,
-        help?:      false,
-        l?:         false,
-        multiple?:  false,
-        pinned?:    false,
-        q?:         false,
-        quiet?:     false,
-        r?:         false,
-        t?:         false,
-        v?:         false,
-        verbose?:   false,
-        versions?:  false,
-      })
+      expect(compiler.args_table(list_parser).keys).to contain_exactly(
+        :"1?", :cask?, :casks?, :d?, :debug?, :formula?, :formulae?, :full_name?, :h?, :help?, :l?, :multiple?,
+        :pinned?, :q?, :quiet?, :r?, :t?, :v?, :verbose?, :versions?
+      )
     end
 
     it "rreturns a mapping of update-python-resources args to default values" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Resolves https://github.com/Homebrew/brew/actions/runs/8329015201/job/22790407761 – let's just validate the keys, since it seems that the values vary by OS.