### PR TITLE
tests: remove unnecessary cache clearing

### DIFF
--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe Homebrew::API::Cask do
 
   before do
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
-    Homebrew::API.clear_cache
-    described_class.clear_cache
   end
 
   def mock_curl_download(stdout:)

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe Homebrew::API::Formula do
 
   before do
     stub_const("Homebrew::API::HOMEBREW_CACHE_API", cache_dir)
-    described_class.clear_cache
   end
 
   def mock_curl_download(stdout:)

--- a/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
+++ b/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
@@ -44,12 +44,6 @@ RSpec.describe "Internal Tap JSON -- Formula" do
 
       # To allow `formula_names.txt` to be written to the cache.
       (HOMEBREW_CACHE/"api").mkdir
-
-      Homebrew::API::Formula.clear_cache
-    end
-
-    after do
-      Homebrew::API::Formula.clear_cache
     end
 
     it "loads tap aliases" do

--- a/Library/Homebrew/test/api_spec.rb
+++ b/Library/Homebrew/test/api_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe Homebrew::API do
   let(:json_hash) { JSON.parse(json) }
   let(:json_invalid) { '{"foo":"bar"' }
 
-  before do
-    described_class.clear_cache
-  end
-
   def mock_curl_output(stdout: "", success: true)
     curl_output = instance_double(SystemCommand::Result, stdout:, success?: success)
     allow(Utils::Curl).to receive(:curl_output).and_return curl_output

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -81,8 +81,6 @@ RSpec.describe Formulary do
     end
 
     context "with sharded Formula directory" do
-      before { CoreTap.instance.clear_cache }
-
       let(:formula_name) { "testball_sharded" }
       let(:formula_path) do
         core_tap = CoreTap.instance
@@ -236,7 +234,6 @@ RSpec.describe Formulary do
       before do
         alias_dir.mkpath
         FileUtils.ln_s formula_path, alias_path
-        tap.clear_cache
       end
 
       it "returns a Formula when given a name" do

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -4,10 +4,6 @@ require "utils/analytics"
 require "formula_installer"
 
 RSpec.describe Utils::Analytics do
-  before do
-    described_class.clear_cache
-  end
-
   describe "::default_package_tags" do
     let(:ci) { ", CI" if ENV["CI"] }
 

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -16,6 +16,8 @@ module Utils
     INFLUX_HOST = "https://eu-central-1-1.aws.cloud2.influxdata.com"
     INFLUX_ORG = "d81a3e6d582d485f"
 
+    extend Cachable
+
     class << self
       include Context
 
@@ -277,14 +279,9 @@ module Utils
         nil
       end
 
-      def clear_cache
-        remove_instance_variable(:@default_package_tags) if instance_variable_defined?(:@default_package_tags)
-        remove_instance_variable(:@default_package_fields) if instance_variable_defined?(:@default_package_fields)
-      end
-
       sig { returns(T::Hash[Symbol, String]) }
       def default_package_tags
-        @default_package_tags ||= begin
+        cache[:default_package_tags] ||= begin
           # Only display default prefixes to reduce cardinality and improve privacy
           prefix = Homebrew.default_prefix? ? HOMEBREW_PREFIX.to_s : "custom-prefix"
 
@@ -305,7 +302,7 @@ module Utils
       # remove macOS patch release
       sig { returns(T::Hash[Symbol, String]) }
       def default_package_fields
-        @default_package_fields ||= begin
+        cache[:default_package_fields] ||= begin
           version = if (match_data = HOMEBREW_VERSION.match(/^[\d.]+/))
             suffix = "-dev" if HOMEBREW_VERSION.include?("-")
             match_data[0] + suffix.to_s


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR removes all remaining unnecessary cache clearing in tests from the codebase since we now clear all cachable classes between tests making this functionally unnecessary.

Original PR to automatically clear caches:
- https://github.com/Homebrew/brew/pull/16746

I also moved the `Utils::Analytics` module to use cachable so that we don't have to clear caches specifically in tests anymore.