### PR TITLE
vendor-install: fix incorrect portable Ruby version reference.

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -8,6 +8,7 @@
 # HOMEBREW_MACOS_VERSION_NUMERIC and HOMEBREW_PROCESSOR are set by brew.sh
 # shellcheck disable=SC2154
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/lock.sh"
+source "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby.sh"
 
 VENDOR_DIR="${HOMEBREW_LIBRARY}/Homebrew/vendor"
 
@@ -21,18 +22,18 @@ set_ruby_variables() {
        # use a x86_64 Portable Ruby.
        [[ "${VENDOR_PHYSICAL_PROCESSOR}" == "arm64" && "${HOMEBREW_PREFIX}" == "/usr/local" ]]
     then
-      ruby_FILENAME="portable-ruby-3.3.3.el_capitan.bottle.tar.gz"
+      ruby_FILENAME="portable-ruby-${HOMEBREW_PORTABLE_RUBY_VERSION}.el_capitan.bottle.tar.gz"
       ruby_SHA="a5ef040e054444a0eb2cbcc1032fed14702dfbe2e55b25e609f3ce643f23c4ee"
     elif [[ "${VENDOR_PHYSICAL_PROCESSOR}" == "arm64" ]]
     then
-      ruby_FILENAME="portable-ruby-3.3.3.arm64_big_sur.bottle.tar.gz"
+      ruby_FILENAME="portable-ruby-${HOMEBREW_PORTABLE_RUBY_VERSION}.arm64_big_sur.bottle.tar.gz"
       ruby_SHA="49847c7a13f7094b211f6d0025900dd23716be07dac894a3d6941d7696296306"
     fi
   elif [[ -n "${HOMEBREW_LINUX}" ]]
   then
     case "${VENDOR_PROCESSOR}" in
       x86_64)
-        ruby_FILENAME="portable-ruby-3.3.3.x86_64_linux.bottle.tar.gz"
+        ruby_FILENAME="portable-ruby-${HOMEBREW_PORTABLE_RUBY_VERSION}.x86_64_linux.bottle.tar.gz"
         ruby_SHA="40a1dbc25bb1a8bbdf0bba53d3f16c45416be12d4c6d48b4530f90b2a77d64ce"
         ;;
       *) ;;
@@ -59,7 +60,7 @@ set_ruby_variables() {
     fi
     ruby_URLs+=(
       "https://ghcr.io/v2/homebrew/portable-ruby/portable-ruby/blobs/sha256:${ruby_SHA}"
-      "https://github.com/Homebrew/homebrew-portable-ruby/releases/download/3.3.3/${ruby_FILENAME}"
+      "https://github.com/Homebrew/homebrew-portable-ruby/releases/download/${HOMEBREW_PORTABLE_RUBY_VERSION}/${ruby_FILENAME}"
     )
     ruby_URL="${ruby_URLs[0]}"
   fi

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -29,7 +29,7 @@ $LOAD_PATH.reject! { |path| path.start_with?(RbConfig::CONFIG["sitedir"]) }
 require "pathname"
 dir = __dir__ || raise("__dir__ is not defined")
 HOMEBREW_LIBRARY_PATH = Pathname(dir).parent.realpath.freeze
-HOMEBREW_USING_PORTABLE_RUBY = Pathname.new(RbConfig.ruby).to_s.include?("/vendor/portable-ruby/").freeze
+HOMEBREW_USING_PORTABLE_RUBY = RbConfig.ruby.include?("/vendor/portable-ruby/").freeze
 
 require_relative "../utils/gems"
 Homebrew.setup_gem_environment!(setup_path: false)

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,11 +1,14 @@
 # When bumping, run `brew vendor-gems --update=--ruby`
 # When bumping to a new major/minor version, also update the bounds in the Gemfile
-export HOMEBREW_REQUIRED_RUBY_VERSION=3.3
+# HOMEBREW_LIBRARY set by bin/brew
+# shellcheck disable=SC2154
+export HOMEBREW_REQUIRED_RUBY_VERSION="3.3"
+HOMEBREW_PORTABLE_RUBY_VERSION="$(cat "${HOMEBREW_LIBRARY}/Homebrew/vendor/portable-ruby-version")"
 
 # Disable Ruby options we don't need.
 export HOMEBREW_RUBY_DISABLE_OPTIONS="--disable=gems,rubyopt"
 
-# HOMEBREW_LIBRARY is from the user environment
+# HOMEBREW_LIBRARY set by bin/brew
 # shellcheck disable=SC2154
 test_ruby() {
   if [[ ! -x "$1" ]]
@@ -88,7 +91,6 @@ setup-ruby-path() {
   local vendor_ruby_root
   local vendor_ruby_path
   local vendor_ruby_terminfo
-  local vendor_ruby_latest_version
   local vendor_ruby_current_version
   local ruby_exec
   local upgrade_fail
@@ -113,7 +115,6 @@ If there's no Homebrew Portable Ruby available for your processor:
   vendor_ruby_root="${vendor_dir}/portable-ruby/current"
   vendor_ruby_path="${vendor_ruby_root}/bin/ruby"
   vendor_ruby_terminfo="${vendor_ruby_root}/share/terminfo"
-  vendor_ruby_latest_version="$(cat "${vendor_dir}/portable-ruby-version")"
   vendor_ruby_current_version="$(readlink "${vendor_ruby_root}")"
 
   unset HOMEBREW_RUBY_PATH
@@ -127,7 +128,7 @@ If there's no Homebrew Portable Ruby available for your processor:
   then
     HOMEBREW_RUBY_PATH="${vendor_ruby_path}"
     TERMINFO_DIRS="${vendor_ruby_terminfo}"
-    if [[ "${vendor_ruby_current_version}" != "${vendor_ruby_latest_version}" ]]
+    if [[ "${vendor_ruby_current_version}" != "${HOMEBREW_PORTABLE_RUBY_VERSION}" ]]
     then
       brew vendor-install ruby || odie "${upgrade_fail}"
     fi

--- a/docs/.ruby-version
+++ b/docs/.ruby-version
@@ -1,1 +1,1 @@
-3.3.3
+../Library/Homebrew/.ruby-version


### PR DESCRIPTION
- Use the `HOMEBREW_PORTABLE_RUBY_VERSION` environment variable to determine the version of the Portable Ruby to use in `vendor-install.sh` and `ruby.sh`.
- Replace the `docs/.ruby-version` file with a symlink to `Library/Homebrew/.ruby-version`.
- Fix an incorrect `HOMEBREW_LIBRARY` comment.
- Use a simpler `HOMEBREW_USING_PORTABLE_RUBY` definition.