### PR TITLE
Fix missing requires for `tap-info` command

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -4,6 +4,7 @@
 require "api/analytics"
 require "api/cask"
 require "api/formula"
+require "development_tools"
 require "warnings"
 Warnings.ignore :default_gems do
   require "base64" # TODO: Add this to the Gemfile or remove it before moving to Ruby 3.4.

--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -4,7 +4,6 @@
 require "api/analytics"
 require "api/cask"
 require "api/formula"
-require "development_tools"
 require "warnings"
 Warnings.ignore :default_gems do
   require "base64" # TODO: Add this to the Gemfile or remove it before moving to Ruby 3.4.
@@ -41,6 +40,9 @@ module Homebrew
     }
     def self.fetch_json_api_file(endpoint, target: HOMEBREW_CACHE_API/endpoint,
                                  stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
+      # Lazy-load dependency.
+      require "development_tools"
+
       retry_count = 0
       url = "#{Homebrew::EnvConfig.api_domain}/#{endpoint}"
       default_url = "#{HOMEBREW_API_DEFAULT_DOMAIN}/#{endpoint}"

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -3,6 +3,7 @@
 
 require "url"
 require "checksum"
+require "download_strategy"
 
 class Downloadable
   include Context

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "api"
 require "commands"
 require "settings"
 


### PR DESCRIPTION
Previously, running `brew tap-info --installed --json` in a github actions linux runner would throw:

```
Error: uninitialized constant Homebrew::API
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/tap.rb:1359:in `formula_names'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/tap.rb:868:in `to_hash'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/tap-info.rb:87:in `map'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/tap-info.rb:87:in `print_tap_json'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/tap-info.rb:37:in `run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:95:in `<main>'
```

After the setup steps:
```
    steps:
      - name: Set up Homebrew
        id: set-up-homebrew
        uses: Homebrew/actions/setup-homebrew@master
        with:
          token: ${{ github.token }}

      - name: Cache Homebrew Bundler RubyGems
        id: cache
        uses: actions/cache@v3
        with:
          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
          restore-keys: ${{ runner.os }}-rubygems-

      - name: Install Homebrew Bundler RubyGems
        if: steps.cache.outputs.cache-hit != 'true'
        run: brew install-bundler-gems
```