### PR TITLE
Remove macos-12 from test matrix

### DIFF
--- a/.github/workflows/pkg-installer.yml
+++ b/.github/workflows/pkg-installer.yml
@@ -133,8 +133,6 @@ jobs:
       matrix:
         include:
           # Intel
-          - runner: macos-12
-            name: macos-12-x86_64
           - runner: macos-13
             name: macos-13-x86_64
           # Apple Silicon


### PR DESCRIPTION
Should resolve https://github.com/Homebrew/brew/actions/runs/10854929440/job/30126441752?pr=18305#logs
Perhaps due to https://github.com/Homebrew/brew/pull/18314