### PR TITLE
Output version upgrade info using `puts`

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -136,10 +136,8 @@ module Homebrew
       else
         "-> #{formula.pkg_version}"
       end
-      oh1 <<~EOS
-        Upgrading #{Formatter.identifier(formula.full_specified_name)}
-          #{version_upgrade} #{fi_options.to_a.join(" ")}
-      EOS
+      oh1 "Upgrading #{Formatter.identifier(formula.full_specified_name)}"
+      puts "  #{version_upgrade} #{fi_options.to_a.join(" ")}"
     end
 
     def create_formula_installer(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR changes the two-line upgrade message to use `puts` for the second line (`oh1` is still used for the first line). This prevents version numbers from being truncated when upgrading formulae, which can happen if a formula has a very long name or is in a non-core tap. More info is at #16942 and [this comment on that issue](https://github.com/Homebrew/brew/issues/16942#issuecomment-2018088306).

I attempted to write a test for this, but I have not been successful. This is my attempted test (for inclusion in [cmd/upgrade](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/cmd/upgrade_spec.rb)):

```rb
it "outputs complete version numbers", :integration_test do
  allow($stdout).to receive(:tty?).and_return(true)
  allow(Tty).to receive(:width).and_return(80)

  name = "testball-with-long-name-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
  setup_test_formula name

  expect { brew "upgrade" }
    .to output(/^  -> 0.1\b/).to_stdout
    .and be_a_success
end
```

The problem I’m having is that `$stdout.tty?` doesn’t seem to return `true`, so no messages are truncated [here](https://github.com/Homebrew/brew/blob/4.2.15/Library/Homebrew/extend/kernel.rb#L53) (because `$stdout.tty?` is actually `false`):

```rb
title = Tty.truncate(title.to_s) if $stdout.tty? && !verbose && truncate == :auto
```

Consequently, this test is passing currently (that is, without the changes in this PR), so I left this test out.