### PR TITLE
Restrict AbstractCommand test to commands in repo

### DIFF
--- a/Library/Homebrew/test/abstract_command_spec.rb
+++ b/Library/Homebrew/test/abstract_command_spec.rb
@@ -62,17 +62,14 @@ RSpec.describe Homebrew::AbstractCommand do
 
   describe "command paths" do
     it "match command name" do
-      # Ensure all commands are loaded
       ["cmd", "dev-cmd"].each do |dir|
-        Dir[File.join(__dir__, "../#{dir}", "*.rb")].each { require(_1) }
-      end
-      test_classes = ["TestCat", "Tac"]
-
-      described_class.subclasses.each do |klass|
-        next if test_classes.include?(klass.name)
-
-        dir = klass.name.start_with?("Homebrew::DevCmd") ? "dev-cmd" : "cmd"
-        expect(Pathname(File.join(__dir__, "../#{dir}/#{klass.command_name}.rb"))).to exist
+        Dir[File.join(__dir__, "../#{dir}", "*.rb")].each do |file|
+          filename = File.basename(file, ".rb")
+          require(file)
+          command = described_class.command(filename)
+          dir = command.name.start_with?("Homebrew::DevCmd") ? "dev-cmd" : "cmd"
+          expect(Pathname(File.join(__dir__, "../#{dir}/#{command.command_name}.rb"))).to exist
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
…otherwise failure will occur if other commands are loaded, e.g. https://github.com/Homebrew/brew/actions/runs/8557029372/job/23450781543?pr=17024#step:12:44 (which somehow had required https://github.com/Homebrew/homebrew-services/blob/master/cmd/services.rb )