### PR TITLE
sorbet: Ignore `Formula` and `Casks` directories

### DIFF
--- a/Library/Homebrew/sorbet/config
+++ b/Library/Homebrew/sorbet/config
@@ -4,5 +4,7 @@
 --ignore=/vendor/gems
 --ignore=/vendor/portable-ruby
 --ignore=/test/.gem
+--ignore=Formula
+--ignore=Casks
 --suppress-error-code=3008
 --suppress-error-code=7019


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- These get in the way of typechecking `cmd` Ruby scripts in package taps, and we don't want formulae or casks to be considered for typing.

Before:

```shell
$ brew typecheck homebrew/core
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/z/zlib.rb:1: Zlib was previously defined as a module https://srb.help/4012
     1 |class Zlib < Formula
        ^^^^^^^^^^^^^^^^^^^^
https://github.com/sorbet/sorbet/tree/263d0ae6713962fd66db0700d6290f6e43685b45/rbi/stdlib/zlib.rbi#L74: Previous definition
    74 |module Zlib
        ^^^^^^^^^^^
```

After:

```shell
$ brew typecheck homebrew/core
No errors! Great job.