### PR TITLE
filter pinned test dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -379,6 +379,7 @@ class FormulaInstaller
       next unless dep.to_formula.pinned?
       next if dep.satisfied?(inherited_options_for(dep))
       next if dep.build? && pour_bottle?
+      next if dep.test?
 
       pinned_unsatisfied_deps << dep
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Addresses #18554. When upgrading formulae, [`check_install_sanity`](https://github.com/Homebrew/brew/blob/3291ad4fc78f33f8e9bb7ce37745d2a0e697f5fb/Library/Homebrew/formula_installer.rb#L295) is called, which seems to walk the dependency tree for a formula to create a [full list of dependencies](https://github.com/Homebrew/brew/blob/3291ad4fc78f33f8e9bb7ce37745d2a0e697f5fb/Library/Homebrew/formula_installer.rb#L369) and then - when determining the unsatisfied pinned dependencies - [filters out](https://github.com/Homebrew/brew/blob/3291ad4fc78f33f8e9bb7ce37745d2a0e697f5fb/Library/Homebrew/formula_installer.rb#L381) the dependencies tagged as `build`. A problem with this is that build dependencies might have other non-build dependencies themselves, which won't be tagged as `build` but will still be present in the dependencies list, despite not being required for the formula being poured from bottle.

In the example from #18554, `llvm` had been pinned, and was preventing the upgrade of `libomp`, even though it was not required for the bottle. This was because `libomp` had a `:build` dependency on `lit`, which in turn had a `:test` dependency on `llvm`.

This PR just adds an additional check for `test` before adding to the `pinned_unsatisfied_deps` list, and in the related issue I suggested it might be better to prune the expansion of build/test dependencies somewhere [here](https://github.com/Homebrew/brew/blob/3291ad4fc78f33f8e9bb7ce37745d2a0e697f5fb/Library/Homebrew/dependency.rb#L128-L179).
However, that might more trouble than it's worth for an issue that is not likely to affect many users, especially since there's a simple solution of just unpinning the formulae in question.