### PR TITLE
Support for opt-in network isolation in build/test sandboxes

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -44,6 +44,8 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = T.let([
   [{ name: :go_resource, type: :block_call }, { name: :resource, type: :block_call }],
   [{ name: :patch, type: :method_call }, { name: :patch, type: :block_call }],
   [{ name: :needs, type: :method_call }],
+  [{ name: :allow_network_access!, type: :method_call }],
+  [{ name: :deny_network_access!, type: :method_call }],
   [{ name: :install, type: :method_definition }],
   [{ name: :post_install, type: :method_definition }],
   [{ name: :caveats, type: :method_definition }],

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -80,7 +80,7 @@ module Homebrew
 
             exec_args << "--HEAD" if f.head?
 
-            Utils.safe_fork do
+            Utils.safe_fork do |error_pipe|
               if Sandbox.available?
                 sandbox = Sandbox.new
                 f.logs.mkpath
@@ -92,6 +92,7 @@ module Homebrew
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
+                sandbox.deny_all_network_except_pipe(error_pipe) unless f.class.network_access_allowed?(:test)
                 sandbox.exec(*exec_args)
               else
                 exec(*exec_args)

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -228,6 +228,21 @@ module Homebrew
                      "of Ruby is new enough.",
         boolean:     true,
       },
+      HOMEBREW_FORMULA_BUILD_NETWORK:            {
+        description: "If set, controls network access to the sandbox for formulae builds. Overrides any " \
+                     "controls set through DSL usage inside formulae. Must be `allow` or `deny`. If no value is " \
+                     "set through this environment variable or DSL usage, the default behavior is `allow`.",
+      },
+      HOMEBREW_FORMULA_POSTINSTALL_NETWORK:      {
+        description: "If set, controls network access to the sandbox for formulae postinstall. Overrides any " \
+                     "controls set through DSL usage inside formulae. Must be `allow` or `deny`. If no value is " \
+                     "set through this environment variable or DSL usage, the default behavior is `allow`.",
+      },
+      HOMEBREW_FORMULA_TEST_NETWORK:             {
+        description: "If set, controls network access to the sandbox for formulae test. Overrides any " \
+                     "controls set through DSL usage inside formulae. Must be `allow` or `deny`. If no value is " \
+                     "set through this environment variable or DSL usage, the default behavior is `allow`.",
+      },
       HOMEBREW_GITHUB_API_TOKEN:                 {
         description: "Use this personal access token for the GitHub API, for features such as " \
                      "`brew search`. You can create one at <https://github.com/settings/tokens>. If set, " \

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -70,6 +70,11 @@ class Formula
   extend Attrable
   extend APIHashable
 
+  SUPPORTED_NETWORK_ACCESS_PHASES = [:build, :test, :postinstall].freeze
+  DEFAULT_NETWORK_ACCESS_ALLOWED = true
+  private_constant :SUPPORTED_NETWORK_ACCESS_PHASES
+  private_constant :DEFAULT_NETWORK_ACCESS_ALLOWED
+
   # The name of this {Formula}.
   # e.g. `this-formula`
   sig { returns(String) }
@@ -400,6 +405,7 @@ class Formula
     !!head && !stable
   end
 
+  # Stop RuboCop from erroneously indenting hash target
   delegate [ # rubocop:disable Layout/HashAlignment
     :bottle_defined?,
     :bottle_tag?,
@@ -458,6 +464,13 @@ class Formula
   # @!method version
   # @see .version
   delegate version: :active_spec
+
+  # Stop RuboCop from erroneously indenting hash target
+  delegate [ # rubocop:disable Layout/HashAlignment
+    :allow_network_access!,
+    :deny_network_access!,
+    :network_access_allowed?,
+  ] => :"self.class"
 
   # Whether this formula was loaded using the formulae.brew.sh API
   # @!method loaded_from_api?
@@ -3028,6 +3041,9 @@ class Formula
         @skip_clean_paths = Set.new
         @link_overwrite_paths = Set.new
         @loaded_from_api = false
+        @network_access_allowed = SUPPORTED_NETWORK_ACCESS_PHASES.to_h do |phase|
+          [phase, DEFAULT_NETWORK_ACCESS_ALLOWED]
+        end
       end
     end
 
@@ -3102,6 +3118,59 @@ class Formula
       else
         @licenses = args
       end
+    end
+
+    # @!attribute [w] allow_network_access!
+    # The phases for which network access is allowed. By default, network
+    # access is allowed for all phases. Valid phases are `:build`, `:test`,
+    # and `:postinstall`. When no argument is passed, network access will be
+    # allowed for all phases.
+    # <pre>allow_network_access!</pre>
+    # <pre>allow_network_access! :build</pre>
+    # <pre>allow_network_access! [:build, :test]</pre>
+    sig { params(phases: T.any(Symbol, T::Array[Symbol])).void }
+    def allow_network_access!(phases = [])
+      phases_array = Array(phases)
+      if phases_array.empty?
+        @network_access_allowed.each_key { |phase| @network_access_allowed[phase] = true }
+      else
+        phases_array.each do |phase|
+          raise ArgumentError, "Unknown phase: #{phase}" unless SUPPORTED_NETWORK_ACCESS_PHASES.include?(phase)
+
+          @network_access_allowed[phase] = true
+        end
+      end
+    end
+
+    # @!attribute [w] deny_network_access!
+    # The phases for which network access is denied. By default, network
+    # access is allowed for all phases. Valid phases are `:build`, `:test`,
+    # and `:postinstall`. When no argument is passed, network access will be
+    # denied for all phases.
+    # <pre>deny_network_access!</pre>
+    # <pre>deny_network_access! :build</pre>
+    # <pre>deny_network_access! [:build, :test]</pre>
+    sig { params(phases: T.any(Symbol, T::Array[Symbol])).void }
+    def deny_network_access!(phases = [])
+      phases_array = Array(phases)
+      if phases_array.empty?
+        @network_access_allowed.each_key { |phase| @network_access_allowed[phase] = false }
+      else
+        phases_array.each do |phase|
+          raise ArgumentError, "Unknown phase: #{phase}" unless SUPPORTED_NETWORK_ACCESS_PHASES.include?(phase)
+
+          @network_access_allowed[phase] = false
+        end
+      end
+    end
+
+    # Whether the specified phase should be forced offline.
+    sig { params(phase: Symbol).returns(T::Boolean) }
+    def network_access_allowed?(phase)
+      raise ArgumentError, "Unknown phase: #{phase}" unless SUPPORTED_NETWORK_ACCESS_PHASES.include?(phase)
+
+      env_var = Homebrew::EnvConfig.send(:"formula_#{phase}_network")
+      env_var.nil? ? @network_access_allowed[phase] : env_var == "allow"
     end
 
     # @!attribute [w] homepage

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -925,7 +925,7 @@ on_request: installed_on_request?, options:)
       formula.specified_path,
     ].concat(build_argv)
 
-    Utils.safe_fork do
+    Utils.safe_fork do |error_pipe|
       if Sandbox.available?
         sandbox = Sandbox.new
         formula.logs.mkpath
@@ -937,6 +937,7 @@ on_request: installed_on_request?, options:)
         sandbox.allow_fossil
         sandbox.allow_write_xcode
         sandbox.allow_write_cellar(formula)
