### PR TITLE
Use cached json API file for formulae and cask specified paths

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -10,7 +10,7 @@ module Homebrew
     module Cask
       extend Cachable
 
-      DEFAULT_API_ENDPOINT = "cask.jws.json"
+      DEFAULT_API_FILENAME = "cask.jws.json"
 
       private_class_method :cache
 
@@ -41,12 +41,12 @@ module Homebrew
       end
 
       def self.cached_json_file_path
-        HOMEBREW_CACHE_API/DEFAULT_API_ENDPOINT
+        HOMEBREW_CACHE_API/DEFAULT_API_FILENAME
       end
 
       sig { returns(T::Boolean) }
       def self.download_and_cache_data!
-        json_casks, updated = Homebrew::API.fetch_json_api_file "cask.jws.json"
+        json_casks, updated = Homebrew::API.fetch_json_api_file DEFAULT_API_FILENAME
 
         cache["renames"] = {}
         cache["casks"] = json_casks.to_h do |json_cask|

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -10,6 +10,8 @@ module Homebrew
     module Cask
       extend Cachable
 
+      DEFAULT_API_ENDPOINT = "cask.jws.json"
+
       private_class_method :cache
 
       sig { params(token: String).returns(Hash) }
@@ -36,6 +38,10 @@ module Homebrew
         download.fetch
         ::Cask::CaskLoader::FromPathLoader.new(download.symlink_location)
                                           .load(config: cask.config)
+      end
+
+      def self.cached_json_file_path
+        HOMEBREW_CACHE_API/DEFAULT_API_ENDPOINT
       end
 
       sig { returns(T::Boolean) }

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -10,8 +10,8 @@ module Homebrew
     module Formula
       extend Cachable
 
-      DEFAULT_API_ENDPOINT = "formula.jws.json"
-      INTERNAL_V3_API_ENDPOINT = "internal/v3/homebrew-core.jws.json"
+      DEFAULT_API_FILENAME = "formula.jws.json"
+      INTERNAL_V3_API_FILENAME = "internal/v3/homebrew-core.jws.json"
 
       private_class_method :cache
 
@@ -40,19 +40,19 @@ module Homebrew
 
       def self.cached_json_file_path
         if Homebrew::API.internal_json_v3?
-          HOMEBREW_CACHE_API/INTERNAL_V3_API_ENDPOINT
+          HOMEBREW_CACHE_API/INTERNAL_V3_API_FILENAME
         else
-          HOMEBREW_CACHE_API/DEFAULT_API_ENDPOINT
+          HOMEBREW_CACHE_API/DEFAULT_API_FILENAME
         end
       end
 
       sig { returns(T::Boolean) }
       def self.download_and_cache_data!
         if Homebrew::API.internal_json_v3?
-          json_formulae, updated = Homebrew::API.fetch_json_api_file INTERNAL_V3_API_ENDPOINT
+          json_formulae, updated = Homebrew::API.fetch_json_api_file INTERNAL_V3_API_FILENAME
           overwrite_cache! T.cast(json_formulae, T::Hash[String, T.untyped])
         else
-          json_formulae, updated = Homebrew::API.fetch_json_api_file DEFAULT_API_ENDPOINT
+          json_formulae, updated = Homebrew::API.fetch_json_api_file DEFAULT_API_FILENAME
 
           cache["aliases"] = {}
           cache["renames"] = {}

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -10,6 +10,9 @@ module Homebrew
     module Formula
       extend Cachable
 
+      DEFAULT_API_ENDPOINT = "formula.jws.json"
+      INTERNAL_V3_API_ENDPOINT = "internal/v3/homebrew-core.jws.json"
+
       private_class_method :cache
 
       sig { params(name: String).returns(Hash) }
@@ -35,13 +38,21 @@ module Homebrew
                           flags:      formula.class.build_flags)
       end
 
+      def self.cached_json_file_path
+        if Homebrew::API.internal_json_v3?
+          HOMEBREW_CACHE_API/INTERNAL_V3_API_ENDPOINT
+        else
+          HOMEBREW_CACHE_API/DEFAULT_API_ENDPOINT
+        end
+      end
+
       sig { returns(T::Boolean) }
       def self.download_and_cache_data!
         if Homebrew::API.internal_json_v3?
-          json_formulae, updated = Homebrew::API.fetch_json_api_file "internal/v3/homebrew-core.jws.json"
+          json_formulae, updated = Homebrew::API.fetch_json_api_file INTERNAL_V3_API_ENDPOINT
           overwrite_cache! T.cast(json_formulae, T::Hash[String, T.untyped])
         else
-          json_formulae, updated = Homebrew::API.fetch_json_api_file "formula.jws.json"
+          json_formulae, updated = Homebrew::API.fetch_json_api_file DEFAULT_API_ENDPOINT
 
           cache["aliases"] = {}
           cache["renames"] = {}

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -289,7 +289,7 @@ module Cask
       sig { params(token: String, from_json: Hash, path: T.nilable(Pathname)).void }
       def initialize(token, from_json: T.unsafe(nil), path: nil)
         @token = token.sub(%r{^homebrew/(?:homebrew-)?cask/}i, "")
-        @sourcefile_path = path
+        @sourcefile_path = path || Homebrew::API::Cask.cached_json_file_path
         @path = path || CaskLoader.default_path(@token)
         @from_json = from_json
       end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -249,7 +249,7 @@ module Homebrew
           formula.path.relative_path_from(T.must(formula.tap).path)
         when Cask::Cask
           cask = formula_or_cask
