### PR TITLE
dev-cmd/typecheck: Support typechecking in taps

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -46,6 +46,8 @@ module Homebrew
       def run
         if (args.dir.present? || args.file.present?) && args.named.present?
           raise UsageError, "Cannot use `--dir` or `--file` when specifying a tap."
+        elsif args.fix? && args.named.present?
+          raise UsageError, "Cannot use `--fix` when specifying a tap."
         end
 
         update = args.update? || args.update_all?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Theoretically, anyway?
- Part of https://github.com/Homebrew/brew/issues/17297.

```shell
$ brew typecheck homebrew/bundle
No sorbet/ directory found. Maybe you want to run 'srb init'?

A type checker for Ruby

Usage:
  srb                                 Same as "srb t"
  srb (init | initialize)             Initializes the `sorbet` directory
  srb rbi [options]                   Manage the `sorbet` directory
  srb (t | tc | typecheck) [options]  Typechecks the code

Options:
  -h, --help     View help for this subcommand.
  --version      Show version.

For full help:
  https://sorbet.org
Check https://docs.brew.sh/Typechecking for more information on how to resolve these errors.
```