### PR TITLE
Adjust typing around #check_pull_requests

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -467,7 +467,7 @@ module Homebrew
 
       sig {
         params(formula: Formula, tap_remote_repo: String, state: T.nilable(String),
-               version: T.nilable(String)).returns(T.nilable(T::Array[String]))
+               version: T.nilable(String)).void
       }
       def check_pull_requests(formula, tap_remote_repo, state: nil, version: nil)
         tap = formula.tap

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -629,7 +629,17 @@ module GitHub
     pull_requests || []
   end
 
-  def self.check_for_duplicate_pull_requests(name, tap_remote_repo, file:, quiet:, state: nil, version: nil)
+  sig {
+    params(
+      name:            String,
+      tap_remote_repo: String,
+      file:            String,
+      quiet:           T::Boolean,
+      state:           T.nilable(String),
+      version:         T.nilable(String),
+    ).void
+  }
+  def self.check_for_duplicate_pull_requests(name, tap_remote_repo, file:, quiet: false, state: nil, version: nil)
     pull_requests = fetch_pull_requests(name, tap_remote_repo, state:, version:)
 
     pull_requests.select! do |pr|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew bump-formula-pr` is encountering a type error (e.g., as seen in [a recent homebrew/core autobump run](https://github.com/Homebrew/homebrew-core/actions/runs/10647361012/job/29515230778)), as the inferred return type of `GitHub#check_for_duplicate_pull_requests` doesn't align with the explicit return type of `#check_pull_requests`:

```
Error: Return value: Expected type T.nilable(T::Array[String]), got type Module with value T::Private::Types::Void::VOID
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:137
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:472 (Homebrew::DevCmd::BumpFormulaPr#check_pull_requests)
```

This addresses the issue by adding a type signature with a `void` return type to `#check_for_duplicate_pull_requests` and setting the return type of `#check_pull_requests` to `void` as well. The return type from `#check_pull_requests` isn't used, so a `void` return type is arguably a better reflection of the method's behavior. The `#check_pull_requests` method in `BumpCaskPr` has a `void` return type, so this change brings the `BumpFormulaPr` method in line.