### PR TITLE
livecheck: finish expanding `typed: strict`

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
@@ -97,17 +97,13 @@ module Homebrew
       # @return [Hash]
       sig { returns(T::Hash[Symbol, T.untyped]) }
       def strategies
-        return @strategies if defined? @strategies
-
-        @strategies = {}
-        Strategy.constants.sort.each do |const_symbol|
+        @strategies ||= T.let(Strategy.constants.sort.each_with_object({}) do |const_symbol, hash|
           constant = Strategy.const_get(const_symbol)
           next unless constant.is_a?(Class)
 
           key = Utils.underscore(const_symbol).to_sym
-          @strategies[key] = constant
-        end
-        @strategies
+          hash[key] = constant
+        end, T.nilable(T::Hash[Symbol, T.untyped]))
       end
       private_class_method :strategies
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I previously [expanded use of `typed: strict` in livecheck files](https://github.com/Homebrew/brew/pull/17632) but the exception was `livecheck/strategy.rb`. This addresses the `@strategies` type errors in that file and upgrades it to `typed: strict`.

Related to https://github.com/Homebrew/brew/issues/17297.