### PR TITLE
extract: Add the --git-revision argument

### DIFF
--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/extract.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/extract.rbi
@@ -18,5 +18,8 @@ class Homebrew::DevCmd::Extract::Args < Homebrew::CLI::Args
   def force?; end
 
   sig { returns(T.nilable(String)) }
+  def git_revision; end
+
+  sig { returns(T.nilable(String)) }
   def version; end
 end

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -44,6 +44,16 @@ RSpec.describe Homebrew::DevCmd::Extract do
       expect(Formulary.factory(path).version).to eq "0.2"
     end
 
+    it "retrieves the most recent version of formula starting at the specified revision", :integration_test do
+      path = target[:path]/"Formula/testball@0.1.rb"
+      expect { brew "extract", "testball", target[:name], "--git-revision=HEAD~1" }
+        .to output(/^#{path}$/).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+      expect(path).to exist
+      expect(Formulary.factory(path).version).to eq "0.1"
+    end
+
     it "retrieves the specified version of formula", :integration_test do
       path = target[:path]/"Formula/testball@0.1.rb"
       expect { brew "extract", "testball", target[:name], "--version=0.1" }

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -44,16 +44,6 @@ RSpec.describe Homebrew::DevCmd::Extract do
       expect(Formulary.factory(path).version).to eq "0.2"
     end
 
-    it "retrieves the most recent version of formula starting at the specified revision", :integration_test do
-      path = target[:path]/"Formula/testball@0.1.rb"
-      expect { brew "extract", "testball", target[:name], "--git-revision=HEAD~1" }
-        .to output(/^#{path}$/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-      expect(path).to exist
-      expect(Formulary.factory(path).version).to eq "0.1"
-    end
-
     it "retrieves the specified version of formula", :integration_test do
       path = target[:path]/"Formula/testball@0.1.rb"
       expect { brew "extract", "testball", target[:name], "--version=0.1" }


### PR DESCRIPTION
When pinning formula alongside its dependencies it's important to limit the search scope.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
