### PR TITLE
livecheck: expand `typed: strict` usage

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "livecheck/constants"
@@ -22,15 +22,15 @@ class Livecheck
   sig { params(package_or_resource: T.any(Cask::Cask, T.class_of(Formula), Resource)).void }
   def initialize(package_or_resource)
     @package_or_resource = package_or_resource
-    @referenced_cask_name = nil
-    @referenced_formula_name = nil
-    @regex = nil
-    @skip = false
-    @skip_msg = nil
-    @strategy = nil
-    @strategy_block = nil
-    @throttle = nil
-    @url = nil
+    @referenced_cask_name = T.let(nil, T.nilable(String))
+    @referenced_formula_name = T.let(nil, T.nilable(String))
+    @regex = T.let(nil, T.nilable(Regexp))
+    @skip = T.let(false, T::Boolean)
+    @skip_msg = T.let(nil, T.nilable(String))
+    @strategy = T.let(nil, T.nilable(Symbol))
+    @strategy_block = T.let(nil, T.nilable(Proc))
+    @throttle = T.let(nil, T.nilable(Integer))
+    @url = T.let(nil, T.any(NilClass, String, Symbol))
   end
 
   # Sets the `@referenced_cask_name` instance variable to the provided `String`

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
@@ -14,7 +14,7 @@ module Homebrew
           livecheckable:       T::Boolean,
           full_name:           T::Boolean,
           verbose:             T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def package_or_resource_skip(package_or_resource, livecheckable, full_name: false, verbose: false)
         formula = package_or_resource if package_or_resource.is_a?(Formula)
@@ -51,7 +51,7 @@ module Homebrew
           _livecheckable: T::Boolean,
           full_name:      T::Boolean,
           verbose:        T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def formula_head_only(formula, _livecheckable, full_name: false, verbose: false)
         return {} if !formula.head_only? || formula.any_version_installed?
@@ -71,7 +71,7 @@ module Homebrew
           livecheckable: T::Boolean,
           full_name:     T::Boolean,
           verbose:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def formula_deprecated(formula, livecheckable, full_name: false, verbose: false)
         return {} if !formula.deprecated? || livecheckable
@@ -85,7 +85,7 @@ module Homebrew
           livecheckable: T::Boolean,
           full_name:     T::Boolean,
           verbose:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def formula_disabled(formula, livecheckable, full_name: false, verbose: false)
         return {} if !formula.disabled? || livecheckable
@@ -99,7 +99,7 @@ module Homebrew
           livecheckable: T::Boolean,
           full_name:     T::Boolean,
           verbose:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def formula_versioned(formula, livecheckable, full_name: false, verbose: false)
         return {} if !formula.versioned_formula? || livecheckable
@@ -113,7 +113,7 @@ module Homebrew
           livecheckable: T::Boolean,
           full_name:     T::Boolean,
           verbose:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def cask_deprecated(cask, livecheckable, full_name: false, verbose: false)
         return {} if !cask.deprecated? || livecheckable
@@ -127,7 +127,7 @@ module Homebrew
           livecheckable: T::Boolean,
           full_name:     T::Boolean,
           verbose:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def cask_disabled(cask, livecheckable, full_name: false, verbose: false)
         return {} if !cask.disabled? || livecheckable
@@ -142,7 +142,7 @@ module Homebrew
           full_name:      T::Boolean,
           verbose:        T::Boolean,
           extract_plist:  T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def cask_extract_plist(cask, _livecheckable, full_name: false, verbose: false, extract_plist: false)
         return {} if extract_plist || cask.livecheck.strategy != :extract_plist
@@ -162,7 +162,7 @@ module Homebrew
           livecheckable: T::Boolean,
           full_name:     T::Boolean,
           verbose:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def cask_version_latest(cask, livecheckable, full_name: false, verbose: false)
         return {} if !(cask.present? && cask.version&.latest?) || livecheckable
@@ -176,7 +176,7 @@ module Homebrew
           livecheckable: T::Boolean,
           full_name:     T::Boolean,
           verbose:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def cask_url_unversioned(cask, livecheckable, full_name: false, verbose: false)
         return {} if !(cask.present? && cask.url&.unversioned?) || livecheckable
@@ -185,28 +185,28 @@ module Homebrew
       end
 
       # Skip conditions for formulae.
-      FORMULA_CHECKS = [
+      FORMULA_CHECKS = T.let([
         :package_or_resource_skip,
         :formula_head_only,
         :formula_deprecated,
         :formula_disabled,
         :formula_versioned,
-      ].freeze
+      ].freeze, T::Array[Symbol])
 
       # Skip conditions for casks.
