### PR TITLE
brew.sh: cache HOMEBREW_VERSION on disk.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -495,7 +495,27 @@ setup_git() {
 setup_curl
 setup_git
 
-HOMEBREW_VERSION="$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" describe --tags --dirty --abbrev=7 2>/dev/null)"
+GIT_DESCRIBE_CACHE="${HOMEBREW_REPOSITORY}/.git/describe-cache"
+GIT_REVISION=$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" rev-parse HEAD 2>/dev/null)
+if [[ -n "${GIT_REVISION}" ]]
+then
+  GIT_DESCRIBE_CACHE_FILE="${GIT_DESCRIBE_CACHE}/${GIT_REVISION}"
+  if [[ -f "${GIT_DESCRIBE_CACHE_FILE}" ]]
+  then
+    HOMEBREW_VERSION="$(cat "${GIT_DESCRIBE_CACHE_FILE}")"
+  else
+    rm -rf "${GIT_DESCRIBE_CACHE}"
+    HOMEBREW_VERSION="$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" describe --tags --dirty --abbrev=7 2>/dev/null)"
+    mkdir -p "${GIT_DESCRIBE_CACHE}"
+    echo "${HOMEBREW_VERSION}" >"${GIT_DESCRIBE_CACHE_FILE}"
+  fi
+  unset GIT_DESCRIBE_CACHE_FILE
+else
+  rm -rf "${GIT_DESCRIBE_CACHE}"
+fi
+unset GIT_REVISION
+unset GIT_DESCRIBE_CACHE
+
 HOMEBREW_USER_AGENT_VERSION="${HOMEBREW_VERSION}"
 if [[ -z "${HOMEBREW_VERSION}" ]]
 then

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -3,15 +3,32 @@
 ##### to be able to `source` in shell configurations run quickly.
 #####
 
-# Doesn't need a default case because we don't support other OSs
-# shellcheck disable=SC2249
-HOMEBREW_PROCESSOR="$(uname -m)"
-HOMEBREW_PHYSICAL_PROCESSOR="${HOMEBREW_PROCESSOR}"
-HOMEBREW_SYSTEM="$(uname -s)"
-case "${HOMEBREW_SYSTEM}" in
-  Darwin) HOMEBREW_MACOS="1" ;;
-  Linux) HOMEBREW_LINUX="1" ;;
+case "${MACHTYPE}" in
+  arm64-*)
+    HOMEBREW_PROCESSOR="arm64"
+    ;;
+  x86_64-*)
+    HOMEBREW_PROCESSOR="x86_64"
+    ;;
+  *)
+    HOMEBREW_PROCESSOR="$(uname -m)"
+    ;;
 esac
+
+case "${OSTYPE}" in
+  darwin*)
+    HOMEBREW_SYSTEM="Darwin"
+    HOMEBREW_MACOS="1"
+    ;;
+  linux*)
+    HOMEBREW_SYSTEM="Linux"
+    HOMEBREW_LINUX="1"
+    ;;
+  *)
+    HOMEBREW_SYSTEM="$(uname -s)"
+    ;;
+esac
+HOMEBREW_PHYSICAL_PROCESSOR="${HOMEBREW_PROCESSOR}"
 
 HOMEBREW_MACOS_ARM_DEFAULT_PREFIX="/opt/homebrew"
 HOMEBREW_MACOS_ARM_DEFAULT_REPOSITORY="${HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}"
@@ -79,11 +96,11 @@ HOMEBREW_CACHE="${HOMEBREW_CACHE:-${HOMEBREW_DEFAULT_CACHE}}"
 HOMEBREW_LOGS="${HOMEBREW_LOGS:-${HOMEBREW_DEFAULT_LOGS}}"
 HOMEBREW_TEMP="${HOMEBREW_TEMP:-${HOMEBREW_DEFAULT_TEMP}}"
 
-# Don't need to handle a default case.
-# HOMEBREW_LIBRARY set by bin/brew
-# shellcheck disable=SC2249,SC2154
-#
 # commands that take a single or no arguments.
+# HOMEBREW_LIBRARY set by bin/brew
+# shellcheck disable=SC2154
+# doesn't need a default case as other arguments handled elsewhere.
+# shellcheck disable=SC2249
 case "$1" in
   formulae)
     source "${HOMEBREW_LIBRARY}/Homebrew/cmd/formulae.sh"
