### PR TITLE
rubocops: `xcodebuild` needs an Xcode dependency

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -62,6 +62,10 @@ module RuboCop
             problem %q(use "xcodebuild *args" instead of "system 'xcodebuild', *args")
           end
 
+          if !depends_on?(:xcode) && method_called_ever?(body_node, :xcodebuild)
+            problem "`xcodebuild` needs an Xcode dependency"
+          end
+
           if (method_node = find_method_def(body_node, :install))
             find_method_with_args(method_node, :system, "go", "get") do
               problem "Do not use `go get`. Please ask upstream to implement Go vendoring"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Since `xcodebuild` isn't part of CLT so build will fail.

Should be okay on Linux as `depends_on :xcode`/`depends_on xcode: ...` is a no-op.

Seperately, may look into either setting `DEVELOPER_DIR` or using absolute path to Xcode.app since `xcode-select --switch /Library/Developer/CommandLineTools` will cause build to fail, e.g.
```console
❯ DEVELOPER_DIR=/Applications/Xcode.app xcodebuild --help 2>&1 | head -1
Usage: xcodebuild [-project <projectname>] [[-target <targetname>]...|-alltargets] [-configuration <configurationname>] [-arch <architecture>]... [-sdk [<sdkname>|<sdkpath>]] [-showBuildSettings [-json]] [<buildsetting>=<value>]... [<buildaction>]...

~
❯ DEVELOPER_DIR=/Library/Developer/CommandLineTools xcodebuild --help 2>&1 | head -1
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```