### PR TITLE
cask/audit: fix nested container extraction

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -549,6 +549,13 @@ module Cask
 
       # Extract the container to the temporary directory.
       primary_container.extract_nestedly(to: @tmpdir, basename: downloaded_path.basename, verbose: false)
+
+      if (nested_container = @cask.container&.nested)
+        FileUtils.chmod_R "+rw", @tmpdir/nested_container, force: true, verbose: false
+        UnpackStrategy.detect(@tmpdir/nested_container, merge_xattrs: true)
+                      .extract_nestedly(to: @tmpdir, verbose: false)
+      end
+
       @artifacts_extracted = true # Set the flag to indicate that extraction has occurred.
 
       # Yield the artifacts and temp directory to the block if provided.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes edge cases where nested containers are used. Extraction for auditing artifacts did not pull the secondary container, which tried to audit the container instead of the contents.

These couple lines are the same used to extract nested containers in `installer.rb`

-----

n.b. I'm happy to take a shot at writing tests for this in the future, but think we would need some signed / unsigned artifacts to source.  I noticed a test for a signed app in `audit_spec.rb`, but nothing that covers pkg or binary, or a nested container (which I only found this breakage by auditing a Cask using `container: nested`)