### PR TITLE
fix: ignore SAML issues in GH API

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -917,6 +917,8 @@ module GitHub
     return false if !more_graphql_data && prs.length < MAXIMUM_OPEN_PRS
 
     homebrew_prs_count = graphql_result.dig("viewer", "pullRequests", "nodes").count do |pr|
+      next unless pr.present?
+
       pr["headRepositoryOwner"]["login"] == "Homebrew"
     end
     return true if homebrew_prs_count >= MAXIMUM_OPEN_PRS

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -322,7 +322,15 @@ module GitHub
 
       if raise_errors
         if result["errors"].present?
-          raise Error, result["errors"].map { |e| "#{e["type"]}: #{e["message"]}" }.join("\n")
+          related_errors = result["errors"].reject do |e|
+            e.key?("extensions") && e["extensions"]["saml_failure"] == true
+          end
+
+          if related_errors.present?
+            raise Error, related_errors.map { |e|
+                           "#{e["type"]}: #{e["message"]}"
+                         }.join("\n")
+          end
         end
 
         result["data"]

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -323,7 +323,7 @@ module GitHub
       if raise_errors
         if result["errors"].present?
           related_errors = result["errors"].reject do |e|
-            # comment explaining why we don't care about saml_failure
+            # saml_failure only happens for other orgs, Homebrew doesn't have it
             e.dig("extensions", "saml_failure") == true
           end
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -323,7 +323,8 @@ module GitHub
       if raise_errors
         if result["errors"].present?
           related_errors = result["errors"].reject do |e|
-            e.key?("extensions") && e["extensions"]["saml_failure"] == true
+            # comment explaining why we don't care about saml_failure
+            e.dig("extensions", "saml_failure") == true
           end
 
           if related_errors.present?


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This should allow people with SAML login for organisations that are not related to Homebrew (like me) to use commands that need the GH API.