### PR TITLE
rubocops/uses_from_macos: allow using Sequoia `jq`

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -83,6 +83,7 @@ module RuboCop
           git
           groff
           gzip
+          jq
           less
           mandoc
           openssl


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think `jq` was added in Sequoia:
```console
❯ /usr/bin/jq --version
jq-1.6-159-apple-gcff5336-dirty
```

So could use it as dependency via `uses_from_macos "jq", since: :sequoia`

Probably not going to make formula `keg_only` so adding to UsesFromMacos rather than ProvidedByMacos given comment:
```
# These formulae aren't `keg_only :provided_by_macos` but are provided by
# macOS (or very similarly, e.g. OpenSSL where system provides LibreSSL).
```