### PR TITLE
Add env to disable Debrew

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -122,7 +122,7 @@ class Build
     }
 
     with_env(new_env) do
-      if args.debug?
+      if args.debug? && !Homebrew::EnvConfig.disable_debrew?
         require "debrew"
         formula.extend(Debrew::Formula)
       end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -152,6 +152,10 @@ module Homebrew
                      "budding) by e.g. turning warnings into errors.",
         boolean:     true,
       },
+      HOMEBREW_DISABLE_DEBREW:                   {
+        description: "If set, the interactive formula debugger available via `--debug` will be disabled.",
+        boolean:     true,
+      },
       HOMEBREW_DISABLE_LOAD_FORMULA:             {
         description: "If set, refuse to load formulae. This is useful when formulae are not trusted (such " \
                      "as in pull requests).",

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -21,7 +21,7 @@ begin
   trap("INT", old_trap)
 
   formula = T.must(args.named.to_resolved_formulae.first)
-  if args.debug?
+  if args.debug? && !Homebrew::EnvConfig.disable_debrew?
     require "debrew"
     formula.extend(Debrew::Formula)
   end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -89,6 +89,9 @@ module Homebrew::EnvConfig
     def developer?; end
 
     sig { returns(T::Boolean) }
+    def disable_debrew?; end
+
+    sig { returns(T::Boolean) }
     def disable_load_formula?; end
 
     sig { returns(T.nilable(::String)) }

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -35,7 +35,7 @@ begin
   formula = T.must(args.named.to_resolved_formulae.first)
   formula.extend(Homebrew::Assertions)
   formula.extend(Homebrew::FreePort)
-  if args.debug?
+  if args.debug? && !Homebrew::EnvConfig.disable_debrew?
     require "debrew"
     formula.extend(Debrew::Formula)
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3691,6 +3691,11 @@ command execution e.g. `$(cat file)`.
 : If set, tweak behaviour to be more relevant for Homebrew developers (active or
   budding) by e.g. turning warnings into errors.
 
+`HOMEBREW_DISABLE_DEBREW`
+
+: If set, the interactive formula debugger available via `--debug` will be
+  disabled.
+
 `HOMEBREW_DISABLE_LOAD_FORMULA`
 
 : If set, refuse to load formulae. This is useful when formulae are not trusted

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2395,6 +2395,9 @@ If set, always assume \fB\-\-debug\fP when running commands\.
 \fBHOMEBREW_DEVELOPER\fP
 If set, tweak behaviour to be more relevant for Homebrew developers (active or budding) by e\.g\. turning warnings into errors\.
 .TP
+\fBHOMEBREW_DISABLE_DEBREW\fP
+If set, the interactive formula debugger available via \fB\-\-debug\fP will be disabled\.
+.TP
 \fBHOMEBREW_DISABLE_LOAD_FORMULA\fP
 If set, refuse to load formulae\. This is useful when formulae are not trusted (such as in pull requests)\.
 .TP


### PR DESCRIPTION
Similar to #17840, Debrew allows you to modify the formula install. It's also not supported on certain terminals (#16299).

Adding an env to disable the feature seems easy and reasonable.