### PR TITLE
fix tap migration renames with API

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -269,14 +269,13 @@ module Cask
         return if Homebrew::EnvConfig.no_install_from_api?
         return unless ref.is_a?(String)
 
-        token = parse_token(ref)
-        token ||= begin
-          ref = CoreCaskTap.instance.tap_migration_renames[ref]
-          parse_token(ref) if ref
+        ref = if (token = parse_token(ref))
+          "#{CoreCaskTap.instance}/#{token}"
+        else
+          CoreCaskTap.instance.tap_migration_oldnames_to_full_names[ref]
         end
-        return unless token
 
-        ref = "#{CoreCaskTap.instance}/#{token}"
+        return unless ref
 
         token, tap, = CaskLoader.tap_cask_token_type(ref, warn:)
         new("#{tap}/#{token}")

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -918,23 +918,23 @@ module Formulary
       return if Homebrew::EnvConfig.no_install_from_api?
       return unless ref.is_a?(String)
 
-      name = parse_name(ref)
-      name ||= begin
-        ref = CoreTap.instance.tap_migration_renames[ref]
-        parse_name(ref) if ref
+      ref = if (name = parse_name(ref))
+        "#{CoreTap.instance}/#{name}"
+      else
+        name = ref.split("/").last
+        CoreTap.instance.tap_migration_oldnames_to_full_names[ref]
       end
-      return unless name
+
+      return unless ref
 
       alias_name = name
-
-      ref = "#{CoreTap.instance}/#{name}"
 
       return unless (name_tap_type = Formulary.tap_formula_name_type(ref, warn:))
 
       name, tap, type = name_tap_type
 
       options = if type == :alias
-        { alias_name: alias_name.downcase }
+        { alias_name: T.must(alias_name).downcase }
       else
         {}
       end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1284,6 +1284,19 @@ class CoreTap < AbstractCoreTap
     end
   end
 
+  # External formula names to core formula renames
+  sig { returns(T::Hash[String, String]) }
+  def tap_migration_renames
+    @tap_migration_renames ||= Tap.each_with_object({}) do |tap, hash|
+      tap.tap_migrations.each do |old_name, new_name|
+        next unless new_name.start_with?("homebrew/core/")
+
+        hash[old_name] = new_name
+        hash["#{tap}/#{old_name}"] = new_name
+      end
+    end
+  end
+
   sig { returns(T::Array[String]) }
   def autobump
     @autobump ||= begin
@@ -1453,6 +1466,19 @@ class CoreCaskTap < AbstractCoreTap
       migrations, = Homebrew::API.fetch_json_api_file "cask_tap_migrations.jws.json",
                                                       stale_seconds: TAP_MIGRATIONS_STALE_SECONDS
       migrations
+    end
+  end
+
+  # External cask names to core cask renames
+  sig { returns(T::Hash[String, String]) }
+  def tap_migration_renames
+    @tap_migration_renames ||= Tap.each_with_object({}) do |tap, hash|
+      tap.tap_migrations.each do |old_name, new_name|
+        next unless new_name.start_with?("homebrew/cask/")
+
+        hash[old_name] = new_name
+        hash["#{tap}/#{old_name}"] = new_name
+      end
     end
   end
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -236,6 +236,7 @@ class Tap
     @command_files = nil
 
     @tap_migrations = nil
+    @tap_migration_renames = nil
     @reverse_tap_migrations_renames = nil
 
     @audit_exceptions = nil

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -236,7 +236,7 @@ class Tap
     @command_files = nil
 
     @tap_migrations = nil
-    @tap_migration_renames = nil
+    @tap_migration_oldnames_to_full_names = nil
     @reverse_tap_migrations_renames = nil
 
     @audit_exceptions = nil
@@ -1285,15 +1285,16 @@ class CoreTap < AbstractCoreTap
     end
   end
 
-  # External formula names to core formula renames
+  # Old formula names (that were migrated to homebrew/core) to old full names.
   sig { returns(T::Hash[String, String]) }
