### PR TITLE
exceptions: skip `#fetch_issues` is `HOMEBREW_NO_BUILD_ERROR_ISSUES` is set

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -495,6 +495,8 @@ class BuildError < RuntimeError
 
   sig { returns(T::Array[T.untyped]) }
   def fetch_issues
+    return [] if ENV["HOMEBREW_NO_BUILD_ERROR_ISSUES"].present?
+
     GitHub.issues_for_formula(formula.name, tap: formula.tap, state: "open", type: "issue")
   rescue GitHub::API::Error => e
     opoo "Unable to query GitHub for recent issues on the tap\n#{e.message}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will allow us to set `HOMEBREW_NO_BUILD_ERROR_ISSUES` in our
workflows, which will avoid needlessly burning through our rate limit.
