### PR TITLE
sorbet: Make more files (that have public APIs defined in them) `typed: strict`

### DIFF
--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -8,7 +8,7 @@ module UnpackStrategy
     module MacOSZipExtension
       private
 
-      sig { params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+      sig { params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
       def extract_to_dir(unpack_dir, basename:, verbose:)
         with_env(TZ: "UTC") do
           if merge_xattrs && contains_extended_attributes?(path)

--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
@@ -10,15 +10,18 @@ module Homebrew
     require "minitest/assertions"
     include ::Minitest::Assertions
 
+    sig { params(assertions: Integer).returns(Integer) }
     attr_writer :assertions
 
+    sig { returns(Integer) }
     def assertions
-      @assertions ||= 0
+      @assertions ||= T.let(0, T.nilable(Integer))
     end
 
     # Returns the output of running cmd and asserts the exit status.
     #
     # @api public
+    sig { params(cmd: String, result: Integer).returns(String) }
     def shell_output(cmd, result = 0)
       ohai cmd
       output = `#{cmd}`
@@ -33,6 +36,7 @@ module Homebrew
     # optionally asserts the exit status.
     #
     # @api public
+    sig { params(cmd: String, input: T.nilable(String), result: T.nilable(Integer)).returns(String) }
     def pipe_output(cmd, input = nil, result = nil)
       ohai cmd
       output = IO.popen(cmd, "w+") do |pipe|

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -9,8 +9,9 @@ module UnpackStrategy
   include SystemCommand::Mixin
   abstract!
 
+  # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
   # rubocop:disable Style/MutableConstant
-  UnpackStrategyImpl = T.type_alias { T.all(T::Class[UnpackStrategy], UnpackStrategy::ClassMethods) }
+  UnpackStrategyType = T.type_alias { T.all(T::Class[UnpackStrategy], UnpackStrategy::ClassMethods) }
   # rubocop:enable Style/MutableConstant
 
   module ClassMethods
@@ -26,7 +27,7 @@ module UnpackStrategy
 
   mixes_in_class_methods(ClassMethods)
 
-  sig { returns(T.nilable(T::Array[UnpackStrategyImpl])) }
+  sig { returns(T.nilable(T::Array[UnpackStrategyType])) }
   def self.strategies
     @strategies ||= T.let([
       Tar, # Needs to be before Bzip2/Gzip/Xz/Lzma/Zstd.
@@ -61,11 +62,11 @@ module UnpackStrategy
       Sit,
       Rar,
       Lha,
-    ].freeze, T.nilable(T::Array[UnpackStrategyImpl]))
+    ].freeze, T.nilable(T::Array[UnpackStrategyType]))
   end
   private_class_method :strategies
 
