### PR TITLE
bin/brew: fix tracking of original paths with brew-in-brew calls

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -391,9 +391,6 @@ auto-update() {
     unset HOMEBREW_AUTO_UPDATING
     unset HOMEBREW_AUTO_UPDATE_TAP
 
-    # Restore user path as it'll be refiltered by HOMEBREW_BREW_FILE (bin/brew)
-    export PATH=${HOMEBREW_PATH}
-
     # exec a new process to set any new environment variables.
     exec "${HOMEBREW_BREW_FILE}" "$@"
   fi

--- a/bin/brew
+++ b/bin/brew
@@ -57,6 +57,12 @@ do
 done
 unset cmd
 
+# Take the HOMEBREW_PATH if we are running brew within brew, otherwise we would lose the original path.
+if [[ -n "${HOMEBREW_BREW_FILE:-}" && -n "${HOMEBREW_PATH:-}" ]]
+then
+  PATH="${HOMEBREW_PATH}"
+fi
+
 BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"


### PR DESCRIPTION
When running something that invokes brew-within-brew, such as `brew update`, the original `PATH` normally stored in `HOMEBREW_PATH` is lost. This is because we block `HOMEBREW_PATH` from being set from the user environment.

Instead, special case it to allow `HOMEBREW_PATH` to be set if `HOMEBREW_BREW_FILE` is also set which is likely to only ever happen when called within brew.

This fixes system Ruby detection not working consistently and sometimes failing for `brew update` but not other commands.