### PR TITLE
tap_auditor: check renamed formula exists

### DIFF
--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -10,6 +10,7 @@ module Homebrew
     sig { params(tap: Tap, strict: T.nilable(T::Boolean)).void }
     def initialize(tap, strict:)
       Homebrew.with_no_api_env do
+        tap.clear_cache if Homebrew::EnvConfig.automatically_set_no_install_from_api?
         @name                      = tap.name
         @path                      = tap.path
         @tap_audit_exceptions      = tap.audit_exceptions
@@ -54,6 +55,7 @@ module Homebrew
       check_formula_list_directory "style_exceptions", @tap_style_exceptions
       check_formula_list "pypi_formula_mappings", @tap_pypi_formula_mappings
       check_formula_list ".github/autobump.txt", @tap_autobump
+      check_formula_list "formula_renames", @formula_renames.values
     end
 
     sig { void }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Audit renames so we remove old ones that can no longer be resolved to an actual formula/alias, ~~further renames, or a tap migration.~~ EDIT: remove support for latter and instead require cleaning those old renames.

```console
❯ brew audit --tap homebrew/core --only tap_formula_lists
homebrew/core
  * formula_renames.json references
    formulae or casks that are not found in the homebrew/core tap.
    Invalid formulae or casks: antlr@2, elasticsearch@6, gcc@5, gcc@6, gnuplot@4, perl@5.18, tomcat@7, v8@3.15, wxwidgets@3.0
Error: 1 problem in 1 tap detected.
```