### PR TITLE
cmd/setup-ruby: handle empty command path.

### DIFF
--- a/Library/Homebrew/cmd/setup-ruby.sh
+++ b/Library/Homebrew/cmd/setup-ruby.sh
@@ -24,14 +24,15 @@ homebrew-setup-ruby() {
     source "${HOMEBREW_LIBRARY}/Homebrew/command_path.sh"
 
     command_path="$(homebrew-command-path "${command}")"
-    if [[ -n "${command_path}" && "${command_path}" != *"/dev-cmd/"* ]]
+    if [[ -n "${command_path}" ]]
     then
-      return
-    fi
-
-    if ! grep -q "Homebrew.install_bundler_gems\!" "${command_path}"
-    then
-      return
+      if [[ "${command_path}" != *"/dev-cmd/"* ]]
+      then
+        return
+      elif ! grep -q "Homebrew.install_bundler_gems\!" "${command_path}"
+      then
+        return
+      fi
     fi
   fi
 


### PR DESCRIPTION
If this is empty: don't try to `grep` it.