### PR TITLE
extend/os/linux/keg: use `typed: strict`

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg.rb
+++ b/Library/Homebrew/extend/os/linux/keg.rb
@@ -1,9 +1,8 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 class Keg
-  undef binary_executable_or_library_files
-
+  sig { returns(T::Array[Pathname]) }
   def binary_executable_or_library_files
     elf_files
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Part of https://github.com/Homebrew/brew/issues/17297.