### PR TITLE
cmd/--repository: improve tap name error checking

### DIFF
--- a/Library/Homebrew/cmd/--repository.sh
+++ b/Library/Homebrew/cmd/--repository.sh
@@ -13,6 +13,11 @@ tap_path() {
   local repo
   local part
 
+  if [[ "${tap}" != *"/"* ]]
+  then
+    odie "Invalid tap name: ${tap}"
+  fi
+
   user="$(echo "${tap%%/*}" | tr '[:upper:]' '[:lower:]')"
   repo="$(echo "${tap#*/}" | tr '[:upper:]' '[:lower:]')"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before:

```console
$ brew --repo core
/usr/local/Homebrew/Library/Taps/core/homebrew-core
```

After:

```console
$ brew --repo core
Error: Invalid tap name: core
```
