### PR TITLE
Portable Ruby cleanup/fixes

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -59,7 +59,7 @@ set_ruby_variables() {
     fi
     ruby_URLs+=(
       "https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:${ruby_SHA}"
-      "https://github.com/Homebrew/homebrew-portable-ruby/releases/download/3.3.2/${ruby_FILENAME}"
+      "https://github.com/Homebrew/homebrew-portable-ruby/releases/download/3.3.3/${ruby_FILENAME}"
     )
     ruby_URL="${ruby_URLs[0]}"
   fi

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -29,7 +29,7 @@ $LOAD_PATH.reject! { |path| path.start_with?(RbConfig::CONFIG["sitedir"]) }
 require "pathname"
 dir = __dir__ || raise("__dir__ is not defined")
 HOMEBREW_LIBRARY_PATH = Pathname(dir).parent.realpath.freeze
-HOMEBREW_PORTABLE_RUBY = Pathname.new(RbConfig.ruby).to_s.include?("/vendor/portable-ruby/").freeze
+HOMEBREW_USING_PORTABLE_RUBY = Pathname.new(RbConfig.ruby).to_s.include?("/vendor/portable-ruby/").freeze
 
 require_relative "../utils/gems"
 Homebrew.setup_gem_environment!(setup_path: false)
@@ -48,7 +48,7 @@ unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
   $LOAD_PATH.insert(last_homebrew_path_idx + 1, HOMEBREW_LIBRARY_PATH.to_s)
 end
 require_relative "../vendor/bundle/bundler/setup"
-require "portable_ruby_gems" if HOMEBREW_PORTABLE_RUBY
+require "portable_ruby_gems" if HOMEBREW_USING_PORTABLE_RUBY
 $LOAD_PATH.unshift "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/" \
                    "bundler-#{Homebrew::HOMEBREW_BUNDLER_VERSION}/lib"
 $LOAD_PATH.uniq!

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -14,7 +14,7 @@ if homebrew_bootsnap_enabled
   begin
     require "bootsnap"
   rescue LoadError
-    raise if ENV["HOMEBREW_BOOTSNAP_RETRY"] || HOMEBREW_PORTABLE_RUBY
+    raise if ENV["HOMEBREW_BOOTSNAP_RETRY"] || HOMEBREW_USING_PORTABLE_RUBY
 
     Homebrew.install_bundler_gems!(groups: ["bootsnap"], only_warn_on_failure: true)
 

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -241,7 +241,7 @@ module Homebrew
 
     # Combine the passed groups with the ones stored in settings.
     groups |= (user_gem_groups & valid_gem_groups)
-    groups.delete("bootsnap") if HOMEBREW_PORTABLE_RUBY
+    groups.delete("bootsnap") if HOMEBREW_USING_PORTABLE_RUBY
     groups.sort!
 
     if (homebrew_bundle_user_cache = ENV.fetch("HOMEBREW_BUNDLE_USER_CACHE", nil))


### PR DESCRIPTION
Post-merge review cleanup on https://github.com/Homebrew/brew/pull/17501.

@carlocab suggested variable name change (I agree) and there was a missed version variable change.