### PR TITLE
rubocops/uses_from_macos: remove `gnu-getopt` and `rpcgen`

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -11,6 +11,7 @@ module RuboCop
         PROVIDED_BY_MACOS_FORMULAE = %w[
           apr
           bc
+          bc-gh
           berkeley-db
           bison
           bzip2
@@ -22,7 +23,6 @@ module RuboCop
           expat
           file-formula
           flex
-          gnu-getopt
           gperf
           icu4c
           krb5
@@ -46,7 +46,6 @@ module RuboCop
           pax
           pcsc-lite
           pod2man
-          rpcgen
           ruby
           sqlite
           ssh-copy-id


### PR DESCRIPTION
Also add `bc-gh` which is the version of bc provided by Ventura and
newer macOS. Other `bc` (GNU bc) was provided until Monterey

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

* `gnu-getopt` is not provided by macOS. BSD getopt is, so switched DSL in https://github.com/Homebrew/homebrew-core/pull/183637
* `rpcgen` removal PR https://github.com/Homebrew/homebrew-core/pull/183671 (this could cause tests/CI to fail based on state of PRs).
* `bc-gh` added in https://github.com/Homebrew/homebrew-core/pull/183679