### PR TITLE
cmd/outdated: display warning for disabled casks

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -78,6 +78,7 @@ module Homebrew
           end
 
           print_outdated(outdated)
+          print_disabled(disabled_casks)
         end
 
         Homebrew.failed = args.named.present? && outdated.present?
@@ -121,6 +122,13 @@ module Homebrew
             puts c.outdated_info(args.greedy?, verbose?, false, args.greedy_latest?, args.greedy_auto_updates?)
           end
         end
+      end
+
+      def print_disabled(casks)
+        casks.each do |cask|
+          opoo "#{cask.token} is #{DeprecateDisable.message(cask)}"
+        end
+        puts "Consider looking for alternatives, as they will be removed from Homebrew soon."
       end
 
       def json_info(formulae_or_casks)
@@ -177,6 +185,14 @@ module Homebrew
         end
       end
 
+      def disabled_casks
+        if args.named.present?
+          select_disabled(args.named.to_casks)
+        else
+          select_disabled(Cask::Caskroom.casks)
+        end
+      end
+
       def outdated_formulae_casks
         formulae, casks = args.named.to_resolved_formulae_to_casks
 
@@ -197,6 +213,10 @@ module Homebrew
                                       greedy_auto_updates: args.greedy_auto_updates?)
           end
         end
+      end
+
+      def select_disabled(casks)
+        casks.select(&:disabled?)
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is an initial pass at warning users when they have casks installed that are disabled so that they can consider alternatives, and be alerted that a cask is leaving soon.

I am not 100% sure on the best place to position the warning yet, so the first option here is to show the list when running `brew outdated`. I'm not sure if this should be behind a flag, but it should probably be suppressed with the `--quiet` flag. The other location could be when running `brew upgrade` or `brew update`, but I'm hesitant for it to be too naggy.