### PR TITLE
Add `HOMEBREW_TEST_TIMEOUT_SECS` env var

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -16,7 +16,7 @@ require "cli/parser"
 require "dev-cmd/test"
 require "json/add/exception"
 
-TEST_TIMEOUT_SECONDS = 5 * 60
+DEFAULT_TEST_TIMEOUT_SECONDS = 5 * 60
 
 begin
   ENV.delete("HOMEBREW_FORBID_PACKAGES_FROM_PATHS")
@@ -49,7 +49,9 @@ begin
   if args.debug? # --debug is interactive
     run_test.call
   else
-    Timeout.timeout(TEST_TIMEOUT_SECONDS, &run_test)
+    # HOMEBREW_TEST_TIMEOUT_SECS is private API and subject to change.
+    timeout = ENV["HOMEBREW_TEST_TIMEOUT_SECS"]&.to_i || DEFAULT_TEST_TIMEOUT_SECONDS
+    Timeout.timeout(timeout, &run_test)
   end
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.puts e.to_json


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Intended mainly for third-party formulae, this allows formula tests to be run with a customised timeout.
    
This is a private, undocumented API and subject to change.
