### PR TITLE
Add `allow_in_sandbox!` DSL

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -46,6 +46,7 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = T.let([
   [{ name: :needs, type: :method_call }],
   [{ name: :allow_network_access!, type: :method_call }],
   [{ name: :deny_network_access!, type: :method_call }],
+  [{ name: :allow_in_sandbox!, type: :method_call }],
   [{ name: :install, type: :method_definition }],
   [{ name: :post_install, type: :method_definition }],
   [{ name: :caveats, type: :method_definition }],

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -53,12 +53,12 @@ if [[ -n "${HOMEBREW_MACOS}" ]]
 then
   HOMEBREW_DEFAULT_CACHE="${HOME}/Library/Caches/Homebrew"
   HOMEBREW_DEFAULT_LOGS="${HOME}/Library/Logs/Homebrew"
-  HOMEBREW_DEFAULT_TEMP="/private/tmp"
+  HOMEBREW_DEFAULT_TEMP="/private/tmp/homebrew"
 else
   CACHE_HOME="${HOMEBREW_XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_DEFAULT_CACHE="${CACHE_HOME}/Homebrew"
   HOMEBREW_DEFAULT_LOGS="${CACHE_HOME}/Homebrew/Logs"
-  HOMEBREW_DEFAULT_TEMP="/tmp"
+  HOMEBREW_DEFAULT_TEMP="/tmp/homebrew"
 fi
 
 realpath() {

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -86,7 +86,7 @@ module Homebrew
                 sandbox = Sandbox.new
                 f.logs.mkpath
                 sandbox.record_log(f.logs/"test.sandbox.log")
-                sandbox.allow_write_temp_and_cache
+                sandbox.allow_write_temp_and_cache(formula)
                 sandbox.allow_write_log(f)
                 sandbox.allow_write_xcode
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/cache")

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -86,7 +86,7 @@ module Homebrew
                 sandbox = Sandbox.new
                 f.logs.mkpath
                 sandbox.record_log(f.logs/"test.sandbox.log")
-                sandbox.allow_write_temp_and_cache(formula)
+                sandbox.allow_write_temp_and_cache(f)
                 sandbox.allow_write_log(f)
                 sandbox.allow_write_xcode
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/cache")

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -86,7 +86,7 @@ module Homebrew
                 sandbox = Sandbox.new
                 f.logs.mkpath
                 sandbox.record_log(f.logs/"test.sandbox.log")
-                sandbox.allow_write_temp_and_cache(f)
+                sandbox.allow_write_temp_and_cache
                 sandbox.allow_write_log(f)
                 sandbox.allow_write_xcode
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/cache")
@@ -94,6 +94,8 @@ module Homebrew
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
                 sandbox.deny_all_network_except_pipe(error_pipe) unless f.class.network_access_allowed?(:test)
+                sandbox.allow_write_global_temp if f.allowed_in_sandbox?(:write_to_temp, phase: :test)
+                sandbox.deny_signal if f.allowed_in_sandbox?(:signal, phase: :test)
                 sandbox.exec(*exec_args)
               else
                 exec(*exec_args)

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -93,9 +93,9 @@ module Homebrew
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
                 sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
-                sandbox.deny_all_network_except_pipe(error_pipe) unless f.class.network_access_allowed?(:test)
+                sandbox.deny_all_network_except_pipe(error_pipe) unless f.allowed_in_sandbox?(:network, phase: :test)
                 sandbox.allow_write_global_temp if f.allowed_in_sandbox?(:write_to_temp, phase: :test)
-                sandbox.deny_signal if f.allowed_in_sandbox?(:signal, phase: :test)
+                sandbox.deny_signal unless f.allowed_in_sandbox?(:signal, phase: :test)
                 sandbox.exec(*exec_args)
               else
                 exec(*exec_args)

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -432,7 +432,7 @@ module Homebrew
                       "different volumes, as macOS has trouble moving symlinks across volumes when the target " \
                       "does not yet exist. This issue typically occurs when using FileVault or custom SSD " \
                       "configurations.",
-        default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
+        default_text: "macOS: `/private/tmp/homebrew`, Linux: `/tmp/homebrew`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
       HOMEBREW_UPDATE_TO_TAG:                    {

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -35,6 +35,7 @@ require "utils/spdx"
 require "extend/on_system"
 require "api"
 require "extend/api_hashable"
+require "sandbox"
 
 # A formula provides instructions and metadata for Homebrew to install a piece
 # of software. Every Homebrew formula is a {Formula}.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -943,6 +943,7 @@ on_request: installed_on_request?, options:)
         sandbox.allow_fossil
         sandbox.allow_write_xcode
         sandbox.allow_write_cellar(formula)
+        sandbox.deny_signal(formula)
         sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:build)
         sandbox.exec(*args)
       else

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -937,7 +937,7 @@ on_request: installed_on_request?, options:)
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"build.sandbox.log")
         sandbox.allow_write_path(Dir.home) if interactive?
-        sandbox.allow_write_temp_and_cache
+        sandbox.allow_write_temp_and_cache(formula)
         sandbox.allow_write_log(formula)
         sandbox.allow_cvs
         sandbox.allow_fossil
@@ -1153,7 +1153,7 @@ on_request: installed_on_request?, options:)
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"postinstall.sandbox.log")
-        sandbox.allow_write_temp_and_cache
+        sandbox.allow_write_temp_and_cache(formula)
         sandbox.allow_write_log(formula)
         sandbox.allow_write_xcode
         sandbox.deny_write_homebrew_repository

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -943,9 +943,9 @@ on_request: installed_on_request?, options:)
         sandbox.allow_fossil
         sandbox.allow_write_xcode
         sandbox.allow_write_cellar(formula)
