### PR TITLE
Fix `BundleVersion` comparison when `short_version` is not comparable

### DIFF
--- a/Library/Homebrew/bundle_version.rb
+++ b/Library/Homebrew/bundle_version.rb
@@ -74,7 +74,9 @@ module Homebrew
         short_version = self.short_version.then(&make_version)
         other_short_version = other.short_version.then(&make_version)
 
-        return short_version <=> other_short_version
+        short_version_difference = short_version <=> other_short_version
+
+        return short_version_difference unless short_version_difference.nil?
       end
 
       difference


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR fixes an issue when comparing two `BundleVersion` objects where the `version` variables are equal and the `short_version` variables are `nil`. In this case, the result of the initial `version` comparison should be returned.

Before:

```console
$ brew livecheck --cask teamviewer
Error: teamviewer: comparison of Array with Array failed
```

After:

```console
$ brew livecheck --cask teamviewer
teamviewer: 15.58.4 ==> 15.58.4
```
