### PR TITLE
Go: Add `-gcflags` to `std_go_args`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1837,12 +1837,16 @@ class Formula
 
   # Standard parameters for Go builds.
   sig {
-    params(output:  T.any(String, Pathname),
-           ldflags: T.nilable(T.any(String, T::Array[String]))).returns(T::Array[String])
+    params(
+      output:  T.any(String, Pathname),
+      ldflags: T.nilable(T.any(String, T::Array[String])),
+      gcflags: T.nilable(T.any(String, T::Array[String])),
+    ).returns(T::Array[String])
   }
-  def std_go_args(output: bin/name, ldflags: nil)
+  def std_go_args(output: bin/name, ldflags: nil, gcflags: nil)
     args = ["-trimpath", "-o=#{output}"]
     args += ["-ldflags=#{Array(ldflags).join(" ")}"] if ldflags
+    args += ["-gcflags=#{Array(gcflags).join(" ")}"] if gcflags
     args
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds support for compiler flags (`gcflags`) as standard arguments in Go builds, enabling better control over compilation behavior.

So, instead of:
```rb
*std_go_args(
  ldflags: "-w -s"
) + ["-gcflags=all=-l -B -wb=false"]
```

You can pass them as arguments:
```rb
*std_go_args(
  ldflags: "-w -s",
  gcflags: "all=-l -B -wb=false",
)
```
