### PR TITLE
tap: add repository key.

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -887,6 +887,7 @@ class Tap
       "name"          => name,
       "user"          => user,
       "repo"          => repository,
+      "repository"    => repository,
       "path"          => path.to_s,
       "installed"     => installed?,
       "official"      => official?,


### PR DESCRIPTION
Follow up from #18445 that may allow us to deprecate the old name in future.