### PR TITLE
extend/ENV/super: use brew libs for some Python packages

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -93,6 +93,11 @@ module Superenv
     # Prevent Go from automatically downloading a newer toolchain than the one that we have.
     # https://tip.golang.org/doc/toolchain
     self["GOTOOLCHAIN"] = "local"
+    # Prevent Python packages from using bundled libraries by default.
+    # Currently for hidapi, pyzmq and pynacl
+    self["HIDAPI_SYSTEM_HIDAPI"] = "1"
+    self["PYZMQ_NO_BUNDLE"] = "1"
+    self["SODIUM_INSTALL"] = "system"
 
     set_debug_symbols if debug_symbols
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This avoids using bundled libraries for:

* `hidapi`[^1]
* `pynacl`[^2]
* `pyzmq`[^3]

The build should now fail if dependency is missing.

Essentially reverses default so now that using bundled copy is now opt-in via `ENV` modification, e.g. `ENV.delete "SODIUM_INSTALL"`

[^1]: https://github.com/trezor/cython-hidapi/blob/0.14.0.post2/setup.py#L229
[^2]: https://github.com/pyca/pynacl/blob/1.5.0/setup.py#L71-L73
[^3]: https://github.com/zeromq/pyzmq/blob/v26.2.0/CMakeLists.txt#L41-L43