### PR TITLE
resource: further fix manifest retry handling

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -311,8 +311,6 @@ class Resource
     def verify_download_integrity(_filename)
       # We don't have a checksum, but we can at least try parsing it.
       tab
-    rescue Error => e
-      raise DownloadError.new(self, e)
     end
 
     def tab


### PR DESCRIPTION
Regression from https://github.com/Homebrew/brew/commit/ae6f43921ae0389973fe62b0f74d11ba6bbbd31b. Manifest retry treats `DownloadError` different than validity errors.

Fixes https://github.com/Homebrew/homebrew-core/issues/190870.