### PR TITLE
Formula-Cookbook: Stop recommending `rm_f` in `postinstall`

### DIFF
--- a/docs/.rubocop.yml
+++ b/docs/.rubocop.yml
@@ -32,3 +32,7 @@ Style/RedundantRegexpArgument:
 # Want to be able to display partial formulae in the docs.
 Style/TopLevelMethodDefinition:
   Enabled: false
+
+# Formulae and Casks no longer use `rm_f`/`rm_rf`, so the docs need to match.
+Lint/NonAtomicFileOperation:
+  Enabled: false

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -995,7 +995,7 @@ class Foo < Formula
   url "https://example.com/foo-1.0.tar.gz"
 
   def post_install
-    rm_f pkgetc/"cert.pem"
+    rm pkgetc/"cert.pem" if File.exist?(pkgetc/"cert.pem")
     pkgetc.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
   end
   # ...


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- After all the work that went into https://github.com/Homebrew/brew/pull/17705, we don't want the docs disagreeing with what CI says the style should be.