### PR TITLE
github_runner_matrix: increase timeout for self-hosted 12-x86_64

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -145,7 +145,7 @@ class GitHubRunnerMatrix
       end
 
       # macOS 12-x86_64 is usually slower.
-      timeout += 30 if !(use_github_runner && github_runner_available) && macos_version <= :monterey
+      timeout += 30 if macos_version <= :monterey
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-x86_64",
         runner:,

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -144,6 +144,8 @@ class GitHubRunnerMatrix
         ["#{version}#{ephemeral_suffix}", runner_timeout]
       end
 
+      # macOS 12-x86_64 is usually slower.
+      timeout += 30 if !(use_github_runner && github_runner_available) && macos_version <= :monterey
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-x86_64",
         runner:,


### PR DESCRIPTION
It is usually slower than other Intel runners and has timed out more often recently.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
