### PR TITLE
Fix incompatibility in `brew shellenv` with older version of Fish shell

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -24,8 +24,8 @@ homebrew-shellenv() {
       echo "set -gx HOMEBREW_CELLAR \"${HOMEBREW_CELLAR}\";"
       echo "set -gx HOMEBREW_REPOSITORY \"${HOMEBREW_REPOSITORY}\";"
       echo "fish_add_path -gP \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\";"
-      echo "set -q MANPATH; and set MANPATH[1] \":\$(string trim --left --chars=\":\" \$MANPATH[1])\";"
-      echo "! set -q INFOPATH; and set INFOPATH ''; set -gx INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH;"
+      echo "if test -n \"\$MANPATH[1]\"; set -gx MANPATH '' \$MANPATH; end;"
+      echo "if not contains \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; set -gx INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; end;"
       ;;
     csh | -csh | tcsh | -tcsh)
       echo "setenv HOMEBREW_PREFIX ${HOMEBREW_PREFIX};"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fish didn't support `$(...)` substitution until v3.4.0, but using `(...)` didn't produce expected output so I rewrote the Fish command for `MANPATH` (and updated `INFOPATH` so that it doesn't add duplicate entries).

I didn't have any issues until a recent `brew update`, I think the issue was introduced [here](https://github.com/Homebrew/brew/commit/4ff36552f6e9cc0c62e7dacc2ca6ff3e87ad10b5).

This is the error that was happening on Fish 3.3.1 (Ubuntu 22.04 LTS):
```
❯ eval (/home/linuxbrew/.linuxbrew/bin/brew shellenv)
fish: $(...) is not supported. In fish, please use '(string)'.
set -gx HOMEBREW_PREFIX "/home/linuxbrew/.linuxbrew"; set -gx HOMEBREW_CELLAR "/home/linuxbrew/.linuxbrew/Cellar"; set -gx HOMEBREW_REPOSITORY "/home/linuxbrew/.linuxbrew/Homebrew"; fish_add_path -gP "/home/linuxbrew/.linuxbrew/bin" "/home/linuxbrew/.linuxbrew/sbin"; set -q MANPATH; and set MANPATH[1] ":$(string trim --left --chars=":" $MANPATH[1])"; ! set -q INFOPATH; and set INFOPATH ''; set -gx INFOPATH "/home/linuxbrew/.linuxbrew/share/info" $INFOPATH;
                                                                                                                                                                                                                                                                                                                 ^
```
