### PR TITLE
formula_auditor: fix eol check

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -587,10 +587,14 @@ module Homebrew
       metadata = SharedAudits.eol_data(name, formula.version.major)
       metadata ||= SharedAudits.eol_data(name, formula.version.major_minor)
 
-      return if metadata.blank? || (eol_date = metadata["eol"]).blank?
+      return if metadata.blank? || (eol = metadata["eol"]).blank?
+
+      is_eol = eol == true
+      is_eol ||= eol.is_a?(String) && (eol_date = Date.parse(eol)) <= Date.today
+      return unless is_eol
 
       message = "Product is EOL"
-      message += " since #{eol_date}" if Date.parse(eol_date.to_s) <= Date.today
+      message += " since #{eol_date}" if eol_date.present?
       message += ", see #{Formatter.url("https://endoflife.date/#{name}")}"
 
       problem message

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -10,9 +10,9 @@ module SharedAudits
 
   module_function
 
-  sig { params(product: String, cycle: String).returns(T.nilable(T::Hash[String, T::Hash[Symbol, T.untyped]])) }
+  sig { params(product: String, cycle: String).returns(T.nilable(T::Hash[String, T.untyped])) }
   def eol_data(product, cycle)
-    @eol_data ||= T.let({}, T.nilable(T::Hash[String, T::Hash[String, T.untyped]]))
+    @eol_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
     @eol_data["#{product}/#{cycle}"] ||= begin
       out, _, status = Utils::Curl.curl_output("--location", "https://endoflife.date/api/#{product}/#{cycle}.json")
       json = JSON.parse(out) if status.success?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

currently the eol check failed for bazel 7.3.0, https://github.com/Homebrew/homebrew-core/pull/180958 (which is a bit off)

reverting to the old logic