### PR TITLE
dev-cmd/dispatch-build-bottle: add missing `require`

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "tap"
+require "utils/bottles"
 require "utils/github"
 
 module Homebrew


### PR DESCRIPTION


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

seeing some failures while running `brew dispatch-build-bottle xxx`
```
Error: uninitialized constant Homebrew::DevCmd::DispatchBuildBottle::Tap
Error: uninitialized constant Utils::Bottles
```