### PR TITLE
sorbet: Comment more files that can't be `strict` because of `undef`

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "ostruct"

--- a/Library/Homebrew/extend/os/linux/cleanup.rb
+++ b/Library/Homebrew/extend/os/linux/cleanup.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "os/linux/glibc"

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "tempfile"

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class Formula

--- a/Library/Homebrew/extend/os/linux/formula_installer.rb
+++ b/Library/Homebrew/extend/os/linux/formula_installer.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class FormulaInstaller

--- a/Library/Homebrew/extend/os/linux/keg.rb
+++ b/Library/Homebrew/extend/os/linux/keg.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class Keg

--- a/Library/Homebrew/extend/os/linux/parser.rb
+++ b/Library/Homebrew/extend/os/linux/parser.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/linux/simulate_system.rb
+++ b/Library/Homebrew/extend/os/linux/simulate_system.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/mac/cleaner.rb
+++ b/Library/Homebrew/extend/os/mac/cleaner.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class Cleaner

--- a/Library/Homebrew/extend/os/mac/cleanup.rb
+++ b/Library/Homebrew/extend/os/mac/cleanup.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/mac/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/mac/dependency_collector.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class DependencyCollector

--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "os/mac/xcode"

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Stdenv

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Superenv

--- a/Library/Homebrew/extend/os/mac/formula.rb
+++ b/Library/Homebrew/extend/os/mac/formula.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class Formula

--- a/Library/Homebrew/extend/os/mac/formula_installer.rb
+++ b/Library/Homebrew/extend/os/mac/formula_installer.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class FormulaInstaller

--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "macho"

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "system_command"

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class Keg

--- a/Library/Homebrew/extend/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/mac/linkage_checker.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 class LinkageChecker

--- a/Library/Homebrew/extend/os/mac/readall.rb
+++ b/Library/Homebrew/extend/os/mac/readall.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Readall

--- a/Library/Homebrew/extend/os/mac/simulate_system.rb
+++ b/Library/Homebrew/extend/os/mac/simulate_system.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "system_command"

--- a/Library/Homebrew/ignorable.rb
+++ b/Library/Homebrew/ignorable.rb
@@ -1,4 +1,4 @@
-# typed: true
+# typed: true # This cannot be `# typed: strict` due to the use of `undef`.
 # frozen_string_literal: true
 
 require "warnings"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/17297.
- Found with `grep -rL "# typed: strict" Library/Homebrew | xargs grep -l "undef "`.
- This stops people from trying to bump them and getting an error that they can't fix because  [it's a Sorbet limitation](https://sorbet.org/docs/error-reference#3008), wasting contributor time.