### PR TITLE
faq: add missing `brew install` flag

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -136,7 +136,7 @@ Yes! It’s easy! If `brew tap` doesn't show `homebrew/core`, set yourself up to
 2. Run `brew tap --force homebrew/core` and wait for the clone to complete, then
 3. Run `brew edit <formula>` to open the formula in `EDITOR`.
 
-You don’t have to submit modifications back to `homebrew/core`, just edit the formula to what you personally need and `brew install <formula>`. As a bonus, `brew update` will merge your changes with upstream so you can still keep the formula up-to-date **with** your personal modifications!
+You don’t have to submit modifications back to `homebrew/core`, just edit the formula to what you personally need and `brew install --build-from-source <formula>`. As a bonus, `brew update` will merge your changes with upstream so you can still keep the formula up-to-date **with** your personal modifications!
 
 Note that if you are editing a core formula or cask you must set `HOMEBREW_NO_INSTALL_FROM_API=1` before using `brew install` or `brew update` otherwise they will ignore your local changes and default to the API.
 


### PR DESCRIPTION
Otherwise `brew install` keeps installing from bottle and ignoring users' edits.

Addresses https://github.com/orgs/Homebrew/discussions/2394#discussioncomment-10393518

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
