### PR TITLE
dev-cmd/edit: correct path types

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -62,7 +62,7 @@ module Homebrew
         exec_editor(*paths)
 
         if paths.any? do |path|
-             next if path.is_a?(String) && path == "--project"
+             next if path == "--project"
 
              !Homebrew::EnvConfig.no_install_from_api? &&
              !Homebrew::EnvConfig.no_env_hints? &&

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -41,7 +41,7 @@ module Homebrew
           # Sublime requires opting into the project editing path,
           # as opposed to VS Code which will infer from the .vscode path
           if which_editor(silent: true) == "subl"
-            ["--project", "#{HOMEBREW_REPOSITORY}/.sublime/homebrew.sublime-project"]
+            ["--project", HOMEBREW_REPOSITORY/".sublime/homebrew.sublime-project"]
           else
             # If no formulae are listed, open the project root in an editor.
             [HOMEBREW_REPOSITORY]
@@ -62,6 +62,8 @@ module Homebrew
         exec_editor(*paths)
 
         if paths.any? do |path|
+             next if path.is_a?(String) && path == "--project"
+
              !Homebrew::EnvConfig.no_install_from_api? &&
              !Homebrew::EnvConfig.no_env_hints? &&
              (core_formula_path?(path) || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a couple of type-related errors in the `brew edit` dev-cmd.

* Avoids passing the `--project` pseudopath to path checking methods
* Ensures the project path is a Pathname, not a String