### PR TITLE
tap: allow sharding of fonts in Homebrew/cask

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1397,7 +1397,12 @@ class CoreCaskTap < AbstractCoreTap
 
   sig { params(token: String).returns(Pathname) }
   def new_cask_path(token)
-    cask_subdir = token[0].to_s
+    cask_subdir = if token.start_with?("font-")
+      "font/font-#{token[5]}"
+    else
+      token[0].to_s
+    end
+
     cask_dir/cask_subdir/"#{token.downcase}.rb"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We want to migrate Homebrew/cask-fonts into the main Homebrew/cask repo. There are ~2,200 font casks that need to be put into sharded subdirectories. This PR allows for paths such as `Casks/fonts/font-a/font-apple.rb`.