### PR TITLE
unpack_strategy: fix unpack Dir.mktmpdir group

### DIFF
--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -160,6 +160,27 @@ module UnpackStrategy
     Dir.mktmpdir("homebrew-unpack", HOMEBREW_TEMP) do |tmp_unpack_dir|
       tmp_unpack_dir = Pathname(tmp_unpack_dir)
 
+      # Make sure files inside the temporary directory have the same group as the brew instance.
+      #
+      # @see https://github.com/Homebrew/brew/blob/4.4.0/Library/Homebrew/mktemp.rb#L57-L72
+      group_id = if HOMEBREW_BREW_FILE.grpowned?
+        HOMEBREW_BREW_FILE.stat.gid
+      else
+        Process.gid
+      end
+      begin
+        tmp_unpack_dir.chown(nil, group_id)
+      rescue Errno::EPERM
+        require "etc"
+        group_name = begin
+          Etc.getgrgid(group_id)&.name
+        rescue ArgumentError
+          # Cover for misconfigured NSS setups
+          nil
+        end
+        opoo "Failed setting group \"#{group_name || group_id}\" on #{tmp_unpack_dir}"
+      end
+
       extract(to: tmp_unpack_dir, basename:, verbose:)
 
       children = tmp_unpack_dir.children


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise the files will be unpacked with group wheel on macOS which gets copied over when running `cp -al`.

This used to be implicitly "fixed" due to `cp -pR` usage which would recreate the files.

After #18497, files that are copied via `cp -al` retain wheel group, which isn't what we want.

Was exploring another alternative in #18518 but this seems like cleaner option.

---

Probably should move the logic to `utils/` or somewhere else that can be shared to avoid code duplication. Perhaps a follow up as would be good to avoid current bottles getting installed as wheel group.