### PR TITLE
software_spec: remove confusing missing version error

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -87,8 +87,7 @@ class SoftwareSpec
     resources.each_value do |r|
       r.owner = self
       next if r.version
-
-      raise "#{full_name}: version missing for \"#{r.name}\" resource!" if version.nil?
+      next if version.nil?
 
       r.version(version.head? ? Version.new("HEAD") : version.dup)
     end


### PR DESCRIPTION
This code only ever run when there was at least one resource, but the parent formula will run `validate_attributes!` to check for nil versions always anyway so let's just direct it all to that one error which is much clearer.

Fixes #17815.

