### PR TITLE
attestation: only fallback to backfill on 404

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1310,7 +1310,7 @@ on_request: installed_on_request?, options:)
 
             gh auth login
         EOS
-      rescue Homebrew::Attestation::InvalidAttestationError => e
+      rescue Homebrew::Attestation::MissingAttestationError, Homebrew::Attestation::InvalidAttestationError => e
         raise CannotInstallFormulaError, <<~EOS
           The bottle for #{formula.name} has an invalid build provenance attestation.
 

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -251,14 +251,14 @@ RSpec.describe Homebrew::Attestation do
       described_class.check_core_attestation fake_bottle
     end
 
-    it "calls gh with args for backfill when homebrew-core fails" do
+    it "calls gh with args for backfill when homebrew-core attestation is missing" do
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .once
-        .and_raise(described_class::InvalidAttestationError)
+        .and_raise(described_class::MissingAttestationError)
 
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
@@ -277,7 +277,7 @@ RSpec.describe Homebrew::Attestation do
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .once
-        .and_raise(described_class::InvalidAttestationError)
+        .and_raise(described_class::MissingAttestationError)
 
       expect(described_class).to receive(:system_command!)
         .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",


### PR DESCRIPTION
This feels correct unless we're aware of older invalid attestations in homebrew-core that we need to catch too?

The goal here is to:
* Make verification errors visible as currently it will always print 404 on the backfill when homebrew-core verification fails on newer bottles: https://github.com/Homebrew/homebrew-core/issues/177384#issuecomment-2244530891.
* Avoid an unnecessary second roundtrip on verification failures when we know the backfill isn't the issue here.

This can maybe also be argued to be slightly more secure in that we make sure Homebrew/homebrew-core trumps the backfill repo, though that wasn't the goal here.