### PR TITLE
extend/ENV: remove fake `EnvMethods` from RBI

### DIFF
--- a/Library/Homebrew/extend/ENV.rbi
+++ b/Library/Homebrew/extend/ENV.rbi
@@ -1,42 +1,6 @@
 # typed: strict
 
-# @!visibility private
-module EnvMethods
-  include Kernel
-
-  sig { params(key: String).returns(T::Boolean) }
-  def key?(key); end
-
-  sig { params(key: String).returns(T.nilable(String)) }
-  def [](key); end
-
-  sig { params(key: String).returns(String) }
-  def fetch(key); end
-
-  sig { params(key: String, value: T.nilable(T.any(String, PATH))).returns(T.nilable(String)) }
-  def []=(key, value); end
-
-  sig { params(block: T.proc.params(arg0: [String, String]).returns(T::Boolean)).returns(T::Hash[String, String]) }
-  def select(&block); end
-
-  sig { params(block: T.proc.params(arg0: String).void).void }
-  def each_key(&block); end
-
-  sig { params(key: String).returns(T.nilable(String)) }
-  def delete(key); end
-
-  sig {
-    params(other: T.any(T::Hash[String, String], Sorbet::Private::Static::ENVClass))
-      .returns(Sorbet::Private::Static::ENVClass)
-  }
-  def replace(other); end
-
-  sig { returns(T::Hash[String, String]) }
-  def to_hash; end
-end
-
 module EnvActivation
-  include EnvMethods
   include Superenv
 end
 

--- a/Library/Homebrew/extend/ENV/shared.rbi
+++ b/Library/Homebrew/extend/ENV/shared.rbi
@@ -1,7 +1,16 @@
 # typed: strict
 
 module SharedEnvExtension
-  include EnvMethods
+  requires_ancestor { Sorbet::Private::Static::ENVClass }
+
+  # Overload to allow `PATH` values.
+  sig {
+    type_parameters(:U).params(
+      key:   String,
+      value: T.all(T.type_parameter(:U), T.nilable(T.any(String, PATH))),
+    ).returns(T.type_parameter(:U))
+  }
+  def []=(key, value); end
 end
 
 # @!visibility private


### PR DESCRIPTION
Can use `requires_ancestor` which simplifies this.

Keep the `[]=` overload for now since we rely on it in a few places. We don't actually overload `[]=` - it just accepts anything with `#to_str`.