### PR TITLE
Replace removed constants with overridable methods

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -117,7 +117,7 @@ module Cask
       @dsl.language_eval
     end
 
-    DSL::DSL_METHODS.each do |method_name|
+    ::Cask::DSL::DSL_METHODS.each do |method_name|
       define_method(method_name) { |&block| @dsl.send(method_name, &block) }
     end
 

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -555,7 +555,7 @@ module Homebrew
     end
 
     def rm_ds_store(dirs = nil)
-      dirs ||= Keg::MUST_EXIST_DIRECTORIES + [
+      dirs ||= Keg.must_exist_directories + [
         HOMEBREW_PREFIX/"Caskroom",
       ]
       dirs.select(&:directory?)
@@ -623,7 +623,7 @@ module Homebrew
       dirs = []
       children_count = {}
 
-      Keg::MUST_EXIST_SUBDIRECTORIES.each do |dir|
+      Keg.must_exist_subdirectories.each do |dir|
         next unless dir.directory?
 
         dir.find do |path|
@@ -639,7 +639,7 @@ module Homebrew
                 path.unlink
               end
             end
-          elsif path.directory? && Keg::MUST_EXIST_SUBDIRECTORIES.exclude?(path)
+          elsif path.directory? && Keg.must_exist_subdirectories.exclude?(path)
             dirs << path
             children_count[path] = path.children.length if dry_run?
           end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -315,7 +315,7 @@ module Homebrew
       def check_for_broken_symlinks
         broken_symlinks = []
 
-        Keg::MUST_EXIST_SUBDIRECTORIES.each do |d|
+        Keg.must_exist_subdirectories.each do |d|
           next unless d.directory?
 
           d.find do |path|
@@ -344,7 +344,7 @@ module Homebrew
       def check_exist_directories
         return if HOMEBREW_PREFIX.writable?
 
-        not_exist_dirs = Keg::MUST_EXIST_DIRECTORIES.reject(&:exist?)
+        not_exist_dirs = Keg.must_exist_directories.reject(&:exist?)
         return if not_exist_dirs.empty?
 
         <<~EOS
@@ -359,8 +359,8 @@ module Homebrew
 
       def check_access_directories
         not_writable_dirs =
-          Keg::MUST_BE_WRITABLE_DIRECTORIES.select(&:exist?)
-                                           .reject(&:writable?)
+          Keg.must_be_writable_directories.select(&:exist?)
+             .reject(&:writable?)
         return if not_writable_dirs.empty?
 
         <<~EOS

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -3,32 +3,38 @@
 
 require "system_command"
 
-class Keg
-  include SystemCommand::Mixin
-
-  # TODO: re-implement these as functions, so that we aren't modifying constants:
-  GENERIC_KEG_LINK_DIRECTORIES = (remove_const :KEG_LINK_DIRECTORIES).freeze
-  KEG_LINK_DIRECTORIES = (GENERIC_KEG_LINK_DIRECTORIES + ["Frameworks"]).freeze
-  GENERIC_MUST_EXIST_SUBDIRECTORIES = (remove_const :MUST_EXIST_SUBDIRECTORIES).freeze
-  MUST_EXIST_SUBDIRECTORIES = (
-    GENERIC_MUST_EXIST_SUBDIRECTORIES +
-    [HOMEBREW_PREFIX/"Frameworks"]
-  ).sort.uniq.freeze
-  GENERIC_MUST_EXIST_DIRECTORIES = (remove_const :MUST_EXIST_DIRECTORIES).freeze
-  MUST_EXIST_DIRECTORIES = (
-    GENERIC_MUST_EXIST_DIRECTORIES +
-    [HOMEBREW_PREFIX/"Frameworks"]
-  ).sort.uniq.freeze
-  GENERIC_MUST_BE_WRITABLE_DIRECTORIES = (remove_const :MUST_BE_WRITABLE_DIRECTORIES).freeze
-  MUST_BE_WRITABLE_DIRECTORIES = (
-    GENERIC_MUST_BE_WRITABLE_DIRECTORIES +
-    [HOMEBREW_PREFIX/"Frameworks"]
-  ).sort.uniq.freeze
-end
-
 module OS
   module Mac
     module Keg
+      include SystemCommand::Mixin
+
+      module ClassMethods
+        def keg_link_directories
+          @keg_link_directories ||= (super + ["Frameworks"]).freeze
+        end
+
+        def must_exist_subdirectories
+          @must_exist_subdirectories ||= (
+            super +
+            [HOMEBREW_PREFIX/"Frameworks"]
+          ).sort.uniq.freeze
+        end
+
+        def must_exist_directories
+          @must_exist_directories = (
+            super +
+            [HOMEBREW_PREFIX/"Frameworks"]
+          ).sort.uniq.freeze
+        end
+
+        def must_be_writable_directories
+          @must_be_writable_directories ||= (
+            super +
+            [HOMEBREW_PREFIX/"Frameworks"]
+          ).sort.uniq.freeze
+        end
+      end
+
       def binary_executable_or_library_files = mach_o_files
 
       def codesign_patched_binary(file)
@@ -121,4 +127,5 @@ module OS
   end
 end
 
+Keg.singleton_class.prepend(OS::Mac::Keg::ClassMethods)
 Keg.prepend(OS::Mac::Keg)

--- a/Library/Homebrew/extend/os/mac/keg.rb
+++ b/Library/Homebrew/extend/os/mac/keg.rb
@@ -3,6 +3,22 @@
 
 require "system_command"
 
+class Keg
+  # TODO: re-implement these as functions, so that we aren't modifying constants:
+  GENERIC_KEG_LINK_DIRECTORIES = (remove_const :KEG_LINK_DIRECTORIES).freeze
+  KEG_LINK_DIRECTORIES = (GENERIC_KEG_LINK_DIRECTORIES + ["Frameworks"]).freeze
+  GENERIC_MUST_EXIST_SUBDIRECTORIES = (remove_const :MUST_EXIST_SUBDIRECTORIES).freeze
+  MUST_EXIST_SUBDIRECTORIES = (
+    GENERIC_MUST_EXIST_SUBDIRECTORIES +
+    [HOMEBREW_PREFIX/"Frameworks"]
+  ).sort.uniq.freeze
+  GENERIC_MUST_BE_WRITABLE_DIRECTORIES = (remove_const :MUST_BE_WRITABLE_DIRECTORIES).freeze
+  MUST_BE_WRITABLE_DIRECTORIES = (
+    GENERIC_MUST_BE_WRITABLE_DIRECTORIES +
+    [HOMEBREW_PREFIX/"Frameworks"]
+  ).sort.uniq.freeze
+end
+
 module OS
   module Mac
     module Keg

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1229,7 +1229,7 @@ on_request: installed_on_request?, options:)
       sandbox.deny_write_homebrew_repository
       sandbox.allow_write_cellar(formula)
       sandbox.deny_all_network unless formula.network_access_allowed?(:postinstall)