-  def tap_migration_renames
-    @tap_migration_renames ||= Tap.each_with_object({}) do |tap, hash|
+  def tap_migration_oldnames_to_full_names
+    @tap_migration_oldnames_to_full_names ||= Tap.each_with_object({}) do |tap, hash|
       tap.tap_migrations.each do |old_name, new_name|
         next unless new_name.start_with?("homebrew/core/")
 
-        hash[old_name] = new_name
-        hash["#{tap}/#{old_name}"] = new_name
+        full_name = "#{tap}/#{old_name}"
+        hash[old_name] = full_name
+        hash[full_name] = full_name
       end
     end
   end
@@ -1470,15 +1471,16 @@ class CoreCaskTap < AbstractCoreTap
     end
   end
 
-  # External cask names to core cask renames
+  # Old cask names (that were migrated to homebrew/cask) to old full names.
   sig { returns(T::Hash[String, String]) }
-  def tap_migration_renames
-    @tap_migration_renames ||= Tap.each_with_object({}) do |tap, hash|
+  def tap_migration_oldnames_to_full_names
+    @tap_migration_oldnames_to_full_names ||= Tap.each_with_object({}) do |tap, hash|
       tap.tap_migrations.each do |old_name, new_name|
         next unless new_name.start_with?("homebrew/cask/")
 
-        hash[old_name] = new_name
-        hash["#{tap}/#{old_name}"] = new_name
+        full_name = "#{tap}/#{old_name}"
+        hash[old_name] = full_name
+        hash[full_name] = full_name
       end
     end
   end

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -14,12 +14,14 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
 
     before do
       allow(Homebrew::API::Cask)
-        .to receive(:all_casks)
-        .and_return(casks_from_api_hash)
+        .to receive_messages(all_casks: casks_from_api_hash, all_renames: {})
+
+      # The call to `Cask::CaskLoader.load` above sets the Tap cache prematurely.
+      Tap.clear_cache
     end
   end
 
-  describe ".can_load?" do
+  describe ".try_new" do
     include_context "with API setup", "test-opera"
 
     context "when not using the API", :no_api do
@@ -34,15 +36,63 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
       end
 
       it "returns a loader for valid token" do
-        expect(described_class.try_new(token)).not_to be_nil
+        expect(described_class.try_new(token))
+          .to be_a(described_class)
+          .and have_attributes(token:)
       end
 
       it "returns a loader for valid full name" do
-        expect(described_class.try_new("homebrew/cask/#{token}")).not_to be_nil
+        expect(described_class.try_new("homebrew/cask/#{token}"))
+          .to be_a(described_class)
+          .and have_attributes(token:)
       end
 
       it "returns nil for full name with invalid tap" do
         expect(described_class.try_new("homebrew/foo/#{token}")).to be_nil
+      end
+
+      context "with core tap migration renames" do
+        let(:foo_tap) { Tap.fetch("homebrew", "foo") }
+
+        before do
+          foo_tap.path.mkpath
+        end
+
+        after do
+          FileUtils.rm_rf foo_tap.path
+        end
+
+        it "returns the core cask if the short name clashes with a tap migration rename" do
+          (foo_tap.path/"tap_migrations.json").write <<~JSON
+            { "#{token}": "homebrew/cask/#{token}-v2" }
+          JSON
+
+          expect(described_class.try_new(token))
+            .to be_a(described_class)
+            .and have_attributes(token:)
+        end
+
+        it "returns the tap migration rename by old token" do
+          old_token = "#{token}-old"
+          (foo_tap.path/"tap_migrations.json").write <<~JSON
+            { "#{old_token}": "homebrew/cask/#{token}" }
+          JSON
+
+          expect(described_class.try_new(old_token))
+            .to be_a(described_class)
+            .and have_attributes(token:)
+        end
+
+        it "returns the tap migration rename by old full name" do
+          old_token = "#{token}-old"
+          (foo_tap.path/"tap_migrations.json").write <<~JSON
+            { "#{old_token}": "homebrew/cask/#{token}" }
+          JSON
+
+          expect(described_class.try_new("#{foo_tap}/#{old_token}"))
+            .to be_a(described_class)
+            .and have_attributes(token:)
+        end
       end
     end
   end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -383,6 +383,7 @@ RSpec.describe Formulary do
         # avoid unnecessary network calls
         allow(Homebrew::API::Formula).to receive_messages(all_aliases: {}, all_renames: {})
         allow(CoreTap.instance).to receive(:tap_migrations).and_return({})
