### PR TITLE
cask: fix trash.swift under Xcode 16

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -457,12 +457,13 @@ module Cask
       def trash_paths(*paths, command: nil, **_)
         return if paths.empty?
 
-        stdout, stderr, = system_command HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
-                                         args:         paths,
-                                         print_stderr: false
+        stdout, = system_command HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
+                                 args:         paths,
+                                 print_stderr: Homebrew::EnvConfig.developer?
 
-        trashed = stdout.split(":").sort
-        untrashable = stderr.split(":").sort
+        trashed, _, untrashable = stdout.partition("\n")
+        trashed = trashed.split(":")
+        untrashable = untrashable.split(":")
 
         return trashed, untrashable if untrashable.empty?
 
@@ -470,7 +471,7 @@ module Cask
           Utils.gain_permissions(path, ["-R"], SystemCommand) do
             system_command! HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
                             args:         [path],
-                            print_stderr: false
+                            print_stderr: Homebrew::EnvConfig.developer?
           end
 
           true

--- a/Library/Homebrew/cask/utils/trash.swift
+++ b/Library/Homebrew/cask/utils/trash.swift
@@ -2,14 +2,6 @@
 
 import Foundation
 
-extension FileHandle : TextOutputStream {
-  public func write(_ string: String) {
-      if let data = string.data(using: .utf8) { self.write(data) }
-  }
-}
-
-var stderr = FileHandle.standardError
-
 let manager = FileManager.default
 
 var success = true
@@ -17,18 +9,23 @@ var success = true
 // The command line arguments given but without the script's name
 let CMDLineArgs = Array(CommandLine.arguments.dropFirst())
 
+var trashed: [String] = []
+var untrashable: [String] = []
 for item in CMDLineArgs {
     do {
         let url = URL(fileURLWithPath: item)
         var trashedPath: NSURL!
         try manager.trashItem(at: url, resultingItemURL: &trashedPath)
-        print((trashedPath as URL).path, terminator: ":")
+        trashed.append((trashedPath as URL).path)
         success = true
     } catch {
-        print(item, terminator: ":", to: &stderr)
+        untrashable.append(item)
         success = false
     }
 }
+
+print(trashed.joined(separator: ":"))
+print(untrashable.joined(separator: ":"), terminator: "")
 
 guard success else {
     exit(1)


### PR DESCRIPTION
`trash.swift` emits a warning to stderr starting with Swift 6 (Xcode 16):

```console
/opt/homebrew/Library/Homebrew/cask/utils/trash.swift:5:1: warning: extension declares a conformance of imported type 'FileHandle' to imported protocol 'TextOutputStream'; this will not behave correctly if the owners of 'Foundation' introduce this conformance in the future
 3 | import Foundation
 4 | 
 5 | extension FileHandle : TextOutputStream {
   | |- warning: extension declares a conformance of imported type 'FileHandle' to imported protocol 'TextOutputStream'; this will not behave correctly if the owners of 'Foundation' introduce this conformance in the future
   | `- note: add '@retroactive' to silence this warning
 6 |   public func write(_ string: String) {
 7 |       if let data = string.data(using: .utf8) { self.write(data) }
````

This breaks the code because we also output data to parse to stderr.

Fix both the warning and the future handling of warnings by getting rid of stderr writing and instead parse the output based on line order to stdout.

Also print full stderr for developers to make future warnings more clear.