### PR TITLE
dev-cmd/update-test: fix dev channel testing

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -40,12 +40,13 @@ module Homebrew
         ENV["HOMEBREW_DEV_CMD_RUN"] = nil
         ENV["HOMEBREW_MERGE"] = nil
         ENV["HOMEBREW_NO_UPDATE_CLEANUP"] = nil
+        ENV["HOMEBREW_UPDATE_TO_TAG"] = nil
 
         branch = if args.to_tag?
           ENV["HOMEBREW_UPDATE_TO_TAG"] = "1"
           "stable"
         else
-          ENV["HOMEBREW_UPDATE_TO_TAG"] = nil
+          ENV["HOMEBREW_DEV_CMD_RUN"] = "1"
           "master"
         end
 


### PR DESCRIPTION
Prior to #17745, `brew update-test` was mistakenly bleeding dev command status into `brew update`, making brew think `brew update` itself was a developer command thus making `HOMEBREW_DEV_CMD_RUN` always set.

Fix the logic to not rely on that bad behaviour by explicitly setting `HOMEBREW_DEV_CMD_RUN` when we want to test the developer channel path. The explicit `HOMEBREW_UPDATE_TO_TAG` env for this stable path is likely unnecessary now but have kept it anyhow.

Fixes issue mentioned in https://github.com/Homebrew/brew/pull/17746#issuecomment-2227612846