### PR TITLE
Don't assume ENV is a superenv in RBI

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -75,9 +75,10 @@ class Build
     ENV.activate_extensions!(env: args.env)
 
     if superenv?(args.env)
-      ENV.keg_only_deps = keg_only_deps
-      ENV.deps = formula_deps
-      ENV.run_time_deps = run_time_deps
+      superenv = T.cast(ENV, Superenv)
+      superenv.keg_only_deps = keg_only_deps
+      superenv.deps = formula_deps
+      superenv.run_time_deps = run_time_deps
       ENV.setup_build_environment(
         formula:,
         cc:            args.cc,

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -31,7 +31,7 @@ module Homebrew
       sig { override.void }
       def run
         ENV.activate_extensions!
-        ENV.deps = args.named.to_formulae if superenv?(nil)
+        T.cast(ENV, Superenv).deps = args.named.to_formulae if superenv?(nil)
         ENV.setup_build_environment
 
         shell = if args.plain?

--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -28,7 +28,9 @@ module Homebrew
       def run
         ENV.activate_extensions!(env: args.env)
 
-        ENV.deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? } if superenv?(args.env)
+        if superenv?(args.env)
+          T.cast(ENV, Superenv).deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? }
+        end
         ENV.setup_build_environment
         if superenv?(args.env)
           # superenv stopped adding brew's bin but generally users will want it

--- a/Library/Homebrew/extend/ENV.rbi
+++ b/Library/Homebrew/extend/ENV.rbi
@@ -1,7 +1,7 @@
 # typed: strict
 
 module EnvActivation
-  include Superenv
+  include SharedEnvExtension
 end
 
 # @!visibility private

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -51,8 +51,8 @@ module SharedEnvExtension
     @debug_symbols = debug_symbols
     reset
   end
-  private :setup_build_environment
   alias generic_shared_setup_build_environment setup_build_environment
+  private :generic_shared_setup_build_environment
 
   sig { void }
   def reset
@@ -315,6 +315,14 @@ module SharedEnvExtension
 
   sig { void }
   def permit_arch_flags; end
+
+  sig { returns(Integer) }
+  def make_jobs
+    Homebrew::EnvConfig.make_jobs.to_i
+  end
+
+  sig { void }
+  def refurbish_args; end
 
   private
 

--- a/Library/Homebrew/extend/ENV/shared.rbi
+++ b/Library/Homebrew/extend/ENV/shared.rbi
@@ -12,14 +12,3 @@ module SharedEnvExtension
   }
   def []=(key, value); end
 end
-
-# @!visibility private
-class Sorbet
-  module Private
-    module Static
-      class ENVClass
-        include SharedEnvExtension
-      end
-    end
-  end
-end

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -149,15 +149,6 @@ module Stdenv
     append "CXX", "-stdlib=libc++" if compiler == :clang
   end
 
-  sig { returns(Integer) }
-  def make_jobs
-    Homebrew::EnvConfig.make_jobs.to_i
-  end
-
-  # This method does nothing in {Stdenv} since there is no argument refurbishment.
-  sig { void }
-  def refurbish_args; end
-
   private
 
   sig { params(before: Regexp, after: String).void }

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -21,7 +21,6 @@ module SharedEnvExtension
     # Normalise the system Perl version used, where multiple may be available
     self["VERSIONER_PERL_VERSION"] = MacOS.preferred_perl_version
   end
-  private :setup_build_environment
 
   sig { returns(T::Boolean) }
   def no_weak_imports_support?


### PR DESCRIPTION
Some methods are superenv specific, so it's better for type safety to not assume `ENV` is always a superenv and instead `T.cast` where necessary. Also moved some stdenv definitions to the shared ENV to help achieve this.

We still assume that `ENV.activate_extensions!` has been called and thus some form of `SharedEnvExtension` has been included.

⚠️ Depends on #18132.