### PR TITLE
Gemfile: use rubocop-sorbet from GitHub.

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -48,7 +48,9 @@ group :style, optional: true do
   gem "rubocop-md", require: false
   gem "rubocop-performance", require: false
   gem "rubocop-rspec", require: false
-  gem "rubocop-sorbet", require: false
+  # use rubocop-sorbet from github until a fix for this is released:
+  # https://github.com/Shopify/rubocop-sorbet/issues/238
+  gem "rubocop-sorbet", require: false, github: "Shopify/rubocop-sorbet"
 end
 group :tests, optional: true do
   gem "parallel_tests", require: false

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/Shopify/rubocop-sorbet.git
+  revision: 80f2a03e3d115a2d27eefe99d3bb37b9f2ba5dd4
+  specs:
+    rubocop-sorbet (0.8.3)
+      rubocop (>= 0.90.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -97,8 +104,6 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rspec (3.0.3)
       rubocop (~> 1.61)
-    rubocop-sorbet (0.8.3)
-      rubocop (>= 0.90.0)
     ruby-macho (4.1.0)
     ruby-prof (1.7.0)
     ruby-progressbar (1.13.0)
@@ -176,7 +181,7 @@ DEPENDENCIES
   rubocop-md
   rubocop-performance
   rubocop-rspec
-  rubocop-sorbet
+  rubocop-sorbet!
   ruby-macho
   ruby-prof
   ruby-progressbar


### PR DESCRIPTION
Use rubocop-sorbet from github until a fix for this is released: https://github.com/Shopify/rubocop-sorbet/issues/238