### PR TITLE
docs: more workflow improvements.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Check code blocks conform to our Ruby style guide
         run: brew style docs
 
+      - name: Generate formulae.brew.sh API samples
+        if: github.repository == 'Homebrew/formulae.brew.sh'
+        working-directory: docs
+        run: ../script/generate-api-samples.rb
+
       - name: Build the site and check for broken links
         working-directory: docs
         run: bundle exec rake test

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -17,26 +17,27 @@ task test: :build do
   require "html-proofer"
   HTMLProofer.check_directory(
     "./_site",
-    parallel: { in_threads: 4 },
-    favicon: true,
+    parallel:            { in_threads: 4 },
+    favicon:             true,
     ignore_status_codes: [0, 403],
-    check_favicon: true,
-    check_opengraph: true,
-    check_html: true,
-    check_img_http: true,
-    enforce_https: true,
-    ignore_files: [
-      %r{Kickstarter-Supporters},
+    check_favicon:       true,
+    check_opengraph:     true,
+    check_html:          true,
+    check_img_http:      true,
+    enforce_https:       true,
+    ignore_files:        [
+      /Kickstarter-Supporters/,
     ],
-    ignore_urls: [
+    ignore_urls:         [
+      "/",
       %r{https://formulae.brew.sh"},
       %r{https://github.com/},
-      'https://legacy.python.org/dev/peps/pep-0453/#recommendations-for-downstream-distributors',
+      "https://legacy.python.org/dev/peps/pep-0453/#recommendations-for-downstream-distributors",
     ],
-    cache: {
+    cache:               {
       timeframe: {
-        external: "1h"
-      }
-    }
+        external: "1h",
+      },
+    },
   ).run
 end


### PR DESCRIPTION
- Add a special step to handle formulae.brew.sh API samples generation.
- Ignore the root URL: it always works and often is a false-positive failure.

While we're here:
- Autofix some RuboCop offenses in the Rakefile.