### PR TITLE
cmd/upgrade: require named args when upgrading from source

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -120,6 +120,10 @@ module Homebrew
 
       sig { override.void }
       def run
+        if args.build_from_source? && args.named.empty?
+          raise ArgumentError, "--build-from-source requires at least one formula"
+        end
+
         formulae, casks = args.named.to_resolved_formulae_to_casks
         # If one or more formulae are specified, but no casks were
         # specified, we want to make note of that so we don't


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Resolves #18226

The `--build-from-source` flag can currently be used without specifying a formula by name but it doesn't behave the way you'd expect it to.

It will upgrade everything using bottles if they are available and skip building things from source. This is intentional because we want to discourage non-developers from building packages from source since the result is less predictable.

The change here is to error out in that case. It might be smarter to go through the entire deprecation cycle here just in case someone is using this in scripts.