### PR TITLE
rubocops/text: Allow all "#{bin}/foo" interpolated strings with spaces

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -158,6 +158,8 @@ module RuboCop
         end
 
         def path_starts_with_bin?(path, starts_with)
+          return false if path.include?(" ")
+
           path_starts_with?(path, starts_with, bin: true)
         end
 

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -150,6 +150,8 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
         class Foo < Formula
           test do
             shell_output("\#{bin}/foo --version")
+            assert_match "help", shell_output("\#{bin}/foo-something --help 2>&1")
+            assert_match "OK", shell_output("\#{bin}/foo-something_else --check 2>&1")
           end
         end
       RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was complaining about `shell_output("#{bin}/abricate-get_db --help 2>&1")` which we didn't want.
- Hence, allow all interpolated strings with spaces in the `bin` audit.