### PR TITLE
Use FormulaInstaller OS extensions

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1546,3 +1546,5 @@ on_request: installed_on_request?, options:)
     $stderr.puts @requirement_messages
   end
 end
+
+require "extend/os/formula_installer"

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -450,27 +450,6 @@ RSpec.describe FormulaInstaller do
     end
   end
 
-  describe "#fresh_install" do
-    subject(:formula_installer) { described_class.new(Testball.new) }
-
-    it "is false by default" do
-      formula = Testball.new
-      expect(formula_installer.fresh_install?(formula)).to be false
-    end
-
-    it "is false in developer mode" do
-      formula = Testball.new
-      allow(Homebrew::EnvConfig).to receive_messages(developer?: true)
-      expect(formula_installer.fresh_install?(formula)).to be false
-    end
-
-    it "is false on outdated releases" do
-      formula = Testball.new
-      allow(OS::Mac.version).to receive_messages(outdated_release?: true)
-      expect(formula_installer.fresh_install?(formula)).to be false
-    end
-  end
-
   describe "#install_service" do
     it "works if service is set" do
       formula = Testball.new

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -450,6 +450,27 @@ RSpec.describe FormulaInstaller do
     end
   end
 
+  describe "#fresh_install" do
+    subject(:formula_installer) { described_class.new(Testball.new) }
+
+    it "is false by default" do
+      formula = Testball.new
+      expect(formula_installer.fresh_install?(formula)).to be false
+    end
+
+    it "is false in developer mode" do
+      formula = Testball.new
+      allow(Homebrew::EnvConfig).to receive_messages(developer?: true)
+      expect(formula_installer.fresh_install?(formula)).to be false
+    end
+
+    it "is false on outdated releases" do
+      formula = Testball.new
+      allow(OS::Mac.version).to receive_messages(outdated_release?: true)
+      expect(formula_installer.fresh_install?(formula)).to be false
+    end
+  end
+
   describe "#install_service" do
     it "works if service is set" do
       formula = Testball.new

--- a/Library/Homebrew/test/os/linux/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_installer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "formula_installer"
+require "test/support/fixtures/testball"
+
+RSpec.describe FormulaInstaller do
+  include FileUtils
+
+  subject(:keg) { described_class.new(keg_path) }
+
+  describe "#fresh_install" do
+    subject(:formula_installer) { described_class.new(Testball.new) }
+
+    it "is true by default" do
+      formula = Testball.new
+      expect(formula_installer.fresh_install?(formula)).to be true
+    end
+
+    it "is false in developer mode" do
+      formula = Testball.new
+      allow(Homebrew::EnvConfig).to receive_messages(developer?: true)
+      expect(formula_installer.fresh_install?(formula)).to be false
+    end
+  end
+end

--- a/Library/Homebrew/test/os/mac/formula_installer_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_installer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "formula_installer"
+require "test/support/fixtures/testball"
+
+RSpec.describe FormulaInstaller do
+  include FileUtils
+
+  subject(:keg) { described_class.new(keg_path) }
+
+  describe "#fresh_install" do
+    subject(:formula_installer) { described_class.new(Testball.new) }
+
+    it "is true by default" do
+      formula = Testball.new
+      expect(formula_installer.fresh_install?(formula)).to be true
+    end
+
+    it "is false in developer mode" do
+      formula = Testball.new
+      allow(Homebrew::EnvConfig).to receive_messages(developer?: true)
+      expect(formula_installer.fresh_install?(formula)).to be false
+    end
+
+    it "is false on outdated releases" do
+      formula = Testball.new
+      allow(OS::Mac.version).to receive_messages(outdated_release?: true)
+      expect(formula_installer.fresh_install?(formula)).to be false
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
(Vaguely) relates to: https://github.com/Homebrew/brew/issues/17998

It looks like these OS extensions, introduced in https://github.com/Homebrew/brew/pull/14163, were not required from `formula_installer`, so are not actually in use. I fixed that issue, and added some tests intended to prevent a regression. (I don't think I've added OS-specific tests before, so I'm not sure how the magic works, or what assumptions can be made within them, so apologies if this is a bumpy ride.)