### PR TITLE
Revert "sandbox: deny signal to other processes"

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -302,7 +302,6 @@ class Sandbox
           (literal "/bin/ps")
           (with no-sandbox)
           ) ; allow certain processes running without sandbox
-      (deny signal (target others)) ; deny sending signals to other processes
       (allow default) ; allow everything else
     ERB
 

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -129,22 +129,4 @@ RSpec.describe Sandbox, :needs_macos do
       end
     end
   end
-
-  describe "disallow sending signal to other processes" do
-    # we have to spawn a process, otherwise kill doesn't try to send a signal if the process doesn't exist
-    let(:pid) do
-      pid = spawn("sleep 1000")
-      sleep 0.1 # Ensure the process has started
-      pid
-    end
-
-    after do
-      Process.kill("KILL", pid)
-      Process.wait(pid)
-    end
-
-    it "sandbox stops signal to other processes" do
-      expect { sandbox.exec "kill", "-SIGTERM", pid.to_s }.to raise_error(ErrorDuringExecution)
-    end
-  end
 end


### PR DESCRIPTION
Reverts Homebrew/brew#17719

We'll retry this once we have the new sandbox DSL suggested in https://github.com/Homebrew/brew/pull/17734