### PR TITLE
Refactor method to remove extra tap requires

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -65,10 +65,8 @@ begin
   internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd) if cmd
 
   unless internal_cmd
-    require "tap"
-
     # Add contributed commands to PATH before checking.
-    homebrew_path.append(Tap.cmd_directories)
+    homebrew_path.append(Commands.cmd_directories)
 
     # External commands expect a normal PATH
     ENV["PATH"] = homebrew_path.to_s

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -66,7 +66,7 @@ begin
 
   unless internal_cmd
     # Add contributed commands to PATH before checking.
-    homebrew_path.append(Commands.cmd_directories)
+    homebrew_path.append(Commands.tap_cmd_directories)
 
     # External commands expect a normal PATH
     ENV["PATH"] = homebrew_path.to_s

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -58,7 +58,7 @@ module Homebrew
           info += ", #{private_count} private"
           info += ", #{Utils.pluralize("formula", formula_count, plural: "e", include_count: true)}"
           info += ", #{Utils.pluralize("command", command_count, include_count: true)}"
-          info += ", #{Tap::TAP_DIRECTORY.dup.abv}" if Tap::TAP_DIRECTORY.directory?
+          info += ", #{HOMEBREW_TAP_DIRECTORY.dup.abv}" if HOMEBREW_TAP_DIRECTORY.directory?
           puts info
         else
           info = ""

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -70,23 +70,17 @@ module Commands
 
   # Ruby commands which can be `require`d without being run.
   def self.external_ruby_v2_cmd_path(cmd)
-    require "tap"
-
-    path = which("#{cmd}.rb", Tap.cmd_directories)
+    path = which("#{cmd}.rb", cmd_directories)
     path if require?(path)
   end
 
   # Ruby commands which are run by being `require`d.
   def self.external_ruby_cmd_path(cmd)
-    require "tap"
-
-    which("brew-#{cmd}.rb", PATH.new(ENV.fetch("PATH")).append(Tap.cmd_directories))
+    which("brew-#{cmd}.rb", PATH.new(ENV.fetch("PATH")).append(cmd_directories))
   end
 
   def self.external_cmd_path(cmd)
-    require "tap"
-
-    which("brew-#{cmd}", PATH.new(ENV.fetch("PATH")).append(Tap.cmd_directories))
+    which("brew-#{cmd}", PATH.new(ENV.fetch("PATH")).append(cmd_directories))
   end
 
   def self.path(cmd)
@@ -105,6 +99,12 @@ module Commands
     cmds += external_commands if external
     cmds += internal_commands_aliases if aliases
     cmds.sort
+  end
+
+  # An array of all tap cmd directory {Pathname}s.
+  sig { returns(T::Array[Pathname]) }
+  def self.cmd_directories
+    Pathname.glob HOMEBREW_TAP_DIRECTORY/"*/*/cmd"
   end
 
   def self.internal_commands_paths
@@ -144,9 +144,7 @@ module Commands
   end
 
   def self.external_commands
-    require "tap"
-
-    Tap.cmd_directories.flat_map do |path|
+    cmd_directories.flat_map do |path|
       find_commands(path).select(&:executable?)
                          .map { basename_without_extension(_1) }
                          .map { |p| p.to_s.delete_prefix("brew-").strip }

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -70,17 +70,17 @@ module Commands
 
   # Ruby commands which can be `require`d without being run.
   def self.external_ruby_v2_cmd_path(cmd)
-    path = which("#{cmd}.rb", cmd_directories)
+    path = which("#{cmd}.rb", tap_cmd_directories)
     path if require?(path)
   end
 
   # Ruby commands which are run by being `require`d.
   def self.external_ruby_cmd_path(cmd)
-    which("brew-#{cmd}.rb", PATH.new(ENV.fetch("PATH")).append(cmd_directories))
+    which("brew-#{cmd}.rb", PATH.new(ENV.fetch("PATH")).append(tap_cmd_directories))
   end
 
   def self.external_cmd_path(cmd)
