### PR TITLE
Globally silence default gem warnings

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -4,10 +4,7 @@
 require "api/analytics"
 require "api/cask"
 require "api/formula"
-require "warnings"
-Warnings.ignore :default_gems do
-  require "base64" # TODO: Add this to the Gemfile or remove it before moving to Ruby 3.4.
-end
+require "base64" # TODO: vendor this for Ruby 3.4.
 
 module Homebrew
   # Helper functions for using Homebrew's formulae.brew.sh API.

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -124,10 +124,7 @@ module Homebrew
 
       sig { params(totals: T::Hash[String, T::Hash[Symbol, Integer]]).returns(String) }
       def generate_csv(totals)
-        require "warnings"
-        Warnings.ignore :default_gems do
-          require "csv"
-        end
+        require "csv" # TODO: this will be removed from Ruby 3.4
 
         CSV.generate do |csv|
           csv << %w[user repo author committer coauthor review total]

--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -52,3 +52,15 @@ require "portable_ruby_gems" if HOMEBREW_USING_PORTABLE_RUBY
 $LOAD_PATH.unshift "#{HOMEBREW_LIBRARY_PATH}/vendor/bundle/#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/" \
                    "bundler-#{Homebrew::HOMEBREW_BUNDLER_VERSION}/lib"
 $LOAD_PATH.uniq!
+
+# These warnings are nice but often flag problems that are not even our responsibly,
+# including in some cases from other Ruby standard library gems.
+# We strictly only allow one version of Ruby at a time so future compatibility
+# doesn't need to be handled ahead of time.
+if defined?(Gem::BUNDLED_GEMS)
+  [Kernel.singleton_class, Kernel].each do |kernel_class|
+    next unless kernel_class.respond_to?(:no_warning_require, true)
+
+    kernel_class.alias_method :require, :no_warning_require
+  end
+end

--- a/Library/Homebrew/warnings.rb
+++ b/Library/Homebrew/warnings.rb
@@ -9,13 +9,7 @@ module Warnings
     parser_syntax: [
       %r{warning: parser/current is loading parser/ruby\d+, which recognizes},
       /warning: \d+\.\d+\.\d+-compliant syntax, but you are running \d+\.\d+\.\d+\./,
-      # FIXME: https://github.com/errata-ai/vale/issues/818
-      # <!-- vale off -->
       %r{warning: please see https://github\.com/whitequark/parser#compatibility-with-ruby-mri\.},
-      # <!-- vale on -->
-    ],
-    default_gems:  [
-      /warning: .+\.rb was loaded from the standard library, .+ default gems since Ruby \d+\.\d+\.\d+\./,
     ],
   }.freeze
 


### PR DESCRIPTION
Otherwise we're going to get spammed even more in Ruby 3.3.5, in ways that are arguably upstream bugs (`require "json"` now issues a deprecation warning for its internal code).