### PR TITLE
rubocops/class: allow disabled formulae to be without a test block

### DIFF
--- a/Library/Homebrew/rubocops/class.rb
+++ b/Library/Homebrew/rubocops/class.rb
@@ -71,6 +71,7 @@ module RuboCop
       class TestPresent < FormulaCop
         def audit_formula(_node, class_node, _parent_class_node, body_node)
           return if find_block(body_node, :test)
+          return if find_node_method_by_name(body_node, :disable!)
 
           offending_node(class_node) if body_node.nil?
           problem "A `test do` test block should be added"

--- a/Library/Homebrew/test/rubocops/class/test_present.rb
+++ b/Library/Homebrew/test/rubocops/class/test_present.rb
@@ -13,4 +13,14 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::TestPresent do
       end
     RUBY
   end
+
+  it "reports no offenses when there is no test block and formula is disabled" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
+        url 'https://brew.sh/foo-1.0.tgz'
+
+        disable! date: "2024-07-03", because: :unsupported
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
In `homebrew/core`, we currently have 225 disabled formulae, and 209 of them have a test block:
```
$ git grep '  disable!' Formula | wc -l
     225
$ git grep -l '  disable!' Formula | xargs grep '  test do' | wc -l
     209
```

This PR makes audit not to complain about the lack of test block for disabled formulae


