### PR TITLE
formula_installer: skip attestations on local_bottle_path

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1258,7 +1258,12 @@ on_request: installed_on_request?, options:)
   def pour
     # We skip `gh` to avoid a bootstrapping cycle, in the off-chance a user attempts
     # to explicitly `brew install gh` without already having a version for bootstrapping.
-    if Homebrew::Attestation.enabled? && formula.tap&.core_tap? && formula.name != "gh"
+    # We also skip bottle installs from local bottle paths, as these are done in CI
+    # as part of the build lifecycle before attestations are produced.
+    if Homebrew::Attestation.enabled? \
+        && formula.tap&.core_tap? \
+        && formula.name != "gh" \
+        && formula.local_bottle_path.blank?
       ohai "Verifying attestation for #{formula.name}"
       begin
         Homebrew::Attestation.check_core_attestation formula.bottle

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1260,10 +1260,10 @@ on_request: installed_on_request?, options:)
     # to explicitly `brew install gh` without already having a version for bootstrapping.
     # We also skip bottle installs from local bottle paths, as these are done in CI
     # as part of the build lifecycle before attestations are produced.
-    if Homebrew::Attestation.enabled? \
-        && formula.tap&.core_tap? \
-        && formula.name != "gh" \
-        && formula.local_bottle_path.blank?
+    if Homebrew::Attestation.enabled? &&
+       formula.tap&.core_tap? &&
+       formula.name != "gh" &&
+       formula.local_bottle_path.blank?
       ohai "Verifying attestation for #{formula.name}"
       begin
         Homebrew::Attestation.check_core_attestation formula.bottle


### PR DESCRIPTION
This should fix observed failures on https://github.com/Homebrew/homebrew-core/pull/177256 and https://github.com/Homebrew/homebrew-core/pull/177260.

TL;DR: `Formula#bottle` is not present when a bottle is being installed from a bottle path, e.g. on CI. This is not a normal user installation path and there's no attestation to verify in these cases (since the bottle is still being produced), so we just skip it outright.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