-      Keg::KEG_LINK_DIRECTORIES.each do |dir|
+      Keg.keg_link_directories.each do |dir|
         sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
       end
       sandbox.run(*args)

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -325,7 +325,7 @@ module Homebrew
       end
 
       def attempt_directory_creation
-        Keg::MUST_EXIST_DIRECTORIES.each do |dir|
+        Keg.must_exist_directories.each do |dir|
           FileUtils.mkdir_p(dir) unless dir.exist?
         rescue
           nil

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -78,38 +78,6 @@ class Keg
   # Locale-specific directories have the form `language[_territory][.codeset][@modifier]`
   LOCALEDIR_RX = %r{(locale|man)/([a-z]{2}|C|POSIX)(_[A-Z]{2})?(\.[a-zA-Z\-0-9]+(@.+)?)?}
   INFOFILE_RX = %r{info/([^.].*?\.info(\.gz)?|dir)$}
-  KEG_LINK_DIRECTORIES = %w[
-    bin etc include lib sbin share var
-  ].freeze
-  MUST_EXIST_SUBDIRECTORIES = (
-    KEG_LINK_DIRECTORIES - %w[var] + %w[
-      opt
-      var/homebrew/linked
-    ]
-  ).map { |dir| HOMEBREW_PREFIX/dir }.sort.uniq.freeze
-
-  # Keep relatively in sync with
-  # {https://github.com/Homebrew/install/blob/HEAD/install.sh}
-  MUST_EXIST_DIRECTORIES = (MUST_EXIST_SUBDIRECTORIES + [
-    HOMEBREW_CELLAR,
-  ].sort.uniq).freeze
-  MUST_BE_WRITABLE_DIRECTORIES = (
-    %w[
-      etc/bash_completion.d lib/pkgconfig
-      share/aclocal share/doc share/info share/locale share/man
-      share/man/man1 share/man/man2 share/man/man3 share/man/man4
-      share/man/man5 share/man/man6 share/man/man7 share/man/man8
-      share/zsh share/zsh/site-functions
-      var/log
-    ].map { |dir| HOMEBREW_PREFIX/dir } + MUST_EXIST_SUBDIRECTORIES + [
-      HOMEBREW_CACHE,
-      HOMEBREW_CELLAR,
-      HOMEBREW_LOCKS,
-      HOMEBREW_LOGS,
-      HOMEBREW_REPOSITORY,
-      Language::Python.homebrew_site_packages,
-    ]
-  ).sort.uniq.freeze
 
   # These paths relative to the keg's share directory should always be real
   # directories in the prefix, never symlinks.
@@ -144,6 +112,51 @@ class Keg
 
   def self.all
     Formula.racks.flat_map(&:subdirs).map { |d| new(d) }
