### PR TITLE
cli/named_args: silence `package_conflicts_message` with `--quiet`

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -231,11 +231,13 @@ module Homebrew
                   Failed to load cask: #{name}
                   #{unreadable_error}
                 EOS
-                opoo package_conflicts_message(name, "formula", cask)
+                opoo package_conflicts_message(name, "formula", cask) unless Context.current.quiet?
               end
               return formula_or_kegs
             elsif cask
-              opoo package_conflicts_message(name, "cask", formula_or_kegs) if formula_or_kegs
+              if formula_or_kegs && !Context.current.quiet?
+                opoo package_conflicts_message(name, "cask", formula_or_kegs)
+              end
               return cask
             end
           end
@@ -519,6 +521,7 @@ module Homebrew
           nil
         end
         return unless available
+        return if Context.current.quiet?
 
         opoo package_conflicts_message(ref, loaded_type, cask)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Based on feedback from Homebrew/discussions#5602.

While users can already silence this by passing `--formula` or `--cask`
as required, I am inclined to agree that `--quiet` should probably
silence messages that are relatively low priority (of which I think this
is one).
