### PR TITLE
Fix `NoSuchKegFromTapError` handling

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -423,7 +423,7 @@ module Homebrew
             keg.tab.tap == requested_tap
           end
 
-          raise NoSuchKegFromTapError.new(requested_formula, requested_tap) if kegs.none?
+          raise NoSuchKegError.new(requested_formula, tap: requested_tap) if kegs.none?
         end
 
         raise NoSuchKegError, name if kegs.none?

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -53,23 +53,14 @@ class NotAKegError < RuntimeError; end
 
 # Raised when a keg doesn't exist.
 class NoSuchKegError < RuntimeError
-  attr_reader :name
-
-  def initialize(name)
-    @name = name
-    super "No such keg: #{HOMEBREW_CELLAR}/#{name}"
-  end
-end
-
-# Raised when a keg from a specific tap doesn't exist.
-class NoSuchKegFromTapError < RuntimeError
   attr_reader :name, :tap
 
-  sig { params(name: String, tap: Tap).void }
-  def initialize(name, tap)
+  def initialize(name, tap: nil)
     @name = name
     @tap = tap
-    super "No such keg: #{HOMEBREW_CELLAR}/#{name} from tap #{tap}"
+    message = "No such keg: #{HOMEBREW_CELLAR}/#{name}"
+    message += " from tap #{tap}" if tap
+    super message
   end
 end
 

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Homebrew::CLI::NamedArgs do
       it "raises an error if there is no tap match" do
         stub_formula_loader bar, "other/tap/bar"
 
-        expect { described_class.new("other/tap/bar").to_kegs }.to raise_error(NoSuchKegFromTapError)
+        expect { described_class.new("other/tap/bar").to_kegs }.to raise_error(NoSuchKegError, %r{from tap other/tap})
       end
     end
   end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -19,18 +19,20 @@ RSpec.describe "Exception" do
     end
   end
 
-  describe NoSuchKegFromTapError do
-    subject(:error) { described_class.new("foo", tap) }
-
-    let(:tap) { instance_double(Tap, to_s: "u/r") }
-
-    it(:to_s) { expect(error.to_s).to eq("No such keg: #{HOMEBREW_CELLAR}/foo from tap u/r") }
-  end
-
   describe NoSuchKegError do
-    subject(:error) { described_class.new("foo") }
+    context "without a tap" do
+      subject(:error) { described_class.new("foo") }
 
-    it(:to_s) { expect(error.to_s).to eq("No such keg: #{HOMEBREW_CELLAR}/foo") }
+      it(:to_s) { expect(error.to_s).to eq("No such keg: #{HOMEBREW_CELLAR}/foo") }
+    end
+
+    context "with a tap" do
+      subject(:error) { described_class.new("foo", tap:) }
+
+      let(:tap) { instance_double(Tap, to_s: "u/r") }
+
+      it(:to_s) { expect(error.to_s).to eq("No such keg: #{HOMEBREW_CELLAR}/foo from tap u/r") }
+    end
   end
 
   describe FormulaValidationError do


### PR DESCRIPTION
We had several places where we had `rescue NoSuchKegError` that was not catching the new `NoSuchKegFromTapError`.

We could either add `NoSuchKegFromTapError` or collapse the two into one. I chose the latter as it's the safer option for existing code compatibility.

Fixes `brew uninstall --force` being broken for taps: https://github.com/orgs/Homebrew/discussions/5607