### PR TITLE
Revert "bottle/github_packages: include path_exec_files, all_files."

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -500,7 +500,6 @@ module Homebrew
             tab.poured_from_bottle = false
             tab.time = nil
             tab.changed_files = changed_files.dup
-
             if args.only_json_tab?
               tab.changed_files.delete(Pathname.new(Tab::FILENAME))
               tab.tabfile.unlink
@@ -629,18 +628,6 @@ module Homebrew
 
         return unless args.json?
 
-        if keg
-          keg_prefix = "#{keg}/"
-          path_exec_files = [keg/"bin", keg/"sbin"].select(&:exist?)
-                                                   .flat_map(&:children)
-                                                   .select(&:executable?)
-                                                   .map { |path| path.to_s.delete_prefix(keg_prefix) }
-          all_files = keg.find
-                         .select(&:file?)
-                         .map { |path| path.to_s.delete_prefix(keg_prefix) }
-                         .join(",")
-        end
-
         json = {
           formula.full_name => {
             "formula" => {
@@ -665,12 +652,10 @@ module Homebrew
               "date"     => Pathname(filename.to_s).mtime.strftime("%F"),
               "tags"     => {
                 bottle_tag.to_s => {
-                  "filename"        => filename.url_encode,
-                  "local_filename"  => filename.to_s,
-                  "sha256"          => sha256,
-                  "tab"             => tab.to_bottle_hash,
-                  "path_exec_files" => path_exec_files,
-                  "all_files"       => all_files,
+                  "filename"       => filename.url_encode,
+                  "local_filename" => filename.to_s,
+                  "sha256"         => sha256,
+                  "tab"            => tab.to_bottle_hash,
                 },
               },
             },


### PR DESCRIPTION
Reverts Homebrew/brew#17507

This broke uploading bottles in homebrew-core. Let's revert for now to unblock.