### PR TITLE
Speed up the `Tap#formula_files` and `Tap#cask_files` methods

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -712,10 +712,10 @@ class Tap
       if formula_dir == path
         # We only want the top level here so we don't treat commands & casks as formulae.
         # Sharding is only supported in Formula/ and HomebrewFormula/.
-        formula_dir.children
+        Dir.glob(File.join(formula_dir.to_s, "*.rb"))
       else
-        formula_dir.find
-      end.select { formula_file?(_1) }
+        Dir.glob(File.join(formula_dir.to_s, "**/*.rb"))
+      end.map { Pathname(_1) }
     else
       []
     end
@@ -736,7 +736,7 @@ class Tap
   sig { returns(T::Array[Pathname]) }
   def cask_files
     @cask_files ||= if cask_dir.directory?
-      cask_dir.find.select { ruby_file?(_1) }
+      Dir.glob(File.join(cask_dir.to_s, "**/*.rb")).map { Pathname(_1) }
     else
       []
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These are slow because of some Pathname related reasons so it's been changed up to use `Dir.glob` instead and that makes a large difference. This is an alternative approach to #18163 that is a little bit faster.

```
$ hyperfine --parameter-list branch master,speed-up-loading-cask-and-formula-file-names,speed-up-loading-cask-and-formula-file-names_v2 --warmup 5 --setup 'git switch {branch}' 'brew cat gimp'
Benchmark 1: brew cat gimp (branch = master)
  Time (mean ± σ):      2.150 s ±  0.014 s    [User: 1.369 s, System: 0.745 s]
  Range (min … max):    2.126 s …  2.174 s    10 runs

Benchmark 2: brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names)
  Time (mean ± σ):      1.814 s ±  0.012 s    [User: 1.068 s, System: 0.711 s]
  Range (min … max):    1.797 s …  1.840 s    10 runs

Benchmark 3: brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names_v2)
  Time (mean ± σ):      1.489 s ±  0.009 s    [User: 0.905 s, System: 0.550 s]
  Range (min … max):    1.478 s …  1.503 s    10 runs

Summary
  brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names_v2) ran
    1.22 ± 0.01 times faster than brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names)
    1.44 ± 0.01 times faster than brew cat gimp (branch = master)
```