### PR TITLE
Speed up `brew tap` for no arguments

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -172,6 +172,11 @@ case "$@" in
     source "${HOMEBREW_LIBRARY}/Homebrew/list.sh"
     homebrew-list "$@" && exit 0
     ;;
+  # falls back to cmd/tap.rb on a non-zero return
+  tap*)
+    source "${HOMEBREW_LIBRARY}/Homebrew/tap.sh"
+    homebrew-tap "$@" && exit 0
+    ;;
   # falls back to cmd/help.rb on a non-zero return
   help | --help | -h | --usage | "-?" | "")
     homebrew-help "$@" && exit 0

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -173,7 +173,7 @@ case "$@" in
     homebrew-list "$@" && exit 0
     ;;
   # falls back to cmd/tap.rb on a non-zero return
-  tap*)
+  tap)
     source "${HOMEBREW_LIBRARY}/Homebrew/tap.sh"
     homebrew-tap "$@" && exit 0
     ;;

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -172,9 +172,11 @@ case "$@" in
     source "${HOMEBREW_LIBRARY}/Homebrew/list.sh"
     homebrew-list "$@" && exit 0
     ;;
+  # homebrew-tap only handles invocations with no arguments
   tap)
     source "${HOMEBREW_LIBRARY}/Homebrew/tap.sh"
-    homebrew-tap "$@" && exit 0
+    homebrew-tap "$@"
+    exit 0
     ;;
   # falls back to cmd/help.rb on a non-zero return
   help | --help | -h | --usage | "-?" | "")

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -172,7 +172,6 @@ case "$@" in
     source "${HOMEBREW_LIBRARY}/Homebrew/list.sh"
     homebrew-list "$@" && exit 0
     ;;
-  # falls back to cmd/tap.rb on a non-zero return
   tap)
     source "${HOMEBREW_LIBRARY}/Homebrew/tap.sh"
     homebrew-tap "$@" && exit 0

--- a/Library/Homebrew/tap.sh
+++ b/Library/Homebrew/tap.sh
@@ -7,8 +7,8 @@ normalise_tap_name() {
   local user
   local repo
 
-  user="$(echo "${dir%%/*}" | tr '[:upper:]' '[:lower:]')"
-  repo="$(echo "${dir#*/}" | tr '[:upper:]' '[:lower:]')"
+  user="$(tr '[:upper:]' '[:lower:]' <<<"${dir%%/*}")"
+  repo="$(tr '[:upper:]' '[:lower:]' <<<"${dir#*/}")"
   repo="${repo#@(home|linux)brew-}"
   echo "${user}/${repo}"
 }

--- a/Library/Homebrew/tap.sh
+++ b/Library/Homebrew/tap.sh
@@ -1,0 +1,41 @@
+# Does the quickest output of brew tap possible for no arguments.
+# HOMEBREW_LIBRARY is set by bin/brew
+# shellcheck disable=SC2154
+
+normalise_tap_name() {
+  local dir="$1"
+  local user
+  local repo
+
+  user="$(echo "${dir%%/*}" | tr '[:upper:]' '[:lower:]')"
+  repo="$(echo "${dir#*/}" | tr '[:upper:]' '[:lower:]')"
+  repo="${repo#@(home|linux)brew-}"
+  echo "${user}/${repo}"
+}
+
+homebrew-tap() {
+  case "$1" in
+    # check we actually have tap and not e.g. tapsomething
+    tap) ;;
+    tap*) return 1 ;;
+    *) ;;
+  esac
+
+  # Named args are handled by the Ruby code.
+  if [[ "$#" -gt 1 ]]
+  then
+    return 1
+  fi
+
+  local taplib="${HOMEBREW_LIBRARY}/Taps"
+  (
+    shopt -s extglob
+
+    for dir in "${taplib}"/*/*
+    do
+      [[ -d "${dir}" ]] || continue
+      dir="${dir#"${taplib}"/}"
+      normalise_tap_name "${dir}"
+    done | sort
+  )
+}

--- a/Library/Homebrew/tap.sh
+++ b/Library/Homebrew/tap.sh
@@ -14,19 +14,6 @@ normalise_tap_name() {
 }
 
 homebrew-tap() {
-  case "$1" in
-    # check we actually have tap and not e.g. tapsomething
-    tap) ;;
-    tap*) return 1 ;;
-    *) ;;
-  esac
-
-  # Named args are handled by the Ruby code.
-  if [[ "$#" -gt 1 ]]
-  then
-    return 1
-  fi
-
   local taplib="${HOMEBREW_LIBRARY}/Taps"
   (
     shopt -s extglob

--- a/Library/Homebrew/tap.sh
+++ b/Library/Homebrew/tap.sh
@@ -3,14 +3,14 @@
 # shellcheck disable=SC2154
 
 normalise_tap_name() {
-  local dir="$1"
+  local directory="$1"
   local user
-  local repo
+  local repository
 
-  user="$(tr '[:upper:]' '[:lower:]' <<<"${dir%%/*}")"
-  repo="$(tr '[:upper:]' '[:lower:]' <<<"${dir#*/}")"
-  repo="${repo#@(home|linux)brew-}"
-  echo "${user}/${repo}"
+  user="$(tr '[:upper:]' '[:lower:]' <<<"${directory%%/*}")"
+  repository="$(tr '[:upper:]' '[:lower:]' <<<"${directory#*/}")"
+  repository="${repository#@(home|linux)brew-}"
+  echo "${user}/${repository}"
 }
 
 homebrew-tap() {
@@ -18,11 +18,10 @@ homebrew-tap() {
   (
     shopt -s extglob
 
-    for dir in "${taplib}"/*/*
+    for directory in "${taplib}"/*/*
     do
-      [[ -d "${dir}" ]] || continue
-      dir="${dir#"${taplib}"/}"
-      normalise_tap_name "${dir}"
+      [[ -d "${directory}" ]] || continue
+      normalise_tap_name "${directory#"${taplib}"/}"
     done | sort
   )
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This provides a >3x speedup for `brew tap` with no arguments (i.e., when listing taps). It also makes the completion significantly faster.

```console
$ hyperfine --warmup=3 --setup 'git checkout {branch}' --parameter-list branch master,brew-tap-speedup 'brew tap'
Benchmark 1: brew tap (branch = master)
  Time (mean ± σ):      1.405 s ±  0.080 s    [User: 0.561 s, System: 0.238 s]
  Range (min … max):    1.332 s …  1.549 s    10 runs

Benchmark 2: brew tap (branch = brew-tap-speedup)
  Time (mean ± σ):     404.1 ms ± 124.8 ms    [User: 107.9 ms, System: 200.7 ms]
  Range (min … max):   308.8 ms … 693.7 ms    10 runs

Summary
  brew tap (branch = brew-tap-speedup) ran
    3.48 ± 1.09 times faster than brew tap (branch = master)
```
