### PR TITLE
Use effective_arch for rustflags

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -34,7 +34,7 @@ module Stdenv
     self["PKG_CONFIG_LIBDIR"] = determine_pkg_config_libdir
 
     self["MAKEFLAGS"] = "-j#{make_jobs}"
-    self["RUSTFLAGS"] = Hardware.rustflags_target_cpu
+    self["RUSTFLAGS"] = Hardware.rustflags_target_cpu(effective_arch)
 
     if HOMEBREW_PREFIX.to_s != "/usr/local"
       # /usr/local is already an -isystem and -L directory so we skip it

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -62,7 +62,7 @@ module Superenv
 
     self["HOMEBREW_ENV"] = "super"
     self["MAKEFLAGS"] ||= "-j#{determine_make_jobs}"
-    self["RUSTFLAGS"] = Hardware.rustflags_target_cpu
+    self["RUSTFLAGS"] = Hardware.rustflags_target_cpu(effective_arch)
     self["PATH"] = determine_path
     self["PKG_CONFIG_PATH"] = determine_pkg_config_path
     self["PKG_CONFIG_LIBDIR"] = determine_pkg_config_libdir

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -231,7 +231,7 @@ module Hardware
       # Rust already defaults to the oldest supported cpu for each target-triplet
       # so it's safe to ignore generic archs such as :armv6 here.
       # Rust defaults to apple-m1 since Rust 1.71 for aarch64-apple-darwin.
-      @target_cpu ||= case (arch)
+      @target_cpu ||= case arch
       when :core
         :prescott
       when :native, :ivybridge, :sandybridge, :westmere, :nehalem, :core2

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -226,16 +226,16 @@ module Hardware
 
     # Returns a Rust flag to set the target CPU if necessary.
     # Defaults to nil.
-    sig { returns(T.nilable(String)) }
-    def rustflags_target_cpu
+    sig { params(arch: Symbol).returns(T.nilable(String)) }
+    def rustflags_target_cpu(arch)
       # Rust already defaults to the oldest supported cpu for each target-triplet
       # so it's safe to ignore generic archs such as :armv6 here.
       # Rust defaults to apple-m1 since Rust 1.71 for aarch64-apple-darwin.
-      @target_cpu ||= case (cpu = oldest_cpu)
+      @target_cpu ||= case (arch)
       when :core
         :prescott
       when :native, :ivybridge, :sandybridge, :westmere, :nehalem, :core2
-        cpu
+        arch
       end
       return if @target_cpu.blank?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix for issue: #17566

This PR adds a parameter to the `rustflags_target_cpu` method to provide the desired architecture rather than using a hard-coded value of `oldest_cpu`. This allows for bottles built locally using Rust to use the `native` CPU architecture. 

I was able to test this locally by interactively installing a bottle and checking the `RUSTFLAGS` environment variable was set correctly.
