### PR TITLE
devcontainer: Fix Codespace repository permissions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,11 +14,11 @@
         "Homebrew/homebrew-bundle": {
           "permissions": {
             "contents": "write"
-          },
-          "Homebrew/homebrew-services": {
-            "permissions": {
-              "contents": "write"
-            }
+          }
+        },
+        "Homebrew/homebrew-services": {
+          "permissions": {
+            "contents": "write"
           }
         }
       }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As pointed out in https://github.com/Homebrew/brew/commit/8b3be30a839788972a56b44a1ffacf8f7bee4053#r146048190 (thank you, @noahsettersten!), this was nested wrong. I think this fixes it? JSON is hard!