### PR TITLE
cask/dsl/caveats: allow for simulated system checks in rosetta caveat

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -141,7 +141,7 @@ module Cask
       end
 
       caveat :requires_rosetta do
-        next unless Hardware::CPU.arm?
+        next if !Hardware::CPU.arm? && Homebrew::SimulateSystem.current_arch != :arm
 
         <<~EOS
           #{@cask} is built for Intel macOS and so requires Rosetta 2 to be installed.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There is currently the possibility of audits failing when CI is run on an intel runner the the `--arch=intel` flag.
This ensures that the caveat is also printed if `Homebrew::SimulateSystem` is set to `arm`.

Unblocks: https://github.com/Homebrew/homebrew-cask/pull/178165