### PR TITLE
dev-cmd/generate-*-api: ensure title is a string

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -72,7 +72,7 @@ module Homebrew
       def html_template(title)
         <<~EOS
           ---
-          title: #{title}
+          title: '#{title}'
           layout: cask
           ---
           {{ content }}

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -72,7 +72,7 @@ module Homebrew
       def html_template(title)
         <<~EOS
           ---
-          title: #{title}
+          title: '#{title}'
           layout: formula
           redirect_from: /formula-linux/#{title}
           ---


### PR DESCRIPTION
We got away with integers before, but not using strings can cause errors such as the blanking of this page: https://formulae.brew.sh/cask/7777