### PR TITLE
Remove problematic :final from Requirement sigs

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -60,8 +60,9 @@ class Requirement
     s
   end
 
-  # Pass a block or boolean to the satisfy DSL method instead of overriding.
-  sig(:final) {
+  # Overriding {#satisfied?} is unsupported.
+  # Pass a block or boolean to the satisfy DSL method instead.
+  sig {
     params(
       env:          T.nilable(String),
       cc:           T.nilable(String),
@@ -82,8 +83,9 @@ class Requirement
     true
   end
 
-  # Pass a boolean to the fatal DSL method instead of overriding.
-  sig(:final) { returns(T::Boolean) }
+  # Overriding {#fatal?} is unsupported.
+  # Pass a boolean to the fatal DSL method instead.
+  sig { returns(T::Boolean) }
   def fatal?
     self.class.fatal || false
   end

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -59,17 +59,6 @@ RSpec.describe Requirement do
     describe "#fatal is omitted" do
       it { is_expected.not_to be_fatal }
     end
-
-    describe "in subclasses" do
-      it "raises an error when instantiated" do
-        expect do
-          Class.new(described_class) do
-            def fatal? = false
-          end
-        end
-        .to raise_error(RuntimeError, /\AThe method `fatal\?` on #{described_class.name} was declared as final/)
-      end
-    end
   end
 
   describe "#satisfied?" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Partial revert of https://github.com/Homebrew/brew/pull/16640/files#diff-b75efe9741aed6830d257b35e55eb243a38c7b187774b42cf26be6deef8990db

We only [enabled](https://github.com/Homebrew/brew/pull/18801) `:final` enforcement two days ago, which has caused GH Action failures, e.g. https://github.com/Homebrew/homebrew-core/actions/runs/11991937306/job/33431223236?pr=198784#step:3:322