### PR TITLE
rubocops/livecheck: Rework LivecheckUrlProvided

### DIFF
--- a/Library/Homebrew/rubocops/livecheck.rb
+++ b/Library/Homebrew/rubocops/livecheck.rb
@@ -45,20 +45,19 @@ module RuboCop
       class LivecheckUrlProvided < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           livecheck_node = find_block(body_node, :livecheck)
-          return if livecheck_node.blank?
+          return unless livecheck_node
 
-          skip = find_every_method_call_by_name(livecheck_node, :skip).first
-          return if skip.present?
+          url_node = find_every_method_call_by_name(livecheck_node, :url).first
+          return if url_node
 
-          formula_node = find_every_method_call_by_name(livecheck_node, :formula).first
-          cask_node = find_every_method_call_by_name(livecheck_node, :cask).first
-          return if formula_node.present? || cask_node.present?
-
-          livecheck_url = find_every_method_call_by_name(livecheck_node, :url).first
-          return if livecheck_url.present?
+          # A regex and/or strategy is specific to a particular URL, so we
+          # should require an explicit URL.
+          regex_node = find_every_method_call_by_name(livecheck_node, :regex).first
+          strategy_node = find_every_method_call_by_name(livecheck_node, :strategy).first
+          return if !regex_node && !strategy_node
 
           offending_node(livecheck_node)
-          problem "A `url` must be provided to livecheck."
+          problem "A `url` should be provided when `regex` or `strategy` are used."
         end
       end
 

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -5,20 +5,31 @@ require "rubocops/livecheck"
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
   subject(:cop) { described_class.new }
 
-  it "reports an offense when a `url` is not specified in the livecheck block" do
+  it "reports an offense when a `url` is not specified in a livecheck block" do
     expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
 
         livecheck do
-        ^^^^^^^^^^^^ FormulaAudit/LivecheckUrlProvided: A `url` must be provided to livecheck.
+        ^^^^^^^^^^^^ FormulaAudit/LivecheckUrlProvided: A `url` should be provided when `regex` or `strategy` are used.
           regex(%r{href=.*?/formula[._-]v?(\\d+(?:\\.\\d+)+)\\.t}i)
+        end
+      end
+    RUBY
+
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        livecheck do
+        ^^^^^^^^^^^^ FormulaAudit/LivecheckUrlProvided: A `url` should be provided when `regex` or `strategy` are used.
+          strategy :page_match
         end
       end
     RUBY
   end
 
-  it "reports no offenses when a `url` is specified in the livecheck block" do
+  it "reports no offenses when a `url` and `regex` are specified in the livecheck block" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
@@ -26,6 +37,19 @@ RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
         livecheck do
           url :stable
           regex(%r{href=.*?/formula[._-]v?(\\d+(?:\\.\\d+)+)\\.t}i)
+        end
+      end
+    RUBY
+  end
+
+  it "reports no offenses when a `url` and `strategy` are specified in the livecheck block" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+
+        livecheck do
+          url :stable
+          strategy :page_match
         end
       end
     RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The existing `LivecheckUrlProvided` RuboCop requires a `url` for all `livecheck` blocks except those using `skip`, `formula`, or `cask`, as those only appear in a `livecheck` block with no other DSL methods.

We now have a `throttle` method that can be used alongside other DSL methods (e.g., `url`, `regex`, `strategy`) or by itself. `brew style` currently fails when `throttle` is used by itself (e.g., https://github.com/Homebrew/homebrew-core/pull/166501), so this updates the conditions to allow this usage.

~I'm currently doing this by specifically exempting `livecheck` blocks that only include `#throttle` (i.e., so we don't unexpectedly skip the check for `livecheck` blocks that use `#throttle` alongside other methods). I'm not very versed with RuboCop, so there may be a better way of achieving the same goal.~

I've gone about this by reworking the `LivecheckUrlProvided` RuboCop to only require a `url` when a `livecheck` block uses `#regex` and/or `#strategy`, as that information is intended for a specific URL. This allows us to get rid of the special-case conditions for `#skip`, `#formula`, and `#cask` (and avoid adding additional conditions for `#throttle`).