### PR TITLE
cask/audit: tune sourceforge.net URL regex

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -868,7 +868,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def bad_sourceforge_url?
-      bad_url_format?(/sourceforge/,
+      bad_url_format?(%r{((downloads|\.dl)\.|//)sourceforge},
                       [
                         %r{\Ahttps://sourceforge\.net/projects/[^/]+/files/latest/download\Z},
                         %r{\Ahttps://downloads\.sourceforge\.net/(?!(project|sourceforge)/)},

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -143,10 +143,7 @@ module RuboCop
             end
 
             if url.match?(%r{^https?://prdownloads\.})
-              problem <<~EOS.chomp
-                Don't use prdownloads in SourceForge urls (url is #{url}).
-                        See: http://librelist.com/browser/homebrew/2011/1/12/prdownloads-is-bad/
-              EOS
+              problem "Don't use prdownloads in SourceForge urls (url is #{url})."
             end
 
             if url.match?(%r{^http://\w+\.dl\.})

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -63,10 +63,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "col" => 2,
     }, {
       "url" => "http://prdownloads.sourceforge.net/foo/foo-1.tar.gz",
-      "msg" => <<~EOS.chomp,
-        Don't use prdownloads in SourceForge urls (url is http://prdownloads.sourceforge.net/foo/foo-1.tar.gz).
-                See: http://librelist.com/browser/homebrew/2011/1/12/prdownloads-is-bad/
-      EOS
+      "msg" => "Don't use prdownloads in SourceForge urls " \
+               "(url is http://prdownloads.sourceforge.net/foo/foo-1.tar.gz).",
       "col" => 2,
     }, {
       "url" => "http://foo.dl.sourceforge.net/sourceforge/foozip/foozip_1.0.tar.bz2",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Some projects are hosted on custom sites that use sourceforge.net subdomains, like [bcrypt](https://bcrypt.sourceforge.net/) and [potrace](https://potrace.sourceforge.net/). These URLs are allowed for formulae but not for casks, like the [KEGS cask](https://github.com/lifepillar/homebrew-appleii/blob/master/Casks/kegs.rb). This change increases the specificity of the cask URL audit to only consider URLs pointing to downloads hosted from within the SourceForge site itself, and still catch the problematic URL patterns currently caught for formulae by [urls.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/rubocops/urls.rb#L127).

This also drops printing of a related link to a long-gone mailing list thread, although it's still [readable at archive.org](https://web.archive.org/web/20190128011957/http://librelist.com/browser/homebrew/2011/1/12/prdownloads-is-bad/).