### PR TITLE
rubocops/text: Add autocorrection for the interpolated bin audit

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -115,6 +115,8 @@ module RuboCop
     module FormulaAuditStrict
       # This cop contains stricter checks for various problems in a formula's source code.
       class Text < FormulaCop
+        extend AutoCorrector
+
         sig { override.params(formula_nodes: FormulaNodes).void }
         def audit_formula(formula_nodes)
           return if (body_node = formula_nodes.body_node).nil?
@@ -140,7 +142,9 @@ module RuboCop
           interpolated_bin_path_starts_with(body_node, "/#{@formula_name}") do |bin_node|
             offending_node(bin_node)
             cmd = bin_node.source.match(%r{\#{bin}/(\S+)})[1]&.delete_suffix('"') || @formula_name
-            problem "Use `bin/\"#{cmd}\"` instead of `\"\#{bin}/#{cmd}\"`"
+            problem "Use `bin/\"#{cmd}\"` instead of `\"\#{bin}/#{cmd}\"`" do |corrector|
+              corrector.replace(bin_node.loc.expression, "bin/\"#{cmd}\"")
+            end
           end
 
           return if formula_tap != "homebrew-core"

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -132,14 +132,23 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it 'reports an offense if "\#{bin}/<formula_name>" or other dashed binaries too are present' do
+    it 'reports an offense & autocorrects if "\#{bin}/<formula_name>" or other dashed binaries too are present' do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           test do
-            ohai "\#{bin}/foo", "-v"
-                 ^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"\#{bin}/foo"`
-            ohai "\#{bin}/foo-bar", "-v"
-                 ^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo-bar"` instead of `"\#{bin}/foo-bar"`
+            system "\#{bin}/foo", "-v"
+                   ^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"\#{bin}/foo"`
+            system "\#{bin}/foo-bar", "-v"
+                   ^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo-bar"` instead of `"\#{bin}/foo-bar"`
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class Foo < Formula
+          test do
+            system bin/"foo", "-v"
+            system bin/"foo-bar", "-v"
           end
         end
       RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- I got bored doing them manually.
- Also now more people can help with letters of the alphabet using `brew style --only=FormulaAuditStrict/Text --fix homebrew/core` if they so wish. Not that it's that important, because it's a strict audit, but either way I got bored of doing them manually. :-)