### PR TITLE
utils/gems: don't run `bundle clean`.

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -312,18 +312,6 @@ module Homebrew
           end
           false
         end
-      elsif system bundle, "clean", out: :err # even if we have nothing to install, we may have removed gems
-        true
-      else
-        message = <<~EOS
-          failed to run `#{bundle} clean`!
-        EOS
-        if only_warn_on_failure
-          opoo_if_defined message
-        else
-          odie_if_defined message
-        end
-        false
       end
 
       if bundle_installed


### PR DESCRIPTION
This (incorrectly) removes gems that are also part of the system Ruby e.g. `base64` which contradicts warnings from Ruby itself when `require`ing these gems.

Extracted from #17342 as this needs to be in `master` for that PR's vendored gems job to pass.