### PR TITLE
dev-cmd/vendor-gems: run bundle clean

### DIFF
--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -46,6 +46,9 @@ module Homebrew
           ohai "bundle pristine"
           safe_system "bundle", "pristine"
 
+          ohai "bundle clean"
+          safe_system "bundle", "clean"
+
           # Workaround Bundler 2.4.21 issue where platforms may be removed.
           # Although we don't use 2.4.21, Dependabot does as it currently ignores your lockfile version.
           # https://github.com/rubygems/rubygems/issues/7169


### PR DESCRIPTION
Fixes install inconsistencies between standalone and all other bundle operations.

Should work as is but will test properly in a bit