### PR TITLE
attestation: drop workflow check on core attestation

### DIFF
--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -157,8 +157,7 @@ RSpec.describe Homebrew::Attestation do
     it "calls gh with args for homebrew-core" do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json", "--cert-identity",
-                              described_class::HOMEBREW_CORE_CI_URI],
+                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
         .and_return(fake_result_json_resp)
 
@@ -168,8 +167,7 @@ RSpec.describe Homebrew::Attestation do
     it "calls gh with args for backfill when homebrew-core fails" do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json", "--cert-identity",
-                              described_class::HOMEBREW_CORE_CI_URI],
+                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
         .once
         .and_raise(described_class::InvalidAttestationError)
@@ -186,8 +184,7 @@ RSpec.describe Homebrew::Attestation do
     it "raises when the backfilled attestation is too new" do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
-                              described_class::HOMEBREW_CORE_REPO, "--format", "json", "--cert-identity",
-                              described_class::HOMEBREW_CORE_CI_URI],
+                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
         .once
         .and_raise(described_class::InvalidAttestationError)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This follows the workflow changes I made in homebrew-core:

* https://github.com/Homebrew/homebrew-core/pull/171819
* https://github.com/Homebrew/homebrew-core/pull/171986
* https://github.com/Homebrew/homebrew-core/pull/172005

With those changes, (hopefully) all of our bottle-uploading workflows now produce provenance. However, this means we no longer have a single workflow to verify on. As a result, this change relaxes the check to allow any attestation from `Homebrew/homebrew-core`, not just ones from the original publish workflow. I've left a detailed comment on how to ratchet this back down, but I figured I'd fix the verification failure first and then work on that 🙂 

(This should not meaningfully impact the security model, since an attacker would still need to obtain access to an OIDC credential within the context of `homebrew-core`.)