### PR TITLE
Revert "Deprecate installing casks/formulae from paths."

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -211,13 +211,8 @@ rescue Exception => e # rubocop:disable Lint/RescueException
     $stderr.puts "If reporting this issue please do so at (not Homebrew/brew or Homebrew/homebrew-core):"
     $stderr.puts "  #{Formatter.url(issues_url)}"
   elsif internal_cmd
-    if e.is_a?(MethodDeprecatedError) && (first_backtrace = e.backtrace&.first.presence) &&
-       (first_backtrace.include?("/formulary.rb") || first_backtrace.include?("/cask_loader.rb"))
-      $stderr.puts Utils::Backtrace.clean(e) if ARGV.include?("--debug") || args.debug?
-    else
-      $stderr.puts "#{Tty.bold}Please report this issue:#{Tty.reset}"
-      $stderr.puts "  #{Formatter.url(OS::ISSUES_URL)}"
-    end
+    $stderr.puts "#{Tty.bold}Please report this issue:#{Tty.reset}"
+    $stderr.puts "  #{Formatter.url(OS::ISSUES_URL)}"
   end
 
   exit 1

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -105,19 +105,10 @@ module Cask
         end
 
         return if %w[.rb .json].exclude?(path.extname)
-        return if path.to_s.include?("/Formula/")
         return unless path.expand_path.exist?
 
-        unless path.realpath.to_s.start_with?("#{Caskroom.path}/", "#{HOMEBREW_LIBRARY}/Taps/",
-                                              "#{HOMEBREW_LIBRARY_PATH}/test/support/fixtures/")
-          return if Homebrew::EnvConfig.forbid_packages_from_paths?
-
-          # So many tests legimately use casks from paths that we can't warn about them all.
-          # Let's focus on end-users for now.
-          unless ENV["HOMEBREW_TESTS"]
-            odeprecated "installing formulae from paths or URLs", "installing formulae from taps"
-          end
-        end
+        return if Homebrew::EnvConfig.forbid_packages_from_paths? &&
+                  !path.realpath.to_s.start_with?("#{Caskroom.path}/", "#{HOMEBREW_LIBRARY}/Taps/")
 
         new(path)
       end
@@ -203,8 +194,6 @@ module Cask
 
       def load(config:)
         path.dirname.mkpath
-
-        odeprecated "installing casks from paths or URLs", "installing casks from taps"
 
         if ALLOWED_URL_SCHEMES.exclude?(url.scheme)
           raise UnsupportedInstallationMethod,

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -646,6 +646,9 @@ module Formulary
 
       return unless path.expand_path.exist?
 
+      return if Homebrew::EnvConfig.forbid_packages_from_paths? &&
+                !path.realpath.to_s.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/")
+
       options = if (tap = Tap.from_path(path))
         # Only treat symlinks in taps as aliases.
         if path.symlink?
@@ -671,17 +674,6 @@ module Formulary
       end
 
       return if path.extname != ".rb"
-
-      unless path.realpath.to_s.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_TAP_DIRECTORY}/",
-                                            "#{HOMEBREW_LIBRARY_PATH}/test/support/fixtures/")
-        return if Homebrew::EnvConfig.forbid_packages_from_paths?
-
-        # So many tests legimately use formulae from paths that we can't warn about them all.
-        # Let's focus on end-users for now.
-        unless ENV["HOMEBREW_TESTS"]
-          odeprecated "installing formulae from paths or URLs", "installing formulae from taps"
-        end
-      end
 
       new(path, **options)
     end
@@ -723,8 +715,6 @@ module Formulary
       uri = URI(uri)
       return unless uri.path
       return unless uri.scheme.present?
-
-      odeprecated "installing formulae from paths or URLs", "installing formulae from taps"
 
       new(uri, from:)
     end

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -29,28 +29,28 @@ RSpec.describe Cask::CaskLoader::FromURILoader do
       loader = described_class.new("https://brew.sh/foo.rb")
       expect do
         loader.load(config: nil)
