### PR TITLE
revert setting `--insecure` to download ca-certificates

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -1,8 +1,11 @@
 # Documentation defined in Library/Homebrew/cmd/vendor-install.rb
 
-# HOMEBREW_CURLRC, HOMEBREW_LIBRARY is from the user environment
-# HOMEBREW_CACHE, HOMEBREW_CURL, HOMEBREW_LINUX, HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION, HOMEBREW_MACOS,
-# HOMEBREW_MACOS_VERSION_NUMERIC and HOMEBREW_PROCESSOR are set by brew.sh
+# HOMEBREW_ARTIFACT_DOMAIN, HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK, HOMEBREW_BOTTLE_DOMAIN, HOMEBREW_CACHE,
+# HOMEBREW_CURLRC, HOMEBREW_DEVELOPER, HOMEBREW_DEBUG, HOMEBREW_VERBOSE are from the user environment
+# HOMEBREW_PORTABLE_RUBY_VERSION is set by utils/ruby.sh
+# HOMEBREW_LIBRARY, HOMEBREW_PREFIX are set by bin/brew
+# HOMEBREW_CURL, HOMEBREW_GITHUB_PACKAGES_AUTH, HOMEBREW_LINUX, HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION, HOMEBREW_MACOS,
+# HOMEBREW_PHYSICAL_PROCESSOR, HOMEBREW_PROCESSOR, HOMEBREW_USER_AGENT_CURL are set by brew.sh
 # shellcheck disable=SC2154
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/lock.sh"
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby.sh"
@@ -127,11 +130,6 @@ fetch() {
   elif [[ -z "${HOMEBREW_VERBOSE}" ]]
   then
     curl_args[${#curl_args[*]}]="--progress-bar"
-  fi
-
-  if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "100600" ]]
-  then
-    curl_args[${#curl_args[*]}]="--insecure"
   fi
 
   temporary_path="${CACHED_LOCATION}.incomplete"

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -559,14 +559,6 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += meta.fetch(:headers, []).flat_map { |h| ["--header", h.strip] }
 
-    if meta[:insecure]
-      unless @insecure_warning_shown
-        opoo DevelopmentTools.insecure_download_warning("an updated certificates file")
-        @insecure_warning_shown = true
-      end
-      args += ["--insecure"]
-    end
-
     args
   end
 

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -51,20 +51,6 @@ class Resource
   def owner=(owner)
     @owner = owner
     patches.each { |p| p.owner = owner }
-
-    return if !owner.respond_to?(:full_name) || owner.full_name != "ca-certificates"
-    return if Homebrew::EnvConfig.no_insecure_redirect?
-
-    @insecure = !specs[:bottle] && (DevelopmentTools.ca_file_substitution_required? ||
-                                    DevelopmentTools.curl_substitution_required?)
-    return if @url.nil?
-
-    specs = if @insecure
-      @url.specs.merge({ insecure: true })
-    else
-      @url.specs.except(:insecure)
-    end
-    @url = URL.new(@url.to_s, specs)
   end
 
   # Removes /s from resource names; this allows Go package names


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Previously, [adding `--insecure` was necessary](https://github.com/Homebrew/brew/pull/12172) for curl to download the [ca-certificates .pem file](https://curl.se/ca/cacert-2024-09-24.pem) on older macOS versions. At some point since then, the way Homebrew downloads this file was changed in a way that happens to allow stock curl on macOS 10.11 & 10.12 (`curl 7.54.0 (x86_64-apple-darwin16.0) libcurl/7.54.0 SecureTransport zlib/1.2.8`) to download it during installation without needing `--insecure`.

This would have gone unnoticed, except that now adding `--insecure` actively prevents downloading from servers whose certificates rely on SNI because of a [quirk of Secure Transport](https://github.com/curl/curl/issues/998):
```
$ /usr/bin/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.4.6-25-gf597978\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.12.6\)\ curl/7.54.0 --header Accept-Language:\ en --fail --retry 3 --insecure --remote-time --output /Users/vmadmin/Library/Caches/Homebrew/downloads/4080d87775c0373afc13f3d24afaa24bdbbec40879ce7e9c09896f1ab36e5259--cacert-2024-09-24.pem.incomplete --location https://curl.se/ca/cacert-2024-09-24.pem --http1.1 --verbose
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 151.101.1.91...
* TCP_NODELAY set
* Connected to curl.se (151.101.1.91) port 443 (#0)
* WARNING: disabling hostname validation also disables SNI.
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: n.sni-347-default.ssl.fastly.net
* Server certificate: GlobalSign Atlas R3 DV TLS CA 2024 Q4
* Server certificate: GlobalSign
> GET /ca/cacert-2024-09-24.pem HTTP/1.1
> Host: curl.se
> User-Agent: Homebrew/4.4.6-25-gf597978 (Macintosh; Intel Mac OS X 10.12.6) curl/7.54.0
> Accept: */*
> Accept-Language: en
> 
* The requested URL returned error: 421 Misdirected Request
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
curl: (22) The requested URL returned error: 421 Misdirected Request
```
This doesn't affect macOS 10.13 and later, whose curl uses LibreSSL (`curl 7.54.0 (x86_64-apple-darwin17.0) libcurl/7.54.0 LibreSSL/2.0.20 zlib/1.2.11 nghttp2/1.24.0`). 

Removing the code for adding `--insecure` to download ca-certificates allows fresh installs on macOS 10.11 & 10.12 to work again, which now only need the flag when downloading API *.json files from GitHub.

(This also removes a long-forgotten `--insecure` reference in vendor-install.sh.)