### PR TITLE
style: chdir before running rubocop

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -327,6 +327,11 @@ Style/Documentation:
     - "**/{Formula,Casks}/**/*.rb"
     - "**/*.rbi"
 
+# This is impossible to fix if the line exceeds the maximum length.
+Style/EmptyMethod:
+  Exclude:
+    - "**/*.rbi"
+
 # This is quite a large change, so don't enforce this yet for formulae.
 # We should consider doing so in the future, but be aware of the impact on third-party taps.
 Style/FetchEnvVar:


### PR DESCRIPTION
This fixes longstanding issues when the working directory is incorrect, including incorrect globbing of include/excludes and spurious warnings such as:

```console
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-minitest (https://rubygems.org/gems/rubocop-minitest)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```