### PR TITLE
dev-cmd/tap-new: add Brewfile documentation to readme template

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -57,6 +57,13 @@ module Homebrew
 
           Or `brew tap #{tap}` and then `brew install <formula>`.
 
+          Optionally, in a [brew-bundle](https://github.com/Homebrew/homebrew-bundle) `Brewfile`:
+
+          ```ruby
+          tap "#{tap}"
+          brew "<formula>"
+          ```
+
           ## Documentation
 
           `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -57,7 +57,7 @@ module Homebrew
 
           Or `brew tap #{tap}` and then `brew install <formula>`.
 
-          Optionally, in a [brew-bundle](https://github.com/Homebrew/homebrew-bundle) `Brewfile`:
+          Or, in a [`brew bundle`](https://github.com/Homebrew/homebrew-bundle) `Brewfile`:
 
           ```ruby
           tap "#{tap}"


### PR DESCRIPTION
It would be helpful for taps to document how they are to be used with `Brewfile`.

Adding documentation for formulae installation to the generated tap readme would help ensure that new taps have this helpful documentation in their repos from the start.

This is primarily a follow-up to https://github.com/Homebrew/homebrew-cask-fonts/pull/9359 which itself was opened after I spent a significant amount of time trying to figure out how to get a font installed as part of my Brewfile.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
