### PR TITLE
sandbox: only allow local network operations

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -93,6 +93,7 @@ module Homebrew
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
                 sandbox.deny_all_network_except_pipe(error_pipe) unless f.class.network_access_allowed?(:test)
+                sandbox.allow_network_localhost
                 sandbox.exec(*exec_args)
               else
                 exec(*exec_args)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -76,7 +76,7 @@ class Formula
 
   SUPPORTED_NETWORK_ACCESS_PHASES = [:build, :test, :postinstall].freeze
   private_constant :SUPPORTED_NETWORK_ACCESS_PHASES
-  DEFAULT_NETWORK_ACCESS_ALLOWED = true
+  DEFAULT_NETWORK_ACCESS_ALLOWED = false
   private_constant :DEFAULT_NETWORK_ACCESS_ALLOWED
 
   # The name of this {Formula}.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -943,6 +943,7 @@ on_request: installed_on_request?, options:)
         sandbox.allow_write_xcode
         sandbox.allow_write_cellar(formula)
         sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:build)
+        sandbox.allow_network_localhost
         sandbox.exec(*args)
       else
         exec(*args)
@@ -1158,6 +1159,7 @@ on_request: installed_on_request?, options:)
         sandbox.deny_write_homebrew_repository
         sandbox.allow_write_cellar(formula)
         sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:postinstall)
+        sandbox.allow_network_localhost
         Keg::KEG_LINK_DIRECTORIES.each do |dir|
           sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
         end

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -130,6 +130,7 @@ class Sandbox
     allow_network path:, type: :literal
   end
 
+  sig { void }
   def allow_network_localhost
     add_rule allow: true, operation: "network-inbound", filter: "local ip \"localhost:*\""
     add_rule allow: true, operation: "network*", filter: "remote ip \"localhost:*\""

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -130,6 +130,12 @@ class Sandbox
     allow_network path:, type: :literal
   end
 
+  def allow_network_localhost
+    add_rule allow: true, operation: "network-inbound", filter: "local ip \"localhost:*\""
+    add_rule allow: true, operation: "network*", filter: "remote ip \"localhost:*\""
+    add_rule allow: true, operation: "network*", filter: "remote unix"
+  end
+
   sig { params(args: T.any(String, Pathname)).void }
   def exec(*args)
     seatbelt = Tempfile.new(["homebrew", ".sb"], HOMEBREW_TEMP)

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Homebrew::DevCmd::Test do
       RUBY
 
       expect { brew "test", "--verbose", "testball_offline_test" }
-        .to output(/curl: \(6\) Could not resolve host: example\.org/).to_stdout
+        .to output(/curl: \(7\) Failed to connect to example.org/).to_stdout
         .and be_a_failure
     end
   end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Formula do
       expect(f.alias_name).to be_nil
       expect(f.full_alias_name).to be_nil
       expect(f.specified_path).to eq(path)
-      [:build, :test, :postinstall].each { |phase| expect(f.network_access_allowed?(phase)).to be(true) }
+      [:build, :test, :postinstall].each { |phase| expect(f.network_access_allowed?(phase)).to be(false) }
       expect { klass.new }.to raise_error(ArgumentError)
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Formula do
       expect(f_alias.specified_path).to eq(Pathname(alias_path))
       expect(f_alias.full_alias_name).to eq(alias_name)
       expect(f_alias.full_specified_name).to eq(alias_name)
-      [:build, :test, :postinstall].each { |phase| expect(f_alias.network_access_allowed?(phase)).to be(true) }
+      [:build, :test, :postinstall].each { |phase| expect(f_alias.network_access_allowed?(phase)).to be(false) }
       expect { klass.new }.to raise_error(ArgumentError)
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR is an attempt to restrict network operations in the sandbox (for `build`, `postinstall` and `test`) to just local network operations. The sandbox rules were inspired from: https://github.com/bazelbuild/bazel/blob/4d62c8f7557a4673ffe5600f963fdfddd7b99d3b/src/main/java/com/google/devtools/build/lib/sandbox/DarwinSandboxedSpawnRunner.java#L300-L302

This might have to be modified a bit and may cause problems with a bunch of formulae too, so further testing will be required. CC @woodruffw.