### PR TITLE
keg: mkpath while linking `{include,lib,share}/postgresql@X`

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -415,7 +415,14 @@ class Keg
     link_dir("etc", verbose:, dry_run:, overwrite:) { :mkpath }
     link_dir("bin", verbose:, dry_run:, overwrite:) { :skip_dir }
     link_dir("sbin", verbose:, dry_run:, overwrite:) { :skip_dir }
-    link_dir("include", verbose:, dry_run:, overwrite:) { :link }
+    link_dir("include", verbose:, dry_run:, overwrite:) do |relative_path|
+      case relative_path.to_s
+      when %r{^postgresql@\d+/}
+        :mkpath
+      else
+        :link
+      end
+    end
 
     link_dir("share", verbose:, dry_run:, overwrite:) do |relative_path|
       case relative_path.to_s
@@ -429,6 +436,7 @@ class Keg
            /^fish/,
            %r{^lua/}, #  Lua, Lua51, Lua53 all need the same handling.
            %r{^guile/},
+           %r{^postgresql@\d+/},
            *SHARE_PATHS
         :mkpath
       else
@@ -452,6 +460,7 @@ class Keg
            /^ocaml/,
            /^perl5/,
            "php",
+           %r{^postgresql@\d+/},
            /^python[23]\.\d+/,
            /^R/,
            /^ruby/


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think this will make it easier to retain extensions on different PostgreSQL.

`citus`, for example, installs files like:
* `include/postgresql@14/server/citus_version.h`
* `lib/postgresql@14/citus.so`
* `share/postgresql@14/extension/citus--10.0-1--10.0-2.sql`

---

Reasoning here is we may need to manually link some `keg_only` files/dirs inside the post install of `postgresql@X` formulae; however, if another formula already created symlink paths then it will make things complicated.

I guess some other alternatives would be:
1. expose the `keg.link_dir` logic that does all the symlink-to-real-directory conversion. However, `Keg` is `@api private` and we may not want to change this.
  https://github.com/Homebrew/brew/blob/c3094acbaf2b0a89bf7f80de93b1e33f6bced925/Library/Homebrew/keg.rb#L618
2. extend `keg_only` DSL to allow "partial" `keg_only`. Con here is this will require various code modifications (across link code, DSL, JSON API, etc) for something that may only be useful for PostgreSQL.
