### PR TITLE
linkage_checker: skip files with incompatible architectures

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -469,6 +469,11 @@ class Pathname
     false
   end
 
+  sig { params(_wanted_arch: Symbol).returns(T::Boolean) }
+  def arch_compatible?(_wanted_arch)
+    false
+  end
+
   sig { returns(T::Array[String]) }
   def rpaths
     []

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -471,7 +471,7 @@ class Pathname
 
   sig { params(_wanted_arch: Symbol).returns(T::Boolean) }
   def arch_compatible?(_wanted_arch)
-    false
+    true
   end
 
   sig { returns(T::Array[String]) }

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -115,6 +115,7 @@ class LinkageChecker
       @keg.find do |file|
         next if file.symlink? || file.directory?
         next if !file.dylib? && !file.binary_executable? && !file.mach_o_bundle?
+        next unless file.arch_compatible?(Hardware::CPU.arch)
 
         # weakly loaded dylibs may not actually exist on disk, so skip them
         # when checking for broken linkage

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -68,6 +68,12 @@ module ELFShim
     end
   end
 
+  def arch_compatible?(wanted_arch)
+    return true unless elf?
+
+    wanted_arch == arch
+  end
+
   def elf_type
     return :dunno unless elf?
 

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -155,6 +155,13 @@ module MachOShim
     arch == :ppc64
   end
 
+  def arch_compatible?(wanted_arch)
+    return true unless mach_data.present?
+    return arch == wanted_arch unless universal?
+
+    archs.include?(wanted_arch)
+  end
+
   def dylib?
     mach_data.any? { |m| m.fetch(:type) == :dylib }
   end

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -155,13 +155,6 @@ module MachOShim
     arch == :ppc64
   end
 
-  def arch_compatible?(wanted_arch)
-    return true unless mach_data.present?
-    return arch == wanted_arch unless universal?
-
-    archs.include?(wanted_arch)
-  end
-
   def dylib?
     mach_data.any? { |m| m.fetch(:type) == :dylib }
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some formulae include these files, and they can't always be removed.
However, they can cause spurious linkage failures, so let's skip them
when checking for linkage. See, for example, faust at
Homebrew/homebrew-core#191308.
