### PR TITLE
Add env to disable finding packages from paths

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -32,10 +32,13 @@ module Homebrew
           cache: HOMEBREW_CACHE_API_SOURCE/"#{tap}/#{git_head}/Formula",
         )
         download.fetch
-        Formulary.factory(download.symlink_location,
-                          formula.active_spec_sym,
-                          alias_path: formula.alias_path,
-                          flags:      formula.class.build_flags)
+
+        with_env(HOMEBREW_FORBID_PACKAGES_FROM_PATHS: nil) do
+          Formulary.factory(download.symlink_location,
+                            formula.active_spec_sym,
+                            alias_path: formula.alias_path,
+                            flags:      formula.class.build_flags)
+        end
       end
 
       def self.cached_json_file_path

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -216,6 +216,7 @@ class Build
 end
 
 begin
+  ENV.delete("HOMEBREW_FORBID_PACKAGES_FROM_PATHS")
   args = Homebrew::Cmd::InstallCmd.new.args
   Context.current = args.context
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -103,6 +103,9 @@ module Cask
         return if %w[.rb .json].exclude?(path.extname)
         return unless path.expand_path.exist?
 
+        return if Homebrew::EnvConfig.forbid_packages_from_paths? &&
+                  !path.realpath.to_s.start_with?("#{Caskroom.path}/", "#{HOMEBREW_LIBRARY}/Taps/")
+
         new(path)
       end
 
@@ -159,6 +162,8 @@ module Cask
                 .returns(T.nilable(T.attached_class))
       }
       def self.try_new(ref, warn: false)
+        return if Homebrew::EnvConfig.forbid_packages_from_paths?
+
         # Cache compiled regex
         @uri_regex ||= begin
           uri_regex = ::URI::DEFAULT_PARSER.make_regexp

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -218,6 +218,11 @@ module Homebrew
         description: "A space-separated list of taps. Homebrew will refuse to install a " \
                      "formula if it or any of its dependencies is in a tap on this list.",
       },
+      HOMEBREW_FORBID_PACKAGES_FROM_PATHS:       {
+        description: "If set, Homebrew will refuse to read formulae or casks provided from file paths, " \
+                     "e.g. `brew install ./package.rb`.",
+        boolean:     true,
+      },
       HOMEBREW_FORCE_BREWED_CA_CERTIFICATES:     {
         description: "If set, always use a Homebrew-installed `ca-certificates` rather than the system version. " \
                      "Automatically set if the system version is too old.",

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -592,6 +592,8 @@ module Formulary
         .returns(T.nilable(T.attached_class))
     }
     def self.try_new(ref, from: T.unsafe(nil), warn: false)
+      return if Homebrew::EnvConfig.forbid_packages_from_paths?
+
       ref = ref.to_s
 
       new(ref) if HOMEBREW_BOTTLES_EXTNAME_REGEX.match?(ref) && File.exist?(ref)
@@ -643,6 +645,9 @@ module Formulary
       end
 
       return unless path.expand_path.exist?
+
+      return if Homebrew::EnvConfig.forbid_packages_from_paths? &&
+                !path.realpath.to_s.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/")
 
       options = if (tap = Tap.from_path(path))
         # Only treat symlinks in taps as aliases.
@@ -696,6 +701,8 @@ module Formulary
         .returns(T.nilable(T.attached_class))
     }
     def self.try_new(ref, from: T.unsafe(nil), warn: false)
+      return if Homebrew::EnvConfig.forbid_packages_from_paths?
+
       # Cache compiled regex
       @uri_regex ||= begin
         uri_regex = ::URI::DEFAULT_PARSER.make_regexp

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -14,6 +14,7 @@ require "cmd/postinstall"
 require "json/add/exception"
 
 begin
