### PR TITLE
dev-cmd/typecheck: Stop dry running Spoom sigil bumps

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Update RBI files
         id: update
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        continue-on-error: true
         run: |
           if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]
           then

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Update RBI files
         id: update
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
-        continue-on-error: true
         run: |
           if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]
           then

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -61,9 +61,9 @@ module Homebrew
               ohai "Checking if we can bump Sorbet `typed` sigils..."
               # --sorbet needed because of https://github.com/Shopify/spoom/issues/488
               system "bundle", "exec", "spoom", "srb", "bump", "--from", "false", "--to", "true",
-                          "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
+                     "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
               system "bundle", "exec", "spoom", "srb", "bump", "--from", "true", "--to", "strict",
-                          "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
+                     "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
             end
 
             return

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -60,9 +60,9 @@ module Homebrew
             if args.suggest_typed?
               ohai "Checking if we can bump Sorbet `typed` sigils..."
               # --sorbet needed because of https://github.com/Shopify/spoom/issues/488
-              safe_system "bundle", "exec", "spoom", "srb", "bump", "--from", "false", "--to", "true",
+              system "bundle", "exec", "spoom", "srb", "bump", "--from", "false", "--to", "true",
                           "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
-              safe_system "bundle", "exec", "spoom", "srb", "bump", "--from", "true", "--to", "strict",
+              system "bundle", "exec", "spoom", "srb", "bump", "--from", "true", "--to", "strict",
                           "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
             end
 

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -60,9 +60,9 @@ module Homebrew
             if args.suggest_typed?
               ohai "Checking if we can bump Sorbet `typed` sigils..."
               # --sorbet needed because of https://github.com/Shopify/spoom/issues/488
-              safe_system "bundle", "exec", "spoom", "srb", "bump", "--dry", "--from", "false", "--to", "true",
+              safe_system "bundle", "exec", "spoom", "srb", "bump", "--from", "false", "--to", "true",
                           "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
-              safe_system "bundle", "exec", "spoom", "srb", "bump", "--dry", "--from", "true", "--to", "strict",
+              safe_system "bundle", "exec", "spoom", "srb", "bump", "--from", "true", "--to", "strict",
                           "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
             end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Sixteen months ago in #14921, I made it so that CI ran `brew typecheck --update --suggest-typed` and could commit the changes.
- Except it never actually ever made any changes because of the `--dry` option in the Spoom CLI args. Whoops!
