### PR TITLE
workflows/docs: allow reading GitHub Pages.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pages: read
 
 env:
   HOMEBREW_DEVELOPER: 1


### PR DESCRIPTION
This isn't technically needed for Homebrew/brew but is needed for private repositories that reuse this workflow.