### PR TITLE
unpack_strategy/dmg: fix UID handling

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -157,15 +157,10 @@ module UnpackStrategy
 
           bomfile_path = T.must(bomfile.path)
 
-          # Ditto will try to write as the UID, not the EUID and the Tempfile has 0700 permissions.
-          if Process.euid != Process.uid
-            FileUtils.chown(nil, Process.gid, bomfile_path)
-            FileUtils.chmod "g+rw", bomfile_path
-          end
-
           system_command!("ditto",
-                          args:    ["--bom", bomfile_path, "--", path, unpack_dir],
-                          verbose:)
+                          args:      ["--bom", bomfile_path, "--", path, unpack_dir],
+                          verbose:,
+                          reset_uid: true)
 
           FileUtils.chmod "u+w", Pathname.glob(unpack_dir/"**/*", File::FNM_DOTMATCH).reject(&:symlink?)
         end


### PR DESCRIPTION
The hack here still lead to permission problems. Use the new `reset_uid` instead.