### PR TITLE
cask/audit: Rework tmpdir removal

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -47,12 +47,6 @@ module Cask
       @token_conflicts = token_conflicts
       @only = only || []
       @except = except || []
-
-      # Clean up `#extract_artifacts` tmp dir when Audit object is destroyed
-      ObjectSpace.define_finalizer(
-        self,
-        proc { FileUtils.remove_entry(@tmpdir) if @tmpdir },
-      )
     end
 
     def run!
@@ -539,6 +533,12 @@ module Cask
       return if artifacts.empty?
 
       @tmpdir ||= Pathname(Dir.mktmpdir("cask-audit", HOMEBREW_TEMP))
+
+      # Clean up tmp dir when @tmpdir object is destroyed
+      ObjectSpace.define_finalizer(
+        @tmpdir,
+        proc { FileUtils.remove_entry(@tmpdir) },
+      )
 
       ohai "Downloading and extracting artifacts"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I previously introduced a finalizer method in `Cask::Audit` to remove the created `@tmpdir` once it's no longer needed (#17358) but the existing approach produces a `finalizer references object to be finalized` warning when `brew audit` is run. I didn't see this warning when I was originally testing it but now it reliably appears.

This reworks the finalizer to define it within the `#extract_artifacts` method and use `@tmpdir` as the target object.

Fixes #17374.