### PR TITLE
package/scripts/postinstall: avoid writing to `~/.gitconfig`

### DIFF
--- a/.github/workflows/pkg-installer.yml
+++ b/.github/workflows/pkg-installer.yml
@@ -146,6 +146,9 @@ jobs:
         with:
           name: "${{ needs.build.outputs.installer_path }}"
 
+      - name: Unset global Git safe directory setting
+        run: git config --global --unset-all safe.directory
+
       - name: Remove existing Homebrew installations
         run: |
           sudo rm -rf brew /{usr/local,opt/homebrew}/{Cellar,Caskroom,Homebrew/Library/Taps}

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -21,35 +21,15 @@ fi
 # add Git to path
 export PATH="/Library/Developer/CommandLineTools/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:${PATH}"
 
-# helpers for setting/unsetting Git's safe directory setting
-set_git_safe_directory() {
-  if git config --global --get-all safe.directory | grep -q "${1}"
-  then
-    return
-  fi
-  SET_GIT_SAFE_DIRECTORY="${1}"
-  git config --global --add safe.directory "${1}"
-}
-unset_git_safe_directory() {
-  if [[ -z "${SET_GIT_SAFE_DIRECTORY-}" ]]
-  then
-    return
-  fi
-
-  git config --global --unset safe.directory "${1}" || git config --global --unset-all safe.directory
-  if [[ ${SET_GIT_SAFE_DIRECTORY-} == "${1}" ]]
-  then
-    unset SET_GIT_SAFE_DIRECTORY
-  fi
-}
+# use `git -c key=value` to avoid writing to Git's global config
+# https://github.com/Homebrew/brew/issues/17067
+git=(git -c "safe.directory=${homebrew_directory}")
 
 # reset Git repository
 cd "${homebrew_directory}"
-set_git_safe_directory "${homebrew_directory}"
-git reset --hard
-git checkout --force master
-git branch | grep -v '\*' | xargs -n 1 git branch --delete --force || true
-unset_git_safe_directory "${homebrew_directory}"
+"${git[@]}" reset --hard
+"${git[@]}" checkout --force master
+"${git[@]}" branch | grep -v '\*' | xargs -n 1 "${git[@]}" branch --delete --force || true
 
 # move to /usr/local if on x86_64
 if [[ $(uname -m) == "x86_64" ]]
@@ -59,10 +39,8 @@ then
     cp -pRL "${homebrew_directory}/.git" "/usr/local/Homebrew/"
     mv "${homebrew_directory}/cache_api" "/usr/local/Homebrew/"
 
-    set_git_safe_directory /usr/local/Homebrew
-    git -C /usr/local/Homebrew reset --hard
-    git -C /usr/local/Homebrew checkout --force master
-    unset_git_safe_directory /usr/local/Homebrew
+    "${git[@]}" -C /usr/local/Homebrew reset --hard
+    "${git[@]}" -C /usr/local/Homebrew checkout --force master
   else
     mkdir -vp /usr/local/bin
     mv "${homebrew_directory}" "/usr/local/Homebrew/"

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -39,6 +39,7 @@ then
     cp -pRL "${homebrew_directory}/.git" "/usr/local/Homebrew/"
     mv "${homebrew_directory}/cache_api" "/usr/local/Homebrew/"
 
+    git=(git -c safe.directory="/usr/local/Homebrew")
     "${git[@]}" -C /usr/local/Homebrew reset --hard
     "${git[@]}" -C /usr/local/Homebrew checkout --force master
   else

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -21,15 +21,17 @@ fi
 # add Git to path
 export PATH="/Library/Developer/CommandLineTools/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:${PATH}"
 
-# use `git -c key=value` to avoid writing to Git's global config
-# https://github.com/Homebrew/brew/issues/17067
-git=(git -c "safe.directory=${homebrew_directory}")
-
 # reset Git repository
 cd "${homebrew_directory}"
