### PR TITLE
Improve diagnostic for Git fsmonitor settings in Homebrew repository:

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -520,6 +520,26 @@ module Homebrew
         examine_git_origin(repo, Homebrew::EnvConfig.brew_git_remote)
       end
 
+      def check_git_fsmonitor_settings
+        return unless Utils::Git.available?
+
+        fsmonitor = HOMEBREW_REPOSITORY.cd { `git config --get core.fsmonitor`.chomp }
+        return if fsmonitor != "true"
+
+        <<~EOS
+          Suspicious Git fsmonitor settings found.
+
+          The detected Git fsmonitor settings could interfere with Homebrew operations:
+            core.fsmonitor = #{fsmonitor}
+
+          This setting might block the lock file during a `brew upgrade` operation,
+          leading to potential issues and interruptions.
+
+          If you encounter problems, consider disabling fsmonitor in the Homebrew repository by running:
+            cd #{HOMEBREW_REPOSITORY} && git config core.fsmonitor false
+        EOS
+      end
+
       def check_coretap_integrity
         core_tap = CoreTap.instance
         unless core_tap.installed?


### PR DESCRIPTION
- Added a check for the core.fsmonitor setting in the Homebrew repository
- Provided an error message with instructions to disable fsmonitor if it is set to 'true'
- Ensured the instructions specify making the change in the Homebrew repository folder

This update helps prevent potential issues with lock files during 'brew upgrade' operations.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