-        sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:build)
+        sandbox.deny_all_network_except_pipe(error_pipe) unless formula.allowed_in_sandbox?(:network, phase: :build)
         sandbox.allow_write_global_temp if formula.allowed_in_sandbox?(:write_to_temp, phase: :build)
-        sandbox.deny_signal if formula.allowed_in_sandbox?(:signal, phase: :build)
+        sandbox.deny_signal unless formula.allowed_in_sandbox?(:signal, phase: :build)
         sandbox.exec(*args)
       else
         exec(*args)
@@ -1160,12 +1160,14 @@ on_request: installed_on_request?, options:)
         sandbox.allow_write_xcode
         sandbox.deny_write_homebrew_repository
         sandbox.allow_write_cellar(formula)
-        sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:postinstall)
         Keg::KEG_LINK_DIRECTORIES.each do |dir|
           sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
         end
+        unless formula.allowed_in_sandbox?(:network, phase: :postinstall)
+          sandbox.deny_all_network_except_pipe(error_pipe)
+        end
         sandbox.allow_write_global_temp if formula.allowed_in_sandbox?(:write_to_temp, phase: :postinstall)
-        sandbox.deny_signal if formula.allowed_in_sandbox?(:signal, phase: :postinstall)
+        sandbox.deny_signal unless formula.allowed_in_sandbox?(:signal, phase: :postinstall)
         sandbox.exec(*args)
       else
         exec(*args)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -937,14 +937,15 @@ on_request: installed_on_request?, options:)
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"build.sandbox.log")
         sandbox.allow_write_path(Dir.home) if interactive?
-        sandbox.allow_write_temp_and_cache(formula)
+        sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_cvs
         sandbox.allow_fossil
         sandbox.allow_write_xcode
         sandbox.allow_write_cellar(formula)
-        sandbox.deny_signal(formula)
         sandbox.deny_all_network_except_pipe(error_pipe) unless formula.network_access_allowed?(:build)
+        sandbox.allow_write_global_temp if formula.allowed_in_sandbox?(:write_to_temp, phase: :build)
+        sandbox.deny_signal if formula.allowed_in_sandbox?(:signal, phase: :build)
         sandbox.exec(*args)
       else
         exec(*args)
@@ -1154,7 +1155,7 @@ on_request: installed_on_request?, options:)
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"postinstall.sandbox.log")
-        sandbox.allow_write_temp_and_cache(formula)
+        sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_write_xcode
         sandbox.deny_write_homebrew_repository
@@ -1163,6 +1164,8 @@ on_request: installed_on_request?, options:)
         Keg::KEG_LINK_DIRECTORIES.each do |dir|
           sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
         end
+        sandbox.allow_write_global_temp if formula.allowed_in_sandbox?(:write_to_temp, phase: :postinstall)
+        sandbox.deny_signal if formula.allowed_in_sandbox?(:signal, phase: :postinstall)
         sandbox.exec(*args)
       else
         exec(*args)

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -11,7 +11,7 @@ class Sandbox
   SANDBOX_EXEC = "/usr/bin/sandbox-exec"
   private_constant :SANDBOX_EXEC
 
-  SANDBOX_REDUCTIONS = [:allow_write_to_temp].freeze
+  SANDBOX_REDUCTIONS = [:allow_write_to_temp, :allow_signal].freeze
 
   sig { returns(T::Boolean) }
   def self.available?
@@ -66,6 +66,14 @@ class Sandbox
     allow_write path: "^/private/var/folders/[^/]+/[^/]+/[C,T]/", type: :regex
     allow_write_path HOMEBREW_TEMP
     allow_write_path HOMEBREW_CACHE