-  sig { params(type: Symbol).returns(T.nilable(UnpackStrategyImpl)) }
+  sig { params(type: Symbol).returns(T.nilable(UnpackStrategyType)) }
   def self.from_type(type)
     type = {
       naked:     :uncompressed,
@@ -80,7 +81,7 @@ module UnpackStrategy
     end
   end
 
-  sig { params(extension: String).returns(T.nilable(UnpackStrategyImpl)) }
+  sig { params(extension: String).returns(T.nilable(UnpackStrategyType)) }
   def self.from_extension(extension)
     return unless strategies
 
@@ -89,7 +90,7 @@ module UnpackStrategy
               &.find { |s| s.extensions.any? { |ext| extension.end_with?(ext) } }
   end
 
-  sig { params(path: Pathname).returns(T.nilable(UnpackStrategyImpl)) }
+  sig { params(path: Pathname).returns(T.nilable(UnpackStrategyType)) }
   def self.from_magic(path)
     strategies&.find { |s| s.can_extract?(path) }
   end

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -96,7 +96,7 @@ module UnpackStrategy
   end
 
   sig {
-    params(path: Pathname, prioritize_extension: T::Boolean, type: T.nilable(Symbol), ref_type: T.nilable(String),
+    params(path: Pathname, prioritize_extension: T::Boolean, type: T.nilable(Symbol), ref_type: T.nilable(Symbol),
            ref: T.nilable(String), merge_xattrs: T::Boolean).returns(T.untyped)
   }
   def self.detect(path, prioritize_extension: false, type: nil, ref_type: nil, ref: nil, merge_xattrs: false)
@@ -123,14 +123,14 @@ module UnpackStrategy
   attr_reader :merge_xattrs
 
   sig {
-    params(path: T.any(String, Pathname), ref_type: T.nilable(String), ref: T.nilable(String),
+    params(path: T.any(String, Pathname), ref_type: T.nilable(Symbol), ref: T.nilable(String),
            merge_xattrs: T::Boolean).void
   }
   def initialize(path, ref_type: nil, ref: nil, merge_xattrs: false)
     @path = T.let(Pathname(path).expand_path, Pathname)
-    @ref_type = ref_type
-    @ref = ref
-    @merge_xattrs = merge_xattrs
+    @ref_type = T.let(ref_type, T.nilable(Symbol))
+    @ref = T.let(ref, T.nilable(String))
+    @merge_xattrs = T.let(merge_xattrs, T::Boolean)
   end
 
   sig { abstract.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }

--- a/Library/Homebrew/unpack_strategy/air.rb
+++ b/Library/Homebrew/unpack_strategy/air.rb
@@ -27,7 +27,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! AIR_APPLICATION_INSTALLER,
                       args:    ["-silent", "-location", unpack_dir, path],

--- a/Library/Homebrew/unpack_strategy/air.rb
+++ b/Library/Homebrew/unpack_strategy/air.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Air
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".air"]
     end

--- a/Library/Homebrew/unpack_strategy/air.rb
+++ b/Library/Homebrew/unpack_strategy/air.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,13 +11,15 @@ module UnpackStrategy
       [".air"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       mime_type = "application/vnd.adobe.air-application-installer-package+zip"
       path.magic_number.match?(/.{59}#{Regexp.escape(mime_type)}/)
     end
 
+    sig { returns(T.nilable(T::Array[Cask::Cask])) }
     def dependencies
-      @dependencies ||= [Cask::CaskLoader.load("adobe-air")]
+      @dependencies ||= T.let([Cask::CaskLoader.load("adobe-air")], T.nilable(T::Array[Cask::Cask]))
     end
 
     AIR_APPLICATION_INSTALLER =

--- a/Library/Homebrew/unpack_strategy/bazaar.rb
+++ b/Library/Homebrew/unpack_strategy/bazaar.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "directory"
@@ -6,8 +6,9 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Bazaar archives.
   class Bazaar < Directory
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
-      super && (path/".bzr").directory?
+      !!(super && (path/".bzr").directory?)
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/bazaar.rb
+++ b/Library/Homebrew/unpack_strategy/bazaar.rb
@@ -12,7 +12,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       super
 

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       FileUtils.cp path, unpack_dir/basename, preserve: true
       quiet_flags = verbose ? [] : ["-q"]

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Bzip2
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".bz2"]
     end

--- a/Library/Homebrew/unpack_strategy/bzip2.rb
+++ b/Library/Homebrew/unpack_strategy/bzip2.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".bz2"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\ABZh/n)
     end

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -15,7 +15,7 @@ module UnpackStrategy
       path.magic_number.match?(/\AMSCF/n)
     end
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "cabextract",
                       args:    ["-d", unpack_dir, "--", path],

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Cab
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".cab"]
     end

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".cab"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\AMSCF/n)
     end
@@ -23,8 +24,9 @@ module UnpackStrategy
                       verbose:
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["cabextract"]]
+      @dependencies ||= T.let([Formula["cabextract"]], T.nilable(T::Array[Formula]))
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/compress.rb
+++ b/Library/Homebrew/unpack_strategy/compress.rb
@@ -6,7 +6,7 @@ require_relative "tar"
 module UnpackStrategy
   # Strategy for unpacking compress archives.
   class Compress < Tar
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".Z"]
     end

