### PR TITLE
docker: revert back linuxbrew's UID to 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,11 @@ ARG version=22.04
 FROM ubuntu:"${version}"
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Set the user ID to the default value of 1001 since different ubuntu
-# versions yield to different user IDs with `useradd`
-ENV USER_ID=1001
+# Deterministic UID (first user). Helps with docker build cache
+ENV USER_ID=1000
+# Delete the default ubuntu user & group UID=1000 GID=1000 in Ubuntu 23.04+
+# that conflicts with the linuxbrew user
+RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu; true
 
 # We don't want to manually pin versions, happy to use whatever
 # Ubuntu thinks is best.


### PR DESCRIPTION
In https://github.com/Homebrew/brew/pull/17584 we have changed "linuxbrew" user's UID/GID to 1001 in order to mitigate for Ubuntu 23.04 and higher, which started creating a default "ubuntu" user taking over UID/GID 1000 .

While we may desire a deterministic UID in the homebrew docker image, the change effectively modified the behaviour for all current 3 images based on Ubuntu 18.04 20.04 and 22.04 by changing the linuxbrew's user UID/GID from 1000 to 1001. As per https://hub.docker.com/u/homebrew, we do not currently publish an image for 24.04 which the change is mitigating for.

Rather than mitigating for indeterministic behaviour of upstream changes, this commit implements the workaround in https://bugs.launchpad.net/cloud-images/+bug/2005129 to delete the default "ubuntu" user.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For background, changing the UID breaks downstream clients assuming the linuxbrew user has UID/GID 1000. Going from docker image 4.3.8 to 4.3.9 blocks everything due to EACCESS permission denied errors, thus a breaking change.

cc @marcosnils