### PR TITLE
generate-cask-api: fall back to previous URL if network fails

### DIFF
--- a/Library/Homebrew/extend/api_hashable.rb
+++ b/Library/Homebrew/extend/api_hashable.rb
@@ -3,6 +3,43 @@
 
 # Used to substitute common paths with generic placeholders when generating JSON for the API.
 module APIHashable
+  extend T::Helpers
+
+  requires_ancestor { Module }
+
+  module CaskURLFallbackExtension
+    extend T::Helpers
+
+    requires_ancestor { Kernel }
+    requires_ancestor { Cask::Cask }
+
+    def url(...)
+      url = super
+
+      # URLs with blocks are lazy-evaluated, so we let's force an evaluation to ensure the URL can be determined
+      begin
+        url.to_s
+      rescue
+        raise unless self.class.generating_hash?
+        raise unless (json_cask = Homebrew::API::Cask.all_casks[token])
+
+        prev_url = json_cask["url"]
+        prev_specs = json_cask["url_specs"] || {}
+        url = Cask::URL.new(prev_url, **prev_specs)
+
+        opoo "Unable to determine URL for #{token}. Falling back to previous value: #{url}"
+      end
+
+      url
+    end
+  end
+
+  def self.extended(base)
+    return if base != Cask::Cask
+
+    base.prepend CaskURLFallbackExtension
+  end
+
   def generating_hash!
     return if generating_hash?
 


### PR DESCRIPTION
If casks have a `url` stanza with a block (like [`transmission@nightly`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/t/transmission%40nightly.rb)), `brew generate-cask-api` needs to go to that URL in order to determine the correct download URL for the cask. It's very common for this to fail when generating the API (especially with `transmission@nightly`), so this PR adds a fallback mechanism. If `generate-cask-api` is unable to reach the URL specified in the block, it will simply fall back to whatever URL value existed previously in the API. This should hopefully reduce the number of generation failures we see in Homebrew/formulae.brew.sh.
