### PR TITLE
keg: mkpath on main `postgresql@X` directories

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -427,7 +427,7 @@ class Keg
     link_dir("sbin", verbose:, dry_run:, overwrite:) { :skip_dir }
     link_dir("include", verbose:, dry_run:, overwrite:) do |relative_path|
       case relative_path.to_s
-      when %r{^postgresql@\d+/}
+      when /^postgresql@\d+/
         :mkpath
       else
         :link
@@ -446,7 +446,7 @@ class Keg
            /^fish/,
            %r{^lua/}, #  Lua, Lua51, Lua53 all need the same handling.
            %r{^guile/},
-           %r{^postgresql@\d+/},
+           /^postgresql@\d+/,
            *SHARE_PATHS
         :mkpath
       else
@@ -470,7 +470,7 @@ class Keg
            /^ocaml/,
            /^perl5/,
            "php",
-           %r{^postgresql@\d+/},
+           /^postgresql@\d+/,
            /^python[23]\.\d+/,
            /^R/,
            /^ruby/


### PR DESCRIPTION
Fix logic in #16966 as it only matched subdirectories

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I didn't realize pattern missed top directory.

A stricter regex would be `%r{^postgresql@\d+[$/]}` but I doubt anything would use a directory name like `postgresql@16<some-extra-text>` and the change matches our other regex patterns (e.g. Python's `/^python[23]\.\d+/`)

---

Example of problem with previous logic:
```console
$ brew link temporal_tables
Linking /usr/local/Cellar/temporal_tables/1.2.2_1... 3 symlinks created.

$ realpath /usr/local/share/postgresql@16
/usr/local/Cellar/temporal_tables/1.2.2_1/share/postgresql@16

$ realpath /usr/local/share/postgresql@16/extension
/usr/local/Cellar/temporal_tables/1.2.2_1/share/postgresql@16/extension
```
