### PR TITLE
formula_installer: re-enable mirror usage when installing via API

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1317,6 +1317,7 @@ on_request: installed_on_request?, options:)
 
       formula.fetch_patches
       formula.resources.each(&:fetch)
+      downloadable_object = downloadable
 
       false
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Since #18562, installing from source via the API doesn't download from a mirror if the original is unreachable. Re-initializing `downloadable_object` seems to fix this. (🎩 @Bo98)

Note that this only works for `brew install -s`, and not for `brew fetch -s`.

Before:
```
$ tail -n 1 /etc/hosts
127.0.0.1   ftp.gnu.org
$ brew install -s libunistring
libunistring 1.2 is already installed but outdated (so it will be upgraded).
==> Fetching libunistring
==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-core/bcf0b597f2caa3342586ca5e0d2379b2337b7a56/Formul
Already downloaded: /Users/eric/Library/Caches/Homebrew/downloads/027cce73171392f3c59ccae026aaad023c190d1dadcce6b9ee572f6a5eb2804e--libunistring.rb
==> Downloading https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz
curl: (7) Failed to connect to ftp.gnu.org port 443 after 1 ms: Couldn't connect to server

Error: libunistring: Failed to download resource "libunistring"
Download failed: https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz
```

After:
```
$ brew install -s libunistring
libunistring 1.2 is already installed but outdated (so it will be upgraded).
==> Fetching libunistring
==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-core/bcf0b597f2caa3342586ca5e0d2379b2337b7a56/Formul
Already downloaded: /Users/eric/Library/Caches/Homebrew/downloads/027cce73171392f3c59ccae026aaad023c190d1dadcce6b9ee572f6a5eb2804e--libunistring.rb
==> Downloading https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz
curl: (7) Failed to connect to ftp.gnu.org port 443 after 1 ms: Couldn't connect to server

Trying a mirror...
==> Downloading https://ftpmirror.gnu.org/libunistring/libunistring-1.3.tar.gz
==> Downloading from https://mirror.its.dal.ca/gnu/libunistring/libunistring-1.3.tar.gz
###########                                                                                                         9.8%
```