### PR TITLE
Fix/reenable `brew style docs`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,9 +60,8 @@ jobs:
         working-directory: docs
         run: bundle exec rake lint
 
-      # TODO: reenable when possible.
-      # - name: Check code blocks conform to our Ruby style guide
-      #   run: brew style docs
+      - name: Check code blocks conform to our Ruby style guide
+        run: brew style docs
 
       - name: Generate formulae.brew.sh API samples
         if: github.repository == 'Homebrew/formulae.brew.sh'

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -151,8 +151,8 @@ module Homebrew
       files&.map!(&:expand_path)
       if files.blank? || files == [HOMEBREW_REPOSITORY]
         files = [HOMEBREW_LIBRARY_PATH]
-      elsif files.any? { |f| f.to_s.start_with?(HOMEBREW_REPOSITORY/"docs") || (f.basename == "docs") }
-        args << "--config" << (HOMEBREW_REPOSITORY/"docs/.rubocop.yml")
+      elsif files.any? { |f| f.to_s.start_with?(HOMEBREW_REPOSITORY/"docs") || (f.basename.to_s == "docs") }
+        args << "--config" << (HOMEBREW_REPOSITORY/"docs/docs_rubocop_style.yml")
       elsif files.none? { |f| f.to_s.start_with? HOMEBREW_LIBRARY_PATH }
         args << "--config" << (HOMEBREW_LIBRARY/".rubocop.yml")
       end

--- a/docs/.rubocop.yml
+++ b/docs/.rubocop.yml
@@ -2,9 +2,9 @@ inherit_from: ../Library/.rubocop.yml
 
 AllCops:
   Exclude:
-    - "_site/**/*"
-    - Manpage.md
-    - "vendor/**/*"
+    - "**/_site/**/*"
+    - "**/Manpage.md"
+    - "**/vendor/**/*"
 
 # These are included in docs deliberately to show what
 # `brew create` does and what the user should replace.
@@ -19,7 +19,7 @@ FormulaAudit/Homepage:
 
 Layout/LineLength:
   Exclude:
-    - Bottles.md # The bottle block line length is long in its full form.
+    - "**/Bottles.md" # The bottle block line length is long in its full form.
 
 # Apparently Casks are allowed to have constant definitions in blocks and we document this.
 Lint/ConstantDefinitionInBlock:

--- a/docs/docs_rubocop_style.yml
+++ b/docs/docs_rubocop_style.yml
@@ -1,0 +1,1 @@
+.rubocop.yml


### PR DESCRIPTION
This was disabled to get https://github.com/Homebrew/brew/pull/17482 over the line but let's fix it up now.

- start running this check again
- check the `docs` basename correctly
- use a different name (to a symlink) for the docs rubocop 
  configuration so that path relativity is done correctly:
  https://docs.rubocop.org/rubocop/configuration.html#path-relativity
- add more wildcards to fix docs rubocop exclusions