### PR TITLE
formula_auditor: ensure tag is not nil when doing online audit

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -802,7 +802,7 @@ module Homebrew
         tag = SharedAudits.github_tag_from_url(url)
         tag ||= formula.stable.specs[:tag]
 
-        if @online
+        if @online && !tag.nil?
           error = SharedAudits.github_release(owner, repo, tag, formula:)
           problem error if error
         end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

seeing some audit failure in https://github.com/Homebrew/homebrew-core/actions/runs/10541117023/job/29206546013?pr=182329

```
  Error: Parameter 'tag': Expected type String, got type NilClass
  Caller: /opt/homebrew/Library/Homebrew/formula_auditor.rb:806
  Definition: /opt/homebrew/Library/Homebrew/utils/shared_audits.rb:55 (SharedAudits.github_release)
```

as tag is nil in this case, `https://github.com/LuaJIT/LuaJIT/archive/f725e44cda8f359869bf8f92ce71787ddca45618.tar.gz`

relates to https://github.com/Homebrew/homebrew-core/pull/182329