### PR TITLE
fix: Display a warning (instead of exiting early) when unable to find recent issues on a tap

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -490,8 +490,8 @@ class BuildError < RuntimeError
   sig { returns(T::Array[T.untyped]) }
   def fetch_issues
     GitHub.issues_for_formula(formula.name, tap: formula.tap, state: "open", type: "issue")
-  rescue GitHub::API::RateLimitExceededError => e
-    opoo e.message
+  rescue GitHub::API::Error => e
+    opoo "Unable to query GitHub for recent issues on the tap\n#{e.message}"
     []
   end
 


### PR DESCRIPTION
Occasionally, when failing to `brew install` or `brew upgrade` a formula, users will get an error message and the last line of it will be:
```
Error: Validation Failed: [{"message"=>"The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.", "resource"=>"Search", "field"=>"q", "code"=>"invalid"}]
```

Here's an old public example: https://gitlab.com/tabos/rogerrouter/-/issues/21

At Square, this error can be caused by a transient issue with a user's GitHub credentials.

My proposal is that any error which prevents `brew` from showing related issues should:
1. Not cause `brew` to exit early (vs. printing diagnostic checks and doing any other cleanup)
2. Be clearly differentiated from the original failure (so it doesn't become a red herring for users troubleshooting their broken formula)

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
