### PR TITLE
SBOM: more fixes.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -494,7 +494,6 @@ module Homebrew
             Tab.clear_cache
             Dependency.clear_cache
             Requirement.clear_cache
-            SBOM.clear_cache
 
             tab = keg.tab
             original_tab = tab.dup
@@ -509,7 +508,7 @@ module Homebrew
             end
 
             sbom = SBOM.create(formula, tab)
-            sbom.write
+            sbom.write(bottling: true)
 
             keg.consistent_reproducible_symlink_permissions!
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -829,8 +829,8 @@ on_request: installed_on_request?, options:)
     tab.runtime_dependencies = Tab.runtime_deps_hash(formula, f_runtime_deps)
     tab.write
 
-    # write a SBOM file (if we don't already have one and aren't bottling)
-    if !build_bottle? && !SBOM.exist?(formula)
+    # write/update a SBOM file (if we aren't bottling)
+    unless build_bottle?
       sbom = SBOM.create(formula, tab)
       sbom.write(validate: Homebrew::EnvConfig.developer?)
     end


### PR DESCRIPTION
- Remove use of (unused) `Cachable` module.
- Pass whether we're bottling to determine whether to create reproducible SBOM or not. A reproducible SBOM omits the time and compiler.
- Remove bottle information when bottling: we cannot know what e.g. the checksum (and, with GitHub Packages, therefore also the download location) will be before we've created the tarball contents.
- Always write a bottle on installation (unless we're bottling) to provide new bottle information or freshen the existing one with the information we stripped out for reproducibility e.g. the time and compiler.
- Don't need to handle a `nil` `@source_modified_time` as it's always set.

Fixes #17281