### PR TITLE
formula: add size information to JSON API

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -47,6 +47,8 @@ module Homebrew
         switch "--force-bottle",
                description: "Download a bottle if it exists for the current or newest version of macOS, " \
                             "even if it would not be used during installation."
+        switch "--only-manifests",
+               description: "Only download GitHub Packages manifests."
         switch "--[no-]quarantine",
                description: "Disable/enable quarantining of downloads (default: enabled).",
                env:         :cask_opts_quarantine
@@ -62,6 +64,7 @@ module Homebrew
         conflicts "--cask", "--build-bottle"
         conflicts "--cask", "--force-bottle"
         conflicts "--cask", "--bottle-tag"
+        conflicts "--cask", "--only-manifests"
         conflicts "--formula", "--cask"
         conflicts "--os", "--bottle-tag"
         conflicts "--arch", "--bottle-tag"
@@ -173,7 +176,7 @@ module Homebrew
                     if (manifest_resource = bottle.github_packages_manifest_resource)
                       fetch_downloadable(manifest_resource)
                     end
-                    fetch_downloadable(bottle)
+                    fetch_downloadable(bottle) unless args.only_manifests?
                   rescue Interrupt
                     raise
                   rescue => e
@@ -187,7 +190,7 @@ module Homebrew
                   end
                 end
 
-                next if fetched_bottle
+                next if fetched_bottle || args.only_manifests?
 
                 fetch_downloadable(formula.resource)
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2623,6 +2623,13 @@ class Formula
       end
       file_hash["sha256"] = checksum
 
+      if (bottle = bottle_for_tag(tag))
+        bottle_size = bottle.bottle_size
+        installed_size = bottle.installed_size
+        file_hash["bottle_size"] = bottle_size if bottle_size
+        file_hash["installed_size"] = installed_size if installed_size
+      end
+
       hash["files"][tag.to_sym] = file_hash
     end
     hash

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -350,7 +350,8 @@ module Formulary
           rebuild bottles_stable["rebuild"]
           bottles_stable["files"].each do |tag, bottle_spec|
             cellar = Formulary.convert_to_string_or_symbol bottle_spec["cellar"]
-            sha256 cellar:, tag.to_sym => bottle_spec["sha256"]
+            sizes = bottle_spec.slice("bottle_size", "installed_size").transform_keys!(&:to_sym)
+            sha256 cellar:, tag.to_sym => bottle_spec["sha256"], **sizes
           end
         end
       end

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -306,6 +306,7 @@ class Resource
     def initialize(bottle)
       super("#{bottle.name}_bottle_manifest")
       @bottle = bottle
+      @manifest_annotations = nil
     end
 
     def verify_download_integrity(_filename)
@@ -314,6 +315,29 @@ class Resource
     end
 
     def tab
+      tab = manifest_annotations["sh.brew.tab"]
+      raise Error, "Couldn't find tab from manifest." if tab.blank?
+
+      begin
+        JSON.parse(tab)
+      rescue JSON::ParserError
+        raise Error, "Couldn't parse tab JSON."
+      end
+    end
+
+    def bottle_size
+      manifest_annotations["sh.brew.bottle.size"]&.to_i
+    end
+
+    def installed_size
+      manifest_annotations["sh.brew.bottle.installed_size"]&.to_i
+    end
+
+    private
+
+    def manifest_annotations
+      return @manifest_annotations if @manifest_annotations.present?
+
       json = begin
         JSON.parse(cached_download.read)
       rescue JSON::ParserError
@@ -336,14 +360,7 @@ class Resource
       end
       raise Error, "Couldn't find manifest matching bottle checksum." if manifest_annotations.blank?
 
