### PR TITLE
Use API for description searches

### DIFF
--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -47,7 +47,7 @@ module Homebrew
         end
 
         if search_type.present?
-          if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
+          if !args.eval_all? && !Homebrew::EnvConfig.eval_all? && Homebrew::EnvConfig.no_install_from_api?
             raise UsageError, "`brew desc --search` needs `--eval-all` passed or `HOMEBREW_EVAL_ALL` set!"
           end
 

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -70,7 +70,7 @@ module Homebrew
         string_or_regex = Search.query_regexp(query)
 
         if args.desc?
-          if !args.eval_all? && !Homebrew::EnvConfig.eval_all?
+          if !args.eval_all? && !Homebrew::EnvConfig.eval_all? && Homebrew::EnvConfig.no_install_from_api?
             raise UsageError, "`brew search --desc` needs `--eval-all` passed or `HOMEBREW_EVAL_ALL` set!"
           end
 

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -8,8 +8,10 @@ require "search"
 # Helper class for printing and searching descriptions.
 class Descriptions
   # Given a regex, find all formulae whose specified fields contain a match.
-  def self.search(string_or_regex, field, cache_store, eval_all = Homebrew::EnvConfig.eval_all?)
-    cache_store.populate_if_empty!(eval_all:)
+  def self.search(string_or_regex, field, cache_store,
+                  eval_all = Homebrew::EnvConfig.eval_all?, cache_store_hash: false)
+
+    cache_store.populate_if_empty!(eval_all:) unless cache_store_hash
 
     results = case field
     when :name

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -30,4 +30,11 @@ RSpec.describe Homebrew::Cmd::Desc do
       .to output(/testball: Some test/).to_stdout
       .and not_to_output.to_stderr
   end
+
+  it "successfully searches without --eval-all, with API", :integration_test do
+    setup_test_formula "testball"
+
+    expect { brew "desc", "--search", "testball", "HOMEBREW_NO_INSTALL_FROM_API" => nil }
+      .to be_a_success
+  end
 end


### PR DESCRIPTION
Both `brew search --desc` and `brew desc --search` use API for cask and formula searches unless `--eval-all` or `HOMEBREW_EVAL_ALL` set. Description searches do not use the description cache or eval any formulas/casks.

With `--eval-all`, description search reverts to the old behavior.

This will resolve #16237.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is intentionally a draft, looking for comments on this direction.