### PR TITLE
workflows/pkg-installer: create an issue when publish fails

### DIFF
--- a/.github/workflows/pkg-installer.yml
+++ b/.github/workflows/pkg-installer.yml
@@ -213,3 +213,29 @@ jobs:
         run: gh release upload --repo Homebrew/brew
                                 "${GITHUB_REF//refs\/tags\//}"
                                 "${{ needs.build.outputs.installer_path }}"
+
+  issue:
+    needs: [build, test, upload]
+    if: always() && github.event_name == 'release'
+    runs-on: ubuntu-latest
+    env:
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    permissions:
+      # To create or update issues
+      issues: write
+    steps:
+      - name: Open, update, or close pkg installer issue
+        uses: Homebrew/actions/create-or-update-issue@master
+        with:
+          title: Failed to publish pkg installer
+          body: >
+            The pkg installer workflow [failed](${{ env.RUN_URL }}) for release
+            ${{ github.ref_name }}. No pkg installer was uploaded to the GitHub
+            release.
+          labels: bug,release blocker
+          update-existing: ${{ contains(needs.*.result, 'failure') }}
+          close-existing: ${{ needs.upload.result == 'success' }}
+          close-from-author: github-actions[bot]
+          close-comment: >
+            The pkg installer workflow [succeeded](${{ env.RUN_URL }}) for
+            release ${{ github.ref_name }}. Closing this issue.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This uses the `Homebrew/actions/create-or-update-issue` action added in Homebrew/actions#588 to create an issue when the publish fails for a release. It also automatically updates the issue on repeated failures, and closes the issue when the latest workflow run succeeds.
