### PR TITLE
formula: add `std_npm_args`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1847,6 +1847,16 @@ class Formula
     ["--prefix=#{prefix}", "--libdir=#{lib}", "--buildtype=release", "--wrap-mode=nofallback"]
   end
 
+  # Standard parameters for npm builds.
+  sig { params(prefix: T.any(String, Pathname, FalseClass)).returns(T::Array[String]) }
+  def std_npm_args(prefix: libexec)
+    require "language/node"
+
+    return Language::Node.std_npm_install_args(Pathname(prefix)) if prefix
+
+    Language::Node.local_npm_install_args
+  end
+
   # Standard parameters for pip builds.
   sig {
     params(prefix:          T.any(String, Pathname, FalseClass),
@@ -2964,6 +2974,8 @@ class Formula
         pretty_args -= std_go_args
       when "meson"
         pretty_args -= std_meson_args
+      when "npm"
+        pretty_args -= std_npm_args
       when %r{(^|/)(pip|python)(?:[23](?:\.\d{1,2})?)?$}
         pretty_args -= std_pip_args
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

While working on #17773, another node inconsistency that has bothered me is our npm args helper isn't exposed on the `Formula` class like all our other `std_*_args`. This fixes that by introducing a `Formula.std_npm_args` function, which for now just wraps the existing functions

Before:

```ruby
require "language/node"
system "npm", "install", *Language::Node.local_npm_install_args
system "npm", "install", *Language::Node.std_npm_install_args(libexec)
```

After:

```ruby
system "npm", "install", *std_npm_args(prefix: false)
system "npm", "install", *std_npm_args
```

Feedback welcome, if we like this I can also work on a rubocop to migrate to this new API
