### PR TITLE
cmd/shellenv: improve for newer macOS using `/usr/libexec/path_helper`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -54,6 +54,13 @@ then
   HOMEBREW_DEFAULT_CACHE="${HOME}/Library/Caches/Homebrew"
   HOMEBREW_DEFAULT_LOGS="${HOME}/Library/Logs/Homebrew"
   HOMEBREW_DEFAULT_TEMP="/private/tmp"
+
+  HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
+
+  IFS=. read -r -a MACOS_VERSION_ARRAY <<<"${HOMEBREW_MACOS_VERSION}"
+  printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
+
+  unset MACOS_VERSION_ARRAY
 else
   CACHE_HOME="${HOMEBREW_XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_DEFAULT_CACHE="${CACHE_HOME}/Homebrew"
@@ -534,7 +541,6 @@ then
   HOMEBREW_PRODUCT="Homebrew"
   HOMEBREW_SYSTEM="Macintosh"
   [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]] && HOMEBREW_PROCESSOR="Intel"
-  HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X ${HOMEBREW_MACOS_VERSION}"
 
@@ -544,9 +550,6 @@ then
     # shellcheck disable=SC2034
     HOMEBREW_PHYSICAL_PROCESSOR="arm64"
   fi
-
-  IFS=. read -r -a MACOS_VERSION_ARRAY <<<"${HOMEBREW_MACOS_VERSION}"
-  printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"
 
   IFS=. read -r -a MACOS_VERSION_ARRAY <<<"${HOMEBREW_MACOS_OLDEST_ALLOWED}"
   printf -v HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC "%02d%02d%02d" "${MACOS_VERSION_ARRAY[@]}"

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -22,12 +22,14 @@ homebrew-shellenv() {
      [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -ge "140000" ]] &&
      [[ -x /usr/libexec/path_helper ]]
   then
-    if [[ ! -f "${HOMEBREW_PREFIX}/etc/paths" ]]
+    HOMEBREW_PATHS_FILE="${HOMEBREW_PREFIX}/etc/paths"
+
+    if [[ ! -f "${HOMEBREW_PATHS_FILE}" ]]
     then
-      printf '%s/bin\n%s/sbin\n' "${HOMEBREW_PREFIX}" "${HOMEBREW_PREFIX}" >"${HOMEBREW_PREFIX}/etc/paths"
+      printf '%s/bin\n%s/sbin\n' "${HOMEBREW_PREFIX}" "${HOMEBREW_PREFIX}" >"${HOMEBREW_PATHS_FILE}"
     fi
 
-    if [[ -r "${HOMEBREW_PREFIX}/etc/paths" ]]
+    if [[ -r "${HOMEBREW_PATHS_FILE}" ]]
     then
       PATH_HELPER_ROOT="${HOMEBREW_PREFIX}"
     fi

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -26,7 +26,7 @@ homebrew-shellenv() {
 
     if [[ ! -f "${HOMEBREW_PATHS_FILE}" ]]
     then
-      printf '%s/bin\n%s/sbin\n' "${HOMEBREW_PREFIX}" "${HOMEBREW_PREFIX}" >"${HOMEBREW_PATHS_FILE}"
+      printf '%s/bin\n%s/sbin\n' "${HOMEBREW_PREFIX}" "${HOMEBREW_PREFIX}" >"${HOMEBREW_PATHS_FILE}" 2>/dev/null
     fi
 
     if [[ -r "${HOMEBREW_PATHS_FILE}" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

On macOS 14 and newer, `/usr/libexec/path_helper` supports setting a
`PATH_HELPER_ROOT` environment variable.

With this set, `path_helper` checks `$PATH_HELPER_ROOT/etc/paths` and
`$PATH_HELPER_ROOT/etc/paths.d` in the same way it checks `/etc/paths`
and `/etc/paths.d`.

We can use this to simplify management of the user's `PATH` variable
when they do `brew shellenv`. In particular, if their system supports
it, we delegate setting the `PATH` environment variable to `path_helper`
instead of our own code. We also write a default `etc/paths` file if one
is not already present.

This is nicer because it simplifies management of the user's `PATH`
variable. For example, if a user wants a keg-only formula to be in their
`PATH`, they can simply add the necessary path to `etc/paths` or
`etc/paths.d` without having to do something like `brew link --force`
or adding to `PATH` themselves.

When `/usr/libexec/path_helper` is not available, we just fall back to
the existing code.