-    which("brew-#{cmd}", PATH.new(ENV.fetch("PATH")).append(cmd_directories))
+    which("brew-#{cmd}", PATH.new(ENV.fetch("PATH")).append(tap_cmd_directories))
   end
 
   def self.path(cmd)
@@ -103,7 +103,7 @@ module Commands
 
   # An array of all tap cmd directory {Pathname}s.
   sig { returns(T::Array[Pathname]) }
-  def self.cmd_directories
+  def self.tap_cmd_directories
     Pathname.glob HOMEBREW_TAP_DIRECTORY/"*/*/cmd"
   end
 
@@ -144,7 +144,7 @@ module Commands
   end
 
   def self.external_commands
-    cmd_directories.flat_map do |path|
+    tap_cmd_directories.flat_map do |path|
       find_commands(path).select(&:executable?)
                          .map { basename_without_extension(_1) }
                          .map { |p| p.to_s.delete_prefix("brew-").strip }

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -764,7 +764,7 @@ module Homebrew
       end
 
       def check_for_external_cmd_name_conflict
-        cmds = Tap.cmd_directories.flat_map { |p| Dir["#{p}/brew-*"] }.uniq
+        cmds = Commands.cmd_directories.flat_map { |p| Dir["#{p}/brew-*"] }.uniq
         cmds = cmds.select { |cmd| File.file?(cmd) && File.executable?(cmd) }
         cmd_map = {}
         cmds.each do |cmd|

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -764,7 +764,7 @@ module Homebrew
       end
 
       def check_for_external_cmd_name_conflict
-        cmds = Commands.cmd_directories.flat_map { |p| Dir["#{p}/brew-*"] }.uniq
+        cmds = Commands.tap_cmd_directories.flat_map { |p| Dir["#{p}/brew-*"] }.uniq
         cmds = cmds.select { |cmd| File.file?(cmd) && File.executable?(cmd) }
         cmd_map = {}
         cmds.each do |cmd|

--- a/Library/Homebrew/startup/config.rb
+++ b/Library/Homebrew/startup/config.rb
@@ -51,6 +51,9 @@ HOMEBREW_TEMP = Pathname(ENV.fetch("HOMEBREW_TEMP")).then do |tmp|
   tmp.realpath
 end.freeze
 
