### PR TITLE
Add more `HOMEBREW_FORBIDDEN_*` configuration

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -71,6 +71,9 @@ module Cask
       download(quiet:, timeout:)
 
       satisfy_cask_and_formula_dependencies
+
+      forbidden_tap_check
+      forbidden_cask_and_formula_check
     end
 
     def stage
@@ -569,6 +572,107 @@ on_request: true)
     def purge_caskroom_path
       odebug "Purging all staged versions of Cask #{@cask}"
       gain_permissions_remove(@cask.caskroom_path)
+    end
+
+    sig { void }
+    def forbidden_tap_check
+      forbidden_taps = Homebrew::EnvConfig.forbidden_taps
+      return if forbidden_taps.blank?
+
+      forbidden_taps_set = Set.new(forbidden_taps.split.filter_map do |tap|
+        Tap.fetch(tap)
+      rescue Tap::InvalidNameError
+        opoo "Invalid tap name in `HOMEBREW_FORBIDDEN_TAPS`: #{tap}"
+        nil
+      end)
+
+      owner = Homebrew::EnvConfig.forbidden_owner
+      owner_contact = if (contact = Homebrew::EnvConfig.forbidden_owner_contact.presence)
+        "\n#{contact}"
+      end
+
+      unless skip_cask_deps?
+        cask_and_formula_dependencies.each do |cask_or_formula|
+          dep_tap = cask_or_formula.tap
+          next if dep_tap.blank?
+          next unless forbidden_taps_set.include?(dep_tap)
+
+          dep_full_name = cask_or_formula.full_name
+          raise CaskCannotBeInstalledError.new(@cask, <<~EOS
+            The installation of #{@cask} has a dependency #{dep_full_name}
+            but the #{dep_tap} tap was forbidden by #{owner} in `HOMEBREW_FORBIDDEN_TAPS`.#{owner_contact}
+          EOS
+          )
+        end
+      end
+
+      cask_tap = @cask.tap
+      return if cask_tap.blank?
+      return unless forbidden_taps_set.include?(cask_tap)
+
+      raise CaskCannotBeInstalledError.new(@cask, <<~EOS
+        The installation of #{@cask.full_name} has the tap #{cask_tap}
+        which was forbidden by #{owner} in `HOMEBREW_FORBIDDEN_TAPS`.#{owner_contact}
+      EOS
+      )
+    end
+
+    sig { void }
+    def forbidden_cask_and_formula_check
+      forbidden_formulae = Set.new(Homebrew::EnvConfig.forbidden_formulae.to_s.split)
+      forbidden_casks = Set.new(Homebrew::EnvConfig.forbidden_casks.to_s.split)
+      return if forbidden_formulae.blank? && forbidden_casks.blank?
+
+      owner = Homebrew::EnvConfig.forbidden_owner
+      owner_contact = if (contact = Homebrew::EnvConfig.forbidden_owner_contact.presence)
+        "\n#{contact}"
+      end
+
+      unless skip_cask_deps?
+        cask_and_formula_dependencies.each do |dep_cask_or_formula|
+          dep_name, dep_type, variable = if dep_cask_or_formula.is_a?(Cask) && forbidden_casks.present?
+            dep_cask = dep_cask_or_formula
+            dep_cask_name = if forbidden_casks.include?(dep_cask.token)
+              dep_cask.token
+            elsif dep_cask.tap.present? &&
+                  forbidden_casks.include?(dep_cask.full_name)
+              dep_cask.full_name
+            end
+            [dep_cask_name, "cask", "HOMEBREW_FORBIDDEN_CASKS"]
+          elsif dep_cask_or_formula.is_a?(Formula) && forbidden_formulae.present?
+            dep_formula = dep_cask_or_formula
+            formula_name = if forbidden_formulae.include?(dep_formula.name)
+              dep_formula.name
+            elsif dep_formula.tap.present? &&
+                  forbidden_formulae.include?(dep_formula.full_name)
+              dep_formula.full_name
+            end
+            [formula_name, "formula", "HOMEBREW_FORBIDDEN_FORMULAE"]
+          end
+          next if dep_name.blank?
+
+          raise CaskCannotBeInstalledError.new(@cask, <<~EOS
+            The installation of #{@cask} has a dependency #{dep_name}
+            but the #{dep_name} #{dep_type} was forbidden by #{owner} in `#{variable}`.#{owner_contact}
+          EOS
+          )
+        end
+      end
+      return if forbidden_casks.blank?
+
+      cask_name = if forbidden_casks.include?(@cask.token)
+        @cask.token
+      elsif forbidden_casks.include?(@cask.full_name)
+        @cask.full_name
+      else
+        return
+      end
+
+      raise CaskCannotBeInstalledError.new(@cask, <<~EOS
+        The installation of #{cask_name} was forbidden by #{owner}
+        in `HOMEBREW_FORBIDDEN_CASKS`.#{owner_contact}
+      EOS
+      )
     end
 
     private

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -185,9 +185,28 @@ module Homebrew
         description: "Output this many lines of output on formula `system` failures.",
         default:     15,
       },
