### PR TITLE
utils/github/api: use real UID for auth fetching

### DIFF
--- a/Library/Homebrew/utils/uid.rb
+++ b/Library/Homebrew/utils/uid.rb
@@ -1,0 +1,19 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Utils
+  module UID
+    sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
+    def self.drop_euid(&_block)
+      return yield if Process.euid == Process.uid
+
+      original_euid = Process.euid
+      begin
+        Process::Sys.seteuid(Process.uid)
+        yield
+      ensure
+        Process::Sys.seteuid(original_euid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
GitHub auth handlers need to have the correct user & home set. I think we're assuming UID is the calling user we care about rather than EUID.