### PR TITLE
formula_cellar_checks: fix type from #16946

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -65,7 +65,7 @@ module FormulaCellarChecks
     EOS
   end
 
-  sig { returns(T.nilable(String)) }
+  sig { void }
   def check_linkage
     return unless formula.prefix.directory?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixing my mistake from #16946.

https://github.com/Homebrew/homebrew-core/actions/runs/8421011317/job/23072966026?pr=166409
```
  Error: Return value: Expected type T.nilable(String), got type Module with value T::Private::Types::Void::VOID
  Caller: /opt/homebrew/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb:127
  Definition: /opt/homebrew/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb:69
```