### PR TITLE
shellenv: Add zsh site-functions to `fpath`

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -81,6 +81,10 @@ homebrew-shellenv() {
       echo "export HOMEBREW_PREFIX=\"${HOMEBREW_PREFIX}\";"
       echo "export HOMEBREW_CELLAR=\"${HOMEBREW_CELLAR}\";"
       echo "export HOMEBREW_REPOSITORY=\"${HOMEBREW_REPOSITORY}\";"
+      if [[ "${HOMEBREW_SHELL_NAME}" == "zsh" ]] || [[ "${HOMEBREW_SHELL_NAME}" == "-zsh" ]]
+      then
+        echo "fpath[1,0]=\"${HOMEBREW_PREFIX}/share/zsh/site-functions\";"
+      fi
       if [[ -n "${PATH_HELPER_ROOT}" ]]
       then
         PATH_HELPER_ROOT="${PATH_HELPER_ROOT}" PATH="${HOMEBREW_PATH}" /usr/libexec/path_helper -s

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -34,14 +34,14 @@ If you are using Homebrew's `bash` as your shell (i.e. `bash` >= v4) you should 
 
 ## Configuring Completions in `zsh`
 
-To make Homebrew's completions available in `zsh`, the Homebrew-managed `zsh/site-functions` path needs to be inserted into `FPATH` before initialising `zsh`'s completion facility. This is done by `brew shellenv`, so if you followed the post-Homebrew installation steps and have `eval "$(brew shellenv)"` in your `~/.zprofile`, all you need is add the following to your `~/.zshrc` if it's not already there:
+To make Homebrew's completions available in `zsh`, the Homebrew-managed `zsh/site-functions` path needs to be inserted into `FPATH` before initialising `zsh`'s completion facility. This is done by `brew shellenv`, so if you followed the post-Homebrew installation steps, `eval "$(brew shellenv)"` should be in your `~/.zprofile` (on macOS) or `~/.zshrc` (on Linux). All you need is add the following to your `~/.zshrc` if it's not already there, and, if you're on Linux, make sure it's placed after `eval "$(brew shellenv)"`:
 
 ```sh
 autoload -Uz compinit
 compinit
 ```
 
-Note that if you are using Oh My Zsh, it will call `compinit` for you when you source `oh-my-zsh.sh`. In this case, you should be all set without any additional configuration.
+Note that if you are using Oh My Zsh, it will call `compinit` for you when you source `oh-my-zsh.sh`. In this case, make sure `eval "$(brew shellenv)"` is called before sourcing `oh-my-zsh.sh` if you're on Linux, and you should be all set without any additional configuration.
 
 You may also need to forcibly rebuild `zcompdump`:
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -34,23 +34,14 @@ If you are using Homebrew's `bash` as your shell (i.e. `bash` >= v4) you should 
 
 ## Configuring Completions in `zsh`
 
-To make Homebrew's completions available in `zsh`, you must insert the Homebrew-managed `zsh/site-functions` path into your `FPATH` before initialising `zsh`'s completion facility. Add the following to your `~/.zshrc`:
+To make Homebrew's completions available in `zsh`, the Homebrew-managed `zsh/site-functions` path needs to be inserted into `FPATH` before initialising `zsh`'s completion facility. This is done by `brew shellenv`, so if you followed the post-Homebrew installation steps and have `eval "$(brew shellenv)"` in your `~/.zprofile`, all you need is add the following to your `~/.zshrc` if it's not already there:
 
 ```sh
-if type brew &>/dev/null
-then
-  FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
-
-  autoload -Uz compinit
-  compinit
-fi
+autoload -Uz compinit
+compinit
 ```
 
-This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you when you source `oh-my-zsh.sh`. In this case, instead of the above, add the following line to your `~/.zshrc`, before you source `oh-my-zsh.sh`:
-
-```sh
-FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
-```
+Note that if you are using Oh My Zsh, it will call `compinit` for you when you source `oh-my-zsh.sh`. In this case, you should be all set without any additional configuration.
 
 You may also need to forcibly rebuild `zcompdump`:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds the brew zsh site-functions directory to the fpath during `brew shellenv`, allowing us to enable completions in one line instead of the seven currently suggested on the [Shell Completions](https://docs.brew.sh/Shell-Completion) page.

The shell-completions documentations page states we don't do this by default because managing completions is complex. This is true, however, I still think it's fair to pick the low-hanging-fruit on behalf of the user; many installations already call `compinit` on their behalf, and by including the homebrew fpath we can give those users completions for free. Remaining users only need to call compinit (assuming they have shellenv already setup). 

If this gets accepted, I can make another PR to update the docs, suggesting users eval the shellenv command instead of the manual fpath manipulation instructions.

For the implementation itself, I made a few design choices for backwards compatibility (documented in the commit description), but I'm flexible if someone prefers it another way.
