### PR TITLE
attestation: allow disabling verification.

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -45,9 +45,13 @@ module Homebrew
     # @api private
     sig { returns(T::Boolean) }
     def self.enabled?
-      Homebrew::EnvConfig.verify_attestations? \
-        || Homebrew::EnvConfig.developer? \
-        || Homebrew::Settings.read("devcmdrun") == "true"
+      # TODO: allow this undocumented variable until this is rolled out more
+      #       widely and then we can remove or document it.
+      return false if ENV.fetch("HOMEBREW_NO_VERIFY_ATTESTATIONS", false)
+
+      Homebrew::EnvConfig.verify_attestations? ||
+        Homebrew::EnvConfig.developer? ||
+        Homebrew::Settings.read("devcmdrun") == "true"
     end
 
     # Returns a path to a suitable `gh` executable for attestation verification.


### PR DESCRIPTION
Add the (for now undocumented) `HOMEBREW_NO_VERIFY_ATTESTATIONS` to disable attestation verification if it's having issues or when doing development.

While we're here, do a little style cleanup too.