### PR TITLE
diagnostic: check for strings in XDG_DATA_DIRS

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -61,7 +61,8 @@ module Homebrew
 
       def check_xdg_data_dirs
         xdg_data_dirs = ENV.fetch("HOMEBREW_XDG_DATA_DIRS", nil)
-        return if xdg_data_dirs.blank? || xdg_data_dirs.split(":").include?(HOMEBREW_PREFIX/"share")
+        return if xdg_data_dirs.blank?
+        return if xdg_data_dirs.split(":").include?("#{HOMEBREW_PREFIX}/share")
 
         <<~EOS
           Homebrew's share was not found in your XDG_DATA_DIRS but you have


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

To fix https://github.com/orgs/Homebrew/discussions/5549

One thing this ignores is canonicalizing paths (e.g. "${HOMEBREW_PREFIX}/share/" or any other equivalent paths)