+        sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:build)
         sandbox.exec(*args)
       else
         exec(*args)
@@ -1151,7 +1152,7 @@ on_request: installed_on_request?, options:)
 
     args << post_install_formula_path
 
-    Utils.safe_fork do
+    Utils.safe_fork do |error_pipe|
       if Sandbox.available?
         sandbox = Sandbox.new
         formula.logs.mkpath
@@ -1161,6 +1162,7 @@ on_request: installed_on_request?, options:)
         sandbox.allow_write_xcode
         sandbox.deny_write_homebrew_repository
         sandbox.allow_write_cellar(formula)
+        sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:postinstall)
         Keg::KEG_LINK_DIRECTORIES.each do |dir|
           sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
         end

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -91,6 +91,32 @@ class Sandbox
     end
   end
 
+  sig { params(path: T.any(String, Pathname), type: Symbol).void }
+  def allow_network(path:, type: :literal)
+    add_rule allow: true, operation: "network*", filter: path_filter(path, type)
+  end
+
+  sig { params(path: T.any(String, Pathname), type: Symbol).void }
+  def deny_network(path:, type: :literal)
+    add_rule allow: false, operation: "network*", filter: path_filter(path, type)
+  end
+
+  sig { void }
+  def allow_all_network
+    add_rule allow: true, operation: "network*"
+  end
+
+  sig { void }
+  def deny_all_network
+    add_rule allow: false, operation: "network*"
+  end
+
+  sig { params(path: T.any(String, Pathname)).void }
+  def deny_all_network_except_pipe(path)
+    deny_all_network
+    allow_network path:, type: :literal
+  end
+
   def exec(*args)
     seatbelt = Tempfile.new(["homebrew", ".sb"], HOMEBREW_TEMP)
     seatbelt.write(@profile.dump)

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -2,6 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 require "dev-cmd/test"
+require "sandbox"
 
 RSpec.describe Homebrew::DevCmd::Test do
   it_behaves_like "parseable arguments"
