### PR TITLE
Only `brew desc --search` needs `--eval-all`

### DIFF
--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -9,9 +9,25 @@ RSpec.describe Homebrew::Cmd::Desc do
   it "shows a given Formula's description", :integration_test do
     setup_test_formula "testball"
 
-    expect { brew "desc", "--eval-all", "testball" }
+    expect { brew "desc", "testball" }
       .to output("testball: Some test\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+  end
+
+  it "errors when searching without --eval-all", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "desc", "--search", "testball" }
+      .to output(/`brew desc --search` needs `--eval-all` passed or `HOMEBREW_EVAL_ALL` set!/).to_stderr
+      .and be_a_failure
+  end
+
+  it "successfully searches with --search --eval-all", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "desc", "--search", "--eval-all", "ball" }
+      .to output(/testball: Some test/).to_stdout
+      .and not_to_output.to_stderr
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes https://github.com/Homebrew/brew/issues/16733
- It was suggested in https://github.com/Homebrew/brew/issues/16733 that `brew desc <formula_or_cask>` should work like `brew info <formula_or_cask>` and print the description of the package without needing `--eval-all`.
- It seems like it's only searching that needs `--eval-all`, so limit the check to that.
- This is useful to review with `?w=1`.

Before:

```shell
$ brew desc hello
Error: `brew desc` needs `--eval-all` passed or `HOMEBREW_EVAL_ALL` set!
```

After:

```shell
$ brew desc hello
hello: Program providing model for GNU coding standards and practices

$ brew desc --search hello
Error: Invalid usage: `brew desc --search` needs `--eval-all` passed or `HOMEBREW_EVAL_ALL` set!

$ brew desc --search --eval-all hello
==> Formulae
dsh: Dancer's shell, or distributed shell
hello: Program providing model for GNU coding standards and practices
```