### PR TITLE
Gemfile.lock: bump Ruby version

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -202,7 +202,7 @@ DEPENDENCIES
   yard-sorbet
 
 RUBY VERSION
-   ruby 3.3.4p94
+   ruby 3.3.5p100
 
 BUNDLED WITH
    2.5.20


### PR DESCRIPTION
Doesn't really matter too much but should do it anyway.