### PR TITLE
superenv: disable `ConstraintEliminationPass` on Xcode 16

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -120,6 +120,7 @@ module Superenv
     # o - Pass `-oso_prefix` to `ld` whenever it is invoked
     # c - Pass `-ld_classic` to `ld` whenever it is invoked
     #     with `-dead_strip_dylibs`
+    # E - Pass `-mllvm -enable-constraint-elimination=0` to clang.
     #
     # These flags will also be present:
     # a - apply fix for apr-1-config path

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -39,4 +39,16 @@ module SharedEnvExtension
     # https://en.wikipedia.org/wiki/Xcode#Xcode_11.0_-_14.x_(since_SwiftUI_framework)_2
     OS::Mac::DevelopmentTools.ld64_version >= 711
   end
+
+  # ConstraintEliminiationPass can silently miscompile some formulae.
+  # https://github.com/Homebrew/homebrew-core/issues/195325
+  sig { returns(T::Boolean) }
+  def disable_contraint_elimination?
+    return false if compiler != :clang
+
+    return false if !MacOS::Xcode.version.null? && MacOS::Xcode.version.major != 16
+    return false if !MacOS::CLT.version.null? && MacOS::CLT.version.major != 16
+
+    true
+  end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -114,4 +114,8 @@ module Stdenv
   def no_fixup_chains
     append "LDFLAGS", "-Wl,-no_fixup_chains" if no_fixup_chains_support?
   end
+
+  def disable_constraint_elimination_if_needed
+    append_to_cflags "-mllvm -enable-constraint-elimination=0" if disable_contraint_elimination?
+  end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -159,6 +159,9 @@ module Superenv
     if OS::Mac::DevelopmentTools.ld64_version >= "1015.7" && OS::Mac::DevelopmentTools.ld64_version <= "1022.1"
       append_to_cccfg "c"
     end
+
+    # https://github.com/Homebrew/homebrew-core/issues/195325
+    disable_constraint_elimination_if_needed
   end
 
   def no_weak_imports
@@ -167,5 +170,9 @@ module Superenv
 
   def no_fixup_chains
     append_to_cccfg "f" if no_fixup_chains_support?
+  end
+
+  def disable_constraint_elimination_if_needed
+    append_to_cccfg "E" if disable_contraint_elimination?
   end
 end

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -299,6 +299,7 @@ class Cmd
     args.concat(archflags)
     args << "-std=#{@arg0}" if /c[89]9/.match?(@arg0)
     args << "-g" if debug_symbols?
+    args += ["-mllvm", "-enable-constraint-elimination=0"] if disable_contraint_elimination?
     args
   end
 
@@ -433,6 +434,10 @@ class Cmd
   def linker_flags
     @args.select { |arg| arg.start_with?("-Wl,") }
          .flat_map { |arg| arg.delete_prefix("-Wl,").split(",") }
+  end
+
+  def disable_contraint_elimination?
+    config.include?("E")
   end
 
   def no_fixup_chains?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This can result in build failures (e.g. OpenJDK) and silently miscompile
some formulae (e.g. Vim).

See Homebrew/homebrew-core#195325.
