### PR TITLE
Improve locking UX

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -87,6 +87,7 @@ begin
   if internal_cmd || Commands.external_ruby_v2_cmd_path(cmd)
     cmd = T.must(cmd)
     cmd_class = Homebrew::AbstractCommand.command(cmd)
+    Homebrew.running_command = cmd
     if cmd_class
       command_instance = cmd_class.new
 
@@ -97,6 +98,7 @@ begin
       Homebrew.public_send Commands.method_name(cmd)
     end
   elsif (path = Commands.external_ruby_cmd_path(cmd))
+    Homebrew.running_command = cmd
     require?(path)
     exit Homebrew.failed? ? 1 : 0
   elsif Commands.external_cmd_path(cmd)

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -411,7 +411,7 @@ module Homebrew
       (downloads - referenced_downloads).each do |download|
         if self.class.incomplete?(download)
           begin
-            LockFile.new(download.basename).with_lock do
+            DownloadLock.new(download).with_lock do
               download.unlink
             end
           rescue OperationInProgressError

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -359,7 +359,7 @@ homebrew-vendor-install() {
 
   CACHED_LOCATION="${HOMEBREW_CACHE}/${VENDOR_FILENAME}"
 
-  lock "vendor-install-${VENDOR_NAME}"
+  lock "vendor-install ${VENDOR_NAME}"
   fetch
   install
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -395,7 +395,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   def fetch(timeout: nil)
     end_time = Time.now + timeout if timeout
 
-    download_lock = LockFile.new(temporary_path.basename)
+    download_lock = DownloadLock.new(temporary_path)
     download_lock.lock
 
     urls = [url, *mirrors]

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -295,6 +295,10 @@ module Homebrew
                       "or `$HOME/.homebrew/livecheck_watchlist.txt` otherwise.",
         default:      "#{ENV.fetch("HOMEBREW_USER_CONFIG_HOME")}/livecheck_watchlist.txt",
       },
+      HOMEBREW_LOCK_CONTEXT:                     {
+        description: "If set, Homebrew will add this output as additional context for locking errors. " \
+                     "This is useful when running `brew` in the background.",
+      },
       HOMEBREW_LOGS:                             {
         description:  "Use this directory to store log files.",
         default_text: "macOS: `$HOME/Library/Logs/Homebrew`, " \

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -359,10 +359,14 @@ end
 
 # Raised when another Homebrew operation is already in progress.
 class OperationInProgressError < RuntimeError
-  def initialize(name)
+  sig { params(locked_path: Pathname).void }
+  def initialize(locked_path)
+    full_command = Homebrew.running_command_with_args.presence || "brew"
+    lock_context = if (env_lock_context = Homebrew::EnvConfig.lock_context.presence)
+      "\n#{env_lock_context}"
+    end
     message = <<~EOS
-      Operation already in progress for #{name}
-      Another active Homebrew process is already using #{name}.
+      A `#{full_command}` process has already locked #{locked_path}.#{lock_context}
       Please wait for it to finish or terminate it to continue.
     EOS
 

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -110,6 +110,16 @@ module Homebrew
     def auto_update_command?
       ENV.fetch("HOMEBREW_AUTO_UPDATE_COMMAND", false).present?
     end
+
+    sig { params(cmd: T.nilable(String)).void }
+    def running_command=(cmd)
+      @running_command_with_args = "#{cmd} #{ARGV.join(" ")}"
+    end
+
+    sig { returns String }
+    def running_command_with_args
+      "brew #{@running_command_with_args}".strip
+    end
   end
 end
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -191,6 +191,9 @@ module Homebrew::EnvConfig
     def livecheck_watchlist; end
 
     sig { returns(String) }
+    def lock_context; end
+
+    sig { returns(String) }
     def logs; end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -149,9 +149,9 @@ RSpec.describe "Exception" do
   end
 
   describe OperationInProgressError do
-    subject(:error) { described_class.new("foo") }
+    subject(:error) { described_class.new(Pathname("foo")) }
 
-    it(:to_s) { expect(error.to_s).to match(/Operation already in progress for foo/) }
+    it(:to_s) { expect(error.to_s).to match(/has already locked foo/) }
   end
 
   describe FormulaInstallationAlreadyAttemptedError do

--- a/Library/Homebrew/test/lock_file_spec.rb
+++ b/Library/Homebrew/test/lock_file_spec.rb
@@ -3,7 +3,7 @@
 require "lock_file"
 
 RSpec.describe LockFile do
-  subject(:lock_file) { described_class.new("foo") }
+  subject(:lock_file) { described_class.new(:lock, Pathname("foo")) }
 
   describe "#lock" do
     it "does not raise an error when already locked" do
@@ -16,7 +16,7 @@ RSpec.describe LockFile do
       lock_file.lock
 
       expect do
-        described_class.new("foo").lock
+        described_class.new(:lock, Pathname("foo")).lock
       end.to raise_error(OperationInProgressError)
     end
   end
@@ -30,7 +30,7 @@ RSpec.describe LockFile do
       lock_file.lock
       lock_file.unlock
 
-      expect { described_class.new("foo").lock }.not_to raise_error
+      expect { described_class.new(:lock, Pathname("foo")).lock }.not_to raise_error
     end
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3872,6 +3872,11 @@ command execution e.g. `$(cat file)`.
   `$XDG_CONFIG_HOME` is set or `$HOME/.homebrew/livecheck_watchlist.txt`
   otherwise.
 
+`HOMEBREW_LOCK_CONTEXT`
+
+: If set, Homebrew will add this output as additional context for locking
+  errors. This is useful when running `brew` in the background.
+
 `HOMEBREW_LOGS`
 
 : Use this directory to store log files.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2526,6 +2526,9 @@ Consult this file for the list of formulae to check by default when no formula a
 \fIDefault:\fP \fB$XDG_CONFIG_HOME/homebrew/livecheck_watchlist\.txt\fP if \fB$XDG_CONFIG_HOME\fP is set or \fB$HOME/\.homebrew/livecheck_watchlist\.txt\fP otherwise\.
 .RE
 .TP
+\fBHOMEBREW_LOCK_CONTEXT\fP
+If set, Homebrew will add this output as additional context for locking errors\. This is useful when running \fBbrew\fP in the background\.
+.TP
 \fBHOMEBREW_LOGS\fP
 Use this directory to store log files\.
 .RS


### PR DESCRIPTION
My experience recently playing around with our locking behaviour is that, while mostly seamless and not seen by users, it's leaks implementation details a bit too heavily.

As a result, the following improvements are in this PR:
- Ensure that, whenever possible, we tell the user the actual command that is holding a given lock instead of the lock name (an internal implementation detail)
- Make the locking error output a little more consistent and user friendly
- Add a `DownloadLock` class to simplify locking downloads
- Add a `HOMEBREW_LOCK_CONTEXT` variable to allow adding additional context for logging error messages
- Lock paths and leave deciding how this translates to lock names up to the locking code itself
- Lock the Cellar/Caskroom paths explicitly rather than implicitly