### PR TITLE
enable `typed: strict` in Homebrew::CLI::Args

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -11,10 +11,9 @@ module Homebrew
       # Represents a processed option. The array elements are:
       #   0: short option name (e.g. "-d")
       #   1: long option name (e.g. "--debug")
-      #   2: ???
-      #   3: option description (e.g. "Print debugging information")
-      #   4: whether the option is hidden)
-      OptionsType = T.type_alias { T::Array[[String, T.nilable(String), NilClass, String, T::Boolean]] }
+      #   2: option description (e.g. "Print debugging information")
+      #   3: whether the option is hidden
+      OptionsType = T.type_alias { T::Array[[String, T.nilable(String), String, T::Boolean]] }
       # rubocop:enable Style/MutableConstant
 
       sig { returns(T::Array[String]) }

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -8,7 +8,13 @@ module Homebrew
     class Args < OpenStruct
       # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
       # rubocop:disable Style/MutableConstant
-      OptionsType = T.type_alias { T::Array[[String, T.nilable(String), T.nilable(String), String, T::Boolean]] }
+      # Represents a processed option. The array elements are:
+      #   0: short option name (e.g. "-d")
+      #   1: long option name (e.g. "--debug")
+      #   2: ???
+      #   3: option description (e.g. "Print debugging information")
+      #   4: whether the option is hidden)
+      OptionsType = T.type_alias { T::Array[[String, T.nilable(String), NilClass, String, T::Boolean]] }
       # rubocop:enable Style/MutableConstant
 
       sig { returns(T::Array[String]) }

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -670,7 +670,7 @@ module Homebrew
       def process_option(*args, type:, hidden: false)
         option, = @parser.make_switch(args)
         @processed_options.reject! { |existing| existing.second == option.long.first } if option.long.first.present?
-        @processed_options << [option.short.first, option.long.first, option.arg, option.desc.first, hidden]
+        @processed_options << [option.short.first, option.long.first, option.desc.first, hidden]
 
         args.pop # last argument is the description
         if type == :switch

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -16,7 +16,6 @@ module Homebrew
       # FIXME: Enable cop again when https://github.com/sorbet/sorbet/issues/3532 is fixed.
       # rubocop:disable Style/MutableConstant
       ArgType = T.type_alias { T.any(NilClass, Symbol, T::Array[String], T::Array[Symbol]) }
-      OptionsType = T.type_alias { T::Array[[String, T.nilable(String), T.nilable(String), String, T::Boolean]] }
       # rubocop:enable Style/MutableConstant
       HIDDEN_DESC_PLACEHOLDER = "@@HIDDEN@@"
       SYMBOL_TO_USAGE_MAPPING = T.let({
@@ -25,7 +24,7 @@ module Homebrew
       }.freeze, T::Hash[Symbol, String])
       private_constant :ArgType, :HIDDEN_DESC_PLACEHOLDER, :SYMBOL_TO_USAGE_MAPPING
 
-      sig { returns(OptionsType) }
+      sig { returns(Args::OptionsType) }
       attr_reader :processed_options
 
       sig { returns(T::Boolean) }
@@ -177,7 +176,7 @@ module Homebrew
         @constraints = T.let([], T::Array[[String, String]])
         @conflicts = T.let([], T::Array[T::Array[String]])
         @switch_sources = T.let({}, T::Hash[String, Symbol])
-        @processed_options = T.let([], OptionsType)
+        @processed_options = T.let([], Args::OptionsType)
         @non_global_processed_options = T.let([], T::Array[[String, ArgType]])
         @named_args_type = T.let(nil, T.nilable(ArgType))
         @max_named_args = T.let(nil, T.nilable(Integer))

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -199,7 +199,7 @@ module Commands
     return if path.blank?
 
     if (cmd_parser = Homebrew::CLI::Parser.from_cmd_path(path))
-      cmd_parser.processed_options.filter_map do |short, long, _, desc, hidden|
+      cmd_parser.processed_options.filter_map do |short, long, desc, hidden|
         next if hidden
 
         [long || short, desc]

--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -96,9 +96,10 @@ module Homebrew
       man_page_lines.compact.join("\n")
     end
 
+    sig { params(cmd_parser: CLI::Parser).returns(T::Array[String]) }
     def self.cmd_parser_manpage_lines(cmd_parser)
       lines = [format_usage_banner(cmd_parser.usage_banner_text)]
-      lines += cmd_parser.processed_options.filter_map do |short, long, _, desc, hidden|
+      lines += cmd_parser.processed_options.filter_map do |short, long, desc, hidden|
         next if hidden
 
         if long.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Part of https://github.com/Homebrew/brew/issues/17297

Also helpful as I hack at removing the `OpenStruct` dependency