### PR TITLE
bump-*-pr: handle HOMEBREW_NO_GITHUB_API=1 being set

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -521,6 +521,8 @@ module GitHub
       .returns(T::Array[T::Hash[String, T.untyped]])
   }
   def self.fetch_pull_requests(name, tap_remote_repo, state: nil, version: nil)
+    return [] if Homebrew::EnvConfig.no_github_api?
+
     regex = pull_request_title_regex(name, version)
     query = "is:pr #{name} #{version}".strip
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

#### Commits _(oldest to newest)_

e11f797f25 bump-*-pr: handle HOMEBREW_NO_GITHUB_API=1 being set

We early return here
https://github.com/homebrew/brew/blob/92a4311868322188478d7a90511ec0e8e6b0d7df/Library/Homebrew/utils/github/api.rb#L220
, but don't then handle that through the stack.

Repro:

```console
❯ HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_GITHUB_API=1 brew bump-formula-pr --write-only --version 1.2.3 --no-audit jq
Error: undefined method `[]' for nil:NilClass
Do not report this issue until you've run `brew update` and tried again.
Warning: Removed Sorbet lines from backtrace!
/opt/homebrew/Library/Homebrew/utils/github.rb:565:in `block in fetch_pull_requests'
/opt/homebrew/Library/Homebrew/utils/github/api.rb:334:in `paginate_graphql'
/opt/homebrew/Library/Homebrew/utils/github.rb:564:in `fetch_pull_requests'
/opt/homebrew/Library/Homebrew/utils/github.rb:628:in `check_for_duplicate_pull_requests'
/opt/homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:456:in `check_open_pull_requests'
/opt/homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:135:in `run'
/opt/homebrew/Library/Homebrew/brew.rb:89:in `<main>'
Rerun with `--verbose` to see the original backtrace
```

<br/>