### PR TITLE
Deprecate Homebrew/homebrew-command-not-found

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,6 @@ jobs:
         run: |
           brew tap homebrew/aliases
           brew tap homebrew/bundle
-          brew tap homebrew/command-not-found
           brew tap homebrew/formula-analytics
           brew tap homebrew/portable-ruby
           brew tap homebrew/services
@@ -125,7 +124,6 @@ jobs:
                      homebrew/test-bot
 
           brew style homebrew/aliases \
-                     homebrew/command-not-found \
                      homebrew/formula-analytics \
                      homebrew/portable-ruby
 

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -6,11 +6,10 @@ OFFICIAL_CASK_TAPS = %w[
 ].freeze
 
 OFFICIAL_CMD_TAPS = {
-  "homebrew/aliases"           => ["alias", "unalias"],
-  "homebrew/bundle"            => ["bundle"],
-  "homebrew/command-not-found" => ["command-not-found-init", "which-formula", "which-update"],
-  "homebrew/test-bot"          => ["test-bot"],
-  "homebrew/services"          => ["services"],
+  "homebrew/aliases"  => ["alias", "unalias"],
+  "homebrew/bundle"   => ["bundle"],
+  "homebrew/test-bot" => ["test-bot"],
+  "homebrew/services" => ["services"],
 }.freeze
 
 DEPRECATED_OFFICIAL_TAPS = %w[
@@ -20,6 +19,7 @@ DEPRECATED_OFFICIAL_TAPS = %w[
   cask-eid
   cask-fonts
   cask-versions
+  command-not-found
   completions
   devel-only
   dupes

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -532,7 +532,7 @@ __fish_brew_complete_arg 'contributions' -l debug -d 'Display any debugging info
 __fish_brew_complete_arg 'contributions' -l from -d 'Date (ISO-8601 format) to start searching contributions. Omitting this flag searches the last year'
 __fish_brew_complete_arg 'contributions' -l help -d 'Show this message'
 __fish_brew_complete_arg 'contributions' -l quiet -d 'Make some output more quiet'
-__fish_brew_complete_arg 'contributions' -l repositories -d 'Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot` and `services`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. '
+__fish_brew_complete_arg 'contributions' -l repositories -d 'Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `test-bot` and `services`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. '
 __fish_brew_complete_arg 'contributions' -l to -d 'Date (ISO-8601 format) to stop searching contributions'
 __fish_brew_complete_arg 'contributions' -l user -d 'Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches maintainers'
 __fish_brew_complete_arg 'contributions' -l verbose -d 'Make some output more verbose'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -683,7 +683,7 @@ _brew_contributions() {
     '--from[Date (ISO-8601 format) to start searching contributions. Omitting this flag searches the last year]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
-    '--repositories[Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `command-not-found`, `test-bot` and `services`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. ]' \
+    '--repositories[Specify a comma-separated list of repositories to search. Supported repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `test-bot` and `services`. Omitting this flag, or specifying `--repositories=primary`, searches only the main repositories: brew,core,cask. Specifying `--repositories=all`, searches all repositories. ]' \
     '--to[Date (ISO-8601 format) to stop searching contributions]' \
     '--user[Specify a comma-separated list of GitHub usernames or email addresses to find contributions from. Omitting this flag searches maintainers]' \
     '--verbose[Make some output more verbose]'

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1997,10 +1997,10 @@ Summarise contributions to Homebrew repositories.
 `--repositories`
 
 : Specify a comma-separated list of repositories to search. Supported
-  repositories: `brew`, `core`, `cask`, `aliases`, `bundle`,
-  `command-not-found`, `test-bot` and `services`. Omitting this flag, or
-  specifying `--repositories=primary`, searches only the main repositories:
-  brew,core,cask. Specifying `--repositories=all`, searches all repositories.
+  repositories: `brew`, `core`, `cask`, `aliases`, `bundle`, `test-bot` and
+  `services`. Omitting this flag, or specifying `--repositories=primary`,
+  searches only the main repositories: brew,core,cask. Specifying
+  `--repositories=all`, searches all repositories.
 
 `--from`
 
@@ -3119,11 +3119,6 @@ flags which will help with finding keg-only dependencies like `openssl`,
 
 : `cleanup` casks using the `zap` command instead of `uninstall`.
 
-### `command-not-found-init`
-
-Print instructions for setting up the command-not-found hook for your shell. If
-the output is not to a tty, print the appropriate handler script for your shell.
-
 ### `services` \[*`subcommand`*\]
 
 Manage background services with macOS' `launchctl`(1) daemon manager or Linux's
@@ -3378,45 +3373,6 @@ and Linux workers.
 ### `unalias` *`alias`* \[...\]
 
 Remove aliases.
-
-### `which-formula` \[`--explain`\] *`command`* \[...\]
-
-Show which formula(e) provides the given command.
-
-`--explain`
-
-: Output explanation of how to get *`command`* by installing one of the
-  providing formulae.
-
-### `which-update` \[*`options`*\] \[*`database`*\]
-
-Database update for `brew which-formula`.
-
-`--stats`
-
-: Print statistics about the database contents (number of commands and formulae,
-  list of missing formulae).
-
-`--commit`
-
-: Commit the changes using `git`.
-
-`--update-existing`
-
-: Update database entries with outdated formula versions.
-
-`--install-missing`
-
-: Install and update formulae that are missing from the database and don't have
-  bottles.
-
-`--eval-all`
-
-: Evaluate all installed taps, rather than just the core tap.
-
-`--max-downloads`
-
-: Specify a maximum number of formulae to download and update.
 
 ## CUSTOM EXTERNAL COMMANDS
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1265,7 +1265,7 @@ Treat all named arguments as casks\.
 Summarise contributions to Homebrew repositories\.
 .TP
 \fB\-\-repositories\fP
-Specify a comma\-separated list of repositories to search\. Supported repositories: \fBbrew\fP, \fBcore\fP, \fBcask\fP, \fBaliases\fP, \fBbundle\fP, \fBcommand\-not\-found\fP, \fBtest\-bot\fP and \fBservices\fP\&\. Omitting this flag, or specifying \fB\-\-repositories=primary\fP, searches only the main repositories: brew,core,cask\. Specifying \fB\-\-repositories=all\fP, searches all repositories\.
+Specify a comma\-separated list of repositories to search\. Supported repositories: \fBbrew\fP, \fBcore\fP, \fBcask\fP, \fBaliases\fP, \fBbundle\fP, \fBtest\-bot\fP and \fBservices\fP\&\. Omitting this flag, or specifying \fB\-\-repositories=primary\fP, searches only the main repositories: brew,core,cask\. Specifying \fB\-\-repositories=all\fP, searches all repositories\.
 .TP
 \fB\-\-from\fP
 Date (ISO\-8601 format) to start searching contributions\. Omitting this flag searches the last year\.
@@ -1993,8 +1993,6 @@ Read the \fBBrewfile\fP from \fB~/\.Brewfile\fP or the \fBHOMEBREW_BUNDLE_FILE_G
 .TP
 \fB\-\-zap\fP
 \fBcleanup\fP casks using the \fBzap\fP command instead of \fBuninstall\fP\&\.
-.SS "\fBcommand\-not\-found\-init\fP"
-Print instructions for setting up the command\-not\-found hook for your shell\. If the output is not to a tty, print the appropriate handler script for your shell\.
 .SS "\fBservices\fP \fR[\fIsubcommand\fP]"
 Manage background services with macOS\[u2019] \fBlaunchctl\fP(1) daemon manager or Linux\[u2019]s \fBsystemctl\fP(1) service manager\.
 .P
@@ -2164,31 +2162,6 @@ Use these deleted formulae rather than running the formulae detection steps\.
 Use these skipped or failed formulae from formulae steps for a formulae dependents step\.
 .SS "\fBunalias\fP \fIalias\fP \fR[\.\.\.]"
 Remove aliases\.
-.SS "\fBwhich\-formula\fP \fR[\fB\-\-explain\fP] \fIcommand\fP \fR[\.\.\.]"
-Show which formula(e) provides the given command\.
-.TP
-\fB\-\-explain\fP
-Output explanation of how to get \fIcommand\fP by installing one of the providing formulae\.
-.SS "\fBwhich\-update\fP \fR[\fIoptions\fP] \fR[\fIdatabase\fP]"
-Database update for \fBbrew which\-formula\fP\&\.
-.TP
-\fB\-\-stats\fP
-Print statistics about the database contents (number of commands and formulae, list of missing formulae)\.
-.TP
-\fB\-\-commit\fP
-Commit the changes using \fBgit\fP\&\.
-.TP
-\fB\-\-update\-existing\fP
-Update database entries with outdated formula versions\.
-.TP
-\fB\-\-install\-missing\fP
-Install and update formulae that are missing from the database and don\[u2019]t have bottles\.
-.TP
-\fB\-\-eval\-all\fP
-Evaluate all installed taps, rather than just the core tap\.
-.TP
-\fB\-\-max\-downloads\fP
-Specify a maximum number of formulae to download and update\.
 .SH "CUSTOM EXTERNAL COMMANDS"
 Homebrew, like \fBgit\fP(1), supports external commands\. These are executable scripts that reside somewhere in the \fBPATH\fP, named \fBbrew\-\fP\fIcmdname\fP or \fBbrew\-\fP\fIcmdname\fP\fB\&\.rb\fP, which can be invoked like \fBbrew\fP \fIcmdname\fP\&\. This allows you to create your own commands without modifying Homebrew\[u2019]s internals\.
 .P


### PR DESCRIPTION
This doesn't seem to be used at all nowadays:
https://formulae.brew.sh/analytics/brew-command-run/365d/

As an official tap, it has overhead on e.g. RuboCop upgrades and a presence in Homebrew/brew CI, manpage, etc. that no longer seems to be warranted.

If there's enough 👍🏻 to do this: I'll add various `odeprecated` or `odisabled` calls to Homebrew/homebrew-command-not-found and archive the repository.