### PR TITLE
cmd/info: avoid waiting indefinitely for analytics unless requested

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -17,16 +17,16 @@ module Homebrew
     HOMEBREW_CACHE_API = (HOMEBREW_CACHE/"api").freeze
     HOMEBREW_CACHE_API_SOURCE = (HOMEBREW_CACHE/"api-source").freeze
 
-    sig { params(endpoint: String).returns(Hash) }
-    def self.fetch(endpoint)
+    sig { params(endpoint: String, timeout: T.nilable(Integer)).returns(Hash) }
+    def self.fetch(endpoint, timeout: nil)
       return cache[endpoint] if cache.present? && cache.key?(endpoint)
 
       api_url = "#{Homebrew::EnvConfig.api_domain}/#{endpoint}"
-      output = Utils::Curl.curl_output("--fail", api_url)
+      output = Utils::Curl.curl_output("--fail", api_url, timeout:)
       if !output.success? && Homebrew::EnvConfig.api_domain != HOMEBREW_API_DEFAULT_DOMAIN
         # Fall back to the default API domain and try again
         api_url = "#{HOMEBREW_API_DEFAULT_DOMAIN}/#{endpoint}"
-        output = Utils::Curl.curl_output("--fail", api_url)
+        output = Utils::Curl.curl_output("--fail", api_url, timeout:)
       end
       raise ArgumentError, "No file found at #{Tty.underline}#{api_url}#{Tty.reset}" unless output.success?
 

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -14,9 +14,9 @@ module Homebrew
 
       private_class_method :cache
 
-      sig { params(token: String).returns(Hash) }
-      def self.fetch(token)
-        Homebrew::API.fetch "cask/#{token}.json"
+      sig { params(token: String, timeout: T.nilable(Integer)).returns(Hash) }
+      def self.fetch(token, timeout: nil)
+        Homebrew::API.fetch("cask/#{token}.json", timeout:)
       end
 
       sig { params(cask: ::Cask::Cask).returns(::Cask::Cask) }

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -15,9 +15,9 @@ module Homebrew
 
       private_class_method :cache
 
-      sig { params(name: String).returns(Hash) }
-      def self.fetch(name)
-        Homebrew::API.fetch "formula/#{name}.json"
+      sig { params(name: String, timeout: T.nilable(Integer)).returns(Hash) }
+      def self.fetch(name, timeout: nil)
+        Homebrew::API.fetch("formula/#{name}.json", timeout:)
       end
 
       sig { params(formula: ::Formula).returns(::Formula) }

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -317,18 +317,23 @@ module Utils
         puts "#{number_readable(thirty_day_download_count)} (30 days)"
       end
 
+      # How long we're willing to wait for analytics for `brew info foo`.
+      # Set this to something small because `brew info foo` should be fast.
+      ANALYTICS_DEFAULT_TIMEOUT_UNLESS_REQUESTED = 1
+
       def formula_output(formula, args:)
         return if Homebrew::EnvConfig.no_analytics? || Homebrew::EnvConfig.no_github_api?
 
         require "api"
 
-        json = Homebrew::API::Formula.fetch formula.name
+        timeout = ANALYTICS_DEFAULT_TIMEOUT_UNLESS_REQUESTED unless args.analytics?
+        json = Homebrew::API::Formula.fetch(formula.name, timeout:)
         return if json.blank? || json["analytics"].blank?
 
         output_analytics(json, args:)
         output_github_packages_downloads(formula, args:)
-      rescue ArgumentError
-        # Ignore failed API requests
+      rescue ArgumentError, Timeout::Error
+        # Ignore failed/timed-out API requests
         nil
       end
 
@@ -337,12 +342,13 @@ module Utils
 
         require "api"
 
-        json = Homebrew::API::Cask.fetch cask.token
+        timeout = ANALYTICS_DEFAULT_TIMEOUT_UNLESS_REQUESTED unless args.analytics?
+        json = Homebrew::API::Cask.fetch(cask.token, timeout:)
         return if json.blank? || json["analytics"].blank?
 
         output_analytics(json, args:)
-      rescue ArgumentError
-        # Ignore failed API requests
+      rescue ArgumentError, Timeout::Error
+        # Ignore failed/timed-out API requests
         nil
       end
 

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -332,9 +332,9 @@ module Utils
 
         output_analytics(json, args:)
         output_github_packages_downloads(formula, args:)
-      rescue ArgumentError, Timeout::Error
+      rescue ArgumentError, Timeout::Error => e
         # Ignore failed/timed-out API requests
-        nil
+        odebug e
       end
 
       def cask_output(cask, args:)
@@ -347,9 +347,9 @@ module Utils
         return if json.blank? || json["analytics"].blank?
 
         output_analytics(json, args:)
-      rescue ArgumentError, Timeout::Error
+      rescue ArgumentError, Timeout::Error => e
         # Ignore failed/timed-out API requests
-        nil
+        odebug e
       end
 
       sig { returns(T::Hash[Symbol, String]) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

On a poor connection, e.g., `brew info bat` can hang indefinitely trying
to fetch analytics data.

Let's bail out early instead unless these analytics were specifically
requested with `--analytics`.
