### PR TITLE
generate-cask-ci-matrix-syntax: allow no argument for syntax-only jobs

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -44,7 +44,7 @@ module Homebrew
         conflicts "--syntax-only", "--skip-install"
         conflicts "--syntax-only", "--new"
 
-        named_args [:cask, :url], min: 1
+        named_args [:cask, :url], min: 0
         hide_from_man_page!
       end
 
@@ -61,7 +61,10 @@ module Homebrew
 
         tap = T.let(Tap.fetch(repository), Tap)
 
-        raise UsageError, "Either `--cask` or `--url` must be specified." if casks.blank? && pr_url.blank?
+        unless syntax_only
+          raise UsageError, "Either `--cask` or `--url` must be specified." if !args.casks? && !args.url?
+          raise UsageError, "Please provide a cask or url argument" if casks.blank? && pr_url.blank?
+        end
         raise UsageError, "Only one url can be specified" if pr_url&.count&.> 1
 
         labels = if pr_url


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

CI for casks is also run on pushes to master, which should be a `syntax-only` job, in this case we shouldn't require an argument, as neither a cask token, or a PR url is available. I couldn't think of a better way to deal with this case.