### PR TITLE
cmd/update-report: don't output cask updates on linux

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -820,6 +820,8 @@ class ReporterHub
   end
 
   def dump_new_cask_report
+    return if Homebrew::SimulateSystem.simulating_or_running_on_linux?
+
     casks = select_formula_or_cask(:AC).sort.filter_map do |name|
       name.split("/").last unless cask_installed?(name)
     end
@@ -836,6 +838,8 @@ class ReporterHub
   end
 
   def dump_deleted_cask_report
+    return if Homebrew::SimulateSystem.simulating_or_running_on_linux?
+
     casks = select_formula_or_cask(:DC).sort.filter_map do |name|
       name = name.split("/").last
       pretty_uninstalled(name) if cask_installed?(name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Don't output the new and deleted casks when running `brew update` on Linux.
Should the entire Cask API be skipped also? I imagine this is only relevant post API, as `homebrew-cask` would not traditionally been tapped on Linux.