### PR TITLE
.rubocop.yml: add `respond_to_missing?` to `OptionalBooleanParameter` exemptions

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -408,9 +408,10 @@ Style/OpenStructUse:
 
 Style/OptionalBooleanParameter:
   AllowedMethods:
-    # This is an override of a core library method
+    # These are overrides of core library methods
     # see https://ruby-doc.org/3.3.4/Object.html#method-i-respond_to-3F
     - respond_to?
+    - respond_to_missing?
 
 # Rescuing `StandardError` is an understood default.
 Style/RescueStandardError:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a CI failure on `master`.[^1]

[^1]: https://github.com/Homebrew/brew/actions/runs/10469292764/job/28991992536
