### PR TITLE
Require `utils/backtrace` when install fails to load formula

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -338,6 +338,8 @@ module Homebrew
         Homebrew.messages.display_messages(display_times: args.display_times?)
       rescue FormulaUnreadableError, FormulaClassUnavailableError,
              TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
+        require "utils/backtrace"
+
         # Need to rescue before `FormulaUnavailableError` (superclass of this)
         # is handled, as searching for a formula doesn't make sense here (the
         # formula was found, but there's a problem with its implementation).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Require `utils/backtrace` when there is some sort of install fails to load a formula so that it reports properly.
