### PR TITLE
utils/analytics: strip out more data.

### DIFF
--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -113,6 +113,10 @@ module Utils
 
         # Strip out any flag values to reduce cardinality and preserve privacy.
         options_array.map! { |option| option.sub(/=.*/, "=") }
+
+        # Strip out --with-* and --without-* options
+        options_array.reject! { |option| option.match(/^--with(out)?-/) }
+
         options = options_array.sort.uniq.join(" ")
 
         # Tags must have low cardinality.


### PR DESCRIPTION
We've filter this out in `brew formula-analytics` too but let's avoid sending it here in the first place so we can delete the formula-analytics filtering later.