### PR TITLE
Curl#curl_headers: Work with 56 exit_status

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -22,6 +22,10 @@ module Utils
     # code that is >= 400.
     CURL_HTTP_RETURNED_ERROR_EXIT_CODE = 22
 
+    # Error returned when curl gets an error from the lowest networking layers
+    # that the receiving of data failed.
+    CURL_RECV_ERROR_EXIT_CODE = 56
+
     # This regex is used to extract the part of an ETag within quotation marks,
     # ignoring any leading weak validator indicator (`W/`). This simplifies
     # ETag comparison in `#curl_check_http_content`.
@@ -38,6 +42,7 @@ module Utils
 
     private_constant :CURL_WEIRD_SERVER_REPLY_EXIT_CODE,
                      :CURL_HTTP_RETURNED_ERROR_EXIT_CODE,
+                     :CURL_RECV_ERROR_EXIT_CODE,
                      :ETAG_VALUE_REGEX, :HTTP_RESPONSE_BODY_SEPARATOR,
                      :HTTP_STATUS_LINE_REGEX
 
@@ -237,8 +242,11 @@ module Utils
 
         # We still receive usable headers with certain non-successful exit
         # statuses, so we special case them below.
-        if result.success? ||
-           [CURL_WEIRD_SERVER_REPLY_EXIT_CODE, CURL_HTTP_RETURNED_ERROR_EXIT_CODE].include?(result.exit_status)
+        if result.success? || [
+          CURL_WEIRD_SERVER_REPLY_EXIT_CODE,
+          CURL_HTTP_RETURNED_ERROR_EXIT_CODE,
+          CURL_RECV_ERROR_EXIT_CODE,
+        ].include?(result.exit_status)
           parsed_output = parse_curl_output(result.stdout)
 
           if request_args.empty?


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I previously added the 8 curl exit code (weird server reply) to the list of non-success exit codes that `#curl_headers` will handle. We're now seeing failures with a 56 exit code (failure in receiving network data), where the server returns a 4xx response for a `HEAD` request but the same request using `GET` works as expected (e.g., casks like `beeper`, `get-api`, [`odrive`](https://github.com/Homebrew/homebrew-cask/pull/184369#pullrequestreview-2287227449), `ui`, etc.).

This adds 56 to the list of exit codes in `#curl_headers`, so a response with a 4xx HTTP status will be automatically retried using `GET`.