### PR TITLE
workflows/docker: publish `homebrew/brew:master`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,9 @@ jobs:
                   "${GITHUB_REF}" == "refs/heads/master" &&
                   "${{ matrix.version }}" == "22.04" ]]; then
             tags+=(
+              "ghcr.io/homebrew/brew:master"
               "ghcr.io/homebrew/ubuntu${{ matrix.version }}:master"
+              "homebrew/brew:master"
               "homebrew/ubuntu${{matrix.version}}:master"
             )
           fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When we don't care about which specific Ubuntu version to use, `homebrew/brew:master` is better than `homebrew/ubuntu22.04:master` as it allows us to implicitly rely on the default Ubuntu version.

See discussion at #18395.
