### PR TITLE
hardware: rename none optimization flags to dunno

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -10,7 +10,7 @@ module SharedEnvExtension
     elsif Hardware::CPU.intel? || Hardware::CPU.arm?
       :native
     else
-      :none
+      :dunno
     end
   end
 end

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -27,7 +27,7 @@ module Hardware
       sig { returns(T::Hash[Symbol, String]) }
       def optimization_flags
         @optimization_flags ||= T.let({
-          none:               "",
+          dunno:              "",
           native:             arch_flag("native"),
           ivybridge:          "-march=ivybridge",
           sandybridge:        "-march=sandybridge",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to https://github.com/Homebrew/brew/pull/18759. This helps catch the case of building bottles when the CPU type is `dunno` (in this case, `Hardware.oldest_cpu` returns `:dunno`).

Without this, the flag `-march=dunno` is passed when using the `cc` shim, which really doesn't work for any architecture.