### PR TITLE
`brew bump`: do not call repology by default

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -34,6 +34,8 @@ module Homebrew
                description: "Check only formulae."
         switch "--cask", "--casks",
                description: "Check only casks."
+        switch "--eval-all",
+               description: "Evaluate all formulae and casks."
         flag   "--tap=",
                description: "Check formulae and casks within the given tap, specified as <user>`/`<repo>."
         switch "--installed",
@@ -76,6 +78,10 @@ module Homebrew
             formulae + casks
           elsif args.named.present?
             args.named.to_formulae_and_casks_with_taps
+          else
+            formulae = args.cask? ? [] : Formula.all(eval_all: args.eval_all?)
+            casks = args.formula? ? [] : Cask::Cask.all(eval_all: args.eval_all?)
+            formulae + casks
           end
 
           formulae_and_casks = formulae_and_casks&.sort_by do |formula_or_cask|

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
@@ -24,6 +24,9 @@ class Homebrew::DevCmd::Bump::Args < Homebrew::CLI::Args
   def eval_all?; end
 
   sig { returns(T::Boolean) }
+  def repology?; end
+
+  sig { returns(T::Boolean) }
   def formulae?; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
@@ -21,6 +21,9 @@ class Homebrew::DevCmd::Bump::Args < Homebrew::CLI::Args
   def formula?; end
 
   sig { returns(T::Boolean) }
+  def eval_all?; end
+
+  sig { returns(T::Boolean) }
   def formulae?; end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow up of https://github.com/Homebrew/brew/issues/17021 : by running `brew bump` without other argument, the command would still query repology on all formulae then hide the repology information in the output. I spotted that due to some formulae having matching formula version and livecheck version without any mention that they were up to date. There was an extra comparison with the repology version.

This PR adds the `--eval-all` flag to make this behaviour explicit. It also stops calling repology by default.