### PR TITLE
curl: handle multiple Content-Type headers

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -467,9 +467,15 @@ module Utils
 
       if status.success?
         open_args = {}
+        content_type = headers["content-type"]
+
+        # Use the last `Content-Type` header if there is more than one instance
+        # in the response
+        content_type = content_type.last if content_type.is_a?(Array)
+
         # Try to get encoding from Content-Type header
         # TODO: add guessing encoding by <meta http-equiv="Content-Type" ...> tag
-        if (content_type = headers["content-type"]) &&
+        if content_type &&
            (match = content_type.match(/;\s*charset\s*=\s*([^\s]+)/)) &&
            (charset = match[1])
           begin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`#curl_http_content_headers_and_checksum` contains code that works with a `Content-Type` header in a response but it expects there to always be only one header in the response. This is normally a reasonable assumption but we've come across a server that is giving a response with multiple `Content-Type` headers in the response (https://github.com/Homebrew/homebrew-cask/pull/189072), so this produces an error and causes `brew audit` to fail when checking the URL.

This works around the issue by naively using the last `Content-Type` header in the response when there's more than one. It's not something that should normally occur but this will handle the situation when it does.