### PR TITLE
cmd/update: make chown suggestion consistent

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -386,7 +386,7 @@ EOS
 ${HOMEBREW_CELLAR} is not writable. You should change the
 ownership and permissions of ${HOMEBREW_CELLAR} back to your
 user account:
-  sudo chown -R \$(whoami) ${HOMEBREW_CELLAR}
+  sudo chown -R ${USER-\$(whoami)} ${HOMEBREW_CELLAR}
 EOS
   fi
 


### PR DESCRIPTION
There's two permission checks in cmd/update.sh but the suggestion of which `chown` command to run is for some reason different. Let's make them consistent to the style predominantly used throughout `brew`.