### PR TITLE
Remove GraphQL debug output

### DIFF
--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -334,7 +334,6 @@ module GitHub
     def self.open_graphql(query, variables: nil, scopes: [].freeze, raise_errors: true)
       data = { query:, variables: }
       result = open_rest("#{API_URL}/graphql", scopes:, data:, request_method: "POST")
-      odebug "GraphQL Query Response", result
 
       if raise_errors
         if result["errors"].present?


### PR DESCRIPTION
Let's get this ready to go since we don't want to accidentally leak
private information.
