### PR TITLE
feat: do not use existing sudo authentication in brew commands

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -36,6 +36,12 @@ then
   exit 1
 fi
 
+# Reset sudo timestamp to avoid running unauthorized sudo commands
+if command -v sudo >/dev/null
+then
+  sudo --reset-timestamp
+fi
+
 quiet_cd() {
   CDPATH='' cd -- "$@" &>/dev/null || return
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
If anyone adds `sudo` to a formula, it might run without user input without this change. Probably bad.