### PR TITLE
unpack_strategy/dmg: fix permissions when needed.

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -147,8 +147,16 @@ module UnpackStrategy
                             verbose:
           end
 
+          bomfile_path = T.must(bomfile.path)
+
+          # Ditto will try to write as the UID, not the EUID and the Tempfile has 0700 permissions.
+          if Process.euid != Process.uid
+            FileUtils.chown(nil, Process.gid, bomfile_path)
+            FileUtils.chmod "g+rw", bomfile_path
+          end
+
           system_command!("ditto",
-                          args:    ["--bom", bomfile.path, "--", path, unpack_dir],
+                          args:    ["--bom", bomfile_path, "--", path, unpack_dir],
                           verbose:)
 
           FileUtils.chmod "u+w", Pathname.glob(unpack_dir/"**/*", File::FNM_DOTMATCH).reject(&:symlink?)


### PR DESCRIPTION
`ditto` behaves weirdly when the EUID is different from the UID. This fix ensures that the BOM file is written with the correct permissions in this case.