### PR TITLE
fix: github_runner_matrix timeout

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -154,7 +154,6 @@ class GitHubRunnerMatrix
       next if macos_version < :big_sur
 
       runner = +"#{version}-arm64"
-      runner_timeout = timeout
 
       use_ephemeral = macos_version >= :monterey
       runner << ephemeral_suffix if use_ephemeral

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -105,7 +105,6 @@ class GitHubRunnerMatrix
     runner.freeze
   end
 
-  NEWEST_GITHUB_ACTIONS_MACOS_RUNNER = :ventura
   OLDEST_GITHUB_ACTIONS_MACOS_RUNNER = :big_sur
   GITHUB_ACTIONS_RUNNER_TIMEOUT = 360
 
@@ -137,7 +136,6 @@ class GitHubRunnerMatrix
 
       # Use GitHub Actions macOS Runner for testing dependents if compatible with timeout.
       runner, runner_timeout = if (@dependent_matrix || use_github_runner) &&
-                                  macos_version <= NEWEST_GITHUB_ACTIONS_MACOS_RUNNER &&
                                   macos_version >= OLDEST_GITHUB_ACTIONS_MACOS_RUNNER &&
                                   runner_timeout <= GITHUB_ACTIONS_RUNNER_TIMEOUT
         ["macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
@@ -164,7 +162,9 @@ class GitHubRunnerMatrix
       runner.freeze
 
       # The ARM runners are typically over twice as fast as the Intel runners.
-      runner_timeout /= 2 if runner_timeout < GITHUB_ACTIONS_LONG_TIMEOUT
+      if runner_timeout != GITHUB_ACTIONS_LONG_TIMEOUT && runner_timeout != GITHUB_ACTIONS_RUNNER_TIMEOUT
+        runner_timeout /= 2
+      end
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-arm64",
         runner:,


### PR DESCRIPTION
- remove `NEWEST_GITHUB_ACTIONS_MACOS_RUNNER` as no one will remember to update it
   Brew always supports the latest version of the macOS release.
- no need to half the time on github runners
   It is still possible for arm runners to hit the time limit. https://github.com/Homebrew/homebrew-core/actions/runs/8553455945

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
