### PR TITLE
formula_installer: fix gh bootstrap cycle

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1256,7 +1256,9 @@ on_request: installed_on_request?, options:)
 
   sig { void }
   def pour
-    if Homebrew::EnvConfig.verify_attestations? && formula.tap&.core_tap?
+    # We skip `gh` to avoid a bootstrapping cycle, in the off-chance a user attempts
+    # to explicitly `brew install gh` without already having a version for bootstrapping.
+    if Homebrew::EnvConfig.verify_attestations? && formula.tap&.core_tap? && formula.name != "gh"
       ohai "Verifying attestation for #{formula.name}"
       begin
         Homebrew::Attestation.check_core_attestation formula.bottle


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a bootstrap cycle that @carlocab noticed a few weeks ago and I forgot to fix, until @trevrosen hit it externally.

TL;DR: a user can force a bootstrap cycle by not having `gh` installed and then explicitly installing it with attestations enabled, causing `ensure_executable!` to recurse as it tries to bootstrap `gh` for verification:

```console
arbet:homebrew william$ brew uninstall gh
Uninstalling /opt/homebrew/Cellar/gh/2.51.0... (199 files, 48.3MB)
arbet:homebrew william$ HOMEBREW_VERIFY_ATTESTATIONS=1 brew install gh
==> Downloading https://ghcr.io/v2/homebrew/core/gh/manifests/2.51.0
Already downloaded: /Users/william/Library/Caches/Homebrew/downloads/640826987b6720657d42428353fc895c85f30f5b38a39220d488ccb98c3a073f--gh-2.51.0.bottle_manifest.json
==> Fetching gh
==> Downloading https://ghcr.io/v2/homebrew/core/gh/blobs/sha256:85b3ff30728ed342b9
Already downloaded: /Users/william/Library/Caches/Homebrew/downloads/594d5255194d89f78b8bf6a0acfb7e8a680ea210a074500dc46152e2a1e446b1--gh--2.51.0.arm64_sonoma.bottle.tar.gz
==> Verifying attestation for gh
==> Installing `gh`...
==> Downloading https://ghcr.io/v2/homebrew/core/gh/manifests/2.51.0
Already downloaded: /Users/william/Library/Caches/Homebrew/downloads/640826987b6720657d42428353fc895c85f30f5b38a39220d488ccb98c3a073f--gh-2.51.0.bottle_manifest.json
==> Fetching gh
==> Downloading https://ghcr.io/v2/homebrew/core/gh/blobs/sha256:85b3ff30728ed342b9
Already downloaded: /Users/william/Library/Caches/Homebrew/downloads/594d5255194d89f78b8bf6a0acfb7e8a680ea210a074500dc46152e2a1e446b1--gh--2.51.0.arm64_sonoma.bottle.tar.gz
Error: Operation already in progress for gh.formula
Another active Homebrew process is already using gh.formula.
Please wait for it to finish or terminate it to continue.
==> Installing `gh`...
==> Downloading https://ghcr.io/v2/homebrew/core/gh/manifests/2.51.0
Already downloaded: /Users/william/Library/Caches/Homebrew/downloads/640826987b6720657d42428353fc895c85f30f5b38a39220d488ccb98c3a073f--gh-2.51.0.bottle_manifest.json
==> Fetching gh
==> Downloading https://ghcr.io/v2/homebrew/core/gh/blobs/sha256:85b3ff30728ed342b9
Already downloaded: /Users/william/Library/Caches/Homebrew/downloads/594d5255194d89f78b8bf6a0acfb7e8a680ea210a074500dc46152e2a1e446b1--gh--2.51.0.arm64_sonoma.bottle.tar.gz
Error: Operation already in progress for gh.formula
Another active Homebrew process is already using gh.formula.
Please wait for it to finish or terminate it to continue.
Error: The bottle for gh has an invalid build provenance attestation.

This may indicate that the bottle was not produced by the expected
tap, or was maliciously inserted into the expected tap's bottle
storage.

Additional context:

attestation verification failed: Failure while executing; `/opt/homebrew/bin/brew install --formula gh` exited with 1.
```

This cycle can't be easily avoided, since `gh` is our current root of trust: we have no way to *a priori* verify its attestation without a previous copy of `gh` installed. This doesn't bite 99% of users since they'll have `gh` transparently installed during our normally bootstrapping phase; it only affects users who attempt to explicitly `brew install gh` with attestations enabled.

(We could *a posteriori* verify `gh` after allowing it to install, but this (1) complicates the bootstrap and (2) has a contradictory security position, since a malicious `gh` could at that point rewrite the verification step into a no-op.)

Long term, we'll be able to fully eliminate this bootstrap cycle by replacing our use of `gh attestation` with `sigstore-ruby`. But that's still a whiles away 🙂 