### PR TITLE
linkage_checker: exclude test deps from being considered runtime dep

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -196,7 +196,7 @@ class LinkageChecker
 
   def check_formula_deps
     filter_out = proc do |dep|
-      next true if dep.build?
+      next true if dep.build? || dep.test?
 
       (dep.optional? || dep.recommended?) && formula.build.without?(dep)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A couple situations this helps:
* Avoid no linkage message for test dependencies, e.g. `harfbuzz`:
  ```
  Dependencies with no linkage:
    pygobject3
  ```
* Properly detect when a `:test`-dependency that is also an indirect dep should actually be made a direct runtime dependency.