### PR TITLE
shims/mac/super: add `pkgconf` symlink

### DIFF
--- a/Library/Homebrew/shims/mac/super/pkgconf
+++ b/Library/Homebrew/shims/mac/super/pkgconf
@@ -1,0 +1,1 @@
+pkg-config


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Since we switched to `pkgconf`, it is possible that a build tool may use it before `pkg-config` so make sure both shims are available.

---

Not specifically likely, but just in case. Also handles running `pkgconf` directly in formula.

May want to update `pkg-config` shim later on (e.g. so actual executable is found on shim-excluded superenv's PATH rather than hardcoded).

Or perhaps seeing if `pkgconf` is willing to support the environment variables overrides as those are less intrusive in build than shim. 