### PR TITLE
Remove broken opavote links

### DIFF
--- a/docs/governance/2021-agm-minutes.md
+++ b/docs/governance/2021-agm-minutes.md
@@ -12,8 +12,6 @@
   Greg Brimble moves to adopt the STV election method to elect the PLC and the Schulze method to elect the project leader. <https://github.com/Homebrew/brew/pull/10637>
 
   Motion carried unanimously.
-
-  <https://www.opavote.com/results/4758678377857024>
 - Shaun Jackman moves to suspend the rules requiring a three week waiting period and to adopt these election systems immediately.
   Motion carried unanimously.
 
@@ -29,8 +27,6 @@
 - 11:55–11:57 Election of the Project Leadership Committee
 
   Jonathan Chang and Issy Long are elected.
-
-  <https://www.opavote.com/results/5937355983683584>
 - 11:57–12:00 Election of the Project Leader
 
   Mike McQuaid elected by acclamation.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These links seem to be gone, and now this is blocking CI in this repo.

CC @Homebrew/plc