### PR TITLE
brew.sh: fix `brew -v`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -166,7 +166,7 @@ case "$@" in
     homebrew-list "$@" && exit 0
     ;;
   # falls back to cmd/help.rb on a non-zero return
-  help | --help | -h | --usage | -? | "")
+  help | --help | -h | --usage | "-?" | "")
     homebrew-help "$@" && exit 0
     ;;
 esac


### PR DESCRIPTION
`brew -v` was previously equivalent to `brew --version`, but it
currently returns the output of `brew help`. (This also occurs with
`brew -x`, where x is any single character.)

This is because the `-?` pattern matches `-` followed by any single
character. We need to quote it to capture the intended meaning.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?