### PR TITLE
cmd/update: silence git advice where possible

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -488,6 +488,7 @@ EOS
 
   if [[ -z "${HOMEBREW_VERBOSE}" ]]
   then
+    export GIT_ADVICE="false"
     QUIET_ARGS=(-q)
   else
     QUIET_ARGS=()


### PR DESCRIPTION
We pass the `-q` flag to silence warnings. However some warnings are followed by advice messages and these currently do not respect `-q`, e.g.

```
hint: use --reapply-cherry-picks to include skipped commits
hint: Disable this message with "git config advice.skippedCherryPicks false"
```

Git 2.46 will introduce a new `GIT_ADVICE` environment variable that silences these messages so let's use it. It will probably be a while before Apple Git supports it. They seem to staying on 2.39 for some reason.