### PR TITLE
livecheck/strategy: verify `--fail-with-body` support

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -219,7 +219,7 @@ module Homebrew
           stdout, stderr, status = curl_output(
             *PAGE_CONTENT_CURL_ARGS, url,
             **DEFAULT_CURL_OPTIONS,
-            use_homebrew_curl: homebrew_curl,
+            use_homebrew_curl: homebrew_curl || !curl_supports_fail_with_body?,
             user_agent:
           )
           next unless status.success?

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -470,6 +470,13 @@ module Utils
       T.must(file).unlink
     end
 
+    def curl_supports_fail_with_body?
+      @curl_supports_fail_with_body ||= Hash.new do |h, key|
+        h[key] = Version.new(curl_output("-V").stdout[/curl (\d+(\.\d+)+)/, 1]) >= Version.new("7.76.0")
+      end
+      @curl_supports_fail_with_body[curl_path]
+    end
+
     def curl_supports_tls13?
       @curl_supports_tls13 ||= Hash.new do |h, key|
         h[key] = quiet_system(curl_executable, "--tlsv1.3", "--head", "https://brew.sh/")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The `--fail-with-body` flag was [added in curl 7.76.0](https://daniel.haxx.se/blog/2021/02/11/curl-fail-with-body/), so systems with an earlier version will need to use brewed curl for page content livechecks to complete successfully. 

Before: (curl 7.54.0)
```console
$ brew livecheck zulu@8
curl: option --fail-with-body: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
Error: zulu@8: Unable to get versions
```

After:
```console
$ brew livecheck zulu@8
zulu@8: 8.0.412,8.78.0.19 ==> 8.0.412,8.78.0.19
```