--- a/Library/Homebrew/unpack_strategy/compress.rb
+++ b/Library/Homebrew/unpack_strategy/compress.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "tar"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".Z"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\A\037\235/n)
     end

--- a/Library/Homebrew/unpack_strategy/cvs.rb
+++ b/Library/Homebrew/unpack_strategy/cvs.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "directory"
@@ -6,8 +6,9 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking CVS repositories.
   class Cvs < Directory
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
-      super && (path/"CVS").directory?
+      !!(super && (path/"CVS").directory?)
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,6 +11,7 @@ module UnpackStrategy
       []
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.directory?
     end

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       path.children.each do |child|
         system_command! "cp",

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Directory
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       []
     end

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -121,6 +121,12 @@ module UnpackStrategy
         end
       end
 
+      sig { override.returns(T::Array[String]) }
+      def self.extensions = []
+
+      sig { override.params(_path: Pathname).returns(T::Boolean) }
+      def self.can_extract?(_path) = false
+
       private
 
       sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
@@ -165,7 +171,7 @@ module UnpackStrategy
     end
     private_constant :Mount
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".dmg"]
     end

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -129,7 +129,7 @@ module UnpackStrategy
 
       private
 
-      sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+      sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
       def extract_to_dir(unpack_dir, basename:, verbose:)
         tries = 3
         bom = begin
@@ -183,7 +183,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       mount(verbose:) do |mounts|
         raise "No mounts found in '#{path}'; perhaps this is a bad disk image?" if mounts.empty?

--- a/Library/Homebrew/unpack_strategy/executable.rb
+++ b/Library/Homebrew/unpack_strategy/executable.rb
@@ -6,7 +6,7 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking executables.
   class Executable < Uncompressed
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".sh", ".bash"]
     end

--- a/Library/Homebrew/unpack_strategy/executable.rb
+++ b/Library/Homebrew/unpack_strategy/executable.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "uncompressed"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".sh", ".bash"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\A#!\s*\S+/n) ||
         path.magic_number.match?(/\AMZ/n)

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -24,7 +24,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       args = if @ref_type && @ref
         [@ref]

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "system_command"
@@ -14,6 +14,7 @@ module UnpackStrategy
       []
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       return false unless path.magic_number.match?(/\ASQLite format 3\000/n)
 

--- a/Library/Homebrew/unpack_strategy/fossil.rb
+++ b/Library/Homebrew/unpack_strategy/fossil.rb
@@ -9,7 +9,7 @@ module UnpackStrategy
     include UnpackStrategy
     extend SystemCommand::Mixin
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       []
     end

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       []
     end
 
