### PR TITLE
os/linux/ld: harden `brewed_ld_so_diagnostics` against `TypeError`

### DIFF
--- a/Library/Homebrew/os/linux/ld.rb
+++ b/Library/Homebrew/os/linux/ld.rb
@@ -21,6 +21,7 @@ module OS
         @brewed_ld_so_diagnostics[brewed_ld_so_target].to_s
       rescue TypeError
         # Workaround for intermittent `Error: no implicit conversion of false into String`
+        # https://github.com/Homebrew/brew/issues/17828
         unless @retried_brewed_ld_so_diagnostics&.fetch(brewed_ld_so_target, false)
           @retried_brewed_ld_so_diagnostics ||= T.let({}, T.nilable(T::Hash[Pathname, T::Boolean]))
           @retried_brewed_ld_so_diagnostics[brewed_ld_so_target] = true

--- a/Library/Homebrew/os/linux/ld.rb
+++ b/Library/Homebrew/os/linux/ld.rb
@@ -7,7 +7,7 @@ module OS
     module Ld
       sig { returns(String) }
       def self.brewed_ld_so_diagnostics
-        @brewed_ld_so_diagnostics ||= T.let({}, T.nilable(T::Hash[Pathname, T.nilable(String)]))
+        @brewed_ld_so_diagnostics ||= T.let({}, T.nilable(T::Hash[Pathname, String]))
 
         brewed_ld_so = HOMEBREW_PREFIX/"lib/ld.so"
         return "" unless brewed_ld_so.exist?
@@ -19,17 +19,6 @@ module OS
         end
 
         @brewed_ld_so_diagnostics[brewed_ld_so_target].to_s
-      rescue TypeError
-        # Workaround for intermittent `Error: no implicit conversion of false into String`
-        # https://github.com/Homebrew/brew/issues/17828
-        unless @retried_brewed_ld_so_diagnostics&.fetch(brewed_ld_so_target, false)
-          @retried_brewed_ld_so_diagnostics ||= T.let({}, T.nilable(T::Hash[Pathname, T::Boolean]))
-          @retried_brewed_ld_so_diagnostics[brewed_ld_so_target] = true
-          sleep 0.5
-          retry
-        end
-
-        raise
       end
 
       sig { returns(String) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think this is a bug in Ruby, but I've no idea how to track it down. I
can reproduce it intermittently in a codespace when `brew install`ing a
large number of formulae.

To work around this:
- cache the return value of `brewed_ld_so_diagnostics` so that we can
  limit the number of calls to `IO.popen`
- retry once when we see a `TypeError`

Closes #17828.
