### PR TITLE
Remove redundant early return in livecheck `skip_conditions`

### DIFF
--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -230,7 +230,6 @@ module Homebrew
         when Resource
           RESOURCE_CHECKS
         end
-        return {} unless checks
 
         checks.each do |method_name|
           skip_hash = case method_name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is currently blocking <https://github.com/Homebrew/brew/pull/17586>, <https://github.com/Homebrew/brew/pull/17586>, and <https://github.com/Homebrew/brew/pull/17587>:

```console
$ brew typecheck
livecheck/skip_conditions.rb:233: This code is unreachable https://srb.help/7006
     233 |        return {} unless checks
                  ^^^^^^^^^
    livecheck/skip_conditions.rb:233: This condition was always `truthy` (`[Symbol, Symbol, Symbol, Symbol, Symbol]`)
     233 |        return {} unless checks
                                   ^^^^^^
  Got `[Symbol, Symbol, Symbol, Symbol, Symbol] (5-tuple)` originating from:
    livecheck/skip_conditions.rb:188:
     188 |      FORMULA_CHECKS = [
                ^^^^^^^^^^^^^^
    livecheck/skip_conditions.rb:233: This condition was always `truthy` (`[Symbol, Symbol, Symbol, Symbol, Symbol, Symbol]`)
     233 |        return {} unless checks
                                   ^^^^^^
  Got `[Symbol, Symbol, Symbol, Symbol, Symbol, Symbol] (6-tuple)` originating from:
    livecheck/skip_conditions.rb:197:
     197 |      CASK_CHECKS = [
                ^^^^^^^^^^^
    livecheck/skip_conditions.rb:233: This condition was always `truthy` (`[Symbol]`)
     233 |        return {} unless checks
                                   ^^^^^^
  Got `[Symbol] (1-tuple)` originating from:
    livecheck/skip_conditions.rb:207:
     207 |      RESOURCE_CHECKS = [
                ^^^^^^^^^^^^^^^

```

As far as I can tell, `brew typecheck` is correct that `check` can never be falsey at this point. I believe that only `Formula`, `Cask::Cask`, and `Resource` implement `#livecheckable?`, so I don't think there's a way for `package_or_resource` to not match one of the three cases.

If we are worried, we can also change the next line to be `checks&.each do |method_name|`.
