### PR TITLE
download_strategy: add ssh://git scheme for git download strategy

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1468,7 +1468,8 @@ class DownloadStrategyDetector
       GitHubGitDownloadStrategy
     when %r{^https?://.+\.git$},
          %r{^git://},
-         %r{^https?://git\.sr\.ht/[^/]+/[^/]+$}
+         %r{^https?://git\.sr\.ht/[^/]+/[^/]+$},
+         %r{^ssh://git}
       GitDownloadStrategy
     when %r{^https?://www\.apache\.org/dyn/closer\.cgi},
          %r{^https?://www\.apache\.org/dyn/closer\.lua}

--- a/Library/Homebrew/test/download_strategies/detector_spec.rb
+++ b/Library/Homebrew/test/download_strategies/detector_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe DownloadStrategyDetector do
       it { is_expected.to eq(GitDownloadStrategy) }
     end
 
+    context "when given SSH Git URL" do
+      let(:url) { "ssh://git@example.com/foo.git" }
+
+      it { is_expected.to eq(GitDownloadStrategy) }
+    end
+
     context "when given a GitHub Git URL" do
       let(:url) { "https://github.com/homebrew/brew.git" }
 


### PR DESCRIPTION
Fixes #17120.

This can be extends the git download strategy for the url with `ssh://git` where this type of url is used Bitbucket server or gitlab and so on. The result command of git download strategy is
```
git ls-remote <url>
```
and actually git accepts a lot of scheme or url formats and so here I want to extends the feature.

----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
