### PR TITLE
rubocop: Don't run `Sorbet/StrictSigil` on Markdown lint config files

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -279,6 +279,7 @@ Sorbet/StrictSigil:
     - "/**/{Formula,Casks}/**/*.rb"
     - "**/{Formula,Casks}/**/*.rb"
     - "Homebrew/test/**/*.rb"
+    - "**/.md*.rb"
 
 Sorbet/TrueSigil:
   Enabled: true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- We were seeing weirdness with the requiring Sorbet `typed: strict` for `.mdl_*.rb` files in Homebrew/governance-private (https://github.com/Homebrew/governance-private/actions/runs/10474702994/job/29009583922).
- This should make that stop (once the RuboCop config file syncs over there).