### PR TITLE
livecheck: support throttle DSL

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -472,6 +472,7 @@ module Homebrew
 
       def check_throttle(formula, new_version)
         throttled_rate = formula.tap.audit_exceptions.dig(:throttled_formulae, formula.name)
+        throttled_rate ||= formula.livecheck.throttle
         return if throttled_rate.blank?
 
         formula_suffix = Version.new(new_version).patch.to_i

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -471,8 +471,8 @@ module Homebrew
       end
 
       def check_throttle(formula, new_version)
-        throttled_rate = formula.tap.audit_exceptions.dig(:throttled_formulae, formula.name)
-        throttled_rate ||= formula.livecheck.throttle
+        throttled_rate = formula.livecheck.throttle
+        throttled_rate ||= formula.tap.audit_exceptions.dig(:throttled_formulae, formula.name)
         return if throttled_rate.blank?
 
         formula_suffix = Version.new(new_version).patch.to_i

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -248,9 +248,7 @@ module Homebrew
       end
 
       sig {
-        params(
-          formula_or_cask: T.any(Formula, Cask::Cask),
-        ).returns([T.any(Version, String), T.nilable(T.any(Version, String))])
+        params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T.any(Version, String))
       }
       def livecheck_result(formula_or_cask)
         name = Livecheck.package_or_resource_name(formula_or_cask)
@@ -279,8 +277,7 @@ module Homebrew
 
         if skip_info.present?
           return "#{skip_info[:status]}" \
-                 "#{" - #{skip_info[:messages].join(", ")}" if skip_info[:messages].present?}",
-                 nil
+                 "#{" - #{skip_info[:messages].join(", ")}" if skip_info[:messages].present?}"
         end
 
         version_info = Livecheck.latest_version(
@@ -288,20 +285,17 @@ module Homebrew
           referenced_formula_or_cask:,
           json: true, full_name: false, verbose: true, debug: false
         )
-        return "unable to get versions", nil if version_info.blank?
+        return "unable to get versions" if version_info.blank?
 
-        latest = Version.new(version_info[:latest])
-        latest_throttled = if !version_info.key?(:latest_throttled)
-          nil
+        if !version_info.key?(:latest_throttled)
+          Version.new(version_info[:latest])
         elsif version_info[:latest_throttled].nil?
           "unable to get throttled versions"
         else
           Version.new(version_info[:latest_throttled])
         end
-
-        [latest, latest_throttled]
       rescue => e
