### PR TITLE
caveats_spec: remove outdated plist_startup reference.

### DIFF
--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Caveats do
         expect(described_class.new(f).caveats).to include("startup")
       end
 
-      it "prints service login information when f.plist_startup is nil" do
+      it "prints service login information" do
         f = formula do
           url "foo-1.0"
           service do


### PR DESCRIPTION
This was removed a long time ago.