### PR TITLE
autoremove: don't remove formulae that were built from source

### DIFF
--- a/Library/Homebrew/test/cmd/autoremove_spec.rb
+++ b/Library/Homebrew/test/cmd/autoremove_spec.rb
@@ -11,13 +11,18 @@ RSpec.describe Homebrew::Cmd::Autoremove do
     let(:unused_formula) { Formula["testball2"] }
 
     before do
+      # Make testball1 poured from a bottle
       install_test_formula "testball1"
-      install_test_formula "testball2"
+      tab = Tab.for_name("testball1")
+      tab.poured_from_bottle = true
+      tab.write
 
-      # Make testball2 an unused dependency
+      # Make testball2 poured from a bottle and an unused dependency
+      install_test_formula "testball2"
       tab = Tab.for_name("testball2")
       tab.installed_on_request = false
       tab.installed_as_dependency = true
+      tab.poured_from_bottle = true
       tab.write
     end
 

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Utils::Autoremove do
     end
   end
 
-  describe "::formulae_with_no_formula_dependents" do
+  describe "::bottled_formulae_with_no_formula_dependents" do
     include_context "with formulae for dependency testing"
 
     before do
@@ -72,17 +72,17 @@ RSpec.describe Utils::Autoremove do
       it "filters out runtime dependencies" do
         allow(tab_from_keg).to receive(:poured_from_bottle).and_return(true)
 
-        expect(described_class.send(:formulae_with_no_formula_dependents, formulae))
+        expect(described_class.send(:bottled_formulae_with_no_formula_dependents, formulae))
           .to eq([formula_with_deps, formula_is_build_dep])
       end
     end
 
     context "when formulae are built from source" do
-      it "filters out runtime and build dependencies" do
+      it "filters out formulae" do
         allow(tab_from_keg).to receive(:poured_from_bottle).and_return(false)
 
-        expect(described_class.send(:formulae_with_no_formula_dependents, formulae))
-          .to eq([formula_with_deps])
+        expect(described_class.send(:bottled_formulae_with_no_formula_dependents, formulae))
+          .to eq([])
       end
     end
   end


### PR DESCRIPTION
When a formula was built from source, it should not be removed by `brew autoremove` as it will take a while to be installed again.

Fixes https://github.com/Homebrew/brew/issues/17433