### PR TITLE
formula_installer: allow installing/upgrading disabled formulae

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -254,8 +254,12 @@ class FormulaInstaller
       when :deprecated
         opoo message
       when :disabled
-        GitHub::Actions.puts_annotation_if_env_set(:error, message)
-        raise CannotInstallFormulaError, message
+        if force?
+          opoo message
+        else
+          GitHub::Actions.puts_annotation_if_env_set(:error, message)
+          raise CannotInstallFormulaError, message
+        end
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Currently it's not possible to upgrade previously installed formulae that are now disabled. Let's allow that with `--force`.