### PR TITLE
Build brew docker image for x86 and arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Fetch origin/master from Git
         run: git fetch origin master
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
 
@@ -110,6 +113,7 @@ jobs:
           tags: brew
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           build-args: version=${{ matrix.version }}
           labels: ${{ steps.attributes.outputs.labels }}
 
@@ -140,5 +144,6 @@ jobs:
           tags: ${{ steps.attributes.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
           build-args: version=${{ matrix.version }}
           labels: ${{ steps.attributes.outputs.labels }}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When opening the `brew` repository with VSCode on am M1 Mac, it prompted me to reopen the window in a devcontainer. I agreed, then that devcontainer failed to startup, saying there was no such image. Attempting to pull manually resulted in this:
```
❯ docker pull ghcr.io/homebrew/brew:latest
latest: Pulling from homebrew/brew
no matching manifest for linux/arm64/v8 in the manifest list entries
```

This PR will build the `linux/arm64` image in parallel with the amd64 image, allowing arm-based macs (and any other arm64-based system) to use the brew container.