### PR TITLE
rubocops/shared/url_helper: fix url audit

### DIFF
--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -242,6 +242,7 @@ module RuboCop
           next if url.match? %r{raw.githubusercontent.com/.*/.*/(main|master|HEAD)/}
           next if url.include?("releases/download")
           next if url.include?("desktop.githubusercontent.com/github-desktop/releases/")
+          next if url.include?("desktop.githubusercontent.com/releases/")
 
           problem "Use GitHub tarballs rather than zipballs (url is #{url})."
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR updates the guard clause to account for changes in GitHub Desktop's download URL.

Before:

```console
$ brew style --fix g/github.rb
Taps/homebrew/homebrew-cask/Casks/g/github.rb:25:3: C: Cask/Url: Use GitHub tarballs rather than zipballs (url is url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop-#{arch}.zip",
      verified: "desktop.githubusercontent.com/").
  url "https://desktop.githubusercontent.com/releases/#{version}/GitHubDesktop-#{arch}.zip", ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

Unblocks https://github.com/Homebrew/homebrew-cask/pull/181392.
