### PR TITLE
cask/audit: handle cask_min_os is nil

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -672,6 +672,7 @@ module Cask
       return if cask_min_os&.to_sym == min_os.to_sym
       return if cask.on_system_blocks_exist? &&
                 OnSystem.arch_condition_met?(:arm) &&
+                cask_min_os.present? &&
                 cask_min_os < MacOSVersion.new("11")
 
       min_os_definition = if cask_min_os.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR addresses a scenario where a cask uses `on_system_blocks` but does not declare a minimum OS version (e.g., [`itau`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/i/itau.rb)). In such cases, the variable `cask_min_os` is `nil`.

Before:

```sh
❯ brew audit --cask --strict --online --arch=arm --only=min_os itau
audit for itau: failed
 - exception while auditing itau: undefined method `<' for nil
itau
  * exception while auditing itau: undefined method `<' for nil
Error: 1 problem in 1 cask detected.
```

Follow-up to https://github.com/Homebrew/brew/pull/17596.
