### PR TITLE
keg: update sorting by version logic

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -381,7 +381,7 @@ module Homebrew
           end
         end
 
-        Keg.sort(stable_kegs).first
+        stable_kegs.max_by(&:scheme_and_version)
       end
 
       def resolve_default_keg(name)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -296,7 +296,7 @@ module Homebrew
         heads, versioned = kegs.partition { |k| k.version.head? }
         kegs = [
           *heads.sort_by { |k| -Tab.for_keg(k).time.to_i },
-          *Keg.sort(versioned),
+          *versioned.sort_by(&:scheme_and_version),
         ]
         if kegs.empty?
           puts "Not installed"

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -175,7 +175,7 @@ module Homebrew
       end
 
       not_outdated.each do |f|
-        latest_keg = Keg.sort(f.installed_kegs).first
+        latest_keg = f.installed_kegs.max_by(&:scheme_and_version)
         if latest_keg.nil?
           ofail "#{f.full_specified_name} not installed"
         else

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1508,7 +1508,7 @@ class Formula
         []
       else
         all_kegs += old_installed_formulae.flat_map(&:installed_kegs)
-        Keg.sort(all_kegs)
+        all_kegs.sort_by(&:scheme_and_version)
       end
     end
   end
@@ -2268,7 +2268,7 @@ class Formula
 
     hsh.merge!(dependencies_hash)
 
-    hsh["installed"] = Keg.sort(installed_kegs).map do |keg|
+    hsh["installed"] = installed_kegs.sort_by(&:scheme_and_version).map do |keg|
       tab = Tab.for_keg keg
       {
         "version"                 => keg.version.to_s,
@@ -2841,7 +2841,7 @@ class Formula
       eligible_kegs = if head? && (head_prefix = latest_head_prefix)
         head, stable = installed_kegs.partition { |k| k.version.head? }
         # Remove newest head and stable kegs
-        head - [Keg.new(head_prefix)] + Keg.sort(stable).drop(1)
+        head - [Keg.new(head_prefix)] + stable.sort_by(&:scheme_and_version).slice(0...-1)
       else
         installed_kegs.select do |keg|
           tab = Tab.for_keg(keg)

--- a/Library/Homebrew/formula_pin.rb
+++ b/Library/Homebrew/formula_pin.rb
@@ -22,7 +22,7 @@ class FormulaPin
   end
 
   def pin
-    latest_keg = Keg.sort(@formula.installed_kegs).first
+    latest_keg = @formula.installed_kegs.max_by(&:scheme_and_version)
     return if latest_keg.nil?
 
     pin_at(latest_keg.version)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -994,7 +994,7 @@ module Formulary
     flags: T.unsafe(nil)
   )
     kegs = rack.directory? ? rack.subdirs.map { |d| Keg.new(d) } : []
-    keg = kegs.find(&:linked?) || kegs.find(&:optlinked?) || Keg.sort(kegs).first
+    keg = kegs.find(&:linked?) || kegs.find(&:optlinked?) || kegs.max_by(&:scheme_and_version)
 
     options = {
       alias_path:,

--- a/Library/Homebrew/installed_dependents.rb
+++ b/Library/Homebrew/installed_dependents.rb
@@ -56,7 +56,7 @@ module InstalledDependents
         f_kegs = kegs_by_source[[f.name, f.tap]]
         next unless f_kegs
 
-        Keg.sort(f_kegs).first
+        f_kegs.max_by(&:scheme_and_version)
       end
 
       next if required_kegs.empty?

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -148,11 +148,6 @@ class Keg
     Formula.racks.flat_map(&:subdirs).map { |d| new(d) }
   end
 
-  sig { params(kegs: T::Array[Keg]).returns(T::Array[Keg]) }
-  def self.sort(kegs)
-    kegs.sort_by { |keg| [keg.version_scheme, keg.version] }.reverse!
-  end
-
   attr_reader :path, :name, :linked_keg_record, :opt_record
 
   protected :path
@@ -394,6 +389,12 @@ class Keg
 
   def version_scheme
     @version_scheme ||= tab.version_scheme
+  end
+
+  # For ordering kegs by version with `.sort_by`, `.max_by`, etc.
+  # @see Formula.version_scheme
+  def scheme_and_version
+    [version_scheme, version]
   end
 
   def to_formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This updates logic to add a `#scheme_and_version` method to be used with `.sort_by` and `.max_by`. Using `Keg#version` by itself can be inaccurate when different version schemes are present. ~This also updates the behavior of `Formula#eligible_kegs_for_cleanup` to match the previous behavior. We were dropping the wrong keg based on the sort being reversed in a previous PR.~

More info: https://github.com/Homebrew/brew/pull/16973