### PR TITLE
bottle/github_packages: include `path_exec_files`.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -628,6 +628,17 @@ module Homebrew
 
         return unless args.json?
 
+        if keg
+          keg_prefix = "#{keg}/"
+          path_exec_files = [keg/"bin", keg/"sbin"].select(&:exist?)
+                                                   .flat_map(&:children)
+                                                   .select(&:executable?)
+                                                   .map { |path| path.to_s.delete_prefix(keg_prefix) }
+          all_files = keg.find
+                         .select(&:file?)
+                         .map { |path| path.to_s.delete_prefix(keg_prefix) }
+        end
+
         json = {
           formula.full_name => {
             "formula" => {
@@ -652,10 +663,12 @@ module Homebrew
               "date"     => Pathname(filename.to_s).mtime.strftime("%F"),
               "tags"     => {
                 bottle_tag.to_s => {
-                  "filename"       => filename.url_encode,
-                  "local_filename" => filename.to_s,
-                  "sha256"         => sha256,
-                  "tab"            => tab.to_bottle_hash,
+                  "filename"        => filename.url_encode,
+                  "local_filename"  => filename.to_s,
+                  "sha256"          => sha256,
+                  "tab"             => tab.to_bottle_hash,
+                  "path_exec_files" => path_exec_files,
+                  "all_files"       => all_files,
                 },
               },
             },

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -384,6 +384,10 @@ class GitHubPackages
 
       local_file_size = File.size(local_file)
 
+      path_exec_files_string = if (path_exec_files = tag_hash["path_exec_files"].presence)
+        path_exec_files.join(",")
+      end
+
       descriptor_annotations_hash = {
         "org.opencontainers.image.ref.name" => tag,
         "sh.brew.bottle.cpu.variant"        => cpu_variant,
@@ -391,7 +395,10 @@ class GitHubPackages
         "sh.brew.bottle.glibc.version"      => glibc_version,
         "sh.brew.bottle.size"               => local_file_size.to_s,
         "sh.brew.tab"                       => tab.to_json,
+        "sh.brew.path_exec_files"           => path_exec_files_string,
       }.compact_blank
+
+      # TODO: upload/add tag_hash["all_files"] somewhere.
 
       annotations_hash = formula_annotations_hash.merge(descriptor_annotations_hash).merge(
         {


### PR DESCRIPTION
`all_files` is added to the bottle JSON but not actually used by `GitHubPackages` yet.

Awaiting fixes for what caused the issues: https://github.com/Homebrew/homebrew-core/actions/runs/9568731423/job/26379623093

Reverts Homebrew/brew#17529