### PR TITLE
Add missing_formula require to Homebrew::CLI::NamedArgs

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -28,6 +28,8 @@ module Homebrew
         cask_options: false,
         without_api: false
       )
+        require "missing_formula"
+
         @args = args
         @override_spec = override_spec
         @force_bottle = force_bottle


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
5 days ago we merged a [PR that reworked requires](https://github.com/Homebrew/brew/pull/17707), but that has led to some unhandled errors, namely: `Error: uninitialized constant Homebrew::CLI::NamedArgs::MissingFormula` within ` Homebrew::CLI::NamedArgs` as raised by https://github.com/Homebrew/brew/issues/17807. 

This re_adds the require to address the uninitialized constant. 