### PR TITLE
shared: only fall back to -march=native on supported architectures

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -7,8 +7,10 @@ module SharedEnvExtension
       @bottle_arch.to_sym
     elsif @build_bottle
       Hardware.oldest_cpu
-    else
+    elsif Hardware::CPU.intel? || Hardware::CPU.arm?
       :native
+    else
+      :none
     end
   end
 end

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -27,6 +27,7 @@ module Hardware
       sig { returns(T::Hash[Symbol, String]) }
       def optimization_flags
         @optimization_flags ||= T.let({
+          none:               "",
           native:             arch_flag("native"),
           ivybridge:          "-march=ivybridge",
           sandybridge:        "-march=sandybridge",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

On Linux, `-march=native` is added in the optflags when building from source (and not for a bottle). This works fine for the case where users install `brew` in a custom prefix on a supported architecture, but breaks the case where the user is building from source for running under Linux on an unsupported architecture for which the `-march=native` flag is not valid (I specifically ran into this issue while tinkering with `brew` under Ubuntu on RISC-V).

Introduce a new optimization flag option `none` and adjust `effective_arch` to only fall back on `:native` if running on Intel or ARM (which are not the only architectures which support `-march=native`, but it does cover all existing supported use cases and leaves room for current development/experimentation happening with `brew` on Linux arm64), and falls back on the more conservative `:none` option if not running one of those architectures.