### PR TITLE
contributions, github: reorder requires

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "abstract_command"
-require "tap"
-require "utils/github"
 
 module Homebrew
   module DevCmd
@@ -68,6 +66,7 @@ module Homebrew
 
         contribution_types = [:author, :committer, :coauthor, :review]
 
+        require "utils/github"
         users = args.user.presence || GitHub.members_by_team("Homebrew", "maintainers").keys
         users.each do |username|
           # TODO: Using the GitHub username to scan the `git log` undercounts some
@@ -106,6 +105,7 @@ module Homebrew
       def find_repo_path_for_repo(repo)
         return HOMEBREW_REPOSITORY if repo == "brew"
 
+        require "tap"
         Tap.fetch("homebrew", repo).path
       end
 
@@ -169,6 +169,8 @@ module Homebrew
         data = {}
         return data if repos.blank?
 
+        require "tap"
+        require "utils/github"
         repos.each do |repo|
           repo_path = find_repo_path_for_repo(repo)
           tap = Tap.fetch("homebrew", repo)
@@ -229,6 +231,7 @@ module Homebrew
                to: T.nilable(String)).returns(Integer)
       }
       def count_reviews(repo_full_name, person, from:, to:)
+        require "utils/github"
         GitHub.count_issues("", is: "pr", repo: repo_full_name, reviewed_by: person, review: "approved", from:, to:)
       rescue GitHub::API::ValidationFailedError
         if args.verbose?

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -2,8 +2,6 @@
 # frozen_string_literal: true
 
 require "uri"
-require "utils/curl"
-require "utils/popen"
 require "utils/github/actions"
 require "utils/github/api"
 
@@ -705,6 +703,7 @@ module GitHub
     pr_message = info[:pr_message]
 
     sourcefile_path.parent.cd do
+      require "utils/popen"
       git_dir = Utils.popen_read("git", "rev-parse", "--git-dir").chomp
       shallow = !git_dir.empty? && File.exist?("#{git_dir}/shallow")
       changed_files = [sourcefile_path]
@@ -814,6 +813,7 @@ module GitHub
   def self.last_commit(user, repo, ref, version)
     return if Homebrew::EnvConfig.no_github_api?
 
+    require "utils/curl"
     output, _, status = Utils::Curl.curl_output(
       "--silent", "--head", "--location",
       "--header", "Accept: application/vnd.github.sha",
@@ -832,6 +832,7 @@ module GitHub
   def self.multiple_short_commits_exist?(user, repo, commit)
     return false if Homebrew::EnvConfig.no_github_api?
 
+    require "utils/curl"
     output, _, status = Utils::Curl.curl_output(
       "--silent", "--head", "--location",
       "--header", "Accept: application/vnd.github.sha",

--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -1,9 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "securerandom"
-require "utils/tty"
-
 module GitHub
   # Helper functions for interacting with GitHub Actions.
   #
@@ -22,6 +19,7 @@ module GitHub
       # Format multiline strings for environment files
       # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
 
+      require "securerandom"
       delimiter = "ghadelimiter_#{SecureRandom.uuid}"
 
       if name.include?(delimiter) || value.include?(delimiter)
@@ -84,6 +82,7 @@ module GitHub
       def initialize(type, message, file: nil, title: nil, line: nil, end_line: nil, column: nil, end_column: nil)
         raise ArgumentError, "Unsupported type: #{type.inspect}" if ANNOTATION_TYPES.exclude?(type)
 
+        require "utils/tty"
         @type = type
         @message = T.let(Tty.strip_ansi(message), String)
         @file = T.let(self.class.path_relative_to_workspace(file), T.nilable(Pathname)) if file.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Per feedback to https://github.com/Homebrew/brew/pull/17806, this moves some `require` statements in `dev-cmd/contributions.rb` and `Utils::GitHub` into the methods that need them.