### PR TITLE
Fix setup-ruby/rubocop issues when euid != uid

### DIFF
--- a/Library/Homebrew/cmd/setup-ruby.sh
+++ b/Library/Homebrew/cmd/setup-ruby.sh
@@ -17,7 +17,8 @@ homebrew-setup-ruby() {
     return
   fi
 
-  GEM_VERSION="$("${HOMEBREW_RUBY_PATH}" "${HOMEBREW_RUBY_DISABLE_OPTIONS}" -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]')"
+  GEM_VERSION="$("${HOMEBREW_RUBY_PATH}" "${HOMEBREW_RUBY_DISABLE_OPTIONS}" /dev/stdin <<<'require "rbconfig"; puts RbConfig::CONFIG["ruby_version"]')"
+  echo "${GEM_VERSION}"
   GEM_HOME="${HOMEBREW_LIBRARY}/Homebrew/vendor/bundle/ruby/${GEM_VERSION}"
   BUNDLE_GEMFILE="${HOMEBREW_LIBRARY}/Homebrew/Gemfile"
 

--- a/Library/Homebrew/dev-cmd/rubocop.sh
+++ b/Library/Homebrew/dev-cmd/rubocop.sh
@@ -11,7 +11,7 @@ homebrew-rubocop() {
   source "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby.sh"
   setup-ruby-path
 
-  GEM_VERSION="$("${HOMEBREW_RUBY_PATH}" "${HOMEBREW_RUBY_DISABLE_OPTIONS}" -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]')"
+  GEM_VERSION="$("${HOMEBREW_RUBY_PATH}" "${HOMEBREW_RUBY_DISABLE_OPTIONS}" /dev/stdin <<<'require "rbconfig"; puts RbConfig::CONFIG["ruby_version"]')"
   GEM_HOME="${HOMEBREW_LIBRARY}/Homebrew/vendor/bundle/ruby/${GEM_VERSION}"
   BUNDLE_GEMFILE="${HOMEBREW_LIBRARY}/Homebrew/Gemfile"
   BUNDLE_WITH="style"


### PR DESCRIPTION
Similar fix as to utils/lock.sh.

Bit unfortunate this is necessary but it's an upstream limitation.