### PR TITLE
spec_helper: improve parallel test handling.

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -10,10 +10,13 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
   ]
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
 
-  # Needed for outputting coverage reporting only once for parallel_tests
-  if RUBY_PLATFORM[/darwin/] && ENV["TEST_ENV_NUMBER"]
+  # Needed for outputting coverage reporting only once for parallel_tests.
+  # Otherwise, "Coverage report generated" will get spammed for each process.
+  if ENV["TEST_ENV_NUMBER"]
     SimpleCov.at_exit do
       result = SimpleCov.result
+      # `SimpleCov.result` calls `ParallelTests.wait_for_other_processes_to_finish`
+      # internally for you on the last process.
       result.format! if ParallelTests.last_process?
     end
   end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -10,10 +10,11 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
   ]
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
 
+  # Needed for outputting coverage reporting only once for parallel_tests
   if RUBY_PLATFORM[/darwin/] && ENV["TEST_ENV_NUMBER"]
     SimpleCov.at_exit do
       result = SimpleCov.result
-      result.format! if ParallelTests.number_of_running_processes <= 1
+      result.format! if ParallelTests.last_process?
     end
   end
 end


### PR DESCRIPTION
- Clarify the comment of why we have SimpleCov special logic for parallel tests
- use a nicer ParallelTests API for checking which process to output the coverage format on