### PR TITLE
homebrew/cask-versions: remove

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,6 @@ jobs:
           brew tap homebrew/aliases
           brew tap homebrew/bundle
           brew tap homebrew/cask-fonts
-          brew tap homebrew/cask-versions
           brew tap homebrew/command-not-found
           brew tap homebrew/formula-analytics
           brew tap homebrew/portable-ruby
@@ -134,8 +133,7 @@ jobs:
       - name: Run brew style on cask taps
         run: |
           brew style homebrew/cask \
-                     homebrew/cask-fonts \
-                     homebrew/cask-versions
+                     homebrew/cask-fonts
 
   formula-audit:
     name: formula audit
@@ -177,16 +175,14 @@ jobs:
       - name: Set up Homebrew all cask taps
         run: |
           brew tap homebrew/cask-fonts
-          brew tap homebrew/cask-versions
 
       - name: Run brew readall on all casks
-        run: brew readall --os=all --arch=all homebrew/cask homebrew/cask-fonts homebrew/cask-versions
+        run: brew readall --os=all --arch=all homebrew/cask homebrew/cask-fonts
 
       - name: Run brew audit --skip-style on casks
         run: |
           brew audit --skip-style --except=version --tap=homebrew/cask
           brew audit --skip-style --except=version --tap=homebrew/cask-fonts
-          brew audit --skip-style --except=version --tap=homebrew/cask-versions
 
       - name: Generate formula API
         run: brew generate-formula-api --dry-run

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -430,7 +430,7 @@ module Cask
       add_error "cask token contains .app" if token.end_with? ".app"
 
       match_data = /-(?<designation>alpha|beta|rc|release-candidate)$/.match(cask.token)
-      if match_data && cask.tap&.official? && cask.tap != "homebrew/cask-versions"
+      if match_data && cask.tap&.official?
         add_error "cask token contains version designation '#{match_data[:designation]}'"
       end
 

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -135,7 +135,7 @@ module Cask
         else
           <<~EOS
             #{@cask} requires Java #{java_version}. You can install it with:
