### PR TITLE
Enable HOMEBREW_AUTOREMOVE by default

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -288,7 +288,11 @@ module Homebrew
           cleanup_formula(formula, quiet:, ds_store: false, cache_db: false)
         end
 
-        Cleanup.autoremove(dry_run: dry_run?) if Homebrew::EnvConfig.autoremove?
+        if ENV["HOMEBREW_AUTOREMOVE"].present?
+          opoo "HOMEBREW_AUTOREMOVE is now a no-op as it is the default behaviour. " \
+               "Set HOMEBREW_NO_AUTO_REMOVE=1 to disable it."
+        end
+        Cleanup.autoremove(dry_run: dry_run?) unless Homebrew::EnvConfig.no_autoremove?
 
         cleanup_cache
         cleanup_empty_api_source_directories

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -77,7 +77,11 @@ module Homebrew
           )
         end
 
-        Cleanup.autoremove if Homebrew::EnvConfig.autoremove?
+        if ENV["HOMEBREW_AUTOREMOVE"].present?
+          opoo "HOMEBREW_AUTOREMOVE is now a no-op as it is the default behaviour. " \
+               "Set HOMEBREW_NO_AUTO_REMOVE=1 to disable it."
+        end
+        Cleanup.autoremove unless Homebrew::EnvConfig.no_autoremove?
       end
     end
   end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -44,12 +44,6 @@ module Homebrew
                      "to instead be downloaded from " \
                      "`http://localhost:8080/v2/homebrew/core/gettext/manifests/0.21`",
       },
-      HOMEBREW_AUTOREMOVE:                       {
-        description: "If set, calls to `brew cleanup` and `brew uninstall` will automatically " \
-                     "remove unused formula dependents and if `HOMEBREW_NO_INSTALL_CLEANUP` is not set, " \
-                     "`brew cleanup` will start running `brew autoremove` periodically.",
-        boolean:     true,
-      },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
         description:  "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
                       "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
@@ -303,6 +297,11 @@ module Homebrew
       HOMEBREW_NO_ANALYTICS:                     {
         description: "If set, do not send analytics. Google Analytics were destroyed. " \
                      "For more information, see: <https://docs.brew.sh/Analytics>",
+        boolean:     true,
+      },
+      HOMEBREW_NO_AUTOREMOVE:                    {
+        description: "If set, calls to `brew cleanup` and `brew uninstall` will not automatically " \
+                     "remove unused formula dependents.",
         boolean:     true,
       },
       HOMEBREW_NO_AUTO_UPDATE:                   {

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -191,6 +191,9 @@ module Homebrew::EnvConfig
     def no_auto_update?; end
 
     sig { returns(T::Boolean) }
+    def no_autoremove?; end
+
+    sig { returns(T::Boolean) }
     def no_bootsnap?; end
 
     sig { returns(T.nilable(::String)) }

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3510,12 +3510,6 @@ command execution e.g. `$(cat file)`.
   downloaded from
   `http://localhost:8080/v2/homebrew/core/gettext/manifests/0.21`
 
-`HOMEBREW_AUTOREMOVE`
-
-: If set, calls to `brew cleanup` and `brew uninstall` will automatically remove
-  unused formula dependents and if `HOMEBREW_NO_INSTALL_CLEANUP` is not set,
-  `brew cleanup` will start running `brew autoremove` periodically.
-
 `HOMEBREW_AUTO_UPDATE_SECS`
 
 : Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some
@@ -3829,6 +3823,11 @@ command execution e.g. `$(cat file)`.
 
 : If set, do not send analytics. Google Analytics were destroyed. For more
   information, see: <https://docs.brew.sh/Analytics>
+
+`HOMEBREW_NO_AUTOREMOVE`
+
+: If set, calls to `brew cleanup` and `brew uninstall` will not automatically
+  remove unused formula dependents.
 
 `HOMEBREW_NO_AUTO_UPDATE`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2244,9 +2244,6 @@ Linux only: Pass this value to a type name representing the compiler\[u2019]s \f
 \fBHOMEBREW_ARTIFACT_DOMAIN\fP
 Prefix all download URLs, including those for bottles, with this value\. For example, \fBHOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080\fP will cause a formula with the URL \fBhttps://example\.com/foo\.tar\.gz\fP to instead download from \fBhttp://localhost:8080/https://example\.com/foo\.tar\.gz\fP\&\. Bottle URLs however, have their domain replaced with this prefix\. This results in e\.g\. \fBhttps://ghcr\.io/v2/homebrew/core/gettext/manifests/0\.21\fP to instead be downloaded from \fBhttp://localhost:8080/v2/homebrew/core/gettext/manifests/0\.21\fP
 .TP
-\fBHOMEBREW_AUTOREMOVE\fP
-If set, calls to \fBbrew cleanup\fP and \fBbrew uninstall\fP will automatically remove unused formula dependents and if \fBHOMEBREW_NO_INSTALL_CLEANUP\fP is not set, \fBbrew cleanup\fP will start running \fBbrew autoremove\fP periodically\.
-.TP
 \fBHOMEBREW_AUTO_UPDATE_SECS\fP
 Run \fBbrew update\fP once every \fBHOMEBREW_AUTO_UPDATE_SECS\fP seconds before some commands, e\.g\. \fBbrew install\fP, \fBbrew upgrade\fP and \fBbrew tap\fP\&\. Alternatively, disable auto\-update entirely with \fBHOMEBREW_NO_AUTO_UPDATE\fP\&\.
 .RS
@@ -2502,6 +2499,9 @@ Use this value as the number of parallel jobs to run when building with \fBmake\
 If set, do not send analytics\. Google Analytics were destroyed\. For more information, see: 
 .UR https://docs\.brew\.sh/Analytics
 .UE
+.TP
+\fBHOMEBREW_NO_AUTOREMOVE\fP
+If set, calls to \fBbrew cleanup\fP and \fBbrew uninstall\fP will not automatically remove unused formula dependents\.
 .TP
 \fBHOMEBREW_NO_AUTO_UPDATE\fP
 If set, do not automatically update before running some commands, e\.g\. \fBbrew install\fP, \fBbrew upgrade\fP and \fBbrew tap\fP\&\. Preferably, run this less often by setting \fBHOMEBREW_AUTO_UPDATE_SECS\fP to a value higher than the default\. Note that setting this and e\.g\. tapping new taps may result in a broken configuration\. Please ensure you always run \fBbrew update\fP before reporting any issues\.


### PR DESCRIPTION
Enabled `HOMEBREW_AUTOREMOVE` by default, and added `HOMEBREW_NO_AUTOREMOVE` to disable it.

I've been running this for years and it's been rock-solid. An incoming minor release feels like a good time to change this default and document it.