### PR TITLE
livecheck: error on invalid url symbol

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -508,10 +508,10 @@ module Homebrew
       params(
         livecheck_url:       T.any(String, Symbol),
         package_or_resource: T.any(Formula, Cask::Cask, Resource),
-      ).returns(T.nilable(String))
+      ).returns(String)
     }
     def self.livecheck_url_to_string(livecheck_url, package_or_resource)
-      case livecheck_url
+      livecheck_url_string = case livecheck_url
       when String
         livecheck_url
       when :url
@@ -521,6 +521,12 @@ module Homebrew
       when :homepage
         package_or_resource.homepage unless package_or_resource.is_a?(Resource)
       end
+
+      if livecheck_url.is_a?(Symbol) && !livecheck_url_string
+        raise ArgumentError, "`url #{livecheck_url.inspect}` does not reference a checkable URL"
+      end
+
+      livecheck_url_string
     end
 
     # Returns an Array containing the formula/cask/resource URLs that can be used by livecheck.
@@ -846,7 +852,7 @@ module Homebrew
       livecheck_strategy = livecheck.strategy
       livecheck_strategy_block = livecheck.strategy_block
 
-      livecheck_url_string = livecheck_url_to_string(livecheck_url, resource)
+      livecheck_url_string = livecheck_url_to_string(livecheck_url, resource) if livecheck_url
 
       urls = [livecheck_url_string] if livecheck_url_string
       urls ||= checkable_urls(resource)

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Homebrew::Livecheck do
     end
   end
 
+  let(:f_stable_url_only) do
+    stable_url_s = stable_url
+
+    formula("test_stable_url_only") do
+      desc "Test formula with only a stable URL"
+      url stable_url_s
+    end
+  end
+
   let(:r) { f.resources.first }
 
   let(:c) do
@@ -52,6 +61,17 @@ RSpec.describe Homebrew::Livecheck do
           url "https://formulae.brew.sh/api/formula/ruby.json"
           regex(/"stable":"(\d+(?:.\d+)+)"/i)
         end
+      end
+    RUBY
+  end
+
+  let(:c_no_checkable_urls) do
+    Cask::CaskLoader.load(+<<-RUBY)
+      cask "test_no_checkable_urls" do
+        version "1.2.3"
+
+        name "Test"
+        desc "Test cask with no checkable URLs"
       end
     RUBY
   end
@@ -134,15 +154,6 @@ RSpec.describe Homebrew::Livecheck do
       end
     end
 
-    let(:f_stable_url_only) do
-      stable_url_s = stable_url
-
-      formula("test_stable_url_only") do
-        desc "Test formula with only a stable URL"
-        url stable_url_s
-      end
-    end
-
     let(:r_livecheck_url) { f_livecheck_url.resources.first }
 
     let(:c_livecheck_url) do
@@ -154,17 +165,6 @@ RSpec.describe Homebrew::Livecheck do
           name "Test"
           desc "Test Livecheck URL cask"
           homepage "https://brew.sh"
-        end
-      RUBY
-    end
-
-    let(:c_no_checkable_urls) do
-      Cask::CaskLoader.load(+<<-RUBY)
-        cask "test_no_checkable_urls" do
-          version "1.2.3"
-
-          name "Test"
-          desc "Test cask with no checkable URLs"
         end
       RUBY
     end
@@ -235,6 +235,8 @@ RSpec.describe Homebrew::Livecheck do
       expect(livecheck.checkable_urls(c)).to eq([cask_url, homepage_url])
       expect(livecheck.checkable_urls(r)).to eq([resource_url])
       expect(livecheck.checkable_urls(f_duplicate_urls)).to eq([stable_url, head_url])
+      expect(livecheck.checkable_urls(f_stable_url_only)).to eq([stable_url])
+      expect(livecheck.checkable_urls(c_no_checkable_urls)).to eq([])
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Up to now, we haven't been accounting for `#url` symbol arguments in `livecheck` blocks that don't reference a checkable URL. This can either be an invalid symbol (e.g., using the `:stable` formula symbol in a cask) or a valid symbol where the referenced URL doesn't exist (e.g., using `:head` when there's no `head` URL). [Almost all of the valid symbols are required URLs but `head` is optional.]

Over the years, we've had a handful of slips where we've [used `:url` in formulae](https://github.com/Homebrew/homebrew-core/pull/195414) (when it's only valid in casks) and [`:stable` in casks](https://github.com/Homebrew/homebrew-cask/pull/189215) (when it's only valid in formulae). In this scenario, `livecheck_url_string` is `nil`, so livecheck falls back to `#checkable_urls`. `stable` and `url` are the first checkable URLs for formulae and casks (respectively), so the checks ended up working as expected merely by chance. This isn't obvious in the output and even the debug output looks normal. It only becomes apparent that livecheck isn't working as expected if it iterates through more than one checkable URL before reaching one that works (not the case in those instances).

With that in mind, this adds an error when a `#url` symbol is used but it doesn't correspond to a checkable URL. This will account for both of the mentioned scenarios (invalid symbols and valid ones referencing a non-existent URL) and prevent livecheck from quietly proceeding in an unexpected manner.

-----

It's worth mentioning that I will also be creating a RuboCop for this in a later PR, so we can catch this with `brew style`/`brew audit` (not just at runtime).

I'm currently reworking the livecheck RuboCops to share cops between formulae, resources, and casks. We originally implemented them as `FormulaCop`s before `livecheck` blocks were available in casks (and later `resource` blocks) but we didn't have a way of sharing cops at the time. We now have some shared cops, so it's just a matter of migrating the cops to that pattern. I have most of that done (it works for formulae/resources and most casks) but I'm working on writing tests and handling less common cask setups. Once that's done, I'll create a PR for the refactor and added RuboCops.