### PR TITLE
livecheck: remove unused `require` calls

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -7,7 +7,6 @@ require "livecheck/livecheck_version"
 require "livecheck/skip_conditions"
 require "livecheck/strategy"
 require "addressable"
-require "uri"
 
 module Homebrew
   # The {Livecheck} module consists of methods used by the `brew livecheck`

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -1,7 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "open3"
 require "system_command"
 
 module Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This removes unused `require` calls in livecheck. Namely:

* `URI#parse` was originally added in https://github.com/Homebrew/brew/pull/9074 and replaced with `Addressable::URI#parse` in https://github.com/Homebrew/brew/pull/13306 but `require "uri"` wasn't removed at the time.
* I refactored the `Git` strategy to use `SystemCommand` instead of `Open3#capture3` in https://github.com/Homebrew/brew/pull/13387 but I forgot to remove `require "open3"`.