### PR TITLE
Assume the `--greedy` flag for `brew outdated` when `HOMEBREW_UPGRADE_GREEDY` is set

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -32,6 +32,7 @@ module Homebrew
                             "formula is outdated. Otherwise, the repository's HEAD will only be checked for " \
                             "updates when a new stable or development version has been released."
         switch "-g", "--greedy",
+               env:         :upgrade_greedy,
                description: "Also include outdated casks with `auto_updates true` or `version :latest`."
 
         switch "--greedy-latest",
@@ -48,8 +49,6 @@ module Homebrew
 
       sig { override.void }
       def run
-        @greedy = Homebrew::EnvConfig.upgrade_greedy? || args.greedy?
-
         case json_version(args.json)
         when :v1
           odie "`brew outdated --json=v1` is no longer supported. Use brew outdated --json=v2 instead."
@@ -120,7 +119,7 @@ module Homebrew
           else
             c = formula_or_cask
 
-            puts c.outdated_info(@greedy, verbose?, false, args.greedy_latest?, args.greedy_auto_updates?)
+            puts c.outdated_info(args.greedy?, verbose?, false, args.greedy_latest?, args.greedy_auto_updates?)
           end
         end
       end
@@ -145,7 +144,7 @@ module Homebrew
           else
             c = formula_or_cask
 
-            c.outdated_info(@greedy, verbose?, true, args.greedy_latest?, args.greedy_auto_updates?)
+            c.outdated_info(args.greedy?, verbose?, true, args.greedy_latest?, args.greedy_auto_updates?)
           end
         end
       end
@@ -195,7 +194,7 @@ module Homebrew
           if formula_or_cask.is_a?(Formula)
             formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
           else
-            formula_or_cask.outdated?(greedy: @greedy, greedy_latest: args.greedy_latest?,
+            formula_or_cask.outdated?(greedy: args.greedy?, greedy_latest: args.greedy_latest?,
                                       greedy_auto_updates: args.greedy_auto_updates?)
           end
         end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -48,6 +48,8 @@ module Homebrew
 
       sig { override.void }
       def run
+        @greedy = Homebrew::EnvConfig.upgrade_greedy? || args.greedy?
+
         case json_version(args.json)
         when :v1
           odie "`brew outdated --json=v1` is no longer supported. Use brew outdated --json=v2 instead."
@@ -118,7 +120,7 @@ module Homebrew
           else
             c = formula_or_cask
 
-            puts c.outdated_info(args.greedy?, verbose?, false, args.greedy_latest?, args.greedy_auto_updates?)
+            puts c.outdated_info(@greedy, verbose?, false, args.greedy_latest?, args.greedy_auto_updates?)
           end
         end
       end
@@ -143,7 +145,7 @@ module Homebrew
           else
             c = formula_or_cask
 
-            c.outdated_info(args.greedy?, verbose?, true, args.greedy_latest?, args.greedy_auto_updates?)
+            c.outdated_info(@greedy, verbose?, true, args.greedy_latest?, args.greedy_auto_updates?)
           end
         end
       end
@@ -193,7 +195,7 @@ module Homebrew
           if formula_or_cask.is_a?(Formula)
             formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
           else
-            formula_or_cask.outdated?(greedy: args.greedy?, greedy_latest: args.greedy_latest?,
+            formula_or_cask.outdated?(greedy: @greedy, greedy_latest: args.greedy_latest?,
                                       greedy_auto_updates: args.greedy_auto_updates?)
           end
         end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -436,7 +436,7 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_UPGRADE_GREEDY:                   {
-        description: "If set, pass `--greedy` to all cask upgrade commands and `brew outdated`.",
+        description: "If set, pass `--greedy` to all cask upgrade commands.",
         boolean:     true,
       },
       HOMEBREW_VERBOSE:                          {

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -436,7 +436,7 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_UPGRADE_GREEDY:                   {
-        description: "If set, pass `--greedy` to all cask upgrade commands.",
+        description: "If set, pass `--greedy` to all cask upgrade commands and `brew outdated`.",
         boolean:     true,
       },
       HOMEBREW_VERBOSE:                          {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If a user has set the `HOMEBREW_UPGRADE_GREEDY` env var, it implies that they are interested in always having their Casks upgraded "greedily" during `brew upgrade`.

It follows that such a user would additionally always be interested in knowing whether their Casks are "greedily" outdated when running `brew outdated`. Thus, this change makes `brew outdated` respect `HOMEBREW_UPGRADE_GREEDY` in the same manner as `brew upgrade`.