### PR TITLE
CurlDownloadStrategy: Ignore invalid `last-modified` header values

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -522,7 +522,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
             .flat_map { |headers| [*headers["last-modified"]] }
             .filter_map do |t|
               t.match?(/^\d+$/) ? Time.at(t.to_i) : Time.parse(t)
-            rescue ArgumentError
+            rescue ArgumentError # When `Time.parse` gets a badly formatted date.
               nil
             end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes https://github.com/Homebrew/brew/issues/17556.
- Some download locations return a non-standard formatting of date string for the `Last-Modified` header. This causes `Time.parse` to blow up. The user sees `error: argument out of range`.
- In this commit we handle the error and return nil, which `filter_map` (equivalent to `.map.compact`) gets rid of and then `time.last` is as normal.

-----

TODO: Figure out how to write some tests for this.

----

Before:

```shell
❯ brew install --cask ./olex2.rb                                                                                                        
Error: argument out of range
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.3.3/lib/ruby/3.3.0/time.rb:271:in `local'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.3.3/lib/ruby/3.3.0/time.rb:271:in `make_time'
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.3.3/lib/ruby/3.3.0/time.rb:386:in `parse'
/opt/homebrew/Library/Homebrew/download_strategy.rb:523:in `block in resolve_url_basename_time_file_size'
```

After:

```shell
❯ brew install --cask ./olex2.rb
==> Downloading https://secure.olex2.org/olex2-distro/olex2-1.5.app.dmg
###########################
```