### PR TITLE
linkage_checker: remove `gcc` from `@indirect_deps` on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -45,5 +45,6 @@ class LinkageChecker
     #   https://github.com/Homebrew/brew/pull/13796
     # TODO: Find a nicer way to handle this. (e.g. examining the ELF file to determine the required libstdc++.)
     @undeclared_deps.delete("gcc")
+    @indirect_deps.delete("gcc")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Closes #17303.
