### PR TITLE
Improve VSCode configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,9 +3,15 @@
     "Shopify.ruby-lsp",
     "sorbet.sorbet-vscode-extension",
     "github.vscode-github-actions",
-    "timonwong.shellcheck",
-    "foxundermoon.shell-format",
+    "anykeyh.simplecov-vscode",
+    "ms-azuretools.vscode-docker",
+    "github.vscode-pull-request-github",
     "davidanson.vscode-markdownlint",
+    "foxundermoon.shell-format",
+    "timonwong.shellcheck",
+    "ban.spellright",
+    "redhat.vscode-yaml",
+    "koichisasada.vscode-rdbg",
     "editorconfig.editorconfig"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,15 @@
 {
+  "search.exclude": {
+    "Library/Homebrew/vendor/bundle/ruby/": true,
+    "Library/Homebrew/vendor/gems/": true,
+    "Library/Homebrew/vendor/portable-ruby/": true
+  },
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
+  "editor.rulers": [
+    80,
+    118
+  ],
   "files.encoding": "utf8",
   "files.eol": "\n",
   "files.trimTrailingWhitespace": true,
@@ -9,6 +18,13 @@
   "rubyLsp.rubyVersionManager": {
     "identifier": "custom"
   },
+  "spellright.language": [
+    "en_GB",
+    "en_US"
+  ],
+  "spellright.documentTypes": [
+    "markdown",
+  ],
   "rubyLsp.customRubyCommand": "source ../../.vscode/ruby-lsp-activate.sh",
   "rubyLsp.bundleGemfile": "Library/Homebrew/Gemfile",
   "rubyLsp.formatter": "rubocop",
@@ -49,5 +65,7 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.shellcheck": "explicit"
     }
-  }
+  },
+  "simplecov-vscode.path": "Library/Homebrew/test/coverage/.resultset.json",
+  "simplecov-vscode.enabled": false
 }

--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -13,6 +13,12 @@ SimpleCov.start do
   # enables branch coverage as well as, the default, line coverage
   enable_coverage :branch
 
+  # enables coverage for `eval`ed code
+  enable_coverage_for_eval
+
+  # ensure that we always default to line coverage
+  primary_coverage :line
+
   # We manage the result cache ourselves and the default of 10 minutes can be
   # too low causing results from some integration tests to be dropped. This
   # causes random fluctuations in test coverage.


### PR DESCRIPTION
- Update outdated and add new recommended extensions
- Exclude some vendored code from search results by default
- Add more VSCode editor settings that are consistent with our linting
- Provide configuration for coverage visualization in VSCode but disable it by default
- Add SimpleCov coverage for `eval` and ensure that we always default to line coverage in case upstream defaults ever change