### PR TITLE
cask: ignore minimum macOS in on_os blocks for variations

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -440,7 +440,9 @@ module Cask
           MacOSVersion::SYMBOLS.keys.product(OnSystem::ARCH_OPTIONS).each do |os, arch|
             bottle_tag = ::Utils::Bottles::Tag.new(system: os, arch:)
             next unless bottle_tag.valid_combination?
-            next if depends_on.macos && !depends_on.macos.allows?(bottle_tag.to_macos_version)
+            next if depends_on.macos &&
+                    !@dsl.depends_on_set_in_block? &&
+                    !depends_on.macos.allows?(bottle_tag.to_macos_version)
 
             Homebrew::SimulateSystem.with(os:, arch:) do
               refresh

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -95,6 +95,7 @@ module Cask
       :livecheck,
       :livecheckable?,
       :on_system_blocks_exist?,
+      :depends_on_set_in_block?,
       *ORDINARY_ARTIFACT_CLASSES.map(&:dsl_key),
       *ACTIVATABLE_ARTIFACT_CLASSES.map(&:dsl_key),
       *ARTIFACT_BLOCK_CLASSES.flat_map { |klass| [klass.dsl_key, klass.uninstall_dsl_key] },
@@ -105,7 +106,7 @@ module Cask
 
     attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :disable_date, :disable_reason
 
-    attr_predicate :on_system_blocks_exist?, :deprecated?, :disabled?, :livecheckable?
+    attr_predicate :deprecated?, :disabled?, :livecheckable?, :on_system_blocks_exist?, :depends_on_set_in_block?
 
     def initialize(cask)
       @cask = cask
@@ -353,6 +354,7 @@ module Cask
     # @api public
     def depends_on(**kwargs)
       @depends_on ||= DSL::DependsOn.new
+      @depends_on_set_in_block = true if @called_in_on_system_block
       return @depends_on if kwargs.empty?
 
       begin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The fixes I made for variations generation in #17386 didn't account for when `depends_on macos:` is called inside an on_os block. Affected casks are set to be fixed in Homebrew/homebrew-cask#176710; until then, any cask with a minimum macOS set anywhere will not show versions older than that. 

For example, [macupdater](https://formulae.brew.sh/cask/macupdater) is shown as requiring Ventura despite defining an older version in an `on_monterey :or_older` block. 

It was recently [pointed out](https://github.com/Homebrew/brew/pull/17386#issuecomment-2181695871) that this causes affected casks to be [incorrectly shown](https://github.com/orgs/Homebrew/discussions/5448) as upgradeable on older systems.

This PR revises the variations generation fix to ignore `depends_on` stanzas that are set within on_os blocks. This'll briefly bring back some of the issues with formulae.brew.sh pages until the affected casks are fixed. 