### PR TITLE
Output GitHub warning/error annotations to stderr

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -166,7 +166,6 @@ module Kernel
 
     disable = true if disable_for_developers && Homebrew::EnvConfig.developer?
     if disable || Homebrew.raise_deprecation_exceptions?
-      puts GitHub::Actions::Annotation.new(:error, message, file:, line:) if GitHub::Actions.env_set?
       GitHub::Actions.puts_annotation_if_env_set(:error, message, file:, line:)
       exception = MethodDeprecatedError.new(message)
       exception.set_backtrace(backtrace)

--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -50,8 +50,10 @@ module GitHub
     def self.puts_annotation_if_env_set(type, message, file: nil, line: nil)
       # Don't print annotations during tests, too messy to handle these.
       return if ENV.fetch("HOMEBREW_TESTS", false)
+      return unless env_set?
 
-      puts Annotation.new(type, message) if env_set?
+      std = (type == :notice) ? $stdout : $stderr
+      std.puts Annotation.new(type, message)
     end
 
     # Helper class for formatting annotations on GitHub Actions.


### PR DESCRIPTION
This will mean e.g. `opoo` etc. will output to stdout and not end up being in the stdout of `brew deps` etc.

While we're here, remove a duplicate annotation output I noticed in `extend/kernel.rb`.

Inspired by conversation in:
https://github.com/Homebrew/homebrew-test-bot/issues/1082