### PR TITLE
feat: only block cask install on Linux

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -280,9 +280,16 @@ on_request: true)
       end
     end
 
+    sig { void }
     def check_requirements
+      check_stanza_os_requirements
       check_macos_requirements
       check_arch_requirements
+    end
+
+    sig { void }
+    def check_stanza_os_requirements
+      nil
     end
 
     def check_macos_requirements
@@ -710,3 +717,5 @@ on_request: true)
     end
   end
 end
+
+require "extend/os/cask/installer"

--- a/Library/Homebrew/extend/os/cask/installer.rb
+++ b/Library/Homebrew/extend/os/cask/installer.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/linux/cask/installer" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/cask/installer.rb
+++ b/Library/Homebrew/extend/os/linux/cask/installer.rb
@@ -1,0 +1,23 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Linux
+    module Cask
+      module Installer
+        private
+
+        extend T::Helpers
+
+        requires_ancestor { ::Cask::Installer }
+
+        sig { void }
+        def check_stanza_os_requirements
+          raise ::Cask::CaskError, "macOS is required for this software."
+        end
+      end
+    end
+  end
+end
+
+Cask::Installer.prepend(OS::Linux::Cask::Installer)

--- a/Library/Homebrew/extend/os/linux/cli/parser.rb
+++ b/Library/Homebrew/extend/os/linux/cli/parser.rb
@@ -11,17 +11,9 @@ module OS
 
         sig { void }
         def set_default_options
+          return if args.only_formula_or_cask == :cask
+
           args.set_arg(:formula?, true)
-        end
-
-        sig { void }
-        def validate_options
-          return unless args.respond_to?(:cask?)
-          return unless T.unsafe(self).args.cask?
-
-          # NOTE: We don't raise an error here because we don't want
-          #       to print the help page or a stack trace.
-          odie "Invalid `--cask` usage: Casks do not work on Linux"
         end
       end
     end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -574,13 +574,6 @@ RSpec.describe Homebrew::CLI::Parser do
         end
       end
 
-      it "throws an error when defined" do
-        expect { parser.parse(["--cask"]) }
-          .to output("Error: Invalid `--cask` usage: Casks do not work on Linux\n").to_stderr
-          .and not_to_output.to_stdout
-          .and raise_exception SystemExit
-      end
-
       # Developers want to be able to use `audit` and `bump`
       # commands for formulae and casks on Linux.
       it "succeeds for developer commands" do
@@ -599,18 +592,9 @@ RSpec.describe Homebrew::CLI::Parser do
         end
       end
 
-      it "throws an error when --cask defined" do
-        expect { parser.parse(["--cask"]) }
-          .to output("Error: Invalid `--cask` usage: Casks do not work on Linux\n").to_stderr
-          .and not_to_output.to_stdout
-          .and raise_exception SystemExit
-      end
-
       it "throws an error when both defined" do
         expect { parser.parse(["--cask", "--formula"]) }
-          .to output("Error: Invalid `--cask` usage: Casks do not work on Linux\n").to_stderr
-          .and not_to_output.to_stdout
-          .and raise_exception SystemExit
+          .to raise_exception Homebrew::CLI::OptionConflictError
       end
     end
   end
@@ -628,6 +612,14 @@ RSpec.describe Homebrew::CLI::Parser do
       end
       args = parser.parse([])
       expect(args.formula?).to be(true)
+    end
+
+    it "does not set --formula to true when --cask" do
+      parser = described_class.new(Cmd) do
+        switch "--cask"
+      end
+      args = parser.parse([])
+      expect(args.respond_to?(:formula?)).to be(false)
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is the first step to allowing font (and later binary) casks to be installable on Linux.
TODO:
- [x] Think about how to handle `brew search --cask X`
- [x] Think about how to handle `brew info --cask X`