### PR TITLE
system_command: fix EBADF on Ctrl+C

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -265,15 +265,16 @@ class SystemCommand
     raise Timeout::Error if raw_wait_thr.join(Utils::Timer.remaining(end_time)).nil?
 
     @status = raw_wait_thr.value
-
-    thread_ready_queue.pop
-    line_thread.raise ProcessTerminatedInterrupt.new
-    thread_done_queue << true
-    line_thread.join
   rescue Interrupt
     Process.kill("INT", raw_wait_thr.pid) if raw_wait_thr && !sudo?
     raise Interrupt
   ensure
+    if line_thread
+      thread_ready_queue.pop
+      line_thread.raise ProcessTerminatedInterrupt.new
+      thread_done_queue << true
+      line_thread.join
+    end
     raw_stdin&.close
     raw_stdout&.close
     raw_stderr&.close


### PR DESCRIPTION
We now close pipes correctly whereas we previously didn't. This however caused a scenario where the thread reading them wasn't ready for closing, in particular when an interrupt was received.

This moves the thread handling to cover that scenario.