### PR TITLE
update.sh: use 'read' instead of 'cat'

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -726,8 +726,11 @@ EOS
         if ! git fetch --tags --force "${QUIET_ARGS[@]}" origin \
            "refs/heads/${UPSTREAM_BRANCH_DIR}:refs/remotes/origin/${UPSTREAM_BRANCH_DIR}" 2>>"${tmp_failure_file}"
         then
+          local fetch_error=
+          2>/dev/null read -rd '' fetch_error <"${tmp_failure_file}" || :
+
           # Reprint fetch errors to stderr
-          [[ -f "${tmp_failure_file}" ]] && cat "${tmp_failure_file}" 1>&2
+          echo -ne "${fetch_error:+${fetch_error}\\\n}" 1>&2
 
           if [[ "${UPSTREAM_SHA_HTTP_CODE}" == "404" ]]
           then
@@ -736,8 +739,7 @@ EOS
           else
             echo "Fetching ${DIR} failed!" >>"${update_failed_file}"
 
-            if [[ -f "${tmp_failure_file}" ]] &&
-               [[ "$(cat "${tmp_failure_file}")" == "fatal: couldn't find remote ref refs/heads/${UPSTREAM_BRANCH_DIR}" ]]
+            if [[ ${fetch_error} == "fatal: couldn't find remote ref refs/heads/${UPSTREAM_BRANCH_DIR}" ]]
             then
               echo "${DIR}" >>"${missing_remote_ref_dirs_file}"
             fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Assign the contents of the file pointed to by `tmp_failure_file` to a new local variable, `fetch_error`. This removes the need to check for the existence of the file pointed to by `tmp_failure_file` as well as using `cat` to read its contents.