### PR TITLE
Interpolated `shell_output("#{bin}/foo -v")`, for example, is fine

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -153,7 +153,7 @@ module RuboCop
         # Check whether value starts with the formula name and then a "/", " " or EOS.
         # If we're checking for "#{bin}", we also check for "-" since similar binaries also don't need interpolation.
         def path_starts_with?(path, starts_with, bin: false)
-          ending = bin ? "/| |-|$" : "/| |$"
+          ending = bin ? "/|-|$" : "/| |$"
           path.match?(/^#{Regexp.escape(starts_with)}(#{ending})/)
         end
 

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -145,12 +145,11 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it 'reports an offense if "\#{bin}" is in a `shell_output` string' do
-      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+    it 'does not report an offense if \#{bin}/foo and then a space and more text' do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           test do
             shell_output("\#{bin}/foo --version")
-                         ^^^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"\#{bin}/foo"`
           end
         end
       RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This would be weird to change because it's a string not a pathname passed to `shell_output`.
- I had misunderstood https://github.com/Homebrew/brew/pull/17826#discussion_r1690806375.