### PR TITLE
brew.rb: improve no auto-update exception handling.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -186,8 +186,10 @@ rescue Exception => e # rubocop:disable Lint/RescueException
 
   if OS.unsupported_configuration?
     $stderr.puts "#{Tty.bold}Do not report this issue: you are running in an unsupported configuration.#{Tty.reset}"
-  elsif Homebrew::EnvConfig.no_auto_update?
-    $stderr.puts "#{Tty.bold}You have disabled automatic updates.#{Tty.reset}"
+  elsif Homebrew::EnvConfig.no_auto_update? &&
+        (fetch_head = HOMEBREW_REPOSITORY/".git/FETCH_HEAD") &&
+        (!fetch_head.exist? || (fetch_head.mtime.to_date < Date.today))
+    $stderr.puts "#{Tty.bold}You have disabled automatic updates and have not updated today.#{Tty.reset}"
     $stderr.puts "#{Tty.bold}Do not report this issue until you've run `brew update` and tried again.#{Tty.reset}"
   elsif (issues_url = (method_deprecated_error && e.issues_url) || Utils::Backtrace.tap_error_url(e))
     $stderr.puts "If reporting this issue please do so at (not Homebrew/brew or Homebrew/homebrew-core):"


### PR DESCRIPTION
Instead of unconditionally telling people to `brew update` rather than not reporting the issue, only do so if they haven't run `brew update` today.

As suggested by @carlocab in https://github.com/Homebrew/brew/pull/17003#discussion_r1549140045