+# Where installed taps live
+HOMEBREW_TAP_DIRECTORY = (HOMEBREW_LIBRARY/"Taps").freeze
+
 # The Ruby path and args to use for forked Ruby calls
 HOMEBREW_RUBY_EXEC_ARGS = [
   RUBY_PATH,

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -14,8 +14,6 @@ require "settings"
 class Tap
   extend Cachable
 
-  TAP_DIRECTORY = (HOMEBREW_LIBRARY/"Taps").freeze
-
   HOMEBREW_TAP_CASK_RENAMES_FILE = "cask_renames.json"
   private_constant :HOMEBREW_TAP_CASK_RENAMES_FILE
   HOMEBREW_TAP_FORMULA_RENAMES_FILE = "formula_renames.json"
@@ -201,7 +199,7 @@ class Tap
     @repository = repository
     @name = "#{@user}/#{@repository}".downcase
     @full_name = "#{@user}/homebrew-#{@repository}"
-    @path = TAP_DIRECTORY/@full_name.downcase
+    @path = HOMEBREW_TAP_DIRECTORY/@full_name.downcase
     @git_repository = GitRepository.new(@path)
   end
 
@@ -286,7 +284,7 @@ class Tap
   sig { returns(String) }
   def repository_var_suffix
     @repository_var_suffix ||= path.to_s
-                                   .delete_prefix(TAP_DIRECTORY.to_s)
+                                   .delete_prefix(HOMEBREW_TAP_DIRECTORY.to_s)
                                    .tr("^A-Za-z0-9", "_")
                                    .upcase
   end
@@ -1021,8 +1019,8 @@ class Tap
   # @api public
   sig { returns(T::Array[Tap]) }
   def self.installed
-    cache[:installed] ||= if TAP_DIRECTORY.directory?
-      TAP_DIRECTORY.subdirs.flat_map(&:subdirs).map { from_path(_1) }
+    cache[:installed] ||= if HOMEBREW_TAP_DIRECTORY.directory?
+      HOMEBREW_TAP_DIRECTORY.subdirs.flat_map(&:subdirs).map { from_path(_1) }
     else
       []
     end
@@ -1058,12 +1056,6 @@ class Tap
     odeprecated "`#{self}.names`"
 
     map(&:name).sort
-  end
-
-  # An array of all tap cmd directory {Pathname}s.
-  sig { returns(T::Array[Pathname]) }
-  def self.cmd_directories
-    Pathname.glob TAP_DIRECTORY/"*/*/cmd"
   end
 
   # An array of official taps that have been manually untapped

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+HOMEBREW_TAP_DIRECTORY = T.let((HOMEBREW_LIBRARY/"Taps").freeze, Pathname)
+
 # Match a formula name.
 HOMEBREW_TAP_FORMULA_NAME_REGEX = T.let(/(?<name>[\w+\-.@]+)/, Regexp)
 # Match taps' formulae, e.g. `someuser/sometap/someformula`.

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -1,8 +1,6 @@
 # typed: strict
 # frozen_string_literal: true
 
-HOMEBREW_TAP_DIRECTORY = T.let((HOMEBREW_LIBRARY/"Taps").freeze, Pathname)
-
 # Match a formula name.
 HOMEBREW_TAP_FORMULA_NAME_REGEX = T.let(/(?<name>[\w+\-.@]+)/, Regexp)
 # Match taps' formulae, e.g. `someuser/sometap/someformula`.

--- a/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
+++ b/Library/Homebrew/test/api/internal_tap_json/formula_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe "Internal Tap JSON -- Formula", type: :system do
 
   context "when generating JSON", :needs_macos do
     before do
-      cp_r(TEST_FIXTURE_DIR/"internal_tap_json/homebrew-core", Tap::TAP_DIRECTORY/"homebrew")
+      cp_r(TEST_FIXTURE_DIR/"internal_tap_json/homebrew-core", HOMEBREW_TAP_DIRECTORY/"homebrew")
 
       # NOTE: Symlinks can't be copied recursively so we create them manually here.
-      (Tap::TAP_DIRECTORY/"homebrew/homebrew-core").tap do |core_tap|
+      (HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-core").tap do |core_tap|
         mkdir(core_tap/"Aliases")
         ln_s(core_tap/"Formula/f/fennel.rb", core_tap/"Aliases/fennel-lang")
         ln_s(core_tap/"Formula/p/ponyc.rb", core_tap/"Aliases/ponyc-lang")

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Commands do
 
       FileUtils.touch "#{dir}/brew-t4"
 
-      allow(Tap).to receive(:cmd_directories).and_return([dir])
+      allow(described_class).to receive(:cmd_directories).and_return([dir])
 
       cmds = described_class.external_commands
 

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Commands do
 
       FileUtils.touch "#{dir}/brew-t4"
 
-      allow(described_class).to receive(:cmd_directories).and_return([dir])
+      allow(described_class).to receive(:tap_cmd_directories).and_return([dir])
 
       cmds = described_class.external_commands
 

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Homebrew::DevCmd::Extract do
 
   context "when extracting a formula" do
     let!(:target) do
-      path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
+      path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
       (path/"Formula").mkpath
       target = Tap.from_path(path)
       core_tap = CoreTap.instance

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Homebrew::DevCmd::PrPull do
   let(:tap) { Tap.fetch("Homebrew", "foo") }
   let(:formula_file) { tap.path/"Formula/foo.rb" }
   let(:cask_file) { tap.cask_dir/"food.rb" }
-  let(:path) { Pathname(Tap::TAP_DIRECTORY/"homebrew/homebrew-foo") }
+  let(:path) { Pathname(HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo") }
 
   it_behaves_like "parseable arguments"
 

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Homebrew::Diagnostic::Checks do
           FileUtils.chmod 0755, cmd
         end
 
-        allow(Tap).to receive(:cmd_directories).and_return([path1, path2])
+        allow(Commands).to receive(:cmd_directories).and_return([path1, path2])
 
         expect(checks.check_for_external_cmd_name_conflict)
           .to match("brew-foo")

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Homebrew::Diagnostic::Checks do
           FileUtils.chmod 0755, cmd
         end
 
-        allow(Commands).to receive(:cmd_directories).and_return([path1, path2])
+        allow(Commands).to receive(:tap_cmd_directories).and_return([path1, path2])
 
         expect(checks.check_for_external_cmd_name_conflict)
           .to match("brew-foo")

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Homebrew::FormulaAuditor do
     @count += 1
   end
   let(:formula_subpath) { "Formula/foo#{foo_version}.rb" }
-  let(:origin_tap_path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-foo" }
+  let(:origin_tap_path) { HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo" }
   let(:origin_formula_path) { origin_tap_path/formula_subpath }
-  let(:tap_path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-bar" }
+  let(:tap_path) { HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-bar" }
   let(:formula_path) { tap_path/formula_subpath }
 
   def formula_auditor(name, text, options = {})

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -751,7 +751,7 @@ RSpec.describe Formulary do
           end
 
           after do
-            FileUtils.rm_rf Tap::TAP_DIRECTORY/"another"
+            FileUtils.rm_rf HOMEBREW_TAP_DIRECTORY/"another"
           end
 
           # FIXME

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Homebrew::MissingFormula do
     subject { described_class.tap_migration_reason(formula) }
 
     before do
-      tap_path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
+      tap_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
       tap_path.mkpath
       (tap_path/"tap_migrations.json").write <<~JSON
         { "migrated-formula": "homebrew/bar" }
@@ -58,7 +58,7 @@ RSpec.describe Homebrew::MissingFormula do
     subject { described_class.deleted_reason(formula, silent: true) }
 
     before do
-      tap_path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
+      tap_path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
       (tap_path/"Formula").mkpath
       (tap_path/"Formula/deleted-formula.rb").write "placeholder"
       ENV.delete "GIT_AUTHOR_DATE"

--- a/Library/Homebrew/test/rubocops/text/make_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/make_check_spec.rb
@@ -5,7 +5,7 @@ require "rubocops/lines"
 RSpec.describe RuboCop::Cop::FormulaAuditStrict::MakeCheck do
   subject(:cop) { described_class.new }
 
-  let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-core" }
+  let(:path) { HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-core" }
 
   before do
     path.mkpath

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -210,7 +210,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
   end
 
   def setup_test_tap
-    path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
+    path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo"
     path.mkpath
     path.cd do
       system "git", "init"

--- a/Library/Homebrew/test/support/lib/startup/config.rb
+++ b/Library/Homebrew/test/support/lib/startup/config.rb
@@ -33,6 +33,7 @@ HOMEBREW_LOCKS         = (HOMEBREW_PREFIX.parent/"locks").freeze
 HOMEBREW_CELLAR        = (HOMEBREW_PREFIX.parent/"cellar").freeze
 HOMEBREW_LOGS          = (HOMEBREW_PREFIX.parent/"logs").freeze
 HOMEBREW_TEMP          = (HOMEBREW_PREFIX.parent/"temp").freeze
+HOMEBREW_TAP_DIRECTORY = (HOMEBREW_LIBRARY/"Taps").freeze
 HOMEBREW_RUBY_EXEC_ARGS = [
   RUBY_PATH,
   ENV.fetch("HOMEBREW_RUBY_WARNINGS"),

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Tap do
 
   subject(:homebrew_foo_tap) { described_class.fetch("Homebrew", "foo") }
 
-  let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-foo" }
+  let(:path) { HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-foo" }
   let(:formula_file) { path/"Formula/foo.rb" }
   let(:alias_file) { path/"Aliases/bar" }
   let(:cmd_file) { path/"cmd/brew-tap-cmd.rb" }
@@ -172,7 +172,7 @@ RSpec.describe Tap do
 
   specify "#issues_url" do
     t = described_class.fetch("someone", "foo")
-    path = Tap::TAP_DIRECTORY/"someone/homebrew-foo"
+    path = HOMEBREW_TAP_DIRECTORY/"someone/homebrew-foo"
     path.mkpath
     cd path do
       system "git", "init"
@@ -182,7 +182,7 @@ RSpec.describe Tap do
     expect(t.issues_url).to eq("https://github.com/someone/homebrew-foo/issues")
     expect(homebrew_foo_tap.issues_url).to eq("https://github.com/Homebrew/homebrew-foo/issues")
 
-    (Tap::TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
+    (HOMEBREW_TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
     expect(described_class.fetch("someone", "no-git").issues_url).to be_nil
   ensure
     path.parent.rmtree
@@ -378,7 +378,7 @@ RSpec.describe Tap do
       end.to raise_error(ErrorDuringExecution)
 
       expect(tap).not_to be_installed
-      expect(Tap::TAP_DIRECTORY/"user").not_to exist
+      expect(HOMEBREW_TAP_DIRECTORY/"user").not_to exist
     end
   end
 
@@ -652,7 +652,7 @@ RSpec.describe Tap do
     end
 
     specify "files" do
-      path = Tap::TAP_DIRECTORY/"homebrew/homebrew-core"
+      path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-core"
       formula_file = core_tap.formula_dir/"foo.rb"
       core_tap.formula_dir.mkpath
       formula_file.write <<~RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We were selectively requiring the tap.rb file in a few places for performance reasons. The main method we were referencing was the `Tap.cmd_directories` method which uses `Pathname` and the `TAP_DIRECTORY` constant internally. `Tap.cmd_directories` is mostly used in the `Commands` module and that is loaded very early on in the program so it made sense to move that command to that module. To facilitate that I moved the `TAP_DIRECTORY` constant to the top-level and renamed it to `HOMEBREW_TAP_DIRECTORY`. It now lies in the tap_constants.rb file.

A nice bonus of this refactor is that it speeds up loading external commands since the tap.rb file is no longer required by default in those cases.

```console
$ hyperfine --parameter-list branch master,refactor-method-to-remove-extra-tap-requires --war
mup 5 --setup 'git switch {branch}' 'brew branch-compare -h'
Benchmark 1: brew branch-compare -h (branch = master)
  Time (mean ± σ):     869.5 ms ±   5.1 ms    [User: 506.0 ms, System: 333.7 ms]
  Range (min … max):   858.3 ms … 876.7 ms    10 runs
 
Benchmark 2: brew branch-compare -h (branch = refactor-method-to-remove-extra-tap-requires)
  Time (mean ± σ):     723.3 ms ±   5.7 ms    [User: 418.1 ms, System: 275.5 ms]
  Range (min … max):   713.6 ms … 733.1 ms    10 runs
 
Summary
  brew branch-compare -h (branch = refactor-method-to-remove-extra-tap-requires) ran
    1.20 ± 0.01 times faster than brew branch-compare -h (branch = master)
```

`brew commands` also gets a speed boost since `Commands.commands` no longer requires tap.rb.

```console
$ hyperfine --parameter-list branch master,refactor-method-to-remove-extra-tap-requires --war
mup 5 --setup 'git switch {branch}' 'brew commands'
Benchmark 1: brew commands (branch = master)
  Time (mean ± σ):     875.6 ms ±   8.0 ms    [User: 512.5 ms, System: 332.6 ms]
  Range (min … max):   864.7 ms … 889.5 ms    10 runs
 
Benchmark 2: brew commands (branch = refactor-method-to-remove-extra-tap-requires)
  Time (mean ± σ):     723.4 ms ±   5.5 ms    [User: 420.1 ms, System: 274.2 ms]
  Range (min … max):   718.4 ms … 733.8 ms    10 runs
 
Summary
  brew commands (branch = refactor-method-to-remove-extra-tap-requires) ran
    1.21 ± 0.01 times faster than brew commands (branch = master)
```

Note: All benchmarks are on an old iMac so may not be as noticeable on newer machines.

Risks: It's possible that another file was counting on the inclusion of tap.rb somewhere else in the codebase and this causes a missing require error. We have no easy way to test for that that I'm aware of.