### PR TITLE
shims/super/cc: unset `LD_LIBRARY_PATH`

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -5,6 +5,7 @@ then
   echo "${0##*/}: The build tool has reset ENV; --env=std required." >&2
   exit 1
 fi
+unset LD_LIBRARY_PATH
 unset RUBYLIB
 exec "${HOMEBREW_RUBY_PATH}" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -x "$0" "$@"
 #!/usr/bin/env ruby -W0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A local `ruby` build failed while building extensions, with:

```
*** Following extensions are not compiled:
-test-/file:
  Could not be configured. It will not be installed.
  /tmp/ruby-20240824-893184-ehcnsa/ruby-3.3.4/lib/mkmf.rb:480: The compiler failed to generate an executable file.
  You have to install development tools first.
  Check ext/-test-/file/mkmf.log for more details.
-test-/symbol:
  Could not be configured. It will not be installed.
  /tmp/ruby-20240824-893184-ehcnsa/ruby-3.3.4/lib/mkmf.rb:480: The compiler failed to generate an executable file.
  You have to install development tools first.
  Check ext/-test-/symbol/mkmf.log for more details.
[...]
```
    
`mkmf.log` indicated that the compiler shim failed to load `pathname`:

```
LD_LIBRARY_PATH=.:../../.. "gcc-13 -o conftest -I../../../.ext/include/aarch64-linux -I../../.././include -I../../.././ext/-test-/file -I/home/linuxbrew/.linuxbrew/opt/libyaml/include -I/home/linuxbrew/.linuxbrew/opt/openssl@3/include    -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wmisleading-indentation -Wundef  -fPIC conftest.c  -L. -L../../.. -L/home/linuxbrew/.linuxbrew/opt/libyaml/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/openssl@3/lib -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl@3/lib -L. -fstack-protector-strong -L/home/linuxbrew/.linuxbrew/opt/libyaml/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/libyaml/lib -L/home/linuxbrew/.linuxbrew/opt/openssl@3/lib  -Wl,-rpath,/home/linuxbrew/.linuxbrew/opt/openssl@3/lib -rdynamic -Wl,-export-dynamic -Wl,--no-as-needed     -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/ruby/3.3.4/lib -L/home/linuxbrew/.linuxbrew/Cellar/ruby/3.3.4/lib -lruby-static -lz -lrt -lrt -ldl -lcrypt -lm -lpthread   -lm -lpthread  -lc"
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/gcc-13:12:in `require': cannot load such file -- pathname (LoadError)
  from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/gcc-13:12:in `<main>'
```

I believe this was due to `../../..` in `LD_LIBRARY_PATH` containing `libruby.so`, causing the Ruby script to load the being-built Ruby library instead of the system/portable one.