-          if cask.sourcefile_path.blank?
+          if cask.sourcefile_path.blank? || cask.sourcefile_path.extname != ".rb"
             return "#{cask.tap.default_remote}/blob/HEAD/#{cask.tap.relative_cask_path(cask.token)}"
           end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -358,6 +358,7 @@ class Formula
 
   # The path that was specified to find this formula.
   def specified_path
+    return Homebrew::API::Formula.cached_json_file_path if loaded_from_api?
     return alias_path if alias_path&.exist?
 
     return @unresolved_path if @unresolved_path.exist?

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
         expect(cask_from_api.token).to eq(api_token)
         expect(cask_from_api.loaded_from_api?).to be(true)
         expect(cask_from_api.caskfile_only?).to be(caskfile_only)
+        expect(cask_from_api.sourcefile_path).to eq(Homebrew::API::Cask.cached_json_file_path)
       end
     end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1932,4 +1932,42 @@ RSpec.describe Formula do
       expect { f.network_access_allowed?(:foo) }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#specified_path" do
+    let(:klass) do
+      Class.new(described_class) do
+        url "https://brew.sh/foo-1.0.tar.gz"
+      end
+    end
+
+    let(:name) { "formula_name" }
+    let(:path) { Formulary.core_path(name) }
+    let(:spec) { :stable }
+    let(:alias_name) { "baz@1" }
+    let(:alias_path) { CoreTap.instance.alias_dir/alias_name }
+    let(:f) { klass.new(name, path, spec) }
+    let(:f_alias) { klass.new(name, path, spec, alias_path:) }
+
+    context "when loading from a formula file" do
+      it "returns the formula file path" do
+        expect(f.specified_path).to eq(path)
+      end
+    end
+
+    context "when loaded from an alias" do
+      it "returns the alias path" do
+        expect(f_alias.specified_path).to eq(alias_path)
+      end
+    end
+
+    context "when loaded from the API" do
+      before do
+        allow(f).to receive(:loaded_from_api?).and_return(true)
+      end
+
+      it "returns the API path" do
+        expect(f.specified_path).to eq(Homebrew::API::Formula.cached_json_file_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR aligns `Formula#specified_path` and `Cask#sourcefile_path` with each other. Now, when loading from the API, these methods return the file path of the cached JSON API file that was used by `Homebrew::API` when loading. If the formula/cask was loaded from a ruby file, that file is returned. If the cask was loaded directly from a different JSON file, the path to that file is returned, instead.

Addressing a discussion point from https://github.com/Homebrew/brew/pull/17554#discussion_r1661750338: both `ruby_source_path` and `ruby_source_checksum` are manually set when loading from the API, so those methods don't need to be adjusted with this change.

## Loading a formula

### From the API

```ruby
Formulary.path("hello")
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/h/hello.rb>

Formulary.factory("hello").path
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/h/hello.rb>

Formulary.factory("hello").specified_path
# => #<Pathname:/Users/rylanpolster/Library/Caches/Homebrew/api/formula.jws.json>

Formulary.factory("hello").loaded_from_api?
# => true
```

### Without the API

```ruby
Formulary.path("hello")
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/h/hello.rb>

Formulary.factory("hello").path
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/h/hello.rb>

Formulary.factory("hello").specified_path
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/h/hello.rb>

Formulary.factory("hello").loaded_from_api?
# => false
```

### Directly from a ruby file

```ruby
Formulary.path("/tmp/hello.rb")
# => #<Pathname:/tmp/hello.rb>

Formulary.factory("/tmp/hello.rb").path
# => #<Pathname:/tmp/hello.rb

Formulary.factory("/tmp/hello.rb").specified_path
# => #<Pathname:/tmp/hello.rb

Formulary.factory("/tmp/hello.rb").loaded_from_api?
# => false
```

## Loading a cask

### From the API

```ruby
Cask::CaskLoader.path("slack")
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/s/slack.rb>

Cask::CaskLoader.load("slack").sourcefile_path
# => #<Pathname:/Users/rylanpolster/Library/Caches/Homebrew/api/cask.jws.json>

Cask::CaskLoader.load("slack").loaded_from_api?
# => true
```

### Without the API

```ruby
Cask::CaskLoader.path("slack")
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/s/slack.rb>

Cask::CaskLoader.load("slack").sourcefile_path
# => #<Pathname:/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/s/slack.rb>

Cask::CaskLoader.load("slack").loaded_from_api?
# => false
```

### Directly from a ruby file

```ruby
Cask::CaskLoader.path("/tmp/slack.rb")
# => #<Pathname:/tmp/slack.rb>

Cask::CaskLoader.load("/tmp/slack.rb").sourcefile_path
# => #<Pathname:/tmp/slack.rb>

Cask::CaskLoader.load("/tmp/slack.rb").loaded_from_api?
# => false
```

### Directly from a json file

```ruby
Cask::CaskLoader.path("/tmp/slack.json")
# => #<Pathname:/tmp/slack.json>

Cask::CaskLoader.load("/tmp/slack.json").sourcefile_path
# => #<Pathname:/tmp/slack.json>

Cask::CaskLoader.load("/tmp/slack.json").loaded_from_api?
# => true
```