### PR TITLE
feat: Install an unlinked formula via `brew install` if `--overwrite`  is passed

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -289,6 +289,7 @@ module Homebrew
             only_dependencies: args.only_dependencies?,
             force:             args.force?,
             quiet:             args.quiet?,
+            overwrite:         args.overwrite?,
           )
         end
 

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -60,7 +60,8 @@ module Homebrew
         fetch_head: false,
         only_dependencies: false,
         force: false,
-        quiet: false
+        quiet: false,
+        overwrite: false
       )
         # head-only without --HEAD is an error
         if !head && formula.stable.nil?
@@ -132,7 +133,7 @@ module Homebrew
                 The currently linked version is: #{formula.linked_version}
               EOS
             end
-          elsif only_dependencies
+          elsif only_dependencies || (!formula.linked? && overwrite)
             msg = nil
             return true
           elsif !formula.linked? || formula.keg_only?


### PR DESCRIPTION
If the intention is to overwrite any existing links, then `brew install` should go on to install over an unlinked formula

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
