### PR TITLE
diagnostic: don't show cask taps with no casks.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -945,16 +945,17 @@ module Homebrew
 
         taps = (Tap.to_a + [CoreCaskTap.instance]).uniq
 
-        add_info "Homebrew Cask Taps:", (taps.map do |tap|
+        add_info "Homebrew Cask Taps:", taps.filter_map do |tap|
           cask_count = begin
             tap.cask_files.count
           rescue
             error_tap_paths << tap.path
             0
           end
+          next if cask_count.zero?
 
           "#{tap.path} (#{Utils.pluralize("cask", cask_count, include_count: true)})"
-        end)
+        end
 
         taps_string = Utils.pluralize("tap", error_tap_paths.count)
         "Unable to read from cask #{taps_string}: #{error_tap_paths.to_sentence}" if error_tap_paths.present?


### PR DESCRIPTION
This avoids displaying a bunch of non-cask taps here.