### PR TITLE
cask/dsl/caveats: fix rosetta caveat printing

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -141,7 +141,7 @@ module Cask
       end
 
       caveat :requires_rosetta do
-        next if !Hardware::CPU.arm? || Homebrew::SimulateSystem.current_arch != :arm
+        next if Homebrew::SimulateSystem.current_arch != :arm
 
         <<~EOS
           #{@cask} is built for Intel macOS and so requires Rosetta 2 to be installed.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is the third (and hopefully final) attempt to get the Rosetta caveat for Casks printing correctly.
The conditional in the if statement was changed in a previous PR, however this results in the caveat never printing when the architecture is simulated in audits (because the first half of the check returns first).

`Homebrew::SimulateSystem.current_arch` will be set correctly whether the system is being "simulated" or not. [This mirrors the current logic in `audit_rosetta`](https://github.com/Homebrew/brew/blob/4a1643e/Library/Homebrew/cask/audit.rb#L558).

---

Unblocks https://github.com/Homebrew/homebrew-cask/pull/181053