### PR TITLE
Deny file mode changes outside of specified paths in sandbox

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -37,14 +37,7 @@ class Sandbox
   def allow_write(path:, type: :literal)
     add_rule allow: true, operation: "file-write*", filter: path_filter(path, type)
     add_rule allow: true, operation: "file-write-setugid", filter: path_filter(path, type)
-
-    file_write_mode_path = if Pathname(path).directory?
-      "#{path}/*"
-    else
-      path
-    end
-
-    add_rule allow: true, operation: "file-write-mode", filter: path_filter(file_write_mode_path, type)
+    add_rule allow: true, operation: "file-write-mode", filter: path_filter(path, type)
   end
 
   sig { params(path: T.any(String, Pathname), type: Symbol).void }

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -290,6 +290,7 @@ class Sandbox
           (regex #"^/dev/tty[a-z0-9]*$")
           )
       (deny file-write*) ; deny non-allowlist file write operations
+      (deny file-write-setugid) ; deny non-allowlist file write SUID/SGID operations
       (deny file-write-mode) ; deny non-allowlist file write mode operations
       (allow process-exec
           (literal "/bin/ps")

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -37,6 +37,14 @@ class Sandbox
   def allow_write(path:, type: :literal)
     add_rule allow: true, operation: "file-write*", filter: path_filter(path, type)
     add_rule allow: true, operation: "file-write-setugid", filter: path_filter(path, type)
+
+    file_write_mode_path = if Pathname(path).directory?
+      "#{path}/*"
+    else
+      path
+    end
+
+    add_rule allow: true, operation: "file-write-mode", filter: path_filter(file_write_mode_path, type)
   end
 
   sig { params(path: T.any(String, Pathname), type: Symbol).void }
@@ -289,6 +297,7 @@ class Sandbox
           (regex #"^/dev/tty[a-z0-9]*$")
           )
       (deny file-write*) ; deny non-allowlist file write operations
+      (deny file-write-mode) ; deny non-allowlist file write mode operations
       (allow process-exec
           (literal "/bin/ps")
           (with no-sandbox)

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -60,14 +60,28 @@ RSpec.describe Sandbox, :needs_macos do
 
   describe "#disallow chmod on some directory" do
     it "formula does a chmod to opt" do
-      expect { sandbox.exec "chmod", "ug-w", HOMEBREW_PREFIX}.to raise_error(ErrorDuringExecution)
+      expect { sandbox.exec "chmod", "ug-w", HOMEBREW_PREFIX }.to raise_error(ErrorDuringExecution)
     end
 
     it "allows chmod on a path allowed to write" do
       mktmpdir do |path|
         FileUtils.touch path/"foo"
         sandbox.allow_write_path(path)
-        expect { sandbox.exec "chmod", "ug-w", path/"foo"}.not_to raise_error(ErrorDuringExecution)
+        expect { sandbox.exec "chmod", "ug-w", path/"foo" }.not_to raise_error(ErrorDuringExecution)
+      end
+    end
+  end
+
+  describe "#disallow chmod SUID or SGID on some directory" do
+    it "formula does a chmod 4000 to opt" do
+      expect { sandbox.exec "chmod", "4000", HOMEBREW_PREFIX }.to raise_error(ErrorDuringExecution)
+    end
+
+    it "allows chmod 4000 on a path allowed to write" do
+      mktmpdir do |path|
+        FileUtils.touch path/"foo"
+        sandbox.allow_write_path(path)
+        expect { sandbox.exec "chmod", "4000", path/"foo" }.not_to raise_error(ErrorDuringExecution)
       end
     end
   end

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -57,4 +57,18 @@ RSpec.describe Sandbox, :needs_macos do
         .and output(a_string_matching(/foo/).and(matching(/bar/).and(not_matching(/Python/)))).to_stdout
     end
   end
+
+  describe "#disallow chmod on some directory" do
+    it "formula does a chmod to opt" do
+      expect { sandbox.exec "chmod", "ug-w", HOMEBREW_PREFIX}.to raise_error(ErrorDuringExecution)
+    end
+
+    it "allows chmod on a path allowed to write" do
+      mktmpdir do |path|
+        FileUtils.touch path/"foo"
+        sandbox.allow_write_path(path)
+        expect { sandbox.exec "chmod", "ug-w", path/"foo"}.not_to raise_error(ErrorDuringExecution)
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adjusts the sandbox rules to ensure that file permissions can only be changed for the paths explicitly specified.

CC: @Moisan @krehel