### PR TITLE
Output disable date for deprecated packages

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -279,7 +279,10 @@ module Homebrew
         puts Formatter.url(formula.homepage) if formula.homepage
 
         deprecate_disable_info_string = DeprecateDisable.message(formula)
-        puts deprecate_disable_info_string.capitalize if deprecate_disable_info_string.present?
+        if deprecate_disable_info_string.present?
+          deprecate_disable_info_string.tap { |info_string| info_string[0] = info_string[0].upcase }
+          puts deprecate_disable_info_string
+        end
 
         conflicts = formula.conflicts.map do |conflict|
           reason = " (because #{conflict.reason})" if conflict.reason

--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 # Helper module for handling `disable!` and `deprecate!`.
+# @api internal
 module DeprecateDisable
   module_function
 
@@ -29,6 +30,10 @@ module DeprecateDisable
     unsigned:                 "is unsigned or does not meet signature requirements",
   }.freeze
 
+  # One year when << or >> to Date.today.
+  REMOVE_DISABLED_TIME_WINDOW = 12
+  REMOVE_DISABLED_BEFORE = (Date.today << REMOVE_DISABLED_TIME_WINDOW).freeze
+
   def type(formula_or_cask)
     return :deprecated if formula_or_cask.deprecated?
 
@@ -52,9 +57,19 @@ module DeprecateDisable
       reason
     end
 
-    return "#{type(formula_or_cask)} because it #{reason}!" if reason.present?
+    message = if reason.present?
+      "#{type(formula_or_cask)} because it #{reason}!"
+    else
+      "#{type(formula_or_cask)}!"
+    end
 
-    "#{type(formula_or_cask)}!"
+    disable_date = formula_or_cask.disable_date
+    if !disable_date && formula_or_cask.deprecation_date
+      disable_date = formula_or_cask.deprecation_date >> REMOVE_DISABLED_TIME_WINDOW
+    end
+    message = "#{message} It will be disabled on #{disable_date}." if disable_date
+
+    message
   end
 
   def to_reason_string_or_symbol(string, type:)

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -4,16 +4,20 @@ require "deprecate_disable"
 
 RSpec.describe DeprecateDisable do
   let(:deprecated_formula) do
-    instance_double(Formula, deprecated?: true, disabled?: false, deprecation_reason: :does_not_build)
+    instance_double(Formula, deprecated?: true, disabled?: false, deprecation_reason: :does_not_build,
+                    deprecation_date: nil, disable_date: nil)
   end
   let(:disabled_formula) do
-    instance_double(Formula, deprecated?: false, disabled?: true, disable_reason: "is broken")
+    instance_double(Formula, deprecated?: false, disabled?: true, disable_reason: "is broken",
+                    deprecation_date: nil, disable_date: nil)
   end
   let(:deprecated_cask) do
-    instance_double(Cask::Cask, deprecated?: true, disabled?: false, deprecation_reason: :discontinued)
+    instance_double(Cask::Cask, deprecated?: true, disabled?: false, deprecation_reason: :discontinued,
+                   deprecation_date: nil, disable_date: nil)
   end
   let(:disabled_cask) do
-    instance_double(Cask::Cask, deprecated?: false, disabled?: true, disable_reason: nil)
+    instance_double(Cask::Cask, deprecated?: false, disabled?: true, disable_reason: nil,
+                    deprecation_date: nil, disable_date: nil)
   end
 
   before do


### PR DESCRIPTION
Let's use the disable date, if provided, and use 1 year after the deprecation date otherwise, to display a better message for the various outputs of deprecated package messages.

Also, provide an internal API for this that can be used by Homebrew/actions.

Fixes https://github.com/Homebrew/brew/issues/17653