### PR TITLE
rubocops/lines: rustup-init -> rustup

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -901,7 +901,7 @@ module RuboCop
         end
       end
 
-      # This cop makes sure that formulae build with `rust` instead of `rustup-init`.
+      # This cop makes sure that formulae build with `rust` instead of `rustup`.
       class RustCheck < FormulaCop
         extend AutoCorrector
 
@@ -912,7 +912,7 @@ module RuboCop
           # Enforce use of `rust` for rust dependency in core
           return if formula_tap != "homebrew-core"
 
-          find_method_with_args(body_node, :depends_on, "rustup-init") do
+          find_method_with_args(body_node, :depends_on, "rustup") do
             problem "Formulae in homebrew/core should use 'depends_on \"rust\"' " \
                     "instead of '#{@offensive_node.source}'." do |corrector|
               corrector.replace(@offensive_node.source_range, "depends_on \"rust\"")
@@ -920,9 +920,9 @@ module RuboCop
           end
 
           # TODO: Enforce order of dependency types so we don't need to check for
-          #       depends_on "rustup-init" => [:test, :build]
+          #       depends_on "rustup" => [:test, :build]
           [:build, [:build, :test], [:test, :build]].each do |type|
-            find_method_with_args(body_node, :depends_on, "rustup-init" => type) do
+            find_method_with_args(body_node, :depends_on, "rustup" => type) do
               problem "Formulae in homebrew/core should use 'depends_on \"rust\" => #{type}' " \
                       "instead of '#{@offensive_node.source}'." do |corrector|
                 corrector.replace(@offensive_node.source_range, "depends_on \"rust\" => #{type}")
@@ -936,10 +936,10 @@ module RuboCop
           find_every_method_call_by_name(install_node, :system).each do |method|
             param = parameters(method).first
             next if param.blank?
-            # FIXME: Handle Pathname parameters (e.g. `system bin/"rustup-init"`).
-            next if regex_match_group(param, /rustup-init$/).blank?
+            # FIXME: Handle Pathname parameters (e.g. `system bin/"rustup"`).
+            next if regex_match_group(param, /rustup$/).blank?
 
-            problem "Formula in homebrew/core should not use `rustup-init` at build-time."
+            problem "Formula in homebrew/core should not use `rustup` at build-time."
           end
         end
       end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Just updating this audit since we renamed `rustup-init` to `rustup` in https://github.com/Homebrew/homebrew-core/pull/177840

Now:

```console
$ brew audit --strict rustfmt
rustfmt
  * line 19, col 3: Formulae in homebrew/core should use 'depends_on "rust" => build' instead of 'depends_on "rustup" => :build'.
  * line 25, col 12: Formula in homebrew/core should not use `rustup` at build-time.
```