+        allow(CoreCaskTap.instance).to receive(:tap_migrations).and_return({})
 
         # don't try to load/fetch gcc/glibc
         allow(DevelopmentTools).to receive_messages(needs_libc_formula?: false, needs_compiler_formula?: false)
@@ -481,6 +482,51 @@ RSpec.describe Formulary do
         expect(formula.declared_deps.count).to eq 6
         expect(formula.deps.count).to eq 5
         expect(formula.deps.map(&:name).include?("uses_from_macos_dep")).to be true
+      end
+
+      context "with core tap migration renames" do
+        let(:foo_tap) { Tap.fetch("homebrew", "foo") }
+
+        before do
+          allow(Homebrew::API::Formula).to receive(:all_formulae).and_return formula_json_contents
+          foo_tap.path.mkpath
+        end
+
+        after do
+          FileUtils.rm_rf foo_tap.path
+        end
+
+        it "returns the core formula if the short name clashes with a tap migration rename" do
+          (foo_tap.path/"tap_migrations.json").write <<~JSON
+            { "#{formula_name}": "homebrew/core/#{formula_name}-v2" }
+          JSON
+
+          expect(described_class::FromAPILoader.try_new(formula_name))
+            .to be_a(described_class::FromAPILoader)
+            .and have_attributes(name: formula_name)
+        end
+
+        it "returns the tap migration rename by old formula_name" do
+          old_formula_name = "#{formula_name}-old"
+          (foo_tap.path/"tap_migrations.json").write <<~JSON
+            { "#{old_formula_name}": "homebrew/core/#{formula_name}" }
+          JSON
+
+          expect(described_class::FromAPILoader.try_new(old_formula_name))
+            .to be_a(described_class::FromAPILoader)
+            .and have_attributes(name: formula_name)
+        end
+
+        it "returns the tap migration rename by old full name" do
+          old_formula_name = "#{formula_name}-old"
+          (foo_tap.path/"tap_migrations.json").write <<~JSON
+            { "#{old_formula_name}": "homebrew/core/#{formula_name}" }
+          JSON
+
+          expect(described_class::FromAPILoader.try_new("#{foo_tap}/#{old_formula_name}"))
+            .to be_a(described_class::FromAPILoader)
+            .and have_attributes(name: formula_name)
+        end
       end
     end
   end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -216,7 +216,7 @@ RSpec.configure do |config|
   config.around do |example|
     Homebrew.raise_deprecation_exceptions = true
 
-    Tap.installed.each(&:clear_cache)
+    Tap.all.each(&:clear_cache)
     Cachable::Registry.clear_all_caches
     FormulaInstaller.clear_attempted
     FormulaInstaller.clear_installed

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -567,7 +567,7 @@ RSpec.describe Tap do
         JSON
       end
 
-      describe "#reverse_tap_migration_renames" do
+      describe "#reverse_tap_migrations_renames" do
         it "returns the expected hash" do
           expect(homebrew_foo_tap.reverse_tap_migrations_renames).to eq({
             "homebrew/cask/google-cloud-sdk" => %w[app-engine-go-32 app-engine-go-64],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/17234

We don't load casks and formulae that used to exist in an external tap but have been moved and renamed to an API tap when using the API. Loading works correctly when the core formula or cask tap is tapped locally though.

This PR adds some logic to map tap migration renames to the API and check that when loading formulae and casks.

Todo:
- [x] Add tests
- [ ] Manual testing