### PR TITLE
devcontainer: Tap `bundle` and `services` in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,20 @@
   "onCreateCommand": ".devcontainer/on-create-command.sh",
 
   "customizations": {
+    "codespaces": {
+      "repositories": {
+        "Homebrew/homebrew-bundle": {
+          "permissions": {
+            "contents": "write"
+          },
+          "Homebrew/homebrew-services": {
+            "permissions": {
+              "contents": "write"
+            }
+          }
+        }
+      }
+    },
     "vscode": {
       // Installing all necessary extensions for vscode
       // Taken from: .vscode/extensions.json

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -23,6 +23,9 @@ brew cleanup
 
 # actually tap homebrew/core, no longer done by default
 brew tap --force homebrew/core
+# tap some other repos so codespaces can be used for developing multiple taps
+brew tap homebrew/bundle
+brew tap homebrew/services
 
 # install some useful development things
 sudo apt-get update


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Yes, I wanted to do more Homebrew stuff from Codespaces on my iPad because I couldn't be bothered to get out of bed and walk downstairs to get my laptop.
- For that I needed my `Homebrew/brew` branch and `brew services` tapped, with sufficient permissions for write access so I could push commits.
- So I thought I'd do `bundle` as well as it seemed like another "would maybe use Codespaces for this" tap.
