### PR TITLE
feat: enable audit for wayback urls on all formulae

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -594,7 +594,6 @@ module Homebrew
     end
 
     def audit_wayback_url
-      return unless @strict
       return unless @core_tap
       return if formula.deprecated? || formula.disabled?
 


### PR DESCRIPTION
Still for core only

Follow up of #16476

With https://github.com/Homebrew/homebrew-core/pull/160050 all formuale in core have been treated

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
