### PR TITLE
Strategy#from_url: remove unused param

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -715,7 +715,6 @@ module Homebrew
         strategies = Strategy.from_url(
           url,
           livecheck_strategy:,
-          url_provided:       livecheck_url.present?,
           regex_provided:     livecheck_regex.present?,
           block_provided:     livecheck_strategy_block.present?,
         )
@@ -930,7 +929,6 @@ module Homebrew
         strategies = Strategy.from_url(
           url,
           livecheck_strategy:,
-          url_provided:       livecheck_url.present?,
           regex_provided:     livecheck_regex.present?,
           block_provided:     livecheck_strategy_block.present?,
         )

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -125,8 +125,6 @@ module Homebrew
       # @param url [String] the URL to check for matching strategies
       # @param livecheck_strategy [Symbol] a strategy symbol from the
       #   `livecheck` block
-      # @param url_provided [Boolean] whether a url is provided in the
-      #   `livecheck` block
       # @param regex_provided [Boolean] whether a regex is provided in the
       #   `livecheck` block
       # @param block_provided [Boolean] whether a `strategy` block is provided
@@ -136,12 +134,11 @@ module Homebrew
         params(
           url:                String,
           livecheck_strategy: T.nilable(Symbol),
-          url_provided:       T::Boolean,
           regex_provided:     T::Boolean,
           block_provided:     T::Boolean,
         ).returns(T::Array[T.untyped])
       }
-      def from_url(url, livecheck_strategy: nil, url_provided: false, regex_provided: false, block_provided: false)
+      def from_url(url, livecheck_strategy: nil, regex_provided: false, block_provided: false)
         usable_strategies = strategies.select do |strategy_symbol, strategy|
           if strategy == PageMatch
             # Only treat the strategy as usable if the `livecheck` block


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `url_provided` parameter of the `Strategy#from_url` method was originally introduced in https://github.com/Homebrew/brew/pull/9529 but I removed it in a later commit in that PR in favor of a different approach. Unfortunately, I forgot to remove the `url_provided` parameter, as it was no longer needed after that change. This removes the parameter and updates `#from_url` calls accordingly.