### PR TITLE
brew.sh: speed up `brew --help`, `brew -h`, etc.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -166,7 +166,7 @@ case "$@" in
     homebrew-list "$@" && exit 0
     ;;
   # falls back to cmd/help.rb on a non-zero return
-  help | "")
+  help | --help | -h | --usage | -? | "")
     homebrew-help "$@" && exit 0
     ;;
 esac


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We can handle `brew --help` the same way as we do for `brew help`.

```console
$ hyperfine 'git checkout master; brew -h' 'git checkout brew-h-speedup; brew -h'    
Benchmark 1: git checkout master; brew -h
  Time (mean ± σ):     825.4 ms ±  73.4 ms    [User: 324.0 ms, System: 127.0 ms]
  Range (min … max):   738.4 ms … 997.2 ms    10 runs
 
Benchmark 2: git checkout brew-h-speedup; brew -h
  Time (mean ± σ):      90.8 ms ±  23.2 ms    [User: 22.4 ms, System: 36.7 ms]
  Range (min … max):    78.6 ms … 216.8 ms    33 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
 
Summary
  git checkout brew-h-speedup; brew -h ran
    9.09 ± 2.46 times faster than git checkout master; brew -h
```
