### PR TITLE
extend/pathname/rmtree: improve comment.

### DIFF
--- a/Library/Homebrew/extend/pathname/rmtree.rb
+++ b/Library/Homebrew/extend/pathname/rmtree.rb
@@ -8,6 +8,10 @@ class Pathname
   #
   # @api public
   def rmtree(noop: nil, verbose: nil, secure: nil)
+    # Ideally we'd odeprecate this but probably can't given gems so let's
+    # create a RuboCop autocorrect instead soon.
+    # This is why monkeypatching is non-ideal (but right solution to get
+    # Ruby 3.3 over the line).
     # odeprecated "rmtree", "FileUtils#rm_r"
     FileUtils.rm_r(@path, noop:, verbose:, secure:)
     nil


### PR DESCRIPTION
Clarify that this can't easily be `odeprecated` but keep the wording around so that we remember to do this on the next minor release.