### PR TITLE
language/python: avoid modifying all Python symlinks

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -330,8 +330,9 @@ module Language
           # Robustify symlinks to survive python patch upgrades
           @venv_root.find do |f|
             next unless f.symlink?
-            next unless (rp = f.realpath.to_s).start_with? HOMEBREW_CELLAR
+            next unless f.readlink.expand_path.to_s.start_with? HOMEBREW_CELLAR
 
+            rp = f.realpath.to_s
             version = rp.match %r{^#{HOMEBREW_CELLAR}/python@(.*?)/}o
             version = "@#{version.captures.first}" unless version.nil?
 


### PR DESCRIPTION
Homebrew Python will always have a realpath in HOMEBREW_CELLAR. Instead, check if the symlink target points to HOMEBREW_CELLAR.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Main goals is to retain valid symlinks like `python3 -> #{Formula["python@3.12"].opt_bin}/python3` otherwise the existing logic rewrites to Framework path on macOS which will always differ from Linux.

Still some other differences that need to be fixed up to improve `all` bottle chance, e.g.
* `lib64` symlink on Linux
* Realpath executable saved in `pyvenv.cfg`