### PR TITLE
attestation: don't dupe stderr

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -95,7 +95,7 @@ module Homebrew
 
       begin
         result = system_command!(gh_executable, args: cmd, env: { "GH_TOKEN" => credentials },
-                                secrets: [credentials])
+                                secrets: [credentials], print_stderr: false)
       rescue ErrorDuringExecution => e
         # Even if we have credentials, they may be invalid or malformed.
         raise GhAuthNeeded, "invalid credentials" if e.status.exitstatus == 4

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_error_status))
 
       expect do
@@ -113,7 +114,8 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_auth_status))
 
       expect do
@@ -129,7 +131,8 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_return(fake_result_invalid_json)
 
       expect do
@@ -145,7 +148,8 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_return(fake_json_resp_wrong_sub)
 
       expect do
@@ -161,7 +165,8 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_return(fake_result_json_resp)
 
       described_class.check_attestation fake_all_bottle, described_class::HOMEBREW_CORE_REPO
@@ -181,7 +186,8 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_return(fake_result_json_resp)
 
       described_class.check_core_attestation fake_bottle
@@ -191,14 +197,16 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .once
         .and_raise(described_class::InvalidAttestationError)
 
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::BACKFILL_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_return(fake_result_json_resp_backfill)
 
       described_class.check_core_attestation fake_bottle
@@ -208,14 +216,16 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .once
         .and_raise(described_class::InvalidAttestationError)
 
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::BACKFILL_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds])
+              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              print_stderr: false)
         .and_return(fake_result_json_resp_too_new)
 
       expect do


### PR DESCRIPTION
Silences `system_command!`'s own stderr handling,
since we do it independently.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
