### PR TITLE
formula: configure git/npm to ignore .brew_home

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2673,6 +2673,8 @@ class Formula
   def setup_home(home)
     # Don't let bazel write to tmp directories we don't control or clean.
     (home/".bazelrc").write "startup --output_user_root=#{home}/_bazel"
+    # Don't dirty the git tree for git clones.
+    (home/".gitignore").write "*"
   end
 
   # Returns a list of Dependency objects that are declared in the formula.

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -55,9 +55,6 @@ module Language
     sig { params(libexec: Pathname).returns(T::Array[String]) }
     def self.std_npm_install_args(libexec)
       setup_npm_environment
-      # tell npm to not install .brew_home by adding it to the .npmignore file
-      # (or creating a new one if no .npmignore file already exists)
-      open(".npmignore", "a") { |f| f.write("\n.brew_home\n") }
 
       pack = pack_for_installation
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

In core, there's [4 formulae](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-core+%22rm_rf+%5C%22.brew_home%5C%22%22&type=code) that `rm_rf ".brew_home"` to ensure `git status` reports no changes (for some reason, code search is missing [helm](https://github.com/Homebrew/homebrew-core/blob/7d3a033d4b5e8d0643c0f49ad3a65d14a2aedb34/Formula/h/helm.rb#L24)).

Let's handle this here directly instead with a `~/.gitignore` since imo formulae shouldn't even be aware of `.brew_home`. And because [`npm` respects `.gitignore`](https://docs.npmjs.com/cli/v10/using-npm/developers#keeping-files-out-of-your-package) files (as long as there is not also an `.npmignore` file in the same directory), this removes the need for `std_npm_install_args` to append to `.npmignore`.

To demonstrate this shouldn't change anything:

```console
$ cd "$(brew --repo homebrew/core)"

# for git
$ sed -i "" 's/rm_rf ".brew_home"//' Formula/h/helm.rb
$ brew install -s helm && helm version
version.BuildInfo{Version:"v3.14.4", GitCommit:"81c902a123462fd4052bc5e9aa9c513c4c8fc142", GitTreeState:"clean", GoVersion:"go1.22.2"}

# for npm
$ sed -i "" 's/def install/def install\n\t\ttouch ".npmignore"/' Formula/b/bower.rb
$ brew install -s bower && ls "$(brew --prefix bower)"/libexec/lib/node_modules/bower/.brew_home
ls: /opt/homebrew/opt/bower/libexec/lib/node_modules/bower/.brew_home: No such file or directory
```
