### PR TITLE
Make `brew typecheck --update --suggest-typed` bump strictness further

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -58,10 +58,12 @@ module Homebrew
             safe_system "bundle", "exec", "parlour"
 
             if args.suggest_typed?
-              ohai "Bumping Sorbet `typed` sigils..."
+              ohai "Checking if we can bump Sorbet `typed` sigils..."
               # --sorbet needed because of https://github.com/Shopify/spoom/issues/488
-              safe_system "bundle", "exec", "spoom", "srb", "bump", "--dry", "--sorbet",
-                          "#{Gem.bin_path("sorbet", "srb")} tc"
+              safe_system "bundle", "exec", "spoom", "srb", "bump", "--dry", "--from", "false", "--to", "true",
+                          "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
+              safe_system "bundle", "exec", "spoom", "srb", "bump", "--dry", "--from", "true", "--to", "strict",
+                          "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
             end
 
             return


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Not only `false` to `true` but `true` to `strict`.
- Only humans every run this, but our goal is to increase the typechecking in our files to get to `strict` everywhere so let's make that easy to remember to do.
- Inspired by https://github.com/Homebrew/brew/pull/17410#issuecomment-2143960238.