### PR TITLE
version: loosen Debian orig tarball regex

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -625,14 +625,21 @@ RSpec.describe Version do
         .to be_detected_from("https://www.monkey.org/~provos/libevent-1.4.14b-stable.tar.gz")
     end
 
-    specify "debian style 1" do
+    specify "debian style" do
       expect(described_class.new("3.03"))
         .to be_detected_from("https://ftp.de.debian.org/debian/pool/main/s/sl/sl_3.03.orig.tar.gz")
     end
 
-    specify "debian style 2" do
+    specify "debian style with letter suffix" do
       expect(described_class.new("1.01b"))
         .to be_detected_from("https://ftp.de.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz")
+    end
+
+    specify "debian style dotless" do
+      expect(described_class.new("1"))
+        .to be_detected_from("https://deb.debian.org/debian/pool/main/e/example/example_1.orig.tar.gz")
+      expect(described_class.new("20040914"))
+        .to be_detected_from("https://deb.debian.org/debian/pool/main/e/example/example_20040914.orig.tar.gz")
     end
 
     specify "bottle style" do

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -462,8 +462,11 @@ class Version
     # e.g. `https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/1.2.3/orc-tools-1.2.3-uber.jar`
     StemParser.new(/-(#{NUMERIC_WITH_DOTS})-/),
 
-    # e.g. `dash_0.5.5.1.orig.tar.gz (Debian style)`
-    StemParser.new(/_(#{NUMERIC_WITH_DOTS}[abc]?)\.orig$/),
+    # Debian style
+    # e.g. `dash_0.5.5.1.orig.tar.gz`
+    # e.g. `lcrack_20040914.orig.tar.gz`
+    # e.g. `mkcue_1.orig.tar.gz`
+    StemParser.new(/_(#{NUMERIC_WITH_OPTIONAL_DOTS}[abc]?)\.orig$/),
 
     # e.g. `https://www.openssl.org/source/openssl-0.9.8s.tar.gz`
     StemParser.new(/-v?(\d[^-]+)/),


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The regex to match Debian `orig` tarballs uses the standard regex for versions like `1.2.3` but it won't match versions without a dot. The `lcrack` formula uses a date-based version in the filename (`lcrack_20040914.orig.tar.gz`) and `mkcue` uses a single number (`mkcue_1.orig.tar.gz`), so we have to use a manual `version` in these formulae.

This updates the regex to use the looser `NUMERIC_WITH_OPTIONAL_DOTS` pattern, which will also match the aforementioned versions. I tested this by checking versions of formulae before/after this change and confirming that they remain the same after removing the `version` calls from related formulae.