### PR TITLE
utils/github: use `paginate_graphql` in `sponsorships`

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -348,13 +348,15 @@ module GitHub
 
     sig {
       params(
-        query:     String,
-        variables: T.nilable(T::Hash[Symbol, T.untyped]),
-        _block:    T.proc.params(data: T::Hash[String, T.untyped]).returns(T::Hash[String, T.untyped]),
+        query:        String,
+        variables:    T.nilable(T::Hash[Symbol, T.untyped]),
+        scopes:       T::Array[String],
+        raise_errors: T::Boolean,
+        _block:       T.proc.params(data: T::Hash[String, T.untyped]).returns(T::Hash[String, T.untyped]),
       ).void
     }
-    def self.paginate_graphql(query, variables: nil, &_block)
-      result = API.open_graphql(query, variables:)
+    def self.paginate_graphql(query, variables: nil, scopes: [].freeze, raise_errors: true, &_block)
+      result = API.open_graphql(query, variables:, scopes:, raise_errors:)
 
       has_next_page = T.let(true, T::Boolean)
       variables ||= {}
@@ -363,7 +365,7 @@ module GitHub
         has_next_page = page_info["hasNextPage"]
         if has_next_page
           variables[:after] = page_info["endCursor"]
-          result = API.open_graphql(query, variables:)
+          result = API.open_graphql(query, variables:, scopes:, raise_errors:)
         end
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`sponsorships` has its own implementation of GraphQL pagination. We can
simplify this by using `paginate_graphql` instead.
