### PR TITLE
github/workflows: use macos-15 GitHub Actions runners.

### DIFF
--- a/.github/workflows/pkg-installer.yml
+++ b/.github/workflows/pkg-installer.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
   build:
     if: github.repository_owner == 'Homebrew' && github.actor != 'dependabot[bot]'
-    runs-on: macos-latest
+    runs-on: macos-15
     outputs:
       installer_path: "Homebrew-${{ steps.homebrew-version.outputs.version }}.pkg"
     env:
@@ -143,6 +143,8 @@ jobs:
           # Apple Silicon
           - runner: macos-14
             name: macos-14-arm64
+          - runner: macos-15
+            name: macos-15-arm64
     steps:
       - name: Download installer from GitHub Actions
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
@@ -188,7 +190,7 @@ jobs:
 
   upload:
     needs: [build, test]
-    runs-on: macos-latest
+    runs-on: macos-15
     permissions:
       # To write assets to GitHub release
       contents: write

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   tapioca:
     if: github.repository == 'Homebrew/brew'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
     name: cask audit
     needs: syntax
     if: github.repository_owner == 'Homebrew'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -226,7 +226,7 @@ jobs:
           - name: update-test (Ubuntu 22.04)
             runs-on: ubuntu-22.04
           - name: update-test (macOS)
-            runs-on: macos-14
+            runs-on: macos-15
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -264,9 +264,9 @@ jobs:
           - name: tests (macOS 13 x86_64)
             test-flags: --coverage
             runs-on: macos-13
-          - name: tests (macOS 14 arm64)
+          - name: tests (macOS 15 arm64)
             test-flags: --coverage
-            runs-on: macos-14
+            runs-on: macos-15
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -369,8 +369,8 @@ jobs:
             runs-on: ubuntu-20.04
           - name: test default formula (macOS 13 x86_64)
             runs-on: macos-13
-          - name: test default formula (macOS 14 arm64)
-            runs-on: macos-14
+          - name: test default formula (macOS 15 arm64)
+            runs-on: macos-15
     env:
       HOMEBREW_TEST_BOT_ANALYTICS: 1
       HOMEBREW_ENFORCE_SBOM: 1

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -27,7 +27,7 @@ defaults:
 jobs:
   vendor-gems:
     if: github.repository_owner == 'Homebrew'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -84,7 +84,7 @@ module Homebrew
             test-bot:
               strategy:
                 matrix:
-                  os: [ubuntu-22.04, macos-13, macos-14]
+                  os: [ubuntu-22.04, macos-13, macos-15]
               runs-on: ${{ matrix.os }}
               steps:
                 - name: Set up Homebrew


### PR DESCRIPTION
- Let's use this instead of macOS 14/latest when possible.
- Keep around macOS 13 to ensure we're still testing x86_64.