### PR TITLE
Allow "any" value in github_prerelease_allowlist

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -62,9 +62,9 @@ module SharedAudits
       [cask.tap&.audit_exception(:github_prerelease_allowlist, cask.token), cask.token, cask.version]
     end
 
-    return "#{tag} is a GitHub pre-release." if release["prerelease"] && [version, "all"].exclude?(exception)
+    return "#{tag} is a GitHub pre-release." if release["prerelease"] && [version, "all", "any"].exclude?(exception)
 
-    if !release["prerelease"] && exception
+    if !release["prerelease"] && exception && exception != "any"
       return "#{tag} is not a GitHub pre-release but '#{name}' is in the GitHub prerelease allowlist."
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
	- `test/livecheck/strategy/github_releases_spec.rb` seems like the best place to add a test for this, but there isn't currently anything to cover the `github_prerelease_allowlist` (that I can see).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is required for https://github.com/Homebrew/homebrew-cask/pull/187392. Unfortunately, the vendor there unreliably uses GitHub releases for binary distribution and doesn't consistently set Stable/Pre-release tags.

The change here allows the use of `"any"` instead of `"all"` in the `github_prerelease_allowlist` to effectively suppress the "not a pre-release" audit failure.