### PR TITLE
Revert "dev-cmd/contributions: Show only the CSV output for `--csv`"

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -86,8 +86,6 @@ module Homebrew
           contributions <<
             "#{Utils.pluralize("time", grand_totals[username].values.sum, include_count: true)} (total)"
 
-          next if args.csv?
-
           puts [
             "#{username} contributed",
             *contributions.to_sentence,
@@ -95,7 +93,10 @@ module Homebrew
           ].join(" ")
         end
 
-        puts generate_csv(grand_totals) if args.csv?
+        return unless args.csv?
+
+        puts
+        puts generate_csv(grand_totals)
       end
 
       private


### PR DESCRIPTION
Reverts Homebrew/brew#17887 as people who aren't me and Kevin liked the pre-existing behaviour more, because it wasn't just a blank screen waiting for the CSV to generate (which can take more than a few minutes).