### PR TITLE
dev-cmd/bump*: improve autobump messaging.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -83,7 +83,7 @@ module Homebrew
 
         odie <<~EOS unless cask.tap.allow_bump?(cask.token)
           Whoops, the #{cask.token} cask has its version update
-          pull requests automatically opened by BrewTestBot!
+          pull requests automatically opened by BrewTestBot every ~3 hours!
           We'd still love your contributions, though, so try another one
           that's not in the autobump list:
             #{Formatter.url("#{cask.tap.remote}/blob/master/.github/autobump.txt")}

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -113,7 +113,7 @@ module Homebrew
 
         odie <<~EOS unless formula.tap.allow_bump?(formula.name)
           Whoops, the #{formula.name} formula has its version update
-          pull requests automatically opened by BrewTestBot!
+          pull requests automatically opened by BrewTestBot every ~3 hours!
           We'd still love your contributions, though, so try another one
           that's not in the autobump list:
             #{Formatter.url("#{formula.tap.remote}/blob/master/.github/autobump.txt")}

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -223,15 +223,15 @@ module Homebrew
         if formula_or_cask.is_a?(Formula)
           skip = formula_or_cask.disabled? || formula_or_cask.head_only?
           name = formula_or_cask.name
-          text = "Formula is #{formula_or_cask.disabled? ? "disabled" : "HEAD-only"}.\n"
+          text = "Formula is #{formula_or_cask.disabled? ? "disabled" : "HEAD-only"} so not accepting updates.\n"
         else
           skip = formula_or_cask.disabled?
           name = formula_or_cask.token
-          text = "Cask is disabled.\n"
+          text = "Cask is disabled so not accepting updates.\n"
         end
         if (tap = formula_or_cask.tap) && !tap.allow_bump?(name)
           skip = true
-          text = "#{text.split.first} is on autobump list.\n"
+          text = "#{text.split.first} is autobumped so will have bump PRs opened by BrewTestBot every ~3 hours.\n"
         end
         return false unless skip
 


### PR DESCRIPTION
Let's make it clearer _why_ autobumped PRs cannot be submitted by humans and, while we're here, similarly for disabled/head-only packages.