### PR TITLE
utils/github/api: Fix uninitialized constant `Etc`

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -137,6 +137,7 @@ module GitHub
 
     sig { returns(T.nilable(String)) }
     private_class_method def self.uid_home
+      require "etc"
       Etc.getpwuid(Process.uid)&.dir
     rescue ArgumentError
       # Cover for misconfigured NSS setups


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

```
Error: uninitialized constant GitHub::API::Etc
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/utils/github/api.rb:140:in `uid_home'
/opt/homebrew/Library/Homebrew/utils/github/api.rb:154:in `block in github_cli_token'
/opt/homebrew/Library/Homebrew/utils/uid.rb:8:in `drop_euid'
/opt/homebrew/Library/Homebrew/utils/github/api.rb:150:in `github_cli_token'
/opt/homebrew/Library/Homebrew/utils/github/api.rb:194:in `credentials'
/opt/homebrew/Library/Homebrew/utils/github/api.rb:251:in `open_rest'
/opt/homebrew/Library/Homebrew/utils/github/api.rb:334:in `open_graphql'
/opt/homebrew/Library/Homebrew/utils/github.rb:414:in `members_by_team'
```
