### PR TITLE
mktemp: strict type and allow `#run` without chdir

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2804,7 +2804,7 @@ class Formula
 
     mktemp("#{name}-test") do |staging|
       staging.retain! if keep_tmp
-      @testpath = staging.tmpdir
+      @testpath = T.must(staging.tmpdir)
       test_env[:HOME] = @testpath
       setup_home @testpath
       begin
@@ -3125,8 +3125,16 @@ class Formula
   # recursively delete the temporary directory. Passing `opts[:retain]`
   # or calling `do |staging| ... staging.retain!` in the block will skip
   # the deletion and retain the temporary directory's contents.
-  def mktemp(prefix = name, opts = {}, &block)
-    Mktemp.new(prefix, opts).run(&block)
+  sig {
+    params(
+      prefix:          String,
+      retain:          T::Boolean,
+      retain_in_cache: T::Boolean,
+      block:           T.proc.params(arg0: Mktemp).void,
+    ).void
+  }
+  def mktemp(prefix = name, retain: false, retain_in_cache: false, &block)
+    Mktemp.new(prefix, retain:, retain_in_cache:).run(&block)
   end
 
   # A version of `FileUtils.mkdir` that also changes to that folder in

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "mktemp"
 require "system_command"
 
 # Module containing all available strategies for unpacking archives.
@@ -157,29 +158,8 @@ module UnpackStrategy
     ).returns(T.untyped)
   }
   def extract_nestedly(to: nil, basename: nil, verbose: false, prioritize_extension: false)
-    Dir.mktmpdir("homebrew-unpack", HOMEBREW_TEMP) do |tmp_unpack_dir|
-      tmp_unpack_dir = Pathname(tmp_unpack_dir)
-
-      # Make sure files inside the temporary directory have the same group as the brew instance.
-      #
-      # @see https://github.com/Homebrew/brew/blob/4.4.0/Library/Homebrew/mktemp.rb#L57-L72
-      group_id = if HOMEBREW_BREW_FILE.grpowned?
-        HOMEBREW_BREW_FILE.stat.gid
-      else
-        Process.gid
-      end
-      begin
-        tmp_unpack_dir.chown(nil, group_id)
-      rescue Errno::EPERM
-        require "etc"
-        group_name = begin
-          Etc.getgrgid(group_id)&.name
-        rescue ArgumentError
-          # Cover for misconfigured NSS setups
-          nil
-        end
-        opoo "Failed setting group \"#{group_name || group_id}\" on #{tmp_unpack_dir}"
-      end
+    Mktemp.new("homebrew-unpack").run(chdir: false) do |unpack_dir|
+      tmp_unpack_dir = T.must(unpack_dir.tmpdir)
 
       extract(to: tmp_unpack_dir, basename:, verbose:)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Was looking into #18548 and thought we could avoid some duplication by adjusting `Mktemp`.

In this case, the other PR would use
```rb
Mktemp.new("homebrew-unpack").run(chdir: false) do |tmp_unpack_dir|
  tmp_unpack_dir = T.must(tmp_unpack_dir.tmpdir)
```

---

This PR does restrict arguments for `Mktemp` so no longer an accept an arbitrary hash but instead takes in specific boolean parameters.

I think this is fine as it is a private API, but can restore `opts` if preferred.