### PR TITLE
shims/mac/super/m4: use gm4 if missing m4 (e.g. Xcode 15.3 CLT)

### DIFF
--- a/Library/Homebrew/shims/mac/super/m4
+++ b/Library/Homebrew/shims/mac/super/m4
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This shim is a workaround for the missing `m4` in Xcode CLT 15.3.
+# It can be removed after Apple provides a new CLT with a fix for FB13679972.
+# See https://github.com/Homebrew/homebrew-core/issues/165388
+
+# HOMEBREW_LIBRARY is set by bin/brew
+# HOMEBREW_DEVELOPER_DIR is set by extend/ENV/super.rb
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
+
+try_exec_non_system "${SHIM_FILE}" "$@"
+
+if [[ -n "${HOMEBREW_DEVELOPER_DIR}" && ! -x "${HOMEBREW_DEVELOPER_DIR}/usr/bin/m4" ]]
+then
+  safe_exec "/usr/bin/gm4" "$@"
+fi
+
+exec "/usr/bin/m4" "$@"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Not too sure about this.

May be unnecessary once new CLT is available with `m4`.

Mostly a workaround for source-build users on latest CLT without Xcode.app installed.