### PR TITLE
formula: trap CMake FetchContent usage instead of using FETCHCONTENT_FULLY_DISCONNECTED

### DIFF
--- a/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake
+++ b/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.24) # Dependency providers introduced in CMake 3.24
+
+option(HOMEBREW_ALLOW_FETCHCONTENT "Allow FetchContent to be used in Homebrew builds" OFF)
+
+if (HOMEBREW_ALLOW_FETCHCONTENT)
+    return()
+endif()
+
+macro(trap_fetchcontent_provider method depName)
+    message(FATAL_ERROR "Refusing to populate dependency '${depName}' with FetchContent while building in Homebrew, please use a formula dependency or add a resource to the formula.")
+endmacro()
+
+cmake_language(
+    SET_DEPENDENCY_PROVIDER trap_fetchcontent_provider
+    SUPPORTED_METHODS FETCHCONTENT_MAKEAVAILABLE_SERIAL
+)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1808,7 +1808,7 @@ class Formula
       -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_FIND_FRAMEWORK=#{find_framework}
       -DCMAKE_VERBOSE_MAKEFILE=ON
-      -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+      -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=#{HOMEBREW_LIBRARY_PATH}/cmake/trap_fetchcontent_provider.cmake
       -Wno-dev
       -DBUILD_TESTING=OFF
     ]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to #17075. With this change, when a formula attempts to use `FetchContent_MakeAvailable`, the following error is presented:

```
-- Configuring built-in curl...
CMake Error at /opt/homebrew/Library/Homebrew/trap_fetchcontent_provider.cmake:4 (message):
  Refusing to populate dependency 'zlib' with FetchContent while building in
  Homebrew, please add the dependency as a dependency or resource in the
  formula
Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.29.3/share/cmake/Modules/FetchContent.cmake:2017:EVAL:1 (trap_fetchcontent_provider)
  /opt/homebrew/Cellar/cmake/3.29.3/share/cmake/Modules/FetchContent.cmake:2017 (cmake_language)
  cmake/zlib_external.cmake:15 (FetchContent_MakeAvailable)
  CMakeLists.txt:214 (include)


-- Configuring incomplete, errors occurred!
```

(This is using a modified version of the `cpr` formula to try the scenario where `FetchContent_MakeAvailable` gets used; normally this formula will rely on brewed dependencies.)

Formulae can opt out by adding flag `-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=` (essentially unsetting the variable). Maybe we can provide something less unwieldy/better named to accomplish this.

Seeking feedback especially about:
- The error message and what end users or formula authors can do about it
- Name and location of the `.cmake` file - for now I just dropped it in `HOMEBREW_LIBRARY_PATH`, maybe it makes sense to be in some subdirectory, or in the Cellar somewhere (include this file in the `cmake` formula/bottle rather than as part of `brew`)