### PR TITLE
github_runner_matrix: add `-x86_64` to Intel runner names

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -141,7 +141,7 @@ class GitHubRunnerMatrix
       runner, timeout = if use_github_runner && github_runner_available
         ["macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
       else
-        ["#{version}#{ephemeral_suffix}", runner_timeout]
+        ["#{version}-x86_64#{ephemeral_suffix}", runner_timeout]
       end
 
       # macOS 12-x86_64 is usually slower.

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
       macos_version = MacOSVersion.new(v)
       next if macos_version.unsupported_release?
 
-      out << v
+      out << "#{v}-x86_64"
       out << "#{v}-arm64"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

See Homebrew/ci-orchestrator#15.

Needs Homebrew/ci-orchestrator#15.
