### PR TITLE
Use struct for `#audit_formula` args

### DIFF
--- a/Library/Homebrew/rubocops/bottle.rb
+++ b/Library/Homebrew/rubocops/bottle.rb
@@ -10,8 +10,9 @@ module RuboCop
       class BottleFormat < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          bottle_node = find_block(formula_nodes.body_node, :bottle)
           return if bottle_node.nil?
 
           sha256_nodes = find_method_calls_by_name(bottle_node.body, :sha256)
@@ -55,8 +56,9 @@ module RuboCop
       class BottleTagIndentation < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          bottle_node = find_block(formula_nodes.body_node, :bottle)
           return if bottle_node.nil?
 
           sha256_nodes = find_method_calls_by_name(bottle_node.body, :sha256)
@@ -89,8 +91,9 @@ module RuboCop
       class BottleDigestIndentation < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          bottle_node = find_block(formula_nodes.body_node, :bottle)
           return if bottle_node.nil?
 
           sha256_nodes = find_method_calls_by_name(bottle_node.body, :sha256)
@@ -123,8 +126,9 @@ module RuboCop
       class BottleOrder < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          bottle_node = find_block(body_node, :bottle)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          bottle_node = find_block(formula_nodes.body_node, :bottle)
           return if bottle_node.nil?
           return if bottle_node.child_nodes.blank?
 

--- a/Library/Homebrew/rubocops/caveats.rb
+++ b/Library/Homebrew/rubocops/caveats.rb
@@ -26,7 +26,8 @@ module RuboCop
       # end
       # ```
       class Caveats < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, _body_node)
+        sig { override.params(_formula_nodes: FormulaNodes).void }
+        def audit_formula(_formula_nodes)
           caveats_strings.each do |n|
             if regex_match_group(n, /\bsetuid\b/i)
               problem "Don't recommend `setuid` in the caveats, suggest `sudo` instead."

--- a/Library/Homebrew/rubocops/checksum.rb
+++ b/Library/Homebrew/rubocops/checksum.rb
@@ -8,8 +8,9 @@ module RuboCop
     module FormulaAudit
       # This cop makes sure that deprecated checksums are not used.
       class Checksum < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
 
           problem "MD5 checksums are deprecated, please use SHA-256" if method_called_ever?(body_node, :md5)
 
@@ -44,10 +45,9 @@ module RuboCop
       class ChecksumCase < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
-
-          sha256_calls = find_every_method_call_by_name(body_node, :sha256)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          sha256_calls = find_every_method_call_by_name(formula_nodes.body_node, :sha256)
           sha256_calls.each do |sha256_call|
             checksum = get_checksum_node(sha256_call)
             next if checksum.nil?

--- a/Library/Homebrew/rubocops/class.rb
+++ b/Library/Homebrew/rubocops/class.rb
@@ -16,7 +16,10 @@ module RuboCop
           AmazonWebServicesFormula
         ].freeze
 
