### PR TITLE
bump*: tweak autobump message

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -87,6 +87,13 @@ module Homebrew
           We'd still love your contributions, though, so try another one
           that's not in the autobump list:
             #{Formatter.url("#{cask.tap.remote}/blob/master/.github/autobump.txt")}
+
+          If BrewTestBot doesn't open a version update pull request in the next 3
+          hours, it might be because there is an existing open pull request for
+          the #{cask.token} cask.
+
+          If this is the case, please open a version update pull request manually:
+            #{Formatter.url("https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#cask-related-pull-request")}
         EOS
 
         odie "You have too many PRs open: close or merge some first!" if GitHub.too_many_open_prs?(cask.tap)

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -118,6 +118,13 @@ module Homebrew
           We'd still love your contributions, though, so try another one
           that's not in the autobump list:
             #{Formatter.url("#{formula.tap.remote}/blob/master/.github/autobump.txt")}
+
+          If BrewTestBot doesn't open a version update pull request in the next 3
+          hours, it might be because there is an existing open pull request for
+          the #{formula.name} formula.
+
+          If this is the case, please open a version update pull request manually:
+            #{Formatter.url("https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#formulae-related-pull-request")}
         EOS
 
         odie "You have too many PRs open: close or merge some first!" if GitHub.too_many_open_prs?(formula.tap)

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -181,7 +181,16 @@ module Homebrew
         end
         if (tap = formula_or_cask.tap) && !tap.allow_bump?(name)
           skip = true
-          text = "#{text.split.first} is autobumped so will have bump PRs opened by BrewTestBot every ~3 hours.\n"
+          what = text.split.first
+          text = <<~EOS
+            #{what} is autobumped so will have bump PRs opened by BrewTestBot every ~3 hours.
+
+            If BrewTestBot doesn't open a version update pull request in the next 3
+            hours, it might be because there is an existing open pull request for
+            the #{what.downcase}.
+
+            If this is the case, please open a version update pull request manually.
+          EOS
         end
         return false unless skip
 

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -187,7 +187,7 @@ module Homebrew
 
             If BrewTestBot doesn't open a version update pull request in the next 3
             hours, it might be because there is an existing open pull request for
-            the #{what.downcase}.
+            the #{T.must(what).downcase}.
 
             If this is the case, please open a version update pull request manually.
           EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We've had multiple issues filed because BrewTestBot isn't bumping
formulae, and they're not able to `brew bump` it.

Let's adjust the messaging to encourage them to open a PR manually
instead.

We should probably also make BrewTestBot ignore open PRs that aren't
version-bump PRs, but I'd prefer to punt on that for now.
