### PR TITLE
cmake: don't set cmake_minimum_required

### DIFF
--- a/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake
+++ b/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.24) # Dependency providers introduced in CMake 3.24
+# Dependency providers were introduced in CMake 3.24. We don't set cmake_minimum_required here because that would
+# propagate to downstream projects, which may break projects that rely on deprecated CMake behavior. Since the build
+# is using brewed CMake, we can assume that the CMake version in use is at least 3.24.
 
 option(HOMEBREW_ALLOW_FETCHCONTENT "Allow FetchContent to be used in Homebrew builds" OFF)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This still seems to achieve the accomplished effect without forcing `cmake_minimum_version`.

Context:
- https://github.com/AcademySoftwareFoundation/openexr/issues/1761#issuecomment-2155102178
- https://github.com/orgs/Homebrew/discussions/5430