### PR TITLE
style: resolve symblic links in `HOMEBREW_CACHE`

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -164,7 +164,9 @@ module Homebrew
 
       args += files
 
-      cache_env = { "XDG_CACHE_HOME" => "#{HOMEBREW_CACHE}/style" }
+      HOMEBREW_CACHE.mkpath
+      cache_dir = HOMEBREW_CACHE.realpath
+      cache_env = { "XDG_CACHE_HOME" => "#{cache_dir}/style" }
 
       FileUtils.rm_rf cache_env["XDG_CACHE_HOME"] if reset_cache
 


### PR DESCRIPTION
On Linux HOMEBREW_CACHE may be set to `$HOME/.cache/Homebrew`. Some systems, like Fedora Silverblue, have `/home` set up to be a symbolic link to `/var/home`. While Homebrew generally seems to work fine on Fedora Silverblue, rubocop causes the `brew style` command to emit a lot of warnings because of the symbolic link[1]. This can be resolved by looking up the real path of HOMEBREW_CACHE before passing it to rubocop.

[1] https://github.com/rubocop/rubocop/issues/6228

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
