### PR TITLE
linkage_checker: replace `Fiddle.dlopen` with `libSystem` call

### DIFF
--- a/Library/Homebrew/sorbet/rbi/upstream.rbi
+++ b/Library/Homebrew/sorbet/rbi/upstream.rbi
@@ -2,3 +2,17 @@
 
 # This file contains temporary definitions for fixes that have
 # been submitted upstream to https://github.com/sorbet/sorbet.
+
+# Missing constants we use in `linkage_checker.rb`
+# https://github.com/sorbet/sorbet/pull/8215
+module Fiddle
+  # [`TYPE_BOOL`](https://github.com/ruby/fiddle/blob/v1.1.2/ext/fiddle/fiddle.h#L129)
+  #
+  # C type - bool
+  TYPE_BOOL = T.let(T.unsafe(nil).freeze, Integer)
+
+  # [`TYPE_CONST_STRING`](https://github.com/ruby/fiddle/blob/v1.1.2/ext/fiddle/fiddle.h#L128)
+  #
+  # C type - char\*
+  TYPE_CONST_STRING = T.let(T.unsafe(nil).freeze, Integer)
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`dlopen`ing a library executes potentially untrusted code (e.g. if the
library has initialisers). We can avoid the `dlopen` call by asking
`libSystem` directly about whether a library can be found in the shared
cache.

Of course, the `dlopen` happens after a `ENOENT`, so the attack surface here
is relatively small. But relying on this still exposes us to a potential
TOCTOU[^1] bug. Let's avoid it entirely by skipping `dlopen` altogether.

[^1]: https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use

-----

`brew typecheck` currently returns an error. Looks like the RBI for Fiddle will need updating.
