### PR TITLE
dev-cmd/bottle: improve `:all` bottle handling

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -743,6 +743,14 @@ module Homebrew
                        tag_hashes.count > 1 &&
                        tag_hashes.uniq { |tag_hash| "#{tag_hash["cellar"]}-#{tag_hash["sha256"]}" }.count == 1
 
+          old_all_bottle = old_bottle_spec.tag?(Utils::Bottles.tag(:all))
+          if !all_bottle && old_all_bottle && !args.no_all_checks?
+            odie <<~ERROR
+              #{formula} should have an `:all` bottle but one cannot be created:
+              #{JSON.pretty_generate(tag_hashes)}
+            ERROR
+          end
+
           bottle_hash["bottle"]["tags"].each do |tag, tag_hash|
             cellar = tag_hash["cellar"]
             cellar = cellar.to_sym if any_cellars.include?(cellar)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, we silently ignore cases where a formula previously had an
`:all` bottle but now no longer does.

These are most often due to (in order of likelihood):
- bottle reproducibility breakage in `brew`
- new hard-coded `/usr/local` references in text files in a bottle

The former is a bug that should be fixed, while the latter can be fixed
trivally with an `inreplace`.

Let's try to make sure we always do this by making `brew bottle` error
out so that we can catch these instances as they happen rather than
after the fact.

I haven't encountered any cases where a formula previously had an `:all`
bottle but no longer does for reasons other than the two outlined above.

If we do encouter those in the future, we can either:
- update `brew bottle` to skip this check, perhaps with a new flag
- delete the formula's old `:all` bottle before doing `brew bottle` so
  it doesn't error
