### PR TITLE
cask: try fix a couple of permission edge cases under multi-user

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -116,12 +116,15 @@ module Cask
               print_stderr: false,
             ).stdout
             if plist_status.start_with?("{")
-              command.run!(
+              result = command.run(
                 "/bin/launchctl",
                 args:         ["remove", service],
+                must_succeed: sudo,
                 sudo:,
                 sudo_as_root: sudo,
               )
+              next if !sudo && !result.success?
+
               sleep 1
             end
             paths = [

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -49,9 +49,10 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
         )
         .and_return(instance_double(SystemCommand::Result, stdout: unknown_response))
 
-      expect(fake_system_command).to receive(:run!)
-        .with("/bin/launchctl", args: ["remove", "my.fancy.package.service"], sudo: false, sudo_as_root: false)
-        .and_return(instance_double(SystemCommand::Result))
+      expect(fake_system_command).to receive(:run)
+        .with("/bin/launchctl", args: ["remove", "my.fancy.package.service"],
+        must_succeed: false, sudo: false, sudo_as_root: false)
+        .and_return(instance_double(SystemCommand::Result, success?: true))
 
       subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
     end
@@ -76,9 +77,10 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
         )
         .and_return(instance_double(SystemCommand::Result, stdout: service_info))
 
-      expect(fake_system_command).to receive(:run!)
-        .with("/bin/launchctl", args: ["remove", "my.fancy.package.service"], sudo: true, sudo_as_root: true)
-        .and_return(instance_double(SystemCommand::Result))
+      expect(fake_system_command).to receive(:run)
+        .with("/bin/launchctl", args: ["remove", "my.fancy.package.service"],
+        must_succeed: true, sudo: true, sudo_as_root: true)
+        .and_return(instance_double(SystemCommand::Result, success?: true))
 
       subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
     end
@@ -136,9 +138,10 @@ RSpec.shared_examples "#uninstall_phase or #zap_phase" do
         )
         .and_return(instance_double(SystemCommand::Result, stdout: service_info))
 
-      expect(fake_system_command).to receive(:run!)
-        .with("/bin/launchctl", args: ["remove", "my.fancy.package.service.12345"], sudo: true, sudo_as_root: true)
-        .and_return(instance_double(SystemCommand::Result))
+      expect(fake_system_command).to receive(:run)
+        .with("/bin/launchctl", args: ["remove", "my.fancy.package.service.12345"],
+        must_succeed: true, sudo: true, sudo_as_root: true)
+        .and_return(instance_double(SystemCommand::Result, success?: true))
 
       subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
     end


### PR DESCRIPTION
I haven't been able to reproduce these but they make plausible sense at least:

```
==> Backing App 'Chromium.app' up to '/opt/homebrew/Caskroom/chromium/904870/chrome-mac/Chromium.app'
cp: /Applications/Chromium.app/Contents/Frameworks/Chromium Framework.framework/Versions/94.0.4591.0/settings.dat: Permission denied
```

```
==> Removing launchctl service com.docker.helper
==> Removing launchctl service com.docker.socket
Not privileged to remove service.
```