### PR TITLE
tap: allow an array of values for an audit exception

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1116,6 +1116,8 @@ class Tap
       return false unless list.include? formula_or_cask
       return list[formula_or_cask] if value.blank?
 
+      return list[formula_or_cask].include? value if list[formula_or_cask].is_a? Array
+
       list[formula_or_cask] == value
     end
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1116,7 +1116,7 @@ class Tap
       return false unless list.include? formula_or_cask
       return list[formula_or_cask] if value.blank?
 
-      return list[formula_or_cask].include? value if list[formula_or_cask].is_a? Array
+      return list[formula_or_cask].include?(value) if list[formula_or_cask].is_a?(Array)
 
       list[formula_or_cask] == value
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Discovered in https://github.com/Homebrew/homebrew-cask/pull/191078
The audit fails due to a specific HTTP error, on two URLs within the one cask.
Presently, it isn't possible to pass two URLs to a single token via an array in the audit_exception list because the value isn't read.

This PR correctly parses the array.