### PR TITLE
dev-cmd/typecheck: use EUID with sorbet

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -43,6 +43,9 @@ module Homebrew
         groups = update ? Homebrew.valid_gem_groups : ["typecheck"]
         Homebrew.install_bundler_gems!(groups:)
 
+        # Sorbet doesn't use bash privileged mode so we align EUID and UID here.
+        Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
+
         HOMEBREW_LIBRARY_PATH.cd do
           if update
             safe_system "bundle", "exec", "tapioca", "dsl"


### PR DESCRIPTION
When UID != EUID then Sorbet uses UID, however the rest of Homebrew uses EUID so we get permission errors.