### PR TITLE
cask/url: deprecate `url do` blocks.

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -117,6 +117,8 @@ module Cask
         @uri = uri
         @dsl = dsl
         @block = block
+
+        odeprecated "cask `url do` blocks" if @block
       end
 
       sig { returns(T.any(T.any(URI::Generic, String), [T.any(URI::Generic, String), Hash])) }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -948,36 +948,6 @@ RSpec.describe Cask::Audit, :cask do
       end
     end
 
-    describe "url checks" do
-      let(:only) { %w[unnecessary_verified missing_verified no_match] }
-
-      context "with a block" do
-        let(:cask_token) { "booby-trap" }
-
-        context "when loading the cask" do
-          it "does not evaluate the block" do
-            expect { cask }.not_to raise_error
-          end
-        end
-
-        context "when doing an offline audit" do
-          let(:online) { false }
-
-          it "does not evaluate the block" do
-            expect(run).not_to error_with(/Boom/)
-          end
-        end
-
-        context "when doing and online audit" do
-          let(:online) { true }
-
-          it "evaluates the block" do
-            expect(run).to error_with(/Boom/)
-          end
-        end
-      end
-    end
-
     describe "token conflicts" do
       let(:only) { ["token_conflicts"] }
       let(:cask_token) { "with-binary" }
@@ -1170,36 +1140,6 @@ RSpec.describe Cask::Audit, :cask do
         end
 
         it { is_expected.to error_with(/a homepage stanza is required/) }
-      end
-
-      context "when url is lazy" do
-        let(:strict) { true }
-        let(:cask_token) { "with-lazy" }
-        let(:cask) do
-          tmp_cask cask_token.to_s, <<~RUBY
-            cask '#{cask_token}' do
-              version '1.8.0_72,8.13.0.5'
-              sha256 '8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a'
-              url do
-                ['https://brew.sh/foo.zip', {referer: 'https://example.com', cookies: {'foo' => 'bar'}}]
-              end
-              name 'Audit'
-              desc 'Audit Description'
-              homepage 'https://brew.sh'
-              app 'Audit.app'
-            end
-          RUBY
-        end
-
-        it { is_expected.to pass }
-
-        it "receives a referer" do
-          expect(audit.cask.url.referer).to eq "https://example.com"
-        end
-
-        it "receives cookies" do
-          expect(audit.cask.url.cookies).to eq "foo" => "bar"
-        end
       end
     end
   end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/booby-trap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/booby-trap.rb
@@ -1,8 +1,0 @@
-cask "booby-trap" do
-  version "0.0.7"
-
-  url do
-    # to be lazily evaluated
-    raise "Boom"
-  end
-end


### PR DESCRIPTION
We're removing these in https://github.com/Homebrew/homebrew-cask/pull/186501 and forbidding in https://github.com/Homebrew/brew/pull/18404 so let's deprecate them too (because having functionality like this we don't allow in official taps is recipe for accidental breakage and deprecation later).
