### PR TITLE
shellenv.sh / fish shell: Move Brew PATHs to front if they exist (add -m arg to fish_add_path)

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -40,7 +40,7 @@ homebrew-shellenv() {
       echo "set -gx HOMEBREW_PREFIX \"${HOMEBREW_PREFIX}\";"
       echo "set -gx HOMEBREW_CELLAR \"${HOMEBREW_CELLAR}\";"
       echo "set -gx HOMEBREW_REPOSITORY \"${HOMEBREW_REPOSITORY}\";"
-      echo "fish_add_path -gP \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\";"
+      echo "fish_add_path -gmP \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\";"
       echo "if test -n \"\$MANPATH[1]\"; set -gx MANPATH '' \$MANPATH; end;"
       echo "if not contains \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; set -gx INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; end;"
       ;;


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

(Unchecked steps aren't applicable here, in my opinion)

-----

This PR addresses an issue when a PATH variable with Homebrew paths is inherited, modified, and then `brew shellenv` is evaluated again. In this case, the expected behavior is that Homebrew directories should be placed at the front of the PATH. However, since `-m` (move component) isn’t specified, `fish_add_path` doesn’t modify the variable, this can, for example, cause binaries in `/usr/bin` (like XCode CLI tools' Python) to take precedence.

I encountered this in VSCode, where `eval (/opt/homebrew/bin/brew shellenv fish)` in my `config.fish` didn’t properly update the PATH, as VSCode's environment resolution already included the paths, ~~just not at the top~~. This change ensures `$HOMEBREW_PREFIX/bin` and `$HOMEBREW_PREFIX/sbin` are always placed first in `PATH`.

**Correction:**

It's not actually VSCode's fault that the Brew PATH components aren't at the top, they are, but when `fish` thinks it's a login shell (which it does when run in VSCode's terminal), it will add some PATH components before the inherited ones, causing the issue. Nonetheless, based on the behavior for other shells, it seems like the behavior with `-m` specified, which is what this PR does, would be what is intended for `brew shellenv`.