-      CASK_CHECKS = [
+      CASK_CHECKS = T.let([
         :package_or_resource_skip,
         :cask_deprecated,
         :cask_disabled,
         :cask_extract_plist,
         :cask_version_latest,
         :cask_url_unversioned,
-      ].freeze
+      ].freeze, T::Array[Symbol])
 
       # Skip conditions for resources.
-      RESOURCE_CHECKS = [
+      RESOURCE_CHECKS = T.let([
         :package_or_resource_skip,
-      ].freeze
+      ].freeze, T::Array[Symbol])
 
       # If a formula/cask/resource should be skipped, we return a hash from
       # `Livecheck#status_hash`, which contains a `status` type and sometimes
@@ -217,7 +217,7 @@ module Homebrew
           full_name:           T::Boolean,
           verbose:             T::Boolean,
           extract_plist:       T::Boolean,
-        ).returns(Hash)
+        ).returns(T::Hash[Symbol, T.untyped])
       }
       def skip_information(package_or_resource, full_name: false, verbose: false, extract_plist: true)
         livecheckable = package_or_resource.livecheckable?
@@ -255,7 +255,7 @@ module Homebrew
           full_name:                         T::Boolean,
           verbose:                           T::Boolean,
           extract_plist:                     T::Boolean,
-        ).returns(T.nilable(Hash))
+        ).returns(T.nilable(T::Hash[Symbol, T.untyped]))
       }
       def referenced_skip_information(
         livecheck_package_or_resource,
@@ -298,7 +298,7 @@ module Homebrew
       end
 
       # Prints default livecheck output in relation to skip conditions.
-      sig { params(skip_hash: Hash).void }
+      sig { params(skip_hash: T::Hash[Symbol, T.untyped]).void }
       def print_skip_information(skip_hash)
         return unless skip_hash.is_a?(Hash)
 

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -25,13 +25,13 @@ module Homebrew
 
       # cURL does not set a default `--max-time` value, so we provide a value
       # to ensure cURL will time out in a reasonable amount of time.
-      CURL_MAX_TIME = CURL_CONNECT_TIMEOUT + 5
+      CURL_MAX_TIME = T.let(CURL_CONNECT_TIMEOUT + 5, Integer)
 
       # The `curl` process will sometimes hang indefinitely (despite setting
       # the `--max-time` argument) and it needs to be quit for livecheck to
       # continue. This value is used to set the `timeout` argument on
       # `Utils::Curl` method calls in {Strategy}.
-      CURL_PROCESS_TIMEOUT = CURL_MAX_TIME + 5
+      CURL_PROCESS_TIMEOUT = T.let(CURL_MAX_TIME + 5, Integer)
 
       # The maximum number of redirections that `curl` should allow.
       MAX_REDIRECTIONS = 5
@@ -41,20 +41,20 @@ module Homebrew
       # number of responses in this context. The `+ 1` here accounts for the
       # situation where there are exactly `MAX_REDIRECTIONS` number of
       # redirections, followed by a final `200 OK` response.
-      MAX_PARSE_ITERATIONS = MAX_REDIRECTIONS + 1
+      MAX_PARSE_ITERATIONS = T.let(MAX_REDIRECTIONS + 1, Integer)
 
       # Baseline `curl` arguments used in {Strategy} methods.
-      DEFAULT_CURL_ARGS = [
+      DEFAULT_CURL_ARGS = T.let([
         # Follow redirections to handle mirrors, relocations, etc.
         "--location",
         "--max-redirs", MAX_REDIRECTIONS.to_s,
         # Avoid progress bar text, so we can reliably identify `curl` error
         # messages in output
         "--silent"
-      ].freeze
+      ].freeze, T::Array[String])
 
       # `curl` arguments used in `Strategy#page_content` method.
-      PAGE_CONTENT_CURL_ARGS = ([
+      PAGE_CONTENT_CURL_ARGS = T.let(([
         "--compressed",
         # Return an error when the HTTP response code is 400 or greater but
         # continue to return body content
@@ -62,10 +62,10 @@ module Homebrew
         # Include HTTP response headers in output, so we can identify the
         # final URL after any redirections
         "--include",
-      ] + DEFAULT_CURL_ARGS).freeze
+      ] + DEFAULT_CURL_ARGS).freeze, T::Array[String])
 
       # Baseline `curl` options used in {Strategy} methods.
-      DEFAULT_CURL_OPTIONS = {
+      DEFAULT_CURL_OPTIONS = T.let({
         print_stdout:    false,
         print_stderr:    false,
         debug:           false,
@@ -74,7 +74,7 @@ module Homebrew
         connect_timeout: CURL_CONNECT_TIMEOUT,
         max_time:        CURL_MAX_TIME,
         retries:         0,
-      }.freeze
+      }.freeze, T::Hash[Symbol, T.untyped])
 
       # A regex used to identify a tarball extension at the end of a string.
       TARBALL_EXTENSION_REGEX = /

--- a/Library/Homebrew/livecheck/strategy/crate.rb
+++ b/Library/Homebrew/livecheck/strategy/crate.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
@@ -23,14 +23,17 @@ module Homebrew
 
         # The default `strategy` block used to extract version information when
         # a `strategy` block isn't provided.
-        DEFAULT_BLOCK = proc do |json, regex|
+        DEFAULT_BLOCK = T.let(proc do |json, regex|
           json["versions"]&.map do |version|
             next if version["yanked"]
             next unless (match = version["num"]&.match(regex))
 
             match[1]
           end
-        end.freeze
+        end.freeze, T.proc.params(
+          arg0: T::Hash[String, T.untyped],
+          arg1: Regexp,
+        ).returns(T.any(String, T::Array[String])))
 
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{

--- a/Library/Homebrew/livecheck/strategy/github_releases.rb
+++ b/Library/Homebrew/livecheck/strategy/github_releases.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
@@ -50,7 +50,7 @@ module Homebrew
         # Keys in the release JSON that could contain the version.
         # The tag name is checked first, to better align with the {Git}
         # strategy.
-        VERSION_KEYS = ["tag_name", "name"].freeze
+        VERSION_KEYS = T.let(["tag_name", "name"].freeze, T::Array[String])
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
@@ -20,7 +20,7 @@ module Homebrew
         URL_MATCH_REGEX = %r{^https?://}i
 
         # The header fields to check when a `strategy` block isn't provided.
-        DEFAULT_HEADERS_TO_CHECK = ["content-disposition", "location"].freeze
+        DEFAULT_HEADERS_TO_CHECK = T.let(["content-disposition", "location"].freeze, T::Array[String])
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "bundle_version"
@@ -20,7 +20,7 @@ module Homebrew
         URL_MATCH_REGEX = %r{^https?://}i
 
         # Common `os` values used in appcasts to refer to macOS.
-        APPCAST_MACOS_STRINGS = ["macos", "osx"].freeze
+        APPCAST_MACOS_STRINGS = T.let(["macos", "osx"].freeze, T::Array[String])
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
@@ -56,7 +56,7 @@ module Homebrew
 
         # Used to cache page content, so we don't fetch the same pages
         # repeatedly.
-        @page_data = {}
+        @page_data = T.let({}, T::Hash[String, String])
 
         # Whether the strategy can be applied to the provided URL.
         #


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This updates livecheck files to use `typed: script` where feasible.

The remaining exception is `livecheck/strategy.rb`, as I wasn't able to figure out how to resolve the typing issues around the `@strategies` variable (I tried a couple of approaches but couldn't find a working solution):

```
livecheck/strategy.rb:100: Use of undeclared variable @strategies https://srb.help/6002
     100 |        return @strategies if defined? @strategies
                         ^^^^^^^^^^^
  Note:
    Use T.let to declare this variable.
    For more information, see https://sorbet.org/docs/type-annotations

livecheck/strategy.rb:102: The instance variable @strategies must be declared using T.let when specifying # typed: strict https://srb.help/7043
     102 |        @strategies = {}
                  ^^^^^^^^^^^
  Autocorrect: Use -a to autocorrect
    livecheck/strategy.rb:102: Replace with T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
     102 |        @strategies = {}
                                ^^

livecheck/strategy.rb:100: Use of undeclared variable @strategies https://srb.help/6002
     100 |        return @strategies if defined? @strategies
                         ^^^^^^^^^^^
  Note:
    Use T.let to declare this variable.
    For more information, see https://sorbet.org/docs/type-annotations

livecheck/strategy.rb:102: The instance variable @strategies must be declared using T.let when specifying # typed: strict https://srb.help/7043
     102 |        @strategies = {}
                  ^^^^^^^^^^^
  Autocorrect: Use -a to autocorrect
    livecheck/strategy.rb:102: Replace with T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
     102 |        @strategies = {}
                                ^^
```

This includes changes to resolve the other type errors in `strategy.rb` but leaves the file as `typed: true` for now.

Related to #17297.