### PR TITLE
extend/kernel: fix duplicate messages in GitHub Actions

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -64,9 +64,10 @@ module Kernel
   # @api public
   sig { params(message: T.any(String, Exception)).void }
   def opoo(message)
+    return if GitHub::Actions.puts_annotation_if_env_set(:warning, message.to_s)
+
     Tty.with($stderr) do |stderr|
       stderr.puts Formatter.warning(message, label: "Warning")
-      GitHub::Actions.puts_annotation_if_env_set(:warning, message.to_s)
     end
   end
 
@@ -75,12 +76,13 @@ module Kernel
   # @api public
   sig { params(message: T.any(String, Exception)).void }
   def onoe(message)
-    require "utils/formatter"
     require "utils/github/actions"
+    return if GitHub::Actions.puts_annotation_if_env_set(:error, message.to_s)
+
+    require "utils/formatter"
 
     Tty.with($stderr) do |stderr|
       stderr.puts Formatter.error(message, label: "Error")
-      GitHub::Actions.puts_annotation_if_env_set(:error, message.to_s)
     end
   end
 
@@ -178,8 +180,6 @@ module Kernel
       exception.set_backtrace(backtrace)
       raise exception
     elsif !Homebrew.auditing?
-      require "utils/github/actions"
-      GitHub::Actions.puts_annotation_if_env_set(:warning, message, file:, line:)
       opoo message
     end
   end

--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -43,15 +43,17 @@ module GitHub
         type: Symbol, message: String,
         file: T.nilable(T.any(String, Pathname)),
         line: T.nilable(Integer)
-      ).void
+      ).returns(T::Boolean)
     }
     def self.puts_annotation_if_env_set(type, message, file: nil, line: nil)
       # Don't print annotations during tests, too messy to handle these.
-      return if ENV.fetch("HOMEBREW_TESTS", false)
-      return unless env_set?
+      return false if ENV.fetch("HOMEBREW_TESTS", false)
+      return false unless env_set?
 
       std = (type == :notice) ? $stdout : $stderr
       std.puts Annotation.new(type, message)
+
+      true
     end
 
     # Helper class for formatting annotations on GitHub Actions.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Calls to `opoo` and `onoe` produce duplicate `Warning:` and `Error:`
messages in CI logs because we print something to stdout and print an
annotation. Annotations also produce `Error:` and `Warning:` lines in
the log.

Let's fix this by skipping printing the message if we've already printed
an annotation.
