### PR TITLE
github/workflows: split RubyDoc CI job.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ env:
   HOMEBREW_NO_INSTALL_CLEANUP: 1
 
 jobs:
-  linting:
+  docs:
     if: github.repository == 'Homebrew/brew'
     runs-on: ubuntu-22.04
     steps:
@@ -67,33 +67,3 @@ jobs:
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/docs
         run: |
           bundle exec rake test
-
-  rubydoc:
-    if: github.repository == 'Homebrew/brew'
-    runs-on: ubuntu-22.04
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/rubydoc/Gemfile
-    steps:
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          core: false
-          cask: false
-          test-bot: false
-
-      - name: Checkout Homebrew/rubydoc.brew.sh
-        uses: actions/checkout@v4
-        with:
-          repository: Homebrew/rubydoc.brew.sh
-          path: rubydoc
-
-      - name: Install Ruby
-        uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
-        with:
-          bundler-cache: true
-          working-directory: rubydoc
-
-      - name: Process rubydoc comments
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/Library/Homebrew
-        run: bundle exec yard doc --no-output --fail-on-warning

--- a/.github/workflows/rubydoc.yml
+++ b/.github/workflows/rubydoc.yml
@@ -1,0 +1,48 @@
+name: Ruby Documentation CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_ENV_HINTS: 1
+  HOMEBREW_BOOTSNAP: 1
+  HOMEBREW_NO_INSTALL_CLEANUP: 1
+
+jobs:
+  rubydoc:
+    if: github.repository == 'Homebrew/brew'
+    runs-on: ubuntu-22.04
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/rubydoc/Gemfile
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: false
+          cask: false
+          test-bot: false
+
+      - name: Checkout Homebrew/rubydoc.brew.sh
+        uses: actions/checkout@v4
+        with:
+          repository: Homebrew/rubydoc.brew.sh
+          path: rubydoc
+
+      - name: Install Ruby
+        uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
+        with:
+          bundler-cache: true
+          working-directory: rubydoc
+
+      - name: Process rubydoc comments
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/Library/Homebrew
+        run: bundle exec yard doc --no-output --fail-on-warning


### PR DESCRIPTION
This will allow syncing the documentation CI job to other repositories with `docs` folders in https://github.com/Homebrew/.github/pull/121.