### PR TITLE
contributions, github: add missing requires, fix type errors

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -48,12 +48,20 @@ module Homebrew
         results = {}
         grand_totals = {}
 
-        repos = if args.repositories.blank? || args.repositories&.include?("primary")
-          PRIMARY_REPOS
-        elsif args.repositories&.include?("all")
-          SUPPORTED_REPOS
-        else
-          args.repositories
+        repos = T.must(
+          if args.repositories.blank? || args.repositories&.include?("primary")
+            PRIMARY_REPOS
+          elsif args.repositories&.include?("all")
+            SUPPORTED_REPOS
+          else
+            args.repositories
+          end,
+        )
+
+        repos.each do |repo|
+          if SUPPORTED_REPOS.exclude?(repo)
+            odie "Unsupported repository: #{repo}. Try one of #{SUPPORTED_REPOS.join(", ")}."
+          end
         end
 
         from = args.from.presence || Date.today.prev_year.iso8601
@@ -150,17 +158,18 @@ module Homebrew
         ]
       end
 
-      sig { params(repos: T.nilable(T::Array[String]), person: String, from: String).void }
+      sig {
+        params(
+          repos:  T::Array[String],
+          person: String,
+          from:   String,
+        ).returns(T::Hash[Symbol, T.untyped])
+      }
       def scan_repositories(repos, person, from:)
-        return if repos.blank?
-
         data = {}
+        return data if repos.blank?
 
         repos.each do |repo|
-          if SUPPORTED_REPOS.exclude?(repo)
-            return ofail "Unsupported repository: #{repo}. Try one of #{SUPPORTED_REPOS.join(", ")}."
-          end
-
           repo_path = find_repo_path_for_repo(repo)
           tap = Tap.fetch("homebrew", repo)
           unless repo_path.exist?

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -6,6 +6,8 @@ require "warnings"
 Warnings.ignore :default_gems do
   require "csv"
 end
+require "tap"
+require "utils/github"
 
 module Homebrew
   module DevCmd

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -2,10 +2,6 @@
 # frozen_string_literal: true
 
 require "abstract_command"
-require "warnings"
-Warnings.ignore :default_gems do
-  require "csv"
-end
 require "tap"
 require "utils/github"
 
@@ -120,6 +116,11 @@ module Homebrew
 
       sig { params(totals: T::Hash[String, T::Hash[Symbol, Integer]]).returns(String) }
       def generate_csv(totals)
+        require "warnings"
+        Warnings.ignore :default_gems do
+          require "csv"
+        end
+
         CSV.generate do |csv|
           csv << %w[user repo author committer coauthor review total]
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "uri"
+require "utils/curl"
+require "utils/popen"
 require "utils/github/actions"
 require "utils/github/api"
 

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -3,6 +3,7 @@
 
 require "system_command"
 require "tempfile"
+require "utils/curl"
 require "utils/shell"
 require "utils/formatter"
 require "utils/uid"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This resolves `unitialized constant` errors in `brew contributions` (`Tap`, `GitHub`) and `Utils::GitHub` (`Utils::Curl`). This also preemptively adds some requires to `Utils::GitHub` and `GitHub::API`, to avoid similar errors.

Besides that, this updates the type signature for `#scan_repositories` to address a runtime type error and to reflect the actual return type. The logic in `#scan_repositories` to check for unsupported repositories leads to a type error, as `#ofail` has a void return type. To resolve this, I moved the repository verification code into `#run` (after `repos` is defined but before it's used) and used `#odie`, so the command will exit early with an error.

While I was at it, I updated the type for the `repos` parameter to not be `nilable`, as it shouldn't be `nil` based on how we're handling `repos` in `#run`.

Lastly, since CSV generation is optional, I moved the related `require` into the method where `CSV` is used (following a pattern we've used for other `require` calls throughout `brew`).