### PR TITLE
fix: use UTC for all SBOM times

### DIFF
--- a/Library/Homebrew/sbom.rb
+++ b/Library/Homebrew/sbom.rb
@@ -388,7 +388,7 @@ class SBOM
 
   sig { returns(Time) }
   def source_modified_time
-    Time.at(@source_modified_time || 0)
+    Time.at(@source_modified_time || 0).utc
   end
 
   sig { params(val: T.untyped).returns(T.any(String, Symbol)) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Issue GH-17281

This should make sure times are the same no matter where it was build