### PR TITLE
style: reject *.sh directories.

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -62,7 +62,7 @@ module Homebrew
             shell_scripts
           else
             path.glob("**/*.sh")
-                .reject { |path| path.to_s.include?("/vendor/") }
+                .reject { |path| path.to_s.include?("/vendor/") || path.directory? }
           end
           actionlint_files += (path/".github/workflows").glob("*.y{,a}ml")
         end


### PR DESCRIPTION
Otherwise silly things happen like thinking formulae.brew.sh directories are files.

Needed for https://github.com/Homebrew/formulae.brew.sh/pull/1244