### PR TITLE
Support setting `GIT_COMMITTER_NAME` and `GIT_COMMITTER_EMAIL`

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -273,11 +273,19 @@ module Homebrew
       HOMEBREW_GITHUB_PACKAGES_USER:             {
         description: "Use this username when accessing the GitHub Packages Registry (where bottles may be stored).",
       },
+      HOMEBREW_GIT_COMMITTER_EMAIL:              {
+        description: "Set the Git committer email to this value.",
+      },
+      HOMEBREW_GIT_COMMITTER_NAME:               {
+        description: "Set the Git committer name to this value.",
+      },
       HOMEBREW_GIT_EMAIL:                        {
-        description: "Set the Git author and committer email to this value.",
+        description: "Set the Git author name and, if `HOMEBREW_GIT_COMMITTER_EMAIL` is unset, committer email to " \
+                     "this value.",
       },
       HOMEBREW_GIT_NAME:                         {
-        description: "Set the Git author and committer name to this value.",
+        description: "Set the Git author name and, if `HOMEBREW_GIT_COMMITTER_NAME` is unset, committer name to " \
+                     "this value.",
       },
       HOMEBREW_GIT_PATH:                         {
         description: "Linux only: Set this value to a new enough `git` executable for Homebrew to use.",

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -161,6 +161,12 @@ module Homebrew::EnvConfig
     def ftp_proxy; end
 
     sig { returns(T.nilable(::String)) }
+    def git_committer_email; end
+
+    sig { returns(T.nilable(::String)) }
+    def git_committer_name; end
+
+    sig { returns(T.nilable(::String)) }
     def git_email; end
 
     sig { returns(T.nilable(::String)) }

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -119,10 +119,19 @@ module Utils
         ENV["GIT_COMMITTER_NAME"] = Homebrew::EnvConfig.git_name if committer
       end
 
-      return unless Homebrew::EnvConfig.git_email
+      if Homebrew::EnvConfig.git_committer_name && committer
+        ENV["GIT_COMMITTER_NAME"] = Homebrew::EnvConfig.git_committer_name
+      end
 
-      ENV["GIT_AUTHOR_EMAIL"] = Homebrew::EnvConfig.git_email if author
-      ENV["GIT_COMMITTER_EMAIL"] = Homebrew::EnvConfig.git_email if committer
+      if Homebrew::EnvConfig.git_email
+        ENV["GIT_AUTHOR_EMAIL"] = Homebrew::EnvConfig.git_email if author
+        ENV["GIT_COMMITTER_EMAIL"] = Homebrew::EnvConfig.git_email if committer
+      end
+
+      return unless committer
+      return unless Homebrew::EnvConfig.git_committer_email
+
+      ENV["GIT_COMMITTER_EMAIL"] = Homebrew::EnvConfig.git_committer_email
     end
 
     def self.setup_gpg!

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -756,6 +756,7 @@ module GitHub
 
         safe_system "git", "add", *changed_files
         safe_system "git", "checkout", "--no-track", "-b", branch, "#{remote}/#{remote_branch}" unless args.commit?
+        Utils::Git.set_name_email!
         safe_system "git", "commit", "--no-edit", "--verbose",
                     "--message=#{commit_message}",
                     "--", *changed_files


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Our autobump workflow sets the author and committer to the user who
triggered the workflow, defaulting to @BrewTestBot for scheduled runs.

This can be confusing for maintainers when GitHub shows up as
"Unverified" because the commit is signed with @BrewTestBot's key.[^1]

Let's fix that by configuring our autobump workflow to always commit as
@BrewTestBot, so that the committer matches the GPG signature. To do
that, we need to add support for setting `GIT_COMMITTER_NAME` and
`GIT_COMMITTER_EMAIL`.

[^1]: See, for example, Homebrew/homebrew-core#197234.
