### PR TITLE
Honor homebrew curlrc config for analytics

### DIFF
--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -59,9 +59,7 @@ module Utils
           puts "#{curl} #{args.join(" ")} \"#{url}\""
           puts Utils.popen_read(curl, *args, url)
         else
-          pid = fork do
-            exec curl, *args, url
-          end
+          pid = spawn curl, *args, url
           Process.detach T.must(pid)
         end
       end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -54,12 +54,13 @@ module Utils
         require "utils/curl"
 
         curl = Utils::Curl.curl_executable
+        args = Utils::Curl.curl_args(*args, "--silent", "--output", "/dev/null", show_error: false)
         if ENV["HOMEBREW_ANALYTICS_DEBUG"]
           puts "#{curl} #{args.join(" ")} \"#{url}\""
           puts Utils.popen_read(curl, *args, url)
         else
           pid = fork do
-            exec curl, *args, "--silent", "--output", "/dev/null", url
+            exec curl, *args, url
           end
           Process.detach T.must(pid)
         end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -65,7 +65,7 @@ module Utils
         show_error:      T.nilable(T::Boolean),
         user_agent:      T.any(String, Symbol, NilClass),
         referer:         T.nilable(String),
-      ).returns(T::Array[T.untyped])
+      ).returns(T::Array[String])
     }
     def curl_args(
       *extra_args,
@@ -129,7 +129,7 @@ module Utils
 
       args << "--referer" << referer if referer.present?
 
-      args + extra_args
+      (args + extra_args).map(&:to_s)
     end
 
     def curl_with_workarounds(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I have a `.curlrc` in my home directory: https://github.com/ntkme/home/blob/main/.curlrc

Every time I ran any brew command I do not see output for normal brew downloads but I do see output for brew's analytics, which indicate normal brew operations have curlrc disabled by default, but analytics have curlrc enabled by default:

```
          url: https://eu-central-1-1.aws.cloud2.influxdata.com/api/v2/write?bucket=analytics&precision=s
url_effective: https://eu-central-1-1.aws.cloud2.influxdata.com/api/v2/write?bucket=analytics&precision=s
    dnslookup: 0.006532
      connect: 0.169775
   appconnect: 0.339838
  pretransfer: 0.339923
starttransfer: 0.517155
        total: 0.517178
         size: 0
``` 

This PR makes sure that the same curlrc config is applied for both normal downloads and analytics.