### PR TITLE
Don't allow special characters in sandbox rule paths

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -231,6 +231,22 @@ class Sandbox
     end
   end
 
+  # @api private
+  sig { params(path: T.any(String, Pathname), type: Symbol).returns(String) }
+  def path_filter(path, type)
+    invalid_char = ['"', "'", "(", ")", "\n"].find do |c|
+      path.to_s.include?(c)
+    end
+    raise ArgumentError, "Invalid character #{invalid_char} in path: #{path}" if invalid_char
+
+    case type
+    when :regex   then "regex #\"#{path}\""
+    when :subpath then "subpath \"#{expand_realpath(Pathname.new(path))}\""
+    when :literal then "literal \"#{expand_realpath(Pathname.new(path))}\""
+    else raise ArgumentError, "Invalid path filter type: #{type}"
+    end
+  end
+
   private
 
   sig { params(path: Pathname).returns(Pathname) }
@@ -238,16 +254,6 @@ class Sandbox
     raise unless path.absolute?
 
     path.exist? ? path.realpath : expand_realpath(path.parent)/path.basename
-  end
-
-  sig { params(path: T.any(String, Pathname), type: Symbol).returns(String) }
-  def path_filter(path, type)
-    case type
-    when :regex   then "regex #\"#{path}\""
-    when :subpath then "subpath \"#{expand_realpath(Pathname.new(path))}\""
-    when :literal then "literal \"#{expand_realpath(Pathname.new(path))}\""
-    else raise ArgumentError, "Invalid path filter type: #{type}"
-    end
   end
 
   class SandboxRule

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -21,6 +21,50 @@ RSpec.describe Sandbox, :needs_macos do
     expect(file).to exist
   end
 
+  describe "#path_filter" do
+    ["'", '"', "(", ")", "\n"].each do |char|
+      it "fails if the path contains #{char}" do
+        expect do
+          sandbox.path_filter("foo#{char}bar", :subpath)
+        end.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "#allow_write_cellar" do
+    it "fails when the formula has a name including )" do
+      f = formula do
+        url "https://brew.sh/foo-1.0.tar.gz"
+        version "1.0"
+
+        def initialize(*, **)
+          super
+          @name = "foo)bar"
+        end
+      end
+
+      expect do
+        sandbox.allow_write_cellar f
+      end.to raise_error(ArgumentError)
+    end
+
+    it "fails when the formula has a name including \"" do
+      f = formula do
+        url "https://brew.sh/foo-1.0.tar.gz"
+        version "1.0"
+
+        def initialize(*, **)
+          super
+          @name = "foo\"bar"
+        end
+      end
+
+      expect do
+        sandbox.allow_write_cellar f
+      end.to raise_error(ArgumentError)
+    end
+  end
+
   describe "#exec" do
     it "fails when writing to file not specified with ##allow_write" do
       expect do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR removes the possibility for paths passed to the sandbox profile to include special characters including `"`, `'`, `(`, `)`, `\n`.

CC @Moisan @krehel