### PR TITLE
deprecate_disable: support optional replacement parameter

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -363,38 +363,40 @@ module Cask
 
     def to_h
       {
-        "token"                => token,
-        "full_token"           => full_name,
-        "old_tokens"           => old_tokens,
-        "tap"                  => tap&.name,
-        "name"                 => name,
-        "desc"                 => desc,
-        "homepage"             => homepage,
-        "url"                  => url,
-        "url_specs"            => url_specs,
-        "version"              => version,
-        "installed"            => installed_version,
-        "installed_time"       => install_time&.to_i,
-        "bundle_version"       => bundle_long_version,
-        "bundle_short_version" => bundle_short_version,
-        "outdated"             => outdated?,
-        "sha256"               => sha256,
-        "artifacts"            => artifacts_list,
-        "caveats"              => (caveats unless caveats.empty?),
-        "depends_on"           => depends_on,
-        "conflicts_with"       => conflicts_with,
-        "container"            => container&.pairs,
-        "auto_updates"         => auto_updates,
-        "deprecated"           => deprecated?,
-        "deprecation_date"     => deprecation_date,
-        "deprecation_reason"   => deprecation_reason,
-        "disabled"             => disabled?,
-        "disable_date"         => disable_date,
-        "disable_reason"       => disable_reason,
-        "tap_git_head"         => tap_git_head,
-        "languages"            => languages,
-        "ruby_source_path"     => ruby_source_path,
-        "ruby_source_checksum" => ruby_source_checksum,
+        "token"                   => token,
+        "full_token"              => full_name,
+        "old_tokens"              => old_tokens,
+        "tap"                     => tap&.name,
+        "name"                    => name,
+        "desc"                    => desc,
+        "homepage"                => homepage,
+        "url"                     => url,
+        "url_specs"               => url_specs,
+        "version"                 => version,
+        "installed"               => installed_version,
+        "installed_time"          => install_time&.to_i,
+        "bundle_version"          => bundle_long_version,
+        "bundle_short_version"    => bundle_short_version,
+        "outdated"                => outdated?,
+        "sha256"                  => sha256,
+        "artifacts"               => artifacts_list,
+        "caveats"                 => (caveats unless caveats.empty?),
+        "depends_on"              => depends_on,
+        "conflicts_with"          => conflicts_with,
+        "container"               => container&.pairs,
+        "auto_updates"            => auto_updates,
+        "deprecated"              => deprecated?,
+        "deprecation_date"        => deprecation_date,
+        "deprecation_reason"      => deprecation_reason,
+        "deprecation_replacement" => deprecation_replacement,
+        "disabled"                => disabled?,
+        "disable_date"            => disable_date,
+        "disable_reason"          => disable_reason,
+        "disable_replacement"     => disable_replacement,
+        "tap_git_head"            => tap_git_head,
+        "languages"               => languages,
+        "ruby_source_path"        => ruby_source_path,
+        "ruby_source_checksum"    => ruby_source_checksum,
       }
     end
 
@@ -415,11 +417,13 @@ module Cask
       if deprecation_date
         api_hash["deprecation_date"] = deprecation_date
         api_hash["deprecation_reason"] = deprecation_reason
+        api_hash["deprecation_replacement"] = deprecation_replacement
       end
 
       if disable_date
         api_hash["disable_date"] = disable_date
         api_hash["disable_reason"] = disable_reason
+        api_hash["disable_replacement"] = disable_replacement
       end
 
       if (url_specs_hash = url_specs).present?

--- a/Library/Homebrew/cask/cask.rbi
+++ b/Library/Homebrew/cask/cask.rbi
@@ -26,11 +26,15 @@ module Cask
 
     def deprecation_reason; end
 
+    def deprecation_replacement; end
+
     def disabled?; end
 
     def disable_date; end
 
     def disable_reason; end
+
+    def disable_replacement; end
 
     def homepage; end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -87,10 +87,12 @@ module Cask
       :deprecated?,
       :deprecation_date,
       :deprecation_reason,
+      :deprecation_replacement,
       :disable!,
       :disabled?,
       :disable_date,
       :disable_reason,
+      :disable_replacement,
       :discontinued?, # TODO: remove once discontinued? is removed (4.5.0)
       :livecheck,
       :livecheckable?,
@@ -105,8 +107,8 @@ module Cask
     extend Attrable
     include OnSystem::MacOSOnly
 
-    attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :disable_date, :disable_reason,
-                :on_system_block_min_os
+    attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :deprecation_replacement, :disable_date,
+                :disable_reason, :disable_replacement, :on_system_block_min_os
 
     attr_predicate :deprecated?, :disabled?, :livecheckable?, :on_system_blocks_exist?, :depends_on_set_in_block?
 
@@ -442,11 +444,12 @@ module Cask
     # NOTE: A warning will be shown when trying to install this cask.
     #
     # @api public
