### PR TITLE
formula: fix alias/generic/prepend std_cmake_args issue.

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula.rb
+++ b/Library/Homebrew/extend/os/mac/formula.rb
@@ -21,7 +21,7 @@ module OS
         ).returns(T::Array[String])
       }
       def std_cmake_args(install_prefix: prefix, install_libdir: "lib", find_framework: "LAST")
-        args = generic_std_cmake_args(install_prefix:, install_libdir:, find_framework:)
+        args = super
 
         # Avoid false positives for clock_gettime support on 10.11.
         # CMake cache entries for other weak symbols may be added here as needed.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1822,7 +1822,6 @@ class Formula
       -DBUILD_TESTING=OFF
     ]
   end
-  alias generic_std_cmake_args std_cmake_args
 
   # Standard parameters for configure builds.
   sig {


### PR DESCRIPTION
Seen in https://github.com/Homebrew/homebrew-core/pull/191090#issuecomment-2363215204

There's a missing signature issue here due to the `generic_*` aliasing we're doing. With prepend, though: this is no longer needed and we can use `super` instead which is more idiomatic and nicer overall.

This pattern should probably be applied in other places but: let's try this targetting fix for here first.

Regression from https://github.com/Homebrew/brew/pull/18305

CC @dduugg @carlocab @SMillerDev 