### PR TITLE
cask/audit: always enable codesign audit for casks

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -492,7 +492,7 @@ module Cask
 
           next if result.success?
 
-          add_error <<~EOS, location: cask.url.location, strict_only: true
+          add_error <<~EOS, location: cask.url.location
             Signature verification failed:
             #{result.merged_output}
             macOS on ARM requires software to be signed.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Enable `audit_signing` all the time, as discussed in https://github.com/Homebrew/homebrew-cask/issues/170345#issuecomment-2031334395
Previously this was only applied to "new" casks or when the `--strict` flag was passed.

This change would give us a better indication of how widespread unsigned binaries are in our official cask repositories.