### PR TITLE
Remove global `include Kernel`

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -134,7 +134,7 @@ module Homebrew
             next
           end
           Migrator.migrate_if_needed(formula, force: args.force?)
-          Homebrew.reinstall_formula(
+          Homebrew::Reinstall.reinstall_formula(
             formula,
             flags:                      args.flags_only,
             installed_on_request:       args.named.present?,

--- a/Library/Homebrew/global.rbi
+++ b/Library/Homebrew/global.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module Homebrew
-  include Kernel
-end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -409,7 +409,7 @@ module Homebrew
       return if dry_run
 
       reinstallable_broken_dependents.each do |formula|
-        Homebrew.reinstall_formula(
+        Reinstall.reinstall_formula(
           formula,
           flags:,
           force_bottle:,

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -30,19 +30,17 @@ module Homebrew
   ).freeze
   private_constant :VENDOR_VERSION_FILE
 
-  module_function
-
-  def gemfile
+  def self.gemfile
     File.join(ENV.fetch("HOMEBREW_LIBRARY"), "Homebrew", "Gemfile")
   end
   private_class_method :gemfile
 
-  def bundler_definition
+  def self.bundler_definition
     @bundler_definition ||= Bundler::Definition.build(Bundler.default_gemfile, Bundler.default_lockfile, false)
   end
   private_class_method :bundler_definition
 
-  def valid_gem_groups
+  def self.valid_gem_groups
     install_bundler!
     require "bundler"
 
@@ -54,11 +52,11 @@ module Homebrew
     end
   end
 
-  def ruby_bindir
+  def self.ruby_bindir
     "#{RbConfig::CONFIG["prefix"]}/bin"
   end
 
-  def ohai_if_defined(message)
+  def self.ohai_if_defined(message)
     if defined?(ohai)
       $stderr.ohai message
     else
@@ -66,7 +64,7 @@ module Homebrew
     end
   end
 
-  def opoo_if_defined(message)
+  def self.opoo_if_defined(message)
     if defined?(opoo)
       $stderr.opoo message
     else
@@ -74,7 +72,7 @@ module Homebrew
     end
   end
 
-  def odie_if_defined(message)
+  def self.odie_if_defined(message)
     if defined?(odie)
       odie message
     else
@@ -83,7 +81,7 @@ module Homebrew
     end
   end
 
-  def setup_gem_environment!(setup_path: true)
+  def self.setup_gem_environment!(setup_path: true)
     require "rubygems"
     raise "RubyGems too old!" if Gem::Version.new(Gem::VERSION) < Gem::Version.new("2.2.0")
 
@@ -114,7 +112,7 @@ module Homebrew
     ENV["GEM_PATH"] = gem_home
   end
 
-  def install_gem!(name, version: nil, setup_gem_environment: true)
+  def self.install_gem!(name, version: nil, setup_gem_environment: true)
     setup_gem_environment! if setup_gem_environment
 
     specs = Gem::Specification.find_all_by_name(name, version)
@@ -141,7 +139,7 @@ module Homebrew
     odie_if_defined "failed to install the '#{name}' gem."
   end
 
-  def install_gem_setup_path!(name, version: nil, executable: name, setup_gem_environment: true)
+  def self.install_gem_setup_path!(name, version: nil, executable: name, setup_gem_environment: true)
     install_gem!(name, version:, setup_gem_environment:)
     return if find_in_path(executable)
 
@@ -151,14 +149,14 @@ module Homebrew
     EOS
   end
 
-  def find_in_path(executable)
+  def self.find_in_path(executable)
     ENV.fetch("PATH").split(":").find do |path|
       File.executable?(File.join(path, executable))
     end
   end
   private_class_method :find_in_path
 
-  def install_bundler!
+  def self.install_bundler!
     old_bundler_version = ENV.fetch("BUNDLER_VERSION", nil)
 
     setup_gem_environment!
@@ -174,7 +172,7 @@ module Homebrew
     ENV["BUNDLER_VERSION"] = old_bundler_version
   end
 
-  def user_gem_groups
+  def self.user_gem_groups
     @user_gem_groups ||= if GEM_GROUPS_FILE.exist?
       GEM_GROUPS_FILE.readlines(chomp: true)
     else
@@ -183,7 +181,7 @@ module Homebrew
   end
   private_class_method :user_gem_groups
 
-  def write_user_gem_groups(groups)
+  def self.write_user_gem_groups(groups)
     return if @user_gem_groups == groups && GEM_GROUPS_FILE.exist?
 
     # Write the file atomically, in case we're working parallel
@@ -206,12 +204,12 @@ module Homebrew
   end
   private_class_method :write_user_gem_groups
 
-  def forget_user_gem_groups!
+  def self.forget_user_gem_groups!
     GEM_GROUPS_FILE.truncate(0) if GEM_GROUPS_FILE.exist?
     @user_gem_groups = []
   end
 
-  def user_vendor_version
+  def self.user_vendor_version
     @user_vendor_version ||= if VENDOR_VERSION_FILE.exist?
       VENDOR_VERSION_FILE.read.to_i
     else
@@ -220,7 +218,7 @@ module Homebrew
   end
   private_class_method :user_vendor_version
 
-  def install_bundler_gems!(only_warn_on_failure: false, setup_path: true, groups: [])
+  def self.install_bundler_gems!(only_warn_on_failure: false, setup_path: true, groups: [])
     old_path = ENV.fetch("PATH", nil)
     old_gem_path = ENV.fetch("GEM_PATH", nil)
     old_gem_home = ENV.fetch("GEM_HOME", nil)


### PR DESCRIPTION
`include Kernel` is usually smell from `module_function`

* utils/gems: remove module_function
* reinstall: move to submodule (now `Homebrew::Reinstall.reinstall_formulae`, which is more consistent with install and upgrade modules)
* global.rbi: remove