### PR TITLE
dev-cmd/bottle: use iso8601 for compliance with spec

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -685,7 +685,9 @@ module Homebrew
               "root_url" => bottle.root_url,
               "cellar"   => bottle_cellar.to_s,
               "rebuild"  => bottle.rebuild,
-              "date"     => Pathname(filename.to_s).mtime.strftime("%F"),
+              # date is used for org.opencontainers.image.created which is an RFC 3339 date-time.
+              # Time#iso8601 produces an XML Schema date-time that meets RFC 3339 ABNF.
+              "date"     => Pathname(filename.to_s).mtime.utc.iso8601,
               "tags"     => {
                 bottle_tag.to_s => {
                   "filename"        => filename.url_encode,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Based on https://specs.opencontainers.org/image-spec/annotations/#pre-defined-annotation-keys
> **org.opencontainers.image.created** date and time on which the image was built (string, date-time as defined by [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6)).