### PR TITLE
resource_auditor: normalize PyPI names to kebab case before auditing

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -117,8 +117,10 @@ module Homebrew
         pypi_package_name, = File.basename(path).split("-", 2)
       else
         url =~ %r{/(?<package_name>[^/]+)-}
-        pypi_package_name = Regexp.last_match(:package_name).to_s.gsub(/[_.]/, "-")
+        pypi_package_name = Regexp.last_match(:package_name).to_s
       end
+
+      pypi_package_name.gsub!(/[_.]/, "-")
 
       return if name.casecmp(pypi_package_name).zero?
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a knock-on to #17724 -- we didn't convert the source-only wheel case into the normalized kebab case that our resources are typically named with.