### PR TITLE
Support bash in privileged mode

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -216,7 +216,7 @@ numeric() {
 }
 
 check-run-command-as-root() {
-  [[ "$(id -u)" == 0 ]] || return
+  [[ "$(id -u)" == 0 || "$(id -ur)" == 0 ]] || return
 
   # Allow Azure Pipelines/GitHub Actions/Docker/Concourse/Kubernetes to do everything as root (as it's normal there)
   [[ -f /.dockerenv ]] && return

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -106,8 +106,8 @@ module Homebrew
     end
 
     def running_as_root?
-      @process_uid ||= Process.uid
-      @process_uid.zero?
+      @process_euid ||= Process.euid
+      @process_euid.zero?
     end
 
     def owner_uid

--- a/Library/Homebrew/shims/shared/curl
+++ b/Library/Homebrew/shims/shared/curl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # Make our $HOMEBREW_CURL selection universal - including in formulae usage.
 

--- a/Library/Homebrew/shims/shared/git
+++ b/Library/Homebrew/shims/shared/git
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -p
 
 # This script because we support $HOMEBREW_GIT, $HOMEBREW_SVN, etc., Xcode-only and
 # no Xcode/CLT configurations. Order is careful to be what the user would want.

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -42,6 +42,9 @@ module Utils
           server.close
           read.close
           write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+
+          Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
+
           yield
         rescue Exception => e # rubocop:disable Lint/RescueException
           error_hash = JSON.parse e.to_json

--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -44,9 +44,12 @@ _create_lock() {
   [[ -x "${ruby}" ]] || ruby="$(type -P ruby)"
   [[ -x "${python}" ]] || python="$(type -P python)"
 
-  if [[ -x "${ruby}" ]] && "${ruby}" -e "exit(RUBY_VERSION >= '1.8.7')"
+  # Use /dev/stdin, otherwise Ruby can error if uid != euid.
+  # Can't use "-" as that's also blocked:
+  # https://github.com/ruby/ruby/blob/e51435177e88fc845528dff7cf2bc2b75dd36144/ruby.c#L2333-L2335
+  if [[ -x "${ruby}" ]] && "${ruby}" /dev/stdin <<<"exit(RUBY_VERSION >= '1.8.7')"
   then
-    "${ruby}" -e "File.new(${lock_fd}).flock(File::LOCK_EX | File::LOCK_NB) || exit(1)"
+    "${ruby}" /dev/stdin <<<"File.new(${lock_fd}).flock(File::LOCK_EX | File::LOCK_NB) || exit(1)"
   elif [[ -x "${python}" ]]
   then
     "${python}" -c "import fcntl; fcntl.flock(${lock_fd}, fcntl.LOCK_EX | fcntl.LOCK_NB)"

--- a/bin/brew
+++ b/bin/brew
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -p
 set -u
 
 # Fail fast with concise message when not using bash
@@ -245,4 +245,4 @@ then
 fi
 unset VAR ENV_VAR_NAMES
 
-exec /usr/bin/env -i "${FILTERED_ENV[@]}" /bin/bash "${HOMEBREW_LIBRARY}/Homebrew/brew.sh" "$@"
+exec /usr/bin/env -i "${FILTERED_ENV[@]}" /bin/bash -p "${HOMEBREW_LIBRARY}/Homebrew/brew.sh" "$@"


### PR DESCRIPTION
This enables "privileged" mode in bash (which despite the name doesn't necessary elevate anything). This will filter out _even more_ environment variables. It also enables the ability for EUID to be different to UID. This is a powerful tool that can be used in certain environments to better handle cask sudo privileges and I would like to give users the option to use it.

We defer the safety of such scenarios to the user calling brew. Homebrew will check if EUID or UID is root and abort, which should prevent the most common misuse via `setuid` root executables. No further checks than that are made. The caller should assume that either the EUID or UID can be escalated to at any time.

For compatibility reasons, we will only use the EUID in formula build scripts and set UID to equal that.