+      HOMEBREW_FORBIDDEN_CASKS:                  {
+        description: "A space-separated list of casks. Homebrew will refuse to install a " \
+                     "cask if it or any of its dependencies is on this list.",
+      },
+      HOMEBREW_FORBIDDEN_FORMULAE:               {
+        description: "A space-separated list of formulae. Homebrew will refuse to install a " \
+                     "formula or cask if it or any of its dependencies is on this list.",
+      },
       HOMEBREW_FORBIDDEN_LICENSES:               {
         description: "A space-separated list of licenses. Homebrew will refuse to install a " \
                      "formula if it or any of its dependencies has a license on this list.",
+      },
+      HOMEBREW_FORBIDDEN_OWNER:                  {
+        description: "The person who has set any `HOMEBREW_FORBIDDEN_*` variables.",
+        default:     "you",
+      },
+      HOMEBREW_FORBIDDEN_OWNER_CONTACT:          {
+        description: "How to contact the `HOMEBREW_FORBIDDEN_OWNER`, if set and necessary.",
+      },
+      HOMEBREW_FORBIDDEN_TAPS:                   {
+        description: "A space-separated list of taps. Homebrew will refuse to install a " \
+                     "formula if it or any of its dependencies is in a tap on this list.",
       },
       HOMEBREW_FORCE_BREWED_CA_CERTIFICATES:     {
         description: "If set, always use a Homebrew-installed `ca-certificates` rather than the system version. " \

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -106,7 +106,22 @@ module Homebrew::EnvConfig
     def fail_log_lines; end
 
     sig { returns(T.nilable(::String)) }
+    def forbidden_casks; end
+
+    sig { returns(T.nilable(::String)) }
+    def forbidden_formulae; end
+
+    sig { returns(T.nilable(::String)) }
     def forbidden_licenses; end
+
+    sig { returns(String) }
+    def forbidden_owner; end
+
+    sig { returns(T.nilable(::String)) }
+    def forbidden_owner_contact; end
+
+    sig { returns(T.nilable(::String)) }
+    def forbidden_taps; end
 
     sig { returns(T::Boolean) }
     def force_brewed_ca_certificates?; end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -39,12 +39,14 @@ class Tap
     #{HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR}/*.json
   ].freeze
 
+  class InvalidNameError < ArgumentError; end
+
   sig { params(user: String, repo: String).returns(Tap) }
   def self.fetch(user, repo = T.unsafe(nil))
     user, repo = user.split("/", 2) if repo.nil?
 
     if [user, repo].any? { |part| part.nil? || part.include?("/") }
-      raise ArgumentError, "Invalid tap name: '#{[*user, *repo].join("/")}'"
+      raise InvalidNameError, "Invalid tap name: '#{[*user, *repo].join("/")}'"
     end
 
     user = T.must(user)

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
 
     it "raises an error for invalid tap" do
       taps = described_class.new("homebrew/foo", "barbaz")
-      expect { taps.to_taps }.to raise_error(ArgumentError, /Invalid tap name/)
+      expect { taps.to_taps }.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
     end
   end
 
@@ -333,7 +333,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
 
     it "raises an error for invalid tap" do
       taps = described_class.new("homebrew/foo", "barbaz")
-      expect { taps.to_installed_taps }.to raise_error(ArgumentError, /Invalid tap name/)
+      expect { taps.to_installed_taps }.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
     end
   end
 end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -105,15 +105,15 @@ RSpec.describe Tap do
 
     expect do
       described_class.fetch("foo")
