### PR TITLE
linkage_checker: test indirect dependencies.

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -67,6 +67,7 @@ class LinkageChecker
     display_items("Conflicting libraries", @version_conflict_deps, puts_output:)
     return unless strict
 
+    display_items("Indirect dependencies with linkage", @indirect_deps, puts_output:)
     display_items("Undeclared dependencies with linkage", @undeclared_deps, puts_output:)
     display_items("Files with missing rpath", @files_missing_rpaths, puts_output:)
     display_items "@executable_path references in libraries", @executable_path_dylibs, puts_output:
@@ -79,7 +80,7 @@ class LinkageChecker
     issues = [@broken_deps, @broken_dylibs]
     if test
       issues += [@unwanted_system_dylibs, @version_conflict_deps]
-      issues += [@undeclared_deps, @files_missing_rpaths, @executable_path_dylibs] if strict
+      issues += [@indirect_deps, @undeclared_deps, @files_missing_rpaths, @executable_path_dylibs] if strict
     end
     issues.any?(&:present?)
   end


### PR DESCRIPTION
Check for indirect dependencies with linkage with linkage in strict test mode.

This should be done to ensure we accurately declare dependencies in homebrew/core.

Alternate/complementary approach in https://github.com/Homebrew/homebrew-test-bot/pull/1059