-      end.to raise_error(MethodDeprecatedError)
+      end.to raise_error(UnsupportedInstallationMethod)
     end
 
     it "raises an error when given an ftp URL" do
       loader = described_class.new("ftp://brew.sh/foo.rb")
       expect do
         loader.load(config: nil)
-      end.to raise_error(MethodDeprecatedError)
+      end.to raise_error(UnsupportedInstallationMethod)
     end
 
     it "raises an error when given an sftp URL" do
       loader = described_class.new("sftp://brew.sh/foo.rb")
       expect do
         loader.load(config: nil)
-      end.to raise_error(MethodDeprecatedError)
+      end.to raise_error(UnsupportedInstallationMethod)
     end
 
-    it "raises an error when given a file URL" do
+    it "does not raise an error when given a file URL" do
       loader = described_class.new("file://#{TEST_FIXTURE_DIR}/cask/Casks/local-caffeine.rb")
       expect do
         loader.load(config: nil)
-      end.to raise_error(MethodDeprecatedError)
+      end.not_to raise_error(UnsupportedInstallationMethod)
     end
   end
 end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -46,10 +46,16 @@ RSpec.describe Cask::Cask, :cask do
       expect(c.token).to eq("caffeine")
     end
 
+    it "returns an instance of the Cask from a URL", :needs_utils_curl, :no_api do
+      c = Cask::CaskLoader.load("file://#{tap_path}/Casks/local-caffeine.rb")
+      expect(c).to be_a(described_class)
+      expect(c.token).to eq("local-caffeine")
+    end
+
     it "raises an error when failing to download a Cask from a URL", :needs_utils_curl, :no_api do
       expect do
         Cask::CaskLoader.load("file://#{tap_path}/Casks/notacask.rb")
-      end.to raise_error(MethodDeprecatedError)
+      end.to raise_error(Cask::CaskUnavailableError)
     end
 
     it "returns an instance of the Cask from a relative file location" do

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -129,6 +129,11 @@ RSpec.describe Formulary do
         end.to raise_error(FormulaUnavailableError)
       end
 
+      it "returns a Formula when given a URL", :needs_utils_curl, :no_api do
+        formula = described_class.factory("file://#{formula_path}")
+        expect(formula).to be_a(Formula)
+      end
+
       it "errors when given a URL but paths are disabled" do
         ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
         expect do
@@ -541,31 +546,31 @@ RSpec.describe Formulary do
       it "raises an error when given an https URL" do
         expect do
           described_class.factory("https://brew.sh/foo.rb")
-        end.to raise_error(MethodDeprecatedError)
+        end.to raise_error(UnsupportedInstallationMethod)
       end
 
       it "raises an error when given a bottle URL" do
         expect do
           described_class.factory("https://brew.sh/foo-1.0.arm64_catalina.bottle.tar.gz")
-        end.to raise_error(MethodDeprecatedError)
+        end.to raise_error(UnsupportedInstallationMethod)
       end
 
       it "raises an error when given an ftp URL" do
         expect do
           described_class.factory("ftp://brew.sh/foo.rb")
-        end.to raise_error(MethodDeprecatedError)
+        end.to raise_error(UnsupportedInstallationMethod)
       end
 
       it "raises an error when given an sftp URL" do
         expect do
           described_class.factory("sftp://brew.sh/foo.rb")
-        end.to raise_error(MethodDeprecatedError)
+        end.to raise_error(UnsupportedInstallationMethod)
       end
 
-      it "raises an error when given a file URL" do
+      it "does not raise an error when given a file URL" do
         expect do
           described_class.factory("file://#{TEST_FIXTURE_DIR}/testball.rb")
-        end.to raise_error(MethodDeprecatedError)
+        end.not_to raise_error(UnsupportedInstallationMethod)
       end
     end
 


### PR DESCRIPTION
`brew test-bot` seems to be broken now for third-party taps.

Fixes #18433

Reverts Homebrew/brew#18409