### PR TITLE
Clean up cask audit tmpdir after use

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -47,6 +47,12 @@ module Cask
       @token_conflicts = token_conflicts
       @only = only || []
       @except = except || []
+
+      # Clean up `#extract_artifacts` tmp dir when Audit object is destroyed
+      ObjectSpace.define_finalizer(
+        self,
+        proc { FileUtils.remove_entry(@tmpdir) if @tmpdir },
+      )
     end
 
     def run!


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Cask::Audit#extract_artifacts` is used in the `#audit_signing` and `#cask_plist_min_os` methods to create a directory in `/tmp` and extract cask artifacts without duplicating the work if it's already done. However, due to how this is set up, `tmpdir` isn't removed afterward and the extracted artifacts will take up disk space until the `tmp` directory is cleaned up. As a result, running `brew audit --strict --online` locally can chew through disk space and it may not be clear to the user where their free space has gone.

This adds a finalizer method to `Cask::Audit` to remove the created `@tmpdir` (if any) once it's no longer needed. There may be a better way of addressing the issue but this works for now without having to restructure how these audits work.

-----

As discussed on Slack, it probably makes sense for `brew cleanup` to also clean up `tmp` directories that `brew` has created. From a quick glance at our use of `#mktmpdir`, we would probably have to institute a common prefix (e.g., using `homebrew-` or `homebrew-brew-` before existing prefixes) to be able to reasonably identify `brew`-created `tmp` directories (without manually maintaining a list of prefixes in use). There may be a better way of going about it but that was my initial thought.

That said, it may not be necessary if everything's working correctly. With this patch in place, I've only ended up with a lingering `homebrew-unpack` `tmp` directory on maybe one or two occasions but I haven't figured out why that happened (my best guess is that I may have prematurely interrupted a command using ^C).