### PR TITLE
Improve/fix HOMEBREW_FORBIDDEN_LICENSES handling

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -204,7 +204,7 @@ module Homebrew
                      "formula or cask if it or any of its dependencies is on this list.",
       },
       HOMEBREW_FORBIDDEN_LICENSES:               {
-        description: "A space-separated list of licenses. Homebrew will refuse to install a " \
+        description: "A space-separated list of SPDX license identifiers. Homebrew will refuse to install a " \
                      "formula if it or any of its dependencies has a license on this list.",
       },
       HOMEBREW_FORBIDDEN_OWNER:                  {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -3798,8 +3798,8 @@ command execution e.g. `$(cat file)`.
 
 `HOMEBREW_FORBIDDEN_LICENSES`
 
-: A space-separated list of licenses. Homebrew will refuse to install a formula
-  if it or any of its dependencies has a license on this list.
+: A space-separated list of SPDX license identifiers. Homebrew will refuse to
+  install a formula if it or any of its dependencies has a license on this list.
 
 `HOMEBREW_FORBIDDEN_OWNER`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2470,7 +2470,7 @@ A space\-separated list of casks\. Homebrew will refuse to install a cask if it 
 A space\-separated list of formulae\. Homebrew will refuse to install a formula or cask if it or any of its dependencies is on this list\.
 .TP
 \fBHOMEBREW_FORBIDDEN_LICENSES\fP
-A space\-separated list of licenses\. Homebrew will refuse to install a formula if it or any of its dependencies has a license on this list\.
+A space\-separated list of SPDX license identifiers\. Homebrew will refuse to install a formula if it or any of its dependencies has a license on this list\.
 .TP
 \fBHOMEBREW_FORBIDDEN_OWNER\fP
 The person who has set any \fBHOMEBREW_FORBIDDEN_*\fP variables\.


### PR DESCRIPTION
`HOMEBREW_FORBIDDEN_LICENSES` now actually checks for valid SPDX license identifiers rather than requiring the user to guess.

When an identifier is invalid, it will be ignore and warned about instead.