### PR TITLE
brew.sh: further improve git describe cache.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -488,7 +488,7 @@ unset GIT_DESCRIBE_CACHE
 HOMEBREW_USER_AGENT_VERSION="${HOMEBREW_VERSION}"
 if [[ -z "${HOMEBREW_VERSION}" ]]
 then
-  HOMEBREW_VERSION=">=4.1.0 (shallow or no git repository)"
+  HOMEBREW_VERSION=">=4.3.0 (shallow or no git repository)"
   HOMEBREW_USER_AGENT_VERSION="4.X.Y"
 fi
 


### PR DESCRIPTION
- Use a safe fallback in case git rev-parse fails, e.g. if this is not considered a safe git directory. For hopefully obvious reasons: be super careful and strict with the inputs we'll accept here.
- Better handle more permission errors when reading or writing to/from the git describe cache. We don't care about these errors because they are likely a result of a multiuser configuration where Homebrew is run as several different users and this is just a (small) performance improvement.

Also, while we're here:
- bump the minimum version of `HOMEBREW_VERSION`