### PR TITLE
pkg: adjust setting permissions

### DIFF
--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -61,7 +61,7 @@ then
 fi
 
 # create missing directories
-mkdir -vp Cellar Frameworks etc include lib opt sbin share var/homebrew/linked
+mkdir -vp Caskroom Cellar Frameworks etc include lib opt sbin share var/homebrew/linked
 
 # optionally define an install user at /var/tmp/.homebrew_pkg_user.plist
 homebrew_pkg_user_plist="/var/tmp/.homebrew_pkg_user.plist"
@@ -74,9 +74,12 @@ else
 fi
 
 # set permissions
+chmod ug=rwx Caskroom Cellar Frameworks bin etc include lib opt sbin share var var/homebrew var/homebrew/linked
 if [[ "${homebrew_directory}" == "/usr/local/Homebrew" ]]
 then
-  chown -R "${homebrew_pkg_user}:admin" Cellar Frameworks Homebrew bin etc include lib sbin share opt var
+  chown -h "${homebrew_pkg_user}:admin" bin bin/brew etc include lib opt sbin share var
+  chown -h -R "${homebrew_pkg_user}:admin" Caskroom Cellar Frameworks Homebrew var/homebrew
+  chown -h -R "${homebrew_pkg_user}" etc include share var
 else
   chown -R "${homebrew_pkg_user}:admin" .
 fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This adjusts the .pkg postinstall script to match the ownership and permissions of files & folders installed by the standard bash install script:
- creates Caskroom
- sets user & group read/write/execute for everything in the target directory (except `Homebrew`, which doesn't get group write) 

on just Intel:
- sets the user and group of just the standard subdirectories of `/usr/local`, plus the `bin/brew` symlink via the `-h` flag
- recursively sets the user and group of the Homebrew-specific subdirectories of `/usr/local`
- recursively sets just the user of `etc include share var` to ensure Homebrew can make additions to pre-existing subfolders, e.g. `share/man`

Fixes #17498 by not attempting to change the ownership of pre-existing items within `bin lib sbin opt`.