### PR TITLE
Revert "cask/audit: always enable codesign audit for casks"

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -492,7 +492,7 @@ module Cask
 
           next if result.success?
 
-          add_error <<~EOS, location: cask.url.location
+          add_error <<~EOS, location: cask.url.location, strict_only: true
             Signature verification failed:
             #{result.merged_output}
             macOS on ARM requires software to be signed.


### PR DESCRIPTION
Reverts Homebrew/brew#17002

Reverting until further testing of the audit is completed. 