### PR TITLE
cmd/shellenv: set `XDG_DATA_DIRS` on Linux

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -43,6 +43,10 @@ homebrew-shellenv() {
       echo "fish_add_path --global --move --path \"${HOMEBREW_PREFIX}/bin\" \"${HOMEBREW_PREFIX}/sbin\";"
       echo "if test -n \"\$MANPATH[1]\"; set --global --export MANPATH '' \$MANPATH; end;"
       echo "if not contains \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; set --global --export INFOPATH \"${HOMEBREW_PREFIX}/share/info\" \$INFOPATH; end;"
+      if [[ -n "${HOMEBREW_LINUX}" ]]
+      then
+        echo "if test -n \"\$XDG_DATA_DIRS\"; set --global --export XDG_DATA_DIRS \"${HOMEBREW_PREFIX}/share\" \$XDG_DATA_DIRS; end;"
+      fi
       ;;
     csh | -csh | tcsh | -tcsh)
       echo "setenv HOMEBREW_PREFIX ${HOMEBREW_PREFIX};"
@@ -56,6 +60,10 @@ homebrew-shellenv() {
       fi
       echo "test \${?MANPATH} -eq 1 && setenv MANPATH :\${MANPATH};"
       echo "setenv INFOPATH ${HOMEBREW_PREFIX}/share/info\`test \${?INFOPATH} -eq 1 && echo :\${INFOPATH}\`;"
+      if [[ -n "${HOMEBREW_LINUX}" ]]
+      then
+        echo "test \${?XDG_DATA_DIRS} -eq 1 && setenv XDG_DATA_DIRS \"${HOMEBREW_PREFIX}/share:\$XDG_DATA_DIRS\";"
+      fi
       ;;
     pwsh | -pwsh | pwsh-preview | -pwsh-preview)
       echo "[System.Environment]::SetEnvironmentVariable('HOMEBREW_PREFIX','${HOMEBREW_PREFIX}',[System.EnvironmentVariableTarget]::Process)"
@@ -64,6 +72,10 @@ homebrew-shellenv() {
       echo "[System.Environment]::SetEnvironmentVariable('PATH',\$('${HOMEBREW_PREFIX}/bin:${HOMEBREW_PREFIX}/sbin:'+\$ENV:PATH),[System.EnvironmentVariableTarget]::Process)"
       echo "[System.Environment]::SetEnvironmentVariable('MANPATH',\$('${HOMEBREW_PREFIX}/share/man'+\$(if(\${ENV:MANPATH}){':'+\${ENV:MANPATH}})+':'),[System.EnvironmentVariableTarget]::Process)"
       echo "[System.Environment]::SetEnvironmentVariable('INFOPATH',\$('${HOMEBREW_PREFIX}/share/info'+\$(if(\${ENV:INFOPATH}){':'+\${ENV:INFOPATH}})),[System.EnvironmentVariableTarget]::Process)"
+      if [[ -n "${HOMEBREW_LINUX}" ]]
+      then
+        echo "if(\${ENV:XDG_DATA_DIRS}){[System.Environment]::SetEnvironmentVariable('XDG_DATA_DIRS',\$('${HOMEBREW_PREFIX}/share:'+\${ENV:XDG_DATA_DIRS}),[System.EnvironmentVariableTarget]::Process)}"
+      fi
       ;;
     *)
       echo "export HOMEBREW_PREFIX=\"${HOMEBREW_PREFIX}\";"
@@ -77,6 +89,10 @@ homebrew-shellenv() {
       fi
       echo "[ -z \"\${MANPATH-}\" ] || export MANPATH=\":\${MANPATH#:}\";"
       echo "export INFOPATH=\"${HOMEBREW_PREFIX}/share/info:\${INFOPATH:-}\";"
+      if [[ -n "${HOMEBREW_LINUX}" ]]
+      then
+        echo "[ -z \"\${XDG_DATA_DIRS-}\" ] || export XDG_DATA_DIRS=\"${HOMEBREW_PREFIX}/share:\${XDG_DATA_DIRS-}\";"
+      fi
       ;;
   esac
 }


### PR DESCRIPTION
Some programs like `vapigen` might not work correctly, when `XDG_DATA_DIRS` does not include `$HOMEBREW_PREFIX/share`. Instead of requiring the user to manually adjust the shell environment, we can set `XDG_DATA_DIRS` as part of `cmd/shellenv`, so that it is sufficient to run `brew shellenv` on any particular system.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #18317