### PR TITLE
formula_auditor: reject more SPDX licenses

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -199,14 +199,30 @@ module Homebrew
       "LGPL-3.0" => ["LGPL-3.0-only", "LGPL-3.0-or-later"],
     }.freeze
 
+    # The following licenses are non-free/open based on multiple sources (e.g. Debian, Fedora, FSF, OSI, ...)
+    INCOMPATIBLE_LICENSES = [
+      "JSON",    # https://wiki.debian.org/DFSGLicenses#JSON_evil_license
+      "OPL-1.0", # https://wiki.debian.org/DFSGLicenses#Open_Publication_License_.28OPL.29_v1.0
+    ].freeze
+    INCOMPATIBLE_LICENSE_PREFIXES = [
+      "BUSL",     # https://spdx.org/licenses/BUSL-1.1.html#notes
+      "CC-BY-NC", # https://people.debian.org/~bap/dfsg-faq.html#no_commercial
+      "Elastic",  # https://www.elastic.co/licensing/elastic-license#Limitations
+      "SSPL",     # https://fedoraproject.org/wiki/Licensing/SSPL#License_Notes
+    ].freeze
+
     def audit_license
       if formula.license.present?
         licenses, exceptions = SPDX.parse_license_expression formula.license
 
-        sspl_licensed = licenses.any? { |license| license.to_s.start_with?("SSPL") }
-        if sspl_licensed && @core_tap
+        incompatible_licenses = licenses.select do |license|
+          license.to_s.start_with?(*INCOMPATIBLE_LICENSE_PREFIXES) || INCOMPATIBLE_LICENSES.include?(license.to_s)
+        end
+        if incompatible_licenses.present? && @core_tap
           problem <<~EOS
-            Formula #{formula.name} is SSPL-licensed. Software under the SSPL must not be packaged in homebrew/core.
+            Formula #{formula.name} contains incompatible licenses: #{incompatible_licenses}.
+            Formulae in homebrew/core must either use a Debian Free Software Guidelines license
+            or be released into the public domain. See https://docs.brew.sh/License-Guidelines
           EOS
         end
 
@@ -255,7 +271,7 @@ module Homebrew
 
         problem "Formula license #{licenses} does not match GitHub license #{Array(github_license)}."
 
-      elsif @new_formula && @core_tap
+      elsif @core_tap && !formula.disabled?
         problem "Formulae in homebrew/core must specify a license."
       end
     end


### PR DESCRIPTION
Also require licenses on non-disabled formulae

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I am working on adding licenses to all non-disabled formulae, so opening PR to make some license checks stricter.

The extra licenses are only some examples for now (too much effort to make exhaustive), e.g.
* `BUSL-1.1` and `Elastic-2.0` are ones we have manually rejected in Homebrew/core. For now, just reject all versions (can modify if terms change)
* `CC-BY-NC` I believe are going to be non-free due to non-commercial restriction
  * Debian has `CC-BY-NC-SA` example - https://wiki.debian.org/DFSGLicenses#Creative_Commons_Attribution-NonCommercial-ShareAlike_.28CC_BY-NC-SA.29
  * Fedora rejects all `CC-BY-NC-*` licenses. They do allow `CC-BY-ND-x.y` for "Allowed content". See https://docs.fedoraproject.org/en-US/legal/allowed-licenses/
  * https://www.gnu.org/licenses/license-list.html#NonFreeDocumentationLicenses
  * No check marks for any on FSF of OSI-approved on SPDX list
* `JSON` is non-free pretty much everywhere - https://wiki.debian.org/qa.debian.org/jsonevil

Could consider out-sourcing lists but not sure if there is one that fully matches our preferences.

Fedora has their own list but no idea on what their legal requirements are - https://docs.fedoraproject.org/en-US/legal/not-allowed-licenses/