### PR TITLE
dev-cmd/bump: fix comparison of versions with comma-separated values

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -319,7 +319,9 @@ module Homebrew
 
             livecheck_latest = livecheck_result(loaded_formula_or_cask)
 
-            new_version_value = if (livecheck_latest.is_a?(Version) && livecheck_latest >= current_version_value) ||
+            new_version_value = if (livecheck_latest.is_a?(Version) &&
+                                    Livecheck::LivecheckVersion.create(formula_or_cask, livecheck_latest) >=
+                                    Livecheck::LivecheckVersion.create(formula_or_cask, current_version_value)) ||
                                    current_version_value == "latest"
               livecheck_latest
             elsif livecheck_latest.is_a?(String) && livecheck_latest.start_with?("skipped")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR fixes an issue when running `brew bump` with casks that use `version` stanzas containing comma-separated values.

The problem occurs when the number of components increases (e.g., `9.5,286` ==> `9.5.1,287`), since the versions are compared token by token, leading to incorrect results (e.g., `1 < 286`).
To resolve this, instances of `LivecheckVersion` are used to split the comma-separated values into individual `Version` objects.

Before:

```console
$ brew bump --cask banktivity
==> banktivity
Current cask version:     9.5,286
Latest livecheck version: unable to get versions
...
```

After:

```console
$ brew bump --cask banktivity
==> banktivity
Current cask version:     9.5,286
Latest livecheck version: 9.5.1,287
...
```

Related to https://github.com/Homebrew/homebrew-cask/issues/182564.
