### PR TITLE
Fix constructing search query strings with date ranges

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -151,17 +151,18 @@ module GitHub
   def self.search_query_string(*main_params, **qualifiers)
     params = main_params
 
-    if (args = qualifiers.fetch(:args, nil))
-      params << if args.from && args.to
-        "created:#{args.from}..#{args.to}"
-      elsif args.from
-        "created:>=#{args.from}"
-      elsif args.to
-        "created:<=#{args.to}"
-      end
+    from = qualifiers.fetch(:from, nil)
+    to = qualifiers.fetch(:to, nil)
+
+    params << if from && to
+      "created:#{from}..#{to}"
+    elsif from
+      "created:>=#{from}"
+    elsif to
+      "created:<=#{to}"
     end
 
-    params += qualifiers.except(:args).flat_map do |key, value|
+    params += qualifiers.except(:args, :from, :to).flat_map do |key, value|
       Array(value).map { |v| "#{key.to_s.tr("_", "-")}:#{v}" }
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Both `from` and `to` are now separate keyword arguments in a bunch of places, not part of `args`.
- When we switched this around, we didn't realize this method needed updating to correctly construct the time range query.
- This led to further inaccurate counts in `brew contributions` for reviews, since `from` and `to` are not valid search qualifiers for the GitHub PR search APIs.

Before:

```
$ brew contributions --user=issyl0 --from=2024-03-01 --to=2024-05-31
issyl0 contributed 24 times (author), 1 time (committer), 1 time (coauthor) and 26 times (total) between 2024-03-01 and 2024-05-31.
```

After:

```
$ brew contributions --user=issyl0 --from=2024-03-01 --to=2024-05-31
issyl0 contributed 24 times (author), 1 time (committer), 1 time (coauthor), 13 times (review) and 39 times (total) between 2024-03-01 and 2024-05-31.
```