### PR TITLE
sandbox: disallow backslashes in path filter names

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -235,7 +235,7 @@ class Sandbox
   # @api private
   sig { params(path: T.any(String, Pathname), type: Symbol).returns(String) }
   def path_filter(path, type)
-    invalid_char = ['"', "'", "(", ")", "\n"].find do |c|
+    invalid_char = ['"', "'", "(", ")", "\n", "\\"].find do |c|
       path.to_s.include?(c)
     end
     raise ArgumentError, "Invalid character #{invalid_char} in path: #{path}" if invalid_char

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Sandbox, :needs_macos do
   end
 
   describe "#path_filter" do
-    ["'", '"', "(", ")", "\n"].each do |char|
+    ["'", '"', "(", ")", "\n", "\\"].each do |char|
       it "fails if the path contains #{char}" do
         expect do
           sandbox.path_filter("foo#{char}bar", :subpath)


### PR DESCRIPTION
This should really be an allowlist rather than a denylist, but for the time being this at least prevents someone from causing an obtuse sandbox error by naming a file something like "foo\".

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
