### PR TITLE
brew.sh: fix handling of dirty git repo

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -457,7 +457,9 @@ fi
 if [[ -n "${GIT_REVISION}" ]]
 then
   GIT_DESCRIBE_CACHE_FILE="${GIT_DESCRIBE_CACHE}/${GIT_REVISION}"
-  if [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]]
+  # Pass `--` to guard against `git` being confused by a file named `HEAD`.
+  if "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff-index --quiet --exit-code HEAD -- 2>/dev/null &&
+     [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]]
   then
     GIT_DESCRIBE_CACHE_HOMEBREW_VERSION="$(cat "${GIT_DESCRIBE_CACHE_FILE}")"
     if [[ -n "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" && "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" != *"-dirty" ]]

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -457,9 +457,7 @@ fi
 if [[ -n "${GIT_REVISION}" ]]
 then
   GIT_DESCRIBE_CACHE_FILE="${GIT_DESCRIBE_CACHE}/${GIT_REVISION}"
-  # Pass `--` to guard against `git` being confused by a file named `HEAD`.
-  if [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]] &&
-     "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff-index --quiet HEAD -- 2>/dev/null
+  if [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]] && "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff --quiet --no-ext-diff 2>/dev/null
   then
     read -r GIT_DESCRIBE_CACHE_HOMEBREW_VERSION <"${GIT_DESCRIBE_CACHE_FILE}"
     if [[ -n "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" && "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" != *"-dirty" ]]

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -458,8 +458,8 @@ if [[ -n "${GIT_REVISION}" ]]
 then
   GIT_DESCRIBE_CACHE_FILE="${GIT_DESCRIBE_CACHE}/${GIT_REVISION}"
   # Pass `--` to guard against `git` being confused by a file named `HEAD`.
-  if "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff-index --quiet --exit-code HEAD -- 2>/dev/null &&
-     [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]]
+  if [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]] &&
+     "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff-index --quiet HEAD -- 2>/dev/null
   then
     read -r GIT_DESCRIBE_CACHE_HOMEBREW_VERSION <"${GIT_DESCRIBE_CACHE_FILE}"
     if [[ -n "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" && "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" != *"-dirty" ]]

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -387,7 +387,7 @@ fi
 # Docker image deprecation
 if [[ -f "${HOMEBREW_REPOSITORY}/.docker-deprecate" ]]
 then
-  DOCKER_DEPRECATION_MESSAGE="$(cat "${HOMEBREW_REPOSITORY}/.docker-deprecate")"
+  read -r DOCKER_DEPRECATION_MESSAGE <"${HOMEBREW_REPOSITORY}/.docker-deprecate"
   if [[ -n "${GITHUB_ACTIONS}" ]]
   then
     echo "::warning::${DOCKER_DEPRECATION_MESSAGE}" >&2
@@ -443,13 +443,13 @@ GIT_REVISION=$("${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" rev-parse HEAD 2>/d
 # safe fallback in case git rev-parse fails e.g. if this is not considered a safe git directory
 if [[ -z "${GIT_REVISION}" ]]
 then
-  GIT_HEAD="$(cat "${HOMEBREW_REPOSITORY}/.git/HEAD" 2>/dev/null)"
+  read -r GIT_HEAD <"${HOMEBREW_REPOSITORY}/.git/HEAD" 2>/dev/null
   if [[ "${GIT_HEAD}" == "ref: refs/heads/master" ]]
   then
-    GIT_REVISION="$(cat "${HOMEBREW_REPOSITORY}/.git/refs/heads/master" 2>/dev/null)"
+    read -r GIT_REVISION <"${HOMEBREW_REPOSITORY}/.git/refs/heads/master" 2>/dev/null
   elif [[ "${GIT_HEAD}" == "ref: refs/heads/stable" ]]
   then
-    GIT_REVISION="$(cat "${HOMEBREW_REPOSITORY}/.git/refs/heads/stable" 2>/dev/null)"
+    read -r GIT_REVISION <"${HOMEBREW_REPOSITORY}/.git/refs/heads/stable" 2>/dev/null
   fi
   unset GIT_HEAD
 fi
@@ -461,7 +461,7 @@ then
   if "${HOMEBREW_GIT}" -C "${HOMEBREW_REPOSITORY}" diff-index --quiet --exit-code HEAD -- 2>/dev/null &&
      [[ -r "${GIT_DESCRIBE_CACHE_FILE}" ]]
   then
-    GIT_DESCRIBE_CACHE_HOMEBREW_VERSION="$(cat "${GIT_DESCRIBE_CACHE_FILE}")"
+    read -r GIT_DESCRIBE_CACHE_HOMEBREW_VERSION <"${GIT_DESCRIBE_CACHE_FILE}"
     if [[ -n "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" && "${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}" != *"-dirty" ]]
     then
       HOMEBREW_VERSION="${GIT_DESCRIBE_CACHE_HOMEBREW_VERSION}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We cache the output of `git describe`, but we don't check whether the
cached value is valid.

This fixes that.
