### PR TITLE
audit: add require utils/backtrace

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -4,6 +4,7 @@
 require "abstract_command"
 require "formula"
 require "formula_versions"
+require "utils/backtrace"
 require "utils/curl"
 require "utils/github/actions"
 require "utils/shared_audits"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Spotted in https://github.com/Homebrew/homebrew-core/actions/runs/9942660636/job/27464770982?pr=177398

```
> brew audit --formula gnu-typist --online --git --skip-style output
  Error: uninitialized constant Utils::Backtrace
```