### PR TITLE
Acceptable-Casks: remove outdated info

### DIFF
--- a/docs/Acceptable-Casks.md
+++ b/docs/Acceptable-Casks.md
@@ -24,7 +24,7 @@ We maintain separate taps for different types of binaries. Our nomenclature is:
 
 ### Stable versions
 
-Stable versions live in the main repository at [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask). They should run on the latest release of macOS or the previous point release (Monterey and Ventura as of late 2022).
+Stable versions live in the main repository at [Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask). They should run on the latest major version of macOS.
 
 ### Beta, Unstable, Development, Nightly, or Legacy
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Let's replace this with something consistent that doesn't need to be updated every year. If a cask can't be installed on the current major macOS version, we shouldn't accept it.