### PR TITLE
PythonVersions audit: test mixed runtime dependencies

### DIFF
--- a/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/python_versions_spec.rb
@@ -197,6 +197,23 @@ RSpec.describe RuboCop::Cop::FormulaAudit::PythonVersions do
       RUBY
     end
 
+    it "reports no offenses for a mix of runtime and non-runtime Python dependencies" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.12" => :build
+          depends_on "python@3.13"
+
+          def install
+            puts "python3.12"
+          end
+
+          test do
+            puts "python3.13"
+          end
+        end
+      RUBY
+    end
+
     it "reports and corrects Python references that mismatch single non-runtime Python dependency" do
       expect_offense(<<~RUBY)
         class Foo < Formula


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I have been updating a formula in a 3rd-party tap that currently has a runtime dependency on `python@3.12` (no `:build` or `:test` annotations), and I'd like to update it to depend on multiple python versions in order to build bindings against multiple versions but still depend on one version as a runtime dependency, like the following:

~~~
  depends_on "python@3.12" => [:build, :test]
  depends_on "python@3.13"
~~~

The [PythonVersions](https://github.com/Homebrew/brew/blob/4.4.0/Library/Homebrew/rubocops/lines.rb#L391-L434)  audit currently complains about this:

~~~
C: [Correctable] FormulaAudit/PythonVersions: References to python@3.12 should match the specified python dependency (python@3.13)
  depends_on "python@3.12" => [:build, :test]
             ^^^^^^^^^^^^^
~~~

If there isn't a problem with depending on a mix of runtime and non-runtime versions of python, I'd like to update the audit to allow this. I've opened this as a draft PR with a failing test that should pass once the audit is updated. Please let me know if this obviously won't be accepted before I spend time to try to update the audit.