### PR TITLE
bump: add utils/repology require

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -4,6 +4,7 @@
 require "abstract_command"
 require "bump_version_parser"
 require "livecheck/livecheck"
+require "utils/repology"
 
 module Homebrew
   module DevCmd


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A recent PR reworked `require`s to improve performance (#17707) but this led to an [`uninitialized constant Homebrew::DevCmd::Bump::Repology` error](https://github.com/Homebrew/brew/pull/17707#issuecomment-2227357207) in `brew bump`. This adds a `utils/repology` `require` to `dev-cmd/bump.rb` to resolve the error.