### PR TITLE
formula: this was nilable before so remove it.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2383,7 +2383,6 @@ class Formula
       "name"                     => name,
       "full_name"                => full_name,
       "tap"                      => tap&.name,
-      "oldname"                  => ("odeprecated" if oldnames.first),
       "oldnames"                 => oldnames,
       "aliases"                  => aliases.sort,
       "versioned_formulae"       => versioned_formulae.map(&:name),


### PR DESCRIPTION
Other maintainers consider this preferable to setting to `odeprecated`.