### PR TITLE
Add typing for `Cask#url` and fix detected issues

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -230,6 +230,8 @@ module Cask
     end
 
     def checksumable?
+      return false if (url = self.url).nil?
+
       DownloadStrategyDetector.detect(url.to_s, url.using) <= AbstractFileDownloadStrategy
     end
 

--- a/Library/Homebrew/cask/cask.rbi
+++ b/Library/Homebrew/cask/cask.rbi
@@ -46,10 +46,14 @@ module Cask
 
     def on_system_blocks_exist?; end
 
+    sig { returns(T.nilable(MacOSVersion)) }
+    def on_system_block_min_os; end
+
     def sha256; end
 
     def staged_path; end
 
+    sig { returns(T.nilable(::Cask::URL)) }
     def url; end
 
     def version; end

--- a/Library/Homebrew/cask/url.rbi
+++ b/Library/Homebrew/cask/url.rbi
@@ -3,5 +3,22 @@
 module Cask
   class URL
     include Kernel
+
+    # TODO: Generate this
+
+    sig { returns(T.any(T::Class[T.anything], Symbol, NilClass)) }
+    def using; end
+
+    sig { returns(T.nilable(T.any(URI::Generic, String))) }
+    def referer; end
+
+    sig { returns(T::Hash[Symbol, T.untyped]) }
+    def specs; end
+
+    sig { returns(T.nilable(T.any(Symbol, String))) }
+    def user_agent; end
+
+    sig { returns(T.nilable(String)) }
+    def verified; end
   end
 end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -635,7 +635,7 @@ module Homebrew
           homebrew_curl_root_domains << domain if domain.present?
         end
       when Cask::Cask
-        return false if formula_or_cask.url.using != :homebrew_curl
+        return false if formula_or_cask.url&.using != :homebrew_curl
 
         domain = Addressable::URI.parse(formula_or_cask.url.to_s)&.domain
         homebrew_curl_root_domains << domain if domain.present?


### PR DESCRIPTION
Most runtime TypeErrors indicate we have failed to type things correctly so that those issues can be detected statically (typically due to `T.untyped`).

This PR fixes this error:

```
Error: exception while auditing betterdisplay: Parameter 'url': Expected type String, got type Cask::URL with value #<Cask::URL::DSL:0x00000001...lay/", :user_agent=>:default}>
Caller: /opt/homebrew/Library/Homebrew/cask/audit.rb:768
Definition: /opt/homebrew/Library/Homebrew/utils/shared_audits.rb:187 (SharedAudits.github_tag_from_url)
```

And also fixes the underlying issue so that this issue can be detected in the future via `brew typecheck`