### PR TITLE
Clean up args_parse tests

### DIFF
--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
-RSpec.describe "brew bundle", :integration_test do
-  describe "check" do
-    it "checks if a Brewfile's dependencies are satisfied", :needs_network do
-      setup_remote_tap "homebrew/bundle"
+require "cmd/shared_examples/args_parse"
 
-      HOMEBREW_REPOSITORY.cd do
-        system "git", "init"
-        system "git", "commit", "--allow-empty", "-m", "This is a test commit"
-      end
+RSpec.describe "Homebrew::Cmd::BundleCmd", :integration_test, :needs_network do
+  before { setup_remote_tap "homebrew/bundle" }
 
-      mktmpdir do |path|
-        FileUtils.touch "#{path}/Brewfile"
-        path.cd do
-          expect { brew "bundle", "check" }
-            .to output("The Brewfile's dependencies are satisfied.\n").to_stdout
-            .and not_to_output.to_stderr
-            .and be_a_success
-        end
+  it_behaves_like "parseable arguments", command_name: "bundle"
+
+  it "checks if a Brewfile's dependencies are satisfied" do
+    HOMEBREW_REPOSITORY.cd do
+      system "git", "init"
+      system "git", "commit", "--allow-empty", "-m", "This is a test commit"
+    end
+
+    mktmpdir do |path|
+      FileUtils.touch "#{path}/Brewfile"
+      path.cd do
+        expect { brew "bundle", "check" }
+          .to output("The Brewfile's dependencies are satisfied.\n").to_stdout
+          .and not_to_output.to_stderr
+          .and be_a_success
       end
     end
   end

--- a/Library/Homebrew/test/cmd/services_spec.rb
+++ b/Library/Homebrew/test/cmd/services_spec.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-RSpec.describe "brew services", :integration_test, :needs_network do
-  it "allows controlling services" do
-    setup_remote_tap "homebrew/services"
+require "cmd/shared_examples/args_parse"
 
+RSpec.describe "Homebrew::Cmd::Services", :integration_test, :needs_network do
+  before { setup_remote_tap "homebrew/services" }
+
+  it_behaves_like "parseable arguments", command_name: "services"
+
+  it "allows controlling services" do
     expect { brew "services", "list" }
       .to not_to_output.to_stderr
       .and not_to_output.to_stdout

--- a/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/args_parse.rb
@@ -1,22 +1,20 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "parseable arguments" do |argv: nil|
-  subject(:method_name) { "#{command_name.tr("-", "_")}_args" }
-
-  let(:command_name) do |example|
-    example.metadata[:example_group][:parent_example_group][:description].delete_prefix("brew ")
+RSpec.shared_examples "parseable arguments" do |command_name: nil|
+  let(:command) do |example|
+    example.metadata.dig(:example_group, :parent_example_group, :description)
   end
 
   it "can parse arguments" do
     if described_class
-      argv ||= described_class.parser.instance_variable_get(:@min_named_args)&.times&.map { "argument" }
-      argv ||= []
-      cmd = described_class.new(argv)
-      expect(cmd.args).to be_a Homebrew::CLI::Args
+      klass = described_class
     else
-      require "dev-cmd/#{command_name}" unless require? "cmd/#{command_name}"
-      parser = Homebrew.public_send(method_name)
-      expect(parser).to respond_to(:parse)
+      # for tests of remote taps, we need to load the command class
+      require(Commands.external_ruby_v2_cmd_path(command_name))
+      klass = Object.const_get(command)
     end
+    argv = klass.parser.instance_variable_get(:@min_named_args)&.times&.map { "argument" } || []
+    cmd = klass.new(argv)
+    expect(cmd.args).to be_a Homebrew::CLI::Args
   end
 end

--- a/Library/Homebrew/test/dev-cmd/prof_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/prof_spec.rb
@@ -4,7 +4,7 @@ require "cmd/shared_examples/args_parse"
 require "dev-cmd/prof"
 
 RSpec.describe Homebrew::DevCmd::Prof do
-  it_behaves_like "parseable arguments", argv: ["--", "help"]
+  it_behaves_like "parseable arguments"
 
   describe "integration tests", :integration_test, :needs_network do
     after do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Cleans up the `args_pars` tests, which no longer need to dynamically require paths for commands defined in the same repo. 

I've also extended it, so that it can support commands defined in remote taps.