### PR TITLE
shared_audits: remove `module_function`

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -8,10 +8,8 @@ require "utils/github/api"
 module SharedAudits
   URL_TYPE_HOMEPAGE = "homepage URL"
 
-  module_function
-
   sig { params(product: String, cycle: String).returns(T.nilable(T::Hash[String, T.untyped])) }
-  def eol_data(product, cycle)
+  def self.eol_data(product, cycle)
     @eol_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
     @eol_data["#{product}/#{cycle}"] ||= begin
       out, _, status = Utils::Curl.curl_output("--location", "https://endoflife.date/api/#{product}/#{cycle}.json")
@@ -22,7 +20,7 @@ module SharedAudits
   end
 
   sig { params(user: String, repo: String).returns(T.nilable(T::Hash[String, T.untyped])) }
-  def github_repo_data(user, repo)
+  def self.github_repo_data(user, repo)
     @github_repo_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
     @github_repo_data["#{user}/#{repo}"] ||= GitHub.repository(user, repo)
 
@@ -34,7 +32,7 @@ module SharedAudits
   end
 
   sig { params(user: String, repo: String, tag: String).returns(T.nilable(T::Hash[String, T.untyped])) }
-  def github_release_data(user, repo, tag)
+  private_class_method def self.github_release_data(user, repo, tag)
     id = "#{user}/#{repo}/#{tag}"
     url = "#{GitHub::API_URL}/repos/#{user}/#{repo}/releases/tags/#{tag}"
     @github_release_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
@@ -54,7 +52,7 @@ module SharedAudits
       T.nilable(String),
     )
   }
-  def github_release(user, repo, tag, formula: nil, cask: nil)
+  def self.github_release(user, repo, tag, formula: nil, cask: nil)
     release = github_release_data(user, repo, tag)
     return unless release
 
@@ -74,7 +72,7 @@ module SharedAudits
   end
 
   sig { params(user: String, repo: String).returns(T.nilable(T::Hash[String, T.untyped])) }
-  def gitlab_repo_data(user, repo)
+  def self.gitlab_repo_data(user, repo)
     @gitlab_repo_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
     @gitlab_repo_data["#{user}/#{repo}"] ||= begin
       out, _, status = Utils::Curl.curl_output("https://gitlab.com/api/v4/projects/#{user}%2F#{repo}")
@@ -85,7 +83,7 @@ module SharedAudits
   end
 
   sig { params(user: String, repo: String, tag: String).returns(T.nilable(T::Hash[String, T.untyped])) }
-  def gitlab_release_data(user, repo, tag)
+  private_class_method def self.gitlab_release_data(user, repo, tag)
     id = "#{user}/#{repo}/#{tag}"
     @gitlab_release_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
     @gitlab_release_data[id] ||= begin
@@ -103,7 +101,7 @@ module SharedAudits
       T.nilable(String),
     )
   }
-  def gitlab_release(user, repo, tag, formula: nil, cask: nil)
+  def self.gitlab_release(user, repo, tag, formula: nil, cask: nil)
     release = gitlab_release_data(user, repo, tag)
     return unless release
 
@@ -120,7 +118,7 @@ module SharedAudits
   end
 
   sig { params(user: String, repo: String).returns(T.nilable(String)) }
-  def github(user, repo)
+  def self.github(user, repo)
     metadata = github_repo_data(user, repo)
 
     return if metadata.nil?
@@ -138,7 +136,7 @@ module SharedAudits
   end
 
   sig { params(user: String, repo: String).returns(T.nilable(String)) }
-  def gitlab(user, repo)
+  def self.gitlab(user, repo)
     metadata = gitlab_repo_data(user, repo)
 
     return if metadata.nil?
@@ -154,7 +152,7 @@ module SharedAudits
   end
 
   sig { params(user: String, repo: String).returns(T.nilable(String)) }
-  def bitbucket(user, repo)
+  def self.bitbucket(user, repo)
     api_url = "https://api.bitbucket.org/2.0/repositories/#{user}/#{repo}"
     out, _, status = Utils::Curl.curl_output("--request", "GET", api_url)
     return unless status.success?
@@ -186,7 +184,7 @@ module SharedAudits
   end
 
   sig { params(url: String).returns(T.nilable(String)) }
-  def github_tag_from_url(url)
+  def self.github_tag_from_url(url)
     url = url.to_s
     tag = url.match(%r{^https://github\.com/[\w-]+/[\w-]+/archive/refs/tags/([^/]+)\.(tar\.gz|zip)$})
              .to_a
@@ -198,7 +196,7 @@ module SharedAudits
   end
 
   sig { params(url: String).returns(T.nilable(String)) }
-  def gitlab_tag_from_url(url)
+  def self.gitlab_tag_from_url(url)
     url = url.to_s
     url.match(%r{^https://gitlab\.com/[\w-]+/[\w-]+/-/archive/([^/]+)/})
        .to_a

--- a/Library/Homebrew/utils/shared_audits.rbi
+++ b/Library/Homebrew/utils/shared_audits.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module SharedAudits
-  include ::Kernel
-end


### PR DESCRIPTION
Removes the need for `include Kernel`