### PR TITLE
startup/bootsnap: raise repeated `LoadError`.

### DIFF
--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -13,13 +13,13 @@ end
 if homebrew_bootsnap_enabled
   begin
     require "bootsnap"
-  rescue LoadError
-    unless ENV["HOMEBREW_BOOTSNAP_RETRY"]
-      Homebrew.install_bundler_gems!(groups: ["bootsnap"], only_warn_on_failure: true)
+  rescue LoadError => e
+    raise e if ENV["HOMEBREW_BOOTSNAP_RETRY"]
 
-      ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"
-      exec ENV.fetch("HOMEBREW_BREW_FILE"), *ARGV
-    end
+    Homebrew.install_bundler_gems!(groups: ["bootsnap"], only_warn_on_failure: true)
+
+    ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"
+    exec ENV.fetch("HOMEBREW_BREW_FILE"), *ARGV
   end
 
   ENV.delete("HOMEBREW_BOOTSNAP_RETRY")

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -13,8 +13,8 @@ end
 if homebrew_bootsnap_enabled
   begin
     require "bootsnap"
-  rescue LoadError => e
-    raise e if ENV["HOMEBREW_BOOTSNAP_RETRY"]
+  rescue LoadError
+    raise if ENV["HOMEBREW_BOOTSNAP_RETRY"]
 
     Homebrew.install_bundler_gems!(groups: ["bootsnap"], only_warn_on_failure: true)
 


### PR DESCRIPTION
If `HOMEBREW_BOOTSNAP_RETRY` was set then we should raise the `LoadError` the second time so that the failures are user visible for debugging.