### PR TITLE
Fix brew style path checking

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,8 +60,9 @@ jobs:
         working-directory: docs
         run: bundle exec rake lint
 
-      - name: Check code blocks conform to our Ruby style guide
-        run: brew style docs
+      # TODO: reenable when possible.
+      # - name: Check code blocks conform to our Ruby style guide
+      #   run: brew style docs
 
       - name: Generate formulae.brew.sh API samples
         if: github.repository == 'Homebrew/formulae.brew.sh'

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -270,8 +270,10 @@ module Homebrew
 
     def self.run_actionlint(files)
       files = github_workflow_files if files.blank?
+      # the ignore is to avoid false positives in e.g. actions, homebrew-test-bot
       system actionlint, "-shellcheck", shellcheck,
              "-config-file", HOMEBREW_REPOSITORY/".github/actionlint.yaml",
+             "-ignore", "image: string; options: string",
              *files
       $CHILD_STATUS.success?
     end

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -57,6 +57,7 @@ module Homebrew
         when ".yml"
           actionlint_files << path if path.realpath.to_s.include?("/.github/workflows/")
         else
+          ruby_files << path if path.tap?
           shell_files << path if path.realpath == HOMEBREW_BREW_FILE.realpath
         end
       end

--- a/docs/.mdl_ruleset.rb
+++ b/docs/.mdl_ruleset.rb
@@ -1,6 +1,9 @@
-rule 'HB034', 'Bare unstyled URL used' do
+# typed: true
+# frozen_string_literal: true
+
+rule "HB034", "Bare unstyled URL used" do
   tags :links, :url
-  aliases 'no-bare-unstyled-urls'
+  aliases "no-bare-unstyled-urls"
   check do |doc|
     doc.matching_text_element_lines(%r{(?<=\s)https?://})
   end

--- a/docs/.mdl_style.rb
+++ b/docs/.mdl_style.rb
@@ -1,8 +1,11 @@
+# typed: true
+# frozen_string_literal: true
+
 all
-rule 'MD007', indent: 2 # Unordered list indentation
-rule 'MD026', punctuation: ',;:' # Trailing punctuation in header
-exclude_rule 'MD013' # Line length
-exclude_rule 'MD029' # Ordered list item prefix
-exclude_rule 'MD033' # Inline HTML
-exclude_rule 'MD034' # Bare URL used (replaced by HB034)
-exclude_rule 'MD046' # Code block style
+rule "MD007", indent: 2 # Unordered list indentation
+rule "MD026", punctuation: ",;:" # Trailing punctuation in header
+exclude_rule "MD013" # Line length
+exclude_rule "MD029" # Ordered list item prefix
+exclude_rule "MD033" # Inline HTML
+exclude_rule "MD034" # Bare URL used (replaced by HB034)
+exclude_rule "MD046" # Code block style

--- a/docs/.rubocop.yml
+++ b/docs/.rubocop.yml
@@ -2,9 +2,6 @@ inherit_from: ../Library/.rubocop.yml
 
 AllCops:
   Exclude:
-    - Gemfile
-    - ".mdl*.rb"
-    - Rakefile
     - "_site/**/*"
     - Manpage.md
     - "vendor/**/*"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 ruby file: ".ruby-version"

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 
 task default: :build


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew style` tap support was broken in #17357, so now something like `brew style homebrew/core` exits without checking anything. This happens because the new file-handling logic doesn't do anything with a tap path. Previously, a tap path would be added to `ruby_files` but now it isn't added to any of the arrays of files to check.

This fixes the issue by adding some logic to add the path to the `ruby_files` array if it's a tap. [That's the general idea but feel free to suggest an alternative approach if there's a better way to address this.]

-----

While working on a fix, I was wondering if we had a way to check whether a path is a tap (e.g., `path.tap?`) but I didn't see anything from a quick search (though I may have missed something). This also adds a `#tap?` method to `extend/pathname.rb`, so we can reuse this logic.

If it's unlikely that we will ever use this again/elsewhere, I can just inline this code where it's used.