+  end
+
+  def self.keg_link_directories
+    @keg_link_directories ||= %w[
+      bin etc include lib sbin share var
+    ].freeze
+  end
+
+  def self.must_exist_subdirectories
+    @must_exist_subdirectories ||= (
+    keg_link_directories - %w[var] + %w[
+      opt
+      var/homebrew/linked
+    ]
+  ).map { |dir| HOMEBREW_PREFIX/dir }.sort.uniq.freeze
+  end
+
+  # Keep relatively in sync with
+  # {https://github.com/Homebrew/install/blob/HEAD/install.sh}
+  def self.must_exist_directories
+    @must_exist_directories ||= (must_exist_subdirectories + [
+      HOMEBREW_CELLAR,
+    ].sort.uniq).freeze
+  end
+
+  # Keep relatively in sync with
+  # {https://github.com/Homebrew/install/blob/HEAD/install.sh}
+  def self.must_be_writable_directories
+    @must_be_writable_directories ||= (
+    %w[
+      etc/bash_completion.d lib/pkgconfig
+      share/aclocal share/doc share/info share/locale share/man
+      share/man/man1 share/man/man2 share/man/man3 share/man/man4
+      share/man/man5 share/man/man6 share/man/man7 share/man/man8
+      share/zsh share/zsh/site-functions
+      var/log
+    ].map { |dir| HOMEBREW_PREFIX/dir } + must_exist_subdirectories + [
+      HOMEBREW_CACHE,
+      HOMEBREW_CELLAR,
+      HOMEBREW_LOCKS,
+      HOMEBREW_LOGS,
+      HOMEBREW_REPOSITORY,
+      Language::Python.homebrew_site_packages,
+    ]
+  ).sort.uniq.freeze
   end
 
   attr_reader :path, :name, :linked_keg_record, :opt_record
@@ -288,8 +301,8 @@ class Keg
 
     dirs = []
 
-    keg_directories = KEG_LINK_DIRECTORIES.map { |d| path/d }
-                                          .select(&:exist?)
+    keg_directories = self.class.keg_link_directories.map { |d| path/d }
+                          .select(&:exist?)
     keg_directories.each do |dir|
       dir.find do |src|
         dst = HOMEBREW_PREFIX + src.relative_path_from(path)
@@ -316,7 +329,7 @@ class Keg
     unless dry_run
       remove_old_aliases
       remove_linked_keg_record if linked?
-      (dirs - MUST_EXIST_SUBDIRECTORIES).reverse_each(&:rmdir_if_possible)
+      (dirs - self.class.must_exist_subdirectories).reverse_each(&:rmdir_if_possible)
     end
 
     ObserverPathnameExtension.n

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -78,6 +78,32 @@ class Keg
   # Locale-specific directories have the form `language[_territory][.codeset][@modifier]`
   LOCALEDIR_RX = %r{(locale|man)/([a-z]{2}|C|POSIX)(_[A-Z]{2})?(\.[a-zA-Z\-0-9]+(@.+)?)?}
   INFOFILE_RX = %r{info/([^.].*?\.info(\.gz)?|dir)$}
+  KEG_LINK_DIRECTORIES = %w[
+    bin etc include lib sbin share var
+  ].freeze
+  MUST_EXIST_SUBDIRECTORIES = (
+    KEG_LINK_DIRECTORIES - %w[var] + %w[
+      opt
+      var/homebrew/linked
+    ]
+  ).map { |dir| HOMEBREW_PREFIX/dir }.sort.uniq.freeze
+  MUST_BE_WRITABLE_DIRECTORIES = (
+    %w[
+      etc/bash_completion.d lib/pkgconfig
+      share/aclocal share/doc share/info share/locale share/man
+      share/man/man1 share/man/man2 share/man/man3 share/man/man4
+      share/man/man5 share/man/man6 share/man/man7 share/man/man8
+      share/zsh share/zsh/site-functions
+      var/log
+    ].map { |dir| HOMEBREW_PREFIX/dir } + MUST_EXIST_SUBDIRECTORIES + [
+      HOMEBREW_CACHE,
+      HOMEBREW_CELLAR,
+      HOMEBREW_LOCKS,
+      HOMEBREW_LOGS,
+      HOMEBREW_REPOSITORY,
+      Language::Python.homebrew_site_packages,
+    ]
+  ).sort.uniq.freeze
 
   # These paths relative to the keg's share directory should always be real
   # directories in the prefix, never symlinks.

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -272,7 +272,7 @@ RSpec.configure do |config|
 
       FileUtils.rm_rf [
         *TEST_DIRECTORIES,
-        *Keg::MUST_EXIST_SUBDIRECTORIES,
+        *Keg.must_exist_subdirectories,
         HOMEBREW_LINKED_KEGS,
         HOMEBREW_PINNED_KEGS,
         HOMEBREW_PREFIX/"var",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We should avoid `remove_const`, especially when redefining the removed const, as it violates normal assumptions of a "constant".

Surprisingly, there's no cop to disallow this method, except for the narrow [case](https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecremoveconst) of specs. (There is an open [issue](https://github.com/rubocop/rubocop/issues/1065) for a general `DisallowedMethods` cop, which has some code snippets, should we want to bother with a custom rule.)