### PR TITLE
dev-cmd/tests: fix when euid != uid.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -144,6 +144,10 @@ module Homebrew
             ohai "Running tests with BuildPulse-friendly settings"
           end
 
+          # Workaround for:
+          # ruby: no -r allowed while running setuid (SecurityError)
+          Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
+
           if parallel
             system "bundle", "exec", "parallel_rspec", *parallel_args, "--", *bundle_args, "--", *files
           else


### PR DESCRIPTION
Otherwise you get:
`ruby: no -r allowed while running setuid (SecurityError)`