### PR TITLE
cask/audit: ensure on_os blocks specify a min OS

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -611,7 +611,7 @@ module Cask
 
       return if min_os.nil? || min_os <= HOMEBREW_MACOS_OLDEST_ALLOWED
 
-      cask_min_os = if cask.on_system_blocks_exist?
+      cask_min_os = if cask.on_system_blocks_exist? && cask.on_system_block_min_os.present?
         cask.on_system_block_min_os
       else
         cask.depends_on.macos&.minimum_version


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
A cask with different SHA256 values for ARM and Intel is considered to be using on_os blocks, resulting in `@on_system_block_min_os` being blank. If so, ignore it and check the value of `depends_on macos:` instead.

xref. Homebrew/homebrew-cask#175581