### PR TITLE
Speed up `CoreCaskTap#cask_files_by_name`

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1427,12 +1427,16 @@ class CoreCaskTap < AbstractCoreTap
   def cask_files_by_name
     return super if Homebrew::EnvConfig.no_install_from_api?
 
-    @cask_files_by_name ||= Homebrew::API::Cask.all_casks.each_with_object({}) do |item, hash|
-      name, cask_hash = item
-      # If there's more than one item with the same path: use the longer one to prioritise more specific results.
-      existing_path = hash[name]
-      new_path = path/cask_hash["ruby_source_path"]
-      hash[name] = new_path if existing_path.nil? || existing_path.to_s.length < new_path.to_s.length
+    @cask_files_by_name ||= begin
+      tap_path = path.to_s
+      Homebrew::API::Cask.all_casks.each_with_object({}) do |item, hash|
+        name, cask_hash = item
+        # If there's more than one item with the same path: use the longer one to prioritise more specific results.
+        existing_path = hash[name]
+        # Pathname equivalent is slow in a tight loop
+        new_path = File.join(tap_path, cask_hash.fetch("ruby_source_path"))
+        hash[name] = Pathname(new_path) if existing_path.nil? || existing_path.to_s.length < new_path.length
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is most noticeable when you have a large local tap and it ends up taking a nontrivial percentage of the overall run time for simple commands like `brew info gimp`. The improvement here is to just create paths later on in the loop which copies what we already do for formulae.

See b1ddb05

```console
$ hyperfine --parameter-list branch master,speed-up-cask-files-by-name --warmup 5 --setup 'git switch {branch}' 'brew info gimp'
Benchmark 1: brew info gimp (branch = master)
  Time (mean ± σ):      2.737 s ±  0.010 s    [User: 1.958 s, System: 0.732 s]
  Range (min … max):    2.720 s …  2.748 s    10 runs

Benchmark 2: brew info gimp (branch = speed-up-cask-files-by-name)
  Time (mean ± σ):      2.597 s ±  0.017 s    [User: 1.828 s, System: 0.724 s]
  Range (min … max):    2.577 s …  2.624 s    10 runs

Summary
  brew info gimp (branch = speed-up-cask-files-by-name) ran
    1.05 ± 0.01 times faster than brew info gimp (branch = master)
```

```rb
/u/l/Homebrew (speed-up-cask-files-by-name|✔) $ brew irb
==> Interactive Homebrew Shell
Example commands available with: `brew irb --examples`
brew(main):001> CoreCaskTap.instance.cask_files_by_name.take(15)
=> 
[["0-ad", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/0/0-ad.rb>],
 ["010-editor", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/0/010-editor.rb>],
 ["115", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/115.rb>],
 ["115browser", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/115browser.rb>],
 ["1clipboard", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1clipboard.rb>],
 ["1kc-razer", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1kc-razer.rb>],
 ["1password", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1password.rb>],
 ["1password-cli", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1password-cli.rb>],
 ["1password-cli@1", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1password-cli@1.rb>],
 ["1password-cli@beta", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1password-cli@beta.rb>],
 ["1password@7", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1password@7.rb>],
 ["1password@beta", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1password@beta.rb>],
 ["1password@nightly", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/1/1password@nightly.rb>],
 ["360safe", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/3/360safe.rb>],
 ["3dgenceslicer", #<Pathname:/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/3/3dgenceslicer.rb>]]
```