### PR TITLE
Set correct tap when loading installed casks

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -517,7 +517,7 @@ module Cask
       end
 
       sig { params(path: T.any(Pathname, String), token: String).void }
-      def initialize(path, token: T.unsafe(nil))
+      def initialize(path, token: "")
         super
 
         installed_tap = Cask.new(@token).tab.tap

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -612,7 +612,7 @@ module Cask
     end
 
     sig { params(ref: String, config: T.nilable(Config), warn: T::Boolean).returns(Cask) }
-    def self.load_installed_cask(ref, config: nil, warn: true)
+    def self.load_prefer_installed(ref, config: nil, warn: true)
       tap, token = Tap.with_cask_token(ref)
       token ||= ref
       tap ||= Cask.new(ref).tab.tap

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -56,7 +56,7 @@ module Cask
     sig { params(config: T.nilable(Config)).returns(T::Array[Cask]) }
     def self.casks(config: nil)
       tokens.sort.filter_map do |token|
-        CaskLoader.load(token, config:, warn: false)
+        CaskLoader.load_installed_cask(token, config:, warn: false)
       rescue TapCaskAmbiguityError => e
         T.must(e.loaders.first).load(config:)
       rescue

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -56,7 +56,7 @@ module Cask
     sig { params(config: T.nilable(Config)).returns(T::Array[Cask]) }
     def self.casks(config: nil)
       tokens.sort.filter_map do |token|
-        CaskLoader.load_installed_cask(token, config:, warn: false)
+        CaskLoader.load_prefer_installed(token, config:, warn: false)
       rescue TapCaskAmbiguityError => e
         T.must(e.loaders.first).load(config:)
       rescue

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -61,6 +61,18 @@ class NoSuchKegError < RuntimeError
   end
 end
 
+# Raised when a keg from a specific tap doesn't exist.
+class NoSuchKegFromTapError < RuntimeError
+  attr_reader :name, :tap
+
+  sig { params(name: String, tap: Tap).void }
+  def initialize(name, tap)
+    @name = name
+    @tap = tap
+    super "No such keg: #{HOMEBREW_CELLAR}/#{name} from tap #{tap}"
+  end
+end
+
 # Raised when an invalid attribute is used in a formula.
 class FormulaValidationError < StandardError
   attr_reader :attr, :formula

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -184,4 +184,60 @@ RSpec.describe Cask::CaskLoader, :cask do
       end
     end
   end
+
+  describe "::load_installed_cask" do
+    let(:foo_tap) { Tap.fetch("user", "foo") }
+    let(:bar_tap) { Tap.fetch("user", "bar") }
+
+    let(:blank_tab) { instance_double(Cask::Tab, tap: nil) }
+    let(:installed_tab) { instance_double(Cask::Tab, tap: bar_tap) }
+
+    let(:cask_with_foo_tap) { instance_double(Cask::Cask, token: "test-cask", tap: foo_tap) }
+    let(:cask_with_bar_tap) { instance_double(Cask::Cask, token: "test-cask", tap: bar_tap) }
+
+    let(:load_args) { { config: nil, warn: true } }
+
+    before do
+      allow(described_class).to receive(:load).with("test-cask", load_args).and_return(cask_with_foo_tap)
+      allow(described_class).to receive(:load).with("user/foo/test-cask", load_args).and_return(cask_with_foo_tap)
+      allow(described_class).to receive(:load).with("user/bar/test-cask", load_args).and_return(cask_with_bar_tap)
+    end
+
+    it "returns the correct cask when no tap is specified and no tab exists" do
+      allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(blank_tab)
+      expect(described_class).to receive(:load).with("test-cask", load_args)
+
+      expect(described_class.load_installed_cask("test-cask").tap).to eq(foo_tap)
+    end
+
+    it "returns the correct cask when no tap is specified but a tab exists" do
+      allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
+      expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
+
+      expect(described_class.load_installed_cask("test-cask").tap).to eq(bar_tap)
+    end
+
+    it "returns the correct cask when a tap is specified and no tab exists" do
+      allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(blank_tab)
+      expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
+
+      expect(described_class.load_installed_cask("user/bar/test-cask").tap).to eq(bar_tap)
+    end
+
+    it "returns the correct cask when no tap is specified and a tab exists" do
+      allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
+      expect(described_class).to receive(:load).with("user/foo/test-cask", load_args)
+
+      expect(described_class.load_installed_cask("user/foo/test-cask").tap).to eq(foo_tap)
+    end
+
+    it "returns the correct cask when no tap is specified and the tab lists an tap that isn't installed" do
+      allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
+      expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
+                                               .and_raise(Cask::CaskUnavailableError.new("test-cask", bar_tap))
+      expect(described_class).to receive(:load).with("test-cask", load_args)
+
+      expect(described_class.load_installed_cask("test-cask").tap).to eq(foo_tap)
+    end
+  end
 end

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Cask::CaskLoader, :cask do
     end
   end
 
