### PR TITLE
Add `--scrub` flag alias to cleanup command

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -20,7 +20,7 @@ module Homebrew
                             "If you want to remove everything, use `--prune=all`."
         switch "-n", "--dry-run",
                description: "Show what would be removed, but do not actually remove anything."
-        switch "-s",
+        switch "-s", "--scrub",
                description: "Scrub the cache, including downloads for even the latest versions. " \
                             "Note that downloads for any installed formulae or casks will still not be deleted. " \
                             "If you want to delete those too: `rm -rf \"$(brew --cache)\"`"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
  - Not necessary IMO, already covered by command parser
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
  - This fails on my local machine, but I believe that's an issue with my xcode installation.

-----

Fixes #17413.

Currently, `brew cleanup -s` triggers a cleanup with the scrub flag enabled. I would like to introduce a longer alias of this flag, `--scrub`, for usage in shell-scripts and alike.