### PR TITLE
dev-cmd/extract: trim version to only digits/decimals for class & file names

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -122,15 +122,20 @@ module Homebrew
         # e.g. Foo version 1.2.3 becomes FooAT123 and resides in Foo@1.2.3.rb.
         class_name = Formulary.class_s(name)
 
-        # Remove any existing version suffixes, as a new one will be added later
+        # The version can only contain digits with decimals in between.
+        version_string = version.to_s
+                                .sub(/\D*(.+?)\D*$/, "\\1")
+                                .gsub(/\D+/, ".")
+
+        # Remove any existing version suffixes, as a new one will be added later.
         name.sub!(/\b@(.*)\z\b/i, "")
-        versioned_name = Formulary.class_s("#{name}@#{version}")
+        versioned_name = Formulary.class_s("#{name}@#{version_string}")
         result.sub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
 
-        # Remove bottle blocks, they won't work.
+        # Remove bottle blocks, as they won't work.
         result.sub!(BOTTLE_BLOCK_REGEX, "")
 
-        path = destination_tap.path/"Formula/#{name}@#{version.to_s.downcase}.rb"
+        path = destination_tap.path/"Formula/#{name}@#{version_string}.rb"
         if path.exist?
           unless args.force?
             odie <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
When generating a class name for a formula, remove any non-digit characters following the `@` if present. Allows a command like `brew extract --version` to handle versions that don't start with digits. Fixes #16881.

```
brew(main):001> Formulary.class_s("minio@RELEASE.2024-03-05T04-48-44Z")
=> "MinioAT20240305t044844z"
```