### PR TITLE
formula_auditor: allow `pkg-config` alias for `pkgconf` migration

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -361,8 +361,10 @@ module Homebrew
             EOS
           end
 
-          # we want to allow uses_from_macos for aliases but not bare dependencies
-          if self.class.aliases.include?(dep.name) && !dep.uses_from_macos?
+          # we want to allow uses_from_macos for aliases but not bare dependencies.
+          # we also allow `pkg-config` for backwards compatibility in external taps.
+          # TODO: after migrating all `pkg-config` usage to `pkgconf`, do not allow `pkg-config` in core tap
+          if self.class.aliases.include?(dep.name) && !dep.uses_from_macos? && dep.name != "pkg-config"
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We've discussed migrating `pkg-config` to `pkgconf` a couple times, e.g. https://github.com/Homebrew/homebrew-core/pull/194885

One of requirements is retaining compatibility with wide usage of `depends_on "pkg-config"` which seems to be best handled through an alias and this audit exception.