### PR TITLE
Faster brew formulae command (and formula completion!)

### DIFF
--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -29,7 +29,8 @@ homebrew-items() {
       -name .github -o \
       -name lib -o \
       -name spec -o \
-      -name vendor \
+      -name vendor -o \
+      -name .git \
       \) \
       -prune -false -o -path "${find_include_filter}" |
       sed "${sed_extended_regex_flag}" \


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

`brew formulae` starts to get really slow if you have even a fairly modest number of taps tapped. On my system:

```
time brew formulae

real	0m0.441s
user	0m0.089s
sys	0m0.292s
```

This command gets called every time completion is attempted on the formula list, like `brew install` and half a second is definitely enough to make using tab completion for formulae feel bad rather than snappy. 

The reason this happens is that we haven't added the `.git` repo folder to the list of names for `find` to omit from its search in `items.sh` (which is what `brew formulae` ultimately calls).  The `.git` folder tends to have a large number of files inside and nothing we need for building a list of installable tap formula names. 

This PR is about as simple as they come, it just adds `.git` to the list of things for the `find` command to ignore. 

After this change:

```
time brew formulae

real	0m0.159s
user	0m0.042s
sys	0m0.078s
```

Formula completion now feels much faster! 

