### PR TITLE
dev-cmd/generate-cask-api: fix handling of `+` characters

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -52,7 +52,7 @@ module Homebrew
             html_template_name = html_template(name)
 
             unless args.dry_run?
-              File.write("_data/cask/#{name}.json", "#{json}\n")
+              File.write("_data/cask/#{name.tr("+", "_")}.json", "#{json}\n")
               File.write("api/cask/#{name}.json", CASK_JSON_TEMPLATE)
               File.write("api/cask-source/#{name}.rb", cask_source)
               File.write("cask/#{name}.html", html_template_name)


### PR DESCRIPTION
Aligns with the reverse we do on the other side: https://github.com/Homebrew/formulae.brew.sh/blob/20739b186d71b0ba66fabdb0f2f8172d1ceab9f8/_layouts/cask_json.json#L4

Not looked into the technical reason for it but we do it in `generate-formula-api` so let's just do it here too: https://github.com/Homebrew/brew/blob/051069c0b3f693419fc33d0cf10d7552c2e03364/Library/Homebrew/dev-cmd/generate-formula-api.rb#L54

Hopefully fixes https://github.com/Homebrew/homebrew-cask/issues/185583