### PR TITLE
Remove unnecessary use of `T.cast`

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -155,9 +155,9 @@ module Cask
     sig { returns(T::Array[String]) }
     def languages
       [
-        *T.cast(explicit.fetch(:languages, []), T::Array[String]),
-        *T.cast(env.fetch(:languages, []), T::Array[String]),
-        *T.cast(default.fetch(:languages, []), T::Array[String]),
+        *explicit.fetch(:languages, []),
+        *env.fetch(:languages, []),
+        *default.fetch(:languages, []),
       ].uniq.select do |lang|
         # Ensure all languages are valid.
         Locale.parse(lang)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1829,15 +1829,13 @@ class Formula
   # Standard parameters for cabal-v2 builds.
   sig { returns(T::Array[String]) }
   def std_cabal_v2_args
-    env = T.cast(ENV, T.any(Stdenv, Superenv))
-
     # cabal-install's dependency-resolution backtracking strategy can
     # easily need more than the default 2,000 maximum number of
     # "backjumps," since Hackage is a fast-moving, rolling-release
     # target. The highest known needed value by a formula was 43,478
     # for git-annex, so 100,000 should be enough to avoid most
     # gratuitous backjumps build failures.
-    ["--jobs=#{env.make_jobs}", "--max-backjumps=100000", "--install-method=copy", "--installdir=#{bin}"]
+    ["--jobs=#{ENV.make_jobs}", "--max-backjumps=100000", "--install-method=copy", "--installdir=#{bin}"]
   end
 
   # Standard parameters for meson builds.
@@ -3156,8 +3154,7 @@ class Formula
     if cmd == "python"
       setup_py_in_args = %w[setup.py build.py].include?(args.first)
       setuptools_shim_in_args = args.any? { |a| a.to_s.start_with? "import setuptools" }
-      env = T.cast(ENV, T.any(Stdenv, Superenv))
-      env.refurbish_args if setup_py_in_args || setuptools_shim_in_args
+      ENV.refurbish_args if setup_py_in_args || setuptools_shim_in_args
     end
 
     $stdout.reopen(out)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -462,7 +462,6 @@ module Formulary
       end
     end
 
-    klass = T.cast(klass, T.class_of(Formula))
     mod.const_set(class_name, klass)
 
     platform_cache[:api] ||= {}

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -152,8 +152,7 @@ module Homebrew
       when true, false
         @keep_alive = { always: value }
       when Hash
-        hash = T.cast(value, Hash)
-        unless (hash.keys - KEEP_ALIVE_KEYS).empty?
+        unless (value.keys - KEEP_ALIVE_KEYS).empty?
           raise TypeError, "Service#keep_alive allows only #{KEEP_ALIVE_KEYS}"
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Was poking around and found a few `T.cast`s that we shouldn't need.