### PR TITLE
keg: comment to odeprecated some Python 2 related methods

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -362,11 +362,13 @@ class Keg
   end
 
   def python_site_packages_installed?
+    # odeprecated "Keg#python_site_packages_installed?"
     (path/"lib/python2.7/site-packages").directory?
   end
 
   sig { returns(T::Boolean) }
   def python_pth_files_installed?
+    # odeprecated "Keg#python_pth_files_installed?"
     !Dir["#{path}/lib/python2.7/site-packages/*.pth"].empty?
   end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some unused methods that are only useful for unsupported Python 2.7.

We could adjust them for Python 3, but I think it is better to deprecate until we have an actual use case for them.