### PR TITLE
language/python: reduce some differences between macOS and Linux venv

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -350,6 +350,18 @@ module Language
             prefix_file.atomic_write prefix_path
           end
 
+          # Reduce some differences between macOS and Linux venv
+          lib64 = @venv_root/"lib64"
+          lib64.make_symlink "lib" unless lib64.exist?
+          if (cfg_file = @venv_root/"pyvenv.cfg").exist?
+            cfg = cfg_file.read
+            framework = "Frameworks/Python.framework/Versions"
+            cfg.match(%r{= *(#{HOMEBREW_CELLAR}/(python@[\d.]+)/[^/]+(?:/#{framework}/[\d.]+)?/bin)}) do |match|
+              cfg.sub! match[1].to_s, Formula[match[2]].opt_bin
+              cfg_file.atomic_write cfg
+            end
+          end
+
           # Remove unnecessary activate scripts
           (@venv_root/"bin").glob("[Aa]ctivate*").map(&:unlink)
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Handing some differences I mentioned in #18128

---

For example, existing bottle diff for `autopep8` (ignoring sbom.spdx.json):
```diff
--- /Users/cho-m/Library/Caches/Homebrew/downloads/c954b3f9bb803a4bb095a966d09fd858b5c4a5a25bd7e836b4002794b42e24ab--autopep8--2.3.1.arm64_sonoma.bottle.tar.gz
+++ /Users/cho-m/Library/Caches/Homebrew/downloads/a3abd1a37e45b11c5aab5cbfbd37311ae19a0bfad33125d3dcc2abb30ae2fc91--autopep8--2.3.1.x86_64_linux.bottle.tar.gz
│   --- c954b3f9bb803a4bb095a966d09fd858b5c4a5a25bd7e836b4002794b42e24ab--autopep8--2.3.1.arm64_sonoma.bottle.tar
├── +++ a3abd1a37e45b11c5aab5cbfbd37311ae19a0bfad33125d3dcc2abb30ae2fc91--autopep8--2.3.1.x86_64_linux.bottle.tar
│ ├── file list
...
│ │ --rw-r--r--   0        0        0      358 2024-06-23 05:15:47.000000 autopep8/2.3.1/libexec/pyvenv.cfg
│ │ --rw-r--r--   0        0        0     6267 2024-06-23 05:15:47.000000 autopep8/2.3.1/sbom.spdx.json
│ │ +lrwxrwxrwx   0        0        0        0 2024-06-23 05:15:47.000000 autopep8/2.3.1/libexec/lib64 -> lib
│ │ +-rw-r--r--   0        0        0      316 2024-06-23 05:15:47.000000 autopep8/2.3.1/libexec/pyvenv.cfg
│ │ +-rw-r--r--   0        0        0    14591 2024-06-23 05:15:47.000000 autopep8/2.3.1/sbom.spdx.json
│ ├── autopep8/2.3.1/libexec/bin/python
│ │┄ symlink
│ │ @@ -1 +1 @@
│ │ -destination: ../../../../../opt/python@3.12/Frameworks/Python.framework/Versions/3.12/bin/python3.12
│ │ +destination: ../../../../../opt/python@3.12/bin/python3.12
│ ├── autopep8/2.3.1/libexec/bin/python3
│ │┄ symlink
│ │ @@ -1 +1 @@
│ │ -destination: ../../../../../opt/python@3.12/Frameworks/Python.framework/Versions/3.12/bin/python3.12
│ │ +destination: ../../../../../opt/python@3.12/bin/python3.12
│ ├── autopep8/2.3.1/libexec/bin/python3.12
│ │┄ symlink
│ │ @@ -1 +1 @@
│ │ -destination: ../../../../../opt/python@3.12/Frameworks/Python.framework/Versions/3.12/bin/python3.12
│ │ +destination: ../../../../../opt/python@3.12/bin/python3.12
│ ├── autopep8/2.3.1/libexec/pyvenv.cfg
│ │ @@ -1,5 +1,5 @@
│ │  home = @@HOMEBREW_PREFIX@@/opt/python@3.12/bin
│ │  include-system-site-packages = true
│ │  version = 3.12.4
│ │ -executable = @@HOMEBREW_CELLAR@@/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/bin/python3.12
│ │ +executable = @@HOMEBREW_CELLAR@@/python@3.12/3.12.4/bin/python3.12
│ │  command = @@HOMEBREW_PREFIX@@/opt/python@3.12/bin/python3.12 -m venv --without-pip --system-site-packages @@HOMEBREW_CELLAR@@/autopep8/2.3.1/libexec
```

---

Building bottle locally on ARM Sonoma and ARM Linux, I get same bottle (using this and  #18128 together):
```console
❯ brew bottle --json --only-json-tab autopep8
==> Determining autopep8 bottle rebuild...
==> Bottling autopep8--2.3.1.arm64_sonoma.bottle.1.tar.gz...
./autopep8--2.3.1.arm64_sonoma.bottle.1.tar.gz
  bottle do
    rebuild 1
    sha256 cellar: :any_skip_relocation, arm64_sonoma: "88ff2f77f37f2b66196108838ca19001548a2cddb0204b6670b8049164ef5900"
  end
```
```console
$ brew bottle --json --only-json-tab autopep8
==> Determining autopep8 bottle rebuild...
==> Bottling autopep8--2.3.1.aarch64_linux.bottle.1.tar.gz...
./autopep8--2.3.1.aarch64_linux.bottle.1.tar.gz
  bottle do
    rebuild 1
    sha256 cellar: :any_skip_relocation, aarch64_linux: "88ff2f77f37f2b66196108838ca19001548a2cddb0204b6670b8049164ef5900"
  end
```

---

One remaining situation is the dependency tree and python bindings. For example `uses_from_macos "libxml2"` will produce different bottles due to `libxml2` having Python bindings.

For `uses_from_macos` specifically, it may be possible to identify that macOS doesn't ship Python bindings so we don't need to track them on Linux.