### PR TITLE
Revert "bin/brew: tighten check in `export_homebrew_env_file`"

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -108,14 +108,14 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Load Homebrew's variable configuration files from disk.
 export_homebrew_env_file() {
-  local env_file="${1}"
-  local homebrew_env_regex="^HOMEBREW_[A-Z_]+=[^=]*$"
+  local env_file
 
+  env_file="${1}"
   [[ -r "${env_file}" ]] || return 0
   while read -r line
   do
     # only load HOMEBREW_* lines
-    [[ "${line}" =~ ${homebrew_env_regex} ]] || continue
+    [[ "${line}" = "HOMEBREW_"* ]] || continue
     export "${line?}"
   done <"${env_file}"
 }


### PR DESCRIPTION
Reverts Homebrew/brew#18095
Fixes https://github.com/Homebrew/brew/issues/18110
Fixes https://github.com/Homebrew/brew/issues/18111