### PR TITLE
rubocops/lines: require a comment for `skip_clean`

### DIFF
--- a/Library/Homebrew/test/rubocops/text/skip_clean_commented_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/skip_clean_commented_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rubocops/lines"
+
+RSpec.describe RuboCop::Cop::FormulaAudit::SkipCleanCommented do
+  subject(:cop) { described_class.new }
+
+  context "when auditing formulae in homebrew-core" do
+    it "reports an offense when skip_clean does not have a comment" do
+      expect_offense(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          skip_clean "bin"
+          ^^^^^^^^^^^^^^^^ FormulaAudit/SkipCleanCommented: Formulae in homebrew/core should document why `skip_clean` is needed with a comment.
+        end
+      RUBY
+    end
+
+    it "reports a single offense for multiple skip_clean lines" do
+      expect_offense(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+
+          skip_clean "bin"
+          ^^^^^^^^^^^^^^^^ FormulaAudit/SkipCleanCommented: Formulae in homebrew/core should document why `skip_clean` is needed with a comment.
+          skip_clean "libexec/bin"
+        end
+      RUBY
+    end
+
+    it "does not report an offense for a comment" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          # some reason
+          skip_clean "bin"
+        end
+      RUBY
+    end
+
+    it "does not report an offense for an inline comment" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          skip_clean "bin" # some reason
+        end
+      RUBY
+    end
+
+    it "does not report an offense for a comment above multiple skip_clean lines" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          # some reason
+          skip_clean "bin"
+          skip_clean "libexec/bin"
+        end
+      RUBY
+    end
+  end
+
+  context "when auditing formulae not in homebrew-core" do
+    it "does not report an offense" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          skip_clean "bin"
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Related to the discussion in https://github.com/Homebrew/homebrew-core/issues/176257, I didn't realize we expected `skip_clean` to be documented with a comment. This formalizes that requirement into an audit, scoped only to `homebrew/core`.