-    def deprecate!(date:, because:)
+    def deprecate!(date:, because:, replacement: nil)
       @deprecation_date = Date.parse(date)
       return if @deprecation_date > Date.today
 
       @deprecation_reason = because
+      @deprecation_replacement = replacement
       @deprecated = true
     end
 
@@ -455,16 +458,18 @@ module Cask
     # NOTE: An error will be thrown when trying to install this cask.
     #
     # @api public
-    def disable!(date:, because:)
+    def disable!(date:, because:, replacement: nil)
       @disable_date = Date.parse(date)
 
       if @disable_date > Date.today
         @deprecation_reason = because
+        @deprecation_replacement = replacement
         @deprecated = true
         return
       end
 
       @disable_reason = because
+      @disable_replacement = replacement
       @disabled = true
     end
 

--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -12,7 +12,10 @@ module Cask
       output = "#{title_info(cask)}\n"
       output << "#{Formatter.url(cask.homepage)}\n" if cask.homepage
       deprecate_disable = DeprecateDisable.message(cask)
-      output << "#{deprecate_disable.capitalize}\n" if deprecate_disable
+      if deprecate_disable.present?
+        deprecate_disable.tap { |message| message[0] = message[0].upcase }
+        output << "#{deprecate_disable}\n"
+      end
       output << "#{installation_info(cask)}\n"
       repo = repo_info(cask)
       output << "#{repo}\n" if repo

--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -75,6 +75,20 @@ module DeprecateDisable
       end
     end
 
+    replacement = if formula_or_cask.deprecated?
+      formula_or_cask.deprecation_replacement
+    elsif formula_or_cask.disabled?
+      formula_or_cask.disable_replacement
+    end
+
+    if replacement.present?
+      message << "\n"
+      message << <<~EOS
+        Replacement:
+          brew install #{replacement}
+      EOS
+    end
+
     message
   end
 

