### PR TITLE
ci: Encourage Sorbet `# typed: strict` in new code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,23 @@ jobs:
 
       - run: brew style
 
+      - name: Check new files are Sorbet strictly typed
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: |
+          new_files=$(git diff --cached --name-only --diff-filter=A origin/master -- "*.rb" :^sorbet :^vendor | sort)
+          missing_comment=false
+
+          for file in ${new_files}; do
+            if ! grep -q '# typed: strict' "${file}"; then
+              echo "Add the Sorbet strict sigil ("# typed: strict") to ${file}."
+              missing_comment=true
+            fi
+          done
+
+          if [[ "${missing_comment}" = true ]]; then
+            exit 1
+          fi
+
       - run: brew typecheck
 
       - name: Check RuboCop filepaths


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/17297, specifically the "good transition step" of "requiring `typed: strict` on all new files".
- This adds a new GitHub Actions step in the test job, _before_ typechecking, which ensures that new Ruby files are Sorbet strictly typed, or commented to note that they can't be (just that somewhere there's `# typed: strict`).

Tested with:

```shell
[ci-check-new-files-srb-strict e9dc524ef6] test new files
 Date: Sun Aug 11 23:39:50 2024 +0100
 4 files changed, 5 insertions(+)
 create mode 100644 Library/Homebrew/bad.rb
 create mode 100644 Library/Homebrew/forgot.rb
 create mode 100644 Library/Homebrew/good.rb
 create mode 100644 Library/Homebrew/should_not_care.yml

$ bash sorbet_sigils.sh
Add the Sorbet strict sigil (# typed: strict) to Library/Homebrew/bad.rb.
Add the Sorbet strict sigil (# typed: strict) to Library/Homebrew/forgot.rb.
```