-        def audit_formula(_node, _class_node, parent_class_node, _body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          parent_class_node = formula_nodes.parent_class_node
+
           parent_class = class_name(parent_class_node)
           return unless DEPRECATED_CLASSES.include?(parent_class)
 
@@ -30,8 +33,9 @@ module RuboCop
       class Test < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          test = find_block(body_node, :test)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          test = find_block(formula_nodes.body_node, :test)
           return unless test
 
           if test.body.nil?
@@ -69,11 +73,13 @@ module RuboCop
     module FormulaAuditStrict
       # This cop makes sure that a `test` block exists.
       class TestPresent < FormulaCop
-        def audit_formula(_node, class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
           return if find_block(body_node, :test)
           return if find_node_method_by_name(body_node, :disable!)
 
-          offending_node(class_node) if body_node.nil?
+          offending_node(formula_nodes.class_node) if body_node.nil?
           problem "A `test do` test block should be added"
         end
       end

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -14,8 +14,9 @@ module RuboCop
       class ComponentsOrder < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           @present_components, @offensive_nodes = check_order(FORMULA_COMPONENT_PRECEDENCE_LIST, body_node)
 

--- a/Library/Homebrew/rubocops/components_redundancy.rb
+++ b/Library/Homebrew/rubocops/components_redundancy.rb
@@ -20,8 +20,9 @@ module RuboCop
         STABLE_MSG = "`stable do` should not be present without a `head` spec"
         STABLE_BLOCK_METHODS = [:url, :sha256, :mirror, :version].freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           urls = find_method_calls_by_name(body_node, :url)
 

--- a/Library/Homebrew/rubocops/conflicts.rb
+++ b/Library/Homebrew/rubocops/conflicts.rb
@@ -13,8 +13,9 @@ module RuboCop
         MSG = "Versioned formulae should not use `conflicts_with`. " \
               "Use `keg_only :versioned_formula` instead."
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           find_method_calls_by_name(body_node, :conflicts_with).each do |conflicts_with_call|
             next unless parameters(conflicts_with_call).last.respond_to? :values

--- a/Library/Homebrew/rubocops/dependency_order.rb
+++ b/Library/Homebrew/rubocops/dependency_order.rb
@@ -13,7 +13,10 @@ module RuboCop
       class DependencyOrder < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
+
           check_dependency_nodes_order(body_node)
           check_uses_from_macos_nodes_order(body_node)
           ([:head, :stable] + on_system_methods).each do |block_name|

--- a/Library/Homebrew/rubocops/deprecate_disable.rb
+++ b/Library/Homebrew/rubocops/deprecate_disable.rb
@@ -10,7 +10,10 @@ module RuboCop
       class DeprecateDisableDate < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
+
           [:deprecate!, :disable!].each do |method|
             node = find_node_method_by_name(body_node, method)
 
@@ -39,7 +42,10 @@ module RuboCop
 
         PUNCTUATION_MARKS = %w[. ! ?].freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
+
           [:deprecate!, :disable!].each do |method|
             node = find_node_method_by_name(body_node, method)
 

--- a/Library/Homebrew/rubocops/desc.rb
+++ b/Library/Homebrew/rubocops/desc.rb
@@ -13,10 +13,13 @@ module RuboCop
         include DescHelper
         extend AutoCorrector
 
-        def audit_formula(_node, class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
+
           @name = @formula_name
           desc_call = find_node_method_by_name(body_node, :desc)
-          offending_node(class_node) if body_node.nil?
+          offending_node(formula_nodes.class_node) if body_node.nil?
           audit_desc(:formula, @name, desc_call)
         end
       end

--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -18,6 +18,13 @@ module RuboCop
 
       @registry = Cop.registry
 
+      class FormulaNodes < T::Struct
+        prop :node, RuboCop::AST::ClassNode
+        prop :class_node, RuboCop::AST::ConstNode
+        prop :parent_class_node, RuboCop::AST::ConstNode
+        prop :body_node, RuboCop::AST::Node
+      end
+
       # This method is called by RuboCop and is the main entry point.
       def on_class(node)
         @file_path = processed_source.file_path
@@ -27,19 +34,11 @@ module RuboCop
         class_node, parent_class_node, @body = *node
         @formula_name = Pathname.new(@file_path).basename(".rb").to_s
         @tap_style_exceptions = nil
-        audit_formula(node, class_node, parent_class_node, @body)
+        audit_formula(FormulaNodes.new(node:, class_node:, parent_class_node:, body_node: @body))
       end
 
-      sig {
-        abstract
-          .params(
-            node:              RuboCop::AST::ClassNode,
-            class_node:        RuboCop::AST::ConstNode,
-            parent_class_node: RuboCop::AST::ConstNode,
-            body_node:         RuboCop::AST::Node,
-          ).void
-      }
-      def audit_formula(node, class_node, parent_class_node, body_node); end
+      sig { abstract.params(formula_nodes: FormulaNodes).void }
+      def audit_formula(formula_nodes); end
 
       # Yields to block when there is a match.
       #

--- a/Library/Homebrew/rubocops/files.rb
+++ b/Library/Homebrew/rubocops/files.rb
@@ -8,13 +8,14 @@ module RuboCop
     module FormulaAudit
       # This cop makes sure that a formula's file permissions are correct.
       class Files < FormulaCop
-        def audit_formula(node, _class_node, _parent_class_node, _body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
           return unless file_path
 
           # Codespaces routinely screws up all permissions so don't complain there.
           return if ENV["CODESPACES"] || ENV["HOMEBREW_CODESPACES"]
 
-          offending_node(node)
+          offending_node(formula_nodes.node)
           actual_mode = File.stat(file_path).mode
           # Check that the file is world-readable.
           if actual_mode & 0444 != 0444

--- a/Library/Homebrew/rubocops/homepage.rb
+++ b/Library/Homebrew/rubocops/homepage.rb
@@ -12,11 +12,13 @@ module RuboCop
         include HomepageHelper
         extend AutoCorrector
 
-        def audit_formula(_node, class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
           homepage_node = find_node_method_by_name(body_node, :homepage)
 
           if homepage_node.nil?
-            offending_node(class_node) if body_node.nil?
+            offending_node(formula_nodes.class_node) if body_node.nil?
             problem "Formula should have a homepage."
             return
           end

--- a/Library/Homebrew/rubocops/keg_only.rb
+++ b/Library/Homebrew/rubocops/keg_only.rb
@@ -10,8 +10,9 @@ module RuboCop
       class KegOnly < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          keg_only_node = find_node_method_by_name(body_node, :keg_only)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          keg_only_node = find_node_method_by_name(formula_nodes.body_node, :keg_only)
           return unless keg_only_node
 
           allowlist = %w[

--- a/Library/Homebrew/rubocops/livecheck.rb
+++ b/Library/Homebrew/rubocops/livecheck.rb
@@ -11,8 +11,9 @@ module RuboCop
       class LivecheckSkip < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          livecheck_node = find_block(formula_nodes.body_node, :livecheck)
           return if livecheck_node.blank?
 
           skip = find_every_method_call_by_name(livecheck_node, :skip).first
@@ -39,8 +40,9 @@ module RuboCop
 
       # This cop ensures that a `url` is specified in the `livecheck` block.
       class LivecheckUrlProvided < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          livecheck_node = find_block(formula_nodes.body_node, :livecheck)
           return unless livecheck_node
 
           url_node = find_every_method_call_by_name(livecheck_node, :url).first
@@ -62,7 +64,9 @@ module RuboCop
       class LivecheckUrlSymbol < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          body_node = formula_nodes.body_node
           livecheck_node = find_block(body_node, :livecheck)
           return if livecheck_node.blank?
 
@@ -117,8 +121,9 @@ module RuboCop
       class LivecheckRegexParentheses < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          livecheck_node = find_block(formula_nodes.body_node, :livecheck)
           return if livecheck_node.blank?
 
           skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
@@ -144,8 +149,9 @@ module RuboCop
 
         TAR_PATTERN = /\\?\.t(ar|(g|l|x)z$|[bz2]{2,4}$)(\\?\.((g|l|x)z)|[bz2]{2,4}|Z)?$/i
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          livecheck_node = find_block(formula_nodes.body_node, :livecheck)
           return if livecheck_node.blank?
 
           skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
@@ -171,8 +177,9 @@ module RuboCop
       # This cop ensures that a `regex` is provided when `strategy :page_match` is specified
       # in the `livecheck` block.
       class LivecheckRegexIfPageMatch < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          livecheck_node = find_block(body_node, :livecheck)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          livecheck_node = find_block(formula_nodes.body_node, :livecheck)
           return if livecheck_node.blank?
 
           skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?
@@ -199,10 +206,11 @@ module RuboCop
 
         MSG = "Regexes should be case-insensitive unless sensitivity is explicitly required for proper matching."
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
           return if tap_style_exception? :regex_case_sensitive_allowlist
 
-          livecheck_node = find_block(body_node, :livecheck)
+          livecheck_node = find_block(formula_nodes.body_node, :livecheck)
           return if livecheck_node.blank?
 
           skip = find_every_method_call_by_name(livecheck_node, :skip).first.present?

--- a/Library/Homebrew/rubocops/options.rb
+++ b/Library/Homebrew/rubocops/options.rb
@@ -14,8 +14,9 @@ module RuboCop
         DEP_OPTION = "Formulae in homebrew/core should not use `deprecated_option`."
         OPTION = "Formulae in homebrew/core should not use `option`."
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           option_call_nodes = find_every_method_call_by_name(body_node, :option)
           option_call_nodes.each do |option_call|

--- a/Library/Homebrew/rubocops/resource_requires_dependencies.rb
+++ b/Library/Homebrew/rubocops/resource_requires_dependencies.rb
@@ -10,8 +10,9 @@ module RuboCop
       # to ensure that they also have the correct `uses_from_macos`
       # dependencies.
       class ResourceRequiresDependencies < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           resource_nodes = find_every_method_call_by_name(body_node, :resource)
           return if resource_nodes.empty?

--- a/Library/Homebrew/rubocops/service.rb
+++ b/Library/Homebrew/rubocops/service.rb
@@ -22,8 +22,9 @@ module RuboCop
         # At least one of these methods must be defined in a service block.
         REQUIRED_METHOD_CALLS = [:run, :name].freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          service_node = find_block(body_node, :service)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          service_node = find_block(formula_nodes.body_node, :service)
           return if service_node.blank?
 
           method_calls = service_node.each_descendant(:send).group_by(&:method_name)

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -10,7 +10,9 @@ module RuboCop
       class Text < FormulaCop
         extend AutoCorrector
 
-        def audit_formula(node, _class_node, _parent_class_node, body_node)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          node = formula_nodes.node
           full_source_content = source_buffer(node).source
 
           if (match = full_source_content.match(/^require ['"]formula['"]$/))
@@ -20,7 +22,7 @@ module RuboCop
             end
           end
 
-          return if body_node.nil?
+          return if (body_node = formula_nodes.body_node).nil?
 
           if find_method_def(body_node, :plist)
             problem "`def plist` is deprecated. Please use services instead: https://docs.brew.sh/Formula-Cookbook#service-files"
@@ -113,8 +115,9 @@ module RuboCop
     module FormulaAuditStrict
       # This cop contains stricter checks for various problems in a formula's source code.
       class Text < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           find_method_with_args(body_node, :go_resource) do
             problem "`go_resource`s are deprecated. Please ask upstream to implement Go vendoring"

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -11,8 +11,9 @@ module RuboCop
       class Urls < FormulaCop
         include UrlHelper
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           urls = find_every_func_call_by_name(body_node, :url)
           mirrors = find_every_func_call_by_name(body_node, :mirror)
@@ -42,8 +43,9 @@ module RuboCop
 
       # This cop makes sure that the correct format for PyPI URLs is used.
       class PyPiUrls < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           urls = find_every_func_call_by_name(body_node, :url)
           mirrors = find_every_func_call_by_name(body_node, :mirror)
@@ -72,8 +74,9 @@ module RuboCop
 
       # This cop makes sure that git URLs have a `revision`.
       class GitUrls < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
           return if formula_tap != "homebrew-core"
 
           find_method_calls_by_name(body_node, :url).each do |url|
@@ -94,8 +97,9 @@ module RuboCop
     module FormulaAuditStrict
       # This cop makes sure that git URLs have a `tag`.
       class GitUrls < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
           return if formula_tap != "homebrew-core"
 
           find_method_calls_by_name(body_node, :url).each do |url|

--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -59,8 +59,9 @@ module RuboCop
           zlib
         ].freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           find_method_with_args(body_node, :keg_only, :provided_by_macos) do
             return if PROVIDED_BY_MACOS_FORMULAE.include? @formula_name
@@ -95,8 +96,9 @@ module RuboCop
           zsh
         ].freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if body_node.nil?
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          return if (body_node = formula_nodes.body_node).nil?
 
           depends_on_linux = depends_on?(:linux)
 

--- a/Library/Homebrew/rubocops/version.rb
+++ b/Library/Homebrew/rubocops/version.rb
@@ -8,8 +8,9 @@ module RuboCop
     module FormulaAudit
       # This cop makes sure that a `version` is in the correct format.
       class Version < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          version_node = find_node_method_by_name(body_node, :version)
+        sig { override.params(formula_nodes: FormulaNodes).void }
+        def audit_formula(formula_nodes)
+          version_node = find_node_method_by_name(formula_nodes.body_node, :version)
           return unless version_node
 
           version = string_content(parameters(version_node).first)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As discussed in https://github.com/Homebrew/brew/pull/17643#discussion_r1667381705, adding type signatures to `#audit_formula` methods in formula cops would lead to verbose, repetitive signatures across the existing ~63 instances:

```ruby
sig {
  override.params(
    _node:              RuboCop::AST::ClassNode,
    _class_node:        RuboCop::AST::ConstNode,
    _parent_class_node: RuboCop::AST::ConstNode,
    body_node:          RuboCop::AST::Node,
  ).void
}
```

This reworks `#audit_formula` to use a `T::Struct` for its arguments, which allows us to use a one-line signature for these methods. There may be room for improvement here but this seems to work as expected, at least.