### PR TITLE
Revert "build(deps-dev): bump logger from 1.6.0 to 1.6.1 in /Library/Homebrew"

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     kramdown (2.4.0)
       rexml
     language_server-protocol (3.17.0.3)
-    logger (1.6.1)
+    logger (1.6.0)
     method_source (1.1.0)
     minitest (5.25.1)
     netrc (0.11.0)
@@ -156,6 +156,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm-linux
   arm64-darwin
   x86_64-darwin
   x86_64-linux


### PR DESCRIPTION
Reverts Homebrew/brew#18230