### PR TITLE
rubocops/text: Enforce `bin/"formula"` instead of `"#{bin}/formula"`

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -137,6 +137,11 @@ module RuboCop
             problem "Use `\#{pkgshare}` instead of `\#{share}/#{@formula_name}`"
           end
 
+          interpolated_bin_path_starts_with(body_node, "/#{@formula_name}") do |bin_node|
+            offending_node(bin_node)
+            problem "Use `bin/\"#{@formula_name}\"` instead of `\"\#{bin}/#{@formula_name}\"`"
+          end
+
           return if formula_tap != "homebrew-core"
 
           find_method_with_args(body_node, :env, :std) do
@@ -152,6 +157,11 @@ module RuboCop
         # Find "#{share}/foo"
         def_node_search :interpolated_share_path_starts_with, <<~EOS
           $(dstr (begin (send nil? :share)) (str #path_starts_with?(%1)))
+        EOS
+
+        # Find "#{bin}/foo"
+        def_node_search :interpolated_bin_path_starts_with, <<~EOS
+          $(dstr (begin (send nil? :bin)) (str #path_starts_with?(%1)))
         EOS
 
         # Find share/"foo"

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -137,7 +137,7 @@ module RuboCop
             problem "Use `\#{pkgshare}` instead of `\#{share}/#{@formula_name}`"
           end
 
-          interpolated_bin_path_starts_with(body_node, "/#{@formula_name}", true) do |bin_node|
+          interpolated_bin_path_starts_with(body_node, "/#{@formula_name}") do |bin_node|
             offending_node(bin_node)
             cmd = bin_node.source.match(%r{\#{bin}/(\S+)})[1]&.delete_suffix('"') || @formula_name
             problem "Use `bin/\"#{cmd}\"` instead of `\"\#{bin}/#{cmd}\"`"
@@ -152,9 +152,13 @@ module RuboCop
 
         # Check whether value starts with the formula name and then a "/", " " or EOS.
         # If we're checking for "#{bin}", we also check for "-" since similar binaries also don't need interpolation.
-        def path_starts_with?(path, starts_with, bin = false)
+        def path_starts_with?(path, starts_with, bin: false)
           ending = bin ? "/| |-|$" : "/| |$"
           path.match?(/^#{Regexp.escape(starts_with)}(#{ending})/)
+        end
+
+        def path_starts_with_bin?(path, starts_with)
+          path_starts_with?(path, starts_with, bin: true)
         end
 
         # Find "#{share}/foo"
@@ -164,7 +168,7 @@ module RuboCop
 
         # Find "#{bin}/foo" and "#{bin}/foo-bar"
         def_node_search :interpolated_bin_path_starts_with, <<~EOS
-          $(dstr (begin (send nil? :bin)) (str #path_starts_with?(%1, %2)))
+          $(dstr (begin (send nil? :bin)) (str #path_starts_with_bin?(%1)))
         EOS
 
         # Find share/"foo"

--- a/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/formula_audit_strict/text.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cop/formula_audit_strict/text.rbi
@@ -14,6 +14,16 @@ class RuboCop::Cop::FormulaAuditStrict::Text
       block: T.untyped
     ).returns(T.untyped)
   end
+  def interpolated_bin_path_starts_with(node, *pattern, **kwargs, &block); end
+
+  sig do
+    params(
+      node: RuboCop::AST::Node,
+      pattern: T.any(String, Symbol),
+      kwargs: T.untyped,
+      block: T.untyped
+    ).returns(T.untyped)
+  end
   def interpolated_share_path_starts_with(node, *pattern, **kwargs, &block); end
 
   sig do

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -131,5 +131,16 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
         end
       RUBY
     end
+
+    it 'reports an offense if "\#{bin}/<formula name>" is present' do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          test do
+            ohai "\#{bin}/foo", "-v"
+                 ^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"\#{bin}/foo"`
+          end
+        end
+      RUBY
+    end
   end
 end

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -132,12 +132,14 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it 'reports an offense if "\#{bin}/<formula name>" is present' do
+    it 'reports an offense if "\#{bin}/<formula_name>" or other dashed binaries too are present' do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           test do
             ohai "\#{bin}/foo", "-v"
                  ^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"\#{bin}/foo"`
+            ohai "\#{bin}/foo-bar", "-v"
+                 ^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo-bar"` instead of `"\#{bin}/foo-bar"`
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -144,5 +144,16 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
         end
       RUBY
     end
+
+    it 'reports an offense if "\#{bin}" is in a `shell_output` string' do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          test do
+            shell_output("\#{bin}/foo --version")
+                         ^^^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"\#{bin}/foo"`
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #17825.
- ❓ This is currently a strict audit, because that's where the other things that audited strings vs. not strings were (🤷🏻) - should it be?