### PR TITLE
pypi: allow universal wheels as resources

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -109,7 +109,10 @@ module Homebrew
       return if name == owner.name # Skip the top-level package name as we only care about `resource "foo"` blocks.
 
       if url.end_with? ".whl"
-        pypi_package_name, = File.basename(URI(url).path).split("-", 2)
+        path = URI(url).path
+        return unless path.present?
+
+        pypi_package_name, = File.basename(path).split("-", 2)
       else
         url =~ %r{/(?<package_name>[^/]+)-}
         pypi_package_name = Regexp.last_match(:package_name).to_s.gsub(/[_.]/, "-")

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -108,8 +108,13 @@ module Homebrew
       return unless url.match?(%r{^https?://files\.pythonhosted\.org/packages/})
       return if name == owner.name # Skip the top-level package name as we only care about `resource "foo"` blocks.
 
-      url =~ %r{/(?<package_name>[^/]+)-}
-      pypi_package_name = Regexp.last_match(:package_name).to_s.gsub(/[_.]/, "-")
+      if url.end_with? ".whl"
+        pypi_package_name, = File.basename(URI(url).path).split("-", 2)
+      else
+        url =~ %r{/(?<package_name>[^/]+)-}
+        pypi_package_name = Regexp.last_match(:package_name).to_s.gsub(/[_.]/, "-")
+      end
+
       return if name.casecmp(pypi_package_name).zero?
 
       problem "resource name should be `#{pypi_package_name}` to match the PyPI package name"

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -503,7 +503,7 @@ RSpec.describe Homebrew::FormulaAuditor do
   end
 
   describe "#audit_resource_name_matches_pypi_package_name_in_url" do
-    it "reports a problem if the resource name does not match the python package name" do
+    it "reports a problem if the resource name does not match the python sdist name" do
       fa = formula_auditor "foo", <<~RUBY
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -512,6 +512,25 @@ RSpec.describe Homebrew::FormulaAuditor do
 
           resource "Something" do
             url "https://files.pythonhosted.org/packages/FooSomething-1.0.0.tar.gz"
+            sha256 "def456"
+          end
+        end
+      RUBY
+
+      fa.audit_specs
+      expect(fa.problems.first[:message])
+        .to match("resource name should be `FooSomething` to match the PyPI package name")
+    end
+
+    it "reports a problem if the resource name does not match the python wheel name" do
+      fa = formula_auditor "foo", <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+          sha256 "abc123"
+          homepage "https://brew.sh"
+
+          resource "Something" do
+            url "https://files.pythonhosted.org/packages/FooSomething-1.0.0-py3-none-any.whl"
             sha256 "def456"
           end
         end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -73,12 +73,22 @@ module PyPI
         return
       end
 
-      sdist = json["urls"].find { |url| url["packagetype"] == "sdist" }
-      return if sdist.nil?
+      dist = json["urls"].find do |url|
+        url["packagetype"] == "sdist"
+      end
+
+      # If there isn't an sdist, we use the first source wheel.
+      if dist.nil?
+        dist = json["urls"].find do |url|
+          url["filename"].end_with?("-none-any.whl")
+        end
+      end
+
+      return if dist.nil?
 
       @pypi_info = [
-        PyPI.normalize_python_package(json["info"]["name"]), sdist["url"],
-        sdist["digests"]["sha256"], json["info"]["version"]
+        PyPI.normalize_python_package(json["info"]["name"]), dist["url"],
+        dist["digests"]["sha256"], json["info"]["version"]
       ]
     end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -77,7 +77,7 @@ module PyPI
         url["packagetype"] == "sdist"
       end
 
-      # If there isn't an sdist, we use the first source wheel.
+      # If there isn't an sdist, we use the first universal wheel.
       if dist.nil?
         dist = json["urls"].find do |url|
           url["filename"].end_with?("-none-any.whl")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This changes the PyPI resource resolution strategy, to allow universal wheels as a fallback when an sdist isn't present. No other kinds of wheels are allowed, per policy around resources being source resources.

(NB: A user could always stuff a binary into a universal wheel, but they could do this with an sdist anyways.)

Confirmed that this works locally with `brew update-python-resources`.

CC @alex for vis
