### PR TITLE
Suppress sorbet type errors when using `undef'

### DIFF
--- a/Library/Homebrew/extend/os/linux/cleanup.rb
+++ b/Library/Homebrew/extend/os/linux/cleanup.rb
@@ -5,6 +5,7 @@ module Homebrew
   class Cleanup
     undef use_system_ruby?
 
+    sig { returns(T::Boolean) }
     def use_system_ruby?
       return false if Homebrew::EnvConfig.force_vendor_ruby?
 

--- a/Library/Homebrew/extend/os/linux/cleanup.rb
+++ b/Library/Homebrew/extend/os/linux/cleanup.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/linux/parser.rb
+++ b/Library/Homebrew/extend/os/linux/parser.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/mac/cleaner.rb
+++ b/Library/Homebrew/extend/os/mac/cleaner.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 class Cleaner

--- a/Library/Homebrew/extend/os/mac/cleanup.rb
+++ b/Library/Homebrew/extend/os/mac/cleanup.rb
@@ -1,10 +1,11 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew
   class Cleanup
     undef use_system_ruby?
 
+    sig { returns(T::Boolean) }
     def use_system_ruby?
       return false if Homebrew::EnvConfig.force_vendor_ruby?
 

--- a/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
+++ b/Library/Homebrew/extend/os/mac/dev-cmd/bottle.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/extend/os/mac/formula.rb
+++ b/Library/Homebrew/extend/os/mac/formula.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 class Formula

--- a/Library/Homebrew/extend/os/mac/formula_installer.rb
+++ b/Library/Homebrew/extend/os/mac/formula_installer.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 class FormulaInstaller

--- a/Library/Homebrew/extend/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/mac/linkage_checker.rb
@@ -6,6 +6,7 @@ class LinkageChecker
 
   private
 
+  sig { returns(T::Boolean) }
   def system_libraries_exist_in_cache?
     # In macOS Big Sur and later, system libraries do not exist on-disk and instead exist in a cache.
     MacOS.version >= :big_sur

--- a/Library/Homebrew/extend/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/mac/linkage_checker.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 class LinkageChecker

--- a/Library/Homebrew/extend/os/mac/readall.rb
+++ b/Library/Homebrew/extend/os/mac/readall.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module Readall

--- a/Library/Homebrew/extend/os/mac/simulate_system.rb
+++ b/Library/Homebrew/extend/os/mac/simulate_system.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module Homebrew

--- a/Library/Homebrew/sorbet/config
+++ b/Library/Homebrew/sorbet/config
@@ -4,4 +4,5 @@
 --ignore=/vendor/gems
 --ignore=/vendor/portable-ruby
 --ignore=/test/.gem
+--suppress-error-code=3008
 --suppress-error-code=7019

--- a/Library/Homebrew/sorbet/tapioca/compilers/args.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/args.rb
@@ -32,7 +32,7 @@ module Tapioca
       def decorate
         cmd = T.cast(constant, T.class_of(Homebrew::AbstractCommand))
         # This is a dummy class to make the `brew` command parsable
-        return if cmd.name == "Homebrew::Cmd::Brew"
+        return if cmd == Homebrew::Cmd::Brew
 
         args_class_name = T.must(T.must(cmd.args_class).name)
         root.create_class(args_class_name, superclass_name: "Homebrew::CLI::Args") do |klass|

--- a/Library/Homebrew/sorbet/tapioca/compilers/args.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/args.rb
@@ -31,6 +31,9 @@ module Tapioca
       sig { override.void }
       def decorate
         cmd = T.cast(constant, T.class_of(Homebrew::AbstractCommand))
+        # This is a dummy class to make the `brew` command parsable
+        return if cmd.name == "Homebrew::Cmd::Brew"
+
         args_class_name = T.must(T.must(cmd.args_class).name)
         root.create_class(args_class_name, superclass_name: "Homebrew::CLI::Args") do |klass|
           create_args_methods(klass, cmd.parser)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Per discussion on https://github.com/Homebrew/brew/issues/17998 this unblocks us from `strict` typing OS extensions (and a few other places), perhaps pending a re-architecture of how we approach such extensions.

I've also included a fix for https://github.com/Homebrew/brew/pull/18008#discussion_r1717790932 and included the output of `brew tc --update --suggest-typed`

See https://sorbet.org/docs/error-reference#3008