### PR TITLE
workflows/tests: use the container and `macos-14` for some jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,9 @@ jobs:
     name: formula audit
     needs: syntax
     if: github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/brew:master
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -251,10 +253,10 @@ jobs:
         include:
           - name: tests (online)
             test-flags: --online --coverage
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-latest
           - name: tests (generic OS)
             test-flags: --generic --coverage
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-latest
           - name: tests (Ubuntu 22.04)
             test-flags: --coverage
             runs-on: ubuntu-22.04
@@ -360,13 +362,16 @@ jobs:
     needs: syntax
     if: github.repository_owner == 'Homebrew'
     runs-on: ${{ matrix.runs-on }}
+    container: ${{ matrix.container }}
     strategy:
       matrix:
         include:
           - name: test default formula (Ubuntu 22.04)
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-latest
+            container: ghcr.io/homebrew/ubuntu22.04:master
           - name: test default formula (Ubuntu 20.04)
-            runs-on: ubuntu-20.04
+            runs-on: ubuntu-latest
+            container: ghcr.io/homebrew/ubuntu20.04
           - name: test default formula (macOS 13 x86_64)
             runs-on: macos-13
           - name: test default formula (macOS 14 arm64)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,7 +274,10 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          core: true
+          # We only test needs_homebrew_core tests on macOS because
+          # homebrew/core is not available by default on GitHub-hosted Ubuntu
+          # runners, and it's expensive to tap it.
+          core: ${{ runner.os == 'macOS' }}
           cask: false
           test-bot: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
     name: tap syntax
     needs: syntax
     if: github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The containers have `homebrew/core` tapped so we don't need to wait forever for the core repo to be cloned.

The tap syntax job requires all official taps. Unlike the Ubuntu images [^1], `macos-14` has both core and cask tapped [^2] so setting up Homebrew should be faster there. We don't use the containers because the cask tap is not available by default.

[^1]: https://github.com/actions/runner-images/blob/ubuntu24/20240922.1/images/ubuntu/scripts/build/install-homebrew.sh
[^2]: https://github.com/actions/runner-images/blob/macos-14/20240923.101/images/macos/scripts/build/install-homebrew.sh#L23-L24