-        ["error: #{e}", nil]
+        "error: #{e}"
       end
 
       sig {
@@ -360,9 +354,7 @@ module Homebrew
               current_version_value = Version.new(loaded_formula_or_cask.version)
             end
 
-            livecheck_latest, livecheck_latest_throttled = livecheck_result(loaded_formula_or_cask)
-            # TODO: Pass down `livecheck_latest` info to print output for throttled formulae or casks
-            livecheck_latest = livecheck_latest_throttled if livecheck_latest_throttled
+            livecheck_latest = livecheck_result(loaded_formula_or_cask)
 
             new_version_value = if (livecheck_latest.is_a?(Version) && livecheck_latest >= current_version_value) ||
                                    current_version_value == "latest"

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -25,6 +25,7 @@ class Livecheck
     @referenced_cask_name = nil
     @referenced_formula_name = nil
     @regex = nil
+    @throttle = nil
     @skip = false
     @skip_msg = nil
     @strategy = nil
@@ -84,6 +85,23 @@ class Livecheck
       @regex
     when Regexp
       @regex = pattern
+    end
+  end
+
+  # Sets the `@throttle` instance variable to the provided `Integer` or returns
+  # the `@throttle` instance variable when no argument is provided.
+  sig {
+    params(
+      # Throttle rate of version patch number to use for bumpable versions.
+      rate: T.nilable(Integer),
+    ).returns(T.nilable(Integer))
+  }
+  def throttle(rate = T.unsafe(nil))
+    case rate
+    when nil
+      @throttle
+    when Integer
+      @throttle = rate
     end
   end
 
@@ -168,6 +186,7 @@ class Livecheck
       "cask"     => @referenced_cask_name,
       "formula"  => @referenced_formula_name,
       "regex"    => @regex,
+      "throttle" => @throttle,
       "skip"     => @skip,
       "skip_msg" => @skip_msg,
       "strategy" => @strategy,

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -25,11 +25,11 @@ class Livecheck
     @referenced_cask_name = nil
     @referenced_formula_name = nil
     @regex = nil
-    @throttle = nil
     @skip = false
     @skip_msg = nil
     @strategy = nil
     @strategy_block = nil
+    @throttle = nil
     @url = nil
   end
 
@@ -88,23 +88,6 @@ class Livecheck
     end
   end
 
-  # Sets the `@throttle` instance variable to the provided `Integer` or returns
-  # the `@throttle` instance variable when no argument is provided.
-  sig {
-    params(
-      # Throttle rate of version patch number to use for bumpable versions.
-      rate: T.nilable(Integer),
-    ).returns(T.nilable(Integer))
-  }
-  def throttle(rate = T.unsafe(nil))
-    case rate
-    when nil
-      @throttle
-    when Integer
-      @throttle = rate
-    end
-  end
-
   # Sets the `@skip` instance variable to `true` and sets the `@skip_msg`
   # instance variable if a `String` is provided. `@skip` is used to indicate
   # that the formula/cask/resource should be skipped and the `skip_msg` very
@@ -153,6 +136,23 @@ class Livecheck
   sig { returns(T.nilable(Proc)) }
   attr_reader :strategy_block
 
+  # Sets the `@throttle` instance variable to the provided `Integer` or returns
+  # the `@throttle` instance variable when no argument is provided.
+  sig {
+    params(
+      # Throttle rate of version patch number to use for bumpable versions.
+      rate: T.nilable(Integer),
+    ).returns(T.nilable(Integer))
+  }
+  def throttle(rate = T.unsafe(nil))
+    case rate
+    when nil
+      @throttle
+    when Integer
+      @throttle = rate
+    end
+  end
+
   # Sets the `@url` instance variable to the provided argument or returns the
   # `@url` instance variable when no argument is provided. The argument can be
   # a `String` (a URL) or a supported `Symbol` corresponding to a URL in the
@@ -186,10 +186,10 @@ class Livecheck
       "cask"     => @referenced_cask_name,
       "formula"  => @referenced_formula_name,
       "regex"    => @regex,
-      "throttle" => @throttle,
       "skip"     => @skip,
       "skip_msg" => @skip_msg,
       "strategy" => @strategy,
+      "throttle" => @throttle,
       "url"      => @url,
     }
   end

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -141,7 +141,7 @@ class Livecheck
   sig {
     params(
       # Throttle rate of version patch number to use for bumpable versions.
-      rate: T.nilable(Integer),
+      rate: Integer,
     ).returns(T.nilable(Integer))
   }
   def throttle(rate = T.unsafe(nil))

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -372,9 +372,10 @@ module Homebrew
         info[:version] = {
           current:             current_str,
           latest:              latest_str,
+          latest_throttled:    version_info&.dig(:latest_throttled),
           outdated:            is_outdated,
           newer_than_upstream: is_newer_than_upstream,
-        }
+        }.compact
         info[:meta] = {
           livecheckable: formula_or_cask.livecheckable?,
         }
@@ -678,6 +679,7 @@ module Homebrew
       livecheck_regex = livecheck.regex || referenced_livecheck&.regex
       livecheck_strategy = livecheck.strategy || referenced_livecheck&.strategy
       livecheck_strategy_block = livecheck.strategy_block || referenced_livecheck&.strategy_block
+      livecheck_throttle = livecheck.throttle || referenced_livecheck&.throttle
 
       livecheck_url_string = livecheck_url_to_string(
         livecheck_url,
@@ -695,6 +697,7 @@ module Homebrew
           puts "Cask:             #{cask_name(formula_or_cask, full_name:)}"
         end
         puts "Livecheckable?:   #{has_livecheckable ? "Yes" : "No"}"
+        puts "Throttle:         #{livecheck_throttle}" if livecheck_throttle
 
         livecheck_references.each do |ref_formula_or_cask|
           case ref_formula_or_cask
@@ -826,8 +829,8 @@ module Homebrew
           latest: Version.new(match_version_map.values.max_by { |v| LivecheckVersion.create(formula_or_cask, v) }),
         }
 
