### PR TITLE
rubocop: target Ruby 3.3.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -12,7 +12,7 @@ inherit_mode:
     - Exclude
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3
   NewCops: enable
   Include:
     - "**/*.rbi"

--- a/Library/Homebrew/cask/artifact_set.rb
+++ b/Library/Homebrew/cask/artifact_set.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "set"
-
 module Cask
   # Sorted set containing all cask artifacts.
   class ArtifactSet < ::Set

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -6,7 +6,6 @@ require "utils/bottles"
 require "attrable"
 require "formula"
 require "cask/cask_loader"
-require "set"
 
 module Homebrew
   # Helper class for cleaning up the Homebrew cache.

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -6,7 +6,6 @@ require "env_config"
 require "cask/config"
 require "cli/args"
 require "optparse"
-require "set"
 require "utils/tty"
 
 module Homebrew

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "set"
 require "cache_store"
 
 #

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "set"
-
 module Homebrew
   # Helper module for querying Homebrew-specific environment variables.
   #

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -8,7 +8,6 @@ require "fileutils"
 require "json"
 require "json/add/exception"
 require "forwardable"
-require "set"
 
 require "extend/array"
 require "extend/blank"

--- a/Library/Homebrew/linkage_cache_store.rb
+++ b/Library/Homebrew/linkage_cache_store.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "set"
 require "cache_store"
 
 #


### PR DESCRIPTION
Portable Ruby is at 3.3.1 now so may as well bump RuboCop too.