### PR TITLE
os/mac/pkgconfig/15: drop NTLM_WB reference in libcurl

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/15/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/15/libcurl.pc
@@ -31,7 +31,7 @@ exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 supported_protocols="DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS IPFS IPNS LDAP LDAPS MQTT POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
-supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM NTLM_WB SPNEGO SSL threadsafe UnixSockets"
+supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM SPNEGO SSL threadsafe UnixSockets"
 
 Name: libcurl
 URL: https://curl.se/


### PR DESCRIPTION
Apple removed this with the Curl 8.7.1 update (dropping the reference from `curl-config` in 8.6.0).