### PR TITLE
cmd/list: fix exit codes.

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -165,10 +165,7 @@ module Homebrew
           Formula.racks
         else
           racks = args.named.map { |n| Formulary.to_rack(n) }
-          racks.select do |rack|
-            Homebrew.failed = true unless rack.exist?
-            rack.exist?
-          end
+          racks.select(&:exist?)
         end
         if args.pinned?
           pinned_versions = {}
@@ -194,7 +191,6 @@ module Homebrew
           Cask::Caskroom.casks
         else
           filtered_args = args.named.dup.delete_if do |n|
-            Homebrew.failed = true unless Cask::Caskroom.path.join(n).exist?
             !Cask::Caskroom.path.join(n).exist?
           end
           # NamedAargs subclasses array


### PR DESCRIPTION
Fix exit codes when providing formulae and casks.

Fixes #17434