### PR TITLE
manpages: move `require`s after `install_bundler_gems!`

### DIFF
--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -3,10 +3,6 @@
 
 require "cli/parser"
 require "erb"
-require "kramdown"
-require "manpages/parser/ronn"
-require "manpages/converter/kramdown"
-require "manpages/converter/roff"
 
 SOURCE_PATH = (HOMEBREW_LIBRARY_PATH/"manpages").freeze
 TARGET_MAN_PATH = (HOMEBREW_REPOSITORY/"manpages").freeze
@@ -33,6 +29,11 @@ module Homebrew
 
     def self.regenerate_man_pages(quiet:)
       Homebrew.install_bundler_gems!(groups: ["man"])
+
+      require "kramdown"
+      require "manpages/parser/ronn"
+      require "manpages/converter/kramdown"
+      require "manpages/converter/roff"
 
       markup = build_man_page(quiet:)
       root, warnings = Parser::Ronn.parse(markup)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

May need confirmation these are only needed inside `regenerate_man_pages`.