### PR TITLE
utils/shared_audits: GitHub urls can have '.' in repo and '/' in tag

### DIFF
--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -3,6 +3,28 @@
 require "utils/shared_audits"
 
 RSpec.describe SharedAudits do
+  describe "::github_tag_from_url" do
+    it "finds tags in archive urls" do
+      url = "https://github.com/a/b/archive/refs/tags/v1.2.3.tar.gz"
+      expect(described_class.github_tag_from_url(url)).to eq("v1.2.3")
+    end
+
+    it "finds tags in release urls" do
+      url = "https://github.com/a/b/releases/download/1.2.3/b-1.2.3.tar.bz2"
+      expect(described_class.github_tag_from_url(url)).to eq("1.2.3")
+    end
+
+    it "finds tags with slashes" do
+      url = "https://github.com/a/b/archive/refs/tags/c/d/e/f/g-v1.2.3.tar.gz"
+      expect(described_class.github_tag_from_url(url)).to eq("c/d/e/f/g-v1.2.3")
+    end
+
+    it "finds tags in orgs/repos with special characters" do
+      url = "https://github.com/a-b/c-d_e.f/archive/refs/tags/2.5.tar.gz"
+      expect(described_class.github_tag_from_url(url)).to eq("2.5")
+    end
+  end
+
   describe "::gitlab_tag_from_url" do
     it "doesn't find tags in invalid urls" do
       url = "https://gitlab.com/a/-/archive/v1.2.3/a-v1.2.3.tar.gz"

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -185,14 +185,8 @@ module SharedAudits
 
   sig { params(url: String).returns(T.nilable(String)) }
   def self.github_tag_from_url(url)
-    url = url.to_s
-    tag = url.match(%r{^https://github\.com/[\w-]+/[\w-]+/archive/refs/tags/([^/]+)\.(tar\.gz|zip)$})
-             .to_a
-             .second
-    tag ||= url.match(%r{^https://github\.com/[\w-]+/[\w-]+/releases/download/([^/]+)/})
-               .to_a
-               .second
-    tag
+    tag = url[%r{^https://github\.com/[\w-]+/[\w.-]+/archive/refs/tags/(.+)\.(tar\.gz|zip)$}, 1]
+    tag || url[%r{^https://github\.com/[\w-]+/[\w.-]+/releases/download/([^/]+)/}, 1]
   end
 
   sig { params(url: String).returns(T.nilable(String)) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Also clean up logic using String slices

dot example: `z.lua`
https://github.com/Homebrew/homebrew-core/blob/master/Formula/z/z.lua.rb#L4

slash example: `hz`
https://github.com/Homebrew/homebrew-core/blob/master/Formula/h/hz.rb#L4
