### PR TITLE
unpack_strategy/directory: try preserving hardlinks

### DIFF
--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe UnpackStrategy::Directory do
     mktmpdir.tap do |path|
       FileUtils.touch path/"file"
       FileUtils.ln_s "file", path/"symlink"
+      FileUtils.ln path/"file", path/"hardlink"
       FileUtils.mkdir path/"folder"
       FileUtils.ln_s "folder", path/"folderSymlink"
     end
@@ -24,6 +25,11 @@ RSpec.describe UnpackStrategy::Directory do
   it "does not follow top level symlinks to directories" do
     strategy.extract(to: unpack_dir)
     expect(unpack_dir/"folderSymlink").to be_a_symlink
+  end
+
+  it "preserves hardlinks" do
+    strategy.extract(to: unpack_dir)
+    expect((unpack_dir/"file").stat.ino).to eq (unpack_dir/"hardlink").stat.ino
   end
 
   it "preserves permissions of contained files" do

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -20,11 +20,29 @@ module UnpackStrategy
 
     sig { override.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      path.children.each do |child|
-        system_command! "cp",
-                        args:    ["-pR", (child.directory? && !child.symlink?) ? "#{child}/." : child,
-                                  unpack_dir/child.basename],
-                        verbose:
+      path_children = path.children
+      return if path_children.empty?
+
+      existing = unpack_dir.children
+
+      # We run a few cp attempts in the following order:
+      #
+      # 1. Start with `-al` to create hardlinks rather than copying files if the source and
+      #    target are on the same filesystem. On macOS, this is the only cp option that can
+      #    preserve hardlinks but it is only available since macOS 12.3 (file_cmds-353.100.22).
+      # 2. Try `-a` as GNU `cp -a` preserves hardlinks. macOS `cp -a` is identical to `cp -pR`.
+      # 3. Fall back on `-pR` to handle the case where GNU `cp -a` failed. This may happen if
+      #    installing into a filesystem that doesn't support hardlinks like an exFAT USB drive.
+      cp_arg_attempts = ["-a", "-pR"]
+      cp_arg_attempts.unshift("-al") if path.stat.dev == unpack_dir.stat.dev
+
+      cp_arg_attempts.each do |arg|
+        args = [arg, *path_children, unpack_dir]
+        must_succeed = print_stderr = (arg == cp_arg_attempts.last)
+        result = system_command("cp", args:, verbose:, must_succeed:, print_stderr:)
+        break if result.success?
+
+        FileUtils.rm_r(unpack_dir.children - existing)
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Try running `cp -al` to preserve hardlinks on both macOS and Linux.

If that fails, fall back on `cp -a` which can preserve hardlinks on Linux (but not macOS) assuming target filesystem supports them.

---

Originally tried preserving hardlinks in #13154 but the situation with macOS commands was a bit of a pain (`cp` didn't work well, `rsync` was slow and had mtime issues, `cpio` was a pain to use and could lead to excessive memory as need to stdin every file, etc.).

Exploring this again to figure out a general solution for compacting bottle/install sizes in #18478. Given we now only build bottles for Ventura onward, the limitation on `cp -l` is less of an issue.

I think fallback on older macOS should be quick as `cp` will fail right away on illegal options, e.g.
```console
❯ cp -z
cp: illegal option -- z
```

There is a slow path if `cp -a` fails and falls back to `cp -pR` where:
* In case of macOS, both would fail. Though I consider this similar to exception handling where this is a rare case and slowness is okay.
* In case of Linux, there is an inconvenient point where `-a` (implicit `-R`) continues on failure so it adds overhead of adding then removing files. Again should be rare situation as Linux filesystems would usually support hardlinks. Not sure if possible but maybe could create a scenario of install brew on a USB drive.

---

Specific example is again `trino` but this time the bottle which has hardlinks:

Before:
```
==> Summary
🍺  /opt/homebrew/Cellar/trino/459: 6,310 files, 3.6GB
==> Running `brew cleanup trino`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Installation times
trino                    16.562 s
```

After:
```
==> Summary
🍺  /opt/homebrew/Cellar/trino/459: 6,310 files, 859.9MB
==> Running `brew cleanup trino`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Installation times
trino                    10.458 s
```