### PR TITLE
dev-cmd/tests: skip tests that require core if it's not tapped

### DIFF
--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Homebrew::Cmd::Prefix do
       .and be_a_success
   end
 
-  it "prints the prefix for a Formula", :integration_test do
+  it "prints the prefix for a Formula", :integration_test, :needs_homebrew_core do
     expect { brew_sh "--prefix", "wget" }
       .to output("#{ENV.fetch("HOMEBREW_PREFIX")}/opt/wget\n").to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -160,6 +160,11 @@ RSpec.configure do |config|
     skip "Requires network connection." unless ENV["HOMEBREW_TEST_ONLINE"]
   end
 
+  config.before(:each, :needs_homebrew_core) do
+    core_tap_path = "#{ENV.fetch("HOMEBREW_LIBRARY")}/Taps/homebrew/homebrew-core"
+    skip "Requires homebrew/core to be tapped." unless Dir.exist?(core_tap_path)
+  end
+
   config.before do |example|
     next if example.metadata.key?(:needs_network)
     next if example.metadata.key?(:needs_utils_curl)

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -2,7 +2,7 @@
 
 RSpec.shared_examples "formulae exist" do |array|
   array.each do |f|
-    it "#{f} formula exists" do
+    it "#{f} formula exists", :needs_homebrew_core do
       core_tap = Pathname("#{HOMEBREW_LIBRARY_PATH}/../Taps/homebrew/homebrew-core")
       formula_paths = core_tap.glob("Formula/**/#{f}.rb")
       alias_path = core_tap/"Aliases/#{f}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

There were a few tests which require core to be tapped and fail if it isn't. This is annoying if someone is trying to contribute to the project and they're using the JSON API instead of having the core repo tapped locally.

I'm just skipping these because it's the simplest thing to do. The tests that failed are mostly rubocop tests anyway so it's fine if they only run on CI.

Fixes #17147