### PR TITLE
Add utils/backtrace requires

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -147,8 +147,10 @@ rescue UsageError => e
   Homebrew::Help.help cmd, remaining_args: args&.remaining, usage_error: e.message
 rescue SystemExit => e
   onoe "Kernel.exit" if args&.debug? && !e.success?
-  require "utils/backtrace"
-  $stderr.puts Utils::Backtrace.clean(e) if args&.debug? || ARGV.include?("--debug")
+  if args&.debug? || ARGV.include?("--debug")
+    require "utils/backtrace"
+    $stderr.puts Utils::Backtrace.clean(e)
+  end
   raise
 rescue Interrupt
   $stderr.puts # seemingly a newline is typical
@@ -185,8 +187,10 @@ rescue RuntimeError, SystemCallError => e
   raise if e.message.empty?
 
   onoe e
-  require "utils/backtrace"
-  $stderr.puts Utils::Backtrace.clean(e) if args&.debug? || ARGV.include?("--debug")
+  if args&.debug? || ARGV.include?("--debug")
+    require "utils/backtrace"
+    $stderr.puts Utils::Backtrace.clean(e)
+  end
 
   exit 1
 rescue Exception => e # rubocop:disable Lint/RescueException

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -174,7 +174,10 @@ module Homebrew
           begin
             reporter = Reporter.new(tap)
           rescue Reporter::ReporterRevisionUnsetError => e
-            onoe "#{e.message}\n#{Utils::Backtrace.clean(e)&.join("\n")}" if Homebrew::EnvConfig.developer?
+            if Homebrew::EnvConfig.developer?
+              require "utils/backtrace"
+              onoe "#{e.message}\n#{Utils::Backtrace.clean(e)&.join("\n")}"
+            end
             next
           end
           if reporter.updated?
@@ -624,7 +627,10 @@ class Reporter
             system HOMEBREW_BREW_FILE, "link", new_full_name, "--overwrite"
           end
         rescue Exception => e # rubocop:disable Lint/RescueException
-          onoe "#{e.message}\n#{Utils::Backtrace.clean(e)&.join("\n")}" if Homebrew::EnvConfig.developer?
+          if Homebrew::EnvConfig.developer?
+            require "utils/backtrace"
+            onoe "#{e.message}\n#{Utils::Backtrace.clean(e)&.join("\n")}"
+          end
         end
         next
       end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1034,7 +1034,12 @@ on_request: installed_on_request?, options:)
       ofail "An unexpected error occurred during the `brew link` step"
       puts "The formula built, but is not symlinked into #{HOMEBREW_PREFIX}"
       puts e
-      puts Utils::Backtrace.clean(e) if debug?
+
+      if debug?
+        require "utils/backtrace"
+        puts Utils::Backtrace.clean(e)
+      end
+
       @show_summary_heading = true
       ignore_interrupts do
         keg.unlink
@@ -1080,6 +1085,8 @@ on_request: installed_on_request?, options:)
   rescue Exception => e # rubocop:disable Lint/RescueException
     puts e
     ofail "Failed to install service files"
+
+    require "utils/backtrace"
     odebug e, Utils::Backtrace.clean(e)
   end
 
@@ -1090,7 +1097,10 @@ on_request: installed_on_request?, options:)
     ofail "Failed to fix install linkage"
     puts "The formula built, but you may encounter issues using it or linking other"
     puts "formulae against it."
+
+    require "utils/backtrace"
     odebug e, Utils::Backtrace.clean(e)
+
     @show_summary_heading = true
   end
 
@@ -1101,7 +1111,10 @@ on_request: installed_on_request?, options:)
   rescue Exception => e # rubocop:disable Lint/RescueException
     opoo "The cleaning step did not complete successfully"
     puts "Still, the installation was successful, so we will link it into your prefix."
+
+    require "utils/backtrace"
     odebug e, Utils::Backtrace.clean(e)
