### PR TITLE
Fix message when disablement is in the past.

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -67,7 +67,13 @@ module DeprecateDisable
     if !disable_date && formula_or_cask.deprecation_date
       disable_date = formula_or_cask.deprecation_date >> REMOVE_DISABLED_TIME_WINDOW
     end
-    message = "#{message} It will be disabled on #{disable_date}." if disable_date
+    if disable_date
+      message += if disable_date < Date.today
+        " It was disabled on #{disable_date}."
+      else
+        " It will be disabled on #{disable_date}."
+      end
+    end
 
     message
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The message should use the correct tense, depending on the date.