### PR TITLE
cask/info: fix installed size reporting

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -42,16 +42,15 @@ module Cask
       return "Not installed" unless cask.installed?
 
       versioned_staged_path = cask.caskroom_path.join(cask.installed_version)
-      path_details = if versioned_staged_path.exist?
-        versioned_staged_path.abv
-      else
-        Formatter.error("does not exist")
-      end
+
+      return "Installed\n#{versioned_staged_path} (#{Formatter.error("does not exist")})\n" unless versioned_staged_path.exist?
+
+      path_details = versioned_staged_path.children.sum(&:disk_usage)
 
       tab = Tab.for_cask(cask)
 
       info = ["Installed"]
-      info << "#{versioned_staged_path} (#{path_details})"
+      info << "#{versioned_staged_path} (#{disk_usage_readable(path_details)})"
       info << "  #{tab}" if tab.tabfile&.exist?
       info.join("\n")
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes calculation of size of installed Cask, which currently doesn't traverse the application directory.

Without change:
```
brew info zed
==> zed: 0.143.7 (auto_updates)
https://zed.dev/
Installed
/opt/homebrew/Caskroom/zed/0.143.7 (117B)
```

With change:
```
brew info zed
==> zed: 0.143.7 (auto_updates)
https://zed.dev/
Installed
/opt/homebrew/Caskroom/zed/0.143.7 (169.6MB)
```