### PR TITLE
Revert "attestation: specialize error when `gh` is old"

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -62,9 +62,6 @@ module Homebrew
       return false if ENV.fetch("CI", false)
       return false if OS.unsupported_configuration?
 
-      gh_version = Formula["gh"].any_installed_version
-      return false if gh_version.nil? || gh_version < "2.49"
-
       # Always check credentials last to avoid unnecessary credential extraction.
       (Homebrew::EnvConfig.developer? || Homebrew::EnvConfig.devcmdrun?) && GitHub::API.credentials.present?
     end
@@ -81,7 +78,7 @@ module Homebrew
       #       to prevent a cycle during bootstrapping. This can eventually be resolved
       #       by vendoring a pure-Ruby Sigstore verifier client.
       with_env(HOMEBREW_NO_VERIFY_ATTESTATIONS: "1") do
-        @gh_executable = ensure_formula_installed!("gh", reason: "verifying attestations", latest: true).opt_bin/"gh"
+        @gh_executable = ensure_executable!("gh", reason: "verifying attestations", latest: true)
       end
 
       T.must(@gh_executable)

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -4,7 +4,6 @@ require "diagnostic"
 
 RSpec.describe Homebrew::Attestation do
   let(:fake_gh) { Pathname.new("/extremely/fake/gh") }
-  let(:fake_gh_formula) { instance_double(Formula, opt_bin: Pathname.new("/extremely/fake")) }
   let(:fake_old_gh) { Pathname.new("/extremely/fake/old/gh") }
   let(:fake_gh_creds) { "fake-gh-api-token" }
   let(:fake_error_status) { instance_double(Process::Status, exitstatus: 1, termsig: nil) }
@@ -67,12 +66,12 @@ RSpec.describe Homebrew::Attestation do
   end
 
   describe "::gh_executable" do
-    it "calls ensure_formula_installed" do
-      expect(described_class).to receive(:ensure_formula_installed!)
+    it "calls ensure_executable" do
+      expect(described_class).to receive(:ensure_executable!)
         .with("gh", reason: "verifying attestations", latest: true)
-        .and_return(fake_gh_formula)
+        .and_return(fake_gh)
 
-      described_class.gh_executable == fake_gh
+      described_class.gh_executable
     end
   end
 


### PR DESCRIPTION
Reverts Homebrew/brew#17926

Fixes https://github.com/Homebrew/brew/issues/18028