### PR TITLE
debrew/irb: fix errors under Ruby 3.3

### DIFF
--- a/Library/Homebrew/debrew/irb.rb
+++ b/Library/Homebrew/debrew/irb.rb
@@ -5,6 +5,9 @@ require "irb"
 
 module IRB
   def self.start_within(binding)
+    old_stdout_sync = $stdout.sync
+    $stdout.sync = true
+
     unless @setup_done
       setup(nil, argv: [])
       @setup_done = true
@@ -12,21 +15,8 @@ module IRB
 
     workspace = WorkSpace.new(binding)
     irb = Irb.new(workspace)
-
-    @CONF[:IRB_RC]&.call(irb.context)
-    @CONF[:MAIN_CONTEXT] = irb.context
-
-    prev_trap = trap("SIGINT") do
-      irb.signal_handle
-    end
-
-    begin
-      catch(:IRB_EXIT) do
-        irb.eval_input
-      end
-    ensure
-      trap("SIGINT", prev_trap)
-      irb_at_exit
-    end
+    irb.run(conf)
+  ensure
+    $stdout.sync = old_stdout_sync
   end
 end


### PR DESCRIPTION
Also align `$stdout.sync` behaviour to `brew irb`.

Fixes #17921