### PR TITLE
cask/audit: handle on_os range bounded by depends_on

### DIFF
--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -131,9 +131,9 @@ module OnSystem
         return unless OnSystem.os_condition_met? os_condition, or_condition
 
         @on_system_block_min_os = if or_condition == :or_older
-          MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED).to_sym
+          @called_in_on_system_block ? @on_system_block_min_os : MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED)
         else
-          os_condition
+          MacOSVersion.from_symbol(os_condition)
         end
         @called_in_on_system_block = true
         result = block.call


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Most casks using on_os blocks have `:or_older` on the oldest block to ensure all macOS versions can retrieve a URL and version number for the cask, then also specify a `depends_on macos:` value that matches the oldest macOS version supported by the oldest on_os block. For example, [`airfoil`](https://formulae.brew.sh/cask/airfoil) has both an `on_ventura :or_older` block and a `depends_on macos: ">= :big_sur"` stanza. Others using this arrangement include `audio-hijack`, `cd-to`, `piezo`, `raycast`, and more.

This change adjusts the `audit_min_os` logic to check the minimum OS values of the `depends_on macos:` stanza and current on_os block, and use the greater of the two as the declared minimum OS version for the cask. 

Before:
```console
$ brew audit --cask --strict --online --only=min_os -d --os=ventura --arch=intel airfoil
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromNameLoader): loading airfoil
…
==> Detected minimum OS version: Plist 11 | Sparkle 11
==> Declared minimum OS version: el_capitan
audit for airfoil: failed
 - Upstream defined :big_sur as the minimum OS version and the cask declared a block with a minimum OS version of :el_capitan
```

This also changes `on_system.rb` to check if an on_os block is nested and return the containing block's minimum OS version instead of the oldest supported OS version. This allows casks that use nested on_os blocks to specify an inner range of OS versions all with the same info, which is only used so far by [`birdfont`](https://formulae.brew.sh/cask/birdfont).

Before:
```console
$ brew audit --cask --strict --online --only=min_os -d --os=ventura --arch=intel birdfont
/usr/local/Homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::FromNameLoader): loading birdfont
…
==> Detected minimum OS version: Plist 10.15
==> Declared minimum OS version: el_capitan
audit for birdfont: failed
 - Upstream defined :catalina as the minimum OS version and the cask declared a block with a minimum OS version of :el_capitan
``` 