### PR TITLE
utils/github: use `x-access-token`

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -680,7 +680,7 @@ module GitHub
 
   private_class_method def self.add_auth_token_to_url!(url)
     if API.credentials_type == :env_token
-      url.sub!(%r{^https://github\.com/}, "https://#{API.credentials}@github.com/")
+      url.sub!(%r{^https://github\.com/}, "https://x-access-token:#{API.credentials}@github.com/")
     end
     url
   end


### PR DESCRIPTION
This is mandatory for GitHub App tokens.

It seems to also work for PATs - documentation isn't exactly clear on that but I think it works.

Probably fixes https://github.com/Homebrew/actions/issues/584