### PR TITLE
sorbet: Tighten up `dev-cmd` types

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -495,7 +495,7 @@ module Homebrew
         check_closed_pull_requests(formula, tap_remote_repo, version:)
       end
 
-      sig { params(formula: Formula, new_version: String).returns(NilClass) }
+      sig { params(formula: Formula, new_version: String).void }
       def check_throttle(formula, new_version)
         tap = formula.tap
         return if tap.nil?

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -314,7 +314,7 @@ module Homebrew
       sig {
         params(
           formula_or_cask: T.any(Formula, Cask::Cask),
-          repositories:    T::Array[T.untyped],
+          repositories:    T::Array[String],
           name:            String,
         ).returns(VersionBumpInfo)
       }
@@ -425,7 +425,7 @@ module Homebrew
         params(
           formula_or_cask: T.any(Formula, Cask::Cask),
           name:            String,
-          repositories:    T::Array[T.untyped],
+          repositories:    T::Array[String],
           ambiguous_cask:  T::Boolean,
         ).void
       }

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -164,7 +164,9 @@ module Homebrew
          T.let(formula_installs, T.nilable(T::Hash[Symbol, Integer]))]
       end
 
-      sig { params(all_formulae: T.untyped).returns([T::Hash[String, T.untyped], T::Hash[String, T.untyped]]) }
+      sig {
+        params(all_formulae: T::Array[Formula]).returns([T::Hash[String, T.untyped], T::Hash[String, T.untyped]])
+      }
       def deps_uses_from_formulae(all_formulae)
         ohai "Populating dependency tree..."
 
@@ -186,7 +188,7 @@ module Homebrew
         [deps_hash, uses_hash]
       end
 
-      sig { params(formulae: T::Array[Formula]).returns(NilClass) }
+      sig { params(formulae: T::Array[Formula]).void }
       def output_total(formulae)
         return unless @bottle_tag
 
@@ -205,7 +207,7 @@ module Homebrew
       sig {
         params(formulae: T::Array[Formula], deps_hash: T::Hash[T.any(Symbol, String), T.untyped],
                noun: T.nilable(String), hash: T::Hash[T.any(Symbol, String), T.untyped],
-               any_named_args: T::Boolean).returns(NilClass)
+               any_named_args: T::Boolean).void
       }
       def output_unbottled(formulae, deps_hash, noun, hash, any_named_args)
         return unless @bottle_tag
@@ -279,7 +281,7 @@ module Homebrew
         puts "No unbottled dependencies found!"
       end
 
-      sig { returns(NilClass) }
+      sig { void }
       def output_lost_bottles
         ohai ":#{@bottle_tag} lost bottles"
 

--- a/Library/Homebrew/dev-cmd/update-sponsors.rb
+++ b/Library/Homebrew/dev-cmd/update-sponsors.rb
@@ -26,7 +26,7 @@ module Homebrew
         named_sponsors = []
         logo_sponsors = []
         # FIXME: This T.let should be unnecessary https://github.com/sorbet/sorbet/issues/6894
-        largest_monthly_amount = T.let(0, T.untyped)
+        largest_monthly_amount = T.let(0, Integer)
 
         GitHub.sponsorships("Homebrew").each do |s|
           largest_monthly_amount = [s[:monthly_amount], s[:closest_tier_monthly_amount]].max
@@ -62,17 +62,17 @@ module Homebrew
 
       private
 
-      sig { params(sponsor: T::Hash[Symbol, T.untyped]).returns(T.nilable(String)) }
+      sig { params(sponsor: T::Hash[Symbol, String]).returns(T.nilable(String)) }
       def sponsor_name(sponsor)
         sponsor[:name] || sponsor[:login]
       end
 
-      sig { params(sponsor: T::Hash[Symbol, T.untyped]).returns(String) }
+      sig { params(sponsor: T::Hash[Symbol, String]).returns(String) }
       def sponsor_logo(sponsor)
         "https://github.com/#{sponsor[:login]}.png?size=64"
       end
 
-      sig { params(sponsor: T::Hash[Symbol, T.untyped]).returns(String) }
+      sig { params(sponsor: T::Hash[Symbol, String]).returns(String) }
       def sponsor_url(sponsor)
         "https://github.com/#{sponsor[:login]}"
       end

--- a/Library/Homebrew/dev-cmd/update-sponsors.rb
+++ b/Library/Homebrew/dev-cmd/update-sponsors.rb
@@ -25,7 +25,6 @@ module Homebrew
       def run
         named_sponsors = []
         logo_sponsors = []
-        # FIXME: This T.let should be unnecessary https://github.com/sorbet/sorbet/issues/6894
         largest_monthly_amount = T.let(0, Integer)
 
         GitHub.sponsorships("Homebrew").each do |s|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/17297
- Change `returns(NilClass)` to `void`.
- Get rid of some of the `T.untyped`.
