### PR TITLE
dev-cmd/bottle: include installed_size in metadata

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -661,6 +661,7 @@ module Homebrew
           all_files = keg.find
                          .select(&:file?)
                          .map { |path| path.to_s.delete_prefix(keg_prefix) }
+          installed_size = keg.disk_usage
         end
 
         json = {
@@ -693,6 +694,7 @@ module Homebrew
                   "tab"             => tab.to_bottle_hash,
                   "path_exec_files" => path_exec_files,
                   "all_files"       => all_files,
+                  "installed_size"  => installed_size,
                 },
               },
             },

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -394,6 +394,7 @@ class GitHubPackages
         "sh.brew.bottle.digest"             => tar_gz_sha256,
         "sh.brew.bottle.glibc.version"      => glibc_version,
         "sh.brew.bottle.size"               => local_file_size.to_s,
+        "sh.brew.bottle.installed_size"     => tag_hash["installed_size"].to_s,
         "sh.brew.tab"                       => tab.to_json,
         "sh.brew.path_exec_files"           => path_exec_files_string,
       }.compact_blank


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Could be useful for approximating installations, like what `apt` and other package managers show.

Or adding bottle and approximate install size on https://formulae.brew.sh