### PR TITLE
Add better "--quiet" support to cask upgrade

### DIFF
--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -17,6 +17,7 @@ module Cask
         dry_run:             T.nilable(T::Boolean),
         skip_cask_deps:      T.nilable(T::Boolean),
         verbose:             T.nilable(T::Boolean),
+        quiet:               T.nilable(T::Boolean),
         binaries:            T.nilable(T::Boolean),
         quarantine:          T.nilable(T::Boolean),
         require_sha:         T.nilable(T::Boolean),
@@ -32,6 +33,7 @@ module Cask
       dry_run: false,
       skip_cask_deps: false,
       verbose: false,
+      quiet: false,
       binaries: nil,
       quarantine: nil,
       require_sha: nil
@@ -53,10 +55,10 @@ module Cask
           if cask.outdated?(greedy: true)
             true
           elsif cask.version.latest?
-            opoo "Not upgrading #{cask.token}, the downloaded artifact has not changed"
+            opoo "Not upgrading #{cask.token}, the downloaded artifact has not changed" unless quiet
             false
           else
-            opoo "Not upgrading #{cask.token}, the latest version is already installed"
+            opoo "Not upgrading #{cask.token}, the latest version is already installed" unless quiet
             false
           end
         end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -258,6 +258,7 @@ module Homebrew
               require_sha:    args.require_sha?,
               skip_cask_deps: args.skip_cask_deps?,
               verbose:        args.verbose?,
+              quiet:          args.quiet?,
               args:,
             )
           end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -269,6 +269,7 @@ module Homebrew
           require_sha:         args.require_sha?,
           skip_cask_deps:      args.skip_cask_deps?,
           verbose:             args.verbose?,
+          quiet:               args.quiet?,
           args:,
         )
       end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -175,7 +175,7 @@ module Homebrew
             if latest_keg.nil?
               ofail "#{f.full_specified_name} not installed"
             else
-              opoo "#{f.full_specified_name} #{latest_keg.version} already installed"
+              opoo "#{f.full_specified_name} #{latest_keg.version} already installed" unless args.quiet?
             end
           end
         end


### PR DESCRIPTION
In #9188, the `brew install --quiet` flag behavior was improved so that it doesn't print a warning for no-op upgrades.

However, doing `brew install/upgrade --quiet --cask blah` still prints a warning in this situation.

This PR makes the behavior consistent between formulae and casks.

If any additional message suppression is desired please LMK where, I just addressed the one scenario that I ran into. Thanks!

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
