### PR TITLE
formula: add FETCHCONTENT_FULLY_DISCONNECTED to std_cmake_args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1657,6 +1657,7 @@ class Formula
       -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_FIND_FRAMEWORK=#{find_framework}
       -DCMAKE_VERBOSE_MAKEFILE=ON
+      -DFETCHCONTENT_FULLY_DISCONNECTED=ON
       -Wno-dev
       -DBUILD_TESTING=OFF
     ]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `FetchContent` module can be used by CMake package authors to download/fetch resources at build time. The addition of this flag should disable such behavior.

See also the conversation at https://patchwork.yoctoproject.org/project/oe-core/patch/20220209125315.3177811-1-ross.burton@arm.com/#1436.

Also see the module documentation from CMake at https://cmake.org/cmake/help/latest/module/FetchContent.html, which bears this info and warning:

> When this option is enabled, no attempt is made to download or update any content. It is assumed that all content has already been populated in a previous run or the source directories have been pointed at existing contents the developer has provided manually (using options described further below). When the developer knows that no changes have been made to any content details, turning this option ON can significantly speed up the configure stage. It is OFF by default.
>
> The FETCHCONTENT_FULLY_DISCONNECTED variable is not an appropriate way to prevent any network access on the first run in a build directory. Doing so can break projects, lead to misleading error messages, and hide subtle population failures. This variable is specifically intended to only be turned on after the first time CMake has been run. If you want to prevent network access even on the first run, use a [dependency provider](https://cmake.org/cmake/help/latest/command/cmake_language.html#dependency-providers) and populate the dependency from local content instead.

I would posit that it would be desirable for builds to break if they attempt to download further resources, since packagers/reviewers might not notice the quick line or two in the build log that indicates that a resource/dependency is being downloaded. This behavior could be explicitly enabled if someone adds the equivalent flag to turn it `OFF`, of course.

Another alternative to explore is to add some kind of custom dependency provider as noted in the CMake doc. But it sounds like if we just "blackhole" content fetches, CMake will fall back to the default provider anyways.

---

A more powerful and probably more robust approach would be to offer full network isolation for formulae that we expect to be able to build offline (basically, most C/C++ things).