### PR TITLE
linux/hardware/cpu: add some missing AMD CPUs

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -28,7 +28,7 @@ module Hardware
         when "GenuineIntel"
           intel_family(cpu_family, cpu_model)
         when "AuthenticAMD"
-          amd_family(cpu_family)
+          amd_family(cpu_family, cpu_model)
         end || unknown
       end
 
@@ -87,7 +87,7 @@ module Hardware
         end
       end
 
-      def amd_family(family)
+      def amd_family(family, cpu_model)
         case family
         when 0x06
           :amd_k7
@@ -106,9 +106,21 @@ module Hardware
         when 0x16
           :jaguar
         when 0x17
-          :zen
+          case cpu_model
+          when 0x10..0x2f
+            :zen
+          when 0x30..0x3f, 0x47, 0x60..0x7f, 0x84..0x87, 0x90..0xaf
+            :zen2
+          end
         when 0x19
-          :zen3
+          case cpu_model
+          when ..0x0f, 0x20..0x5f
+            :zen3
+          when 0x10..0x1f, 0x60..0x7f, 0xa0..0xaf
+            :zen4
+          end
+        when 0x1a
+          :zen5
         end
       end
 

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Hardware::CPU do
   describe "::family" do
     let(:cpu_families) do
       [
+        :alderlake,
         :amd_k7,
         :amd_k8,
         :amd_k8_k10_hybrid,
@@ -38,6 +39,7 @@ RSpec.describe Hardware::CPU do
         :arm_twister,
         :arm_typhoon,
         :arm_vortex_tempest,
+        :arrowlake,
         :atom,
         :bobcat,
         :broadwell,
@@ -47,6 +49,7 @@ RSpec.describe Hardware::CPU do
         :core,
         :core2,
         :dothan,
+        :graniterapids,
         :haswell,
         :icelake,
         :ivybridge,
@@ -54,15 +57,22 @@ RSpec.describe Hardware::CPU do
         :kabylake,
         :merom,
         :nehalem,
+        :pantherlake,
         :penryn,
         :ppc,
         :prescott,
         :presler,
+        :rocketlake,
         :sandybridge,
+        :sapphirerapids,
         :skylake,
+        :tigerlake,
         :westmere,
         :zen,
+        :zen2,
         :zen3,
+        :zen4,
+        :zen5,
         :dunno,
       ]
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to #18743.

- Add a `cpu_model` parameter on `amd_family`
- Differentiate between Zen 1 and 2, as well as Zen 3 and 4
- Add Zen 5
- While we're here, add missing families/models (both AMD and Intel) into `cpu_spec.rb`