### PR TITLE
formula_auditor: add exemption for `nghttp2`

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -453,6 +453,9 @@ module Homebrew
       return unless @core_tap
       return unless Homebrew::SimulateSystem.simulating_or_running_on_linux?
       return unless linux_only_gcc_dep?(formula)
+      # https://github.com/Homebrew/homebrew-core/pull/171634
+      # https://github.com/nghttp2/nghttp2/issues/2194
+      return if formula.tap&.audit_exception(:linux_only_gcc_dependency_allowlist, formula.name)
 
       problem "Formulae in homebrew/core should not have a Linux-only dependency on GCC."
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Needed for Homebrew/homebrew-core#171634 due to nghttp2/nghttp2#2194.

~I've avoided adding an allowlist for now because I really don't want to~
~see this list grow.~
