### PR TITLE
cmd/log: fix `wrong exec option symbol` regression

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -42,7 +42,7 @@ module Homebrew
         ENV["PATH"] = PATH.new(ORIGINAL_PATHS).to_s
 
         if args.no_named?
-          git_log(HOMEBREW_REPOSITORY, args:)
+          git_log(HOMEBREW_REPOSITORY)
         else
           path = args.named.to_paths.first
           tap = Tap.from_path(path)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Regression introduced in 59adde2069f1037aaeac7289c0137dcd7aa49ec1.

Fixes #17054.
