### PR TITLE
SBOM: various fixes.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -405,6 +405,7 @@ jobs:
             runs-on: macos-14
     env:
       HOMEBREW_TEST_BOT_ANALYTICS: 1
+      HOMEBREW_ENFORCE_SBOM: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2579,9 +2579,13 @@ class Formula
 
   # Returns the bottle information for a formula.
   def bottle_hash(compact_for_api: false)
-    bottle_spec = T.must(stable).bottle_specification
-
     hash = {}
+    stable_spec = stable
+    return hash unless stable_spec
+    return hash unless bottle_defined?
+
+    bottle_spec = stable_spec.bottle_specification
+
     hash["rebuild"] = bottle_spec.rebuild if !compact_for_api || !bottle_spec.rebuild.zero?
     hash["root_url"] = bottle_spec.root_url unless compact_for_api
     hash["files"] = {}


### PR DESCRIPTION
- be a bit stricter with SBOM handling with the test default formula flow in CI by making it raise errors if SBOM's aren't generated and validated as expected
- fix handling of HEAD installations of formulae so SBOM generation is both correct and doesn't raise errors
- make `Formula#bottle_hash` more accepting of edge cases e.g. HEAD-only formulae without a stable spec

Fixes #17333