### PR TITLE
attestation: handle `:all` bottles

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -103,8 +103,22 @@ module Homebrew
       # for all attestations that match the input's digest. We want to additionally
       # filter these down to just the attestation whose subject matches the bottle's name.
       subject = bottle.filename.to_s if subject.blank?
-      attestation = attestations.find do |a|
-        a.dig("verificationResult", "statement", "subject", 0, "name") == subject
+
+      attestation = if bottle.tag.to_sym == :all
+        # :all-tagged bottles are created by `brew bottle --merge`, and are not directly
+        # bound to their own filename (since they're created by deduplicating other filenames).
+        # To verify these, we parse each attestation subject and look for one with a matching
+        # formula (name, version), but not an exact tag match.
+        # This is sound insofar as the signature has already been verified. However,
+        # longer term, we should also directly attest to `:all`-tagged bottles.
+        attestations.find do |a|
+          subject = a.dig("verificationResult", "statement", "subject", 0, "name")
+          subject.start_with? "#{bottle.filename.name}--#{bottle.filename.version}"
+        end
+      else
+        attestations.find do |a|
+          a.dig("verificationResult", "statement", "subject", 0, "name") == subject
+        end
       end
 
       raise InvalidAttestationError, "no attestation matches subject" if attestation.blank?

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe Homebrew::Attestation do
   let(:cached_download) { "/fake/cached/download" }
   let(:fake_bottle_filename) { instance_double(Bottle::Filename, to_s: "fakebottle--1.0.faketag.bottle.tar.gz") }
   let(:fake_bottle_url) { "https://example.com/#{fake_bottle_filename}" }
+  let(:fake_bottle_tag) { instance_double(Utils::Bottles::Tag, to_sym: :faketag) }
   let(:fake_bottle) do
-    instance_double(Bottle, cached_download:, filename: fake_bottle_filename, url: fake_bottle_url)
+    instance_double(Bottle, cached_download:, filename: fake_bottle_filename, url: fake_bottle_url, tag: fake_bottle_tag)
   end
   let(:fake_result_invalid_json) { instance_double(SystemCommand::Result, stdout: "\"invalid JSON") }
   let(:fake_result_json_resp) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`:all` bottles are an edge case: they're produced by `brew bottle --merge` *after* building and attestation generation, meaning that they have no exact matching subject. Instead, they should match the formula name + version prefix of any other bottle with the same digest.

CC @colindean since he was most recently bit by this (it happens most frequently with non-binary bottles, e.g. `docker-completion`)