### PR TITLE
Sort kegs based on version scheme

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -381,7 +381,7 @@ module Homebrew
           end
         end
 
-        stable_kegs.max_by(&:version)
+        Keg.sort(stable_kegs).first
       end
 
       def resolve_default_keg(name)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -299,7 +299,7 @@ module Homebrew
     heads, versioned = kegs.partition { |k| k.version.head? }
     kegs = [
       *heads.sort_by { |k| -Tab.for_keg(k).time.to_i },
-      *versioned.sort_by(&:version),
+      *Keg.sort(versioned),
     ]
     if kegs.empty?
       puts "Not installed"

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -175,12 +175,11 @@ module Homebrew
       end
 
       not_outdated.each do |f|
-        versions = f.installed_kegs.map(&:version)
-        if versions.empty?
+        latest_keg = Keg.sort(f.installed_kegs).first
+        if latest_keg.nil?
           ofail "#{f.full_specified_name} not installed"
         else
-          version = versions.max
-          opoo "#{f.full_specified_name} #{version} already installed"
+          opoo "#{f.full_specified_name} #{latest_keg.version} already installed"
         end
       end
     end

--- a/Library/Homebrew/formula_pin.rb
+++ b/Library/Homebrew/formula_pin.rb
@@ -22,7 +22,10 @@ class FormulaPin
   end
 
   def pin
-    pin_at(@formula.installed_kegs.map(&:version).max)
+    latest_keg = Keg.sort(@formula.installed_kegs).first
+    return if latest_keg.nil?
+
+    pin_at(latest_keg.version)
   end
 
   def unpin

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -994,7 +994,7 @@ module Formulary
     flags: T.unsafe(nil)
   )
     kegs = rack.directory? ? rack.subdirs.map { |d| Keg.new(d) } : []
-    keg = kegs.find(&:linked?) || kegs.find(&:optlinked?) || kegs.max_by(&:version)
+    keg = kegs.find(&:linked?) || kegs.find(&:optlinked?) || Keg.sort(kegs).first
 
     options = {
       alias_path:,

--- a/Library/Homebrew/installed_dependents.rb
+++ b/Library/Homebrew/installed_dependents.rb
@@ -56,7 +56,7 @@ module InstalledDependents
         f_kegs = kegs_by_source[[f.name, f.tap]]
         next unless f_kegs
 
-        f_kegs.max_by(&:version)
+        Keg.sort(f_kegs).first
       end
 
       next if required_kegs.empty?

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -148,6 +148,11 @@ class Keg
     Formula.racks.flat_map(&:subdirs).map { |d| new(d) }
   end
 
+  sig { params(kegs: T::Array[Keg]).returns(T::Array[Keg]) }
+  def self.sort(kegs)
+    kegs.sort_by { |keg| [keg.version_scheme, keg.version] }.reverse!
+  end
+
   attr_reader :path, :name, :linked_keg_record, :opt_record
 
   protected :path
@@ -385,6 +390,10 @@ class Keg
   def version
     require "pkg_version"
     PkgVersion.parse(path.basename.to_s)
+  end
+
+  def version_scheme
+    @version_scheme ||= tab.version_scheme
   end
 
   def to_formula


### PR DESCRIPTION
`version_scheme` is exclusively used in situations where new version < old version, so all keg sorting techniques need to be aware of it.

Because this requires reading the tab, this has a minor performance penalty. Hopefully it is not noticeable.

This is a best effort attempt to fix all existing call sites - I could have missed some.