### PR TITLE
github_runner_matrix: define timeout values in constants

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -67,6 +67,7 @@ class GitHubRunnerMatrix
 
   SELF_HOSTED_LINUX_RUNNER = "linux-self-hosted-1"
   GITHUB_ACTIONS_LONG_TIMEOUT = 4320
+  GITHUB_ACTIONS_SHORT_TIMEOUT = 120
 
   sig { returns(LinuxRunnerSpec) }
   def linux_runner_spec
@@ -120,8 +121,10 @@ class GitHubRunnerMatrix
     end
 
     github_run_id      = ENV.fetch("GITHUB_RUN_ID")
-    runner_timeout     = ENV.fetch("HOMEBREW_MACOS_TIMEOUT").to_i
+    long_timeout       = ENV.fetch("HOMEBREW_MACOS_LONG_TIMEOUT", "false") == "true"
     use_github_runner  = ENV.fetch("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false") == "true"
+
+    runner_timeout = long_timeout ? GITHUB_ACTIONS_LONG_TIMEOUT : GITHUB_ACTIONS_SHORT_TIMEOUT
 
     # Use GitHub Actions macOS Runner for testing dependents if compatible with timeout.
     use_github_runner ||= @dependent_matrix

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
   let(:ephemeral_suffix) { "-12345" }
   let(:runner_env) do
     {
-      "HOMEBREW_LINUX_RUNNER"  => linux_runner,
-      "HOMEBREW_MACOS_TIMEOUT" => "90",
-      "GITHUB_RUN_ID"          => ephemeral_suffix.split("-").second,
+      "HOMEBREW_LINUX_RUNNER"       => linux_runner,
+      "HOMEBREW_MACOS_LONG_TIMEOUT" => "false",
+      "GITHUB_RUN_ID"               => ephemeral_suffix.split("-").second,
     }.freeze
   end
   let(:all_runners) do

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -6,7 +6,7 @@ require "test/support/fixtures/testball"
 RSpec.describe GitHubRunnerMatrix do
   before do
     allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_RUNNER").and_return("ubuntu-latest")
-    allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_TIMEOUT").and_return("90")
+    allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows us to keep all information about timeout values here in
`brew` instead of both here and in Homebrew/core.

Needed for Homebrew/homebrew-core#171457.
