### PR TITLE
Simplify globbing for casks and formula in taps

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -712,10 +712,10 @@ class Tap
       if formula_dir == path
         # We only want the top level here so we don't treat commands & casks as formulae.
         # Sharding is only supported in Formula/ and HomebrewFormula/.
-        Dir.glob(File.join(formula_dir.to_s, "*.rb"))
+        Pathname.glob(formula_dir/"*.rb")
       else
-        Dir.glob(File.join(formula_dir.to_s, "**/*.rb"))
-      end.map { Pathname(_1) }
+        Pathname.glob(formula_dir/"**/*.rb")
+      end
     else
       []
     end
@@ -736,7 +736,7 @@ class Tap
   sig { returns(T::Array[Pathname]) }
   def cask_files
     @cask_files ||= if cask_dir.directory?
-      Dir.glob(File.join(cask_dir.to_s, "**/*.rb")).map { Pathname(_1) }
+      Pathname.glob(cask_dir/"**/*.rb")
     else
       []
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

TLDR: @Bo98 was right in https://github.com/Homebrew/brew/pull/18165#issuecomment-2309159936.

This is yet another approach to f3a5a3c449cf004aee662966e6c8dd2ebe122c0f which got merged in over the weekend. It is much simpler than what we've got now with almost exactly the same performance characteristics. A better combination of maintainability and performance.

```console
$ hyperfine --parameter-list branch master,speed-up-loading-cask-and-formula-file-names_v4 --warmup 5 --setup 'git switch {branch}' 'brew cat gimp'
Benchmark 1: brew cat gimp (branch = master)
  Time (mean ± σ):      1.459 s ±  0.012 s    [User: 0.892 s, System: 0.536 s]
  Range (min … max):    1.448 s …  1.483 s    10 runs

Benchmark 2: brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names_v4)
  Time (mean ± σ):      1.456 s ±  0.009 s    [User: 0.889 s, System: 0.536 s]
  Range (min … max):    1.445 s …  1.468 s    10 runs

Summary
  brew cat gimp (branch = speed-up-loading-cask-and-formula-file-names_v4) ran
    1.00 ± 0.01 times faster than brew cat gimp (branch = master)
```