### PR TITLE
cask/audit: update signing checks for app, binary, and pkg

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -482,13 +482,25 @@ module Cask
       odebug "Auditing signing"
 
       extract_artifacts do |artifacts, tmpdir|
+        is_container = artifacts.any? { |a| a.is_a?(Artifact::App) || a.is_a?(Artifact::Pkg) }
+
         artifacts.each do |artifact|
+          next if artifact.is_a?(Artifact::Binary) && is_container == true
+
           artifact_path = artifact.is_a?(Artifact::Pkg) ? artifact.path : artifact.source
+
           path = tmpdir/artifact_path.relative_path_from(cask.staged_path)
 
-          next unless path.exist?
-
-          result = system_command("spctl", args: ["--assess", "--type", "install", path], print_stderr: false)
+          result = case artifact
+          when Artifact::Pkg
+            system_command("spctl", args: ["--assess", "--type", "install", path], print_stderr: false)
+          when Artifact::App
+            system_command("spctl", args: ["--assess", "--type", "execute", path], print_stderr: false)
+          when Artifact::Binary
+            system_command("codesign",  args: ["--verify", path], print_stderr: false)
+          else
+            add_error "Unknown artifact type: #{artifact.class}", location: cask.url.location
+          end
 
           next if result.success?
 

--- a/Library/Homebrew/unpack_strategy/uncompressed.rb
+++ b/Library/Homebrew/unpack_strategy/uncompressed.rb
@@ -22,7 +22,7 @@ module UnpackStrategy
 
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
     def extract_to_dir(unpack_dir, basename:, verbose: false)
-      FileUtils.cp path, unpack_dir/basename, preserve: true, verbose:
+      FileUtils.cp path, unpack_dir/basename.sub(/^[\da-f]{64}--/, ""), preserve: true, verbose:
     end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

POC changes to address some issues in auditing Casks, where we are failing some valid Casks.

[This doc](https://developer.apple.com/forums/thread/130560) used as the source material for updating the checks.  Based on it, the checks should be different where it is an app, a pkg, or a binary.

*This is still not complete*, as this will still fail some valid Casks (such as GitHub Desktop), and we need to implement (IMHO) some checking directly DMG's to check signature.  But hopeful this kickstarts a conversation.