### PR TITLE
Pypi: Update strategy regex

### DIFF
--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -67,7 +67,7 @@ module Homebrew
           regex_suffix = Regexp.escape(suffix).gsub("\\-", "-")
 
           # Example regex: `%r{href=.*?/packages.*?/example[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i`
-          regex_name = Regexp.escape(T.must(match[:package_name])).gsub("\\-", "-")
+          regex_name = Regexp.escape(T.must(match[:package_name])).gsub(/\\[_-]/, "[_-]")
           values[:regex] =
             %r{href=.*?/packages.*?/#{regex_name}[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)#{regex_suffix}}i
 

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -5,13 +5,13 @@ require "livecheck/strategy"
 RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
   subject(:pypi) { described_class }
 
-  let(:pypi_url) { "https://files.pythonhosted.org/packages/ab/cd/efg/example-1.2.3.tar.gz" }
+  let(:pypi_url) { "https://files.pythonhosted.org/packages/ab/cd/efg/example-package-1.2.3.tar.gz" }
   let(:non_pypi_url) { "https://brew.sh/test" }
 
   let(:generated) do
     {
-      url:   "https://pypi.org/project/example/#files",
-      regex: %r{href=.*?/packages.*?/example[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i,
+      url:   "https://pypi.org/project/example-package/#files",
+      regex: %r{href=.*?/packages.*?/example[_-]package[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i,
     }
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

livecheck is returning an `Unable to get versions` error for the `ansible-lint`, `aws-sam-cli`, and `pyqt-builder` formulae. These use the `Pypi` strategy without a `livecheck` block, so they use the generated regex from the strategy. The `Pypi` strategy matches the version from the tarball link on the pypi.org package page but this fails for these packages because the formula's `stable` tarball uses hyphens in the filename (e.g., `ansible-lint-...`) but the current tarball filename uses underscores (e.g., `ansible_lint-...`).

This addresses the issue by updating the strategy regex to replace [escaped] `-` or `_` characters in the package name with `[_-]`, so the regex will match regardless of the delimiter used in the formula filename.