### PR TITLE
Cask::Audit: Align user agents with livecheck

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -839,7 +839,8 @@ module Cask
 
       validate_url_for_https_availability(
         url, "livecheck URL",
-        check_content: true
+        check_content: true,
+        user_agents:   [:default, :browser]
       )
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `#page_headers` and `#page_content` methods in `Livecheck::Strategy` will fetch a URL using our default user agent but if the request fails it will retry with the `:browser` user agent. [For context, it was added as an interim measure to make URLs work that require a different user agent but I aim to remove it in the future in favor of specifying the user agent in a `livecheck` block (so we don't make unnecessary requests that we know will fail).]

`Cask::Audit#audit_livecheck_https_availability` checks the `livecheck` block URL but it only does so using our default user agent (i.e., it calls `#validate_url_for_https_availability` which calls `Utils::Curl#curl_check_http_content` which has a `user_agents: [:default]` parameter). Due to this behavioral mismatch, it's possible for a `livecheck` block to work but for this cask audit to fail.

This addresses the issue by adding `user_agents: [:default, :browser]` to the arguments the audit uses, which aligns its behavior with livecheck's.

-----

I know there's some discussion in https://github.com/Homebrew/brew/issues/15350 around whether we should be switching user agents at all and I'll reply to that issue to further the discussion. In the interim time, this PR is simply about aligning existing behavior, so PRs like https://github.com/Homebrew/homebrew-cask/pull/175619 will correctly pass.