### PR TITLE
extend/kernel: add sigs to `opoo`/`onoe`/`ofail`

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -45,6 +45,8 @@ module Homebrew
               To install, run:
                 brew install --HEAD #{name}
             EOS
+
+            nil
           end
         else
           args.named.to_latest_kegs

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -125,6 +125,8 @@ module Homebrew
             end
           rescue => e
             onoe e
+
+            nil
           end
 
           if sha256.present? && last_sha256 != sha256
@@ -134,6 +136,8 @@ module Homebrew
               end
             rescue Timeout::Error
               onoe "Timed out guessing version for cask '#{cask}'."
+
+              nil
             end
 
             if version

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -61,26 +61,29 @@ module Kernel
   # Print a warning message.
   #
   # @api public
+  sig { params(message: T.any(String, Exception)).void }
   def opoo(message)
     Tty.with($stderr) do |stderr|
       stderr.puts Formatter.warning(message, label: "Warning")
-      GitHub::Actions.puts_annotation_if_env_set(:warning, message)
+      GitHub::Actions.puts_annotation_if_env_set(:warning, message.to_s)
     end
   end
 
   # Print an error message.
   #
   # @api public
+  sig { params(message: T.any(String, Exception)).void }
   def onoe(message)
     Tty.with($stderr) do |stderr|
       stderr.puts Formatter.error(message, label: "Error")
-      GitHub::Actions.puts_annotation_if_env_set(:error, message)
+      GitHub::Actions.puts_annotation_if_env_set(:error, message.to_s)
     end
   end
 
   # Print an error message and fail at the end of the program.
   #
   # @api public
+  sig { params(error: T.any(String, Exception)).void }
   def ofail(error)
     onoe error
     Homebrew.failed = true


### PR DESCRIPTION
Add these and correctly pass through a string to `GitHub::Actions.puts_annotation_if_env_set`.

Also, fix some call sites to not rely on the `void` return.

Fixes https://github.com/Homebrew/brew/issues/17269