### PR TITLE
Ignore runner labels in actionlint

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -274,6 +274,7 @@ module Homebrew
       system actionlint, "-shellcheck", shellcheck,
              "-config-file", HOMEBREW_REPOSITORY/".github/actionlint.yaml",
              "-ignore", "image: string; options: string",
+             "-ignore", "label .* is unknown",
              *files
       $CHILD_STATUS.success?
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds an ignore flag to actionlint to ignore GitHub Actions runner labels.