+# avoid writing user's global config file by making
+# "${homebrew_directory}/.gitconfig" the "global" config
+# https://git-scm.com/docs/git-config#SCOPES
+git=(env XDG_CONFIG_HOME="" HOME="${homebrew_directory}" git)
+"${git[@]}" config --global --add safe.directory "${homebrew_directory}"
 "${git[@]}" reset --hard
 "${git[@]}" checkout --force master
 "${git[@]}" branch | grep -v '\*' | xargs -n 1 "${git[@]}" branch --delete --force || true
+rm "${homebrew_directory}/.gitconfig"
 
 # move to /usr/local if on x86_64
 if [[ $(uname -m) == "x86_64" ]]
@@ -39,9 +41,11 @@ then
     cp -pRL "${homebrew_directory}/.git" "/usr/local/Homebrew/"
     mv "${homebrew_directory}/cache_api" "/usr/local/Homebrew/"
 
-    git=(git -c safe.directory="/usr/local/Homebrew")
+    git=(env XDG_CONFIG_HOME="" HOME="/usr/local/Homebrew" git)
+    "${git[@]}" config --global --add safe.directory /usr/local/Homebrew
     "${git[@]}" -C /usr/local/Homebrew reset --hard
     "${git[@]}" -C /usr/local/Homebrew checkout --force master
+    rm /usr/local/Homebrew/.gitconfig
   else
     mkdir -vp /usr/local/bin
     mv "${homebrew_directory}" "/usr/local/Homebrew/"

--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -21,16 +21,17 @@ fi
 # add Git to path
 export PATH="/Library/Developer/CommandLineTools/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:${PATH}"
 
+# avoid writing to user's global config file by overriding HOME
+# https://git-scm.com/docs/git-config#SCOPES
+unset XDG_CONFIG_HOME
+export HOME="${homebrew_directory}"
+
 # reset Git repository
 cd "${homebrew_directory}"
-# avoid writing user's global config file by making
-# "${homebrew_directory}/.gitconfig" the "global" config
-# https://git-scm.com/docs/git-config#SCOPES
-git=(env XDG_CONFIG_HOME="" HOME="${homebrew_directory}" git)
-"${git[@]}" config --global --add safe.directory "${homebrew_directory}"
-"${git[@]}" reset --hard
-"${git[@]}" checkout --force master
-"${git[@]}" branch | grep -v '\*' | xargs -n 1 "${git[@]}" branch --delete --force || true
+git config --global --add safe.directory "${homebrew_directory}"
+git reset --hard
+git checkout --force master
+git branch | grep -v '\*' | xargs -n 1 git branch --delete --force || true
 rm "${homebrew_directory}/.gitconfig"
 
 # move to /usr/local if on x86_64
@@ -41,10 +42,10 @@ then
     cp -pRL "${homebrew_directory}/.git" "/usr/local/Homebrew/"
     mv "${homebrew_directory}/cache_api" "/usr/local/Homebrew/"
 
-    git=(env XDG_CONFIG_HOME="" HOME="/usr/local/Homebrew" git)
-    "${git[@]}" config --global --add safe.directory /usr/local/Homebrew
-    "${git[@]}" -C /usr/local/Homebrew reset --hard
-    "${git[@]}" -C /usr/local/Homebrew checkout --force master
+    export HOME="/usr/local/Homebrew"
+    git config --global --add safe.directory /usr/local/Homebrew
+    git -C /usr/local/Homebrew reset --hard
+    git -C /usr/local/Homebrew checkout --force master
     rm /usr/local/Homebrew/.gitconfig
   else
     mkdir -vp /usr/local/bin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We can eliminate permission issues by not touching `~/.gitconfig` at all.

We pretend that the "global" configs are in the repository itself by overriding `XDG_CONFIG_HOME` and `HOME`. For example:

```console
$ XDG_CONFIG_HOME= HOME=$PWD git config --global section.key value
$ XDG_CONFIG_HOME= HOME=$PWD git config --global section.key
value
$ git config --global section.key
$ cat $PWD/.gitconfig
[section]
  key = value
```

Fixes #17067.

~~Needs testing as I haven't tried to build a `.pkg` locally.~~
