### PR TITLE
cask/audit: fix sharding for font-* casks

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -817,11 +817,7 @@ module Cask
     def audit_cask_path
       return unless cask.tap.core_cask_tap?
 
-      expected_path = if cask.artifacts.any?(Artifact::Font)
-        cask.tap.new_cask_font_path(cask.token)
-      else
-        cask.tap.new_cask_path(cask.token)
-      end
+      expected_path = cask.tap.new_cask_path(cask.token)
 
       return if cask.sourcefile_path.to_s.end_with?(expected_path)
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1397,14 +1397,11 @@ class CoreCaskTap < AbstractCoreTap
 
   sig { params(token: String).returns(Pathname) }
   def new_cask_path(token)
-    cask_subdir = token[0].to_s
-    cask_dir/cask_subdir/"#{token.downcase}.rb"
-  end
-
-  sig { params(token: String).returns(Pathname) }
-  def new_cask_font_path(token)
-    font_first_letter = T.must(token.split("font-").second)[0].to_s
-    cask_subdir = "font/font-#{font_first_letter}"
+    cask_subdir = if token.start_with?("font-")
+      "font/font-#{token.delete_prefix("font-")[0]}"
+    else
+      token[0].to_s
+    end
     cask_dir/cask_subdir/"#{token.downcase}.rb"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The primary issue at hand here is about sharding files, not identifying "font casks", so this PR proposes a change that moves the casks to an appropriate folder solely based on the `token`.

We currently don't have any logic that separates a "font cask" from an "application cask", but perhaps we should have a separate audit for new casks that requires the `font-` prefix when a cask only includes `font` artifacts.

------

If we like this route it depends on https://github.com/Homebrew/homebrew-cask/pull/173942