### PR TITLE
keg: Install `gzip`ed info files during linking

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -77,7 +77,7 @@ class Keg
 
   # Locale-specific directories have the form `language[_territory][.codeset][@modifier]`
   LOCALEDIR_RX = %r{(locale|man)/([a-z]{2}|C|POSIX)(_[A-Z]{2})?(\.[a-zA-Z\-0-9]+(@.+)?)?}
-  INFOFILE_RX = %r{info/([^.].*?\.info|dir)$}
+  INFOFILE_RX = %r{info/([^.].*?\.info(\.gz)?|dir)$}
   KEG_LINK_DIRECTORIES = %w[
     bin etc include lib sbin share var
   ].freeze


### PR DESCRIPTION
Currently, `brew link` installs `*.info` files to `#{HOMEBREW_PREFIX}/share/info/dir` using the `install_info` method. However, some formulae (e.g., `Emacs`) also ship `*.info.gz` files, which are only `symlink`ed but not installed.

This PR allows `*.info.gz` files to be installed during linking in addition to the `*.info` files.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
