### PR TITLE
bottle/github_packages: include path_exec_files, all_files.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -500,6 +500,7 @@ module Homebrew
             tab.poured_from_bottle = false
             tab.time = nil
             tab.changed_files = changed_files.dup
+
             if args.only_json_tab?
               tab.changed_files.delete(Pathname.new(Tab::FILENAME))
               tab.tabfile.unlink
@@ -628,6 +629,18 @@ module Homebrew
 
         return unless args.json?
 
+        if keg
+          keg_prefix = "#{keg}/"
+          path_exec_files = [keg/"bin", keg/"sbin"].select(&:exist?)
+                                                   .flat_map(&:children)
+                                                   .select(&:executable?)
+                                                   .map { |path| path.to_s.delete_prefix(keg_prefix) }
+          all_files = keg.find
+                         .select(&:file?)
+                         .map { |path| path.to_s.delete_prefix(keg_prefix) }
+                         .join(",")
+        end
+
         json = {
           formula.full_name => {
             "formula" => {
@@ -652,10 +665,12 @@ module Homebrew
               "date"     => Pathname(filename.to_s).mtime.strftime("%F"),
               "tags"     => {
                 bottle_tag.to_s => {
-                  "filename"       => filename.url_encode,
-                  "local_filename" => filename.to_s,
-                  "sha256"         => sha256,
-                  "tab"            => tab.to_bottle_hash,
+                  "filename"        => filename.url_encode,
+                  "local_filename"  => filename.to_s,
+                  "sha256"          => sha256,
+                  "tab"             => tab.to_bottle_hash,
+                  "path_exec_files" => path_exec_files,
+                  "all_files"       => all_files,
                 },
               },
             },

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -323,7 +323,7 @@ class GitHubPackages
       processed_image_refs << manifest["annotations"]["org.opencontainers.image.ref.name"]
     end
 
-    manifests += bottle_hash["bottle"]["tags"].map do |bottle_tag, tag_hash|
+    manifests += bottle_hash["bottle"]["tags"].flat_map do |bottle_tag, tag_hash|
       bottle_tag = Utils::Bottles::Tag.from_symbol(bottle_tag.to_sym)
 
       tag = GitHubPackages.version_rebuild(version, rebuild, bottle_tag.to_s)
@@ -391,6 +391,7 @@ class GitHubPackages
         "sh.brew.bottle.glibc.version"      => glibc_version,
         "sh.brew.bottle.size"               => local_file_size.to_s,
         "sh.brew.tab"                       => tab.to_json,
+        "sh.brew.path_exec_files"           => tag_hash["path_exec_files"]&.join(","),
       }.compact_blank
 
       annotations_hash = formula_annotations_hash.merge(descriptor_annotations_hash).merge(
@@ -420,14 +421,26 @@ class GitHubPackages
       }
       validate_schema!(IMAGE_MANIFEST_SCHEMA_URI, image_manifest)
       manifest_json_sha256, manifest_json_size = write_hash(blobs, image_manifest)
+      all_files_json_sha256, all_files_size = write_hash(blobs, tag_hash["all_files"].split(","))
 
-      {
-        mediaType:   "application/vnd.oci.image.manifest.v1+json",
-        digest:      "sha256:#{manifest_json_sha256}",
-        size:        manifest_json_size,
-        platform:    platform_hash,
-        annotations: descriptor_annotations_hash,
-      }
+      [
+        {
+          mediaType:   "application/vnd.oci.image.manifest.v1+json",
+          digest:      "sha256:#{manifest_json_sha256}",
+          size:        manifest_json_size,
+          platform:    platform_hash,
+          annotations: descriptor_annotations_hash,
+        },
+        {
+          mediaType:   "application/sh.brew.all_files+json",
+          digest:      "sha256:#{all_files_json_sha256}",
+          size:        all_files_size,
+          annotations: {
+            "org.opencontainers.image.ref.name" => tag,
+            "sh.brew.bottle.cpu.variant"        => cpu_variant,
+          }.compact_blank,
+        },
+      ]
     end
 
     index_json_sha256, index_json_size = write_image_index(manifests, blobs, formula_annotations_hash)


### PR DESCRIPTION
This provides an extra field to the GitHub Packages manifest about the executable files in `bin` or `sbin` directories of the bottle.

This would allow us (post a large rebottling effort) to start providing this information in the Homebrew JSON API.

It also provides a much nicer information source for e.g. homebrew-command-not-found that doesn't involve downloading actual bottles.