-              brew install --cask homebrew/cask-versions/temurin#{java_version}
+              brew install --cask temurin@#{java_version}
           EOS
         end
       end

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -4,7 +4,6 @@
 OFFICIAL_CASK_TAPS = %w[
   cask
   cask-fonts
-  cask-versions
 ].freeze
 
 OFFICIAL_CMD_TAPS = {
@@ -20,6 +19,7 @@ DEPRECATED_OFFICIAL_TAPS = %w[
   binary
   cask-drivers
   cask-eid
+  cask-versions
   completions
   devel-only
   dupes

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -36,10 +36,10 @@ HOMEBREW_TAP_DIR_REGEX = T.let(
 HOMEBREW_TAP_PATH_REGEX = T.let(Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{(?:/.*)?\Z}.source).freeze, Regexp)
 # Match official cask taps, e.g `homebrew/cask`.
 HOMEBREW_CASK_TAP_REGEX = T.let(
-  %r{(?:([Cc]askroom)/(cask|versions)|([Hh]omebrew)/(?:homebrew-)?(cask|cask-[\w-]+))},
+  %r{(?:([Cc]askroom)/(cask)|([Hh]omebrew)/(?:homebrew-)?(cask|cask-[\w-]+))},
   Regexp,
 )
-# Match official taps' casks, e.g. `homebrew/cask/somecask` or `homebrew/cask-versions/somecask`.
+# Match official taps' casks, e.g. `homebrew/cask/somecask`.
 HOMEBREW_CASK_TAP_CASK_REGEX = T.let(
   %r{\A#{HOMEBREW_CASK_TAP_REGEX.source}/#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z},
   Regexp,

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -335,22 +335,6 @@ RSpec.describe Cask::Audit, :cask do
         end
       end
 
-      context "when cask token contains version designation" do
-        let(:cask_token) { "token-beta" }
-
-        it "fails if the cask is from an official tap" do
-          allow(cask).to receive(:tap).and_return(CoreCaskTap.instance)
-
-          expect(run).to error_with(/token contains version designation/)
-        end
-
-        it "does not fail if the cask is from the `cask-versions` tap" do
-          allow(cask).to receive(:tap).and_return(Tap.fetch("homebrew/cask-versions"))
-
-          expect(run).to pass
-        end
-      end
-
       context "when cask token contains launcher" do
         let(:cask_token) { "token-launcher" }
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -532,7 +532,7 @@ __fish_brew_complete_arg 'contributions' -l debug -d 'Display any debugging info
 __fish_brew_complete_arg 'contributions' -l from -d 'Date (ISO-8601 format) to start searching contributions. Omitting this flag searches the last year'
 __fish_brew_complete_arg 'contributions' -l help -d 'Show this message'
 __fish_brew_complete_arg 'contributions' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'contributions' -l repositories -d 'Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. '
+__fish_brew_complete_arg 'contributions' -l repositories -d 'Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot`, `services` and `cask-fonts`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. '
 __fish_brew_complete_arg 'contributions' -l to -d 'Date (ISO-8601 format) to stop searching contributions'
 __fish_brew_complete_arg 'contributions' -l user -d 'Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches maintainers'
 __fish_brew_complete_arg 'contributions' -l verbose -d 'Make some output more verbose'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -684,7 +684,7 @@ _brew_contributions() {
     '--from[Date (ISO-8601 format) to start searching contributions. Omitting this flag searches the last year]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
-    '--repositories[Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. ]' \
+    '--repositories[Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot`, `services` and `cask-fonts`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. ]' \
     '--to[Date (ISO-8601 format) to stop searching contributions]' \
     '--user[Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches maintainers]' \
     '--verbose[Make some output more verbose]'

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1998,10 +1998,10 @@ Summarise contributions to Homebrew repositories.
 
 : Specify a comma-separated list of repositories to search. Supported
   repositories: `brew`, `core`, `cask`, `aliases`, `bundle`,
-  `command-not-found`, `test-bot`, `services`, `cask-fonts` and `cask-versions`.
-  Omitting this flag, or specifying `--repositories=primary`, searches only the
-  main repositories: brew,core,cask. Specifying `--repositories=all`, searches
-  all repositories.
+  `command-not-found`, `test-bot`, `services` and `cask-fonts`. Omitting this
+  flag, or specifying `--repositories=primary`, searches only the main
+  repositories: brew,core,cask. Specifying `--repositories=all`, searches all
+  repositories.
 
 `--from`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1265,7 +1265,7 @@ Treat all named arguments as casks\.
 Summarise contributions to Homebrew repositories\.
 .TP
 \fB\-\-repositories\fP
-Specify a comma\-separated list of repositories to search\. Supported repositories: \fBbrew\fP, \fBcore\fP, \fBcask\fP, \fBaliases\fP, \fBbundle\fP, \fBcommand\-not\-found\fP, \fBtest\-bot\fP, \fBservices\fP, \fBcask\-fonts\fP and \fBcask\-versions\fP\&\. Omitting this flag, or specifying \fB\-\-repositories=primary\fP, searches only the main repositories: brew,core,cask\. Specifying \fB\-\-repositories=all\fP, searches all repositories\.
+Specify a comma\-separated list of repositories to search\. Supported repositories: \fBbrew\fP, \fBcore\fP, \fBcask\fP, \fBaliases\fP, \fBbundle\fP, \fBcommand\-not\-found\fP, \fBtest\-bot\fP, \fBservices\fP and \fBcask\-fonts\fP\&\. Omitting this flag, or specifying \fB\-\-repositories=primary\fP, searches only the main repositories: brew,core,cask\. Specifying \fB\-\-repositories=all\fP, searches all repositories\.
 .TP
 \fB\-\-from\fP
 Date (ISO\-8601 format) to start searching contributions\. Omitting this flag searches the last year\.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Given deprecation of `Homebrew/homebrew-cask-versions`, removing most mentions of homebrew-cask-versions. We will also need to remove the prerelease audits, but that is not included in this PR.