### PR TITLE
`brew bump`: cleanup and improve `--eval-all` handling

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -22,9 +22,9 @@ module Homebrew
 
       cmd_args do
         description <<~EOS
-          Display out-of-date brew formulae and the latest version available. If the
+          Displays out-of-date packages and the latest version available. If the
           returned current and livecheck versions differ or when querying specific
-          formulae, also displays whether a pull request has been opened with the URL.
+          packages, also displays whether a pull request has been opened with the URL.
         EOS
         switch "--full-name",
                description: "Print formulae/casks with fully-qualified names."
@@ -87,11 +87,18 @@ module Homebrew
                   "`HOMEBREW_EVAL_ALL` set!"
           end
 
+          if args.start_with
+            formulae_and_casks.select! do |formula_or_cask|
+              name = formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
+              name.start_with?(args.start_with)
+            end
+          end
+
           formulae_and_casks = formulae_and_casks&.sort_by do |formula_or_cask|
             formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
           end
 
-          unless Utils::Curl.curl_supports_tls13?
+          if args.repology? && !Utils::Curl.curl_supports_tls13?
             begin
               ensure_formula_installed!("curl", reason: "Repology queries") unless HOMEBREW_BREWED_CURL_PATH.exist?
             rescue FormulaUnavailableError

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -82,7 +82,9 @@ module Homebrew
             casks = args.formula? ? [] : Cask::Cask.all(eval_all:)
             formulae + casks
           else
-            raise UsageError, "`brew bump` without named arguments needs `--installed` or `--eval-all` passed or `HOMEBREW_EVAL_ALL` set!"
+            raise UsageError,
+                  "`brew bump` without named arguments needs `--installed` or `--eval-all` passed or " \
+                  "`HOMEBREW_EVAL_ALL` set!"
           end
 
           formulae_and_casks = formulae_and_casks&.sort_by do |formula_or_cask|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR removes redundant options and improves the `--eval-all` handling for `brew bump`, improving upon #17740.