-        if (throttle = livecheck.throttle || referenced_livecheck&.throttle)
-          match_version_map.keep_if { |_match, version| version.patch.to_i.modulo(throttle).zero? }
+        if livecheck_throttle
+          match_version_map.keep_if { |_match, version| version.patch.to_i.modulo(livecheck_throttle).zero? }
           version_info[:latest_throttled] = if match_version_map.blank?
             nil
           else
@@ -876,6 +879,7 @@ module Homebrew
           version_info[:meta][:strategies] = strategies.map { |s| livecheck_strategy_names[s] } if strategies.present?
           version_info[:meta][:regex] = regex.inspect if regex.present?
           version_info[:meta][:cached] = true if strategy_data[:cached] == true
+          version_info[:meta][:throttle] = livecheck_throttle if livecheck_throttle
         end
 
         return version_info

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -66,17 +66,6 @@ RSpec.describe Livecheck do
     end
   end
 
-  describe "#throttle" do
-    it "returns nil if not set" do
-      expect(livecheckable_f.throttle).to be_nil
-    end
-
-    it "returns the Integer if set" do
-      livecheckable_f.throttle(10)
-      expect(livecheckable_f.throttle).to eq(10)
-    end
-  end
-
   describe "#skip" do
     it "sets @skip to true when no argument is provided" do
       expect(livecheckable_f.skip).to be true
@@ -108,6 +97,17 @@ RSpec.describe Livecheck do
     it "returns the Symbol if set" do
       livecheckable_f.strategy(:page_match)
       expect(livecheckable_f.strategy).to eq(:page_match)
+    end
+  end
+
+  describe "#throttle" do
+    it "returns nil if not set" do
+      expect(livecheckable_f.throttle).to be_nil
+    end
+
+    it "returns the Integer if set" do
+      livecheckable_f.throttle(10)
+      expect(livecheckable_f.throttle).to eq(10)
     end
   end
 
@@ -151,10 +151,10 @@ RSpec.describe Livecheck do
           "cask"     => nil,
           "formula"  => nil,
           "regex"    => nil,
-          "throttle" => nil,
           "skip"     => false,
           "skip_msg" => nil,
           "strategy" => nil,
+          "throttle" => nil,
           "url"      => nil,
         },
       )

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe Livecheck do
     end
   end
 
+  describe "#throttle" do
+    it "returns nil if not set" do
+      expect(livecheckable_f.throttle).to be_nil
+    end
+
+    it "returns the Integer if set" do
+      livecheckable_f.throttle(10)
+      expect(livecheckable_f.throttle).to eq(10)
+    end
+  end
+
   describe "#skip" do
     it "sets @skip to true when no argument is provided" do
       expect(livecheckable_f.skip).to be true
@@ -140,6 +151,7 @@ RSpec.describe Livecheck do
           "cask"     => nil,
           "formula"  => nil,
           "regex"    => nil,
+          "throttle" => nil,
           "skip"     => false,
           "skip_msg" => nil,
           "strategy" => nil,


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Essentially, we need to figure out best way to combine autobump, livecheck, and throttle so that autobumps can properly handle this. Preferably avoiding code duplication across various parts (i.e. bump commands, livecheck logic, github action, etc.)

Some ideas:
1. **Throttle DSL** - This approach
2. Livecheck throttling - ~~e.g. https://github.com/Homebrew/homebrew-core/commit/184767f00391c1aae6dbbfd3a03388c2c5b42857
3. Time-based throttling - would need to change version-based throttling to time-based (days between bump) in JSON, provide a way of detecting some datetime info (e.g. modulo current day of year, attempt during specific timeslot in a day). 
    - Con: This functionality mainly works when on autobump, but is trickier when user bumping is allowed as cannot guarantee cadence here.