+
     Homebrew.failed = true
     @show_summary_heading = true
   end
@@ -1171,7 +1184,10 @@ on_request: installed_on_request?, options:)
     opoo "The post-install step did not complete successfully"
     puts "You can try again using:"
     puts "  brew postinstall #{formula.full_name}"
+
+    require "utils/backtrace"
     odebug e, Utils::Backtrace.clean(e), always_display: Homebrew::EnvConfig.developer?
+
     Homebrew.failed = true
     @show_summary_heading = true
   end

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -55,6 +55,8 @@ class FormulaVersions
       nostdout { Formulary.from_contents(name, path, contents, ignore_errors: true) }
     end
   rescue *IGNORED_EXCEPTIONS => e
+    require "utils/backtrace"
+
     # We rescue these so that we can skip bad versions and
     # continue walking the history
     odebug "#{e} in #{name} at revision #{revision}", Utils::Backtrace.clean(e)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -409,7 +409,10 @@ module Homebrew
           name += " (cask)" if ambiguous_casks.include?(formula_or_cask)
 
           onoe "#{Tty.blue}#{name}#{Tty.reset}: #{e}"
-          $stderr.puts Utils::Backtrace.clean(e) if debug && !e.is_a?(Livecheck::Error)
+          if debug && !e.is_a?(Livecheck::Error)
+            require "utils/backtrace"
+            $stderr.puts Utils::Backtrace.clean(e)
+          end
           print_resources_info(resource_version_info, verbose:) if check_for_resources
           nil
         end
@@ -1056,7 +1059,10 @@ module Homebrew
           status_hash(resource, "error", [e.to_s], verbose:)
         elsif !quiet
           onoe "#{Tty.blue}#{resource.name}#{Tty.reset}: #{e}"
-          $stderr.puts Utils::Backtrace.clean(e) if debug && !e.is_a?(Livecheck::Error)
+          if debug && !e.is_a?(Livecheck::Error)
+            require "utils/backtrace"
+            $stderr.puts Utils::Backtrace.clean(e)
+          end
           nil
         end
       end

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -226,7 +226,10 @@ class Migrator
   rescue Exception => e # rubocop:disable Lint/RescueException
     onoe "The migration did not complete successfully."
     puts e
-    puts Utils::Backtrace.clean(e) if debug?
+    if debug?
+      require "utils/backtrace"
+      puts Utils::Backtrace.clean(e)
+    end
     puts "Backing up..."
     ignore_interrupts { backup_oldname }
   ensure
@@ -357,7 +360,10 @@ class Migrator
     rescue Exception => e # rubocop:disable Lint/RescueException
       onoe "An unexpected error occurred during linking"
       puts e
-      puts Utils::Backtrace.clean(e) if debug?
+      if debug?
+        require "utils/backtrace"
+        puts Utils::Backtrace.clean(e)
+      end
       ignore_interrupts { new_keg.unlink(verbose: verbose?) }
       raise
     end

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -36,6 +36,7 @@ module Repology
     data = JSON.parse(output)
     { name => data }
   rescue => e
+    require "utils/backtrace"
     error_output = [errors, "#{e.class}: #{e}", Utils::Backtrace.clean(e)].compact
     if Homebrew::EnvConfig.developer?
       $stderr.puts(*error_output)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is primarily intended to resolve the `uninitialized constant Utils::Backtrace` error in `formula_versions.rb:60` (e.g., https://github.com/Homebrew/homebrew-core/actions/runs/9942660636/job/27464770982?pr=177398, from https://github.com/Homebrew/homebrew-core/pull/177398) but I expanded it to try to cover all existing usage of `Utils::Backtrace`.

Per Rylan's comment below, I've followed the existing pattern, where `utils/backtrace` is required in the context of where it's used. Many of these cases use `Backtrace` in a conditional manner, so I've tried to ensure that the `require` follows suit.