### PR TITLE
FormulaURILoader: use regex to validate refs before attempting to cast

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -696,9 +696,20 @@ module Formulary
         .returns(T.nilable(T.attached_class))
     }
     def self.try_new(ref, from: T.unsafe(nil), warn: false)
-      ref = ref.to_s
+      # Cache compiled regex
+      @uri_regex ||= begin
+        uri_regex = ::URI::DEFAULT_PARSER.make_regexp
+        Regexp.new("\\A#{uri_regex.source}\\Z", uri_regex.options)
+      end
 
-      new(ref, from:) if URI(ref).scheme.present?
+      uri = ref.to_s
+      return unless uri.match?(@uri_regex)
+
+      uri = URI(uri)
+      return unless uri.path
+      return unless uri.scheme.present?
+
+      new(uri, from:)
     end
 
     attr_reader :url

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -555,6 +555,14 @@ RSpec.describe Formulary do
         end.not_to raise_error(UnsupportedInstallationMethod)
       end
     end
+
+    context "when passed ref with spaces" do
+      it "raises a FormulaUnavailableError error" do
+        expect do
+          described_class.factory("foo bar")
+        end.to raise_error(FormulaUnavailableError)
+      end
+    end
   end
 
   specify "::from_contents" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes <https://github.com/Homebrew/brew/issues/17752>

This PR updates `Formulary::FromURILoader` to match the cask equivalent and check the ref against a URI regex. This avoids trying to run `URI()` where the argument is something that will throw a bad URI error (e.g. a string with spaces).
