### PR TITLE
rubocops/shared/url_helper: tweak SourceForge handling

### DIFF
--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -97,7 +97,8 @@ module RuboCop
                                                %r{^http://hackage\.haskell\.org/},
                                                %r{^http://(?:[^/]*\.)?archive\.org},
                                                %r{^http://(?:[^/]*\.)?freedesktop\.org},
-                                               %r{^http://(?:[^/]*\.)?mirrorservice\.org/}])
+                                               %r{^http://(?:[^/]*\.)?mirrorservice\.org/},
+                                               %r{^http://downloads?\.sourceforge\.net/}])
         audit_urls(urls, http_to_https_patterns) do |_, url, index|
           # It's fine to have a plain HTTP mirror further down the mirror list.
           https_url = url.dup.insert(4, "s")
@@ -153,7 +154,7 @@ module RuboCop
 
           problem "Don't use /download in SourceForge urls (url is #{url})." if url.end_with?("/download")
 
-          if url.match?(%r{^https?://sourceforge\.}) && url != livecheck_url
+          if url.match?(%r{^https?://(sourceforge|sf)\.}) && url != livecheck_url
             problem "Use https://downloads.sourceforge.net to get geolocation (url is #{url})."
           end
 
@@ -165,7 +166,10 @@ module RuboCop
             problem "Don't use specific dl mirrors in SourceForge urls (url is #{url})."
           end
 
-          problem "Please use https:// for #{url}" if url.start_with? "http://downloads"
+          # sf.net does HTTPS -> HTTP redirects.
+          if url.match?(%r{^https?://downloads?\.sf\.net})
+            problem "Use https://downloads.sourceforge.net instead of downloads.sf.net (url is #{url})"
+          end
         end
 
         # Debian has an abundance of secure mirrors. Let's not pluck the insecure


### PR DESCRIPTION
* Allow http://download(s).sourceforge.net to be used as a plain HTTP mirror if the HTTPS equivalent is present
* Ban download(s).sf.net as it always does a HTTPS -> HTTP redirect