### PR TITLE
dev-cmd/contributions: Show only the CSV output for `--csv`

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -86,6 +86,8 @@ module Homebrew
           contributions <<
             "#{Utils.pluralize("time", grand_totals[username].values.sum, include_count: true)} (total)"
 
+          next if args.csv?
+
           puts [
             "#{username} contributed",
             *contributions.to_sentence,
@@ -93,10 +95,7 @@ module Homebrew
           ].join(" ")
         end
 
-        return unless args.csv?
-
-        puts
-        puts generate_csv(grand_totals)
+        puts generate_csv(grand_totals) if args.csv?
       end
 
       private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was overly noisy when using `--csv` as it would print both the text output and the CSV output.