### PR TITLE
github_runner_matrix: filter incompatible testing formulae

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -210,9 +210,10 @@ class GitHubRunnerMatrix
 
   sig { params(runner: GitHubRunner).returns(T::Boolean) }
   def active_runner?(runner)
-    return true if @all_supported || @deleted_formulae.present?
+    return true if @all_supported
+    return true if @deleted_formulae.present? && !@dependent_matrix
 
-    testable_formulae(runner).present?
+    runner.spec.testing_formulae.present?
   end
 
   sig { params(runner: GitHubRunner).returns(T::Array[TestRunnerFormula]) }

--- a/Library/Homebrew/linux_runner_spec.rb
+++ b/Library/Homebrew/linux_runner_spec.rb
@@ -8,15 +8,17 @@ class LinuxRunnerSpec < T::Struct
   const :workdir, String
   const :timeout, Integer
   const :cleanup, T::Boolean
+  prop  :testing_formulae, T::Array[String], default: []
 
   sig {
     returns({
-      name:      String,
-      runner:    String,
-      container: T::Hash[Symbol, String],
-      workdir:   String,
-      timeout:   Integer,
-      cleanup:   T::Boolean,
+      name:             String,
+      runner:           String,
+      container:        T::Hash[Symbol, String],
+      workdir:          String,
+      timeout:          Integer,
+      cleanup:          T::Boolean,
+      testing_formulae: String,
     })
   }
   def to_h
@@ -27,6 +29,7 @@ class LinuxRunnerSpec < T::Struct
       workdir:,
       timeout:,
       cleanup:,
+      testing_formulae: testing_formulae.join(","),
     }
   end
 end

--- a/Library/Homebrew/macos_runner_spec.rb
+++ b/Library/Homebrew/macos_runner_spec.rb
@@ -6,14 +6,24 @@ class MacOSRunnerSpec < T::Struct
   const :runner, String
   const :timeout, Integer
   const :cleanup, T::Boolean
+  prop  :testing_formulae, T::Array[String], default: []
 
-  sig { returns({ name: String, runner: String, timeout: Integer, cleanup: T::Boolean }) }
+  sig {
+    returns({
+      name:             String,
+      runner:           String,
+      timeout:          Integer,
+      cleanup:          T::Boolean,
+      testing_formulae: String,
+    })
+  }
   def to_h
     {
       name:,
       runner:,
       timeout:,
       cleanup:,
+      testing_formulae: testing_formulae.join(","),
     }
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew test-bot` can occasionally spend a long time doing nothing when
testing dependents.[^1] This is because it takes a long time to work out
that there is nothing to do.

To fix this, let's adjust `brew determine-test-runners` to pass on only
the list of formulae for which there is work to be done so that
`brew test-bot` doesn't need to waste time working this out.

TODO: Update some tests.

[^1]: For example, it spends about 15 minutes doing nothing at https://github.com/Homebrew/homebrew-core/actions/runs/10500178069/job/29133091332?pr=180185

