### PR TITLE
dev-cmd/contributions: ‘Coauthorship’ sounds weird

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -60,7 +60,7 @@ module Homebrew
 
         from = args.from.presence || Date.today.prev_year.iso8601
 
-        contribution_types = [:author, :committer, :coauthorship, :review]
+        contribution_types = [:author, :committer, :coauthor, :review]
 
         users = args.user.presence || GitHub.members_by_team("Homebrew", "maintainers").keys
         users.each do |username|
@@ -119,7 +119,7 @@ module Homebrew
       sig { params(totals: Hash).returns(String) }
       def generate_csv(totals)
         CSV.generate do |csv|
-          csv << %w[user repo author committer coauthorship review total]
+          csv << %w[user repo author committer coauthor review total]
 
           totals.sort_by { |_, v| -v.values.sum }.each do |user, total|
             csv << grand_total_row(user, total)
@@ -134,7 +134,7 @@ module Homebrew
           "all",
           grand_total[:author],
           grand_total[:committer],
-          grand_total[:coauthorship],
+          grand_total[:coauthor],
           grand_total[:review],
           grand_total.values.sum,
         ]
@@ -166,10 +166,10 @@ module Homebrew
           author_commits, committer_commits = GitHub.count_repo_commits(repo_full_name, person,
                                                                         from:, to: args.to, max: MAX_REPO_COMMITS)
           data[repo] = {
-            author:       author_commits,
-            committer:    committer_commits,
-            coauthorship: git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", from:, to: args.to),
-            review:       count_reviews(repo_full_name, person, from:, to: args.to),
+            author:    author_commits,
+            committer: committer_commits,
+            coauthor:  git_log_trailers_cmd(T.must(repo_path), person, "Co-authored-by", from:, to: args.to),
+            review:    count_reviews(repo_full_name, person, from:, to: args.to),
           }
         end
 
@@ -178,7 +178,7 @@ module Homebrew
 
       sig { params(results: Hash).returns(Hash) }
       def total(results)
-        totals = { author: 0, committer: 0, coauthorship: 0, review: 0 }
+        totals = { author: 0, committer: 0, coauthor: 0, review: 0 }
 
         results.each_value do |counts|
           counts.each do |kind, count|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This inconsistency of "author", "committer", "coauthorship", that is, only "coauthor" ending in "ship", has annoyed me ever since I wrote it.
- It has finally sufficiently annoyed me to fix it.