### PR TITLE
Relax cask token regex.

### DIFF
--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -15,7 +15,7 @@ HOMEBREW_DEFAULT_TAP_FORMULA_REGEX = T.let(
 )
 
 # Match a cask token.
-HOMEBREW_TAP_CASK_TOKEN_REGEX = T.let(/(?<token>[a-z0-9\-_]+(?:@[a-z0-9\-_.]+)?)/, Regexp)
+HOMEBREW_TAP_CASK_TOKEN_REGEX = T.let(/(?<token>[\w+\-.@]+)/, Regexp)
 # Match taps' casks, e.g. `someuser/sometap/somecask`.
 HOMEBREW_TAP_CASK_REGEX = T.let(
   %r{\A(?<user>[^/]+)/(?<repo>[^/]+)/#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z},


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The audit was relaxed in https://github.com/Homebrew/brew/pull/17562, but we cannot actually load casks containing e.g. `+` yet.

Needed for https://github.com/Homebrew/homebrew-cask/pull/182101.