### PR TITLE
os: use native ruby calls for `uname`

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -30,8 +30,8 @@ module OS
   # @api public
   sig { returns(Version) }
   def self.kernel_version
-    require "utils/popen"
-    @kernel_version ||= T.let(Version.new(Utils.safe_popen_read("uname", "-r").chomp), T.nilable(Version))
+    require "etc"
+    @kernel_version ||= T.let(Version.new(Etc.uname.fetch(:release)), T.nilable(Version))
   end
 
   # Get the kernel name.
@@ -39,8 +39,8 @@ module OS
   # @api public
   sig { returns(String) }
   def self.kernel_name
-    require "utils/popen"
-    @kernel_name ||= T.let(Utils.safe_popen_read("uname", "-s").chomp, T.nilable(String))
+    require "etc"
+    @kernel_name ||= T.let(Etc.uname.fetch(:sysname), T.nilable(String))
   end
 
   ::OS_VERSION = T.let(ENV.fetch("HOMEBREW_OS_VERSION").freeze, String)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This avoids the overhead of shelling out.
