### PR TITLE
tap-info cmd: skip untapped core taps

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -48,7 +48,7 @@ module Homebrew
       formula_count = 0
       command_count = 0
       private_count = 0
-      Tap.each do |tap|
+      Tap.installed.each do |tap|
         tap_count += 1
         formula_count += tap.formula_files.size
         command_count += tap.command_files.size

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe "brew tap-info" do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  it "display brief statistics for all installed taps", :integration_test, :needs_network do
+    expect { brew "tap-info", "HOMEBREW_NO_INSTALL_FROM_API" => nil }
+      .to output(/\d+ taps?, \d+ private/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
 end


### PR DESCRIPTION
When homebrew/core or homebrew/cask are untapped `brew tap-info` fails because `Tap.each` includes them and `tap.private?` fails without a git repo interrogate.

This restores the behavior of `brew tap-info` before #16710

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
