### PR TITLE
Add IRB H = Homebrew alias

### DIFF
--- a/Library/Homebrew/brew_irbrc
+++ b/Library/Homebrew/brew_irbrc
@@ -4,6 +4,6 @@
 
 require 'irb/completion'
 
-IRB.conf[:SAVE_HISTORY] = 100
 IRB.conf[:HISTORY_FILE] = "#{Dir.home}/.brew_irb_history"
 IRB.conf[:IRB_NAME] = "brew"
+H = Homebrew

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -76,7 +76,6 @@ module Homebrew
         if args.pry?
           Pry.config.should_load_rc = false # skip loading .pryrc
           Pry.config.history_file = "#{Dir.home}/.brew_pry_history"
-          Pry.config.memory_size = 100 # max lines to save to history file
           Pry.config.prompt_name = "brew"
 
           Pry.start


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
…to save my a few strokes in irb sessions

Also, an adjacent change to keep the [default](https://github.com/ruby/irb/blob/2057248e40f36bd81940a528b5585ba44fc4672f/lib/irb/init.rb#L95) `SAVE_HISTORY` of 1000 (I couldn't find the rationale for this setting in the [PR](https://github.com/Homebrew/brew/pull/14892/files#diff-6197dbe80aa672aa545d87e07b618e33fa42ba692b2114c54fcd08def0d79ebeR7) that added it (cc @apainintheneck). Happy to remove this change if it's controversial. Perhaps we should provide a hook for folks to inject their own preferred irb settings)

We may want `pry` parity, in which case we'd have to make this change in https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/irb.rb since we don't ship a pryrc file (i think we may not be able to customize the location)