### PR TITLE
dev-cmd/bump-formula-pr: always use full git repo as tap remote

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -129,7 +129,7 @@ module Homebrew
         # spamming during normal output.
         Homebrew.install_bundler_gems!(groups: ["audit", "style"]) unless args.no_audit?
 
-        tap_remote_repo = formula.tap.full_name || formula.tap.remote_repository
+        tap_remote_repo = formula.tap.remote_repository
         remote = "origin"
         remote_branch = formula.tap.git_repository.origin_branch_name
         previous_branch = "-"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -275,10 +275,9 @@ class Tap
   sig { returns(T.nilable(String)) }
   def remote_repository
     return unless (remote = self.remote)
+    return unless (match = remote.match(HOMEBREW_TAP_REPOSITORY_REGEX))
 
-    @remote_repository ||= remote.delete_prefix("https://github.com/")
-                                 .delete_prefix("git@github.com:")
-                                 .delete_suffix(".git")
+    @remote_repository ||= T.must(match[:remote_repository])
   end
 
   # @deprecated

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -13,6 +13,11 @@ HOMEBREW_DEFAULT_TAP_FORMULA_REGEX = T.let(
   %r{\A(?:[Hh]omebrew/(?:homebrew-)?core/)?(?<name>#{HOMEBREW_TAP_FORMULA_NAME_REGEX.source})\Z},
   Regexp,
 )
+# Match taps' remote repository, e.g. `someuser/somerepo`.
+HOMEBREW_TAP_REPOSITORY_REGEX = T.let(
+  %r{\A.+[/:](?<remote_repository>[^/:]+/[^/:]+?(?=\.git/*\Z|/*\Z))},
+  Regexp,
+)
 
 # Match a cask token.
 HOMEBREW_TAP_CASK_TOKEN_REGEX = T.let(/(?<token>[\w+\-.@]+)/, Regexp)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hi there folks!

I'm currently taking care of my GitHub Action [action-homebrew-bump-formula](https://github.com/dawidd6/action-homebrew-bump-formula) and wanted to move my test formulae from separate repository to the same repository where the action is stored.
I've run into an issue, because the repository is not named _properly_ (i.e. `$USER/homebrew-$TAP`), `brew bump-formula-pr` would try to access non-existent repository named for example `dawidd6/tap`, it depends how I cloned the tap of course. I've tracked it down to this changed line. Didn't test it on homebrew-core, but I think it should work the same as for my repository.

Steps to reproduce:
1. `brew tap dawidd6/tap https://github.com/dawidd6/action-homebrew-bump-formula.git`
2. `brew bump-formula-pr --no-audit --no-browse --no-fork --version=0.1.12 --force dawidd6/tap/test-formula-url`
3. Observe error "Not found".