### PR TITLE
Fix SyntaxError introduced by a refactor in bc0f5ee

### DIFF
--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -64,7 +64,7 @@ _create_lock() {
     flock -n "${lock_file_descriptor}"
   elif [[ -x "${python}" ]]
   then
-    "${python}" -c "import fcntl; fcntl.flock(${lock_fd}, fcntl.LOCK_EX | fcntl.LOCK_NB)"
+    "${python}" -c "import fcntl; fcntl.flock(${lock_file_descriptor}, fcntl.LOCK_EX | fcntl.LOCK_NB)"
   else
     onoe "Cannot create \`brew ${command_name_and_args}\` lock due to missing/too old ruby/flock/python, please avoid running Homebrew in parallel."
   fi


### PR DESCRIPTION
Fixes the syntax error introduced by an incomplete refactor in bc0f5ee

```
$ brew update
==> Updating Homebrew...
To restore the stashed changes to /usr/local/Homebrew, run:
  cd /usr/local/Homebrew && git stash pop
  File "<string>", line 1
    import fcntl; fcntl.flock(, fcntl.LOCK_EX | fcntl.LOCK_NB)
                              ^
SyntaxError: invalid syntax
```

Caused by missed variable rename in https://github.com/Homebrew/brew/commit/bc0f5ee62a9f410d81d9a8820083a387a82573f7

The fix finishes the refactor by completing the variable rename and brings the code base back to a (more) consistent state. 

- [✓] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [✓] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [✓] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [✓] Have you successfully run `brew style` with your changes locally?
- [✓] Have you successfully run `brew typecheck` with your changes locally?
- [✓] Have you successfully run `brew tests` with your changes locally?

-----
