### PR TITLE
Dockerfile: run `git gc --aggressive`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,9 @@ RUN --mount=type=cache,target=/home/linuxbrew/.cache,uid="${USER_ID}" \
   && ln -s ../Homebrew/bin/brew .linuxbrew/bin/brew \
   && git -C .linuxbrew/Homebrew remote set-url origin https://github.com/Homebrew/brew \
   && git -C .linuxbrew/Homebrew fetch origin \
+  && git -C .linuxbrew/Homebrew gc --aggressive \
   && HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap --force homebrew/core \
+  && git -C .linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core gc --aggressive \
   && brew install-bundler-gems --groups=all \
   && brew cleanup \
   && { git -C .linuxbrew/Homebrew config --unset gc.auto; true; } \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to #13278 and #15506.

The changes to our `docker` workflow might make it so that we can do
this without extending the time it takes for our CI to run.
