### PR TITLE
cask/audit: handle arch-specific detected min OS

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -667,9 +667,12 @@ module Cask
       end
       odebug "Declared minimum OS version: #{cask_min_os&.to_sym}"
       return if cask_min_os&.to_sym == min_os.to_sym
+      return if cask.on_system_blocks_exist? &&
+                OnSystem.arch_condition_met?(:arm) &&
+                cask_min_os < MacOSVersion.new("11")
 
       min_os_definition = if cask_min_os.present?
-        if cask.on_system_blocks_exist?
+        if cask.on_system_blocks_exist? && cask.on_system_block_min_os.present?
           "a block with a minimum OS version of #{cask.on_system_block_min_os.inspect}"
         else
           cask_min_os.to_sym.inspect


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Some packages that provide separate downloads for Intel and ARM specify different minimum OS versions within each (e.g. `libreoffice-still`, `mixxx`, `motion`, `wireshark`, `xsplit-vcam`). Obviously ARM versions won't run on anything earlier than macOS 11 since previous releases are Intel-only, but `cask/audit` needs to be told as much.

This change helps `cask/audit` assume that the declared `depends_on macos:` value applies only to Intel by returning early if:
- the cask uses on_os blocks in some form, whether explicitly or implicitly (e.g. arch-specific URLs & SHA values) (so an ARM-only cask defining a non-matching `depends_on macos:` will still be flagged)
- audit is evaluating `:arm`
- the declared min OS is less than macOS 11 (so a cask declaring a too-low or too-high `depends_on macos:` that's >= Big Sur will still be flagged)

This does assume we won't encounter a cask whose separate arch builds have the same version number but, say, requiring `>= :monterey` on ARM while still compatible with `:catalina` and earlier on Intel.

Before:
```console
$ brew audit --cask --strict --online --only=min_os -d --os=ventura --arch=arm mixxx
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromNameLoader): loading mixxx
…
==> Detected minimum OS version: Plist 11
==> Declared minimum OS version: sierra
audit for mixxx: failed
 - Upstream defined :big_sur as the minimum OS version and the cask declared :sierra
```

Also fixes a line missed in #17565.