### PR TITLE
Speed up the Tap#formula_files method

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -715,7 +715,7 @@ class Tap
         formula_dir.children
       else
         formula_dir.find
-      end.select { formula_file?(_1) }
+      end.select { ruby_file?(_1) }
     else
       []
     end
@@ -756,7 +756,7 @@ class Tap
   # Check whether the file has a Ruby extension.
   sig { params(file: Pathname).returns(T::Boolean) }
   def ruby_file?(file)
-    file.extname == ".rb"
+    File.extname(file.to_s) == ".rb"
   end
   private :ruby_file?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We already know that files are going to be formula files if they are ruby files since we pull them out of the formula directory so that's all we really need to check for here. I was surprised that `Pathname#extname` was noticeably slower than turning it into a string and checking the end of it.

```
$ hyperfine --parameter-list branch master,speed-up-loading-cask-and-formula-file-names --warmup 5 --setup 'git switch {branch}' 'brew cat gimp'
Benchmark 1: brew cat gimp (branch = master)
  Time (mean ± σ):      2.195 s ±  0.031 s    [User: 1.395 s, System: 0.748 s]
  Range (min … max):    2.163 s …  2.273 s    10 runs

Benchmark 2: brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names)
  Time (mean ± σ):      1.845 s ±  0.034 s    [User: 1.073 s, System: 0.718 s]
  Range (min … max):    1.814 s …  1.920 s    10 runs

Summary
  brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names) ran
    1.19 ± 0.03 times faster than brew cat gimp (branch = master)
```

This also makes it a bit simpler for me to resurrect https://github.com/Homebrew/brew/pull/15489 since it means there is now one less reference to the `Tap#formula_file?` method.