### PR TITLE
context: fix original context not being restored

### DIFF
--- a/Library/Homebrew/context.rb
+++ b/Library/Homebrew/context.rb
@@ -63,7 +63,7 @@ module Context
   end
 
   def with_context(**options)
-    old_context = Thread.current[:context]
+    old_context = Context.current
 
     new_context = ContextStruct.new(
       debug:   options.fetch(:debug, old_context&.debug?),


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes #17641: if `Thread.current[:context]` returns `nil`, the original context won't be saved and restored, so use `self.current` which accounts for that possibility.