### PR TITLE
Formula-Cookbook: add `std_npm_args`

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -514,6 +514,16 @@ The `std_*_args` methods, as well as the arguments they pass, are:
 "--wrap-mode=nofallback"
 ```
 
+#### `std_npm_args`
+
+```ruby
+"-ddd"
+"--global"
+"--build-from-source"
+"--cache=$(brew --cache)/npm_cache"
+"--prefix=#{libexec}"
+```
+
 #### `std_pip_args`
 
 ```ruby


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Adds the new `std_npm_args` to the Formula Cookbook.