### PR TITLE
cmd/install: infer `--overwrite` when in GitHub Actions

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -811,6 +811,7 @@ on_request: installed_on_request?, options:)
       debug:                      debug?,
       quiet:                      quiet?,
       verbose:                    verbose?,
+      overwrite:                  overwrite?,
     )
     oh1 "Installing #{formula.full_name} dependency: #{Formatter.identifier(dep.name)}"
     fi.install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Based on discussion at Homebrew/homebrew-core#195288.

I was initially inclined to scope this only to Python, but I think it
makes sense to apply more generally. The issue is that users often have
no control over what's already inside `HOMEBREW_PREFIX` when they run
`brew install`. Given that, I think it makes sense to assume users want
`--overwrite` unless configured otherwise with
`HOMEBREW_GITHUB_ACTIONS_NO_INSTALL_OVERWRITE`.
