### PR TITLE
completions: improve performance on zsh

### DIFF
--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -46,7 +46,7 @@ __brew_completion_caching_policy() {
   (( $#tmp )) || return 0
 
   # otherwise, invalidate if latest tap index file is missing or newer than cache file
-  tmp=( $(brew --repository)/Library/Taps/*/*/.git/index(om[1]N) )
+  tmp=( "${HOMEBREW_REPOSITORY:-$(brew --repository)}"/Library/Taps/*/*/.git/index(om[1]N) )
   [[ -z $tmp || $tmp -nt $1 ]]
 }
 
@@ -66,7 +66,7 @@ __brew_installed_formulae() {
   [[ -prefix '-' ]] && return 0
 
   local -a formulae
-  formulae=($(brew list --formula))
+  formulae=($(command ls "${HOMEBREW_CELLAR:-$(brew --cellar)}" 2>/dev/null))
   _describe -t formulae 'installed formulae' formulae
 }
 
@@ -98,7 +98,7 @@ __brew_installed_casks() {
 
   local -a list
   local expl
-  list=( $(brew list --cask 2>/dev/null) )
+  list=($(command ls "$(brew --caskroom)" 2>/dev/null))
   _wanted list expl 'installed casks' compadd -a list
 }
 
@@ -114,7 +114,16 @@ __brew_installed_taps() {
   [[ -prefix '-' ]] && return 0
 
   local -a taps
-  taps=($(brew tap))
+  local dir taplib
+  taplib=${HOMEBREW_REPOSITORY:-$(brew --repository)}/Library/Taps
+
+  for dir in "${taplib}"/*/*
+  do
+    [[ -d ${dir} ]] || continue
+    dir=${dir#"${taplib}"/}
+    dir=${dir/homebrew-/}
+    taps+=("${dir}")
+  done
   _describe -t installed-taps 'installed taps' taps
 }
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -50,7 +50,7 @@ __brew_completion_caching_policy() {
   (( $#tmp )) || return 0
 
   # otherwise, invalidate if latest tap index file is missing or newer than cache file
-  tmp=( $(brew --repository)/Library/Taps/*/*/.git/index(om[1]N) )
+  tmp=( "${HOMEBREW_REPOSITORY:-$(brew --repository)}"/Library/Taps/*/*/.git/index(om[1]N) )
   [[ -z $tmp || $tmp -nt $1 ]]
 }
 
@@ -70,7 +70,7 @@ __brew_installed_formulae() {
   [[ -prefix '-' ]] && return 0
 
   local -a formulae
-  formulae=($(brew list --formula))
+  formulae=($(command ls "${HOMEBREW_CELLAR:-$(brew --cellar)}" 2>/dev/null))
   _describe -t formulae 'installed formulae' formulae
 }
 
@@ -102,7 +102,7 @@ __brew_installed_casks() {
 
   local -a list
   local expl
-  list=( $(brew list --cask 2>/dev/null) )
+  list=($(command ls "$(brew --caskroom)" 2>/dev/null))
   _wanted list expl 'installed casks' compadd -a list
 }
 
@@ -118,7 +118,16 @@ __brew_installed_taps() {
   [[ -prefix '-' ]] && return 0
 
   local -a taps
-  taps=($(brew tap))
+  local dir taplib
+  taplib=${HOMEBREW_REPOSITORY:-$(brew --repository)}/Library/Taps
+
+  for dir in "${taplib}"/*/*
+  do
+    [[ -d ${dir} ]] || continue
+    dir=${dir#"${taplib}"/}
+    dir=${dir/homebrew-/}
+    taps+=("${dir}")
+  done
   _describe -t installed-taps 'installed taps' taps
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

By avoiding unneeded `brew` calls we can make zsh completions much faster.

As a rough measurement, completion for `brew list` used to take ~4s on my machine, but now it's instant.
