### PR TITLE
dev-cmd/bump-cask-pr: use FromContentLoader when relevant.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -215,7 +215,8 @@ module Homebrew
                                                             read_only_run: true,
                                                             silent:        true)
 
-            tmp_cask = Cask::CaskLoader.load(tmp_contents)
+            tmp_cask = Cask::CaskLoader::FromContentLoader.new(tmp_contents)
+                                                          .load(config: nil)
             old_hash = tmp_cask.sha256
             if tmp_cask.version.latest? || new_hash == :no_check
               opoo "Ignoring specified `--sha256=` argument." if new_hash.is_a?(String)


### PR DESCRIPTION
When loading from `tmp_contents` in `bump-cask-pr` we're always loading from the contents and not from a e.g. filename etc. As a result, skip the detection of the correct loader (as the regex can be a bit flaky) and instead use `FromContentLoader` directly.