### PR TITLE
Avoid `writable_real?`

### DIFF
--- a/Library/Homebrew/dev-cmd/unpack.rb
+++ b/Library/Homebrew/dev-cmd/unpack.rb
@@ -43,7 +43,7 @@ module Homebrew
           unpack_dir = Pathname.pwd
         end
 
-        odie "Cannot write to #{unpack_dir}" unless unpack_dir.writable_real?
+        odie "Cannot write to #{unpack_dir}" unless unpack_dir.writable?
 
         formulae.each do |f|
           stage_dir = unpack_dir/"#{f.name}-#{f.version}"

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -344,7 +344,7 @@ module Homebrew
       alias generic_check_tmpdir_sticky_bit check_tmpdir_sticky_bit
 
       def check_exist_directories
-        return if HOMEBREW_PREFIX.writable_real?
+        return if HOMEBREW_PREFIX.writable?
 
         not_exist_dirs = Keg::MUST_EXIST_DIRECTORIES.reject(&:exist?)
         return if not_exist_dirs.empty?
@@ -362,7 +362,7 @@ module Homebrew
       def check_access_directories
         not_writable_dirs =
           Keg::MUST_BE_WRITABLE_DIRECTORIES.select(&:exist?)
-                                           .reject(&:writable_real?)
+                                           .reject(&:writable?)
         return if not_writable_dirs.empty?
 
         <<~EOS

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -82,7 +82,7 @@ class Keg
     files = result.stdout.lines.map { |f| Pathname(f.chomp) }
     saved_perms = {}
     files.each do |f|
-      unless f.writable_real?
+      unless f.writable?
         saved_perms[f] = f.stat.mode
         FileUtils.chmod "u+rw", f.to_path
       end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -333,7 +333,7 @@ class Pathname
   # @private
   def ensure_writable
     saved_perms = nil
-    unless writable_real?
+    unless writable?
       saved_perms = stat.mode
       FileUtils.chmod "u+rw", to_path
     end

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -50,7 +50,7 @@ module Language
 
     def self.reads_brewed_pth_files?(python)
       return false unless homebrew_site_packages(python).directory?
-      return false unless homebrew_site_packages(python).writable_real?
+      return false unless homebrew_site_packages(python).writable?
 
       probe_file = homebrew_site_packages(python)/"homebrew-pth-probe.pth"
       begin


### PR DESCRIPTION
Checking the real UID for writability is rarely correct, unless you are doing so for security purposes in a root setuid executable (a scenario Homebrew already forbids). All file operations actually operate using the EUID.

Reverts https://github.com/Homebrew/legacy-homebrew/pull/13689 - insufficient information was given in that PR to determine the actual root cause.