-    end.to raise_error(ArgumentError, /Invalid tap name/)
+    end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
 
     expect do
       described_class.fetch("homebrew/homebrew/bar")
-    end.to raise_error(ArgumentError, /Invalid tap name/)
+    end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
 
     expect do
       described_class.fetch("homebrew", "homebrew/baz")
-    end.to raise_error(ArgumentError, /Invalid tap name/)
+    end.to raise_error(Tap::InvalidNameError, /Invalid tap name/)
   end
 
   describe "::from_path" do

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3647,10 +3647,35 @@ command execution e.g. `$(cat file)`.
   
   *Default:* `15`.
 
+`HOMEBREW_FORBIDDEN_CASKS`
+
+: A space-separated list of casks. Homebrew will refuse to install a cask if it
+  or any of its dependencies is on this list.
+
+`HOMEBREW_FORBIDDEN_FORMULAE`
+
+: A space-separated list of formulae. Homebrew will refuse to install a formula
+  or cask if it or any of its dependencies is on this list.
+
 `HOMEBREW_FORBIDDEN_LICENSES`
 
 : A space-separated list of licenses. Homebrew will refuse to install a formula
   if it or any of its dependencies has a license on this list.
+
+`HOMEBREW_FORBIDDEN_OWNER`
+
+: The person who has set any `HOMEBREW_FORBIDDEN_*` variables.
+  
+  *Default:* `you`.
+
+`HOMEBREW_FORBIDDEN_OWNER_CONTACT`
+
+: How to contact the `HOMEBREW_FORBIDDEN_OWNER`, if set and necessary.
+
+`HOMEBREW_FORBIDDEN_TAPS`
+
+: A space-separated list of taps. Homebrew will refuse to install a formula if
+  it or any of its dependencies is in a tap on this list.
 
 `HOMEBREW_FORCE_BREWED_CA_CERTIFICATES`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2368,8 +2368,27 @@ Output this many lines of output on formula \fBsystem\fP failures\.
 \fIDefault:\fP \fB15\fP\&\.
 .RE
 .TP
+\fBHOMEBREW_FORBIDDEN_CASKS\fP
+A space\-separated list of casks\. Homebrew will refuse to install a cask if it or any of its dependencies is on this list\.
+.TP
+\fBHOMEBREW_FORBIDDEN_FORMULAE\fP
+A space\-separated list of formulae\. Homebrew will refuse to install a formula or cask if it or any of its dependencies is on this list\.
+.TP
 \fBHOMEBREW_FORBIDDEN_LICENSES\fP
 A space\-separated list of licenses\. Homebrew will refuse to install a formula if it or any of its dependencies has a license on this list\.
+.TP
+\fBHOMEBREW_FORBIDDEN_OWNER\fP
+The person who has set any \fBHOMEBREW_FORBIDDEN_*\fP variables\.
+.RS
+.P
+\fIDefault:\fP \fByou\fP\&\.
+.RE
+.TP
+\fBHOMEBREW_FORBIDDEN_OWNER_CONTACT\fP
+How to contact the \fBHOMEBREW_FORBIDDEN_OWNER\fP, if set and necessary\.
+.TP
+\fBHOMEBREW_FORBIDDEN_TAPS\fP
+A space\-separated list of taps\. Homebrew will refuse to install a formula if it or any of its dependencies is in a tap on this list\.
 .TP
 \fBHOMEBREW_FORCE_BREWED_CA_CERTIFICATES\fP
 If set, always use a Homebrew\-installed \fBca\-certificates\fP rather than the system version\. Automatically set if the system version is too old\.


### PR DESCRIPTION
We already had `HOMEBREW_FORBIDDEN_LICENSES` but this PR adds `HOMEBREW_FORBIDDEN_CASKS`, `HOMEBREW_FORBIDDEN_FORMULAE` and `HOMEBREW_FORBIDDEN_TAPS` for also forbidding those.

Relatedly, add `HOMEBREW_FORBIDDEN_OWNER` and `HOMEBREW_FORBIDDEN_OWNER_CONTACT` to allow customising these messages.

There were no existing tests for `HOMEBREW_FORBIDDEN_LICENSES` so have added more tests for all of these checks.