+    sig { override.params(_path: Pathname).returns(T::Boolean) }
     def self.can_extract?(_path)
       false
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["unar"]]
+      @dependencies ||= T.let([Formula["unar"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "unar",
                       args:    [

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class GenericUnar
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       []
     end

--- a/Library/Homebrew/unpack_strategy/git.rb
+++ b/Library/Homebrew/unpack_strategy/git.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "directory"
@@ -6,8 +6,9 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Git repositories.
   class Git < Directory
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
-      super && (path/".git").directory?
+      !!(super && (path/".git").directory?)
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/gzip.rb
+++ b/Library/Homebrew/unpack_strategy/gzip.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       FileUtils.cp path, unpack_dir/basename, preserve: true
       quiet_flags = verbose ? [] : ["-q"]

--- a/Library/Homebrew/unpack_strategy/gzip.rb
+++ b/Library/Homebrew/unpack_strategy/gzip.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Gzip
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".gz"]
     end

--- a/Library/Homebrew/unpack_strategy/gzip.rb
+++ b/Library/Homebrew/unpack_strategy/gzip.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".gz"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\A\037\213/n)
     end

--- a/Library/Homebrew/unpack_strategy/jar.rb
+++ b/Library/Homebrew/unpack_strategy/jar.rb
@@ -6,7 +6,7 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking Java archives.
   class Jar < Uncompressed
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".apk", ".jar"]
     end

--- a/Library/Homebrew/unpack_strategy/jar.rb
+++ b/Library/Homebrew/unpack_strategy/jar.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "uncompressed"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".apk", ".jar"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       return false unless Zip.can_extract?(path)
 

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "lha",
                       args:    ["xq2w=#{unpack_dir}", path],

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Lha
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".lha", ".lzh"]
     end

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       [".lha", ".lzh"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\A..-(lh0|lh1|lz4|lz5|lzs|lh\\40|lhd|lh2|lh3|lh4|lh5)-/n)
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["lha"]]
+      @dependencies ||= T.let([Formula["lha"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/lua_rock.rb
+++ b/Library/Homebrew/unpack_strategy/lua_rock.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "uncompressed"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".rock"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       return false unless Zip.can_extract?(path)
 

--- a/Library/Homebrew/unpack_strategy/lua_rock.rb
+++ b/Library/Homebrew/unpack_strategy/lua_rock.rb
@@ -6,7 +6,7 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking LuaRock archives.
   class LuaRock < Uncompressed
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".rock"]
     end

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       [".lz"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\ALZIP/n)
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["lzip"]]
+      @dependencies ||= T.let([Formula["lzip"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Lzip
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".lz"]
     end

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       FileUtils.cp path, unpack_dir/basename, preserve: true
       quiet_flags = verbose ? [] : ["-q"]

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       [".lzma"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\A\]\000\000\200\000/n)
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["xz"]]
+      @dependencies ||= T.let([Formula["xz"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       FileUtils.cp path, unpack_dir/basename, preserve: true
       quiet_flags = verbose ? [] : ["-q"]

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Lzma
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".lzma"]
     end

--- a/Library/Homebrew/unpack_strategy/mercurial.rb
+++ b/Library/Homebrew/unpack_strategy/mercurial.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "directory"
@@ -6,12 +6,14 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Mercurial repositories.
   class Mercurial < Directory
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
-      super && (path/".hg").directory?
+      !!(super && (path/".hg").directory?)
     end
 
     private
 
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "hg",
                       args:    ["--cwd", path, "archive", "--subrepos", "-y", "-t", "files", unpack_dir],

--- a/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
+++ b/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
@@ -6,7 +6,7 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking Microsoft Office documents.
   class MicrosoftOfficeXml < Uncompressed
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [
         ".doc", ".docx",

--- a/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
+++ b/Library/Homebrew/unpack_strategy/microsoft_office_xml.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "uncompressed"
@@ -15,6 +15,7 @@ module UnpackStrategy
       ]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       return false unless Zip.can_extract?(path)
 

--- a/Library/Homebrew/unpack_strategy/otf.rb
+++ b/Library/Homebrew/unpack_strategy/otf.rb
@@ -6,7 +6,7 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking OpenType fonts.
   class Otf < Uncompressed
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".otf"]
     end

--- a/Library/Homebrew/unpack_strategy/otf.rb
+++ b/Library/Homebrew/unpack_strategy/otf.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "uncompressed"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".otf"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\AOTTO/n)
     end

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class P7Zip
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".7z"]
     end

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "7zr",
                       args:    ["x", "-y", "-bd", "-bso0", path, "-o#{unpack_dir}"],

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       [".7z"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\A7z\xBC\xAF\x27\x1C/n)
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["p7zip"]]
+      @dependencies ||= T.let([Formula["p7zip"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/pax.rb
+++ b/Library/Homebrew/unpack_strategy/pax.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "pax",
                       args:    ["-rf", path],

--- a/Library/Homebrew/unpack_strategy/pax.rb
+++ b/Library/Homebrew/unpack_strategy/pax.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".pax"]
     end
 
+    sig { override.params(_path: Pathname).returns(T::Boolean) }
     def self.can_extract?(_path)
       false
     end

--- a/Library/Homebrew/unpack_strategy/pax.rb
+++ b/Library/Homebrew/unpack_strategy/pax.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Pax
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".pax"]
     end

--- a/Library/Homebrew/unpack_strategy/pkg.rb
+++ b/Library/Homebrew/unpack_strategy/pkg.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "uncompressed"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".pkg", ".mkpg"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.extname.match?(/\A.m?pkg\Z/) &&
         (path.directory? || path.magic_number.match?(/\Axar!/n))

--- a/Library/Homebrew/unpack_strategy/pkg.rb
+++ b/Library/Homebrew/unpack_strategy/pkg.rb
@@ -6,7 +6,7 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking macOS package installers.
   class Pkg < Uncompressed
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".pkg", ".mkpg"]
     end

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       [".rar"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\ARar!/n)
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["libarchive"]]
+      @dependencies ||= T.let([Formula["libarchive"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Rar
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".rar"]
     end

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "bsdtar",
                       args:    ["x", "-f", path, "-C", unpack_dir],

--- a/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
+++ b/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
@@ -6,7 +6,7 @@ require_relative "generic_unar"
 module UnpackStrategy
   # Strategy for unpacking self-extracting executables.
   class SelfExtractingExecutable < GenericUnar
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       []
     end

--- a/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
+++ b/Library/Homebrew/unpack_strategy/self_extracting_executable.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "generic_unar"
@@ -11,6 +11,7 @@ module UnpackStrategy
       []
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\AMZ/n) &&
         path.file_type.include?("self-extracting archive")

--- a/Library/Homebrew/unpack_strategy/sit.rb
+++ b/Library/Homebrew/unpack_strategy/sit.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "generic_unar"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".sit"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\AStuffIt/n)
     end

