### PR TITLE
formula_creator: don't recommend interpolating `bin`

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -224,7 +224,7 @@ module Homebrew
             # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
             #
             # The installed folder is not in the path, so use the entire path to any
-            # executables being tested: `system "\#{bin}/program", "do", "something"`.
+            # executables being tested: `system bin/"program", "do", "something"`.
             system "false"
           end
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We don't interpolate `bin` after https://github.com/Homebrew/brew/pull/17826.