### PR TITLE
rubocops/lines: audit `std_npm_args` usage

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -105,10 +105,6 @@ module Homebrew
         # Documentation: https://docs.brew.sh/Formula-Cookbook
         #                https://rubydoc.brew.sh/Formula
         # PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
-        <% if @mode == :node %>
-        require "language/node"
-
-        <% end %>
         class #{Formulary.class_s(name)} < Formula
         <% if @mode == :python %>
           include Language::Python::Virtualenv
@@ -179,7 +175,7 @@ module Homebrew
             system "meson", "compile", "-C", "build", "--verbose"
             system "meson", "install", "-C", "build"
         <% elsif @mode == :node %>
-            system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+            system "npm", "install", *std_npm_args
             bin.install_symlink Dir["\#{libexec}/bin/*"]
         <% elsif @mode == :perl %>
             ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"

--- a/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rubocops/lines"
+
+RSpec.describe RuboCop::Cop::FormulaAudit::StdNpmArgs do
+  subject(:cop) { described_class.new }
+
+  context "when auditing node formulae" do
+    it "reports an offense when `npm install` is called without std_npm_args arguments" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install"
+            ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use `std_npm_args` for npm install
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects an offense when using local_npm_install_args" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install", *Language::Node.local_npm_install_args, "--production"
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use 'std_npm_args' instead of 'local_npm_install_args'.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install", *std_npm_args(prefix: false), "--production"
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects an offense when using std_npm_install_args with libexec" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install", *Language::Node.std_npm_install_args(libexec), "--production"
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use 'std_npm_args' instead of 'std_npm_install_args'.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install", *std_npm_args, "--production"
+          end
+        end
+      RUBY
+    end
+
+    it "reports and corrects an offense when using std_npm_install_args without libexec" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install", *Language::Node.std_npm_install_args(buildpath), "--production"
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use 'std_npm_args' instead of 'std_npm_install_args'.
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install", *std_npm_args(prefix: buildpath), "--production"
+          end
+        end
+      RUBY
+    end
+
+    it "does not report an offense when using std_npm_args" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "npm", "install", *std_npm_args
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Wanted to add an audit to help migrate existing `std_npm_install_args` usage to `std_npm_args`. This is my first time looking at our rubocops so help is greatly appreciated :)

My plan was to test this out and merge https://github.com/Homebrew/homebrew-core/pull/178538 without bottles, but that triggers our existing audit: `Use Language::Node for npm install args`. So not sure how we want to sequence this, maybe I should first remove the older audit in a separate PR
