### PR TITLE
extend/ENV/super: avoid adding `llvm` to `HOMEBREW_LIBRARY_PATHS`

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -229,7 +229,9 @@ module Superenv
       end
     end
 
-    paths << keg_only_deps.map(&:opt_lib)
+    # Don't add `llvm` to library paths; this leads to undesired linkage to LLVM's `libunwind`
+    paths << keg_only_deps.reject { |dep| dep.name.match?(/^llvm(@\d+)?$/) }
+                          .map(&:opt_lib)
     paths << (HOMEBREW_PREFIX/"lib")
 
     paths += homebrew_extra_library_paths


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This leads to undesired linkage with LLVM's `libunwind` (because it
shadows the system's `libunwind`).

See, for example, Homebrew/homebrew-core#169354.
