### PR TITLE
attestation: remove gh version detection

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -425,7 +425,7 @@ module Kernel
   end
 
   # Ensure the given executable is exist otherwise install the brewed version
-  def ensure_executable!(name, formula_name = nil, reason: "")
+  def ensure_executable!(name, formula_name = nil, reason: "", latest: false)
     formula_name ||= name
 
     executable = [

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -438,7 +438,7 @@ module Kernel
     ].compact.first
     return executable if executable.exist?
 
-    ensure_formula_installed!(formula_name, reason:).opt_bin/name
+    ensure_formula_installed!(formula_name, reason:, latest:).opt_bin/name
   end
 
   def paths

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe Homebrew::Attestation do
   let(:fake_gh) { Pathname.new("/extremely/fake/gh") }
   let(:fake_old_gh) { Pathname.new("/extremely/fake/old/gh") }
   let(:fake_gh_creds) { "fake-gh-api-token" }
-  let(:fake_gh_formula) { instance_double(Formula, "gh", opt_bin: Pathname.new("/extremely/fake")) }
-  let(:fake_gh_version) { instance_double(SystemCommand::Result, stdout: "2.49.0") }
-  let(:fake_old_gh_version) { instance_double(SystemCommand::Result, stdout: "2.48.0") }
   let(:fake_error_status) { instance_double(Process::Status, exitstatus: 1, termsig: nil) }
   let(:fake_auth_status) { instance_double(Process::Status, exitstatus: 4, termsig: nil) }
   let(:cached_download) { "/fake/cached/download" }
@@ -69,24 +66,10 @@ RSpec.describe Homebrew::Attestation do
   end
 
   describe "::gh_executable" do
-    before do
-      allow(Formulary).to receive(:factory)
-        .with("gh")
-        .and_return(instance_double(Formula, version: Version.new("2.49.0")))
-
-      allow(described_class).to receive(:system_command!)
-        .with(fake_old_gh, args: ["--version"], print_stderr: false)
-        .and_return(fake_old_gh_version)
-    end
-
-    it "calls ensure_executable and ensure_formula_installed" do
+    it "calls ensure_executable" do
       expect(described_class).to receive(:ensure_executable!)
-        .with("gh", reason: "verifying attestations")
-        .and_return(fake_old_gh)
-
-      expect(described_class).to receive(:ensure_formula_installed!)
-        .with("gh", latest: true, reason: "verifying attestations")
-        .and_return(fake_gh_formula)
+        .with("gh", reason: "verifying attestations", latest: true)
+        .and_return(fake_gh)
 
       described_class.gh_executable
     end


### PR DESCRIPTION
I'm declaring bankruptcy on this entire approach:

1. We can attempt to match on versions, but this will fail when the version of `gh` installed is built from `HEAD` or similar.
2. We can match on dates instead (since `gh --version` also includes the date), but this is even more brittle + implies a support contract we don't actually have (we don't actually want to say we support random dated builds between public releases of `gh`).

This moves us back to a simpler approach: if `gh` is present, we use it. If `gh` is not present, we attempt to install it with `ensure_executable!`. If the user's `gh` is present but too old, it'll fail during attestation verification with a reasonable error, which IMO is fine for now since this is all still in beta.

CC @nandahkrishna 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See https://github.com/orgs/Homebrew/discussions/5530 for the originating failure here.

Fixes https://github.com/Homebrew/brew/issues/17898.