### PR TITLE
attestation: improve error message when `gh` is too old

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -62,7 +62,7 @@ module Homebrew
     # @api private
     sig { returns(Pathname) }
     def self.gh_executable
-      # NOTE: We disable HOMEBREW_NO_VERIFY_ATTESTATIONS when installing `gh` itself,
+      # NOTE: We set HOMEBREW_NO_VERIFY_ATTESTATIONS when installing `gh` itself,
       #       to prevent a cycle during bootstrapping. This can eventually be resolved
       #       by vendoring a pure-Ruby Sigstore verifier client.
       @gh_executable ||= T.let(with_env(HOMEBREW_NO_VERIFY_ATTESTATIONS: "1") do
@@ -111,7 +111,7 @@ module Homebrew
                                  .stdout.match(/\d+(?:\.\d+)+/i).to_s)
         if gh_version < GH_ATTESTATION_MIN_VERSION
           raise e,
-                "#{gh_executable} is too old, you must upgrade it to continue."
+                "#{gh_executable} is too old, you must upgrade it to continue"
         end
 
         raise InvalidAttestationError, "attestation verification failed: #{e}"

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Homebrew::Attestation do
     end
   end
 
-  describe "::check_attestation (with old gh)" do
+  describe "::check_attestation fails with old gh" do
     before do
       allow(described_class).to receive(:gh_executable)
         .and_return(fake_old_gh)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, when `gh` is too old to verify attestations, the error message is uninterpretable:
```
==> Installing frizbee dependency: go
==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.22.5
==> Verifying attestation for go
Error: The bottle for go has an invalid build provenance attestation.

This may indicate that the bottle was not produced by the expected
tap, or was maliciously inserted into the expected tap's bottle
storage.

Additional context:

attestation verification failed: Failure while executing; `/usr/bin/env GH_TOKEN=****** /opt/homebrew/bin/gh attestation verify /Users/REDACTED/Library/Caches/Homebrew/downloads/3f2258381d80802127c7c7d253acee16b65864703253acd14e6e63e6194b0b62--go--1.22.5.arm64_sonoma.bottle.tar.gz --repo trailofbits/homebrew-brew-verify --format json` exited with 1. Here's the output:
Failed to verify the artifact: failed to fetch attestations for subject: sha256:555bf0e72c91ff434d4ab9e69c001cd998f6ce23fdddcac7013f94343d0defda
```

This PR aims to improve the messaging, like below:
```
➜  homebrew git:(attestation-gh-error) ✗ HOMEBREW_NO_INSTALL_FROM_API=1 brew install -sdv frizbee
[TRUNCATED]
==> Installing dependencies for frizbee: go
==> Installing frizbee dependency: go
==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.22.5
==> Verifying attestation for go
Error: `gh` is too old, you must run `brew upgrade gh` to continue.
```