### PR TITLE
tap: cask font sharding fix

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -673,8 +673,11 @@ class Tap
 
   sig { params(token: String).returns(String) }
   def relative_cask_path(token)
-    new_cask_path(token).to_s
-                        .delete_prefix("#{path}/")
+    if token.start_with?("font-")
+      new_cask_font_path(token)
+    else
+      new_cask_path(token)
+    end.to_s.delete_prefix("#{path}/")
   end
 
   def contents


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is **not** the correct solution, but keeping open for visibility for now.
We need to instead detect if the Cask is a "font cask" based on the artifacts it includes. The same as here - https://github.com/Homebrew/brew/commit/836d819c4337ded190712646ffaa991d502094ed

Before:
```
==> font-abel: latest
...
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/f/font-abel.rb
```

After:
```
brew info font-abel
==> font-abel: latest
...
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/font/font-a/font-abel.rb
```