### PR TITLE
attestion: make `InvalidAttestationError` non-fatal in CI

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -246,6 +246,12 @@ module Homebrew
       end
 
       backfill_attestation
+    rescue InvalidAttestationError => e
+      raise if ENV["HOMEBREW_GITHUB_ACTIONS"].blank?
+
+      opoo "Attestation verification failed (please verify that this is not a network error before rebottling): #{e}"
+
+      {}
     end
   end
 end

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -254,7 +254,7 @@ module Homebrew
 
       sleep_time = 3 ** @attestation_retry_count[bottle]
       opoo "Failed to verify attestation. Retrying in #{sleep_time}..."
-      sleep sleep_time
+      sleep sleep_time if ENV["HOMEBREW_TESTS"].blank?
       @attestation_retry_count[bottle] += 1
       retry
     end

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -179,6 +179,8 @@ module Homebrew
       attestation
     end
 
+    ATTESTATION_MAX_RETRIES = 5
+
     # Verifies the given bottle against a cryptographic attestation of build provenance
     # from homebrew-core's CI, falling back on a "backfill" attestation for older bottles.
     #
@@ -246,12 +248,15 @@ module Homebrew
       end
 
       backfill_attestation
-    rescue InvalidAttestationError => e
-      raise if ENV["HOMEBREW_GITHUB_ACTIONS"].blank?
+    rescue InvalidAttestationError
+      @attestation_retry_count ||= T.let(Hash.new(0), T.nilable(T::Hash[Bottle, Integer]))
+      raise if @attestation_retry_count[bottle] >= ATTESTATION_MAX_RETRIES
 
-      opoo "Attestation verification failed (please verify that this is not a network error before rebottling): #{e}"
-
-      {}
+      sleep_time = 3 ** @attestation_retry_count[bottle]
+      opoo "Failed to verify attestation. Retrying in #{sleep_time}..."
+      sleep sleep_time
+      @attestation_retry_count[bottle] += 1
+      retry
     end
   end
 end

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Homebrew::Attestation do
                               described_class::HOMEBREW_CORE_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
-        .once
+        .exactly(described_class::ATTESTATION_MAX_RETRIES + 1)
         .and_raise(described_class::MissingAttestationError)
 
       expect(described_class).to receive(:system_command!)
@@ -267,6 +267,7 @@ RSpec.describe Homebrew::Attestation do
                               described_class::BACKFILL_REPO, "--format", "json"],
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
+        .exactly(described_class::ATTESTATION_MAX_RETRIES + 1)
         .and_return(fake_result_json_resp_too_new)
 
       expect do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I don't think I've seen an `InvalidAttestationError` that wasn't some
sort of network problem (e.g., rate limit, connection timeout, 503).
Let's emit a warning instead of erroring out.

Note that `MissingAttestationError` is still fatal, and that will still
produce errors in CI.
