### PR TITLE
rubocops/resource_requires_dependencies: check `sym_type?`

### DIFF
--- a/Library/Homebrew/rubocops/resource_requires_dependencies.rb
+++ b/Library/Homebrew/rubocops/resource_requires_dependencies.rb
@@ -27,8 +27,8 @@ module RuboCop
             uses_from_macos_or_depends_on = (uses_from_macos_nodes + depends_on_nodes).filter_map do |node|
               if (dep = node.arguments.first).hash_type?
                 dep_types = dep.values.first
-                dep_types = dep_types.array_type? ? dep_types.values.map(&:value) : [dep_types.value]
-                dep.keys.first.str_content if dep_types.include?(:build)
+                dep_types = dep_types.array_type? ? dep_types.values : [dep_types]
+                dep.keys.first.str_content if dep_types.select(&:sym_type?).map(&:value).include?(:build)
               else
                 dep.str_content
               end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Previous behavior shouldn't impact expected DSL usage; however, in the case of some incorrect DSL `brew audit` will output a message like:
```
An error occurred while FormulaAudit/ResourceRequiresDependencies cop was inspecting ...
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
```

To avoid incorrectly directing users to RuboCop repo, I am following up on #17032 to only operate after filtering the `sym_type?`