@@ -109,6 +126,8 @@ case "$1" in
     ;;
 esac
 # functions that take multiple arguments or handle multiple commands.
+# doesn't need a default case as other arguments handled elsewhere.
+# shellcheck disable=SC2249
 case "$@" in
   --cellar)
     echo "${HOMEBREW_CELLAR}"
@@ -232,7 +251,7 @@ numeric() {
 }
 
 check-run-command-as-root() {
-  [[ "$(id -u)" == 0 || "$(id -ur)" == 0 ]] || return
+  [[ "${EUID}" == 0 || "${UID}" == 0 ]] || return
 
   # Allow Azure Pipelines/GitHub Actions/Docker/Concourse/Kubernetes to do everything as root (as it's normal there)
   [[ -f /.dockerenv ]] && return
@@ -429,11 +448,11 @@ fi
 
 # Many Pathname operations use getwd when they shouldn't, and then throw
 # odd exceptions. Reduce our support burden by showing a user-friendly error.
-if ! [[ -d "$(pwd)" ]]
+if ! [[ -d "${PWD}" ]]
 then
   odie "The current working directory must exist to run brew."
 fi
-if ! [[ -r "$(pwd)" ]]
+if ! [[ -r "${PWD}" ]]
 then
   odie "The current working directory must be readable to ${USER} to run brew."
 fi
@@ -536,6 +555,8 @@ then
 fi
 
 # commands that take a single or no arguments.
+# doesn't need a default case as other arguments handled elsewhere.
+# shellcheck disable=SC2249
 case "$1" in
   --version | -v)
     source "${HOMEBREW_LIBRARY}/Homebrew/cmd/--version.sh"
@@ -807,6 +828,7 @@ EOS
   # a popup window asking the user to install the CLT
   if [[ -n "${XCODE_SELECT_PATH}" ]]
   then
+    # TODO: this is fairly slow, figure out if there's a faster way.
     XCRUN_OUTPUT="$(/usr/bin/xcrun clang 2>&1)"
     XCRUN_STATUS="$?"
 
@@ -836,6 +858,8 @@ HOMEBREW_COMMAND="$1"
 shift
 # If you are going to change anything in below case statement,
 # be sure to also update HOMEBREW_INTERNAL_COMMAND_ALIASES hash in commands.rb
+# doesn't need a default case as other arguments handled elsewhere.
+# shellcheck disable=SC2249
 case "${HOMEBREW_COMMAND}" in
   ls) HOMEBREW_COMMAND="list" ;;
   homepage) HOMEBREW_COMMAND="home" ;;

--- a/bin/brew
+++ b/bin/brew
@@ -76,7 +76,7 @@ then
   HOMEBREW_REPOSITORY="${BREW_FILE_DIRECTORY%/*}"
 fi
 
-# Try to find a /usr/local HOMEBREW_PREFIX where possible (for bottles)
+# Try to find a /usr/local HOMEBREW_PREFIX where possible (for macOS x86_64 bottles)
 if [[ -L "/usr/local/bin/brew" && ! -L "${HOMEBREW_PREFIX}/Cellar" ]]
 then
   USR_LOCAL_BREW_FILE_DIRECTORY="$(symlink_target_directory "/usr/local/bin/brew" "/usr/local/bin")"


### PR DESCRIPTION
This is a (relatively, for this Bash script) expensive operation that can be trivially cached so: let's do so.

Speedup on my machine:

```
$ hyperfine "brew --version" "HOMEBREW_VERSION_CACHE=1 brew --version"
Benchmark 1: brew --version
  Time (mean ± σ):     173.4 ms ±   5.1 ms    [User: 28.7 ms, System: 67.0 ms]
  Range (min … max):   167.3 ms … 182.9 ms    15 runs

Benchmark 2: HOMEBREW_VERSION_CACHE=1 brew --version
  Time (mean ± σ):     145.9 ms ±   4.0 ms    [User: 22.4 ms, System: 33.9 ms]
  Range (min … max):   140.0 ms … 154.5 ms    17 runs

Summary
  HOMEBREW_VERSION_CACHE=1 brew --version ran
    1.19 ± 0.05 times faster than brew --version
```

While we're here:
- improve a comment
- avoid shelling out to further improve performance in more cases