### PR TITLE
cleanup: fix various cases where cache wasn't being removed properly

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -143,7 +143,7 @@ module Homebrew
           return true unless patch_hashes&.include?(Checksum.new(version.to_s))
         elsif resource_name && (resource_version = formula.stable&.resources&.dig(resource_name)&.version)
           return true if resource_version != version
-        elsif formula.version > version
+        elsif (formula.latest_version_installed? && formula.version != version) || formula.version > version
           return true
         end
 

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -134,6 +134,14 @@ module Homebrew
           nil
         end
 
+        if formula.blank? && formula_name.delete_suffix!("_bottle_manifest")
+          formula = begin
+            Formulary.from_rack(HOMEBREW_CELLAR/formula_name)
+          rescue FormulaUnavailableError, TapFormulaAmbiguityError
+            nil
+          end
+        end
+
         return false if formula.blank?
 
         resource_name = basename_str[/\A.*?--(.*?)--?(?:#{Regexp.escape(version.to_s)})/, 1]
@@ -328,7 +336,7 @@ module Homebrew
     def cleanup_formula(formula, quiet: false, ds_store: true, cache_db: true)
       formula.eligible_kegs_for_cleanup(quiet:)
              .each(&method(:cleanup_keg))
-      cleanup_cache(Pathname.glob(cache/"#{formula.name}--*").map { |path| { path:, type: nil } })
+      cleanup_cache(Pathname.glob(cache/"#{formula.name}{_bottle_manifest,}--*").map { |path| { path:, type: nil } })
       rm_ds_store([formula.rack]) if ds_store
       cleanup_cache_db(formula.rack) if cache_db
       cleanup_lockfiles(FormulaLock.new(formula.name).path)

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -340,7 +340,7 @@ class Bottle
 
   extend Forwardable
 
-  attr_reader :name, :resource, :cellar, :rebuild
+  attr_reader :name, :resource, :tag, :cellar, :rebuild
 
   def_delegators :resource, :url, :verify_download_integrity
   def_delegators :resource, :cached_download

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -33,16 +33,15 @@ module Utils
       end
 
       def file_outdated?(formula, file)
+        file = file.resolved_path
+
         filename = file.basename.to_s
         return false if formula.bottle.blank?
 
-        bottle_ext, bottle_tag, = extname_tag_rebuild(filename)
-        return false if bottle_ext.blank?
-        return false if bottle_tag != tag.to_s
+        _, bottle_tag, bottle_rebuild = extname_tag_rebuild(filename)
+        return false if bottle_tag.blank?
 
-        bottle_url_ext, = extname_tag_rebuild(formula.bottle.url)
-
-        bottle_ext && bottle_url_ext && bottle_ext != bottle_url_ext
+        bottle_tag != formula.bottle.tag.to_s || bottle_rebuild.to_i != formula.bottle.rebuild
       end
 
       def extname_tag_rebuild(filename)


### PR DESCRIPTION
* [utils/bottles: fix outdated bottle check](https://github.com/Homebrew/brew/commit/bb0252875e0a4f1100532231a2a8c6594e2ddd9e)
  - This check was completely broken under GitHub Packages as it would compare a classic formula bottle file extension to a ghcr.io url which just contains a sha256 string.
  - Now properly compares tag and rebuild.
* [cleanup: better handle version_scheme scenarios](https://github.com/Homebrew/brew/commit/92d44912e2657a1605772438ebf89b755bd2280e)
  - When `version_scheme` is bumped, `formula.version > version` will not be true. We cannot extract the version scheme here, but we can special case the latest-version-installed case to make that `!=` which should cover most scenarios.
* [cleanup: better support bottle manifests](https://github.com/Homebrew/brew/commit/58de9e0dda7009e245875dbbf2dfebf3983a110c)
  - `brew cleanup <formula>` failed to check any associated bottle manifests and those would only ever be removed by the timed prune.
  - This is now supported under the stale check by removing the `_bottle_manifest` suffix when parsing the formula name.

Will probably make a tag with this given it's causing some confusion/concern.