### PR TITLE
Revert "Enable HOMEBREW_AUTOREMOVE by autoremove_default"

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -287,11 +287,7 @@ module Homebrew
           cleanup_formula(formula, quiet:, ds_store: false, cache_db: false)
         end
 
-        if ENV["HOMEBREW_AUTOREMOVE"].present?
-          opoo "HOMEBREW_AUTOREMOVE is now a no-op as it is the default behaviour. " \
-               "Set HOMEBREW_NO_AUTOREMOVE=1 to disable it."
-        end
-        Cleanup.autoremove(dry_run: dry_run?) unless Homebrew::EnvConfig.no_autoremove?
+        Cleanup.autoremove(dry_run: dry_run?) if Homebrew::EnvConfig.autoremove?
 
         cleanup_cache
         cleanup_empty_api_source_directories

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -77,11 +77,7 @@ module Homebrew
           )
         end
 
-        if ENV["HOMEBREW_AUTOREMOVE"].present?
-          opoo "HOMEBREW_AUTOREMOVE is now a no-op as it is the default behaviour. " \
-               "Set HOMEBREW_NO_AUTOREMOVE=1 to disable it."
-        end
-        Cleanup.autoremove unless Homebrew::EnvConfig.no_autoremove?
+        Cleanup.autoremove if Homebrew::EnvConfig.autoremove?
       end
     end
   end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -48,6 +48,12 @@ module Homebrew
                      "trying any other/default URLs.",
         boolean:     true,
       },
+      HOMEBREW_AUTOREMOVE:                       {
+        description: "If set, calls to `brew cleanup` and `brew uninstall` will automatically " \
+                     "remove unused formula dependents and if `HOMEBREW_NO_INSTALL_CLEANUP` is not set, " \
+                     "`brew cleanup` will start running `brew autoremove` periodically.",
+        boolean:     true,
+      },
       HOMEBREW_AUTO_UPDATE_SECS:                 {
         description:  "Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some commands, " \
                       "e.g. `brew install`, `brew upgrade` and `brew tap`. Alternatively, " \
@@ -304,11 +310,6 @@ module Homebrew
       HOMEBREW_NO_ANALYTICS:                     {
         description: "If set, do not send analytics. Google Analytics were destroyed. " \
                      "For more information, see: <https://docs.brew.sh/Analytics>",
-        boolean:     true,
-      },
-      HOMEBREW_NO_AUTOREMOVE:                    {
-        description: "If set, calls to `brew cleanup` and `brew uninstall` will not automatically " \
-                     "remove unused formula dependents.",
         boolean:     true,
       },
       HOMEBREW_NO_AUTO_UPDATE:                   {

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -28,6 +28,9 @@ module Homebrew::EnvConfig
     sig { returns(T::Boolean) }
     def artifact_domain_no_fallback?; end
 
+    sig { returns(T::Boolean) }
+    def autoremove?; end
+
     sig { returns(T.nilable(::String)) }
     def auto_update_secs; end
 
@@ -192,9 +195,6 @@ module Homebrew::EnvConfig
 
     sig { returns(T::Boolean) }
     def no_auto_update?; end
-
-    sig { returns(T::Boolean) }
-    def no_autoremove?; end
 
     sig { returns(T::Boolean) }
     def no_bootsnap?; end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3519,6 +3519,12 @@ command execution e.g. `$(cat file)`.
   both set, if the request to `HOMEBREW_ARTIFACT_DOMAIN` fails then it Homebrew
   will error rather than trying any other/default URLs.
 
+`HOMEBREW_AUTOREMOVE`
+
+: If set, calls to `brew cleanup` and `brew uninstall` will automatically remove
+  unused formula dependents and if `HOMEBREW_NO_INSTALL_CLEANUP` is not set,
+  `brew cleanup` will start running `brew autoremove` periodically.
+
 `HOMEBREW_AUTO_UPDATE_SECS`
 
 : Run `brew update` once every `HOMEBREW_AUTO_UPDATE_SECS` seconds before some
@@ -3836,11 +3842,6 @@ command execution e.g. `$(cat file)`.
 
 : If set, do not send analytics. Google Analytics were destroyed. For more
   information, see: <https://docs.brew.sh/Analytics>
-
-`HOMEBREW_NO_AUTOREMOVE`
-
-: If set, calls to `brew cleanup` and `brew uninstall` will not automatically
-  remove unused formula dependents.
 
 `HOMEBREW_NO_AUTO_UPDATE`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2250,6 +2250,9 @@ Prefix all download URLs, including those for bottles, with this value\. For exa
 \fBHOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK\fP
 If \fBHOMEBREW_ARTIFACT_DOMAIN\fP and \fBHOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK\fP are both set, if the request to \fBHOMEBREW_ARTIFACT_DOMAIN\fP fails then it Homebrew will error rather than trying any other/default URLs\.
 .TP
+\fBHOMEBREW_AUTOREMOVE\fP
+If set, calls to \fBbrew cleanup\fP and \fBbrew uninstall\fP will automatically remove unused formula dependents and if \fBHOMEBREW_NO_INSTALL_CLEANUP\fP is not set, \fBbrew cleanup\fP will start running \fBbrew autoremove\fP periodically\.
+.TP
 \fBHOMEBREW_AUTO_UPDATE_SECS\fP
 Run \fBbrew update\fP once every \fBHOMEBREW_AUTO_UPDATE_SECS\fP seconds before some commands, e\.g\. \fBbrew install\fP, \fBbrew upgrade\fP and \fBbrew tap\fP\&\. Alternatively, disable auto\-update entirely with \fBHOMEBREW_NO_AUTO_UPDATE\fP\&\.
 .RS
@@ -2508,9 +2511,6 @@ Use this value as the number of parallel jobs to run when building with \fBmake\
 If set, do not send analytics\. Google Analytics were destroyed\. For more information, see: 
 .UR https://docs\.brew\.sh/Analytics
 .UE
-.TP
-\fBHOMEBREW_NO_AUTOREMOVE\fP
-If set, calls to \fBbrew cleanup\fP and \fBbrew uninstall\fP will not automatically remove unused formula dependents\.
 .TP
 \fBHOMEBREW_NO_AUTO_UPDATE\fP
 If set, do not automatically update before running some commands, e\.g\. \fBbrew install\fP, \fBbrew upgrade\fP and \fBbrew tap\fP\&\. Preferably, run this less often by setting \fBHOMEBREW_AUTO_UPDATE_SECS\fP to a value higher than the default\. Note that setting this and e\.g\. tapping new taps may result in a broken configuration\. Please ensure you always run \fBbrew update\fP before reporting any issues\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`autoremove` is destructive, and it can be difficult for users to
recover from it occuring when they weren't expecting it.

Fixes #17363
Fixes Homebrew/discussions#5395

This reverts commit 3d114161b3c3f1a95b94e8530f5bc45bb44bbbd9.
This reverts commit efb14a0ec264c4ef408dbbd5330905dd230e979c.