-  describe "::load_installed_cask" do
+  describe "::load_prefer_installed" do
     let(:foo_tap) { Tap.fetch("user", "foo") }
     let(:bar_tap) { Tap.fetch("user", "bar") }
 
@@ -207,28 +207,28 @@ RSpec.describe Cask::CaskLoader, :cask do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(blank_tab)
       expect(described_class).to receive(:load).with("test-cask", load_args)
 
-      expect(described_class.load_installed_cask("test-cask").tap).to eq(foo_tap)
+      expect(described_class.load_prefer_installed("test-cask").tap).to eq(foo_tap)
     end
 
     it "returns the correct cask when no tap is specified but a tab exists" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
       expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
 
-      expect(described_class.load_installed_cask("test-cask").tap).to eq(bar_tap)
+      expect(described_class.load_prefer_installed("test-cask").tap).to eq(bar_tap)
     end
 
     it "returns the correct cask when a tap is specified and no tab exists" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(blank_tab)
       expect(described_class).to receive(:load).with("user/bar/test-cask", load_args)
 
-      expect(described_class.load_installed_cask("user/bar/test-cask").tap).to eq(bar_tap)
+      expect(described_class.load_prefer_installed("user/bar/test-cask").tap).to eq(bar_tap)
     end
 
     it "returns the correct cask when no tap is specified and a tab exists" do
       allow_any_instance_of(Cask::Cask).to receive(:tab).and_return(installed_tab)
       expect(described_class).to receive(:load).with("user/foo/test-cask", load_args)
 
-      expect(described_class.load_installed_cask("user/foo/test-cask").tap).to eq(foo_tap)
+      expect(described_class.load_prefer_installed("user/foo/test-cask").tap).to eq(foo_tap)
     end
 
     it "returns the correct cask when no tap is specified and the tab lists an tap that isn't installed" do
@@ -237,7 +237,7 @@ RSpec.describe Cask::CaskLoader, :cask do
                                                .and_raise(Cask::CaskUnavailableError.new("test-cask", bar_tap))
       expect(described_class).to receive(:load).with("test-cask", load_args)
 
-      expect(described_class.load_installed_cask("test-cask").tap).to eq(foo_tap)
+      expect(described_class.load_prefer_installed("test-cask").tap).to eq(foo_tap)
     end
   end
 end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe "Exception" do
     end
   end
 
+  describe NoSuchKegFromTapError do
+    subject(:error) { described_class.new("foo", tap) }
+
+    let(:tap) { instance_double(Tap, to_s: "u/r") }
+
+    it(:to_s) { expect(error.to_s).to eq("No such keg: #{HOMEBREW_CELLAR}/foo from tap u/r") }
+  end
+
   describe NoSuchKegError do
     subject(:error) { described_class.new("foo") }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes <https://github.com/Homebrew/brew/issues/17416>

This PR uses the new cask tabs to set the correct tap when loading an installed cask.

I have added two new `CaskLoader` methods:

1. `load_installed_cask`: this method is analogous to `Formulary::from_keg`. It accepts a token and returns a cask with that token from the tap specified in the install receipt of the cask. Essentially, if `slack` was installed from `test/tap`, running `load_installed_cask("slack")` will return the `test/tap/slack` cask and _not_ the `homebrew/cask/slack` cask. Note: if a full name is passed, the tap specified in the name will be used, even if a different tap exists in the install receipt.
2. `load_from_installed_caskfile`: this method takes an installed caskfile and loads a cask from it, making sure to set the correct tap. If passed a path that isn't an installed caskfile or doesn't exist, it will raise a `CaskUnavailableError`.

This means that `Cask::Caskroom::casks` will now return the correct casks when a third-party cask is installed and shares a name with a cask in `homebrew/cask`. This means that `brew list --full-name` will work correctly.

Additionally, handling of named arguments when requesting kegs or keg-like-casks (i.e. installed formulae/casks). Now, specifying a full name will raise an error if the installed formula with that short name does not have a matching tap. For example, if `test/tap/hello` is installed, `brew uninstall homebrew/core/hello` will not uninstall the formula. `brew uninstall hello` and `brew uninstall test/tap/hello` will still work as expected.
