### PR TITLE
sbom: ensure Homebrew versions are more consistent. 

### DIFF
--- a/Library/Homebrew/sbom.rb
+++ b/Library/Homebrew/sbom.rb
@@ -24,9 +24,16 @@ class SBOM
     end
     active_spec_sym = formula.active_spec_sym
 
+    homebrew_version_maybe_dev = if (match_data = HOMEBREW_VERSION.match(/^[\d.]+/))
+      suffix = "-dev" if HOMEBREW_VERSION.include?("-")
+      match_data[0] + suffix.to_s
+    else
+      HOMEBREW_VERSION
+    end
+
     attributes = {
       name:                 formula.name,
-      homebrew_version:     HOMEBREW_VERSION,
+      homebrew_version:     homebrew_version_maybe_dev,
       spdxfile:             SBOM.spdxfile(formula),
       time:                 tab.time,
       source_modified_time: tab.source_modified_time.to_i,


### PR DESCRIPTION
Avoid making bottles non-reproducible by ensuring that the Homebrew
version doesn't include the full commit hash but just a `-dev` suffix.

This is similar to the approach we use for analytics.