### PR TITLE
rubocops/shared/url_helper: update url audit

### DIFF
--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -241,7 +241,6 @@ module RuboCop
         audit_urls(urls, zip_gh_pattern) do |_, url|
           next if url.match? %r{raw.githubusercontent.com/.*/.*/(main|master|HEAD)/}
           next if url.include?("releases/download")
-          next if url.include?("desktop.githubusercontent.com/github-desktop/releases/")
           next if url.include?("desktop.githubusercontent.com/releases/")
 
           problem "Use GitHub tarballs rather than zipballs (url is #{url})."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR removes the superfluous guard clause left in the code to unblock https://github.com/Homebrew/homebrew-cask/pull/181392.

Follow-up to #17937.
