### PR TITLE
dev-cmd/bump-formula-pr: `formula_version` should return `Version` not `String`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -452,7 +452,7 @@ module Homebrew
         [resource.fetch, forced_version]
       end
 
-      sig { params(formula: Formula, contents: T.nilable(String)).returns(String) }
+      sig { params(formula: Formula, contents: T.nilable(String)).returns(Version) }
       def formula_version(formula, contents = nil)
         spec = :stable
         name = formula.name
@@ -531,7 +531,7 @@ module Homebrew
         )
       end
 
-      sig { params(formula: Formula, new_formula_version: String).returns(T.nilable(T::Array[String])) }
+      sig { params(formula: Formula, new_formula_version: Version).returns(T.nilable(T::Array[String])) }
       def alias_update_pair(formula, new_formula_version)
         versioned_alias = formula.aliases.grep(/^.*@\d+(\.\d+)?$/).first
         return if versioned_alias.nil?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes https://github.com/Homebrew/brew/issues/17626.

Before:

```shell
brew bump-formula-pr apify-cli --dry-run --version=0.20.2 --no-browse --message "Automatic update of the \`apify-cli\` formula.\n\nCC @fnesveda @B4nan @vladfrangu"

Error: Return value: Expected type String, got type Version with value #<Version:0x00007f410017f28...9.5", @detected_from_url=true>
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:159
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:456 (Homebrew::DevCmd::BumpFormulaPr#formula_version)
Error: Return value: Expected type String, got type Version with value #<Version:0x00007f410017f28...9.5", @detected_from_url=true>
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:159
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:456 (Homebrew::DevCmd::BumpFormulaPr#formula_version)
```

After:

```shell
brew bump-formula-pr apify-cli --dry-run --version=0.20.2 --no-browse --message "Automatic update of the \`apify-cli\` formula.\n\nCC @fnesveda @B4nan @vladfrangu"

==> Downloading https://registry.npmjs.org/apify-cli/-/apify-cli-0.20.2.tgz
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/bb6d663416af2c1e4cb43e4c0fe0e0db51ce2f5f96c1acdc48136e251ffaf317--apify-cli-0.20.2.tgz
Warning: Cannot verify integrity of 'bb6d663416af2c1e4cb43e4c0fe0e0db51ce2f5f96c1acdc48136e251ffaf317--apify-cli-0.20.2.tgz'.
No checksum was provided.
For your reference, the checksum is:
  sha256 "dfe8bf7a168cf221ef85380b78c3b7b56c1b19b059f8ec4003f3e9c9c2bd6bb0"
==> replace /https:\/\/registry\.npmjs\.org\/apify\-cli\/\-\/apify\-cli\-0\.19\.5\.tgz/ with "https://registry.npmjs.org/apify-cli/-/apify-cli-0.20.2.tgz"
==> replace "bddd03175b0e542737e44ef246f5f7f195901ae4c27b42cd4f9811ee532b3849" with "dfe8bf7a168cf221ef85380b78c3b7b56c1b19b059f8ec4003f3e9c9c2bd6bb0"
==> brew audit --formula apify-cli.rb
==> try to fork repository with GitHub API
==> git add /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/a/apify-cli.rb
==> git checkout --no-track -b bump-apify-cli-0.20.2 origin/master
==> git commit --no-edit --verbose --message='apify-cli 0.20.2' -- /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/a/apify-cli.rb
==> git push --set-upstream FORK_URL bump-apify-cli-0.20.2:bump-apify-cli-0.20.2
==> git checkout --quiet -
==> create pull request with GitHub API (base branch: master)
```