### PR TITLE
utils/curl: workaround curl bug for `--head --request GET`

### DIFF
--- a/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_github_packages_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe CurlGitHubPackagesDownloadStrategy do
     before do
       stub_const("HOMEBREW_GITHUB_PACKAGES_AUTH", authorization) if authorization.present?
 
+      allow(strategy).to receive(:curl_version).and_return(Version.new("8.7.1"))
+
       allow(strategy).to receive(:system_command)
         .with(
           /curl/,

--- a/Library/Homebrew/test/download_strategies/curl_post_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_post_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe CurlPostDownloadStrategy do
 
   describe "#fetch" do
     before do
+      allow(strategy).to receive(:curl_version).and_return(Version.new("8.6.0"))
+
       allow(strategy).to receive(:system_command)
         .with(
           /curl/,

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -234,7 +234,11 @@ module Utils
     end
 
     def curl_headers(*args, wanted_headers: [], **options)
-      [[], ["--request", "GET"]].each do |request_args|
+      get_retry_args = ["--request", "GET"]
+      # This is a workaround for https://github.com/Homebrew/brew/issues/18213
+      get_retry_args << "--http1.1" if curl_version >= Version.new("8.7") && curl_version < Version.new("8.10")
+
+      [[], get_retry_args].each do |request_args|
         result = curl_output(
           "--fail", "--location", "--silent", "--head", *request_args, *args,
           **options
@@ -494,9 +498,14 @@ module Utils
       T.must(file).unlink
     end
 
+    def curl_version
+      @curl_version ||= {}
+      @curl_version[curl_path] ||= Version.new(curl_output("-V").stdout[/curl (\d+(\.\d+)+)/, 1])
+    end
+
     def curl_supports_fail_with_body?
       @curl_supports_fail_with_body ||= Hash.new do |h, key|
-        h[key] = Version.new(curl_output("-V").stdout[/curl (\d+(\.\d+)+)/, 1]) >= Version.new("7.76.0")
+        h[key] = curl_version >= Version.new("7.76.0")
       end
       @curl_supports_fail_with_body[curl_path]
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `curl --head --request GET` causes a full download to happen on
`curl` from 8.7.0 to 8.9.1[^1] which causes poor UX due to slow
Cask downloads that can take almost twice as long as they should.

[^1]: https://github.com/Homebrew/brew/issues/18213
