### PR TITLE
shims: add curl-config shim to fix curl-config http2 report issue for ventura builds

### DIFF
--- a/Library/Homebrew/shims/mac/super/curl-config
+++ b/Library/Homebrew/shims/mac/super/curl-config
@@ -1,0 +1,35 @@
+#!/bin/bash -p
+
+# HOMEBREW_LIBRARY is set by bin/brew
+# HOMEBREW_CURL_CONFIG is set by brew.sh
+# shellcheck disable=SC2154
+source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
+
+# Check if HOMEBREW_CURL_CONFIG is set, fallback to system curl-config if not.
+curl_config_exec="${HOMEBREW_CURL_CONFIG:-/usr/bin/curl-config}"
+
+# Intercept --features and append HTTP2 if needed
+if [[ "$1" == "--features" ]]
+then
+  output="$("${curl_config_exec}" "$@")"
+
+  # Check if HTTP2 is missing but supported
+  if [[ ! "${output}" =~ HTTP2 ]]
+  then
+    curl_version="$("${HOMEBREW_CURL:-curl}" -V)"
+    if [[ "${curl_version}" =~ HTTP/2 ]]
+    then
+      output="${output} HTTP2"
+    fi
+  fi
+
+  echo "${output}"
+  exit 0
+fi
+
+# Fall back to executing the original curl-config
+try_exec_non_system "${curl_config_exec}" "$@"
+safe_exec "/usr/bin/curl-config" "$@"
+
+echo "Could not execute curl-config. Try HOMEBREW_FORCE_BREWED_CURL_CONFIG=1" >&2
+exit 1


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

seeing some ventura build linkage failure due to curl-config reporting issue, adding the shim as result per @Bo98's suggestion. 

- https://github.com/Homebrew/homebrew-core/pull/197727
- https://github.com/Homebrew/homebrew-core/pull/197728