### PR TITLE
attestation: show unit of time for retry message

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -253,7 +253,7 @@ module Homebrew
       raise if @attestation_retry_count[bottle] >= ATTESTATION_MAX_RETRIES
 
       sleep_time = 3 ** @attestation_retry_count[bottle]
-      opoo "Failed to verify attestation. Retrying in #{sleep_time}..."
+      opoo "Failed to verify attestation. Retrying in #{sleep_time}s..."
       sleep sleep_time if ENV["HOMEBREW_TESTS"].blank?
       @attestation_retry_count[bottle] += 1
       retry


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise this just shows a message like

    Failed to verify attestation. Retrying in 27...

which is a little vague. Let's make it clear that that refers to
seconds.
