### PR TITLE
Make `ignore_interrupts` thread-safe.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -433,13 +433,11 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         rescue ErrorDuringExecution
           raise CurlDownloadStrategyError, url
         end
-        ignore_interrupts do
-          cached_location.dirname.mkpath
-          temporary_path.rename(cached_location)
-          symlink_location.dirname.mkpath
-        end
+        cached_location.dirname.mkpath
+        temporary_path.rename(cached_location)
       end
 
+      symlink_location.dirname.mkpath
       FileUtils.ln_s cached_location.relative_path_from(symlink_location.dirname), symlink_location, force: true
     rescue CurlDownloadStrategyError
       raise if urls.empty?

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -351,7 +351,7 @@ module Kernel
 
   IGNORE_INTERRUPTS_MUTEX = Thread::Mutex.new.freeze
 
-  def ignore_interrupts(_opt = nil)
+  def ignore_interrupts(quiet: false)
     IGNORE_INTERRUPTS_MUTEX.synchronize do
       # rubocop:disable Style/GlobalVars
       $ignore_interrupts_nesting_level = 0 unless defined?($ignore_interrupts_nesting_level)
@@ -360,8 +360,11 @@ module Kernel
       $ignore_interrupts_interrupted = false unless defined?($ignore_interrupts_interrupted)
       old_sigint_handler = trap(:INT) do
         $ignore_interrupts_interrupted = true
-        $stderr.print "\n"
-        $stderr.puts "One sec, cleaning up..."
+
+        unless quiet
+          $stderr.print "\n"
+          $stderr.puts "One sec, cleaning up..."
+        end
       end
 
       begin

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -351,16 +351,14 @@ module Kernel
 
   IGNORE_INTERRUPTS_MUTEX = Thread::Mutex.new.freeze
 
-  def ignore_interrupts(quiet: false)
+  def ignore_interrupts
     IGNORE_INTERRUPTS_MUTEX.synchronize do
       interrupted = T.let(false, T::Boolean)
       old_sigint_handler = trap(:INT) do
         interrupted = true
 
-        unless quiet
-          $stderr.print "\n"
-          $stderr.puts "One sec, cleaning up..."
-        end
+        $stderr.print "\n"
+        $stderr.puts "One sec, cleaning up..."
       end
 
       begin

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -353,13 +353,9 @@ module Kernel
 
   def ignore_interrupts(quiet: false)
     IGNORE_INTERRUPTS_MUTEX.synchronize do
-      # rubocop:disable Style/GlobalVars
-      $ignore_interrupts_nesting_level = 0 unless defined?($ignore_interrupts_nesting_level)
-      $ignore_interrupts_nesting_level += 1
-
-      $ignore_interrupts_interrupted = false unless defined?($ignore_interrupts_interrupted)
+      interrupted = false
       old_sigint_handler = trap(:INT) do
-        $ignore_interrupts_interrupted = true
+        interrupted = true
 
         unless quiet
           $stderr.print "\n"
@@ -372,13 +368,8 @@ module Kernel
       ensure
         trap(:INT, old_sigint_handler)
 
-        $ignore_interrupts_nesting_level -= 1
-        if $ignore_interrupts_nesting_level == 0 && $ignore_interrupts_interrupted
-          $ignore_interrupts_interrupted = false
-          raise Interrupt
-        end
+        raise Interrupt if interrupted
       end
-      # rubocop:enable Style/GlobalVars
     end
   end
 

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -353,7 +353,7 @@ module Kernel
 
   def ignore_interrupts(quiet: false)
     IGNORE_INTERRUPTS_MUTEX.synchronize do
-      interrupted = false
+      interrupted = T.let(false, T::Boolean)
       old_sigint_handler = trap(:INT) do
         interrupted = true
 

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -238,14 +238,12 @@ class SystemCommand
     }
     options[:chdir] = chdir if chdir
 
-    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = ignore_interrupts do
-      Open3.popen3(
-        env.merge({ "COLUMNS" => Tty.width.to_s }),
-        [executable, executable],
-        *args,
-        **options,
-      )
-    end
+    raw_stdin, raw_stdout, raw_stderr, raw_wait_thr = Open3.popen3(
+      env.merge({ "COLUMNS" => Tty.width.to_s }),
+      [executable, executable],
+      *args,
+      **options,
+    )
 
     write_input_to(raw_stdin)
     raw_stdin.close_write

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -75,7 +75,7 @@ module Utils
           exit!(true)
         end
 
-        ignore_interrupts(:quietly) do # the child will receive the interrupt and marshal it back
+        ignore_interrupts(quiet: true) do # the child will receive the interrupt and marshal it back
           begin
             socket = server.accept_nonblock
           rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::ECONNABORTED, Errno::EPROTO, Errno::EINTR

--- a/Library/Homebrew/utils/github/artifacts.rb
+++ b/Library/Homebrew/utils/github/artifacts.rb
@@ -43,12 +43,11 @@ class GitHubArtifactDownloadStrategy < AbstractFileDownloadStrategy
       rescue ErrorDuringExecution
         raise CurlDownloadStrategyError, url
       end
-      ignore_interrupts do
-        cached_location.dirname.mkpath
-        temporary_path.rename(cached_location)
-        symlink_location.dirname.mkpath
-      end
+      cached_location.dirname.mkpath
+      temporary_path.rename(cached_location)
     end
+
+    symlink_location.dirname.mkpath
     FileUtils.ln_s cached_location.relative_path_from(symlink_location.dirname), symlink_location, force: true
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Make `ignore_interrupts` thread-safe to prevent race conditions when cancelling concurrent downloads.