### PR TITLE
Call `Homebrew.install_bundler_gems!` more consistently.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -121,6 +121,10 @@ module Homebrew
         skip_style = args.skip_style? || args.no_named? || tap_audit
         no_named_args = T.let(false, T::Boolean)
 
+        gem_groups = ["audit"]
+        gem_groups << "style" unless skip_style
+        Homebrew.install_bundler_gems!(groups: gem_groups)
+
         ENV.activate_extensions!
         ENV.setup_build_environment
 
@@ -163,10 +167,6 @@ module Homebrew
           ofail "No matching formulae or casks to audit!"
           return
         end
-
-        gem_groups = ["audit"]
-        gem_groups << "style" unless skip_style
-        Homebrew.install_bundler_gems!(groups: gem_groups)
 
         style_files = args.named.to_paths unless skip_style
 

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -32,6 +32,8 @@ module Homebrew
         # user path, too.
         ENV["PATH"] = PATH.new(ORIGINAL_PATHS).to_s
 
+        Homebrew.install_bundler_gems!(groups: ["ast"]) unless args.dry_run?
+
         args.named.to_formulae.each do |formula|
           current_revision = formula.revision
           new_revision = current_revision + 1
@@ -47,7 +49,6 @@ module Homebrew
               end
             end
           else
-            Homebrew.install_bundler_gems!(groups: ["ast"])
             require "utils/ast"
 
             formula_ast = Utils::AST::FormulaAST.new(formula.path.read)

--- a/Library/Homebrew/dev-cmd/generate-man-completions.rb
+++ b/Library/Homebrew/dev-cmd/generate-man-completions.rb
@@ -21,6 +21,8 @@ module Homebrew
 
       sig { override.void }
       def run
+        Homebrew.install_bundler_gems!(groups: ["man"])
+
         Commands.rebuild_internal_commands_completion_list
         Manpages.regenerate_man_pages(quiet: args.quiet?)
         Completions.update_shell_completions!

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -44,9 +44,10 @@ module Homebrew
       def run
         json_files = Dir["*.bottle.json"]
         odie "No bottle JSON files found in the current working directory" if json_files.blank?
-        bottles_hash = bottles_hash_from_json_files(json_files, args)
 
         Homebrew.install_bundler_gems!(groups: ["pr_upload"])
+
+        bottles_hash = bottles_hash_from_json_files(json_files, args)
 
         unless args.upload_only?
           bottle_args = ["bottle", "--merge", "--write"]

--- a/Library/Homebrew/dev-cmd/style.rb
+++ b/Library/Homebrew/dev-cmd/style.rb
@@ -43,6 +43,8 @@ module Homebrew
 
       sig { override.void }
       def run
+        Homebrew.install_bundler_gems!(groups: ["style"])
+
         target = if args.no_named?
           nil
         else

--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -26,8 +26,6 @@ module Homebrew
     )
 
     def self.regenerate_man_pages(quiet:)
-      Homebrew.install_bundler_gems!(groups: ["man"])
-
       require "kramdown"
       require "manpages/parser/ronn"
       require "manpages/converter/kramdown"

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -83,8 +83,6 @@ module Homebrew
     def self.run_rubocop(files, output_type,
                          fix: false, except_cops: nil, only_cops: nil, display_cop_names: false, reset_cache: false,
                          debug: false, verbose: false)
-      Homebrew.install_bundler_gems!(groups: ["style"])
-
       require "warnings"
 
       Warnings.ignore :parser_syntax do


### PR DESCRIPTION
- Call `Homebrew.install_bundler_gems!` as early as possible
- Always call `Homebrew.install_bundler_gems!` in `dev-cmd` rather than in `Library/Homebrew` helpers method (to ensure we don't accidentally call this for non-dev-cmd commands)