### PR TITLE
extend/kernel: make `opoo`/`odie`/etc. print GitHub Actions notes.

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -136,10 +136,9 @@ on_request: true)
 
       case deprecate_disable_type
       when :deprecated
-        puts "::warning::#{message_full}" if ENV["GITHUB_ACTIONS"]
         opoo message_full
       when :disabled
-        puts "::error::#{message_full}" if ENV["GITHUB_ACTIONS"]
+        GitHub::Actions.puts_annotation_if_env_set(:error, message)
         raise CaskCannotBeInstalledError.new(@cask, message)
       end
     end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -308,7 +308,7 @@ module Homebrew
           ofail "#{errors_summary}."
         end
 
-        return unless ENV["GITHUB_ACTIONS"]
+        return unless GitHub::Actions.env_set?
 
         annotations = formula_problems.merge(cask_problems).flat_map do |(_, path), problems|
           problems.map do |problem|

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -170,7 +170,7 @@ module Homebrew
               safe_system HOMEBREW_BREW_FILE, *upload_args
             end
           ensure
-            if args.retain_bottle_dir? && ENV["GITHUB_ACTIONS"]
+            if args.retain_bottle_dir? && GitHub::Actions.env_set?
               ohai "Bottle files retained at:", dir
               File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
                 f.puts "bottle_path=#{dir}"

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -925,7 +925,7 @@ module Homebrew
 
       def check_cask_staging_location
         # Skip this check when running CI since the staging path is not writable for security reasons
-        return if ENV["GITHUB_ACTIONS"]
+        return if GitHub::Actions.env_set?
 
         path = Cask::Caskroom.path
 

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -134,7 +134,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI providers
         # Homebrew/brew is currently using.
-        return if ENV["GITHUB_ACTIONS"]
+        return if GitHub::Actions.env_set?
 
         # With fake El Capitan for Portable Ruby, we are intentionally not using Xcode 8.
         # This is because we are not using the CLT and Xcode 8 has the 10.12 SDK.
@@ -165,7 +165,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI providers
         # Homebrew/brew is currently using.
-        return if ENV["GITHUB_ACTIONS"]
+        return if GitHub::Actions.env_set?
 
         <<~EOS
           A newer Command Line Tools release is available.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -206,10 +206,9 @@ class FormulaInstaller
 
       case deprecate_disable_type
       when :deprecated
-        puts "::warning::#{message}" if ENV["GITHUB_ACTIONS"]
         opoo message
       when :disabled
-        puts "::error::#{message}" if ENV["GITHUB_ACTIONS"]
+        GitHub::Actions.puts_annotation_if_env_set(:error, message)
         raise CannotInstallFormulaError, message
       end
     end
@@ -505,7 +504,8 @@ on_request: installed_on_request?, options:)
 
       raise if Homebrew::EnvConfig.developer?
 
-      $stderr.puts "Please report this issue to the #{formula.tap} tap (not Homebrew/brew or Homebrew/homebrew-core)!"
+      $stderr.puts "Please report this issue to the #{formula.tap&.full_name} tap".squeeze(" ")
+      $stderr.puts " (not Homebrew/brew or Homebrew/homebrew-core)!" unless formula.core_formula?
       false
     else
       f.linked_keg.exist? && f.opt_prefix.exist?

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -15,7 +15,7 @@ module Homebrew
     def self.check_style_and_print(files, **options)
       success = check_style_impl(files, :print, **options)
 
-      if ENV["GITHUB_ACTIONS"] && !success
+      if GitHub::Actions.env_set? && !success
         check_style_json(files, **options).each do |path, offenses|
           offenses.each do |o|
             line = o.location.line

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -230,12 +230,12 @@ RSpec.describe Kernel do
       expect do
         odeprecated(
           "method", "replacement",
-          caller:  ["#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/"],
+          caller:  ["#{HOMEBREW_LIBRARY}/Taps/playbrew/homebrew-play/"],
           disable: true
         )
       end.to raise_error(
         MethodDeprecatedError,
-        %r{method.*replacement.*homebrew/core.*/Taps/homebrew/homebrew-core/}m,
+        %r{method.*replacement.*playbrew/homebrew-play.*/Taps/playbrew/homebrew-play/}m,
       )
     end
   end


### PR DESCRIPTION
We already do this for deprecations but these may make warnings and errors from Homebrew easier to spot in GitHub Actions logs.

Maybe we only want to do this for warnings or maybe only for deprecations 🤷🏻. Feedback welcome.