### PR TITLE
cmd/--cache: avoid exception on missing HEAD

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -17,7 +17,7 @@ module Homebrew
         description <<~EOS
           Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 
-          If <formula> is provided, display the file or directory used to cache <formula>.
+          If a <formula> or <cask> is provided, display the file or directory used to cache it.
         EOS
         flag   "--os=",
                description: "Show cache file for the given operating system. " \
@@ -113,7 +113,11 @@ module Homebrew
 
           puts bottle.cached_download
         elsif args.HEAD?
-          puts T.must(formula.head).cached_download
+          if (head = formula.head)
+            puts head.cached_download
+          else
+            opoo "No head is defined for #{formula.full_name}."
+          end
         else
           puts formula.cached_download
         end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1494,8 +1494,8 @@ dependency for their stable builds.
 
 Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 
-If *`formula`* is provided, display the file or directory used to cache
-*`formula`*.
+If a *`formula`* or *`cask`* is provided, display the file or directory used to
+cache it.
 
 `--os`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -938,7 +938,7 @@ Include only casks\.
 .SS "\fB\-\-cache\fP \fR[\fIoptions\fP] \fR[\fIformula\fP|\fIcask\fP \.\.\.]"
 Display Homebrew\[u2019]s download cache\. See also \fBHOMEBREW_CACHE\fP\&\.
 .P
-If \fIformula\fP is provided, display the file or directory used to cache \fIformula\fP\&\.
+If a \fIformula\fP or \fIcask\fP is provided, display the file or directory used to cache it\.
 .TP
 \fB\-\-os\fP
 Show cache file for the given operating system\. (Pass \fBall\fP to show cache files for all operating systems\.)


### PR DESCRIPTION
Also add cask to description

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Original `T.must` is not guaranteed and will lead to less readable exceptions, e.g.
```console
❯ brew --cache --HEAD python@3.12
Error: Passed `nil` into T.must
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11581/lib/types/_types.rb:222:in `must'
/opt/homebrew/Library/Homebrew/cmd/--cache.rb:116:in `print_formula_cache'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11581/lib/types/private/methods/call_validation.rb:270:in `bind_call'
```

Instead, this change just outputs a warning similar to missing bottle scenario. Message used is same as what is output when running `brew install --HEAD` on missing HEAD.
```console
❯ brew --cache --HEAD python@3.12
Warning: No head is defined for python@3.12.
```