### PR TITLE
os/mac/pkgconfig: add bzip2.pc for rust formulae

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/10.11/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.11/bzip2.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.6
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.12/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.12/bzip2.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.6
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/bzip2.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.6
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.6
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.6
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.6
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/12/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/12/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.8
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/13/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/13/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.8
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/14/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/14/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.8
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/15/bzip2.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/15/bzip2.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+bindir=${exec_prefix}/bin
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: 1.0.8
+Libs: -L${libdir} -lbz2
+Cflags:

--- a/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
+++ b/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe "pkg-config", :needs_ci, type: :system do
 
   let(:sdk) { MacOS.sdk_path_if_needed }
 
+  it "returns the correct version for bzip2" do
+    version = File.foreach("#{sdk}/usr/include/bzlib.h")
+                  .lazy
+                  .grep(%r{^\s*bzip2/libbzip2 version (\S+) of }) { Regexp.last_match(1) }
+                  .first
+
+    expect(pc_version("bzip2")).to eq(version)
+  end
+
   it "returns the correct version for expat" do
     version = File.foreach("#{sdk}/usr/include/expat.h")
                   .lazy


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Mainly since the only way to avoid bundled `bzip2` in rust formulae is via `pkg-config` - https://github.com/alexcrichton/bzip2-rs/blob/master/bzip2-sys/build.rs#L16-L23

Similar to pkgconfig file created inside `bzip2` formula based on https://gitlab.com/bzip2/bzip2/-/blob/master/bzip2.pc.in (note that we currently only ship shared libraries & pkg-config file on Linux, so using brew `bzip2` is particularly bad option on macOS).

Removed `bindir=` and `-I${includedir}` in Cflags.

---

Only added macOS 15 for initial discussion. If acceptable, can add older macOS versions.