### PR TITLE
github/actions: fix annotation title handling

### DIFF
--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -81,6 +81,7 @@ module GitHub
       }
       def initialize(type, message, file: nil, title: nil, line: nil, end_line: nil, column: nil, end_column: nil)
         raise ArgumentError, "Unsupported type: #{type.inspect}" if ANNOTATION_TYPES.exclude?(type)
+        raise ArgumentError, "`title` must not contain `::`" if title.present? && title.include?("::")
 
         require "utils/tty"
         @type = type
@@ -110,7 +111,11 @@ module GitHub
           end
         end
 
-        metadata << ",title=#{Actions.escape(@title)}" if @title
+        if @title
+          metadata << (@file ? "," : " ")
+          metadata << "title=#{Actions.escape(@title)}"
+        end
+        metadata << " " if metadata.end_with?(":")
 
         "::#{metadata}::#{Actions.escape(@message)}"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We currently generate invalid workflow commands when we create
annotations with a `title` but no `file`. Let's fix that.

While we're here, let's improve handling of `title`s with `:`s. We
cannot use `title`s with `::` since GitHub Actions uses this as a
separator for different fields between a workflow command.

Let's also make sure `metadata` never ends in a `:` to avoid confusing
the GitHub Actions command parser about where the `::` separator is
meant to be.

