### PR TITLE
Fix GitHub API credential encoding errors

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -59,11 +59,11 @@ module Homebrew
     def self.enabled?
       return false if Homebrew::EnvConfig.no_verify_attestations?
       return true if Homebrew::EnvConfig.verify_attestations?
-      return false if GitHub::API.credentials.blank?
       return false if ENV.fetch("CI", false)
       return false if OS.unsupported_configuration?
 
-      Homebrew::EnvConfig.developer? || Homebrew::EnvConfig.devcmdrun?
+      # Always check credentials last to avoid unnecessary credential extraction.
+      (Homebrew::EnvConfig.developer? || Homebrew::EnvConfig.devcmdrun?) && GitHub::API.credentials.present?
     end
 
     # Returns a path to a suitable `gh` executable for attestation verification.

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -177,8 +177,9 @@ module GitHub
                                                        print_stderr: false
         return unless result.success?
 
-        github_username = git_credential_out[/username=(.+)/, 1]
-        github_password = git_credential_out[/password=(.+)/, 1]
+        git_credential_out.force_encoding("ASCII-8BIT")
+        github_username = git_credential_out[/^username=(.+)/, 1]
+        github_password = git_credential_out[/^password=(.+)/, 1]
         return unless github_username
 
         # Don't use passwords from the keychain unless they look like


### PR DESCRIPTION
* utils/github/api: fix encoding errors when reading from keychain
  - It was previously validating the output to be UTF-8 when that isn't necessarily true.
* attestation: only extract credentials when necessary
  - We were currently unnecessarily decrypting credentials in order to check attestation support on the stable branch when we only need to on the developer branch.

Fixes #17895 and https://github.com/Homebrew/homebrew-core/issues/178886.

Given this issue is being seen by multiple users: I recommend a new tag with this.