### PR TITLE
cask/audit: support on_os blocks in audit_min_os

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -95,6 +95,7 @@ module Cask
       :livecheck,
       :livecheckable?,
       :on_system_blocks_exist?,
+      :on_system_block_min_os,
       :depends_on_set_in_block?,
       *ORDINARY_ARTIFACT_CLASSES.map(&:dsl_key),
       *ACTIVATABLE_ARTIFACT_CLASSES.map(&:dsl_key),
@@ -104,7 +105,8 @@ module Cask
     extend Attrable
     include OnSystem::MacOSOnly
 
-    attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :disable_date, :disable_reason
+    attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :disable_date, :disable_reason,
+                :on_system_block_min_os
 
     attr_predicate :deprecated?, :disabled?, :livecheckable?, :on_system_blocks_exist?, :depends_on_set_in_block?
 

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -130,6 +130,11 @@ module OnSystem
         os_condition = OnSystem.condition_from_method_name T.must(__method__)
         return unless OnSystem.os_condition_met? os_condition, or_condition
 
+        @on_system_block_min_os = if or_condition == :or_older
+          MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED).to_sym
+        else
+          os_condition
+        end
         @called_in_on_system_block = true
         result = block.call
         @called_in_on_system_block = false

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -61,6 +61,13 @@ class MacOSRequirement < Requirement
     false
   end
 
+  def minimum_version
+    return MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED) if @comparator == "<=" || !version_specified?
+    return @version.min if @version.respond_to?(:to_ary)
+
+    @version
+  end
+
   def allows?(other)
     return true unless version_specified?
 

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -5,6 +5,7 @@ require "requirements/macos_requirement"
 RSpec.describe MacOSRequirement do
   subject(:requirement) { described_class.new }
 
+  let(:macos_oldest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED) }
   let(:big_sur_major) { MacOSVersion.new("11.0") }
 
   describe "#satisfied?" do
@@ -23,11 +24,26 @@ RSpec.describe MacOSRequirement do
     end
   end
 
+  specify "#minimum_version" do
+    no_requirement = described_class.new
+    max_requirement = described_class.new([:big_sur], comparator: "<=")
+    min_requirement = described_class.new([:big_sur], comparator: ">=")
+    exact_requirement = described_class.new([:big_sur], comparator: "==")
+    range_requirement = described_class.new([[:monterey, :big_sur]], comparator: "==")
+    expect(no_requirement.minimum_version).to eq macos_oldest_allowed
+    expect(max_requirement.minimum_version).to eq macos_oldest_allowed
+    expect(min_requirement.minimum_version).to eq big_sur_major
+    expect(exact_requirement.minimum_version).to eq big_sur_major
+    expect(range_requirement.minimum_version).to eq big_sur_major
+  end
+
   specify "#allows?" do
+    no_requirement = described_class.new
     max_requirement = described_class.new([:mojave], comparator: "<=")
     min_requirement = described_class.new([:catalina], comparator: ">=")
     exact_requirement = described_class.new([:big_sur], comparator: "==")
     range_requirement = described_class.new([[:monterey, :big_sur]], comparator: "==")
+    expect(no_requirement.allows?(big_sur_major)).to be true
     expect(max_requirement.allows?(big_sur_major)).to be false
     expect(min_requirement.allows?(big_sur_major)).to be true
     expect(exact_requirement.allows?(big_sur_major)).to be true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
As suggested in Homebrew/homebrew-cask#176710, this PR does the following:

- to `MacOSRequirement`, adds and tests `minimum_version` to return the minimum OS version allowed by a `depends_on macos:` stanza
- to `OnSystem`, adds `@on_system_block_min_os` which is made available via `cask/dsl.rb` for fetching the minimum OS version of the current system-specific block
- in `Cask::Audit#audit_min_os`:
  - checks the detected minimum supported OS version of the artifact against the minimum OS version of either the current system-specific block if present or the `depends_on` stanza (and adjust the associated error message to match)
  - fixes a potential issue when checking a cask specifying a `depends_on` array of allowed OS versions by calling `minimum_version` instead of `version`
  
This should help us notice when a cask version bump introduces a new minimum OS requirement.

‌
