### PR TITLE
list.sh: improve arg parsing, support `brew ls`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -168,7 +168,7 @@ case "$@" in
     homebrew-command-path "$@" && exit 0
     ;;
   # falls back to cmd/list.rb on a non-zero return
-  list*)
+  list* | ls*)
     source "${HOMEBREW_LIBRARY}/Homebrew/list.sh"
     homebrew-list "$@" && exit 0
     ;;

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -18,4 +18,6 @@ RSpec.describe Homebrew::Cmd::List do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  # TODO: add a test for the shell fast-path (`brew_sh`)
 end


### PR DESCRIPTION
* Apply `list.sh` optimisation to `brew ls`
* Use `getopts` for parsing to support combined shorthand options (e.g. `brew list -1r` now works in the fast path)