### PR TITLE
os/mac/keg_relocate: don't change Swift stdlib dylib IDs

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -141,6 +141,9 @@ module OS
       end
 
       def dylib_id_for(file)
+        # Swift dylib IDs should be /usr/lib/swift
+        return file.dylib_id if file.dylib_id.start_with?("/usr/lib/swift/libswift")
+
         # The new dylib ID should have the same basename as the old dylib ID, not
         # the basename of the file itself.
         basename = File.basename(file.dylib_id)


### PR DESCRIPTION
Our dylib changes actively break the Swift formula: https://github.com/Homebrew/homebrew-core/actions/runs/11510812283/job/32043670032?pr=195510.

The Swift formulae ships with a stdlib with a dylib ID to `/usr/lib/swift`. This is intentional as it means that `-lswiftCore` will link to `/usr/lib/swift` while still providing the stdlib dylibs as an opt-in or other internal use. Upstream ship it this way in their official builds.

Ideally we'd generalise this check better, e.g. maybe any path not in `HOMEBREW_PREFIX` or the build directory? For now, I've scoped it to Swift so it doesn't impact anything except Swift.