### PR TITLE
rubocops/service: allow require_root to be used without run.

### DIFF
--- a/Library/Homebrew/rubocops/service.rb
+++ b/Library/Homebrew/rubocops/service.rb
@@ -37,7 +37,7 @@ module RuboCop
             offending_node(service_node)
             problem "Service blocks require `run` or `name` to be defined."
           elsif !method_calls.key?(:run)
-            other_method_calls = method_calls.keys - [:name]
+            other_method_calls = method_calls.keys - [:name, :require_root]
             if other_method_calls.any?
               offending_node(service_node)
               problem "`run` must be defined to use methods other than `name` like #{other_method_calls}."

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -970,7 +970,7 @@ end
 
 #### Service block methods
 
-This table lists the options you can set within a `service` block. The `run` or `name` field must be defined inside the service block. The `run` field indicates what command to run and is required before using fields other than `name`.
+This table lists the options you can set within a `service` block. The `run` or `name` field must be defined inside the service block. The `run` field indicates what command to run and is required before using fields other than `name` and `require_root`.
 
 | method                  | default      | macOS | Linux | description |
 | ----------------------- | ------------ | :---: | :---: | ----------- |


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/16908