### PR TITLE
Allow `--display-times` with `--cask`

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -341,7 +341,7 @@ on_request: true)
       missing_formulae_and_casks = missing_cask_and_formula_dependencies
 
       if missing_formulae_and_casks.empty?
-        puts "All formula dependencies satisfied."
+        puts "All dependencies satisfied."
         return
       end
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -290,7 +290,7 @@ module Homebrew
           )
         end
 
-        return if installed_formulae.empty?
+        return if formulae.any? && installed_formulae.empty?
 
         Install.perform_preinstall_checks(cc: args.cc)
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -32,6 +32,9 @@ module Homebrew
         switch "-d", "--debug",
                description: "If brewing fails, open an interactive debugging session with access to IRB " \
                             "or a shell inside the temporary build directory."
+        switch "--display-times",
+               env:         :display_install_times,
+               description: "Print install times for each package at the end of the run."
         switch "-f", "--force",
                description: "Install formulae without checking for previously installed keg-only or " \
                             "non-migrated versions. When installing casks, overwrite existing files " \
@@ -102,10 +105,6 @@ module Homebrew
             depends_on:  "--build-bottle",
             description: "Optimise bottles for the specified architecture rather than the oldest " \
                          "architecture supported by the version of macOS the bottles are built on.",
-          }],
-          [:switch, "--display-times", {
-            env:         :display_install_times,
-            description: "Print install times for each package at the end of the run.",
           }],
           [:switch, "-i", "--interactive", {
             description: "Download and patch <formula>, then open a shell. This allows the user to " \

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -31,6 +31,9 @@ module Homebrew
         switch "-d", "--debug",
                description: "If brewing fails, open an interactive debugging session with access to IRB " \
                             "or a shell inside the temporary build directory."
+        switch "--display-times",
+               env:         :display_install_times,
+               description: "Print install times for each package at the end of the run."
         switch "-f", "--force",
                description: "Install without checking for previously installed keg-only or " \
                             "non-migrated versions."
@@ -56,10 +59,6 @@ module Homebrew
           [:switch, "--debug-symbols", {
             depends_on:  "--build-from-source",
             description: "Generate debug symbols on build. Source will be retained in a cache directory.",
-          }],
-          [:switch, "--display-times", {
-            env:         :display_install_times,
-            description: "Print install times for each formula at the end of the run.",
           }],
           [:switch, "-g", "--git", {
             description: "Create a Git repository, useful for creating patches to the software.",

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -28,6 +28,9 @@ module Homebrew
         switch "-d", "--debug",
                description: "If brewing fails, open an interactive debugging session with access to IRB " \
                             "or a shell inside the temporary build directory."
+        switch "--display-times",
+               env:         :display_install_times,
+               description: "Print install times for each package at the end of the run."
         switch "-f", "--force",
                description: "Install formulae without checking for previously installed keg-only or " \
                             "non-migrated versions. When installing casks, overwrite existing files " \
@@ -68,10 +71,6 @@ module Homebrew
           [:switch, "--debug-symbols", {
             depends_on:  "--build-from-source",
             description: "Generate debug symbols on build. Source will be retained in a cache directory.",
-          }],
-          [:switch, "--display-times", {
-            env:         :display_install_times,
-            description: "Print install times for each package at the end of the run.",
           }],
           [:switch, "--overwrite", {
             description: "Delete files that already exist in the prefix while linking.",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Options `--cask` and `--display-times` do not need to be mutually exclusive with `brew install`, `brew reinstall` and `brew upgrade`.

https://github.com/Homebrew/brew/commit/eb16e10902565f113034fe42793865cc2e3ced90 added recording of cask installation times but didn't update the conflicts.

`install.rb` had a faulty `return if` condition that prevented execution of periodic clean or displaying installation times in cask-only installs. This was because `installed_formulae.empty?` would always evaluate to true.

Ref: https://github.com/orgs/Homebrew/discussions/5262

`brew typecheck` on arm64 led me to this bug https://github.com/sorbet/sorbet/issues/6778