### PR TITLE
feat: Add `brew doctor --ignore-warnings`

### DIFF
--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/doctor.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/doctor.rbi
@@ -18,5 +18,8 @@ class Homebrew::Cmd::Doctor::Args < Homebrew::CLI::Args
   def audit_debug?; end
 
   sig { returns(T::Boolean) }
+  def ignore_warnings?; end
+
+  sig { returns(T::Boolean) }
   def list_checks?; end
 end


### PR DESCRIPTION
When `brew doctor` is run, `brew` exits with a non-zero status if any warnings or errors are encountered. However, this groups warnings and errors together, but (as the output notes) warnings can be innocuous:

> Please note that these warnings are just used to help the Homebrew
> maintainers with debugging if you file an issue. If everything you use
> Homebrew for is working fine: please don't worry or file an issue;
> just ignore this. Thanks!

The `--ignore-warnings` switch makes it possible for automated tools interacting with Homebrew to distinguish between warnings and hard errors.

```
$ brew doctor --ignore-warnings
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Some installed casks are deprecated or disabled.
You should find replacements for the following casks:
  graphql-playground
$ echo "$?"
0
```

Hard errors will still cause a non-zero exit status:

```
$ brew doctor --ignore-warnings
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: gettext files detected at a system prefix.
These files can cause compilation and link failures, especially if they
are compiled with improper architectures. Consider removing these files:
  /opt/homebrew/lib/libgettextlib.dylib
  /opt/homebrew/lib/libintl.dylib
  /opt/homebrew/include/libintl.h
Error: unknown or unsupported macOS version: :dunno
$ echo "$?"
1
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
