### PR TITLE
deprecate_disable: add cask deprecation reason

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -24,6 +24,7 @@ module DeprecateDisable
 
   CASK_DEPRECATE_DISABLE_REASONS = {
     discontinued:             "is discontinued upstream",
+    moved_to_mas:             "is now exclusively distributed on the Mac App Store",
     no_longer_available:      "is no longer available upstream",
     no_longer_meets_criteria: "no longer meets the criteria for acceptable casks",
     unmaintained:             "is not maintained upstream",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Adds an additional `deprecate!/disable!` reason for casks, for when an app moves to the Mac App Store.
Would be used for https://github.com/Homebrew/homebrew-cask/pull/170096 and other similar circumstances.
