### PR TITLE
Show dependencies for casks

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -82,8 +82,8 @@ module Cask
     def self.deps_info(cask)
       depends_on = cask.depends_on
 
-      formula_deps = depends_on[:formula]&.map(&:to_s) || []
-      cask_deps = depends_on[:cask]&.map { |dep| "#{dep} (cask)" } || []
+      formula_deps = Array(depends_on[:formula]).map(&:to_s)
+      cask_deps = Array(depends_on[:cask]).map { |dep| "#{dep} (cask)" }
 
       all_deps = formula_deps + cask_deps
       return if all_deps.empty?

--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -18,6 +18,8 @@ module Cask
       output << "#{repo}\n" if repo
       output << name_info(cask)
       output << desc_info(cask)
+      deps = deps_info(cask)
+      output << deps if deps
       language = language_info(cask)
       output << language if language
       output << "#{artifact_info(cask)}\n"
@@ -73,6 +75,22 @@ module Cask
       <<~EOS
         #{ohai_title("Description")}
         #{cask.desc.nil? ? Formatter.error("None") : cask.desc}
+      EOS
+    end
+
+    sig { params(cask: Cask).returns(T.nilable(String)) }
+    def self.deps_info(cask)
+      depends_on = cask.depends_on
+
+      formula_deps = depends_on[:formula] ? depends_on[:formula].map(&:to_s) : []
+      cask_deps = depends_on[:cask] ? depends_on[:cask].map { |dep| "#{dep} (cask)" } : []
+
+      all_deps = formula_deps + cask_deps
+      return if all_deps.empty?
+
+      <<~EOS
+        #{ohai_title("Dependencies")}
+        #{all_deps.join(", ")}
       EOS
     end
 

--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -82,8 +82,8 @@ module Cask
     def self.deps_info(cask)
       depends_on = cask.depends_on
 
-      formula_deps = depends_on[:formula] ? depends_on[:formula].map(&:to_s) : []
-      cask_deps = depends_on[:cask] ? depends_on[:cask].map { |dep| "#{dep} (cask)" } : []
+      formula_deps = depends_on[:formula]&.map(&:to_s) || []
+      cask_deps = depends_on[:cask]&.map { |dep| "#{dep} (cask)" } || []
 
       all_deps = formula_deps + cask_deps
       return if all_deps.empty?

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -25,6 +25,44 @@ RSpec.describe Cask::Info, :cask do
     EOS
   end
 
+  it "prints cask dependencies if the Cask has any" do
+    expect do
+      described_class.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"))
+    end.to output(<<~EOS).to_stdout
+      ==> with-depends-on-cask-multiple: 1.2.3
+      https://brew.sh/with-depends-on-cask-multiple
+      Not installed
+      From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-cask-multiple.rb
+      ==> Name
+      None
+      ==> Description
+      None
+      ==> Dependencies
+      local-caffeine (cask), local-transmission (cask)
+      ==> Artifacts
+      Caffeine.app (App)
+    EOS
+  end
+
+  it "prints cask and formulas dependencies if the Cask has both" do
+    expect do
+      described_class.info(Cask::CaskLoader.load("with-depends-on-everything"))
+    end.to output(<<~EOS).to_stdout
+      ==> with-depends-on-everything: 1.2.3
+      https://brew.sh/with-depends-on-everything
+      Not installed
+      From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/w/with-depends-on-everything.rb
+      ==> Name
+      None
+      ==> Description
+      None
+      ==> Dependencies
+      unar, local-caffeine (cask), with-depends-on-cask (cask)
+      ==> Artifacts
+      Caffeine.app (App)
+    EOS
+  end
+
   it "prints auto_updates if the Cask has `auto_updates true`" do
     expect do
       described_class.info(Cask::CaskLoader.load("with-auto-updates"))


### PR DESCRIPTION
When running info on a cask show its dependencies.

This mirrors how it already works for formulas.

Fixes https://github.com/Homebrew/brew/issues/17600.