### PR TITLE
env_config: infer HOMEBREW_FORBID_PACKAGES_FROM_PATHS from HOMEBREW_DEVELOPER

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -219,9 +219,11 @@ module Homebrew
                      "formula if it or any of its dependencies is in a tap on this list.",
       },
       HOMEBREW_FORBID_PACKAGES_FROM_PATHS:       {
-        description: "If set, Homebrew will refuse to read formulae or casks provided from file paths, " \
-                     "e.g. `brew install ./package.rb`.",
-        boolean:     true,
+        description:  "If set, Homebrew will refuse to read formulae or casks provided from file paths, " \
+                      "e.g. `brew install ./package.rb`.",
+        boolean:      true,
+        default_text: "Enabled unless `HOMEBREW_DEVELOPER` is set.",
+        default:      -> { !developer? },
       },
       HOMEBREW_FORCE_BREWED_CA_CERTIFICATES:     {
         description: "If set, always use a Homebrew-installed `ca-certificates` rather than the system version. " \
@@ -504,6 +506,7 @@ module Homebrew
     CUSTOM_IMPLEMENTATIONS = T.let(Set.new([
       :HOMEBREW_MAKE_JOBS,
       :HOMEBREW_CASK_OPTS,
+      :HOMEBREW_FORBID_PACKAGES_FROM_PATHS,
     ]).freeze, T::Set[Symbol])
 
     ENVS.each do |env, hash|
@@ -526,6 +529,15 @@ module Homebrew
           ENV[env].presence
         end
       end
+    end
+
+    sig { returns(T::Boolean) }
+    def forbid_packages_from_paths?
+      return true if ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"].present?
+
+      ENVS.fetch(:HOMEBREW_FORBID_PACKAGES_FROM_PATHS)
+          .fetch(:default)
+          .call
     end
 
     # Needs a custom implementation.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If `HOMEBREW_DEVELOPER` is not set, then let's make
`HOMEBREW_FORBID_PACKAGES_FROM_PATHS` default to true.

I used a custom implementation here because we don't currently support
setting defaults for booleans. (See calls to `define_method` below.)

Closes #18371.
