### PR TITLE
Have `tap_git_head` return `nil` when no tap is installed

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -323,6 +323,8 @@ module Cask
 
     def tap_git_head
       @tap_git_head ||= tap&.git_head
+    rescue TapUnavailableError
+      nil
     end
 
     def populate_from_api!(json_cask)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2232,6 +2232,8 @@ class Formula
 
   def tap_git_head
     tap&.git_head
+  rescue TapUnavailableError
+    nil
   end
 
   delegate env: :"self.class"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/discussions/discussions/5493

When the API is not being used but the core/cask taps aren't installed, `tap_git_head` will error on `homebrew/core` and `homebrew/cask`. This PR catches that error and returns `nil`. I think this should be fine since I scanned the code and it seemed like there wasn't much that should break, but it is posisble that I missed something.

Also, if desired, we could scope this to `homebrew/core` and `homebrew/cask`
