### PR TITLE
github_runner_matrix: extend timeout for dependent tests on arm64

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -169,6 +169,8 @@ class GitHubRunnerMatrix
         ["#{version}-arm64", runner_timeout]
       end
 
+      # We test recursive dependents on ARM macOS, so they can be slower than our Intel runners.
+      timeout *= 2 if @dependent_matrix && timeout < GITHUB_ACTIONS_RUNNER_TIMEOUT
       spec = MacOSRunnerSpec.new(
         name:    "macOS #{version}-arm64",
         runner:,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We give our ARM runners half the timeout of the Intel runners because
the ARM runners are faster. However, this is no longer true for
dependent testing because we test recursive dependents on ARM but skip
them on Intel.

This means that we can often hit the timeout on ARM but have all jobs
finish on Intel. We can re-run these with the long build label, but
that's a bit wasteful of our limited long build slots.

Instead, let's just use the same timeout value across ARM and Intel
runners when testing dependents: 2 hours.

