### PR TITLE
formula_assertions: Fix type of `cmd` param in `shell_output`

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -21,7 +21,7 @@ module Homebrew
     # Returns the output of running cmd and asserts the exit status.
     #
     # @api public
-    sig { params(cmd: String, result: Integer).returns(String) }
+    sig { params(cmd: T.any(Pathname, String), result: Integer).returns(String) }
     def shell_output(cmd, result = 0)
       ohai cmd
       output = `#{cmd}`


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This can be either a String or a Pathname, per [the part of the `noseyparker` test that failed](https://github.com/Homebrew/homebrew-core/pull/177177) (in a different part of the test, the command is passed as a string).

```
  ==> Testing noseyparker
  ==> /opt/homebrew/Cellar/noseyparker/0.18.1/bin/noseyparker -V
  Error: noseyparker: failed
  An exception occurred within a child process:
    TypeError: Parameter 'cmd': Expected type String, got type Pathname with value #<Pathname:/opt/homebrew/Ce...ps://github.com/Homebrew/brew>
  Caller: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/n/noseyparker.rb:35
```
