### PR TITLE
go_resource deprecation comments

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3324,6 +3324,7 @@ class Formula
     end
 
     def go_resource(name, &block)
+      # odeprecated "Formula#go_resource", "Go modules"
       specs.each { |spec| spec.go_resource(name, &block) }
     end
 

--- a/Library/Homebrew/language/go.rb
+++ b/Library/Homebrew/language/go.rb
@@ -14,7 +14,7 @@ module Language
     # e.g. `resource "github.com/foo/bar"`.
     sig { params(resources: T::Array[Resource], target: T.any(String, Pathname)).void }
     def self.stage_deps(resources, target)
-      # odeprecated "Language::Go::stage_deps", "or request upstream to migrate to Go modules"
+      # odeprecated "Language::Go::stage_deps", "Go modules"
       if resources.empty?
         if Homebrew::EnvConfig.developer?
           odie "Tried to stage empty Language::Go resources array"

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -138,6 +138,7 @@ class SoftwareSpec
   end
 
   def go_resource(name, &block)
+    # odeprecated "SoftwareSpec#go_resource", "Go modules"
     resource name, Resource::Go, &block
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Continuing discussion at https://github.com/Homebrew/brew/pull/16971#discussion_r1545862059 and following up on related deprecation.

All usage has been removed from Homebrew/core.

---

Open to recommendations for better message.

I just simplified it to say `Use Go modules instead` under the assumption that Go modules is known and well documented. It isn't exactly a "replacement" in Homebrew but an upstream build change.