### PR TITLE
Enable strict typing in `CLI::Parser`

### DIFF
--- a/Library/Homebrew/abstract_command.rb
+++ b/Library/Homebrew/abstract_command.rb
@@ -26,6 +26,9 @@ module Homebrew
       sig { params(name: String).returns(T.nilable(T.class_of(AbstractCommand))) }
       def command(name) = subclasses.find { _1.command_name == name }
 
+      sig { returns(T::Boolean) }
+      def dev_cmd? = T.must(name).start_with?("Homebrew::DevCmd")
+
       sig { returns(CLI::Parser) }
       def parser = CLI::Parser.new(self, &@parser_block)
 

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -136,9 +136,9 @@ begin
   end
 rescue UsageError => e
   require "help"
-  Homebrew::Help.help cmd, remaining_args: T.must(args).remaining, usage_error: e.message
+  Homebrew::Help.help cmd, remaining_args: args&.remaining, usage_error: e.message
 rescue SystemExit => e
-  onoe "Kernel.exit" if T.must(args).debug? && !e.success?
+  onoe "Kernel.exit" if args&.debug? && !e.success?
   $stderr.puts Utils::Backtrace.clean(e) if args&.debug? || ARGV.include?("--debug")
   raise
 rescue Interrupt

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -136,9 +136,9 @@ begin
   end
 rescue UsageError => e
   require "help"
-  Homebrew::Help.help cmd, remaining_args: args.remaining, usage_error: e.message
+  Homebrew::Help.help cmd, remaining_args: T.must(args).remaining, usage_error: e.message
 rescue SystemExit => e
-  onoe "Kernel.exit" if args.debug? && !e.success?
+  onoe "Kernel.exit" if T.must(args).debug? && !e.success?
   $stderr.puts Utils::Backtrace.clean(e) if args&.debug? || ARGV.include?("--debug")
   raise
 rescue Interrupt
@@ -146,7 +146,7 @@ rescue Interrupt
   exit 130
 rescue BuildError => e
   Utils::Analytics.report_build_error(e)
-  e.dump(verbose: args&.verbose?)
+  e.dump(verbose: args&.verbose? || false)
 
   if OS.unsupported_configuration?
     $stderr.puts "#{Tty.bold}Do not report this issue: you are running in an unsupported configuration.#{Tty.reset}"

--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -14,6 +14,9 @@ class Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def quiet?; end
 
+  sig { returns(T::Array[String]) }
+  def remaining; end
+
   sig { returns(T::Boolean) }
   def verbose?; end
 end

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -12,6 +12,7 @@ require "utils/tty"
 module Homebrew
   module CLI
     class Parser
+      # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
       # rubocop:disable Style/MutableConstant
       ArgType = T.type_alias { T.any(NilClass, Symbol, T::Array[String], T::Array[Symbol]) }
       OptionsType = T.type_alias { T::Array[[String, T.nilable(String), T.nilable(String), String, T::Boolean]] }

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -250,7 +250,7 @@ module Homebrew
       end
 
       sig {
-        params(names: String, description: T.nilable(String), replacement: T.untyped, depends_on: T.nilable(String),
+        params(names: String, description: T.nilable(String), replacement: T.any(Symbol, String, NilClass), depends_on: T.nilable(String),
                hidden: T::Boolean).void
       }
       def flag(*names, description: nil, replacement: nil, depends_on: nil, hidden: false)

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -251,8 +251,8 @@ module Homebrew
       end
 
       sig {
-        params(names: String, description: T.nilable(String), replacement: T.any(Symbol, String, NilClass), depends_on: T.nilable(String),
-               hidden: T::Boolean).void
+        params(names: String, description: T.nilable(String), replacement: T.any(Symbol, String, NilClass),
+               depends_on: T.nilable(String), hidden: T::Boolean).void
       }
       def flag(*names, description: nil, replacement: nil, depends_on: nil, hidden: false)
         required, flag_type = if names.any? { |name| name.end_with? "=" }

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -5,6 +5,7 @@ require "abstract_command"
 require "formulary"
 require "cask/cask_loader"
 
+# @!visibility private
 class String
   def f(*args)
     require "formula"

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -5,23 +5,26 @@ require "abstract_command"
 require "formulary"
 require "cask/cask_loader"
 
-# @!visibility private
 class String
+  # @!visibility private
   def f(*args)
     require "formula"
     Formulary.factory(self, *args)
   end
 
+  # @!visibility private
   def c(config: nil)
     Cask::CaskLoader.load(self, config:)
   end
 end
 
 class Symbol
+  # @!visibility private
   def f(*args)
     to_s.f(*args)
   end
 
+  # @!visibility private
   def c(config: nil)
     to_s.c(config:)
   end

--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -116,7 +116,7 @@ module Homebrew
       help_lines = command_help_lines(path)
       return if help_lines.blank?
 
-      Formatter.format_help_text(help_lines.join, width: COMMAND_DESC_WIDTH)
+      Formatter.format_help_text(help_lines.join, width: Formatter::COMMAND_DESC_WIDTH)
                .sub("@hide_from_man_page ", "")
                .sub(/^\* /, "#{Tty.bold}Usage: brew#{Tty.reset} ")
                .gsub(/`(.*?)`/m, "#{Tty.bold}\\1#{Tty.reset}")

--- a/Library/Homebrew/test/abstract_command_spec.rb
+++ b/Library/Homebrew/test/abstract_command_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe Homebrew::AbstractCommand do
           filename = File.basename(file, ".rb")
           require(file)
           command = described_class.command(filename)
-          dir = command.name.start_with?("Homebrew::DevCmd") ? "dev-cmd" : "cmd"
           expect(Pathname(File.join(__dir__, "../#{dir}/#{command.command_name}.rb"))).to exist
         end
       end

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -7,6 +7,9 @@ require "utils/tty"
 #
 # @api private
 module Formatter
+  COMMAND_DESC_WIDTH = 80
+  OPTION_DESC_WIDTH = 45
+
   def self.arrow(string, color: nil)
     prefix("==>", string, color)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I just wanted to capture #parser to work on Args namespacing, but decided to go all the way. (There's a pretty decent chance of type error creeping in, it's hard to find the right balance of rigor & narrowness without allowing an opportunity for some to slip in.)