### PR TITLE
uninstall: don't ignore deps even for developers

### DIFF
--- a/Library/Homebrew/test/uninstall_spec.rb
+++ b/Library/Homebrew/test/uninstall_spec.rb
@@ -47,17 +47,7 @@ RSpec.describe Homebrew::Uninstall do
   end
 
   describe "::handle_unsatisfied_dependents" do
-    specify "when developer" do
-      ENV["HOMEBREW_DEVELOPER"] = "1"
-
-      expect do
-        described_class.handle_unsatisfied_dependents(kegs_by_rack)
-      end.to output(/Warning/).to_stderr
-
-      expect(Homebrew).not_to have_failed
-    end
-
-    specify "when not developer" do
+    specify "when `ignore_dependencies` is false" do
       expect do
         described_class.handle_unsatisfied_dependents(kegs_by_rack)
       end.to output(/Error/).to_stderr
@@ -65,7 +55,7 @@ RSpec.describe Homebrew::Uninstall do
       expect(Homebrew).to have_failed
     end
 
-    specify "when not developer and `ignore_dependencies` is true" do
+    specify "when `ignore_dependencies` is true" do
       expect do
         described_class.handle_unsatisfied_dependents(kegs_by_rack, ignore_dependencies: true)
       end.not_to output.to_stderr


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This was discussed a while back on Slack. The idea behind this is that ignoring dependencies during `brew uninstall` makes it too easy to break things, even for developers. Those who know what they are doing can, and IMO should, always use the `--ignore-dependencies` flag.
