### PR TITLE
install-bundler-gems: `change_privilege` when necessary.

### DIFF
--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -32,6 +32,7 @@ module Homebrew
           Homebrew.forget_user_gem_groups!
         end
 
+        Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
         Homebrew.install_bundler_gems!(groups:)
       end
     end


### PR DESCRIPTION
This ensures that gems are able to be installed when using e.g. `ruby -I` in their installation scripts.

Leaving this as draft for now as I'm not convinced this is the right approach; this should be a temporary change just for `bundle install`. I was unclear how to do that though CC @Bo98 for help when you're back.