### PR TITLE
test/cmd: use brew_sh in more places.

### DIFF
--- a/Library/Homebrew/test/cmd/command_spec.rb
+++ b/Library/Homebrew/test/cmd/command_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Homebrew::Cmd::Command do
   it_behaves_like "parseable arguments"
 
   it "returns the file for a given command", :integration_test do
-    expect { brew "command", "info" }
+    expect { brew_sh "command", "info" }
       .to output(%r{#{Regexp.escape(HOMEBREW_LIBRARY_PATH)}/cmd/info.rb}o).to_stdout
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Homebrew::Cmd::List do
       (HOMEBREW_CELLAR/f/"1.0/somedir").mkpath
     end
 
-    expect { brew "list", "--formula" }
+    expect { brew_sh "list", "--formula" }
       .to output("#{formulae.join("\n")}\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success


### PR DESCRIPTION
We want to do this to ensure the Bash logic is actually tested.