### PR TITLE
version: use `T.unsafe` for https://srb.help/7019

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -732,7 +732,7 @@ class Version
 
   sig { params(options: T.untyped).returns(String) }
   def to_json(*options)
-    version.to_json(*options)
+    T.unsafe(version).to_json(*options)
   end
 
   sig { params(method: T.any(Symbol, String), include_all: T::Boolean).returns(T::Boolean) }


### PR DESCRIPTION
In some configurations, Sorbet gets upset by the `version.to_json` call in `Library/Homebrew/version.rb`. This is because Sorbet's splat support is lacking and it cannot handle the `*options` argument when it does not know the size.