### PR TITLE
utils/github: fix `too_many_open_prs?`

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -915,8 +915,8 @@ module GitHub
     homebrew_prs_count = 0
 
     API.paginate_graphql(query) do |result|
-      data = result["viewer"]
-      github_user = data["login"]
+      data = result.fetch("viewer")
+      github_user = data.fetch("login")
 
       # BrewTestBot can open as many PRs as it wants.
       return false if github_user.casecmp("brewtestbot").zero?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This doesn't count PRs from forks, so it only works correctly for
maintainers (and only if they use non-fork branches).

Let's fix that, and:
- simplify the logic by using `paginate_graphql`
- return early if it's impossible for them to have too many open PRs

