### PR TITLE
Add a bunch more `UNDEFINED_CONSTANTS` for startup.

### DIFF
--- a/Library/Homebrew/test/support/helper/cmd/brew-verify-undefined.rb
+++ b/Library/Homebrew/test/support/helper/cmd/brew-verify-undefined.rb
@@ -4,11 +4,52 @@
 require "cli/parser"
 
 UNDEFINED_CONSTANTS = %w[
+  AbstractDownloadStrategy
+  Addressable
+  Base64
+  CacheStore
   Cask::Cask
+  Cask::CaskLoader
+  Completions
+  CSV
   Formula
   Formulary
+  GitRepository
   Homebrew::API
+  Homebrew::Manpages
+  Homebrew::Settings
+  JSONSchemer
+  Kramdown
+  Metafiles
+  MethodSource
+  Minitest
+  Nokogiri
+  OS::Mac::Version
+  Parlour
+  PatchELF
+  Pry
+  ProgressBar
+  REXML
+  Red
+  RSpec
+  RuboCop
+  StackProf
+  Spoom
   Tap
+  Tapioca
+  UnpackStrategy
+  Utils::Analytics
+  Utils::Backtrace
+  Utils::Bottles
+  Utils::Curl
+  Utils::Fork
+  Utils::Git
+  Utils::GitHub
+  Utils::Link
+  Utils::Svn
+  Uri
+  Vernier
+  YARD
 ].freeze
 
 module Homebrew


### PR DESCRIPTION
This should avoid these getting included globally in future.

I found this list from a combination of https://github.com/Homebrew/brew/pull/17707/files, looking at the Gemfile and just looking around myself.