### PR TITLE
Fix migrations of formulae and casks to non homebrew taps

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -458,6 +458,7 @@ module Cask
 
         loaders = Tap.select { |tap| tap.installed? && !tap.core_cask_tap? }
                      .filter_map { |tap| super("#{tap}/#{token}", warn:) }
+                     .uniq(&:path)
                      .select { |tap| tap.path.exist? }
 
         case loaders.count

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -828,6 +828,7 @@ module Formulary
 
       loaders = Tap.select { |tap| tap.installed? && !tap.core_tap? }
                    .filter_map { |tap| super("#{tap}/#{name}", warn:) }
+                   .uniq(&:path)
                    .select { |tap| tap.path.exist? }
 
       case loaders.count

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -641,6 +641,45 @@ RSpec.describe Formulary do
           #   end
           # end
         end
+
+        context "to a third-party tap" do
+          let(:old_tap) { Tap.fetch("another", "foo") }
+          let(:new_tap) { Tap.fetch("another", "bar") }
+          let(:formula_file) { new_tap.formula_dir/"#{token}.rb" }
+
+          before do
+            new_tap.formula_dir.mkpath
+            FileUtils.touch formula_file
+          end
+
+          after do
+            FileUtils.rm_rf Tap::TAP_DIRECTORY/"another"
+          end
+
+          # FIXME
+          # It would be preferable not to print a warning when installing with the short token
+          it "warns when loading the short token" do
+            expect do
+              described_class.loader_for(token)
+            end.to output(
+              a_string_including("Formula #{old_tap}/#{token} was renamed to #{new_tap}/#{token}.").once,
+            ).to_stderr
+          end
+
+          it "does not warn when loading the full token in the new tap" do
+            expect do
+              described_class.loader_for("#{new_tap}/#{token}")
+            end.not_to output.to_stderr
+          end
+
+          it "warns when loading the full token in the old tap" do
+            expect do
+              described_class.loader_for("#{old_tap}/#{token}")
+            end.to output(
+              a_string_including("Formula #{old_tap}/#{token} was renamed to #{new_tap}/#{token}.").once,
+            ).to_stderr
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is my attempt at fixing https://github.com/Homebrew/brew/issues/17290

The good parts: The error is fixed for formulae and taps.

The missing parts:
- [x] No tests for the formula change. I have not yet figured out how to integrate this in [Library/Homebrew/test/formulary_spec.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/formulary_spec.rb#L184). I'll keep trying myself. But I would be grateful for any tips.
- [x] One test fails. See https://github.com/Homebrew/brew/pull/17385#discussion_r1617756882