### PR TITLE
audit: audit deprecate/disable reasons

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -946,6 +946,12 @@ module Cask
       add_error "Cask should be located in '#{expected_path}'"
     end
 
+    sig { void }
+    def audit_deprecate_disable
+      error = SharedAudits.check_deprecate_disable_reason(cask)
+      add_error error if error
+    end
+
     sig {
       params(
         url_to_check: T.any(String, URL),

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -963,6 +963,11 @@ module Homebrew
       EOS
     end
 
+    def audit_deprecate_disable
+      error = SharedAudits.check_deprecate_disable_reason(formula)
+      problem error if error
+    end
+
     def quote_dep(dep)
       dep.is_a?(Symbol) ? dep.inspect : "'#{dep}'"
     end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1142,5 +1142,52 @@ RSpec.describe Cask::Audit, :cask do
         it { is_expected.to error_with(/a homepage stanza is required/) }
       end
     end
+
+    describe "checking deprecate/disable" do
+      let(:only) { ["deprecate_disable"] }
+      let(:cask_token) { "deprecated-cask" }
+
+      context "when deprecate/disable is used with a valid reason" do
+        let(:cask) do
+          tmp_cask cask_token.to_s, <<~RUBY
+            cask '#{cask_token}' do
+              version "1.0"
+                sha256 "8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a"
+                url "https://brew.sh/foo.zip"
+                name "Audit"
+                desc "Cask Auditor"
+                homepage "https://brew.sh/"
+                app "Audit.app"
+                deprecate! date: "2021-01-01", because: :foobar
+            end
+          RUBY
+        end
+
+        it "fails" do
+          expect(run).to error_with(/foobar is not a valid deprecate! or disable! reason/)
+        end
+      end
+
+      context "when deprecate/disable is used with an invalid reason" do
+        let(:cask) do
+          tmp_cask cask_token.to_s, <<~RUBY
+            cask '#{cask_token}' do
+              version "1.0"
+                sha256 "8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a"
+                url "https://brew.sh/foo.zip"
+                name "Audit"
+                desc "Cask Auditor"
+                homepage "https://brew.sh/"
+                app "Audit.app"
+                disable! date: "2021-01-01", because: :discontinued
+            end
+          RUBY
+        end
+
+        it "passes" do
+          expect(run).to pass
+        end
+      end
+    end
   end
 end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1312,4 +1312,35 @@ RSpec.describe Homebrew::FormulaAuditor do
         .to match("Formula foo should also have a conflict declared with bar")
     end
   end
+
+  describe "#audit_deprecate_disable" do
+    specify "it warns when deprecate/disable reason is invalid" do
+      fa = formula_auditor "foo", <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+        deprecate! date: "2021-01-01", because: :foobar
+        end
+      RUBY
+
+      mkdir_p fa.formula.prefix
+      fa.audit_deprecate_disable
+      expect(fa.problems.first[:message])
+        .to match("foobar is not a valid deprecate! or disable! reason")
+    end
+
+    specify "it does not warn when deprecate/disable reason is valid" do
+      fa = formula_auditor "foo", <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+        deprecate! date: "2021-01-01", because: :repo_archived
+        end
+      RUBY
+
+      mkdir_p fa.formula.prefix
+      fa.audit_deprecate_disable
+      expect(fa.problems).to be_empty
+    end
+  end
 end

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -193,4 +193,20 @@ module SharedAudits
   def self.gitlab_tag_from_url(url)
     url[%r{^https://gitlab\.com/(?:\w[\w.-]*/){2,}-/archive/([^/]+)/}, 1]
   end
+
+  sig { params(formula_or_cask: T.any(Formula, Cask::Cask)).returns(T.nilable(String)) }
+  def self.check_deprecate_disable_reason(formula_or_cask)
+    return if !formula_or_cask.deprecated? && !formula_or_cask.disabled?
+
+    reason = formula_or_cask.deprecated? ? formula_or_cask.deprecation_reason : formula_or_cask.disable_reason
+    return unless reason.is_a?(Symbol)
+
+    reasons = if formula_or_cask.is_a?(Formula)
+      DeprecateDisable::FORMULA_DEPRECATE_DISABLE_REASONS
+    else
+      DeprecateDisable::CASK_DEPRECATE_DISABLE_REASONS
+    end
+
+    "#{reason} is not a valid deprecate! or disable! reason" unless reasons.include?(reason)
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a shared audit for Formulae & Casks that checks the validity of deprecation/disable reasons.