### PR TITLE
cli/named_args: raise priority of core casks

### DIFF
--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -5,8 +5,8 @@ require "formulary"
 module Test
   module Helper
     module Formula
-      def formula(name = "formula_name", path: Formulary.core_path(name), spec: :stable, alias_path: nil, tap: nil,
-                  &block)
+      def formula(name = "formula_name", path: nil, spec: :stable, alias_path: nil, tap: nil, &block)
+        path ||= Formulary.find_formula_in_tap(name, tap || CoreTap.instance)
         Class.new(::Formula, &block).new(name, path, spec, alias_path:, tap:)
       end
 


### PR DESCRIPTION
Previously we had a simple implementation where formulae are higher priority than casks. In the case of a conflict between a third-party tap formula and core tap cask, change this so that the core tap cask is prioritised as this is less confusing since the `homebrew/cask/` prefix is not common practice but is for third-party taps. This will likely better align with the user's intentions.