### PR TITLE
Remove the signing workflow for backfill attestation checks

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -121,6 +121,14 @@ module Homebrew
         url_sha256 = Digest::SHA256.hexdigest(bottle.url)
         subject = "#{url_sha256}--#{bottle.filename}"
 
+        # We don't pass in a signing worfklow for backfill signatures because
+        # some backfilled bottle signatures were signed from a branch, and others
+        # from main, so the signing workflow is slightly different which causes
+        # some bottles to incorrectly fail when checking their attestation.
+        # This shouldn't meaningfully affect security because if somehow someone
+        # could generate false backfill attestations from a different workflow
+        # we will still catch it because the attestation would have been
+        # generated after our cutoff date.
         backfill_attestation = check_attestation bottle, BACKFILL_REPO, nil, subject
         timestamp = backfill_attestation.dig("verificationResult", "verifiedTimestamps",
                                              0, "timestamp")

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -119,14 +119,14 @@ module Homebrew
         url_sha256 = Digest::SHA256.hexdigest(bottle.url)
         subject = "#{url_sha256}--#{bottle.filename}"
 
-        # We don't pass in a signing worfklow for backfill signatures because
-        # some backfilled bottle signatures were signed from a branch, and others
-        # from main, so the signing workflow is slightly different which causes
-        # some bottles to incorrectly fail when checking their attestation.
-        # This shouldn't meaningfully affect security because if somehow someone
-        # could generate false backfill attestations from a different workflow
-        # we will still catch it because the attestation would have been
-        # generated after our cutoff date.
+        # We don't pass in a signing workflow for backfill signatures because
+        # some backfilled bottle signatures were signed from the 'backfill'
+        # branch, and others from 'main', so the signing workflow is slightly
+        # different which causes some bottles to incorrectly fail when checking
+        # their attestation. This shouldn't meaningfully affect security
+        # because if somehow someone could generate false backfill attestations
+        # from a different workflow we will still catch it because the
+        # attestation would have been generated after our cutoff date.
         backfill_attestation = check_attestation bottle, BACKFILL_REPO, nil, subject
         timestamp = backfill_attestation.dig("verificationResult", "verifiedTimestamps",
                                              0, "timestamp")

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -15,8 +15,6 @@ module Homebrew
 
     # @api private
     BACKFILL_REPO = "trailofbits/homebrew-brew-verify"
-    # @api private
-    BACKFILL_REPO_CI_URI = "https://github.com/trailofbits/homebrew-brew-verify/.github/workflows/backfill_signatures.yml@refs/heads/main"
 
     # No backfill attestations after this date are considered valid.
     #

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -121,9 +121,9 @@ module Homebrew
 
         # We don't pass in a signing workflow for backfill signatures because
         # some backfilled bottle signatures were signed from the 'backfill'
-        # branch, and others from 'main', so the signing workflow is slightly
-        # different which causes some bottles to incorrectly fail when checking
-        # their attestation. This shouldn't meaningfully affect security
+        # branch, and others from 'main' of trailofbits/homebrew-brew-verify
+        # so the signing workflow is slightly different which causes some bottles to incorrectly
+        # fail when checking their attestation. This shouldn't meaningfully affect security
         # because if somehow someone could generate false backfill attestations
         # from a different workflow we will still catch it because the
         # attestation would have been generated after our cutoff date.

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -121,7 +121,7 @@ module Homebrew
         url_sha256 = Digest::SHA256.hexdigest(bottle.url)
         subject = "#{url_sha256}--#{bottle.filename}"
 
-        backfill_attestation = check_attestation bottle, BACKFILL_REPO, BACKFILL_REPO_CI_URI, subject
+        backfill_attestation = check_attestation bottle, BACKFILL_REPO, nil, subject
         timestamp = backfill_attestation.dig("verificationResult", "verifiedTimestamps",
                                              0, "timestamp")
 

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -124,8 +124,7 @@ RSpec.describe Homebrew::Attestation do
 
       expect(Utils).to receive(:safe_popen_read)
         .with(fake_gh, "attestation", "verify", cached_download, "--repo",
-              described_class::BACKFILL_REPO, "--format", "json", "--cert-identity",
-              described_class::BACKFILL_REPO_CI_URI)
+              described_class::BACKFILL_REPO, "--format", "json")
         .and_return(fake_json_resp_backfill)
 
       described_class.check_core_attestation fake_bottle
@@ -141,8 +140,7 @@ RSpec.describe Homebrew::Attestation do
 
       expect(Utils).to receive(:safe_popen_read)
         .with(fake_gh, "attestation", "verify", cached_download, "--repo",
-              described_class::BACKFILL_REPO, "--format", "json", "--cert-identity",
-              described_class::BACKFILL_REPO_CI_URI)
+              described_class::BACKFILL_REPO, "--format", "json")
         .and_return(fake_json_resp_too_new)
 
       expect do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Some backfilled bottle signatures were signed from different branches of [trailofbits/homebrew-brew-verify](https://github.com/trailofbits/homebrew-brew-verify), so the signing workflow is slightly different which causes some bottles to incorrectly fail when checking their attestation (`apr` for current example of a broken bottle). The simplest way to solve this is just removing the backfill repo `cert-identity` check and just rely on the repository and attestation date falling before our cutoff. This shouldn't meaningfully affect security because if somehow someone could generate false backfill attestations from a different workflow (the only case this protects against), we will still catch it because the attestation would have been generated after our cutoff date.