### PR TITLE
Restrict direct url installs to the `file://` scheme

### DIFF
--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -18,4 +18,34 @@ RSpec.describe Cask::CaskLoader::FromURILoader do
       RUBY
     end
   end
+
+  describe "::load" do
+    it "raises an error when given an https URL" do
+      loader = described_class.new("https://brew.sh/foo.rb")
+      expect do
+        loader.load(config: nil)
+      end.to raise_error(UnsupportedInstallationMethod)
+    end
+
+    it "raises an error when given an ftp URL" do
+      loader = described_class.new("ftp://brew.sh/foo.rb")
+      expect do
+        loader.load(config: nil)
+      end.to raise_error(UnsupportedInstallationMethod)
+    end
+
+    it "raises an error when given an sftp URL" do
+      loader = described_class.new("sftp://brew.sh/foo.rb")
+      expect do
+        loader.load(config: nil)
+      end.to raise_error(UnsupportedInstallationMethod)
+    end
+
+    it "does not raise an error when given a file URL" do
+      loader = described_class.new("file://#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb")
+      expect do
+        loader.load(config: nil)
+      end.not_to raise_error(UnsupportedInstallationMethod)
+    end
+  end
 end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -523,6 +523,38 @@ RSpec.describe Formulary do
         end
       end
     end
+
+    context "when passed a URL" do
+      it "raises an error when given an https URL" do
+        expect do
+          described_class.factory("https://brew.sh/foo.rb")
+        end.to raise_error(UnsupportedInstallationMethod)
+      end
+
+      it "raises an error when given a bottle URL" do
+        expect do
+          described_class.factory("https://brew.sh/foo-1.0.arm64_catalina.bottle.tar.gz")
+        end.to raise_error(UnsupportedInstallationMethod)
+      end
+
+      it "raises an error when given an ftp URL" do
+        expect do
+          described_class.factory("ftp://brew.sh/foo.rb")
+        end.to raise_error(UnsupportedInstallationMethod)
+      end
+
+      it "raises an error when given an sftp URL" do
+        expect do
+          described_class.factory("sftp://brew.sh/foo.rb")
+        end.to raise_error(UnsupportedInstallationMethod)
+      end
+
+      it "does not raise an error when given a file URL" do
+        expect do
+          described_class.factory("file://#{TEST_FIXTURE_DIR}/testball.rb")
+        end.not_to raise_error(UnsupportedInstallationMethod)
+      end
+    end
   end
 
   specify "::from_contents" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We already don't allow installing or loading formulae directly from a URL (e.g. `brew install https://example.com/foo.tar.gz`), so this PR extends that to casks and also strengthens the check to ensure that the `file://` URL scheme is the only one allowed by `FromURILoader`.

Additionally, this PR does not allow loading formulae directly form a bottle URL (except for a `file://` URL).

I've opted to still have this return an error message like is currently done, but we also could put a deprecation there and eventually just have `Formulary.loader_for("https://...")` go right to `NullLoader`.