### PR TITLE
Perform preinstall checks when a formula is installed via a cask

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -368,6 +368,7 @@ on_request: true)
             force:                   false,
           ).install
         else
+          Homebrew::Install.perform_preinstall_checks_once
           fi = FormulaInstaller.new(
             cask_or_formula,
             **{

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -31,7 +31,7 @@ module Homebrew
 
       sig { override.void }
       def run
-        Install.perform_preinstall_checks(all_fatal: true)
+        Install.perform_preinstall_checks_once(all_fatal: true)
         Install.perform_build_from_source_checks(all_fatal: true)
         return unless (formula = args.named.to_resolved_formulae.first)
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -294,7 +294,8 @@ module Homebrew
 
         return if formulae.any? && installed_formulae.empty?
 
-        Install.perform_preinstall_checks(cc: args.cc)
+        Install.perform_preinstall_checks_once
+        Install.check_cc_argv(args.cc)
 
         Install.install_formulae(
           installed_formulae,

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -154,8 +154,6 @@ module Homebrew
           end
         end
 
-        Install.perform_preinstall_checks
-
         if formulae.blank?
           outdated = Formula.installed.select do |f|
             f.outdated?(fetch_head: args.fetch_HEAD?)
@@ -211,6 +209,8 @@ module Homebrew
           end
           puts formulae_upgrades.join("\n")
         end
+
+        Install.perform_preinstall_checks_once
 
         Upgrade.upgrade_formulae(
           formulae_to_install,

--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -30,11 +30,12 @@ module Homebrew
     ].freeze
     private_constant :GCC_RUNTIME_LIBS
 
-    def self.perform_preinstall_checks(all_fatal: false, cc: nil)
-      generic_perform_preinstall_checks(all_fatal:, cc:)
+    def self.perform_preinstall_checks(all_fatal: false)
+      generic_perform_preinstall_checks(all_fatal:)
       symlink_ld_so
       setup_preferred_gcc_libs
     end
+    private_class_method :perform_preinstall_checks
 
     def self.global_post_install
       generic_global_post_install

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -11,15 +11,24 @@ module Homebrew
   # Helper module for performing (pre-)install checks.
   module Install
     class << self
-      def perform_preinstall_checks(all_fatal: false, cc: nil)
-        check_prefix
-        check_cpu
-        attempt_directory_creation
-        check_cc_argv(cc)
-        Diagnostic.checks(:supported_configuration_checks, fatal: all_fatal)
-        Diagnostic.checks(:fatal_preinstall_checks)
+      sig { params(all_fatal: T::Boolean).void }
+      def perform_preinstall_checks_once(all_fatal: false)
+        @perform_preinstall_checks_once ||= {}
+        @perform_preinstall_checks_once[all_fatal] ||= begin
+          perform_preinstall_checks(all_fatal:)
+          true
+        end
       end
-      alias generic_perform_preinstall_checks perform_preinstall_checks
+
+      def check_cc_argv(cc)
+        return unless cc
+
+        @checks ||= Diagnostic::Checks.new
+        opoo <<~EOS
+          You passed `--cc=#{cc}`.
+          #{@checks.please_create_pull_requests}
+        EOS
+      end
 
       def perform_build_from_source_checks(all_fatal: false)
         Diagnostic.checks(:fatal_build_from_source_checks)
@@ -314,15 +323,14 @@ module Homebrew
 
       private
 
-      def check_cc_argv(cc)
-        return unless cc
-
-        @checks ||= Diagnostic::Checks.new
-        opoo <<~EOS
-          You passed `--cc=#{cc}`.
-          #{@checks.please_create_pull_requests}
-        EOS
+      def perform_preinstall_checks(all_fatal: false)
+        check_prefix
+        check_cpu
+        attempt_directory_creation
+        Diagnostic.checks(:supported_configuration_checks, fatal: all_fatal)
+        Diagnostic.checks(:fatal_preinstall_checks)
       end
+      alias generic_perform_preinstall_checks perform_preinstall_checks
 
       def attempt_directory_creation
         Keg.must_exist_directories.each do |dir|


### PR DESCRIPTION
When formulae were installed as a dependency to a cask, the preinstall checks were bypassed.

This opened up various issues, such as https://github.com/Homebrew/homebrew-cask/pull/188060 but also other issues such as installing the wrong architecture or unexplained failures due to missing system requirements.