### PR TITLE
bin/brew: do not exit on sudo errors for resetting timestamp

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -39,7 +39,7 @@ fi
 # Reset sudo timestamp to avoid running unauthorized sudo commands
 if command -v sudo >/dev/null
 then
-  sudo --reset-timestamp
+  sudo --reset-timestamp 2>/dev/null || true
 fi
 
 quiet_cd() {


### PR DESCRIPTION
In #17694, a call to `sudo --reset-timestamp` was added to prevent cached credentials being run. Unfortunately, this breaks `brew` invocation under `sandbox-exec`, which forbids any attempts to exec setuid executables.  This in turn breaks the OCaml opam package manager, which sandboxes its build commands (including brew prefix queries): see https://github.com/ocaml/opam/issues/6117 for that error.

This commit just changes the sudo invocation to suppress errors and continue if it fails, which should be harmless in normal operation as sudo doesn't emit an error for this option when invoked normally.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
