### PR TITLE
Audit: disable OSDN urls

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -328,8 +328,7 @@ module Cask
         add_error "SourceForge URL format incorrect. See #{Formatter.url(SOURCEFORGE_OSDN_REFERENCE_URL)}",
                   location: cask.url.location
       elsif bad_osdn_url?
-        add_error "OSDN URLs are disabled.",
-                  location: cask.url.location
+        add_error "OSDN download urls are disabled.", location: cask.url.location, strict_only: true
       end
     end
 
@@ -895,7 +894,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def bad_osdn_url?
-      cask.url.to_s.match?(%r{^(?:https?://)?(?:\w+\.)*osdn\.jp(?=/|$)})
+      URI(cask.url.to_s).host.match?(%r{^(?:\w+\.)*osdn\.jp(?=/|$)})
     end
 
     # sig { returns(String) }

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -333,8 +333,6 @@ module Cask
     def audit_download_url_is_osdn
       return unless cask.url
       return if block_url_offline?
-
-      odebug "Auditing download url is OSDN or not"
       return unless bad_osdn_url?
 
       add_error "OSDN download urls are disabled.", location: cask.url.location, strict_only: true

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -895,7 +895,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def bad_osdn_url?
-      cask.url.to_s.match?(/^(?:https?:\/\/)?(?:\w+\.)*osdn\.jp(?=\/|$)/)
+      cask.url.to_s.match?(%r{^(?:https?://)?(?:\w+\.)*osdn\.jp(?=/|$)})
     end
 
     # sig { returns(String) }

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -894,7 +894,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def bad_osdn_url?
-      URI(cask.url.to_s).host.match?(%r{^(?:\w+\.)*osdn\.jp(?=/|$)})
+      T.must(URI(cask.url.to_s).host).match?(%r{^(?:\w+\.)*osdn\.jp(?=/|$)})
     end
 
     # sig { returns(String) }

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -328,7 +328,7 @@ module Cask
         add_error "SourceForge URL format incorrect. See #{Formatter.url(SOURCEFORGE_OSDN_REFERENCE_URL)}",
                   location: cask.url.location
       elsif bad_osdn_url?
-        add_error "OSDN URL format incorrect. See #{Formatter.url(SOURCEFORGE_OSDN_REFERENCE_URL)}",
+        add_error "OSDN URLs are disabled.",
                   location: cask.url.location
       end
     end
@@ -895,7 +895,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def bad_osdn_url?
-      bad_url_format?(/osd/, [%r{\Ahttps?://([^/]+.)?dl\.osdn\.jp/}])
+      cask.url.to_s.match?(/^(?:https?:\/\/)?(?:\w+\.)*osdn\.jp(?=\/|$)/)
     end
 
     # sig { returns(String) }

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -324,12 +324,20 @@ module Cask
       return if block_url_offline?
 
       odebug "Auditing URL format"
-      if bad_sourceforge_url?
-        add_error "SourceForge URL format incorrect. See #{Formatter.url(SOURCEFORGE_OSDN_REFERENCE_URL)}",
-                  location: cask.url.location
-      elsif bad_osdn_url?
-        add_error "OSDN download urls are disabled.", location: cask.url.location, strict_only: true
-      end
+      return unless bad_sourceforge_url?
+
+      add_error "SourceForge URL format incorrect. See #{Formatter.url(SOURCEFORGE_OSDN_REFERENCE_URL)}",
+                location: cask.url.location
+    end
+
+    def audit_download_url_is_osdn
+      return unless cask.url
+      return if block_url_offline?
+
+      odebug "Auditing download url is OSDN or not"
+      return unless bad_osdn_url?
+
+      add_error "OSDN download urls are disabled.", location: cask.url.location, strict_only: true
     end
 
     VERIFIED_URL_REFERENCE_URL = "https://docs.brew.sh/Cask-Cookbook#when-url-and-homepage-domains-differ-add-verified"
@@ -894,7 +902,7 @@ module Cask
 
     sig { returns(T::Boolean) }
     def bad_osdn_url?
-      T.must(URI(cask.url.to_s).host).match?(%r{^(?:\w+\.)*osdn\.jp(?=/|$)})
+      domain.match?(%r{^(?:\w+\.)*osdn\.jp(?=/|$)})
     end
 
     # sig { returns(String) }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -946,7 +946,7 @@ RSpec.describe Cask::Audit, :cask do
       context "when --strict is passed" do
         let(:strict) { true }
 
-        it { is_expected.to error_with(message)}
+        it { is_expected.to error_with(message) }
       end
     end
 

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -932,17 +932,21 @@ RSpec.describe Cask::Audit, :cask do
 
         it { is_expected.not_to error_with(message) }
       end
+    end
 
-      context "with incorrect OSDN URL format" do
-        let(:cask_token) { "osdn-incorrect-url-format" }
+    describe "disable OSDN download url" do
+      let(:only) { ["download_url_is_osdn"] }
+      let(:message) { /OSDN download urls are disabled./ }
+      let(:cask_token) { "osdn-urls" }
 
-        it { is_expected.to error_with(message) }
+      context "when --strict is not passed" do
+        it { is_expected.not_to error_with(message) }
       end
 
-      context "with correct OSDN URL format" do
-        let(:cask_token) { "osdn-correct-url-format" }
+      context "when --strict is passed" do
+        let(:strict) { true }
 
-        it { is_expected.not_to error_with(message) }
+        it { is_expected.to error_with(message)}
       end
     end
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-incorrect-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-incorrect-url-format.rb
@@ -1,6 +1,0 @@
-cask "osdn-incorrect-url-format" do
-  version "1.2.3"
-
-  url "https://osdn.jp/projects/something/files/Something-1.2.3.dmg/download"
-  homepage "https://osdn.jp/projects/something/"
-end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-urls.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-urls.rb
@@ -1,4 +1,4 @@
-cask "osdn-correct-url-format" do
+cask "osdn-urls" do
   version "1.2.3"
 
   url "https://user.dl.osdn.jp/something/id/Something-1.2.3.dmg"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related to https://github.com/Homebrew/homebrew-cask/pull/174285
I think it's better to disable OSDN urls when auditing since their certificate is expired.