### PR TITLE
rubocop: remove SpecFilePathSuffix

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -244,8 +244,6 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/DescribedClassModuleWrapping:
   Enabled: true
-RSpec/SpecFilePathSuffix:
-  Enabled: true
 # Annoying to have these autoremoved.
 RSpec/Focus:
   AutoCorrect: false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is enabled by default in 3.0.0.