--- a/Library/Homebrew/unpack_strategy/sit.rb
+++ b/Library/Homebrew/unpack_strategy/sit.rb
@@ -6,7 +6,7 @@ require_relative "generic_unar"
 module UnpackStrategy
   # Strategy for unpacking Stuffit archives.
   class Sit < GenericUnar
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".sit"]
     end

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "directory"
@@ -6,12 +6,14 @@ require_relative "directory"
 module UnpackStrategy
   # Strategy for unpacking Subversion repositories.
   class Subversion < Directory
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
-      super && (path/".svn").directory?
+      !!(super && (path/".svn").directory?)
     end
 
     private
 
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "svn",
                       args:    ["export", "--force", ".", unpack_dir],

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -9,7 +9,7 @@ module UnpackStrategy
     include UnpackStrategy
     extend SystemCommand::Mixin
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [
         ".tar",

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -34,7 +34,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       Dir.mktmpdir("homebrew-tar", HOMEBREW_TEMP) do |tmpdir|
         tar_path = if DependencyCollector.tar_needs_xz_dependency? && Xz.can_extract?(path)

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require "system_command"
@@ -22,6 +22,7 @@ module UnpackStrategy
       ]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       return true if path.magic_number.match?(/\A.{257}ustar/n)
 

--- a/Library/Homebrew/unpack_strategy/ttf.rb
+++ b/Library/Homebrew/unpack_strategy/ttf.rb
@@ -6,7 +6,7 @@ require_relative "uncompressed"
 module UnpackStrategy
   # Strategy for unpacking TrueType fonts.
   class Ttf < Uncompressed
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".ttc", ".ttf"]
     end

--- a/Library/Homebrew/unpack_strategy/ttf.rb
+++ b/Library/Homebrew/unpack_strategy/ttf.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 require_relative "uncompressed"
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".ttc", ".ttf"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       # TrueType Font
       path.magic_number.match?(/\A\000\001\000\000\000/n) ||

--- a/Library/Homebrew/unpack_strategy/uncompressed.rb
+++ b/Library/Homebrew/unpack_strategy/uncompressed.rb
@@ -26,7 +26,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose: false)
       FileUtils.cp path, unpack_dir/basename.sub(/^[\da-f]{64}--/, ""), preserve: true, verbose:
     end

--- a/Library/Homebrew/unpack_strategy/uncompressed.rb
+++ b/Library/Homebrew/unpack_strategy/uncompressed.rb
@@ -6,6 +6,12 @@ module UnpackStrategy
   class Uncompressed
     include UnpackStrategy
 
