### PR TITLE
formula_installer: fix manifest error handling

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1290,7 +1290,7 @@ on_request: installed_on_request?, options:)
                                                 .fetch("runtime_dependencies", []).then { |deps| deps || [] }
                                                 .each_with_object({}) { |dep, h| h[dep["full_name"]] = dep }
                                                 .freeze
-    rescue DownloadError, ArgumentError
+    rescue DownloadError, Resource::BottleManifest::Error
       # do nothing
     end
     @fetch_bottle_tab = T.let(true, T.nilable(TrueClass))


### PR DESCRIPTION
Regression from https://github.com/Homebrew/brew/commit/ae6f43921ae0389973fe62b0f74d11ba6bbbd31b.

Mainly affected our bottle dispatch workflows.