### PR TITLE
Invalidate Bootsnap cache on Gemfile.lock changes

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -278,6 +278,7 @@ Sorbet/StrictSigil:
     - "Taps/**/*"
     - "/**/{Formula,Casks}/**/*.rb"
     - "**/{Formula,Casks}/**/*.rb"
+    - "Homebrew/{standalone,startup}/*.rb" # These are loaded before sorbet-runtime
     - "Homebrew/test/**/*.rb"
 
 Sorbet/TrueSigil:

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -295,6 +295,7 @@ module Homebrew
 
         cleanup_cache
         cleanup_empty_api_source_directories
+        cleanup_bootsnap
         cleanup_logs
         cleanup_lockfiles
         cleanup_python_site_packages
@@ -314,7 +315,6 @@ module Homebrew
         return if periodic
 
         cleanup_portable_ruby
-        cleanup_bootsnap
       else
         args.each do |arg|
           formula = begin
@@ -528,9 +528,11 @@ module Homebrew
 
     def cleanup_bootsnap
       bootsnap = cache/"bootsnap"
-      return unless bootsnap.exist?
+      return unless bootsnap.directory?
 
-      cleanup_path(bootsnap) { bootsnap.rmtree }
+      bootsnap.each_child do |subdir|
+        cleanup_path(subdir) { subdir.rmtree } if subdir.basename.to_s != Homebrew.bootsnap_key
+      end
     end
 
     def cleanup_cache_db(rack = nil)

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -362,11 +362,4 @@ homebrew-vendor-install() {
   lock "vendor-install ${VENDOR_NAME}"
   fetch
   install
-
-  # Bootsnap needs cleaned up on a new Ruby version.
-  # It's cleaned up by every `brew cleanup` run anyway so not a big deal to do it here, too.
-  if [[ "${VENDOR_NAME}" == "ruby" ]]
-  then
-    rm -rf "${HOMEBREW_CACHE}/bootsnap"
-  fi
 }

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:disable Sorbet/StrictSigil
+# typed: true
 # frozen_string_literal: true
 
 # This file is included before any other files. It intentionally has typing disabled and has minimal use of `require`.

--- a/Library/Homebrew/standalone/sorbet.rb
+++ b/Library/Homebrew/standalone/sorbet.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: true
 # frozen_string_literal: true
 
 require "sorbet-runtime"

--- a/Library/Homebrew/startup/bootsnap.rb
+++ b/Library/Homebrew/startup/bootsnap.rb
@@ -1,15 +1,35 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
 
 homebrew_bootsnap_enabled = HOMEBREW_USING_PORTABLE_RUBY &&
                             ENV["HOMEBREW_NO_BOOTSNAP"].nil? &&
                             !ENV["HOMEBREW_BOOTSNAP"].nil?
 
+module Homebrew
+  def self.bootsnap_key
+    @bootsnap_key ||= begin
+      require "digest/sha2"
+
+      checksum = Digest::SHA256.new
+      begin
+        checksum.file(HOMEBREW_LIBRARY_PATH/"Gemfile.lock")
+      rescue SystemCallError
+        # If it's inaccessible, let's just assume it's empty.
+      end
+      checksum << user_gem_groups.join(",")
+
+      "#{RUBY_VERSION}-#{checksum}"
+    end
+  end
+end
+
 if homebrew_bootsnap_enabled
   require "bootsnap"
 
   cache = ENV.fetch("HOMEBREW_CACHE", nil) || ENV.fetch("HOMEBREW_DEFAULT_CACHE", nil)
   raise "Needs HOMEBREW_CACHE or HOMEBREW_DEFAULT_CACHE!" if cache.nil? || cache.empty?
+
+  cache = File.join(cache, "bootsnap", Homebrew.bootsnap_key)
 
   # We never do `require "vendor/bundle/ruby/..."` or `require "vendor/portable-ruby/..."`,
   # so let's slim the cache a bit by excluding them.

--- a/Library/Homebrew/startup/bootsnap.rbi
+++ b/Library/Homebrew/startup/bootsnap.rbi
@@ -1,5 +1,10 @@
 # typed: strict
 
+module Homebrew
+  sig { returns(String) }
+  def self.bootsnap_key; end
+end
+
 module Bootsnap
   sig {
     params(

--- a/Library/Homebrew/startup/config.rb
+++ b/Library/Homebrew/startup/config.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: true
 # frozen_string_literal: true
 
 raise "HOMEBREW_BREW_FILE was not exported! Please call bin/brew directly!" unless ENV["HOMEBREW_BREW_FILE"]

--- a/Library/Homebrew/startup/ruby_path.rb
+++ b/Library/Homebrew/startup/ruby_path.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: true
 # frozen_string_literal: true
 
 RUBY_PATH = Pathname.new(RbConfig.ruby).freeze


### PR DESCRIPTION
The majority of the time, this isn't necessary. Bootsnap builds an incremental cache correctly.

However we get edge cases when a gem shadows a default gem only under certain gem groups and have occasionally had reports of Bootsnap randomly breaking after a while.

Let's just save ourselves the stress and more aggressively version the Bootsnap cache. Now the whole cache is invalidated whenever `Gemfile.lock` changes or Ruby is updated.

This does in turn have a benefit that `brew cleanup` is now smarter. Now that we version the cache we don't need to nuke the whole cache every time we run `brew cleanup` and can now detect what cache is stale and what isn't. As a result, I've now enabled it for periodic `brew cleanup`.

Probably unblocks at least the LoadError part of #18216.