### PR TITLE
Remove OpenStruct from Uses cmd

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -55,7 +55,7 @@ module Homebrew
       sig {
         params(
           only:               T.nilable(Symbol),
-          ignore_unavailable: T.nilable(T::Boolean),
+          ignore_unavailable: T::Boolean,
           method:             T.nilable(Symbol),
           uniq:               T::Boolean,
           warn:               T::Boolean,
@@ -63,7 +63,7 @@ module Homebrew
       }
       def to_formulae_and_casks(
         only: parent&.only_formula_or_cask,
-        ignore_unavailable: nil,
+        ignore_unavailable: false,
         method: T.unsafe(nil),
         uniq: true,
         warn: T.unsafe(nil)
@@ -367,10 +367,10 @@ module Homebrew
       end
 
       sig {
-        params(only: T.nilable(Symbol), ignore_unavailable: T.nilable(T::Boolean), all_kegs: T.nilable(T::Boolean))
+        params(only: T.nilable(Symbol), ignore_unavailable: T::Boolean, all_kegs: T.nilable(T::Boolean))
           .returns([T::Array[Keg], T::Array[Cask::Cask]])
       }
-      def to_kegs_to_casks(only: parent&.only_formula_or_cask, ignore_unavailable: nil, all_kegs: nil)
+      def to_kegs_to_casks(only: parent&.only_formula_or_cask, ignore_unavailable: false, all_kegs: nil)
         method = all_kegs ? :kegs : :default_kegs
         @to_kegs_to_casks ||= {}
         @to_kegs_to_casks[method] ||=

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -5,7 +5,6 @@ require "abstract_command"
 require "formula"
 require "cask/caskroom"
 require "dependencies_helpers"
-require "ostruct"
 
 module Homebrew
   module Cmd
@@ -14,6 +13,11 @@ module Homebrew
     # The intersection is harder to achieve with shell tools.
     class Uses < AbstractCommand
       include DependenciesHelpers
+
+      class UnavailableFormula < T::Struct
+        const :name, String
+        const :full_name, String
+      end
 
       cmd_args do
         description <<~EOS
@@ -64,10 +68,7 @@ module Homebrew
           opoo e
           used_formulae_missing = true
           # If the formula doesn't exist: fake the needed formula object name.
-          # This is a legacy use of OpenStruct that should be refactored.
-          # rubocop:disable Style/OpenStructUse
-          args.named.map { |name| OpenStruct.new name:, full_name: name }
-          # rubocop:enable Style/OpenStructUse
+          args.named.map { |name| UnavailableFormula.new name:, full_name: name }
         end
 
         use_runtime_dependents = args.installed? &&

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -88,7 +88,10 @@ module Homebrew
 
       private
 
-      sig { params(use_runtime_dependents: T::Boolean, used_formulae: T::Array[Formula]).returns(T::Array[Formula]) }
+      sig {
+        params(use_runtime_dependents: T::Boolean, used_formulae: T::Array[T.any(Formula, UnavailableFormula)])
+          .returns(T::Array[Formula])
+      }
       def intersection_of_dependents(use_runtime_dependents, used_formulae)
         recursive = args.recursive?
         show_formulae_and_casks = !args.formula? && !args.cask?
@@ -96,6 +99,8 @@ module Homebrew
 
         deps = []
         if use_runtime_dependents
+          # We can only get here if `used_formulae_missing` is false, thus there are no UnavailableFormula.
+          used_formulae = T.cast(used_formulae, T::Array[Formula])
           if show_formulae_and_casks || args.formula?
             deps += used_formulae.map(&:runtime_installed_formula_dependents)
                                  .reduce(&:&)
@@ -141,8 +146,8 @@ module Homebrew
 
       sig {
         params(
-          dependents: T::Array[Formula], used_formulae: T::Array[Formula], recursive: T::Boolean,
-          includes: T::Array[Symbol], ignores: T::Array[Symbol]
+          dependents: T::Array[Formula], used_formulae: T::Array[T.any(Formula, UnavailableFormula)],
+          recursive: T::Boolean, includes: T::Array[Symbol], ignores: T::Array[Symbol]
         ).returns(
           T::Array[Formula],
         )

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2886,7 +2886,7 @@ class Formula
 
   sig { returns(T::Boolean) }
   def test_defined?
-    false
+    method(:test).owner != Formula
   end
 
   def test; end
@@ -3346,12 +3346,6 @@ class Formula
           [phase, DEFAULT_NETWORK_ACCESS_ALLOWED]
         end
       end
-    end
-
-    def method_added(method)
-      super
-
-      define_method(:test_defined?) { true } if method == :test
     end
 
     def freeze

--- a/Library/Homebrew/formula.rbi
+++ b/Library/Homebrew/formula.rbi
@@ -1,9 +1,6 @@
 # typed: strict
 
-# This file provides definitions for Forwardable#delegate, which is currently not supported by Sorbet.
-
 class Formula
-  def self.on_system_blocks_exist?; end
   # This method is included by `OnSystem`
   def self.on_macos(&block); end
 end

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cli/named_args"
 require "cmd/shared_examples/args_parse"
 require "cmd/uses"
 require "fileutils"
@@ -43,5 +44,23 @@ RSpec.describe Homebrew::Cmd::Uses do
       .to output(/^(bar\noptional|optional\nbar)$/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
+  end
+
+  it "handles unavailable formula", :integration_test do
+    setup_test_formula "foo"
+    setup_test_formula "bar"
+    setup_test_formula "optional", <<~RUBY
+      url "https://brew.sh/optional-1.0"
+      depends_on "bar" => :optional
+    RUBY
+
+    expect_any_instance_of(Homebrew::CLI::NamedArgs)
+      .to receive(:to_formulae)
+      .and_raise(FormulaUnavailableError, "foo")
+    cmd = described_class.new(%w[foo --eval-all --include-optional --recursive])
+    expect { cmd.run }
+      .to output(/^(bar\noptional|optional\nbar)$/).to_stdout
+      .and output(/Error: Missing formulae should not have dependents!\n/).to_stderr
+      .and raise_error SystemExit
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Relates to https://github.com/Homebrew/brew/issues/18777

Replaces the use of `OpenStruct` in the `uses` command with a `T::Struct`. AFAICT, the OpenStruct defined all the necessary methods, so it isn't necessary to introduce add'l functionality. 

(Some other minor cleanup is included.)