### PR TITLE
dev-cmd/bump-formula-pr: fix type error

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -148,7 +148,7 @@ module Homebrew
         new_mirrors ||= args.mirror
         if new_url.present? && (new_mirror = determine_mirror(new_url))
           new_mirrors ||= [new_mirror]
-          check_for_mirrors(formula, old_mirrors, new_mirrors)
+          check_for_mirrors(formula.name, old_mirrors, new_mirrors)
         end
 
         old_hash = formula_spec.checksum&.hexdigest


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
  - No. Should I add a new test for this? It seems that this was introduced by 587f4ba11bc7be30ece7a5ceae10e3395fdf131 but the commit didn't add any new tests.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The error message:

    Error: Parameter 'formula': Expected type String, got type Formulary::FormulaNamespace87ec47e7f9dec2f39e30adcc9fdea28fb57606eab88d4f83e8ebec591964143c::ApacheArrow with value #<Formula apache-arrow (sta...ore/Formula/a/apache-arrow.rb>
    Caller: /opt/homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:152
    Definition: /opt/homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:417 (Homebrew::DevCmd::BumpFormulaPr#check_for_mirrors)
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/configuration.rb:296:in `call_validation_error_handler_default'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/configuration.rb:303:in `call_validation_error_handler'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/call_validation.rb:310:in `report_error'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/call_validation.rb:218:in `block in validate_call'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/signature.rb:213:in `each_args_value_type'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/call_validation.rb:215:in `validate_call'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
    /opt/homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:152:in `run'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/call_validation.rb:270:in `bind_call'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/call_validation.rb:270:in `validate_call'
    /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11618/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
    /opt/homebrew/Library/Homebrew/brew.rb:94:in `<main>'
    Please report this issue:
      https://docs.brew.sh/Troubleshooting

This happened when I use the following command line:

    brew bump-formula-pr \
         --commit \
         --no-audit \
         --sha256="abcf1934cd0cdddd33664e9f2d9a251d6c55239d1122ad0ed223b13a583c82a9" \
         --url="https://www.apache.org/dyn/closer.lua?path=arrow/arrow-18.0.0/apache-arrow-18.0.0.tar.gz" \
         --verbose \
         --write-only \
         apache-arrow