### PR TITLE
bin/brew: tighten check in `export_homebrew_env_file`

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -108,14 +108,14 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Load Homebrew's variable configuration files from disk.
 export_homebrew_env_file() {
-  local env_file
+  local env_file="${1}"
+  local homebrew_env_regex="^HOMEBREW_[A-Z_]+=[^=]*$"
 
-  env_file="${1}"
   [[ -r "${env_file}" ]] || return 0
   while read -r line
   do
     # only load HOMEBREW_* lines
-    [[ "${line}" = "HOMEBREW_"* ]] || continue
+    [[ "${line}" =~ ${homebrew_env_regex} ]] || continue
     export "${line?}"
   done <"${env_file}"
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The current glob check will accept lines like

    HOMEBREW_FOO=bar BAD_ENV_VAR=baz

and happily export them, but we don't want that.

Let's tighten up the check to reject lines like the above.