-      tab = manifest_annotations["sh.brew.tab"]
-      raise Error, "Couldn't find tab from manifest." if tab.blank?
-
-      begin
-        JSON.parse(tab)
-      rescue JSON::ParserError
-        raise Error, "Couldn't parse tab JSON."
-      end
+      @manifest_annotations = manifest_annotations
     end
   end
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -367,6 +367,8 @@ class Bottle
     @tag = tag_spec.tag
     @cellar = tag_spec.cellar
     @rebuild = spec.rebuild
+    @bottle_size = tag_spec.bottle_size
+    @installed_size = tag_spec.installed_size
 
     @resource.version(formula.pkg_version.to_s)
     @resource.checksum = tag_spec.checksum
@@ -438,6 +440,7 @@ class Bottle
 
   sig { returns(T.nilable(Integer)) }
   def bottle_size
+    return @bottle_size unless @bottle_size.nil?
     return unless (resource = github_packages_manifest_resource)&.downloaded?
 
     resource.bottle_size
@@ -445,6 +448,7 @@ class Bottle
 
   sig { returns(T.nilable(Integer)) }
   def installed_size
+    return @installed_size unless @installed_size.nil?
     return unless (resource = github_packages_manifest_resource)&.downloaded?
 
     resource.installed_size
@@ -610,7 +614,7 @@ class BottleSpecification
 
     cellar ||= tag.default_cellar
 
-    collector.add(tag, checksum: Checksum.new(digest), cellar:)
+    collector.add(tag, checksum: Checksum.new(digest), cellar:, **hash.slice(:bottle_size, :installed_size))
   end
 
   sig {

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -436,6 +436,20 @@ class Bottle
     {}
   end
 
+  sig { returns(T.nilable(Integer)) }
+  def bottle_size
+    return unless (resource = github_packages_manifest_resource)&.downloaded?
+
+    resource.bottle_size
+  end
+
+  sig { returns(T.nilable(Integer)) }
+  def installed_size
+    return unless (resource = github_packages_manifest_resource)&.downloaded?
+
+    resource.installed_size
+  end
+
   sig { returns(Filename) }
   def filename
     Filename.create(resource.owner, @tag, @spec.rebuild)

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -265,10 +265,18 @@ module Utils
       sig { returns(T.any(Symbol, String)) }
       attr_reader :cellar
 
-      def initialize(tag:, checksum:, cellar:)
+      sig { returns(T.nilable(Integer)) }
+      attr_reader :bottle_size
+
+      sig { returns(T.nilable(Integer)) }
+      attr_reader :installed_size
+
+      def initialize(tag:, checksum:, cellar:, bottle_size: nil, installed_size: nil)
         @tag = tag
         @checksum = checksum
         @cellar = cellar
+        @bottle_size = bottle_size
+        @installed_size = installed_size
       end
 
       def ==(other)
@@ -294,9 +302,17 @@ module Utils
       end
       alias eql? ==
 
-      sig { params(tag: Utils::Bottles::Tag, checksum: Checksum, cellar: T.any(Symbol, String)).void }
-      def add(tag, checksum:, cellar:)
-        spec = Utils::Bottles::TagSpecification.new(tag:, checksum:, cellar:)
+      sig {
+        params(
+          tag:            Utils::Bottles::Tag,
+          checksum:       Checksum,
+          cellar:         T.any(Symbol, String),
+          bottle_size:    T.nilable(Integer),
+          installed_size: T.nilable(Integer),
+        ).void
+      }
+      def add(tag, checksum:, cellar:, bottle_size: nil, installed_size: nil)
+        spec = Utils::Bottles::TagSpecification.new(tag:, checksum:, cellar:, bottle_size:, installed_size:)
         @tag_specs[tag] = spec
       end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Will be using this PR to essentially jot some ideas down. Needs #18172 beforehand. May end up combining parts of this into other PR.

* General idea right now is to let JSON code path pick up already fetched manifests and populate size information if they exist.
* Re-use `brew fetch` so we can make use of `--concurrency` with new `--only-manifests` to pull quickly pull down all formulae manifests.
* Need to find where to inject the information to bypass manifest fetch when loading API data
