### PR TITLE
Fix misuse of `fork` in sandbox causing crashes

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -81,21 +81,21 @@ module Homebrew
 
             exec_args << "--HEAD" if f.head?
 
-            Utils.safe_fork do |error_pipe|
-              if Sandbox.available?
-                sandbox = Sandbox.new
-                f.logs.mkpath
-                sandbox.record_log(f.logs/"test.sandbox.log")
-                sandbox.allow_write_temp_and_cache
-                sandbox.allow_write_log(f)
-                sandbox.allow_write_xcode
-                sandbox.allow_write_path(HOMEBREW_PREFIX/"var/cache")
-                sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
-                sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
-                sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
-                sandbox.deny_all_network_except_pipe(error_pipe) unless f.class.network_access_allowed?(:test)
-                sandbox.exec(*exec_args)
-              else
+            if Sandbox.available?
+              sandbox = Sandbox.new
+              f.logs.mkpath
+              sandbox.record_log(f.logs/"test.sandbox.log")
+              sandbox.allow_write_temp_and_cache
+              sandbox.allow_write_log(f)
+              sandbox.allow_write_xcode
+              sandbox.allow_write_path(HOMEBREW_PREFIX/"var/cache")
+              sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
+              sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
+              sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
+              sandbox.deny_all_network unless f.class.network_access_allowed?(:test)
+              sandbox.run(*exec_args)
+            else
+              Utils.safe_fork do
                 exec(*exec_args)
               end
             end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -755,21 +755,14 @@ class BottleFormulaUnavailableError < RuntimeError
   end
 end
 
-# Raised when a child process sends us an exception over its error pipe.
+# Raised when a `Utils.safe_fork` exits with a non-zero code.
 class ChildProcessError < RuntimeError
-  attr_reader :inner, :inner_class
+  attr_reader :status
 
-  def initialize(inner)
-    @inner = inner
-    @inner_class = Object.const_get inner["json_class"]
+  def initialize(status)
+    @status = status
 
-    super <<~EOS
-      An exception occurred within a child process:
-        #{inner_class}: #{inner["m"]}
-    EOS
-
-    # Clobber our real (but irrelevant) backtrace with that of the inner exception.
-    set_backtrace inner["b"]
+    super "Forked child process failed: #{status}"
   end
 end
 

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Sandbox, :needs_macos do
 
   specify "#allow_write" do
     sandbox.allow_write path: file
-    sandbox.exec "touch", file
+    sandbox.run "touch", file
 
     expect(file).to exist
   end
@@ -65,10 +65,10 @@ RSpec.describe Sandbox, :needs_macos do
     end
   end
 
-  describe "#exec" do
+  describe "#run" do
     it "fails when writing to file not specified with ##allow_write" do
       expect do
-        sandbox.exec "touch", file
+        sandbox.run "touch", file
       end.to raise_error(ErrorDuringExecution)
 
       expect(file).not_to exist
@@ -80,7 +80,7 @@ RSpec.describe Sandbox, :needs_macos do
       allow(Utils).to receive(:popen_read).and_call_original
       allow(Utils).to receive(:popen_read).with("syslog", any_args).and_return("foo")
 
-      expect { sandbox.exec "false" }
+      expect { sandbox.run "false" }
         .to raise_error(ErrorDuringExecution)
         .and output(/foo/).to_stdout
     end
@@ -96,7 +96,7 @@ RSpec.describe Sandbox, :needs_macos do
       allow(Utils).to receive(:popen_read).and_call_original
       allow(Utils).to receive(:popen_read).with("syslog", any_args).and_return(with_bogus_error)
 
-      expect { sandbox.exec "false" }
+      expect { sandbox.run "false" }
         .to raise_error(ErrorDuringExecution)
         .and output(a_string_matching(/foo/).and(matching(/bar/).and(not_matching(/Python/)))).to_stdout
     end
@@ -104,28 +104,28 @@ RSpec.describe Sandbox, :needs_macos do
 
   describe "#disallow chmod on some directory" do
     it "formula does a chmod to opt" do
-      expect { sandbox.exec "chmod", "ug-w", HOMEBREW_PREFIX }.to raise_error(ErrorDuringExecution)
+      expect { sandbox.run "chmod", "ug-w", HOMEBREW_PREFIX }.to raise_error(ErrorDuringExecution)
     end
 
     it "allows chmod on a path allowed to write" do
       mktmpdir do |path|
         FileUtils.touch path/"foo"
         sandbox.allow_write_path(path)
-        expect { sandbox.exec "chmod", "ug-w", path/"foo" }.not_to raise_error(ErrorDuringExecution)
+        expect { sandbox.run "chmod", "ug-w", path/"foo" }.not_to raise_error(ErrorDuringExecution)
       end
     end
   end
 
   describe "#disallow chmod SUID or SGID on some directory" do
     it "formula does a chmod 4000 to opt" do
-      expect { sandbox.exec "chmod", "4000", HOMEBREW_PREFIX }.to raise_error(ErrorDuringExecution)
+      expect { sandbox.run "chmod", "4000", HOMEBREW_PREFIX }.to raise_error(ErrorDuringExecution)
     end
 
     it "allows chmod 4000 on a path allowed to write" do
       mktmpdir do |path|
         FileUtils.touch path/"foo"
         sandbox.allow_write_path(path)
-        expect { sandbox.exec "chmod", "4000", path/"foo" }.not_to raise_error(ErrorDuringExecution)
+        expect { sandbox.run "chmod", "4000", path/"foo" }.not_to raise_error(ErrorDuringExecution)
       end
     end
   end


### PR DESCRIPTION
First of all: I recommend viewing the diff with "hide whitespace" enabled - the changes aren't actually that drastic.

---

We've recently received reports of the sandbox hard crashing Ruby in macOS 15 beta for some users. We've also seen related reports on OS X 10.11 after a recent Tempfile crypto RNG change in Ruby 3.3.

The sandbox used to be a `fork` + `exec` but due to security tightening over time this has increased in complexity to the point we no longer actually have an `exec` inside the top-level fork and we are now breaking the golden rule of `fork` on macOS, as stated by `man fork`:

```
CAVEATS
     There are limits to what you can do in the child process.  To be totally
     safe you should restrict yourself to only executing async-signal safe
     operations until such time as one of the exec functions is called.  All
     APIs, including global data symbols, in any framework or library should
     be assumed to be unsafe after a fork() unless explicitly documented to be
     safe or async-signal safe.  If you need to use these frameworks in the
     child process, you must exec.  In this situation it is reasonable to exec
     yourself.
```

The flow was:

```
safe_fork ->
  configures sandbox (calls `Pathname` code which use CoreFoundation unicode normalisation - macOS 15 crasher)
  write sandbox file (uses crypto RNG for `Tempfile` - OS X 10.11 crasher)
  get current time
  create PTY
  create a second fork (inside `PTY.spawn`) ->
    configure child-side of PTY
    exec
  configure parent-side of PTY
  create IO threads
  read syslog
  write sandbox log
````

Instead, let's `Util.safe_fork` inside `sandbox.rb` closely around the minimum set of code required to be run in the child process before a final `exec`. This significantly reduces the surface area of external function calls we are doing in the child process pre-exec.

New flow:

```
configures sandbox
write sandbox file
get current time
create PTY
safe_fork ->
    configure child-side of PTY
    exec
configure parent-side of PTY
create IO threads
read syslog
write sandbox log
```

So only a small part is now under a `fork`.