@@ -17,5 +18,20 @@ RSpec.describe Homebrew::DevCmd::Test do
       .to output(/Testing testball/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+  end
+
+  it "blocks network access when test phase is offline", :integration_test do
+    if Sandbox.available?
+      install_test_formula "testball_offline_test", <<~RUBY
+        deny_network_access! :test
+        test do
+          system "curl", "example.org"
+        end
+      RUBY
+
+      expect { brew "test", "--verbose", "testball_offline_test" }
+        .to output(/curl: \(6\) Could not resolve host: example\.org/).to_stdout
+        .and be_a_failure
+    end
   end
 end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -3,11 +3,13 @@
 require "formula"
 require "formula_installer"
 require "keg"
+require "sandbox"
 require "tab"
 require "cmd/install"
 require "test/support/fixtures/testball"
 require "test/support/fixtures/testball_bottle"
 require "test/support/fixtures/failball"
+require "test/support/fixtures/failball_offline_install"
 
 RSpec.describe FormulaInstaller do
   matcher :be_poured_from_bottle do
@@ -68,6 +70,10 @@ RSpec.describe FormulaInstaller do
       expect(bin.children.count).to eq(3)
       expect(f.prefix/".brew/testball.rb").to be_readable
     end
+  end
+
+  specify "offline installation" do
+    expect { temporary_install(FailballOfflineInstall.new) }.to raise_error(BuildError) if Sandbox.available?
   end
 
   specify "Formula is not poured from bottle when compiler specified" do

--- a/Library/Homebrew/test/support/fixtures/failball_offline_install.rb
+++ b/Library/Homebrew/test/support/fixtures/failball_offline_install.rb
@@ -1,0 +1,31 @@
+# typed: true
+# frozen_string_literal: true
+
+class FailballOfflineInstall < Formula
+  def initialize(name = "failball_offline_install", path = Pathname.new(__FILE__).expand_path, spec = :stable,
+                 alias_path: nil, tap: nil, force_bottle: false)
+    super
+  end
+
+  DSL_PROC = proc do
+    url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
+    sha256 TESTBALL_SHA256
+    deny_network_access! :build
+  end.freeze
+  private_constant :DSL_PROC
+
+  DSL_PROC.call
+
+  def self.inherited(other)
+    super
+    other.instance_eval(&DSL_PROC)
+  end
+
+  def install
+    system "curl", "example.org"
+
+    prefix.install "bin"
+    prefix.install "libexec"
+    Dir.chdir "doc"
+  end
+end

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -37,15 +37,15 @@ module Utils
         pid = fork do
           # bootsnap doesn't like these forked processes
           ENV["HOMEBREW_NO_BOOTSNAP"] = "1"
-
-          ENV["HOMEBREW_ERROR_PIPE"] = server.path
+          error_pipe = server.path
+          ENV["HOMEBREW_ERROR_PIPE"] = error_pipe
           server.close
           read.close
           write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
 
           Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
 
-          yield
+          yield(error_pipe)
         rescue Exception => e # rubocop:disable Lint/RescueException
           error_hash = JSON.parse e.to_json
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is probably going to need a lot of iterating, but I think it's in a state that's ready for some eyes and feedback now.

## Overview

This PR introduces opt-in (disabled by default) support for network isolation during build, test, and postinstall. A formula can opt-in like so:

```ruby
class Hello < Formula
  url "[...]"
  sha256 "[...]"
  [...]
  # For enabling on a single phase:
  enable_offline_phase :build
  # For enabling on multiple phases:
  enable_offline_phase [:build, :postinstall]
  # Without arguments, enables on all phases:
  enable_offline_phase

  bottle do
    [...]
  end
  [...]
```

Suppose we opt-in a formula for offline build phase like so:

```ruby
class Hello < Formula
  desc "Program providing model for GNU coding standards and practices"
  homepage "https://www.gnu.org/software/hello/"
  url "https://ftp.gnu.org/gnu/hello/hello-2.12.1.tar.gz"
  sha256 "8d99142afd92576f30b0cd7cb42a8dc6809998bc5d607d88761f512e26c7db20"
  license "GPL-3.0-or-later"
  enable_offline_phase :build
  [...]
```

and perhaps there's a pesky `curl` call in the install block:

```ruby
def install
    system "curl", "example.org"
    ENV.append "LDFLAGS", "-liconv" if OS.mac?
[...]
```

When we attempt to install this formula:

```
==> curl example.org
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: example.org
[...]
Error: hello 2.12.1 did not build
Logs:
     /Users/caleb/Library/Logs/Homebrew/hello/00.options.out
     /Users/caleb/Library/Logs/Homebrew/hello/01.curl
READ THIS: https://docs.brew.sh/Troubleshooting
```

## Things still to be (re-)considered

- I refer to "phases" here since it was the first term that came to mind. Any opinions on what to call "build", "test", "postinstall", etc.? This naming would be reflected in the method naming.
  - Open generally to feedback on the method/DSL naming.
- Going in a different direction, is the option to choose phases for which to enable this too granular? Maybe we just settle for one big on/off toggle. But then there's a lot of network-related tools/libraries that probably don't need connectivity to build but might need it for a meaningful test.
  - Compromise: combine `:build` and `:postinstall` into `:build`, while leaving `:test` as its own
  - Maybe we can open some exceptions for localhost in the sandbox, at least when running test block
- Running `enable_offline_phase` without arguments currently enables for all. Would it be less surprising for the no-arguments case to enable for build only? build + postinstall? Or maybe require an argument
  - Consider providing `:all` as an easy way to enable for everything, if we decide to require an argument