### PR TITLE
rubocops/cask/array_alphabetization: skip blank lines when sorting

### DIFF
--- a/Library/Homebrew/rubocops/cask/array_alphabetization.rb
+++ b/Library/Homebrew/rubocops/cask/array_alphabetization.rb
@@ -37,6 +37,7 @@ module RuboCop
         def sort_array(source)
           # Combine each comment with the line(s) below so that they remain in the same relative location
           combined_source = source.each_with_index.filter_map do |line, index|
+            next if line.blank?
             next if line.strip.start_with?("#")
 
             next recursively_find_comments(source, index, line)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Minor fix to sorting lines when alphabetizing arrays, as empty lines (or all whitespace) cause an apparent break.  This simply skips those when rewriting `zap` and `uininstall` stanzas.

Cop `Layout/EmptyLines` will correct multiple blank lines in a row, but something like the below won't be fixed (example with the `expressvpn` Cask)

```
  zap trash: [
    "/Library/Application Support/com.expressvpn.ExpressVPN",
    "/Library/LaunchDaemons/com.expressvpn.expressvpnd.plist",
    "~/Library/Application Support/com.expressvpn.ExpressVPN",
    "~/Library/HTTPStorages/com.expressvpn.ExpressVPN",

    "~/Library/Logs/ExpressVPN",
    "~/Library/Preferences/com.expressvpn.ExpressVPN.plist",
  ]
```

Which results in `An error occurred while Cask/ArrayAlphabetization cop was inspecting /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/e/expressvpn.rb:25:2.`