--- a/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
@@ -52,6 +52,9 @@ class Formula
   def deprecation_reason(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def deprecation_replacement(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def deps(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
@@ -62,6 +65,9 @@ class Formula
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def disable_reason(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def disable_replacement(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
   def disabled?(*args, &block); end

--- a/Library/Homebrew/test/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/deprecate_disable_spec.rb
@@ -5,30 +5,61 @@ require "deprecate_disable"
 RSpec.describe DeprecateDisable do
   let(:deprecated_formula) do
     instance_double(Formula, deprecated?: true, disabled?: false, deprecation_reason: :does_not_build,
-                    deprecation_date: nil, disable_date: nil)
+                    deprecation_replacement: nil, deprecation_date: nil, disable_date: nil)
   end
   let(:disabled_formula) do
     instance_double(Formula, deprecated?: false, disabled?: true, disable_reason: "is broken",
-                    deprecation_date: nil, disable_date: nil)
+                    disable_replacement: nil, deprecation_date: nil, disable_date: nil)
   end
   let(:deprecated_cask) do
     instance_double(Cask::Cask, deprecated?: true, disabled?: false, deprecation_reason: :discontinued,
-                   deprecation_date: nil, disable_date: nil)
+                   deprecation_replacement: nil, deprecation_date: nil, disable_date: nil)
   end
   let(:disabled_cask) do
     instance_double(Cask::Cask, deprecated?: false, disabled?: true, disable_reason: nil,
-                    deprecation_date: nil, disable_date: nil)
+                    disable_replacement: nil, deprecation_date: nil, disable_date: nil)
+  end
+  let(:deprecated_formula_with_replacement) do
+    instance_double(Formula, deprecated?: true, disabled?: false, deprecation_reason: :does_not_build,
+                    deprecation_replacement: "foo", deprecation_date: nil, disable_date: nil)
+  end
+  let(:disabled_formula_with_replacement) do
+    instance_double(Formula, deprecated?: false, disabled?: true, disable_reason: "is broken",
+                    disable_replacement: "bar", deprecation_date: nil, disable_date: nil)
+  end
+  let(:deprecated_cask_with_replacement) do
+    instance_double(Cask::Cask, deprecated?: true, disabled?: false, deprecation_reason: :discontinued,
+                    deprecation_replacement: "baz", deprecation_date: nil, disable_date: nil)
+  end
+  let(:disabled_cask_with_replacement) do
+    instance_double(Cask::Cask, deprecated?: false, disabled?: true, disable_reason: nil,
+                    disable_replacement: "qux", deprecation_date: nil, disable_date: nil)
   end
 
   before do
-    allow(deprecated_formula).to receive(:is_a?).with(Formula).and_return(true)
-    allow(deprecated_formula).to receive(:is_a?).with(Cask::Cask).and_return(false)
-    allow(disabled_formula).to receive(:is_a?).with(Formula).and_return(true)
-    allow(disabled_formula).to receive(:is_a?).with(Cask::Cask).and_return(false)
-    allow(deprecated_cask).to receive(:is_a?).with(Formula).and_return(false)
-    allow(deprecated_cask).to receive(:is_a?).with(Cask::Cask).and_return(true)
-    allow(disabled_cask).to receive(:is_a?).with(Formula).and_return(false)
-    allow(disabled_cask).to receive(:is_a?).with(Cask::Cask).and_return(true)
+    formulae = [
+      deprecated_formula,
+      disabled_formula,
+      deprecated_formula_with_replacement,
+      disabled_formula_with_replacement,
+    ]
+
+    casks = [
+      deprecated_cask,
+      disabled_cask,
+      deprecated_cask_with_replacement,
+      disabled_cask_with_replacement,
+    ]
+
+    formulae.each do |f|
+      allow(f).to receive(:is_a?).with(Formula).and_return(true)
+      allow(f).to receive(:is_a?).with(Cask::Cask).and_return(false)
+    end
+
+    casks.each do |c|
+      allow(c).to receive(:is_a?).with(Formula).and_return(false)
+      allow(c).to receive(:is_a?).with(Cask::Cask).and_return(true)
+    end
   end
 
   describe "::type" do
@@ -68,6 +99,26 @@ RSpec.describe DeprecateDisable do
     it "returns a deprecation message with no reason" do
       expect(described_class.message(disabled_cask))
         .to eq "disabled!"
+    end
+
+    it "returns a replacement message for a deprecated formula" do
+      expect(described_class.message(deprecated_formula_with_replacement))
+        .to eq "deprecated because it does not build!\nReplacement:\n  brew install foo\n"
+    end
+
+    it "returns a replacement message for a disabled formula" do
+      expect(described_class.message(disabled_formula_with_replacement))
+        .to eq "disabled because it is broken!\nReplacement:\n  brew install bar\n"
+    end
+
+    it "returns a replacement message for a deprecated cask" do
+      expect(described_class.message(deprecated_cask_with_replacement))
+        .to eq "deprecated because it is discontinued upstream!\nReplacement:\n  brew install baz\n"
+    end
+
+    it "returns a replacement message for a disabled cask" do
+      expect(described_class.message(disabled_cask_with_replacement))
+        .to eq "disabled!\nReplacement:\n  brew install qux\n"
     end
   end
 

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -90,9 +90,11 @@
   "deprecated": false,
   "deprecation_date": null,
   "deprecation_reason": null,
+  "deprecation_replacement": null,
   "disabled": false,
   "disable_date": null,
   "disable_reason": null,
+  "disable_replacement": null,
   "tap_git_head": "abcdef1234567890abcdef1234567890abcdef12",
   "languages": [
     "en",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Addresses https://github.com/Homebrew/brew/issues/18294.

A replacement may be specified like so:

```ruby
deprecate! date: "2024-01-10", because: :repo_removed, replacement: "ffmpeg"
```

which yields something like

```console
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info alac
==> alac: stable 0.2.0 (bottled)
Basic decoder for Apple Lossless Audio Codec files (ALAC)
https://web.archive.org/web/20150319040222/craz.net/programs/itunes/alac.html
Deprecated because it has a removed upstream repository! It will be disabled on 2025-01-10.
Consider replacing it with:
    brew install ffmpeg
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/a/alac.rb
License: MIT
==> Analytics
install: 8 (30 days), 34 (90 days), 110 (365 days)
install-on-request: 8 (30 days), 34 (90 days), 110 (365 days)
build-error: 0 (30 days)
```

and, for disabled:

```ruby
disable! date: "2024-08-03", because: :unmaintained, replacement: "gcalcli"
```

which yields something like

```console
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info gcal
==> gcal: stable 4.1 (bottled)
Program for calculating and printing calendars
https://www.gnu.org/software/gcal/
Disabled because it is not maintained upstream! It was disabled on 2024-08-03.
Consider replacing it with:
    brew install gcalcli
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/g/gcal.rb
License: GPL-3.0-or-later
==> Dependencies
Build: texinfo ✔
==> Analytics
install: 0 (30 days), 2 (90 days), 179 (365 days)
install-on-request: 0 (30 days), 2 (90 days), 179 (365 days)
build-error: 0 (30 days)
```

---

- Replacements are added as an optional keyword argument. The message and behavior when no replacement is provided should remain the same.
- I made an effort to include the replacement in the API JSON as well, but I'm not too familiar. Would appreciate if someone can confirm that the changes made there are sufficient.
- The replacement is just a string for now, which is shown as an argument to the `brew install` help text. Note that there is no distinction between the string argument as a formula or cask; there is no validation on the value of the string.
- I am aware that https://github.com/Homebrew/brew/pull/18661 is open and this may need to be refactored after that is merged (or vice versa).