### PR TITLE
Load tap migration renames from API with short names

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -458,14 +458,14 @@ module Cask
 
         # If it exists in the default tap, never treat it as ambiguous with another tap.
         if (core_cask_tap = CoreCaskTap.instance).installed? &&
-           (loader = super("#{core_cask_tap}/#{token}", warn:))&.path&.exist?
-          return loader
+           (core_cask_loader = super("#{core_cask_tap}/#{token}", warn:))&.path&.exist?
+          return core_cask_loader
         end
 
         loaders = Tap.select { |tap| tap.installed? && !tap.core_cask_tap? }
                      .filter_map { |tap| super("#{tap}/#{token}", warn:) }
                      .uniq(&:path)
-                     .select { |tap| tap.path.exist? }
+                     .select { |loader| loader.is_a?(FromAPILoader) || loader.path.exist? }
 
         case loaders.count
         when 1

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -825,14 +825,14 @@ module Formulary
 
       # If it exists in the default tap, never treat it as ambiguous with another tap.
       if (core_tap = CoreTap.instance).installed? &&
-         (loader = super("#{core_tap}/#{name}", warn:))&.path&.exist?
-        return loader
+         (core_loader = super("#{core_tap}/#{name}", warn:))&.path&.exist?
+        return core_loader
       end
 
       loaders = Tap.select { |tap| tap.installed? && !tap.core_tap? }
                    .filter_map { |tap| super("#{tap}/#{name}", warn:) }
                    .uniq(&:path)
-                   .select { |tap| tap.path.exist? }
+                   .select { |loader| loader.is_a?(FromAPILoader) || loader.path.exist? }
 
       case loaders.count
       when 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
   - I updated existing tests.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to https://github.com/Homebrew/brew/commit/484498ea7c2ad124f3b4efc517ddf5057b225b14. I added loading for tap migration
renames from the API but it apparently only worked for full names.

There were bugs in both the code and the tests which prevented loading by short names as pointed out by @Logicer16 (https://github.com/Homebrew/brew/pull/17599#issuecomment-2199997644). This fixes those bugs so everything should be good now.

I recommend reviewing this with the `Hide Whitespace` setting enabled.

- Issue: https://github.com/Homebrew/brew/issues/17234
- Previous PR: https://github.com/Homebrew/brew/pull/17599