### PR TITLE
Fix UID handling with cask `installer script:`

### DIFF
--- a/Library/Homebrew/cask/artifact/installer.rb
+++ b/Library/Homebrew/cask/artifact/installer.rb
@@ -35,9 +35,10 @@ module Cask
           command.run!(
             executable_path,
             **args,
-            env: { "PATH" => PATH.new(
+            env:       { "PATH" => PATH.new(
               HOMEBREW_PREFIX/"bin", HOMEBREW_PREFIX/"sbin", ENV.fetch("PATH")
             ) },
+            reset_uid: true,
           )
         end
       end

--- a/Library/Homebrew/sorbet/rbi/parlour.rbi
+++ b/Library/Homebrew/sorbet/rbi/parlour.rbi
@@ -279,6 +279,9 @@ class SystemCommand
 
   sig { returns(T::Boolean) }
   def must_succeed?; end
+
+  sig { returns(T::Boolean) }
+  def reset_uid?; end
 end
 
 module Utils

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe SystemCommand do
 
       describe "the resulting command line" do
         it "includes the given variables explicitly" do
-          expect(Open3)
-            .to receive(:popen3)
+          expect(command)
+            .to receive(:exec3)
             .with(
-              an_instance_of(Hash), ["/usr/bin/env", "/usr/bin/env"], "A=1", "B=2", "C=3",
+              an_instance_of(Hash), "/usr/bin/env", "A=1", "B=2", "C=3",
               "env", *env_args,
               pgroup: true
             )
@@ -55,14 +55,14 @@ RSpec.describe SystemCommand do
 
       describe "the resulting command line" do
         it "includes the given variables explicitly" do
-          expect(Open3)
-            .to receive(:popen3)
+          expect(command)
+            .to receive(:exec3)
             .with(
-              an_instance_of(Hash), ["/usr/bin/sudo", "/usr/bin/sudo"], "-E",
+              an_instance_of(Hash), "/usr/bin/sudo", "-E",
               "A=1", "B=2", "C=3", "--", "env", *env_args, pgroup: nil
             )
-            .and_wrap_original do |original_popen3, *_, &block|
-              original_popen3.call("true", &block)
+            .and_wrap_original do |original_exec3, *_, &block|
+              original_exec3.call({}, "true", &block)
             end
 
           command.run!
@@ -76,14 +76,14 @@ RSpec.describe SystemCommand do
 
       describe "the resulting command line" do
         it "includes the given variables explicitly" do
-          expect(Open3)
-            .to receive(:popen3)
+          expect(command)
+            .to receive(:exec3)
             .with(
-              an_instance_of(Hash), ["/usr/bin/sudo", "/usr/bin/sudo"], "-u", "root",
+              an_instance_of(Hash), "/usr/bin/sudo", "-u", "root",
               "-E", "A=1", "B=2", "C=3", "--", "env", *env_args, pgroup: nil
             )
-            .and_wrap_original do |original_popen3, *_, &block|
-              original_popen3.call("true", &block)
+            .and_wrap_original do |original_exec3, *_, &block|
+              original_exec3.call({}, "true", &block)
             end
 
           command.run!


### PR DESCRIPTION
Broadly speaking, Homebrew respects EUID and writes all files using that EUID.

When using `installer script:` this contract may not necessarily be true for third-party scripts, leading to permission issues under setups where EUID != UID. For example, bash scripts by default will respect UID instead unless you use Bash protected mode (`bash -p`).

In formulae, we already handle this here: https://github.com/Homebrew/brew/blob/2cdc092a2623522d21f5fe4a5a8526a40f011e74/Library/Homebrew/utils/fork.rb#L48

This PR adds the same to casks via a `reset_uid` `system_command` option. Unfortunately Open3 isn't flexible enough to handle this so we need to replace it with our own implementation.