### PR TITLE
keg_relocate: fix error when dylib_id doesn't need changing

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -28,7 +28,7 @@ module OS
 
             if file.dylib?
               id = relocated_name_for(file.dylib_id, relocation)
-              modified = change_dylib_id(id, file)
+              modified = change_dylib_id(id, file) if id
               needs_codesigning ||= modified
             end
 
@@ -148,6 +148,7 @@ module OS
         (opt_record/relative_dirname/basename).to_s
       end
 
+      sig { params(old_name: String, relocation: ::Keg::Relocation).returns(T.nilable(String)) }
       def relocated_name_for(old_name, relocation)
         old_prefix, new_prefix = relocation.replacement_pair_for(:prefix)
         old_cellar, new_cellar = relocation.replacement_pair_for(:cellar)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -15,7 +15,7 @@ class Keg
     RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))/
 
     def initialize
-      @replacement_map = {}
+      @replacement_map = T.let({}, T::Hash[Symbol, [T.any(String, Regexp), String]])
     end
 
     def freeze
@@ -29,7 +29,7 @@ class Keg
       @replacement_map[key] = [old_value, new_value]
     end
 
-    sig { params(key: Symbol).returns(T::Array[T.any(String, Regexp)]) }
+    sig { params(key: Symbol).returns([T.any(String, Regexp), String]) }
     def replacement_pair_for(key)
       @replacement_map.fetch(key)
     end
@@ -44,7 +44,7 @@ class Keg
 
       any_changed = T.let(nil, T.nilable(String))
       sorted_keys.each do |key|
-        changed = text.gsub!(key, replacements[key])
+        changed = text.gsub!(key, replacements.fetch(key))
         any_changed ||= changed
       end
       !any_changed.nil?


### PR DESCRIPTION
```
Error: Parameter 'id': Expected type String, got type NilClass
Caller: /opt/homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:31
Definition: /opt/homebrew/Library/Homebrew/os/mac/keg.rb:6 (Keg#change_dylib_id)
```

While we're here, since runtime TypeErrors are usually an indication of insufficient static typing, fix up signatures so that the static typechecker could catch this bug in the future.