### PR TITLE
Use requires_ancestor consistently

### DIFF
--- a/Library/Homebrew/attrable.rb
+++ b/Library/Homebrew/attrable.rb
@@ -2,6 +2,10 @@
 # frozen_string_literal: true
 
 module Attrable
+  extend T::Helpers
+
+  requires_ancestor { Module }
+
   sig { params(attrs: Symbol).void }
   def attr_predicate(*attrs)
     attrs.each do |attr|

--- a/Library/Homebrew/attrable.rbi
+++ b/Library/Homebrew/attrable.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module Attrable
-  requires_ancestor { Module }
-end

--- a/Library/Homebrew/cask/metadata.rb
+++ b/Library/Homebrew/cask/metadata.rb
@@ -4,8 +4,12 @@
 module Cask
   # Helper module for reading and writing cask metadata.
   module Metadata
+    extend T::Helpers
+
     METADATA_SUBDIR = ".metadata"
     TIMESTAMP_FORMAT = "%Y%m%d%H%M%S.%L"
+
+    requires_ancestor { Cask }
 
     def metadata_main_container_path(caskroom_path: self.caskroom_path)
       caskroom_path.join(METADATA_SUBDIR)

--- a/Library/Homebrew/cask/metadata.rbi
+++ b/Library/Homebrew/cask/metadata.rbi
@@ -1,7 +1,0 @@
-# typed: strict
-
-module Cask
-  module Metadata
-    requires_ancestor { Cask }
-  end
-end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -31,6 +31,10 @@ class AbstractDownloadStrategy
 
   # Extension for bottle downloads.
   module Pourable
+    extend T::Helpers
+
+    requires_ancestor { AbstractDownloadStrategy }
+
     def stage
       ohai "Pouring #{basename}"
       super

--- a/Library/Homebrew/download_strategy.rbi
+++ b/Library/Homebrew/download_strategy.rbi
@@ -1,9 +1,5 @@
 # typed: strict
 
-module AbstractDownloadStrategy::Pourable
-  requires_ancestor { AbstractDownloadStrategy }
-end
-
 # This is a third-party implementation
 # rubocop:disable Lint/StructNewOverride
 class Mechanize::HTTP

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -10,6 +10,7 @@ module Downloadable
   extend T::Helpers
 
   abstract!
+  requires_ancestor { Kernel }
 
   sig { overridable.returns(T.nilable(URL)) }
   attr_reader :url

--- a/Library/Homebrew/downloadable.rbi
+++ b/Library/Homebrew/downloadable.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module Downloadable
-  requires_ancestor { Kernel }
-end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -197,6 +197,10 @@ end
 
 # Shared methods for formula unreadable errors.
 module FormulaUnreadableErrorModule
+  extend T::Helpers
+
+  requires_ancestor { FormulaOrCaskUnavailableError }
+
   attr_reader :formula_error
 
   sig { returns(String) }

--- a/Library/Homebrew/exceptions.rbi
+++ b/Library/Homebrew/exceptions.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module FormulaUnreadableErrorModule
-  requires_ancestor { FormulaOrCaskUnavailableError }
-end

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -11,7 +11,10 @@ require "development_tools"
 # @see Stdenv
 # @see https://www.rubydoc.info/stdlib/Env Ruby's ENV API
 module SharedEnvExtension
+  extend T::Helpers
   include CompilerConstants
+
+  requires_ancestor { Sorbet::Private::Static::ENVClass }
 
   CC_FLAG_VARS = %w[CFLAGS CXXFLAGS OBJCFLAGS OBJCXXFLAGS].freeze
   private_constant :CC_FLAG_VARS

--- a/Library/Homebrew/extend/ENV/shared.rbi
+++ b/Library/Homebrew/extend/ENV/shared.rbi
@@ -1,8 +1,6 @@
 # typed: strict
 
 module SharedEnvExtension
-  requires_ancestor { Sorbet::Private::Static::ENVClass }
-
   # Overload to allow `PATH` values.
   sig {
     type_parameters(:U).params(

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -6,6 +6,10 @@ require "system_command"
 module UnpackStrategy
   class Zip
     module MacOSZipExtension
+      extend T::Helpers
+
+      requires_ancestor { UnpackStrategy }
+
       private
 
       sig { params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }

--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rbi
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module UnpackStrategy::Zip::MacOSZipExtension
-  requires_ancestor { UnpackStrategy }
-end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -2,6 +2,10 @@
 # frozen_string_literal: true
 
 module DiskUsageExtension
+  extend T::Helpers
+
+  requires_ancestor { Pathname }
+
   sig { returns(Integer) }
   def disk_usage
     return @disk_usage if defined?(@disk_usage)
@@ -524,6 +528,10 @@ require "extend/os/pathname"
 require "context"
 
 module ObserverPathnameExtension
+  extend T::Helpers
+
+  requires_ancestor { Pathname }
+
   class << self
     include Context
 

--- a/Library/Homebrew/extend/pathname.rbi
+++ b/Library/Homebrew/extend/pathname.rbi
@@ -1,9 +1,0 @@
-# typed: strict
-
-module DiskUsageExtension
-  requires_ancestor { Pathname }
-end
-
-module ObserverPathnameExtension
-  requires_ancestor { Pathname }
-end

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -6,6 +6,8 @@ require "os/linux/ld"
 # {Pathname} extension for dealing with ELF files.
 # @see https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
 module ELFShim
+  extend T::Helpers
+
   MAGIC_NUMBER_OFFSET = 0
   private_constant :MAGIC_NUMBER_OFFSET
   MAGIC_NUMBER_ASCII = "\x7fELF"
@@ -39,6 +41,8 @@ module ELFShim
   private_constant :ARCHITECTURE_X86_64
   ARCHITECTURE_AARCH64 = 0xB7
   private_constant :ARCHITECTURE_AARCH64
+
+  requires_ancestor { Pathname }
 
   def read_uint8(offset)
     read(1, offset).unpack1("C")

--- a/Library/Homebrew/os/linux/elf.rbi
+++ b/Library/Homebrew/os/linux/elf.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module ELFShim
-  requires_ancestor { Pathname }
-end

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -6,6 +6,9 @@ require "macho"
 # {Pathname} extension for dealing with Mach-O files.
 module MachOShim
   extend Forwardable
+  extend T::Helpers
+
+  requires_ancestor { Pathname }
 
   delegate [:dylib_id] => :macho
 

--- a/Library/Homebrew/os/mac/mach.rbi
+++ b/Library/Homebrew/os/mac/mach.rbi
@@ -1,5 +1,0 @@
-# typed: strict
-
-module MachOShim
-  requires_ancestor { Pathname }
-end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We've been using `requires_ancestor` in the runtime since https://github.com/Homebrew/brew/pull/18102 – let's do so consistently and clear out some unnecessary rbi files.