### PR TITLE
extract_plist: fix passing an alternative url

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -762,11 +762,8 @@ module Homebrew
         # in the strategy's `#find_versions` method once we figure out why
         # `strategy.method(:find_versions).parameters` isn't working as
         # expected.
-        if strategy_name == "ExtractPlist"
-          strategy_args[:cask] = cask if cask.present?
-        else
-          strategy_args[:url] = url
-        end
+        strategy_args[:cask] = cask if strategy_name == "ExtractPlist" && cask.present?
+        strategy_args[:url] = url
         strategy_args.compact!
 
         strategy_data = strategy.find_versions(**strategy_args, &livecheck_strategy_block)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A previous change to the way the arguments are passed in to the `extract_plist` strategy meant that the `cask` object is passed in its entirety rather than passing the `livecheck` `url` - this reinstates the previous functionality.

First noticed when preparing - https://github.com/Homebrew/homebrew-cask/pull/173163

CC: @samford 