+  end
+
+  sig { params(formula: T.nilable(Formula)).void }
+  def deny_signal(formula = nil)
+    puts "deny_signal:  #{formula&.reduced_sandbox&.include?(:allow_signal)}"
+    unless formula&.reduced_sandbox&.include?(:allow_signal)
+      add_rule allow: false, operation: "signal", filter: "target others"
+    end
   end
 
   sig { void }

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -11,6 +11,8 @@ class Sandbox
   SANDBOX_EXEC = "/usr/bin/sandbox-exec"
   private_constant :SANDBOX_EXEC
 
+  SANDBOX_REDUCTIONS = [:allow_write_to_temp].freeze
+
   sig { returns(T::Boolean) }
   def self.available?
     false
@@ -55,9 +57,12 @@ class Sandbox
     deny_write path:, type: :subpath
   end
 
-  sig { void }
-  def allow_write_temp_and_cache
-    allow_write_path "/private/var/tmp"
+  sig { params(formula: T.nilable(Formula)).void }
+  def allow_write_temp_and_cache(formula = nil)
+    if formula&.reduced_sandbox&.include?(:allow_write_to_temp)
+      allow_write_path "/private/tmp"
+      allow_write_path "/private/var/tmp"
+    end
     allow_write path: "^/private/var/folders/[^/]+/[^/]+/[C,T]/", type: :regex
     allow_write_path HOMEBREW_TEMP
     allow_write_path HOMEBREW_CACHE

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -57,7 +57,6 @@ class Sandbox
 
   sig { void }
   def allow_write_temp_and_cache
-    allow_write_path "/private/tmp"
     allow_write_path "/private/var/tmp"
     allow_write path: "^/private/var/folders/[^/]+/[^/]+/[C,T]/", type: :regex
     allow_write_path HOMEBREW_TEMP

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -11,7 +11,8 @@ class Sandbox
   SANDBOX_EXEC = "/usr/bin/sandbox-exec"
   private_constant :SANDBOX_EXEC
 
-  SANDBOX_REDUCTIONS = [:allow_write_to_temp, :allow_signal].freeze
+  SANDBOX_DSL_RULES = [:write_to_temp, :signal].freeze
+  SANDBOX_DSL_PHASES = [:build, :postinstall, :test].freeze
 
   sig { returns(T::Boolean) }
   def self.available?
@@ -57,23 +58,22 @@ class Sandbox
     deny_write path:, type: :subpath
   end
 
-  sig { params(formula: T.nilable(Formula)).void }
-  def allow_write_temp_and_cache(formula = nil)
-    if formula&.reduced_sandbox&.include?(:allow_write_to_temp)
-      allow_write_path "/private/tmp"
-      allow_write_path "/private/var/tmp"
-    end
+  sig { void }
+  def allow_write_temp_and_cache
     allow_write path: "^/private/var/folders/[^/]+/[^/]+/[C,T]/", type: :regex
     allow_write_path HOMEBREW_TEMP
     allow_write_path HOMEBREW_CACHE
   end
 
-  sig { params(formula: T.nilable(Formula)).void }
-  def deny_signal(formula = nil)
-    puts "deny_signal:  #{formula&.reduced_sandbox&.include?(:allow_signal)}"
-    unless formula&.reduced_sandbox&.include?(:allow_signal)
-      add_rule allow: false, operation: "signal", filter: "target others"
-    end
+  sig { void }
+  def allow_write_global_temp
+    allow_write_path "/private/tmp"
+    allow_write_path "/private/var/tmp"
+  end
+
+  sig { void }
+  def deny_signal
+    add_rule allow: false, operation: "signal", filter: "target others"
   end
 
   sig { void }

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -11,7 +11,7 @@ class Sandbox
   SANDBOX_EXEC = "/usr/bin/sandbox-exec"
   private_constant :SANDBOX_EXEC
 
-  SANDBOX_DSL_RULES = [:write_to_temp, :signal].freeze
+  SANDBOX_DSL_RULES = [:write_to_temp, :signal, :network].freeze
   SANDBOX_DSL_PHASES = [:build, :postinstall, :test].freeze
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR changes the default `HOMEBREW_TEMP` to be `/private/tmp/homebrew` on macOS and `/tmp/homebrew` on Linux. The sandbox permissions are also updated to not allow writing to `/private/tmp` except for the `homebrew` subdirectory.

I'm marking this as draft because I am not 100% sure this is the correct move.

Additionally, I'm planning on adding a formula DSL to allow us to reduce the file write sandbox restrictions for formulae that need to write to `/private/tmp`. I'm thinking about calling this `reduce_sandbox!` or something similar. That way, this change can be skipped for formulae that need to be updated upstream without blocking us from merging things. Eventually, this might be something that can be enforced so that users can choose to not install any formulae that need a reduced sandbox or something like that.
