### PR TITLE
utils/analytics: improve accuracy of GitHub Packages download counts

### DIFF
--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -307,7 +307,7 @@ module Utils
 
           last_thirty_days_downloads = last_thirty_days_match.captures.first.tr(",", "")
           thirty_day_download_count += if (millions_match = last_thirty_days_downloads.match(/(\d+\.\d+)M/).presence)
-            millions_match.captures.first.to_i * 1_000_000
+            millions_match.captures.first.to_f * 1_000_000
           else
             last_thirty_days_downloads.to_i
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`millions_match.captures.first` will typically be a decimal (since it's
matched using `\d+\.\d+`), except we lose accuracy in the `#to_i`
conversion.

Before:
```
❯ brew info --analytics --github-packages-downloads sqlite
==> Analytics
==> install (30 days)
[snip]
==> GitHub Packages Downloads
1,009,898 (30 days)
```

After:

```
❯ brew info --analytics --github-packages-downloads sqlite
==> Analytics
==> install (30 days)
[snip]
==> GitHub Packages Downloads
1,199,898 (30 days)
```

In this case `1.19M` was being rounded down to `1M`.

