### PR TITLE
attestation: specialize error when `gh` is old

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -52,6 +52,12 @@ module Homebrew
     # @api private
     class GhAuthInvalid < RuntimeError; end
 
+    # Raised if the version of `gh` invoked is too old to support
+    # attestations.
+    #
+    # @api private
+    class GhTooOld < RuntimeError; end
+
     # Returns whether attestation verification is enabled.
     #
     # @api private
@@ -142,6 +148,11 @@ module Homebrew
         end
 
         raise MissingAttestationError, "attestation not found: #{e}" if e.stderr.include?("HTTP 404: Not Found")
+
+        if e.stderr.include?("unknown command \"attestation\" for \"gh\"")
+          raise GhTooOld,
+                "your version of `gh` is too old; run `brew upgrade gh` to continue"
+        end
 
         raise InvalidAttestationError, "attestation verification failed: #{e}"
       end

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -4,6 +4,7 @@ require "diagnostic"
 
 RSpec.describe Homebrew::Attestation do
   let(:fake_gh) { Pathname.new("/extremely/fake/gh") }
+  let(:fake_gh_formula) { instance_double(Formula, opt_bin: Pathname.new("/extremely/fake")) }
   let(:fake_old_gh) { Pathname.new("/extremely/fake/old/gh") }
   let(:fake_gh_creds) { "fake-gh-api-token" }
   let(:fake_error_status) { instance_double(Process::Status, exitstatus: 1, termsig: nil) }
@@ -66,12 +67,12 @@ RSpec.describe Homebrew::Attestation do
   end
 
   describe "::gh_executable" do
-    it "calls ensure_executable" do
-      expect(described_class).to receive(:ensure_executable!)
+    it "calls ensure_formula_installed" do
+      expect(described_class).to receive(:ensure_formula_installed!)
         .with("gh", reason: "verifying attestations", latest: true)
-        .and_return(fake_gh)
+        .and_return(fake_gh_formula)
 
-      described_class.gh_executable
+      described_class.gh_executable == fake_gh
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This isn't really ideal (I'll look further into the bootstrap cycle issues that led us to try version sniffing in the first place), but it'll help more users in the current beta resolve issues they're seeing.

See https://github.com/Homebrew/homebrew-core/issues/177384#issuecomment-2263195832.
