### PR TITLE
formula: make `audit_result` a kwarg in `inreplace`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2872,7 +2872,7 @@ class Formula
     ).void
   }
   def inreplace(paths, before = nil, after = nil, old_audit_result = nil, audit_result: true, &block)
-    # NOTE: must check for `#nil?` and not `#blank?`.
+    # NOTE: must check for `#nil?` and not `#blank?`, or else `old_audit_result = false` will not call `odeprecated`.
     unless old_audit_result.nil?
       # odeprecated "inreplace(paths, before, after, #{old_audit_result})",
       #             "inreplace(paths, before, after, audit_result: #{old_audit_result})"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2863,14 +2863,21 @@ class Formula
   # @api public
   sig {
     params(
-      paths:        T.any(T::Enumerable[T.any(String, Pathname)], String, Pathname),
-      before:       T.nilable(T.any(Pathname, Regexp, String)),
-      after:        T.nilable(T.any(Pathname, String, Symbol)),
-      audit_result: T::Boolean,
-      block:        T.nilable(T.proc.params(s: StringInreplaceExtension).void),
+      paths:            T.any(T::Enumerable[T.any(String, Pathname)], String, Pathname),
+      before:           T.nilable(T.any(Pathname, Regexp, String)),
+      after:            T.nilable(T.any(Pathname, String, Symbol)),
+      old_audit_result: T.nilable(T::Boolean),
+      audit_result:     T::Boolean,
+      block:            T.nilable(T.proc.params(s: StringInreplaceExtension).void),
     ).void
   }
-  def inreplace(paths, before = nil, after = nil, audit_result = true, &block) # rubocop:disable Style/OptionalBooleanParameter
+  def inreplace(paths, before = nil, after = nil, old_audit_result = nil, audit_result: true, &block)
+    # NOTE: must check for `#nil?` and not `#blank?`.
+    unless old_audit_result.nil?
+      # odeprecated "inreplace(paths, before, after, #{old_audit_result})",
+      #             "inreplace(paths, before, after, audit_result: #{old_audit_result})"
+      audit_result = old_audit_result
+    end
     Utils::Inreplace.inreplace(paths, before, after, audit_result:, &block)
   rescue Utils::Inreplace::Error => e
     onoe e.to_s

--- a/Library/Homebrew/utils/string_inreplace_extension.rb
+++ b/Library/Homebrew/utils/string_inreplace_extension.rb
@@ -37,7 +37,7 @@ class StringInreplaceExtension
     ).returns(T.nilable(String))
   }
   def gsub!(before, after, old_audit_result = nil, audit_result: true)
-    # NOTE: must check for `#nil?` and not `#blank?`.
+    # NOTE: must check for `#nil?` and not `#blank?`, or else `old_audit_result = false` will not call `odeprecated`.
     unless old_audit_result.nil?
       # odeprecated "gsub!(before, after, #{old_audit_result})",
       #             "gsub!(before, after, audit_result: #{old_audit_result})"

--- a/Library/Homebrew/utils/string_inreplace_extension.rb
+++ b/Library/Homebrew/utils/string_inreplace_extension.rb
@@ -29,10 +29,20 @@ class StringInreplaceExtension
   #
   # @api public
   sig {
-    params(before: T.any(Pathname, Regexp, String), after: T.any(Pathname, String), audit_result: T::Boolean)
-      .returns(T.nilable(String))
+    params(
+      before:           T.any(Pathname, Regexp, String),
+      after:            T.any(Pathname, String),
+      old_audit_result: T.nilable(T::Boolean),
+      audit_result:     T::Boolean,
+    ).returns(T.nilable(String))
   }
-  def gsub!(before, after, audit_result = true) # rubocop:disable Style/OptionalBooleanParameter
+  def gsub!(before, after, old_audit_result = nil, audit_result: true)
+    # NOTE: must check for `#nil?` and not `#blank?`.
+    unless old_audit_result.nil?
+      # odeprecated "gsub!(before, after, #{old_audit_result})",
+      #             "gsub!(before, after, audit_result: #{old_audit_result})"
+      audit_result = old_audit_result
+    end
     before = before.to_s if before.is_a?(Pathname)
     result = inreplace_string.gsub!(before, after.to_s)
     errors << "expected replacement of #{before.inspect} with #{after.inspect}" if audit_result && result.nil?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows us to get rid of a RuboCop disable, and will make formulae
easier to read.
