### PR TITLE
macos_version: add `KERNEL_MAJOR_VERSIONS` map

### DIFF
--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -18,6 +18,8 @@ class MacOSVersion < Version
 
   # NOTE: When removing symbols here, ensure that they are added
   #       to `DEPRECATED_MACOS_VERSIONS` in `MacOSRequirement`.
+  #       When adding or removing symbols here, ensure that you
+  #       also update the KERNEL_MAJOR_VERSIONS map below.
   SYMBOLS = {
     sequoia:     "15",
     sonoma:      "14",
@@ -29,6 +31,21 @@ class MacOSVersion < Version
     high_sierra: "10.13",
     sierra:      "10.12",
     el_capitan:  "10.11",
+  }.freeze
+
+  # Map of macOS version strings to kernel major versions.
+  # https://en.wikipedia.org/wiki/MacOS_version_history#Releases
+  KERNEL_MAJOR_VERSIONS = {
+    "15"    => "24",
+    "14"    => "23",
+    "13"    => "22",
+    "12"    => "21",
+    "11"    => "20",
+    "10.15" => "19",
+    "10.14" => "18",
+    "10.13" => "17",
+    "10.12" => "16",
+    "10.11" => "15",
   }.freeze
 
   sig { params(version: Symbol).returns(T.attached_class) }

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -18,8 +18,6 @@ class MacOSVersion < Version
 
   # NOTE: When removing symbols here, ensure that they are added
   #       to `DEPRECATED_MACOS_VERSIONS` in `MacOSRequirement`.
-  #       When adding or removing symbols here, ensure that you
-  #       also update the KERNEL_MAJOR_VERSIONS map below.
   SYMBOLS = {
     sequoia:     "15",
     sonoma:      "14",
@@ -33,20 +31,16 @@ class MacOSVersion < Version
     el_capitan:  "10.11",
   }.freeze
 
-  # Map of macOS version strings to kernel major versions.
-  # https://en.wikipedia.org/wiki/MacOS_version_history#Releases
-  KERNEL_MAJOR_VERSIONS = {
-    "15"    => "24",
-    "14"    => "23",
-    "13"    => "22",
-    "12"    => "21",
-    "11"    => "20",
-    "10.15" => "19",
-    "10.14" => "18",
-    "10.13" => "17",
-    "10.12" => "16",
-    "10.11" => "15",
-  }.freeze
+  sig { params(macos_version: MacOSVersion).returns(Version) }
+  def self.kernel_major_version(macos_version)
+    version_major = macos_version.major.to_i
+    if version_major > 10
+      Version.new((version_major + 9).to_s)
+    else
+      version_minor = macos_version.minor.to_i
+      Version.new((version_minor + 4).to_s)
+    end
+  end
 
   sig { params(version: Symbol).returns(T.attached_class) }
   def self.from_symbol(version)

--- a/Library/Homebrew/test/macos_version_spec.rb
+++ b/Library/Homebrew/test/macos_version_spec.rb
@@ -7,6 +7,18 @@ RSpec.describe MacOSVersion do
   let(:big_sur_major) { described_class.new("11.0") }
   let(:big_sur_update) { described_class.new("11.1") }
 
+  describe ".kernel_major_version" do
+    it "returns the kernel major version" do
+      expect(described_class.kernel_major_version(version)).to eq "18"
+      expect(described_class.kernel_major_version(big_sur_major)).to eq "20"
+      expect(described_class.kernel_major_version(big_sur_update)).to eq "20"
+    end
+
+    it "matches the major version returned by OS.kernel_version", :needs_macos do
+      expect(described_class.kernel_major_version(OS::Mac.version)).to eq OS.kernel_version.major
+    end
+  end
+
   specify "comparison with Symbol" do
     expect(version).to be > :high_sierra
     expect(version).to eq :mojave


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will be used by `llvm` (and, presumably, in the future, versioned
LLVM formulae). The idea is that we will write a config file for each OS
version pointing to the correct SDKROOT so that `llvm` does not require
rebuilding/reinstalling when a user upgrades to a new major version of
macOS.

See Homebrew/homebrew-core#196094.
