### PR TITLE
bin/brew: improve `brew` usage on multi-user systems

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -396,9 +396,6 @@ then
   fi
 fi
 
-# USER isn't always set so provide a fall back for `brew` and subprocesses.
-export USER="${USER:-$(id -un)}"
-
 # A depth of 1 means this command was directly invoked by a user.
 # Higher depths mean this command was invoked by another Homebrew command.
 export HOMEBREW_COMMAND_DEPTH="$((HOMEBREW_COMMAND_DEPTH + 1))"

--- a/bin/brew
+++ b/bin/brew
@@ -120,6 +120,9 @@ export_homebrew_env_file() {
   done <"${env_file}"
 }
 
+# We only want to read this from `brew.env` files instead of the environment.
+unset HOMEBREW_USER
+
 # First, load the system-wide configuration.
 unset SYSTEM_ENV_TAKES_PRIORITY
 if [[ -n "${HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY-}" ]]
@@ -146,6 +149,19 @@ export_homebrew_env_file "${HOMEBREW_USER_CONFIG_HOME}/brew.env"
 if [[ -n "${SYSTEM_ENV_TAKES_PRIORITY-}" ]]
 then
   export_homebrew_env_file "/etc/homebrew/brew.env"
+fi
+
+# USER isn't always set so provide a fall back for `brew` and subprocesses.
+export USER="${USER:-$(id -un)}"
+
+if [[ -n "${HOMEBREW_USER-}" && "${HOMEBREW_USER}" != "${USER}" ]]
+then
+  cat >&2 <<ERROR
+Error: \`brew\` is configured to be run by the \`${HOMEBREW_USER}\` user but you are running it as \`${USER}\`!
+Please contact your system administrator for the correct way to run \`brew\`.
+ERROR
+
+  exit 1
 fi
 
 # Copy and export all HOMEBREW_* variables previously mentioned in


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, you can get pretty far with using `brew` on a multi-user
system by creating a specific `homebrew` user that you can `su` to
whenever you want to run `brew`.

If you administrate one such system, this does demand a bit from your
users because `brew` will often ask you to do the equivalent of

    sudo chown "$(whoami)"

when users fail to run `brew` as your designated `homebrew` user.

Let's avoid this situation by allowing administrators to set
`HOMEBREW_USER` in a `brew.env` file, and error out accordingly when
this is set and `brew` isn't being run by the correct user.
