### PR TITLE
formula_assertions: handle result `nil` case

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -21,11 +21,11 @@ module Homebrew
     # Returns the output of running cmd and asserts the exit status.
     #
     # @api public
-    sig { params(cmd: T.any(Pathname, String), result: Integer).returns(String) }
+    sig { params(cmd: T.any(Pathname, String), result: T.nilable(Integer)).returns(String) }
     def shell_output(cmd, result = 0)
       ohai cmd
       output = `#{cmd}`
-      assert_equal result, $CHILD_STATUS.exitstatus
+      assert_equal result, $CHILD_STATUS.exitstatus unless result.nil?
       output
     rescue Minitest::Assertion
       puts output if verbose?

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -7,10 +7,23 @@ require "sandbox"
 RSpec.describe Homebrew::DevCmd::Test do
   it_behaves_like "parseable arguments"
 
-  it "tests a given Formula", :integration_test do
+  it "tests a given Formula when exitStatus as 0", :integration_test do
     install_test_formula "testball", <<~'RUBY'
       test do
         assert_equal "test", shell_output("#{bin}/test")
+      end
+    RUBY
+
+    expect { brew "test", "--verbose", "testball" }
+      .to output(/Testing testball/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "tests a given Formula when exitStatus as nil", :integration_test do
+    install_test_formula "testball", <<~'RUBY'
+      test do
+        assert_equal "test", shell_output("#{bin}/test", nil)
       end
     RUBY
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

seeing the failure in https://github.com/Homebrew/homebrew-core/actions/runs/10230575029/job/28305550081

```
    TypeError: Parameter 'result': Expected type Integer, got type NilClass
```