### PR TITLE
cmd/deps: add `--os` and `--arch`

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -66,6 +66,10 @@ module Homebrew
                             "debugging the `--installed`/`--eval-all` display mode."
         switch "--HEAD",
                description: "Show dependencies for HEAD version instead of stable version."
+        flag   "--os=",
+               description: "Show dependencies for the given operating system."
+        flag   "--arch=",
+               description: "Show dependencies for the given CPU architecture."
         switch "--formula", "--formulae",
                description: "Treat all named arguments as formulae."
         switch "--cask", "--casks",
@@ -82,28 +86,72 @@ module Homebrew
 
       sig { override.void }
       def run
+        raise UsageError, "`brew deps --os=all` is not supported" if args.os == "all"
+        raise UsageError, "`brew deps --arch=all` is not supported" if args.arch == "all"
+
+        os, arch = T.must(args.os_arch_combinations.first)
         all = args.eval_all?
 
         Formulary.enable_factory_cache!
 
-        recursive = !args.direct?
-        installed = args.installed? || dependents(args.named.to_formulae_and_casks).all?(&:any_version_installed?)
+        SimulateSystem.with(os:, arch:) do
+          recursive = !args.direct?
+          installed = args.installed? || dependents(args.named.to_formulae_and_casks).all?(&:any_version_installed?)
 
-        @use_runtime_dependencies = installed && recursive &&
-                                    !args.tree? &&
-                                    !args.graph? &&
-                                    !args.HEAD? &&
-                                    !args.include_build? &&
-                                    !args.include_test? &&
-                                    !args.include_optional? &&
-                                    !args.skip_recommended? &&
-                                    !args.missing?
+          @use_runtime_dependencies = installed && recursive &&
+                                      !args.tree? &&
+                                      !args.graph? &&
+                                      !args.HEAD? &&
+                                      !args.include_build? &&
+                                      !args.include_test? &&
+                                      !args.include_optional? &&
+                                      !args.skip_recommended? &&
+                                      !args.missing? &&
+                                      args.os.nil? &&
+                                      args.arch.nil?
 
-        if args.tree? || args.graph?
-          dependents = if args.named.present?
-            sorted_dependents(args.named.to_formulae_and_casks)
-          elsif args.installed?
-            case args.only_formula_or_cask
+          if args.tree? || args.graph?
+            dependents = if args.named.present?
+              sorted_dependents(args.named.to_formulae_and_casks)
+            elsif args.installed?
+              case args.only_formula_or_cask
+              when :formula
+                sorted_dependents(Formula.installed)
+              when :cask
+                sorted_dependents(Cask::Caskroom.casks)
+              else
+                sorted_dependents(Formula.installed + Cask::Caskroom.casks)
+              end
+            else
+              raise FormulaUnspecifiedError
+            end
+
+            if args.graph?
+              dot_code = dot_code(dependents, recursive:)
+              if args.dot?
+                puts dot_code
+              else
+                exec_browser "https://dreampuf.github.io/GraphvizOnline/##{ERB::Util.url_encode(dot_code)}"
+              end
+              return
+            end
+
+            puts_deps_tree(dependents, recursive:)
+            return
+          elsif all
+            puts_deps(sorted_dependents(
+                        Formula.all(eval_all: args.eval_all?) + Cask::Cask.all(eval_all: args.eval_all?),
+                      ), recursive:)
+            return
+          elsif !args.no_named? && args.for_each?
+            puts_deps(sorted_dependents(args.named.to_formulae_and_casks), recursive:)
+            return
+          end
+
+          if args.no_named?
+            raise FormulaUnspecifiedError unless args.installed?
+
+            sorted_dependents_formulae_and_casks = case args.only_formula_or_cask
             when :formula
               sorted_dependents(Formula.installed)
             when :cask
@@ -111,56 +159,20 @@ module Homebrew
             else
               sorted_dependents(Formula.installed + Cask::Caskroom.casks)
             end
-          else
-            raise FormulaUnspecifiedError
-          end
-
-          if args.graph?
-            dot_code = dot_code(dependents, recursive:)
-            if args.dot?
-              puts dot_code
-            else
-              exec_browser "https://dreampuf.github.io/GraphvizOnline/##{ERB::Util.url_encode(dot_code)}"
-            end
+            puts_deps(sorted_dependents_formulae_and_casks, recursive:)
             return
           end
 
-          puts_deps_tree(dependents, recursive:)
-          return
-        elsif all
-          puts_deps(sorted_dependents(
-                      Formula.all(eval_all: args.eval_all?) + Cask::Cask.all(eval_all: args.eval_all?),
-                    ), recursive:)
-          return
-        elsif !args.no_named? && args.for_each?
-          puts_deps(sorted_dependents(args.named.to_formulae_and_casks), recursive:)
-          return
+          dependents = dependents(args.named.to_formulae_and_casks)
+          check_head_spec(dependents) if args.HEAD?
+
+          all_deps = deps_for_dependents(dependents, recursive:, &(args.union? ? :| : :&))
+          condense_requirements(all_deps)
+          all_deps.map! { |d| dep_display_name(d) }
+          all_deps.uniq!
+          all_deps.sort! unless args.topological?
+          puts all_deps
         end
-
-        if args.no_named?
-          raise FormulaUnspecifiedError unless args.installed?
-
-          sorted_dependents_formulae_and_casks = case args.only_formula_or_cask
-          when :formula
-            sorted_dependents(Formula.installed)
-          when :cask
-            sorted_dependents(Cask::Caskroom.casks)
-          else
-            sorted_dependents(Formula.installed + Cask::Caskroom.casks)
-          end
-          puts_deps(sorted_dependents_formulae_and_casks, recursive:)
-          return
-        end
-
-        dependents = dependents(args.named.to_formulae_and_casks)
-        check_head_spec(dependents) if args.HEAD?
-
-        all_deps = deps_for_dependents(dependents, recursive:, &(args.union? ? :| : :&))
-        condense_requirements(all_deps)
-        all_deps.map! { |d| dep_display_name(d) }
-        all_deps.uniq!
-        all_deps.sort! unless args.topological?
-        puts all_deps
       end
 
       private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Personal use-case is viewing Linux dependency tree for a formula. These extra args provide a simpler way of accessing info rather than using Linux container/VM.

