### PR TITLE
os/mac/pkgconfig/14: update libcurl for 14.5 SDK

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/14/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/14/libcurl.pc
@@ -30,13 +30,13 @@ prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
-supported_protocols="DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS LDAP LDAPS MQTT POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
-supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM NTLM_WB SPNEGO SSL threadsafe UnixSockets"
+supported_protocols="DICT FILE FTP FTPS GOPHER GOPHERS HTTP HTTPS IMAP IMAPS IPFS IPNS LDAP LDAPS MQTT POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
+supported_features="alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM SPNEGO SSL threadsafe UnixSockets"
 
 Name: libcurl
 URL: https://curl.se/
 Description: Library to transfer files with ftp, http, etc.
-Version: 8.4.0
+Version: 8.6.0
 Libs: -L${libdir} -lcurl
 Libs.private: -lldap -lz
 Cflags:


### PR DESCRIPTION
macOS 14.5 SDK has been an Xcode-exclusive SDK until now, so we never updated this pc file. CLT 16 will however include macOS 14.5 SDK so we can update this now.

While the 8.6.0 runtime supports NTLM_WB, the 8.6.0 curl-config dropped the reference to it ahead of Apple dropping it in macOS 14.6's curl 8.7.1 update, which never received a corresponding SDK. Not reporting a feature seems like the safest option.

This PR may have to wait until after the CLT is released fully.