### PR TITLE
Hide default gems warnings for Ruby 3.4.

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -4,7 +4,10 @@
 require "api/analytics"
 require "api/cask"
 require "api/formula"
-require "base64" # TODO: Add this to the Gemfile or remove it before moving to Ruby 3.4.
+require "warnings"
+Warnings.ignore :default_gems do
+  require "base64" # TODO: Add this to the Gemfile or remove it before moving to Ruby 3.4.
+end
 require "extend/cachable"
 
 module Homebrew

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -2,7 +2,10 @@
 # frozen_string_literal: true
 
 require "abstract_command"
-require "csv"
+require "warnings"
+Warnings.ignore :default_gems do
+  require "csv"
+end
 
 module Homebrew
   module DevCmd

--- a/Library/Homebrew/warnings.rb
+++ b/Library/Homebrew/warnings.rb
@@ -14,6 +14,9 @@ module Warnings
       %r{warning: please see https://github\.com/whitequark/parser#compatibility-with-ruby-mri\.},
       # <!-- vale on -->
     ],
+    default_gems:  [
+      /warning: .+\.rb was loaded from the standard library, .+ default gems since Ruby \d+\.\d+\.\d+\./,
+    ],
   }.freeze
 
   def self.ignore(*warnings)


### PR DESCRIPTION
These omit warnings with Ruby 3.3 and are required for Ruby 3.4. We'll fix them when we're upgrading to 3.4 instead.