### PR TITLE
fix: `too_many_open_prs()` fails without SSO access

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -921,7 +921,6 @@ module GitHub
       }
     EOS
     puts
-    puts "In too_many_open_prs"
 
     homebrew_prs_count = 0
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -921,25 +921,31 @@ module GitHub
       }
     EOS
     puts
+    puts "In too_many_open_prs"
 
     homebrew_prs_count = 0
 
-    API.paginate_graphql(query) do |result|
-      data = result.fetch("viewer")
-      github_user = data.fetch("login")
+    begin
+      API.paginate_graphql(query) do |result|
+        data = result.fetch("viewer")
+        github_user = data.fetch("login")
 
-      # BrewTestBot can open as many PRs as it wants.
-      return false if github_user.casecmp?("brewtestbot")
+        # BrewTestBot can open as many PRs as it wants.
+        return false if github_user.casecmp?("brewtestbot")
 
-      pull_requests = data.fetch("pullRequests")
-      return false if pull_requests.fetch("totalCount") < MAXIMUM_OPEN_PRS
+        pull_requests = data.fetch("pullRequests")
+        return false if pull_requests.fetch("totalCount") < MAXIMUM_OPEN_PRS
 
-      homebrew_prs_count += pull_requests.fetch("nodes").count do |node|
-        node.dig("baseRepository", "owner", "login").casecmp?("homebrew")
+        homebrew_prs_count += pull_requests.fetch("nodes").count do |node|
+          node.dig("baseRepository", "owner", "login").casecmp?("homebrew")
+        end
+        return true if homebrew_prs_count >= MAXIMUM_OPEN_PRS
+
+        pull_requests.fetch("pageInfo")
       end
-      return true if homebrew_prs_count >= MAXIMUM_OPEN_PRS
-
-      pull_requests.fetch("pageInfo")
+    rescue => e
+      # Ignore SAML access errors (https://github.com/Homebrew/brew/issues/18610)
+      raise unless e.message.casecmp?("SAML")
     end
 
     false

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -944,7 +944,7 @@ module GitHub
       end
     rescue => e
       # Ignore SAML access errors (https://github.com/Homebrew/brew/issues/18610)
-      raise unless e.message.casecmp?("SAML")
+      raise unless e.message.include?("SAML")
     end
 
     false

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -944,7 +944,7 @@ module GitHub
       end
     rescue => e
       # Ignore SAML access errors (https://github.com/Homebrew/brew/issues/18610)
-      raise unless e.message.include?("SAML")
+      raise unless e.message.include?("Resource protected by organization SAML enforcement")
     end
 
     false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Resolves #18610 by implementing the suggested solution:

> Ignoring any SSO (i.e. extensions contains saml_failure) errors for that specific API call only. SAML errors for other API calls are likely genuine and should continue to error.

`extensions` doesn't appear to be present on this response when an SSO error is thrown. Instead, a check is performed to determine if the error message contains "SAML"; if so, the error is disregarded. I understand "SAML" may be too wide of a filter- please suggest a more narrow alternative if that is the case.
