### PR TITLE
cmd/list: new fix for exit code when supplied both a cask and formula

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -153,7 +153,7 @@ module Homebrew
             system_command! "find", args: casks.map(&:caskroom_path) + find_args, print_stdout: true if casks.present?
           else
             kegs.each { |keg| PrettyListing.new keg } if kegs.present?
-            list_casks if casks.present?
+            Cask::List.list_casks(*casks, one: args.public_send(:"1?")) if casks.present?
           end
         end
       end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -165,7 +165,10 @@ module Homebrew
           Formula.racks
         else
           racks = args.named.map { |n| Formulary.to_rack(n) }
-          racks.select(&:exist?)
+          racks.select do |rack|
+            Homebrew.failed = true unless rack.exist?
+            rack.exist?
+          end
         end
         if args.pinned?
           pinned_versions = {}
@@ -191,6 +194,7 @@ module Homebrew
           Cask::Caskroom.casks
         else
           filtered_args = args.named.dup.delete_if do |n|
+            Homebrew.failed = true unless Cask::Caskroom.path.join(n).exist?
             !Cask::Caskroom.path.join(n).exist?
           end
           # NamedAargs subclasses array


### PR DESCRIPTION
Previous fix broke cases where we want failing exit codes: #17464.

Apply a simpler fix scoped to avoid the special exit-code cask functions for the scenarios we don't want them. We were already doing so for formulae. They're designed for `--versions` and `--pinned` which react differently to uninstalled packages and currently forbid supplying both formulae and casks.

This also fixes cases where `brew ls` on uninstalled casks would not display an error message like it did for formulae.

```console
$ brew ls hello
Error: No such keg: /opt/homebrew/Cellar/hello
$ brew ls thunderbird
```

```console
$ brew ls hello
Error: No such keg: /opt/homebrew/Cellar/hello
$ brew ls thunderbird  
Error: Cask 'thunderbird' is not installed.
```

Fixes https://github.com/Homebrew/brew/issues/17464