### PR TITLE
attestation: fix comment

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -118,8 +118,7 @@ module Homebrew
       cmd += ["--cert-identity", signing_workflow] if signing_workflow.present?
 
       # Fail early if we have no credentials. The command below invariably
-      # fails without them, so this saves us a network roundtrip before
-      # presenting the user with the same error.
+      # fails without them, so this saves us an unnecessary subshell.
       credentials = GitHub::API.credentials
       raise GhAuthNeeded, "missing credentials" if credentials.blank?
 


### PR DESCRIPTION
Tweaks a misleading comment in `attestation.rb`, per https://github.com/cli/cli/issues/9338#issuecomment-2236911577.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