+    sig { override.returns(T::Array[String]) }
+    def self.extensions = []
+
+    sig { override.params(_path: Pathname).returns(T::Boolean) }
+    def self.can_extract?(_path) = false
+
     sig {
       params(
         to:                   T.nilable(Pathname),

--- a/Library/Homebrew/unpack_strategy/xar.rb
+++ b/Library/Homebrew/unpack_strategy/xar.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,6 +11,7 @@ module UnpackStrategy
       [".xar"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\Axar!/n)
     end

--- a/Library/Homebrew/unpack_strategy/xar.rb
+++ b/Library/Homebrew/unpack_strategy/xar.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Xar
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".xar"]
     end

--- a/Library/Homebrew/unpack_strategy/xar.rb
+++ b/Library/Homebrew/unpack_strategy/xar.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "xar",
                       args:    ["-x", "-f", path, "-C", unpack_dir],

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       [".xz"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\A\xFD7zXZ\x00/n)
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["xz"]]
+      @dependencies ||= T.let([Formula["xz"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       FileUtils.cp path, unpack_dir/basename, preserve: true
       quiet_flags = verbose ? [] : ["-q"]

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Xz
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".xz"]
     end

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -23,6 +23,7 @@ module UnpackStrategy
               .returns(SystemCommand::Result)
     }
     def extract_to_dir(unpack_dir, basename:, verbose:)
+      odebug "in unpack_strategy, zip, extract_to_dir, verbose: #{verbose.inspect}"
       unzip = if which("unzip").blank?
         begin
           Formula["unzip"]

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -6,12 +6,12 @@ module UnpackStrategy
   class Zip
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".zip"]
     end
 
-    sig { params(path: Pathname).returns(T::Boolean) }
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\APK(\003\004|\005\006)/n)
     end

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module UnpackStrategy
@@ -11,12 +11,14 @@ module UnpackStrategy
       [".zst"]
     end
 
+    sig { override.params(path: Pathname).returns(T::Boolean) }
     def self.can_extract?(path)
       path.magic_number.match?(/\x28\xB5\x2F\xFD/n)
     end
 
+    sig { returns(T.nilable(T::Array[Formula])) }
     def dependencies
-      @dependencies ||= [Formula["zstd"]]
+      @dependencies ||= T.let([Formula["zstd"]], T.nilable(T::Array[Formula]))
     end
 
     private

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -21,7 +21,7 @@ module UnpackStrategy
 
     private
 
-    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).returns(T.untyped) }
+    sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       FileUtils.cp path, unpack_dir/basename, preserve: true
       quiet_flags = verbose ? [] : ["-q"]

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -6,7 +6,7 @@ module UnpackStrategy
   class Zstd
     include UnpackStrategy
 
-    sig { returns(T::Array[String]) }
+    sig { override.returns(T::Array[String]) }
     def self.extensions
       [".zst"]
     end

--- a/Library/Homebrew/utils/shebang.rb
+++ b/Library/Homebrew/utils/shebang.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Utils
@@ -8,13 +8,20 @@ module Utils
 
     # Specification on how to rewrite a given shebang.
     class RewriteInfo
-      attr_reader :regex, :max_length, :replacement
+      sig { returns(Regexp) }
+      attr_reader :regex
+
+      sig { returns(Integer) }
+      attr_reader :max_length
+
+      sig { returns(T.any(String, Pathname)) }
+      attr_reader :replacement
 
       sig { params(regex: Regexp, max_length: Integer, replacement: T.any(String, Pathname)).void }
       def initialize(regex, max_length, replacement)
-        @regex = regex
-        @max_length = max_length
-        @replacement = replacement
+        @regex = T.let(regex, Regexp)
+        @max_length = T.let(max_length, Integer)
+        @replacement = T.let(replacement, T.any(String, Pathname))
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/17297.
- Discovered which ones of the remaining "not yet `typed: strict`" list were public API-related via `grep -rL "# typed: strict" Library/Homebrew | xargs grep -l "@api public"`.
