### PR TITLE
unpack_strategy: update types

### DIFF
--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -187,7 +187,7 @@ module UnpackStrategy
     end
   end
 
-  sig { returns(T::Array[String]) }
+  sig { returns(T.any(T::Array[Cask::Cask], T::Array[Formula])) }
   def dependencies
     []
   end

--- a/Library/Homebrew/unpack_strategy/air.rb
+++ b/Library/Homebrew/unpack_strategy/air.rb
@@ -17,7 +17,7 @@ module UnpackStrategy
       path.magic_number.match?(/.{59}#{Regexp.escape(mime_type)}/)
     end
 
-    sig { returns(T.nilable(T::Array[Cask::Cask])) }
+    sig { returns(T::Array[Cask::Cask]) }
     def dependencies
       @dependencies ||= T.let([Cask::CaskLoader.load("adobe-air")], T.nilable(T::Array[Cask::Cask]))
     end

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -24,7 +24,7 @@ module UnpackStrategy
                       verbose:
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["cabextract"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/cab.rb
+++ b/Library/Homebrew/unpack_strategy/cab.rb
@@ -16,17 +16,17 @@ module UnpackStrategy
       path.magic_number.match?(/\AMSCF/n)
     end
 
+    sig { returns(T::Array[Formula]) }
+    def dependencies
+      @dependencies ||= T.let([Formula["cabextract"]], T.nilable(T::Array[Formula]))
+    end
+
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
       system_command! "cabextract",
                       args:    ["-d", unpack_dir, "--", path],
                       env:     { "PATH" => PATH.new(Formula["cabextract"].opt_bin, ENV.fetch("PATH")) },
                       verbose:
-    end
-
-    sig { returns(T::Array[Formula]) }
-    def dependencies
-      @dependencies ||= T.let([Formula["cabextract"]], T.nilable(T::Array[Formula]))
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/generic_unar.rb
+++ b/Library/Homebrew/unpack_strategy/generic_unar.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       false
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["unar"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/lha.rb
+++ b/Library/Homebrew/unpack_strategy/lha.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       path.magic_number.match?(/\A..-(lh0|lh1|lz4|lz5|lzs|lh\\40|lhd|lh2|lh3|lh4|lh5)-/n)
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["lha"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/lzip.rb
+++ b/Library/Homebrew/unpack_strategy/lzip.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       path.magic_number.match?(/\ALZIP/n)
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["lzip"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/lzma.rb
+++ b/Library/Homebrew/unpack_strategy/lzma.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       path.magic_number.match?(/\A\]\000\000\200\000/n)
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["xz"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/p7zip.rb
+++ b/Library/Homebrew/unpack_strategy/p7zip.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       path.magic_number.match?(/\A7z\xBC\xAF\x27\x1C/n)
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["p7zip"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/rar.rb
+++ b/Library/Homebrew/unpack_strategy/rar.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       path.magic_number.match?(/\ARar!/n)
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["libarchive"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/xz.rb
+++ b/Library/Homebrew/unpack_strategy/xz.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       path.magic_number.match?(/\A\xFD7zXZ\x00/n)
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["xz"]], T.nilable(T::Array[Formula]))
     end

--- a/Library/Homebrew/unpack_strategy/zstd.rb
+++ b/Library/Homebrew/unpack_strategy/zstd.rb
@@ -16,7 +16,7 @@ module UnpackStrategy
       path.magic_number.match?(/\x28\xB5\x2F\xFD/n)
     end
 
-    sig { returns(T.nilable(T::Array[Formula])) }
+    sig { returns(T::Array[Formula]) }
     def dependencies
       @dependencies ||= T.let([Formula["zstd"]], T.nilable(T::Array[Formula]))
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Resolves an issue seen in Casks when they use the `p7zip` unpack strategy, and receive an automatic dependency.

This was causing a type incompatibility - Seen in https://github.com/Homebrew/homebrew-cask/actions/runs/10122603078/job/27994943380?pr=180814#step:12:45

```
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11495/lib/types/private/methods/signature_validation.rb:272:in `validate_override_types': Incompatible return type in signature for override of method `dependencies`: (RuntimeError)
* Base: `T::Array[String]` (in UnpackStrategy at /opt/homebrew/Library/Homebrew/unpack_strategy.rb:191)
* Override: `T.nilable(T::Array[Formula])` (in UnpackStrategy::P7Zip at /opt/homebrew/Library/Homebrew/unpack_strategy/p7zip.rb:20)
(The types must be covariant.)
```