### PR TITLE
github_packages: use official license annotation

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -306,7 +306,7 @@ class GitHubPackages
         "org.opencontainers.image.created"       => created_date,
         "org.opencontainers.image.description"   => bottle_hash["formula"]["desc"],
         "org.opencontainers.image.documentation" => documentation,
-        "org.opencontainers.image.license"       => bottle_hash["formula"]["license"],
+        "org.opencontainers.image.licenses"      => bottle_hash["formula"]["license"],
         "org.opencontainers.image.ref.name"      => version_rebuild,
         "org.opencontainers.image.revision"      => git_revision,
         "org.opencontainers.image.source"        => source,


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Should get #18169 in first to avoid invalid SPDX.

No idea what happens if we exceed the limit[^1] (maybe upload fails?), but it is possible for some formulae due to very complex licenses (e.g. the full `krb5` license[^2] would exceed limit)

[^1]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
[^2]: https://src.fedoraproject.org/rpms/krb5/blob/rawhide/f/krb5.spec#_82