### PR TITLE
formula_installer: handle nil runtime dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1209,7 +1209,7 @@ on_request: installed_on_request?, options:)
     @fetch_bottle_tab ||= begin
       formula.fetch_bottle_tab
       @bottle_tab_runtime_dependencies = formula.bottle_tab_attributes
-                                                .fetch("runtime_dependencies", [])
+                                                .fetch("runtime_dependencies", []).then { |deps| deps || [] }
                                                 .each_with_object({}) { |dep, h| h[dep["full_name"]] = dep }
                                                 .freeze
       true
@@ -1262,7 +1262,7 @@ on_request: installed_on_request?, options:)
     tab = Utils::Bottles.load_tab(formula)
 
     # fill in missing/outdated parts of the tab
-    # keep in sync with Tab#to_bottle_json
+    # keep in sync with Tab#to_bottle_hash
     tab.used_options = []
     tab.unused_options = []
     tab.built_as_bottle = true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Some old bottles (Sierra and earlier) will fail to install when the downloaded bottle manifest has its `runtime_dependencies` set to `null` rather than `[]`. This happens during manifest generation when `Tab` finds the tab's `homebrew_version` to be either not present or earlier than 1.1.6. The existing `fetch_bottle_tab` method passes an empty list if `runtime_dependencies` is not present; this change ensures that the same happens if `runtime_dependencies` is present but `nil`.

Also, `Tab#runtime_dependencies` could return an empty list if `homebrew_version` < 1.1.6 to avoid this in future manifests. Not sure if that's necessary.

Before:
```
==> Downloading https://ghcr.io/v2/homebrew/core/libcuefile/manifests/r475-1
Already downloaded: /Users/vmadmin/Library/Caches/Homebrew/downloads/bcfd5f9c5e66525827bd2c1024f9dbee05db47868b3077b3e19178fe9e25fd91--libcuefile-r475-1.bottle_manifest.json
Error: undefined method `each_with_object' for nil:NilClass
```

After:
```
==> Downloading https://ghcr.io/v2/homebrew/core/libcuefile/manifests/r475-1
Already downloaded: /Users/vmadmin/Library/Caches/Homebrew/downloads/bcfd5f9c5e66525827bd2c1024f9dbee05db47868b3077b3e19178fe9e25fd91--libcuefile-r475-1.bottle_manifest.json
==> Fetching libcuefile
==> Downloading https://ghcr.io/v2/homebrew/core/libcuefile/blobs/sha256:66ec2d9281a5459326a1b2d220b9f68fa241a6b9f8370324377af
Already downloaded: /Users/vmadmin/Library/Caches/Homebrew/downloads/f1ebb348b1ce9b4e5bd593221f88ed9bd76af0441b08cf3acda6e7fe1c45306e--libcuefile--r475.sierra.bottle.1.tar.gz
==> Pouring libcuefile--r475.sierra.bottle.1.tar.gz
🍺  /usr/local/Cellar/libcuefile/r475: 11 files, 177.2KB
==> Running `brew cleanup libcuefile`...
```
