### PR TITLE
sorbet: Migrate `dev-cmd` files from `typed: true` to `typed: strict`

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -329,6 +329,7 @@ module Homebrew
 
       private
 
+      sig { params(results: T::Hash[[Symbol, Pathname], T::Array[T::Hash[Symbol, T.untyped]]]).void }
       def print_problems(results)
         results.each do |(name, path), problems|
           problem_lines = format_problem_lines(problems)
@@ -343,6 +344,7 @@ module Homebrew
         end
       end
 
+      sig { params(problems: T::Array[T::Hash[Symbol, T.untyped]]).returns(T::Array[String]) }
       def format_problem_lines(problems)
         problems.map do |problem|
           status = " #{Formatter.success("[corrected]")}" if problem.fetch(:corrected)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -299,7 +299,7 @@ module Homebrew
         !absolute_symlinks_start_with_string.empty?
       end
 
-      sig { params(cellar: T.nilable(T.any(String, Symbol))).returns(T.nilable(T::Boolean)) }
+      sig { params(cellar: T.nilable(T.any(String, Symbol))).returns(T::Boolean) }
       def cellar_parameter_needed?(cellar)
         default_cellars = [
           Homebrew::DEFAULT_MACOS_CELLAR,

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -111,8 +111,8 @@ module Homebrew
       end
 
       sig {
-        params(tag: String, digest: String, cellar: T.any(Symbol, String), tag_column: Integer,
-               digest_column: Integer).returns(String)
+        params(tag: Symbol, digest: T.any(Checksum, String), cellar: T.nilable(T.any(String, Symbol)),
+               tag_column: Integer, digest_column: Integer).returns(String)
       }
       def generate_sha256_line(tag, digest, cellar, tag_column, digest_column)
         line = "sha256 "
@@ -299,7 +299,7 @@ module Homebrew
         !absolute_symlinks_start_with_string.empty?
       end
 
-      sig { params(cellar: String).returns(T.nilable(T::Boolean)) }
+      sig { params(cellar: T.nilable(T.any(String, Symbol))).returns(T.nilable(T::Boolean)) }
       def cellar_parameter_needed?(cellar)
         default_cellars = [
           Homebrew::DEFAULT_MACOS_CELLAR,

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -558,7 +558,9 @@ module Homebrew
           end
           return
         end
-        FileUtils.mv T.must(alias_rename.first), T.must(alias_rename.last) if alias_rename.present?
+        if alias_rename && (source = alias_rename.first) && (destination = alias_rename.last)
+          FileUtils.mv source, destination
+        end
         failed_audit = false
         if args.no_audit?
           ohai "Skipping `brew audit`"
@@ -572,7 +574,9 @@ module Homebrew
         return unless failed_audit
 
         formula.path.atomic_write(old_contents)
-        FileUtils.mv T.must(alias_rename.last), T.must(alias_rename.first) if alias_rename.present?
+        if alias_rename && (source = alias_rename.first) && (destination = alias_rename.last)
+          FileUtils.mv source, destination
+        end
         odie "`brew audit` failed!"
       end
     end

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -434,7 +434,10 @@ module Homebrew
         new_url.gsub(%r{/(v?)#{Regexp.escape(partial_old_version)}/}, "/\\1#{partial_new_version}/")
       end
 
-      sig { params(formula: Formula, new_version: T.nilable(String), url: String, specs: Float).returns(T::Array[T.untyped]) }
+      sig {
+        params(formula: Formula, new_version: T.nilable(String), url: String,
+               specs: Float).returns(T::Array[T.untyped])
+      }
       def fetch_resource_and_forced_version(formula, new_version, url, **specs)
         resource = Resource.new
         resource.url(url, **specs)
@@ -459,13 +462,18 @@ module Homebrew
 
       sig { params(formula: Formula, tap_remote_repo: String).returns(T.nilable(T::Array[String])) }
       def check_open_pull_requests(formula, tap_remote_repo)
-        GitHub.check_for_duplicate_pull_requests(formula.name, tap_remote_repo,
-                                                 state: "open",
-                                                 file:  formula.path.relative_path_from(T.must(formula.tap).path).to_s,
-                                                 quiet: args.quiet?)
+        GitHub.check_for_duplicate_pull_requests(
+          formula.name, tap_remote_repo,
+          state: "open",
+          file:  formula.path.relative_path_from(T.must(formula.tap).path).to_s,
+          quiet: args.quiet?
+        )
       end
 
-      sig { params(formula: Formula, tap_remote_repo: String, version: T.nilable(String), url: T.nilable(String), tag: T.nilable(String)).void }
+      sig {
+        params(formula: Formula, tap_remote_repo: String, version: T.nilable(String), url: T.nilable(String),
+               tag: T.nilable(String)).void
+      }
       def check_new_version(formula, tap_remote_repo, version: nil, url: nil, tag: nil)
         if version.nil?
           specs = {}
@@ -493,14 +501,19 @@ module Homebrew
         odie "#{formula} should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
       end
 
-      sig { params(formula: Formula, tap_remote_repo: String, version: T.nilable(String)).returns(T.nilable(T::Array[String])) }
+      sig {
+        params(formula: Formula, tap_remote_repo: String,
+               version: T.nilable(String)).returns(T.nilable(T::Array[String]))
+      }
       def check_closed_pull_requests(formula, tap_remote_repo, version:)
         # if we haven't already found open requests, try for an exact match across closed requests
-        GitHub.check_for_duplicate_pull_requests(formula.name, tap_remote_repo,
-                                                 version:,
-                                                 state:   "closed",
-                                                 file:    formula.path.relative_path_from(T.must(formula.tap).path).to_s,
-                                                 quiet:   args.quiet?)
+        GitHub.check_for_duplicate_pull_requests(
+          formula.name, tap_remote_repo,
+          version:,
+          state:   "closed",
+          file:    formula.path.relative_path_from(T.must(formula.tap).path).to_s,
+          quiet:   args.quiet?
+        )
       end
 
       sig { params(formula: Formula, new_formula_version: String).returns(T.nilable(T::Array[String])) }

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -116,7 +116,7 @@ module Homebrew
         end
       end
 
-      sig { params(totals: T::Hash[T.untyped, T.untyped]).returns(String) }
+      sig { params(totals: T::Hash[String, T::Hash[Symbol, Integer]]).returns(String) }
       def generate_csv(totals)
         CSV.generate do |csv|
           csv << %w[user repo author committer coauthor review total]
@@ -127,7 +127,14 @@ module Homebrew
         end
       end
 
-      sig { params(user: String, grand_total: T::Hash[Symbol, T.untyped]).returns(T::Array[T.any(String, Integer)]) }
+      sig {
+        params(
+          user:        String,
+          grand_total: T::Hash[Symbol, Integer],
+        ).returns(
+          [String, String, T.nilable(Integer), T.nilable(Integer), T.nilable(Integer), T.nilable(Integer), Integer],
+        )
+      }
       def grand_total_row(user, grand_total)
         [
           user,

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -10,7 +10,7 @@ end
 module Homebrew
   module DevCmd
     class Contributions < AbstractCommand
-      PRIMARY_REPOS = %w[brew core cask].freeze
+      PRIMARY_REPOS = T.let(%w[brew core cask].freeze, T::Array[String])
       SUPPORTED_REPOS = T.let([
         PRIMARY_REPOS,
         OFFICIAL_CMD_TAPS.keys.map { |t| t.delete_prefix("homebrew/") },
@@ -50,12 +50,12 @@ module Homebrew
         results = {}
         grand_totals = {}
 
-        repos = if args.repositories.blank? || T.must(args.repositories).include?("primary")
+        repos = if args.repositories.blank? || args.repositories&.include?("primary")
           PRIMARY_REPOS
-        elsif T.must(args.repositories).include?("all")
+        elsif args.repositories&.include?("all")
           SUPPORTED_REPOS
         else
-          T.must(args.repositories)
+          args.repositories
         end
 
         from = args.from.presence || Date.today.prev_year.iso8601
@@ -147,8 +147,10 @@ module Homebrew
         ]
       end
 
-      sig { params(repos: T::Array[String], person: String, from: String).void }
+      sig { params(repos: T.nilable(T::Array[String]), person: String, from: String).void }
       def scan_repositories(repos, person, from:)
+        return if repos.blank?
+
         data = {}
 
         repos.each do |repo|

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "abstract_command"

--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -71,6 +71,7 @@ module Homebrew
 
       private
 
+      sig { params(title: String).returns(String) }
       def html_template(title)
         <<~EOS
           ---

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -69,6 +69,7 @@ module Homebrew
 
       private
 
+      sig { params(title: String).returns(String) }
       def html_template(title)
         <<~EOS
           ---

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -7,12 +7,14 @@ require "cask/cask_loader"
 
 class String
   # @!visibility private
+  sig { params(args: Integer).returns(Formula) }
   def f(*args)
     require "formula"
     Formulary.factory(self, *args)
   end
 
   # @!visibility private
+  sig { params(config: T.nilable(T::Hash[Symbol, T.untyped])).returns(Cask::Cask) }
   def c(config: nil)
     Cask::CaskLoader.load(self, config:)
   end
@@ -20,11 +22,13 @@ end
 
 class Symbol
   # @!visibility private
+  sig { params(args: Integer).returns(Formula) }
   def f(*args)
     to_s.f(*args)
   end
 
   # @!visibility private
+  sig { params(config: T.nilable(T::Hash[Symbol, T.untyped])).returns(Cask::Cask) }
   def c(config: nil)
     to_s.c(config:)
   end
@@ -94,6 +98,7 @@ module Homebrew
 
       # Remove the `--debug`, `--verbose` and `--quiet` options which cause problems
       # for IRB and have already been parsed by the CLI::Parser.
+      sig { returns(T.nilable(T::Array[Symbol])) }
       def clean_argv
         global_options = Homebrew::CLI::Parser
                          .global_options

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "formula"
 require "formulary"
 require "cask/cask_loader"
 
@@ -9,7 +10,6 @@ class String
   # @!visibility private
   sig { params(args: Integer).returns(Formula) }
   def f(*args)
-    require "formula"
     Formulary.factory(self, *args)
   end
 
@@ -76,7 +76,6 @@ module Homebrew
           require "irb"
         end
 
-        require "formula"
         require "keg"
         require "cask"
 

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -113,8 +113,9 @@ module Homebrew
 
       private
 
+      sig { returns(String) }
       def watchlist_path
-        @watchlist_path ||= File.expand_path(Homebrew::EnvConfig.livecheck_watchlist)
+        @watchlist_path ||= T.let(File.expand_path(Homebrew::EnvConfig.livecheck_watchlist), T.nilable(String))
       end
     end
   end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -243,7 +243,10 @@ module Homebrew
         end
       end
 
-      sig { params(old_contents: String, new_contents: String, subject_path: T.any(String, Pathname), reason: T.nilable(String)).returns(String) }
+      sig {
+        params(old_contents: String, new_contents: String, subject_path: T.any(String, Pathname),
+               reason: T.nilable(String)).returns(String)
+      }
       def determine_bump_subject(old_contents, new_contents, subject_path, reason: nil)
         subject_path = Pathname(subject_path)
         tap          = Tap.from_path(subject_path)
@@ -272,7 +275,10 @@ module Homebrew
 
       # Cherry picks a single commit that modifies a single file.
       # Potentially rewords this commit using {determine_bump_subject}.
-      sig { params(commit: String, file: String, git_repo: GitRepository, reason: T.nilable(String), verbose: T::Boolean, resolve: T::Boolean).void }
+      sig {
+        params(commit: String, file: String, git_repo: GitRepository, reason: T.nilable(String), verbose: T::Boolean,
+               resolve: T::Boolean).void
+      }
       def reword_package_commit(commit, file, git_repo:, reason: "", verbose: false, resolve: false)
         package_file = git_repo.pathname / file
         package_name = package_file.basename.to_s.chomp(".rb")
@@ -298,7 +304,10 @@ module Homebrew
       # Cherry picks multiple commits that each modify a single file.
       # Words the commit according to {determine_bump_subject} with the body
       # corresponding to all the original commit messages combined.
-      sig { params(commits: T::Array[String], file: String, git_repo: GitRepository, reason: T.nilable(String), verbose: T::Boolean, resolve: T::Boolean).void }
+      sig {
+        params(commits: T::Array[String], file: String, git_repo: GitRepository, reason: T.nilable(String),
+               verbose: T::Boolean, resolve: T::Boolean).void
+      }
       def squash_package_commits(commits, file, git_repo:, reason: "", verbose: false, resolve: false)
         odebug "Squashing #{file}: #{commits.join " "}"
 
@@ -346,7 +355,10 @@ module Homebrew
       end
 
       # TODO: fix test in `test/dev-cmd/pr-pull_spec.rb` and assume `cherry_picked: false`.
-      sig { params(original_commit: String, tap: Tap, reason: String, verbose: T::Boolean, resolve: T::Boolean, cherry_picked: T::Boolean).void }
+      sig {
+        params(original_commit: String, tap: Tap, reason: String, verbose: T::Boolean, resolve: T::Boolean,
+               cherry_picked: T::Boolean).void
+      }
       def autosquash!(original_commit, tap:, reason: "", verbose: false, resolve: false, cherry_picked: true)
         git_repo = tap.git_repository
         original_head = git_repo.head_ref

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -120,6 +120,7 @@ module Homebrew
 
       private
 
+      sig { params(bottles_hash: T::Hash[String, T.untyped]).void }
       def check_bottled_formulae!(bottles_hash)
         bottles_hash.each do |name, bottle_hash|
           formula_path = HOMEBREW_REPOSITORY/bottle_hash["formula"]["path"]
@@ -131,22 +132,25 @@ module Homebrew
         end
       end
 
+      sig { params(bottles_hash: T::Hash[String, T.untyped]).returns(T::Boolean) }
       def github_releases?(bottles_hash)
-        @github_releases ||= bottles_hash.values.all? do |bottle_hash|
+        @github_releases ||= T.let(bottles_hash.values.all? do |bottle_hash|
           root_url = bottle_hash["bottle"]["root_url"]
           url_match = root_url.match GitHubReleases::URL_REGEX
           _, _, _, tag = *url_match
 
           tag
-        end
+        end, T.nilable(T::Boolean))
       end
 
+      sig { params(bottles_hash: T::Hash[String, T.untyped]).returns(T::Boolean) }
       def github_packages?(bottles_hash)
-        @github_packages ||= bottles_hash.values.all? do |bottle_hash|
+        @github_packages ||= T.let(bottles_hash.values.all? do |bottle_hash|
           bottle_hash["bottle"]["root_url"].match? GitHubPackages::URL_REGEX
-        end
+        end, T.nilable(T::Boolean))
       end
 
+      sig { params(json_files: T::Array[String], args: T.untyped).returns(T::Hash[String, T.untyped]) }
       def bottles_hash_from_json_files(json_files, args)
         puts "Reading JSON files: #{json_files.join(", ")}" if args.verbose?
 

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -197,6 +197,7 @@ module Homebrew
 
       private
 
+      sig { params(tap: Tap, filename: T.any(String, Pathname), content: String).void }
       def write_path(tap, filename, content)
         path = tap.path/filename
         tap.path.mkpath

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -110,8 +110,9 @@ module Homebrew
 
       private
 
+      sig { params(formula: Formula).returns(T::Boolean) }
       def retry_test?(formula)
-        @test_failed ||= Set.new
+        @test_failed ||= T.let(Set.new, T.nilable(T::Set[T.untyped]))
         if args.retry? && @test_failed.add?(formula)
           oh1 "Testing #{formula.full_name} (again)"
           formula.clear_cache

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -168,15 +168,17 @@ module Homebrew
 
       private
 
+      sig { returns(T.nilable(T::Boolean)) }
       def use_buildpulse?
         return @use_buildpulse if defined?(@use_buildpulse)
 
-        @use_buildpulse = ENV["HOMEBREW_BUILDPULSE_ACCESS_KEY_ID"].present? &&
+        @use_buildpulse = T.let(ENV["HOMEBREW_BUILDPULSE_ACCESS_KEY_ID"].present? &&
                           ENV["HOMEBREW_BUILDPULSE_SECRET_ACCESS_KEY"].present? &&
                           ENV["HOMEBREW_BUILDPULSE_ACCOUNT_ID"].present? &&
-                          ENV["HOMEBREW_BUILDPULSE_REPOSITORY_ID"].present?
+                          ENV["HOMEBREW_BUILDPULSE_REPOSITORY_ID"].present?, T.nilable(T::Boolean))
       end
 
+      sig { void }
       def run_buildpulse
         require "formula"
 
@@ -198,6 +200,7 @@ module Homebrew
                        ]
       end
 
+      sig { returns(T::Array[String]) }
       def changed_test_files
         changed_files = Utils.popen_read("git", "diff", "--name-only", "master")
 
@@ -215,6 +218,7 @@ module Homebrew
         end.select(&:exist?)
       end
 
+      sig { returns(T::Array[String]) }
       def setup_environment!
         # Cleanup any unwanted user configuration.
         allowed_test_env = %w[

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -34,11 +34,14 @@ module Homebrew
       def run
         Formulary.enable_factory_cache!
 
-        @bottle_tag = T.let(if (tag = args.tag)
-          Utils::Bottles::Tag.from_symbol(tag.to_sym)
-        else
-          Utils::Bottles.tag
-        end, T.nilable(Utils::Bottles::Tag))
+        @bottle_tag = T.let(
+          if (tag = args.tag)
+            Utils::Bottles::Tag.from_symbol(tag.to_sym)
+          else
+            Utils::Bottles.tag
+          end,
+          T.nilable(Utils::Bottles::Tag),
+        )
 
         if args.lost?
           if args.named.present?
@@ -104,7 +107,9 @@ module Homebrew
 
       private
 
-      sig { params(all: T::Boolean).returns([T::Array[Formula], T::Array[Formula], T.nilable(T::Hash[Symbol, Integer])]) }
+      sig {
+        params(all: T::Boolean).returns([T::Array[Formula], T::Array[Formula], T.nilable(T::Hash[Symbol, Integer])])
+      }
       def formulae_all_installs_from_args(all)
         if args.named.present?
           formulae = all_formulae = args.named.to_formulae
@@ -152,7 +157,8 @@ module Homebrew
         formulae = Array(formulae).reject(&:deprecated?) if formulae.present?
         all_formulae = Array(all_formulae).reject(&:deprecated?) if all_formulae.present?
 
-        [T.let(formulae, T::Array[Formula]), T.let(all_formulae, T::Array[Formula]), T.let(T.must(formula_installs), T.nilable(T::Hash[Symbol, Integer]))]
+        [T.let(formulae, T::Array[Formula]), T.let(all_formulae, T::Array[Formula]),
+         T.let(T.must(formula_installs), T.nilable(T::Hash[Symbol, Integer]))]
       end
 
       sig { params(all_formulae: T.untyped).returns([T::Hash[String, T.untyped], T::Hash[String, T.untyped]]) }
@@ -191,7 +197,11 @@ module Homebrew
         puts "#{unbottled_formulae}/#{formulae.length} remaining."
       end
 
-      sig { params(formulae: T::Array[Formula], deps_hash: T::Hash[T.any(Symbol, String), T.untyped], noun: T.nilable(String), hash: T::Hash[T.any(Symbol, String), T.untyped], any_named_args: T::Boolean).returns(NilClass) }
+      sig {
+        params(formulae: T::Array[Formula], deps_hash: T::Hash[T.any(Symbol, String), T.untyped],
+               noun: T.nilable(String), hash: T::Hash[T.any(Symbol, String), T.untyped],
+               any_named_args: T::Boolean).returns(NilClass)
+      }
       def output_unbottled(formulae, deps_hash, noun, hash, any_named_args)
         ohai ":#{@bottle_tag} bottle status#{@sort}"
         any_found = T.let(false, T::Boolean)

--- a/Library/Homebrew/dev-cmd/update-sponsors.rb
+++ b/Library/Homebrew/dev-cmd/update-sponsors.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -62,14 +62,17 @@ module Homebrew
 
       private
 
+      sig { params(sponsor: T::Hash[Symbol, T.untyped]).returns(T.nilable(String)) }
       def sponsor_name(sponsor)
         sponsor[:name] || sponsor[:login]
       end
 
+      sig { params(sponsor: T::Hash[Symbol, T.untyped]).returns(String) }
       def sponsor_logo(sponsor)
         "https://github.com/#{sponsor[:login]}.png?size=64"
       end
 
+      sig { params(sponsor: T::Hash[Symbol, T.untyped]).returns(String) }
       def sponsor_url(sponsor)
         "https://github.com/#{sponsor[:login]}"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/17297.

-----

~Draft because I'm not quite done yet (`dev-cmd/bottle` is being annoyingly fiddly) and I need to do a self-review of this PR to catch any little things I missed.~

- ~There's lots of `T.must` here. I could probably do better with returning early or otherwise handling `nil`s.~
- There's quite a lot of `T.untyped` that I could think more about? ~Some of them are auto-fixed signatures that I need to go and tighten up.~