### PR TITLE
info: change disabled dates

### DIFF
--- a/Library/Homebrew/cask/cask.rbi
+++ b/Library/Homebrew/cask/cask.rbi
@@ -26,6 +26,8 @@ module Cask
 
     def deprecation_reason; end
 
+    def deprecation_period; end
+
     def disabled?; end
 
     def disable_date; end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -87,6 +87,7 @@ module Cask
       :deprecated?,
       :deprecation_date,
       :deprecation_reason,
+      :deprecation_period,
       :disable!,
       :disabled?,
       :disable_date,
@@ -105,7 +106,13 @@ module Cask
     extend Attrable
     include OnSystem::MacOSOnly
 
-    attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :disable_date, :disable_reason,
+    attr_reader :cask,
+                :token,
+                :deprecation_date,
+                :deprecation_reason,
+                :disable_date,
+                :disable_reason,
+                :deprecation_period,
                 :on_system_block_min_os
 
     attr_predicate :deprecated?, :disabled?, :livecheckable?, :on_system_blocks_exist?, :depends_on_set_in_block?
@@ -442,10 +449,11 @@ module Cask
     # NOTE: A warning will be shown when trying to install this cask.
     #
     # @api public
-    def deprecate!(date:, because:)
+    def deprecate!(date:, because:, deprecation_period: :long)
       @deprecation_date = Date.parse(date)
       return if @deprecation_date > Date.today
 
+      @deprecation_period = deprecation_period
       @deprecation_reason = because
       @deprecated = true
     end

--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -30,9 +30,13 @@ module DeprecateDisable
     unsigned:                 "is unsigned or does not meet signature requirements",
   }.freeze
 
+  DEPRECATE_PERIOD_MONTHS = {
+    short: 1,
+    long:  6,
+  }.freeze
+
   # One year when << or >> to Date.today.
   REMOVE_DISABLED_TIME_WINDOW = 12
-  REMOVE_DISABLED_BEFORE = (Date.today << REMOVE_DISABLED_TIME_WINDOW).freeze
 
   def type(formula_or_cask)
     return :deprecated if formula_or_cask.deprecated?
@@ -65,7 +69,8 @@ module DeprecateDisable
 
     disable_date = formula_or_cask.disable_date
     if !disable_date && formula_or_cask.deprecation_date
-      disable_date = formula_or_cask.deprecation_date >> REMOVE_DISABLED_TIME_WINDOW
+      period = DEPRECATE_PERIOD_MONTHS[formula_or_cask.deprecation_period]
+      disable_date = formula_or_cask.deprecation_date >> period
     end
     if disable_date
       message += if disable_date < Date.today

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1536,6 +1536,13 @@ class Formula
   # @see .deprecate!
   delegate deprecation_reason: :"self.class"
 
+  # The time before the {Formula} becomes disabled
+  # Returns `nil` if no date is specified.
+  # @!method deprecation_period
+  # @return [String, Symbol]
+  # @see .deprecate!
+  delegate deprecation_period: :"self.class"
+
   # Whether this {Formula} is disabled (i.e. cannot be installed).
   # Defaults to false.
   # @!method disabled?
@@ -4225,10 +4232,11 @@ class Formula
     # @see https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae
     # @see DeprecateDisable::FORMULA_DEPRECATE_DISABLE_REASONS
     # @api public
-    def deprecate!(date:, because:)
+    def deprecate!(date:, because:, deprecation_period: :long)
       @deprecation_date = Date.parse(date)
       return if @deprecation_date > Date.today
 
+      @deprecation_period = deprecation_period
       @deprecation_reason = because
       @deprecated = true
     end
@@ -4254,6 +4262,13 @@ class Formula
     # @return [String, Symbol]
     # @see .deprecate!
     attr_reader :deprecation_reason
+
+    # The time before the {Formula} becomes disabled.
+    #
+    # @return [nil] if no reason was provided or the formula is not deprecated.
+    # @return [String, Symbol]
+    # @see .deprecate!
+    attr_reader :deprecation_period
 
     # Disables a {Formula} (on the given date) so it cannot be
     # installed. If the date has not yet passed the formula

--- a/docs/Deprecating-Disabling-and-Removing-Formulae.md
+++ b/docs/Deprecating-Disabling-and-Removing-Formulae.md
@@ -30,12 +30,14 @@ Formulae with dependents should not be deprecated until or when all dependents a
 To deprecate a formula, add a `deprecate!` call. This call should include a deprecation date (in the ISO 8601 format) and a deprecation reason:
 
 ```ruby
-deprecate! date: "YYYY-MM-DD", because: :reason
+deprecate! date: "YYYY-MM-DD", because: :reason, deprecation_period: :short
 ```
 
 The `date` parameter should be set to the date that the deprecation period should begin, which is usually today's date. If the `date` parameter is set to a date in the future, the formula will not become deprecated until that date. This can be useful if the upstream developers have indicated a date when the project or version will stop being supported. Do not backdate the `date` parameter as it causes confusion for users and maintainers.
 
 The `because` parameter can be a preset reason (using a symbol) or a custom reason. See the [Deprecate and Disable Reasons](#deprecate-and-disable-reasons) section below for more details about the `because` parameter.
+
+The `deprecation_period:` can be either :short or :long (1 or 6 months). After this period a formula should be disabled.
 
 ## Disabling
 
@@ -49,10 +51,9 @@ The most common reasons for disabling a formula are:
 - it has been deprecated for a long time
 - the project has no license
 
-Popular formulae (e.g. have more than 1000 [analytics installs in the last 90 days](https://formulae.brew.sh/analytics/install/90d/)) should not be disabled without a deprecation period of at least six months even if e.g. they do not build from source and do not have a license.
+Popular formulae (e.g. have more than 1000 [analytics installs in the last 90 days](https://formulae.brew.sh/analytics/install/90d/)) should not be disabled without a deprecation period of six months even if e.g. they do not build from source and do not have a license.
 
-Unpopular formulae (e.g. have fewer than 1000 [analytics installs in the last 90 days](https://formulae.brew.sh/analytics/install/90d/)) can be disabled immediately for any of the reasons above e.g. they cannot be built from source on any supported macOS version or Linux.
-They can be manually removed three months after their disable date.
+Unpopular formulae (e.g. have fewer than 1000 [analytics installs in the last 90 days](https://formulae.brew.sh/analytics/install/90d/)) can be disabled after one month for any of the reasons above e.g. they cannot be built from source on any supported macOS version or Linux.
 
 To disable a formula, add a `disable!` call. This call should include a deprecation date in the ISO 8601 format and a deprecation reason:
 


### PR DESCRIPTION
- Remove useless REMOVE_DISABLED_BEFORE
- Add deprecated_period attribute to be able to finetune the disable date
- This new attribute is set to :long by default to be backward compatible
- This will allow to write an automated script that will disable the formula after the right amount of time

This also fixes the issue that the disabled date displayed in brew info right now
is way to far in the future (1 year) instead of 6 months (either it's a bug or the code does not aligne with the doc)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
