### PR TITLE
Limit usage of GitHub Actions Annotations

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -65,8 +65,11 @@ module Kernel
   sig { params(message: T.any(String, Exception)).void }
   def opoo(message)
     Tty.with($stderr) do |stderr|
-      stderr.puts Formatter.warning(message, label: "Warning")
-      GitHub::Actions.puts_annotation_if_env_set(:warning, message.to_s)
+      if ENV["HOMEBREW_GITHUB_ACTIONS"].present?
+        GitHub::Actions.puts_annotation_if_env_set(:warning, message.to_s)
+      else
+        stderr.puts Formatter.warning(message, label: "Warning")
+      end
     end
   end
 
@@ -79,8 +82,11 @@ module Kernel
     require "utils/github/actions"
 
     Tty.with($stderr) do |stderr|
-      stderr.puts Formatter.error(message, label: "Error")
-      GitHub::Actions.puts_annotation_if_env_set(:error, message.to_s)
+      if ENV["HOMEBREW_GITHUB_ACTIONS"].present?
+        GitHub::Actions.puts_annotation_if_env_set(:error, message.to_s)
+      else
+        stderr.puts Formatter.error(message, label: "Error")
+      end
     end
   end
 

--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -51,7 +51,7 @@ module GitHub
       return unless env_set?
 
       std = (type == :notice) ? $stdout : $stderr
-      std.puts Annotation.new(type, message)
+      std.puts Annotation.new(type, message, file:, line:)
     end
 
     # Helper class for formatting annotations on GitHub Actions.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- only use annotations for `opoo` and `onoe` if
  `HOMEBREW_GITHUB_ACTIONS` is set. This will make using `brew` less
  noisy in GitHub Actions for third parties. See
  Homebrew/discussions#5602.
- if we've already called `puts_annotation_if_env_set`, then we no
  longer need to print the message to `$stderr`. The message from the
  annotation already show up in the GitHub Actions log, so printing to
  `$stderr` just leads to duplicate messages in the log.

While we're here, let's make sure to forward the `file:` and `line:`
kwargs of `puts_annotation_if_env_set` to the `Annotation` constructor.
