### PR TITLE
fix no autoremove suggestion typo

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -290,7 +290,7 @@ module Homebrew
 
         if ENV["HOMEBREW_AUTOREMOVE"].present?
           opoo "HOMEBREW_AUTOREMOVE is now a no-op as it is the default behaviour. " \
-               "Set HOMEBREW_NO_AUTO_REMOVE=1 to disable it."
+               "Set HOMEBREW_NO_AUTOREMOVE=1 to disable it."
         end
         Cleanup.autoremove(dry_run: dry_run?) unless Homebrew::EnvConfig.no_autoremove?
 

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -79,7 +79,7 @@ module Homebrew
 
         if ENV["HOMEBREW_AUTOREMOVE"].present?
           opoo "HOMEBREW_AUTOREMOVE is now a no-op as it is the default behaviour. " \
-               "Set HOMEBREW_NO_AUTO_REMOVE=1 to disable it."
+               "Set HOMEBREW_NO_AUTOREMOVE=1 to disable it."
         end
         Cleanup.autoremove unless Homebrew::EnvConfig.no_autoremove?
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This currently suggests setting an environment variable that is different than the one we end up checking so I've updated the warning so now things match. If the goal was to have the name in the warning, the environment variable checking logic could be updated. I have no personal preference.

```console
$ brew irb
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
brew(main):001:0> ENV["HOMEBREW_NO_AUTO_REMOVE"] = "1"
=> "1"
brew(main):002:0> Homebrew::EnvConfig.no_autoremove?
=> false
brew(main):003:0> ENV["HOMEBREW_NO_AUTOREMOVE"] = "1"
=> "1"
brew(main):004:0> Homebrew::EnvConfig.no_autoremove?
=> true
```