### PR TITLE
Provides a config option to ignore warnings about Xcode being outdated

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -30,6 +30,10 @@ module Homebrew
       def run
         Homebrew.inject_dump_stats!(Diagnostic::Checks, /^check_*/) if args.audit_debug?
 
+        # While it is probably OK to run an outdated Xcode for normal operations,
+        # it's good to know if we have an outdated Xcode when running `brew doctor`.
+        ENV.delete("HOMEBREW_NO_WARN_OUTDATED_XCODE")
+
         checks = Diagnostic::Checks.new(verbose: args.verbose?)
 
         if args.list_checks?

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -397,6 +397,10 @@ module Homebrew
                      "from homebrew-core.",
         boolean:     true,
       },
+      HOMEBREW_NO_WARN_OUTDATED_XCODE:           {
+        description: "If set, Homebrew will not warn about using outdated (but still compatible) Xcode versions.",
+        boolean:     true,
+      },
       HOMEBREW_PIP_INDEX_URL:                    {
         description:  "If set, `brew install` <formula> will use this URL to download PyPI package resources.",
         default_text: "`https://pypi.org/simple`.",

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -139,7 +139,7 @@ module Homebrew
         # Homebrew/brew is currently using.
         return if GitHub::Actions.env_set?
 
-        return if ENV["HOMEBREW_NO_WARN_OUTDATED_XCODE"]
+        return if Homebrew::EnvConfig.no_warn_outdated_xcode?
 
         # With fake El Capitan for Portable Ruby, we are intentionally not using Xcode 8.
         # This is because we are not using the CLT and Xcode 8 has the 10.12 SDK.

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -139,6 +139,8 @@ module Homebrew
         # Homebrew/brew is currently using.
         return if GitHub::Actions.env_set?
 
+        return if ENV["HOMEBREW_NO_WARN_OUTDATED_XCODE"]
+
         # With fake El Capitan for Portable Ruby, we are intentionally not using Xcode 8.
         # This is because we are not using the CLT and Xcode 8 has the 10.12 SDK.
         return if ENV["HOMEBREW_FAKE_MACOS"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I'm adding this since in our organization, there are parts of the organization which are slower about updating xcode versions. In our case we are using an older version of Xcode 15 – so, still on an Xcode from this year, just not 15.4. This is because we rely on Simulator visual screenshots and these can _sometimes_ change very slightly between Xcode versions. We want to silence the warning for the users who are updating Xcode in a controlled manner.