### PR TITLE
cmd/update-report: improve formula file validation

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -753,34 +753,32 @@ class Tap
     end
   end
 
-  # Check whether the file has a Ruby extension.
-  sig { params(file: Pathname).returns(T::Boolean) }
-  def ruby_file?(file)
-    file.extname == ".rb"
+  sig { returns(Regexp) }
+  def formula_file_regex
+    @formula_file_regex ||= case formula_dir.basename.to_s
+    when "Formula"
+      %r{^Formula(/[^/]+)+\.rb$}
+    when "HomebrewFormula"
+      %r{^HomebrewFormula(/[^/]+)+\.rb$}
+    else
+      %r{^[^/]+\.rb$}
+    end
   end
-  private :ruby_file?
+  private :formula_file_regex
 
-  # Check whether the given path would present a {Formula} file in this {Tap}.
-  # Accepts either an absolute path or a path relative to this {Tap}'s path.
-  sig { params(file: T.any(String, Pathname)).returns(T::Boolean) }
+  # accepts the relative path of a file from {Tap}'s path
+  sig { params(file: String).returns(T::Boolean) }
   def formula_file?(file)
-    file = Pathname.new(file) unless file.is_a? Pathname
-    file = file.expand_path(path)
-    return false unless ruby_file?(file)
-    return false if cask_file?(file)
-
-    file.to_s.start_with?("#{formula_dir}/")
+    file.match?(formula_file_regex)
   end
 
-  # Check whether the given path would present a {Cask} file in this {Tap}.
-  # Accepts either an absolute path or a path relative to this {Tap}'s path.
-  sig { params(file: T.any(String, Pathname)).returns(T::Boolean) }
-  def cask_file?(file)
-    file = Pathname.new(file) unless file.is_a? Pathname
-    file = file.expand_path(path)
-    return false unless ruby_file?(file)
+  CASK_FILE_REGEX = %r{^Casks(/[^/]+)+\.rb$}
+  private_constant :CASK_FILE_REGEX
 
-    file.to_s.start_with?("#{cask_dir}/")
+  # accepts the relative path of a file from {Tap}'s path
+  sig { params(file: String).returns(T::Boolean) }
+  def cask_file?(file)
+    file.match?(CASK_FILE_REGEX)
   end
 
   # An array of all {Formula} names of this {Tap}.

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -755,13 +755,15 @@ class Tap
 
   sig { returns(Regexp) }
   def formula_file_regex
-    @formula_file_regex ||= case formula_dir.basename.to_s
-    when "Formula"
+    @formula_file_regex ||= case formula_dir
+    when path/"Formula"
       %r{^Formula(/[^/]+)+\.rb$}
-    when "HomebrewFormula"
+    when path/"HomebrewFormula"
       %r{^HomebrewFormula(/[^/]+)+\.rb$}
-    else
+    when path
       %r{^[^/]+\.rb$}
+    else
+      raise ArgumentError, "Unexpected formula_dir: #{formula_dir}"
     end
   end
   private :formula_file_regex

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -753,15 +753,21 @@ class Tap
     end
   end
 
+  RUBY_FILE_NAME_REGEX = %r{[^/]+\.rb}
+  private_constant :RUBY_FILE_NAME_REGEX
+
+  ZERO_OR_MORE_SUBDIRECTORIES_REGEX = %r{(?:[^/]+/)*}
+  private_constant :ZERO_OR_MORE_SUBDIRECTORIES_REGEX
+
   sig { returns(Regexp) }
   def formula_file_regex
     @formula_file_regex ||= case formula_dir
     when path/"Formula"
