### PR TITLE
dev-cmd/bump-formula-pr: Fix `fetch_resource_and_forced_version` types

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -440,7 +440,7 @@ module Homebrew
 
       sig {
         params(formula: Formula, new_version: T.nilable(String), url: String,
-               specs: Float).returns(T::Array[T.untyped])
+               specs: String).returns(T::Array[T.untyped])
       }
       def fetch_resource_and_forced_version(formula, new_version, url, **specs)
         resource = Resource.new


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This should fix https://github.com/Homebrew/homebrew-core/actions/runs/9839505520, that is:

```
Parameter 'tag': Expected type Float, got type String with value "2024-07-05"
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11473/lib/types/private/methods/call_validation.rb:215
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:445 (Homebrew::DevCmd::BumpFormulaPr#fetch_resource_and_forced_version)
```

- I think I read https://sorbet.org/docs/sigs#rest-parameters too literally, yes Sorbet expands the kwargs into a hash type, but it's the value type that needs specifying in the sig (which for us is `String`).
