### PR TITLE
attestation: handle bad configurations better

### DIFF
--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_error_status))
 
@@ -132,14 +132,14 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_raise(ErrorDuringExecution.new(["foo"], status: fake_auth_status))
 
       expect do
         described_class.check_attestation fake_bottle,
                                           described_class::HOMEBREW_CORE_REPO
-      end.to raise_error(described_class::GhAuthNeeded)
+      end.to raise_error(described_class::GhAuthInvalid)
     end
 
     it "raises when gh returns invalid JSON" do
@@ -149,7 +149,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_invalid_json)
 
@@ -166,7 +166,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_json_resp_wrong_sub)
 
@@ -183,7 +183,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp)
 
@@ -204,7 +204,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp)
 
@@ -215,7 +215,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .once
         .and_raise(described_class::InvalidAttestationError)
@@ -223,7 +223,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::BACKFILL_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp_backfill)
 
@@ -234,7 +234,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .once
         .and_raise(described_class::InvalidAttestationError)
@@ -242,7 +242,7 @@ RSpec.describe Homebrew::Attestation do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::BACKFILL_REPO, "--format", "json"],
-              env: { "GH_TOKEN" => fake_gh_creds }, secrets: [fake_gh_creds],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp_too_new)
 


### PR DESCRIPTION
* After #17760, we seem to now be forcing installing `gh` for everyone which I didn't initially realise based on the PR description. This can be slow for unsupported configurations as they would need to build Go from source so disable attestations for the `OS.unsupported_configuration?` case. (Though IMO maybe worth thinking whether we actually want to be forcing installs to 15% of users.)
* Set `GH_HOST` explicitly which should avoid the need for `gh auth switch`
* Silently handle 401 bad auth for now. Removing auth is a hard blocker for wider roll out so I don't think we should pain users in the meantime. We've been getting multiple reports a day on this issue and that number doesn't seem to be going down.