### PR TITLE
cask/audit: filter bad artifacts in rosetta audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -580,8 +580,8 @@ module Cask
 
           result = case artifact
           when Artifact::App
-            files = Dir[path/"Contents/MacOS/*"].reject do |f|
-              !File.executable?(f) || File.directory?(f) || f.end_with?(".dylib")
+            files = Dir[path/"Contents/MacOS/*"].select do |f|
+              File.executable?(f) && !File.directory?(f) && !f.end_with?(".dylib")
             end
             add_error "No binaries in App: #{artifact.source}", location: cask.url.location if files.empty?
             system_command("lipo", args: ["-archs", files.first], print_stderr: false)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #17573 to address the following -

1. Remove `binary` artifacts if they are part of an `app` bundle.  This was the same change I made in signing detection to avoid checking shell scripts or other plain files.  Visual Studio Code, for example, fails without this change as a shell script artifact is picked up for assessment.

2. Filter out files like `.dylib` and folders that shouldn't be in the `<app>/Contents/MacOS/`folder, but are there anyway. (See https://github.com/Homebrew/homebrew-cask/pull/177949 for a failure scenario)