### PR TITLE
language/python: support pure-Python wheel installs

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -365,10 +365,12 @@ module Language
         def pip_install(targets, build_isolation: true)
           targets = Array(targets)
           targets.each do |t|
-            if t.is_a?(Resource) && t.url&.end_with?("-none-any.whl")
-              t.stage { do_install(Pathname.pwd/t.downloader.basename, build_isolation:) }
-            elsif t.is_a?(Resource)
-              t.stage { do_install(Pathname.pwd, build_isolation:) }
+            if t.is_a?(Resource)
+              t.stage do
+                target = Pathname.pwd
+                target /= t.downloader.basename if t.url&.end_with?("-none-any.whl")
+                do_install(target, build_isolation:)
+              end
             else
               t = t.lines.map(&:strip) if t.is_a?(String) && t.include?("\n")
               do_install(t, build_isolation:)

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -365,7 +365,7 @@ module Language
         def pip_install(targets, build_isolation: true)
           targets = Array(targets)
           targets.each do |t|
-            if t.is_a?(Resource) && t.url.end_with?("-none-any.whl")
+            if t.is_a?(Resource) && t.url&.end_with?("-none-any.whl")
               t.stage { do_install(Pathname.pwd/t.downloader.basename, build_isolation:) }
             elsif t.is_a?(Resource)
               t.stage { do_install(Pathname.pwd, build_isolation:) }

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -365,7 +365,9 @@ module Language
         def pip_install(targets, build_isolation: true)
           targets = Array(targets)
           targets.each do |t|
-            if t.is_a?(Resource)
+            if t.is_a?(Resource) && t.url.end_with?("-none-any.whl")
+              t.stage { do_install(Pathname.pwd/t.downloader.basename, build_isolation:) }
+            elsif t.is_a?(Resource)
               t.stage { do_install(Pathname.pwd, build_isolation:) }
             else
               t = t.lines.map(&:strip) if t.is_a?(String) && t.include?("\n")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We now expect pure Python wheels as Python resources, and so setting `--no-binary=:all:` causes unexpected failures.

(Ideally, there would be a flag to tell `pip` that pure Python wheels are OK while other wheels aren't. But that doesn't currently exist.)

Related to https://github.com/Homebrew/brew/pull/17724 as well -- this allows pure Python wheels to install correctly when listed as resources.
