### PR TITLE
formula_assertions: Fix `pipe_output` type sig

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -36,7 +36,7 @@ module Homebrew
     # optionally asserts the exit status.
     #
     # @api public
-    sig { params(cmd: String, input: T.nilable(String), result: T.nilable(Integer)).returns(String) }
+    sig { params(cmd: T.any(String, Pathname), input: T.nilable(String), result: T.nilable(Integer)).returns(String) }
     def pipe_output(cmd, input = nil, result = nil)
       ohai cmd
       output = IO.popen(cmd, "w+") do |pipe|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #17779.

```
❯ brew test zstd
==> Testing zstd
Error: zstd: failed
An exception occurred within a child process:
  TypeError: Parameter 'cmd': Expected type String, got type Pathname with value #<Pathname:/opt/homebrew/Cellar/zstd/1.5.6/bin/zstd>
Caller: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/z/zstd.rb:58
Definition: /opt/homebrew/Library/Homebrew/formula_assertions.rb:40 (Homebrew::Assertions#pipe_output)
```
