### PR TITLE
dev-cmd/edit: Show API install warning after the edit is done

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -51,17 +51,6 @@ module Homebrew
           expanded_paths.each do |path|
             raise_with_message!(path, args.cask?) unless path.exist?
           end
-
-          if expanded_paths.any? do |path|
-               !Homebrew::EnvConfig.no_install_from_api? &&
-               !Homebrew::EnvConfig.no_env_hints? &&
-               (core_formula_path?(path) || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))
-             end
-            opoo <<~EOS
-              `brew install` ignores locally edited casks and formulae if
-              HOMEBREW_NO_INSTALL_FROM_API is not set.
-            EOS
-          end
           expanded_paths
         end
 
@@ -71,6 +60,17 @@ module Homebrew
         end
 
         exec_editor(*paths)
+
+        if paths.any? do |path|
+             !Homebrew::EnvConfig.no_install_from_api? &&
+             !Homebrew::EnvConfig.no_env_hints? &&
+             (core_formula_path?(path) || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))
+           end
+          opoo <<~EOS
+            `brew install` ignores locally edited casks and formulae if
+            HOMEBREW_NO_INSTALL_FROM_API is not set.
+          EOS
+        end
       end
 
       private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew edit ocp` outputs this text when the editor is opened.
```sh
$ brew edit ocp
Warning: `brew install` ignores locally edited casks and formulae if
HOMEBREW_NO_INSTALL_FROM_API is not set.
Editing /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/o/ocp.rb
Warning: Using vim because no editor was set in the environment.
This may change in the future, so we recommend setting EDITOR
or HOMEBREW_EDITOR to your preferred text editor.
```
The PR moves the first warning so that it is shown only when the edit is finished.