### PR TITLE
actionlint: suppress zizmor's exit code

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -55,7 +55,9 @@ jobs:
 
           echo "::add-matcher::.github/actionlint-matcher.json"
 
-      - run: zizmor --format sarif . >results.sarif
+      - run: |
+          # NOTE: exit code intentionally suppressed here
+          zizmor --format sarif . > results.sarif || true
 
       - name: Upload SARIF file
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This uses `|| true` to suppress zizmor's exit code, which is being surfaced as a failure due to the workflow wide `set -e` default.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
