### PR TITLE
Fix the error in Doc: How to Open a Homebrew Pull Request

### DIFF
--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -106,12 +106,27 @@ To make changes on a new branch and submit it for review, create a GitHub pull r
    * If there's a `bottle do` block in the formula, don't remove or change it; we'll update it when we merge your PR.
 5. Test your changes by running the following, and ensure they all pass without issue. For changed formulae and casks, make sure you do the `brew audit` step after your changed formula/cask has been installed.
 
+### Test your formulae-related changes
+
    ```sh
-   brew tests
-   HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <CHANGED_FORMULA|CHANGED_CASK>
-   brew test <CHANGED_FORMULA|CHANGED_CASK>
-   brew audit --strict --online <CHANGED_FORMULA|CHANGED_CASK>
+   HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <CHANGED_FORMULA>
+   brew test <CHANGED_FORMULA>
    ```
+
+### Test your cask-related changes
+
+   ```sh
+   HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install <CHANGED_CASK>
+   ```
+
+### Test your formulae/cask-related changes
+
+   ```sh
+   brew audit --strict --online <CHANGED_FORMULA|CHANGED_CASK>
+   brew style --fix <CHANGED_FORMULA|CHANGED_CASK>
+   ```
+
+Additionally, if your changes are more than changed formulae and casks, please use `brew tests` to run Homebrew's unit and integration tests.
 
 6. [Make a separate commit](Formula-Cookbook.md#commit) for each changed formula with `git add` and `git commit`. Each formula's commits must be squashed.
    * Please note that our required commit message format for simple version updates is "`<FORMULA_NAME> <NEW_VERSION>`", e.g. "`source-highlight 3.1.8`".


### PR DESCRIPTION
The Doc [How to Open a Homebrew Pull Request](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request) has some errors, which may mislead user contributors. To be specific,

- `--build-from-source` is for formula only. 
- `brew test` is for formula only.

This pull request is to separate the tests for formulae/cask related changes. 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
