### PR TITLE
Json: strip content before parsing

### DIFF
--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -117,7 +117,7 @@ module Homebrew
             provided_content
           else
             match_data.merge!(Strategy.page_content(url, homebrew_curl:))
-            match_data[:content]
+            match_data[:content]&.strip
           end
           return match_data if content.blank?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I recently encountered an upstream server that includes several blank lines in the response body before the JSON content (the `livecheck` URL for the `toshiba-color-mfp` cask) and this causes `JSON#parse` to return a `ParserError` for some reason. `#parse` can handle leading/trailing blank lines, so I'm not sure why it fails with this particular output. That said, calling `#strip` on the text before it's parsed resolves this particular issue.