### PR TITLE
language/*: only check required deps in `detected_*_shebang`

### DIFF
--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -109,7 +109,7 @@ module Language
 
       sig { params(formula: Formula).returns(Utils::Shebang::RewriteInfo) }
       def detected_node_shebang(formula = T.cast(self, Formula))
-        node_deps = formula.deps.map(&:name).grep(/^node(@.+)?$/)
+        node_deps = formula.deps.select(&:required?).map(&:name).grep(/^node(@.+)?$/)
         raise ShebangDetectionError.new("Node", "formula does not depend on Node") if node_deps.empty?
         raise ShebangDetectionError.new("Node", "formula has multiple Node dependencies") if node_deps.length > 1
 

--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -28,7 +28,7 @@ module Language
 
       sig { params(formula: Formula).returns(Utils::Shebang::RewriteInfo) }
       def detected_perl_shebang(formula = T.cast(self, Formula))
-        perl_deps = formula.declared_deps.select { |dep| dep.name == "perl" }
+        perl_deps = formula.declared_deps.select { |dep| dep.required? && dep.name == "perl" }
         raise ShebangDetectionError.new("Perl", "formula does not depend on Perl") if perl_deps.empty?
 
         perl_path = if perl_deps.any? { |dep| !dep.uses_from_macos? || !dep.use_macos_install? }

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -128,7 +128,7 @@ module Language
         python_path = if use_python_from_path
           "/usr/bin/env python3"
         else
-          python_deps = formula.deps.map(&:name).grep(/^python(@.+)?$/)
+          python_deps = formula.deps.select(&:required?).map(&:name).grep(/^python(@.+)?$/)
           raise ShebangDetectionError.new("Python", "formula does not depend on Python") if python_deps.empty?
           if python_deps.length > 1
             raise ShebangDetectionError.new("Python", "formula has multiple Python dependencies")


### PR DESCRIPTION
Otherwise, we rewrite this even when we have a e.g. build or test dependency on NodeJS.

See context in:
https://github.com/Homebrew/homebrew-core/issues/176257#issuecomment-2277602215