### PR TITLE
workflows/docs: various tweaks.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,6 @@ env:
 
 jobs:
   docs:
-    if: github.repository == 'Homebrew/brew'
     runs-on: ubuntu-22.04
     steps:
       - name: Set up Homebrew
@@ -29,13 +28,16 @@ jobs:
           cask: false
           test-bot: false
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Install vale
         run: brew install vale
 
-      - name: Lint docs
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+      - name: Cleanup Homebrew/brew docs
+        if: github.repository == 'Homebrew/brew'
         run: |
-          set -euo pipefail
+          set -xeuo pipefail
 
           # Avoid failing on broken symlinks.
           rm Library/Homebrew/os/mac/pkgconfig/fuse/fuse.pc
@@ -44,26 +46,24 @@ jobs:
           # No ignore support (https://github.com/errata-ai/vale/issues/131).
           rm -r Library/Homebrew/vendor
 
-          vale .
-
-          # Restore removed files.
-          git reset --hard
+      - name: Run Vale
+        run: vale docs/
 
       - name: Install Ruby
         uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
         with:
           bundler-cache: true
-          working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/docs
+          working-directory: docs
 
       - name: Check Markdown syntax
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/docs
+        working-directory: docs
         run: bundle exec rake lint
 
       - name: Check code blocks conform to our Ruby style guide
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/docs
-        run: brew style .
+        run: brew style docs
 
       - name: Build the site and check for broken links
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}/docs
-        run: |
-          bundle exec rake test
+        working-directory: docs
+        run: bundle exec rake test
+        env:
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- don't limit the entire job to Homebrew/brew (so it can be synced by Homebrew/.github sync jobs)
- always checkout the current repository (as it may not be Homebrew/brew and, when it is, it doesn't take too long anyway)
- only need to do cleanup for Homebrew/brew
- run Vale as separate step
- fix working directory handling