+  ENV.delete("HOMEBREW_FORBID_PACKAGES_FROM_PATHS")
   args = Homebrew::Cmd::Postinstall.new.args
   error_pipe = UNIXSocket.open(ENV.fetch("HOMEBREW_ERROR_PIPE"), &:recv_io)
   error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -115,6 +115,9 @@ module Homebrew::EnvConfig
     sig { returns(Integer) }
     def fail_log_lines; end
 
+    sig { returns(T::Boolean) }
+    def forbid_packages_from_paths?; end
+
     sig { returns(T.nilable(::String)) }
     def forbidden_casks; end
 

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -19,6 +19,7 @@ require "json/add/exception"
 TEST_TIMEOUT_SECONDS = 5 * 60
 
 begin
+  ENV.delete("HOMEBREW_FORBID_PACKAGES_FROM_PATHS")
   args = Homebrew::DevCmd::Test.new.args
   Context.current = args.context
 

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Cask::CaskLoader::FromURILoader do
       expect(described_class.try_new("https://brew.sh/")).not_to be_nil
     end
 
+    it "returns nil when path loading is disabled" do
+      ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
+      expect(described_class.try_new(URI("file://#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb"))).to be_nil
+    end
+
     it "returns nil when given a string with Cask contents containing a URL" do
       expect(described_class.try_new(<<~RUBY)).to be_nil
         cask 'token' do

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -118,9 +118,27 @@ RSpec.describe Formulary do
         expect(described_class.factory(formula_path)).to be_a(Formula)
       end
 
+      it "errors when given a path but paths are disabled" do
+        ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
+        FileUtils.cp formula_path, HOMEBREW_TEMP
+        temp_formula_path = HOMEBREW_TEMP/formula_path.basename
+        expect do
+          described_class.factory(temp_formula_path)
+        ensure
+          temp_formula_path.unlink
+        end.to raise_error(FormulaUnavailableError)
+      end
+
       it "returns a Formula when given a URL", :needs_utils_curl, :no_api do
         formula = described_class.factory("file://#{formula_path}")
         expect(formula).to be_a(Formula)
+      end
+
+      it "errors when given a URL but paths are disabled" do
+        ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
+        expect do
+          described_class.factory("file://#{formula_path}")
+        end.to raise_error(FormulaUnavailableError)
       end
 
       context "when given a bottle" do

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3776,6 +3776,11 @@ command execution e.g. `$(cat file)`.
 : A space-separated list of taps. Homebrew will refuse to install a formula if
   it or any of its dependencies is in a tap on this list.
 
+`HOMEBREW_FORBID_PACKAGES_FROM_PATHS`
+
+: If set, Homebrew will refuse to read formulae or casks provided from file
+  paths, e.g. `brew install ./package.rb`.
+
 `HOMEBREW_FORCE_BREWED_CA_CERTIFICATES`
 
 : If set, always use a Homebrew-installed `ca-certificates` rather than the

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2458,6 +2458,9 @@ How to contact the \fBHOMEBREW_FORBIDDEN_OWNER\fP, if set and necessary\.
 \fBHOMEBREW_FORBIDDEN_TAPS\fP
 A space\-separated list of taps\. Homebrew will refuse to install a formula if it or any of its dependencies is in a tap on this list\.
 .TP
+\fBHOMEBREW_FORBID_PACKAGES_FROM_PATHS\fP
+If set, Homebrew will refuse to read formulae or casks provided from file paths, e\.g\. \fBbrew install \./package\.rb\fP\&\.
+.TP
 \fBHOMEBREW_FORCE_BREWED_CA_CERTIFICATES\fP
 If set, always use a Homebrew\-installed \fBca\-certificates\fP rather than the system version\. Automatically set if the system version is too old\.
 .TP


### PR DESCRIPTION
We have `HOMEBREW_ALLOWED_TAPS` but this is currently bypassable by manually downloading and doing `brew install ./something.rb`

Add a new env to disable this functionality. Unfortunately, a lot of things uses this internally so have to allow HOMEBREW_CELLAR etc. for now (though such environments should be protected anyway in controlled environments).

Naming open to debate.