### PR TITLE
Improve `brew doctor` output on prerelease macOS

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -130,6 +130,9 @@ module Homebrew
       def check_xcode_up_to_date
         return unless MacOS::Xcode.outdated?
 
+        # avoid duplicate very similar messages
+        return if MacOS::Xcode.below_minimum_version?
+
         # CI images are going to end up outdated so don't complain when
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI providers
@@ -160,6 +163,9 @@ module Homebrew
 
       def check_clt_up_to_date
         return unless MacOS::CLT.outdated?
+
+        # avoid duplicate very similar messages
+        return if MacOS::CLT.below_minimum_version?
 
         # CI images are going to end up outdated so don't complain when
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -315,6 +315,11 @@ module OS
             Install the Command Line Tools for Xcode 11.3.1 from:
               #{Formatter.url(MacOS::Xcode::APPLE_DEVELOPER_DOWNLOAD_URL)}
           EOS
+        elsif OS::Mac.version.prerelease?
+          <<~EOS
+            Install the Command Line Tools for Xcode #{minimum_version.split(".").first} from:
+              #{Formatter.url(MacOS::Xcode::APPLE_DEVELOPER_DOWNLOAD_URL)}
+          EOS
         else
           <<~EOS
             Install the Command Line Tools:
@@ -325,6 +330,8 @@ module OS
 
       sig { returns(String) }
       def self.update_instructions
+        return installation_instructions if OS::Mac.version.prerelease?
+
         software_update_location = if MacOS.version >= "13"
           "System Settings"
         elsif MacOS.version >= "10.14"


### PR DESCRIPTION
- Avoid near duplicate messages
- Provide correct CLT download instructions

Before:
```
$ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Your Command Line Tools are too outdated.
Update them from Software Update in System Settings.

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 16.0.

Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Settings.

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 16.0.

Warning: Your Xcode (15.4) at /Applications/Xcode.app is too outdated.
Please update to Xcode 16.0 (or delete it).
Xcode can be updated from:
  https://developer.apple.com/download/all/

Warning: Your Xcode (15.4) is outdated.
Please update to Xcode 16.0 (or delete it).
Xcode can be updated from:
  https://developer.apple.com/download/all/

If 16.0 is installed, you may need to:
  sudo xcode-select --switch /Applications/Xcode.app
Current developer directory is:
  /Applications/Xcode.app/Contents/Developer
```

After:
```console
$ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Your Command Line Tools are too outdated.
Install the Command Line Tools for Xcode 16 from:
  https://developer.apple.com/download/all/

Warning: Your Xcode (15.4) at /Applications/Xcode.app is too outdated.
Please update to Xcode 16.0 (or delete it).
Xcode can be updated from:
  https://developer.apple.com/download/all/
```