### PR TITLE
Revert "Limit usage of GitHub Actions Annotations"

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -65,11 +65,8 @@ module Kernel
   sig { params(message: T.any(String, Exception)).void }
   def opoo(message)
     Tty.with($stderr) do |stderr|
-      if ENV["HOMEBREW_GITHUB_ACTIONS"].present?
-        GitHub::Actions.puts_annotation_if_env_set(:warning, message.to_s)
-      else
-        stderr.puts Formatter.warning(message, label: "Warning")
-      end
+      stderr.puts Formatter.warning(message, label: "Warning")
+      GitHub::Actions.puts_annotation_if_env_set(:warning, message.to_s)
     end
   end
 
@@ -82,11 +79,8 @@ module Kernel
     require "utils/github/actions"
 
     Tty.with($stderr) do |stderr|
-      if ENV["HOMEBREW_GITHUB_ACTIONS"].present?
-        GitHub::Actions.puts_annotation_if_env_set(:error, message.to_s)
-      else
-        stderr.puts Formatter.error(message, label: "Error")
-      end
+      stderr.puts Formatter.error(message, label: "Error")
+      GitHub::Actions.puts_annotation_if_env_set(:error, message.to_s)
     end
   end
 

--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -51,7 +51,7 @@ module GitHub
       return unless env_set?
 
       std = (type == :notice) ? $stdout : $stderr
-      std.puts Annotation.new(type, message, file:, line:)
+      std.puts Annotation.new(type, message)
     end
 
     # Helper class for formatting annotations on GitHub Actions.


### PR DESCRIPTION
Sorry @carlocab, just reverting this for now so it doesn't make it into the next stable release.

I want to keep these errors around for users but avoid doing the `opoo` calls when it doesn't make sense to do so.

Reverts Homebrew/brew#18329