### PR TITLE
cask: skip variations for inapplicable versions

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -440,6 +440,7 @@ module Cask
           MacOSVersion::SYMBOLS.keys.product(OnSystem::ARCH_OPTIONS).each do |os, arch|
             bottle_tag = ::Utils::Bottles::Tag.new(system: os, arch:)
             next unless bottle_tag.valid_combination?
+            next if depends_on.macos && !depends_on.macos.allows?(bottle_tag.to_macos_version)
 
             Homebrew::SimulateSystem.with(os:, arch:) do
               refresh

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -100,6 +100,11 @@ class MacOSVersion < Version
     pretty_name
   end
 
+  sig { returns(String) }
+  def inspect
+    "#<#{self.class.name}: #{to_s.inspect}>"
+  end
+
   sig { returns(T::Boolean) }
   def outdated_release?
     self < HOMEBREW_MACOS_OLDEST_SUPPORTED

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -61,6 +61,19 @@ class MacOSRequirement < Requirement
     false
   end
 
+  def allows?(other)
+    return true unless version_specified?
+
+    case @comparator
+    when ">=" then other >= @version
+    when "<=" then other <= @version
+    else
+      return @version.include?(other) if @version.respond_to?(:to_ary)
+
+      @version == other
+    end
+  end
+
   def message(type: :formula)
     return "macOS is required for this software." unless version_specified?
 

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe MacOSVersion do
     expect(described_class.new("10.14").pretty_name).to eq("Mojave")
   end
 
+  specify "#inspect" do
+    expect(described_class.new("11").inspect).to eq("#<MacOSVersion: \"11\">")
+  end
+
   specify "#requires_nehalem_cpu?", :needs_macos do
     expect(Hardware::CPU).to receive(:type).at_least(:twice).and_return(:intel)
     expect(described_class.new("10.14").requires_nehalem_cpu?).to be true

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -5,6 +5,8 @@ require "requirements/macos_requirement"
 RSpec.describe MacOSRequirement do
   subject(:requirement) { described_class.new }
 
+  let(:big_sur_major) { MacOSVersion.new("11.0") }
+
   describe "#satisfied?" do
     it "returns true on macOS" do
       expect(requirement.satisfied?).to eq OS.mac?
@@ -19,5 +21,16 @@ RSpec.describe MacOSRequirement do
       requirement = described_class.new([:catalina], comparator: "<=")
       expect(requirement.satisfied?).to eq MacOS.version <= :catalina
     end
+  end
+
+  specify "#allows?" do
+    max_requirement = described_class.new([:mojave], comparator: "<=")
+    min_requirement = described_class.new([:catalina], comparator: ">=")
+    exact_requirement = described_class.new([:big_sur], comparator: "==")
+    range_requirement = described_class.new([[:monterey, :big_sur]], comparator: "==")
+    expect(max_requirement.allows?(big_sur_major)).to be false
+    expect(min_requirement.allows?(big_sur_major)).to be true
+    expect(exact_requirement.allows?(big_sur_major)).to be true
+    expect(range_requirement.allows?(big_sur_major)).to be true
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
When running `to_hash_with_variations` on a cask, its min/max macOS version requirements aren’t considered which may result in:

- extra entries in its list of variations for macOS versions that aren’t actually supported, if the oldest on_system block uses `:or_older` -  [anki](https://formulae.brew.sh/cask/anki), [hammerspoon](https://formulae.brew.sh/cask/hammerspoon)
- same as above, but the unsupported macOS versions have the latest version number listed, caused by the on_system block _not_ using `:or_older`, which results in null values being inserted into the variations list - [apparency](https://formulae.brew.sh/cask/apparency), [omnidisksweeper](https://formulae.brew.sh/cask/omnidisksweeper), [saoimageds9](https://formulae.brew.sh/cask/saoimageds9), [sf-symbols](https://formulae.brew.sh/cask/sf-symbols)
- same as above, but every item in the variations list also has the same `depends_on` key if specified as a list - [calhash](https://formulae.brew.sh/cask/calhash)

The first two are solved by checking if each bottle tag is included in the cask’s range of macOS requirements, which itself required adding `MacOSRequirement.allows?` to check if a macOS requirement allows a given macOS version.

The last occurs because each call in `cask.rb` of `public_send(hash_method).each do |key, value|` gets a different result for `depends_on`, because the stock inspect method of the `MacOSVersion` class includes a random hex value, resulting in it being included in the hash every time. Customizing the `inspect` method to just print the class’s version value avoids this.

This change also highlights complications like how some casks' on_system blocks don't line up with their macOS version requirements, e.g.:

- `depends_on` being inside on_system blocks - [airfoil](https://formulae.brew.sh/cask/airfoil)
- `depends_on` excluding entire on_system blocks - [appcleaner](https://formulae.brew.sh/cask/appcleaner)

There are probably others, but these can be manually resolved in time.