### PR TITLE
shims/super/ninja: respect Homebrew parallelism

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -75,6 +75,7 @@ module Superenv
     self["HOMEBREW_TEMP"] = HOMEBREW_TEMP.to_s
     self["HOMEBREW_OPTFLAGS"] = determine_optflags
     self["HOMEBREW_ARCHFLAGS"] = ""
+    self["HOMEBREW_MAKE_JOBS"] = determine_make_jobs.to_s
     self["CMAKE_PREFIX_PATH"] = determine_cmake_prefix_path
     self["CMAKE_FRAMEWORK_PATH"] = determine_cmake_frameworks_path
     self["CMAKE_INCLUDE_PATH"] = determine_cmake_include_path
@@ -313,16 +314,19 @@ module Superenv
   # When passed a block, MAKEFLAGS is removed only for the duration of the block and is restored after its completion.
   sig { params(block: T.nilable(T.proc.returns(T.untyped))).returns(T.untyped) }
   def deparallelize(&block)
-    old = delete("MAKEFLAGS")
+    old_makeflags = delete("MAKEFLAGS")
+    old_make_jobs = delete("HOMEBREW_MAKE_JOBS")
+    self["HOMEBREW_MAKE_JOBS"] = "1"
     if block
       begin
         yield
       ensure
-        self["MAKEFLAGS"] = old
+        self["MAKEFLAGS"] = old_makeflags
+        self["HOMEBREW_MAKE_JOBS"] = old_make_jobs
       end
     end
 
-    old
+    old_makeflags
   end
 
   sig { returns(Integer) }

--- a/Library/Homebrew/shims/super/ninja
+++ b/Library/Homebrew/shims/super/ninja
@@ -11,9 +11,15 @@ fi
 
 source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
 
+parallel_args=()
+if [[ -n "${HOMEBREW_MAKE_JOBS}" ]]
+then
+  parallel_args+=(-j "${HOMEBREW_MAKE_JOBS}")
+fi
+
 # shellcheck disable=SC2154
 export HOMEBREW_CCCFG="O${HOMEBREW_CCCFG}"
-try_exec_non_system "ninja" "$@"
+try_exec_non_system "ninja" "${parallel_args[@]}" "$@"
 
 echo "ninja: Shim failed to find ninja in PATH."
 exit 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`ninja` currently doesn't respect `HOMEBREW_MAKE_JOBS` or
`ENV.deparallelize`. This change fixes that.
