### PR TITLE
docs: updates the node formula example to use the node installed by Homebrew

### DIFF
--- a/docs/Node-for-Formula-Authors.md
+++ b/docs/Node-for-Formula-Authors.md
@@ -102,7 +102,19 @@ class Foo < Formula
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+
+    # "link" the executable `foo`, ensuring that the version of node installed by Homebrew is used
+    # (the created `foo` will set the ENV before exec'ing your executable)
+    env = { PATH: "#{HOMEBREW_PREFIX/"bin"}:$PATH" }
+    (bin/"foo").write_env_script "#{libexec}/bin/foo", env
+
+    # Uncomment if you simply want to symlink the executable – note that this means the first
+    # `node` on the PATH will be used (not necessarily the one Homebrew installed)
+    # bin.install_symlink Dir["#{libexec}/bin/*"]
+
+    # Uncomment if you want to write the completion scripts for bash, fish, and zsh (assuming
+    # your executable has a command "completion" which returns a completion script)
+    # generate_completions_from_executable(libexec/"bin/foo", "completion", base_name: 'foo')
   end
 
   test do


### PR DESCRIPTION
The existing example uses a symlink which means that whatever `node` is first in the PATH will be used. This can mean that a Homebrew-installed nodejs executable may not work reliably (since it may execute with a different version of node)

This PR changes it so that using the Homebrew-installed `node` will be used. It also includes common other options (like shell completion) as well as the old symlink solution.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
