### PR TITLE
Livecheck::SkipConditions: Skip versioned casks

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -635,7 +635,7 @@ module Cask
 
       # Respect cask skip conditions (e.g. deprecated, disabled, latest, unversioned)
       skip_info ||= Homebrew::Livecheck::SkipConditions.skip_information(cask)
-      return :skip if skip_info.present?
+      return :skip if skip_info.present? && skip_info[:status] != "versioned"
 
       latest_version = Homebrew::Livecheck.latest_version(
         cask,

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -301,6 +301,12 @@ module Cask
       end
     end
 
+    # If this is a `@`-versioned cask.
+    sig { returns(T::Boolean) }
+    def versioned_cask?
+      token.include?("@")
+    end
+
     def ruby_source_path
       return @ruby_source_path if defined?(@ruby_source_path)
 

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -178,6 +178,20 @@ module Homebrew
           verbose:       T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
+      def cask_versioned(cask, livecheckable, full_name: false, verbose: false)
+        return {} if !cask.versioned_cask? || livecheckable
+
+        Livecheck.status_hash(cask, "versioned", full_name:, verbose:)
+      end
+
+      sig {
+        params(
+          cask:          Cask::Cask,
+          livecheckable: T::Boolean,
+          full_name:     T::Boolean,
+          verbose:       T::Boolean,
+        ).returns(T::Hash[Symbol, T.untyped])
+      }
       def cask_url_unversioned(cask, livecheckable, full_name: false, verbose: false)
         return {} if !(cask.present? && cask.url&.unversioned?) || livecheckable
 
@@ -200,6 +214,7 @@ module Homebrew
         :cask_disabled,
         :cask_extract_plist,
         :cask_version_latest,
+        :cask_versioned,
         :cask_url_unversioned,
       ].freeze, T::Array[Symbol])
 

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -178,6 +178,22 @@ RSpec.describe Cask::Cask, :cask do
     end
   end
 
+  describe "versioned_cask?" do
+    context "when it is a versioned cask" do
+      it "returns true" do
+        c = Cask::CaskLoader.load("versioned@1")
+        expect(c.versioned_cask?).to be true
+      end
+    end
+
+    context "when it is not a versioned cask" do
+      it "returns false" do
+        c = Cask::CaskLoader.load("local-caffeine")
+        expect(c.versioned_cask?).to be false
+      end
+    end
+  end
+
   describe "full_name" do
     context "when it is a core cask" do
       it "is the cask token" do

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -135,6 +135,14 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
         desc "Latest test cask"
         homepage "https://brew.sh"
       end,
+      versioned:         Cask::Cask.new("test_versioned@1") do
+        version "1.2.3"
+
+        url "https://brew.sh/test-0.0.1.tgz"
+        name "Test Versioned"
+        desc "Versioned test cask"
+        homepage "https://brew.sh"
+      end,
       unversioned:       Cask::Cask.new("test_unversioned") do
         version "1.2.3"
         sha256 :no_check
@@ -274,6 +282,13 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
             livecheckable: false,
           },
         },
+        versioned:         {
+          cask:   "test_versioned@1",
+          status: "versioned",
+          meta:   {
+            livecheckable: false,
+          },
+        },
         unversioned:       {
           cask:   "test_unversioned",
           status: "unversioned",
@@ -385,6 +400,13 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:latest]))
           .to eq(status_hashes[:cask][:latest])
+      end
+    end
+
+    context "when a cask without a livecheckable is versioned" do
+      it "skips" do
+        expect(skip_conditions.skip_information(casks[:versioned]))
+          .to eq(status_hashes[:cask][:versioned])
       end
     end
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/versioned@1.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/versioned@1.rb
@@ -1,0 +1,11 @@
+cask "versioned@1" do
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+
+  zap trash: "#{TEST_FIXTURE_DIR}/cask/caffeine/org.example.caffeine.plist"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

While working on a versioned cask, I realized that livecheck doesn't automatically skip versioned casks without a `livecheck` block. This is the case for formulae but we don't have a similar `SkipCondition` for casks.

This adds a `Cask#versioned_cask?` method with a similar approach as `Formula#versioned_formula?` and uses it in a new `SkipConditions#cask_versioned` method.

-----

One wrinkle is that casks use a broader type of versioning than formulae. All existing versioned formulae have a numeric @ suffix format like `example@1` or `example@1.2`. Some casks have a similar numeric @ suffix but there are also various others like `@beta`, `@nightly`, etc.

This implementation of `#versioned_cask?` will return `true` for any cask with a `@` in the name, which may or may not make sense for non-numeric suffixes like `@beta`. If it should only return `true` for versioned casks with a numeric @ suffix, I can update how we identify versioned casks.

To be clear, the automatic skip can easily be overridden by adding a `livecheck` block. Of the ~202 `versioned` casks, only four don't have a `livecheck` block and each of those should have one anyway, so this shouldn't be a problem. Edit: I updated these casks to have a `livecheck` block in https://github.com/Homebrew/homebrew-cask/pull/181322, so there aren't any versioned casks without a `livecheck` block now.