### PR TITLE
autoremove: skip formulae where installed_on_request is nil

### DIFF
--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -107,6 +107,13 @@ RSpec.describe Utils::Autoremove do
       expect(described_class.send(:unused_formulae_with_no_formula_dependents, formulae))
         .to match_array(formulae)
     end
+
+    specify "installed on request is null" do
+      allow(tab_from_keg).to receive(:installed_on_request).and_return(nil)
+
+      expect(described_class.send(:unused_formulae_with_no_formula_dependents, formulae))
+        .to eq([])
+    end
   end
 
   shared_context "with formulae and casks for dependency testing" do

--- a/Library/Homebrew/utils/autoremove.rb
+++ b/Library/Homebrew/utils/autoremove.rb
@@ -61,8 +61,8 @@ module Utils
       # @private
       sig { params(formulae: T::Array[Formula]).returns(T::Array[Formula]) }
       def unused_formulae_with_no_formula_dependents(formulae)
-        unused_formulae = bottled_formulae_with_no_formula_dependents(formulae).reject do |f|
-          f.any_installed_keg&.tab&.installed_on_request
+        unused_formulae = bottled_formulae_with_no_formula_dependents(formulae).select do |f|
+          f.any_installed_keg&.tab&.installed_on_request == false
         end
 
         unless unused_formulae.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes <https://github.com/Homebrew/brew/issues/17572>

This PR modifies the `autoremove` formula detection logic to only include formulae who's tab `installed_on_request` value is `false`. This is to prevent `autoremove` from removing formulae that have malformed install receipts which make us unsure whether they were actually installed on request or not. Instead, let's err on the side of caution and not remove the formula.