-      %r{^Formula(/[^/]+)+\.rb$}
+      %r{^Formula/#{ZERO_OR_MORE_SUBDIRECTORIES_REGEX.source}#{RUBY_FILE_NAME_REGEX.source}$}o
     when path/"HomebrewFormula"
-      %r{^HomebrewFormula(/[^/]+)+\.rb$}
+      %r{^HomebrewFormula/#{ZERO_OR_MORE_SUBDIRECTORIES_REGEX.source}#{RUBY_FILE_NAME_REGEX.source}$}o
     when path
-      %r{^[^/]+\.rb$}
+      /^#{RUBY_FILE_NAME_REGEX.source}$/o
     else
       raise ArgumentError, "Unexpected formula_dir: #{formula_dir}"
     end
@@ -774,7 +780,7 @@ class Tap
     file.match?(formula_file_regex)
   end
 
-  CASK_FILE_REGEX = %r{^Casks(/[^/]+)+\.rb$}
+  CASK_FILE_REGEX = %r{^Casks/#{ZERO_OR_MORE_SUBDIRECTORIES_REGEX.source}#{RUBY_FILE_NAME_REGEX.source}$}
   private_constant :CASK_FILE_REGEX
 
   # accepts the relative path of a file from {Tap}'s path

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -201,7 +201,6 @@ RSpec.describe Tap do
     expect(homebrew_foo_tap.tap_migrations).to eq("removed-formula" => "homebrew/foo")
     expect(homebrew_foo_tap.command_files).to eq([cmd_file])
     expect(homebrew_foo_tap.to_hash).to be_a(Hash)
-    expect(homebrew_foo_tap).to have_formula_file(formula_file)
     expect(homebrew_foo_tap).to have_formula_file("Formula/foo.rb")
     expect(homebrew_foo_tap).not_to have_formula_file("bar.rb")
     expect(homebrew_foo_tap).not_to have_formula_file("Formula/baz.sh")

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -3,6 +3,7 @@
 RSpec.describe Tap do
   include FileUtils
 
+  alias_matcher :have_cask_file, :be_cask_file
   alias_matcher :have_formula_file, :be_formula_file
   alias_matcher :have_custom_remote, :be_custom_remote
 
@@ -629,6 +630,103 @@ RSpec.describe Tap do
           },
         }
         expect(homebrew_foo_tap.pypi_formula_mappings).to eq expected_result
+      end
+    end
+
+    describe "#formula_file?" do
+      it "matches files from Formula/" do
+        tap = described_class.fetch("hard/core")
+        FileUtils.mkdir_p(tap.path/"Formula")
+
+        %w[
+          kvazaar.rb
+          Casks/kvazaar.rb
+          Casks/k/kvazaar.rb
+          Formula/kvazaar.sh
+          HomebrewFormula/kvazaar.rb
+          HomebrewFormula/k/kvazaar.rb
+        ].each do |relative_path|
+          expect(tap).not_to have_formula_file(relative_path)
+        end
+
+        %w[
+          Formula/kvazaar.rb
+          Formula/k/kvazaar.rb
+        ].each do |relative_path|
+          expect(tap).to have_formula_file(relative_path)
+        end
+      ensure
+        FileUtils.rm_rf(tap.path.parent) if tap
+      end
+
+      it "matches files from HomebrewFormula/" do
+        tap = described_class.fetch("hard/core")
+        FileUtils.mkdir_p(tap.path/"HomebrewFormula")
+
+        %w[
+          kvazaar.rb
+          Casks/kvazaar.rb
+          Casks/k/kvazaar.rb
+          Formula/kvazaar.rb
+          Formula/k/kvazaar.rb
+          HomebrewFormula/kvazaar.sh
+        ].each do |relative_path|
+          expect(tap).not_to have_formula_file(relative_path)
+        end
+
+        %w[
+          HomebrewFormula/kvazaar.rb
+          HomebrewFormula/k/kvazaar.rb
+        ].each do |relative_path|
+          expect(tap).to have_formula_file(relative_path)
+        end
+      ensure
+        FileUtils.rm_rf(tap.path.parent) if tap
+      end
+
+      it "matches files from the top-level directory" do
+        tap = described_class.fetch("hard/core")
+        FileUtils.mkdir_p(tap.path)
+
+        %w[
+          kvazaar.sh
+          Casks/kvazaar.rb
+          Casks/k/kvazaar.rb
+          Formula/kvazaar.rb
+          Formula/k/kvazaar.rb
+          HomebrewFormula/kvazaar.rb
+          HomebrewFormula/k/kvazaar.rb
+        ].each do |relative_path|
+          expect(tap).not_to have_formula_file(relative_path)
+        end
+
+        expect(tap).to have_formula_file("kvazaar.rb")
+      ensure
+        FileUtils.rm_rf(tap.path.parent) if tap
+      end
+    end
+
+    describe "#cask_file?" do
+      it "matches files from Casks/" do
+        tap = described_class.fetch("hard/core")
+
+        %w[
+          kvazaar.rb
+          Casks/kvazaar.sh
+          Formula/kvazaar.rb
+          Formula/k/kvazaar.rb
+          HomebrewFormula/kvazaar.rb
+          HomebrewFormula/k/kvazaar.rb
+        ].each do |relative_path|
+          expect(tap).not_to have_cask_file(relative_path)
+        end
+
+        %w[
+          Casks/kvazaar.rb
+          Casks/k/kvazaar.rb
+        ].each do |relative_path|
+          expect(tap).to have_cask_file(relative_path)
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, ruby files that are not in the Cask directory are considered to be formulae if a Formula or HomebrewFormula directory doesn't exist  which doesn't make sense. We know that these should only be in a few directories so we can check for that explicitly.

Beyond that the `Tap#cask_file?` and `Tap.formula_file?` methods were only used inside update-report so it doesn't make sense to turn them into pathnames and expand things when we know that each string will be a relative path from a tap that we can just check with a regex.

This change will stop other tap changes like new commands or changes to other directories like lib/ from showing up as new formulae.

I tried opening a PR for this a long time ago but I got busy with other things and it got closed by the stale bot.

- https://github.com/Homebrew/brew/pull/15489