### PR TITLE
rubocops/text: Allow `bin` interpolation inside word arrays

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -140,6 +140,8 @@ module RuboCop
           end
 
           interpolated_bin_path_starts_with(body_node, "/#{@formula_name}") do |bin_node|
+            next if bin_node.ancestors.any?(&:array_type?)
+
             offending_node(bin_node)
             cmd = bin_node.source.match(%r{\#{bin}/(\S+)})[1]&.delete_suffix('"') || @formula_name
             problem "Use `bin/\"#{cmd}\"` instead of `\"\#{bin}/#{cmd}\"`" do |corrector|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Follow up to #17826 and #17888.
- We discovered that the following syntax in the formula `sqlsmith` should actually be OK because the `\n` is like whitespace.

```ruby
cmd = %W[
  #{bin}/sqlsmith
  --threads=4
  --timeout=10
]
shell_output(cmd)
```
