### PR TITLE
env_config: deprecate setting boolean vars to falsy values

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -515,7 +515,18 @@ module Homebrew
 
       if hash[:boolean]
         define_method(method_name) do
-          ENV[env].present?
+          env_value = ENV.fetch(env, nil)
+
+          falsy_values = %w[false no off nil 0]
+          if falsy_values.include?(env_value&.downcase)
+            odeprecated "#{env}=#{env_value}", <<~EOS
+              If you wish to enable #{env}, #{env}=1
+              If you wish to disable #{env}, #{env}=
+            EOS
+          end
+
+          # TODO: Uncomment the remaining part of the line below after the deprecation/disable cycle.
+          env_value.present? # && !falsy_values.include(env_value.downcase)
         end
       elsif hash[:default].present?
         define_method(method_name) do

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe GitHubRunnerMatrix do
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")
+    allow(ENV).to receive(:fetch).with("HOMEBREW_NO_INSTALL_FROM_API", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_EVAL_ALL", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_SIMULATE_MACOS_ON_LINUX", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_FORBID_PACKAGES_FROM_PATHS", nil).and_call_original
   end
 
   let(:newest_supported_macos) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The way we handle boolean environment variables is a bit unfortunate.
For example, setting `HOMEBREW_EVAL_ALL=false` actually enables
`HOMEBREW_EVAL_ALL`.

Let's fix this by deprecating setting boolean environment variables to
common false-y values (`false`, `0`, `nil`, `no`, and `off`) so that we
can later ignore these false-y values when reading boolean environment
variables.

Note: I haven't commented out `odeprecated` because I meant to target the PR branch at #18388, but that seems to have merged just before I pushed this.
