### PR TITLE
shims/super/cc: do not pass -pipe

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -294,7 +294,6 @@ class Cmd
 
     return args if !refurbish_args? && !configure?
 
-    args << "-pipe"
     args << "-w" unless configure?
     args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}"
     args.concat(optflags) unless runtime_cpu_detection?


### PR DESCRIPTION
I've been wondering for a long time why we pass `-pipe` to C compilers systematically.

- On modern filesystems its effect is homeopathic
- it has no effect with modern clang, because the assembler is now integrated into clang, so only the linker is called as a separate, and it never supported pipes anyway
- the only other compiler we use for a few formulas is GCC, but even there the effect is marginal on modern OSes

At least, it did not hurt. Well, until clang 16 broke pipe input to the assembler: there, passing `-pipe` can make GCC actually fail to compile. See https://github.com/OpenMathLib/OpenBLAS/issues/4888 for details.

I'll be filing a bug with Apple about that (it's a regression in clang), but I don't expect it to be fixed soon. Given that `-pipe` use is historical, I think it's time to say goodbye to it.