### PR TITLE
livecheck: clarify livecheckable language

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -277,7 +277,7 @@ module Cask
     sig { void }
     def audit_latest_with_livecheck
       return unless cask.version&.latest?
-      return unless cask.livecheckable?
+      return unless cask.livecheck_defined?
       return if cask.livecheck.skip?
 
       add_error "Casks with a `livecheck` should not use `version :latest`."
@@ -299,7 +299,7 @@ module Cask
       return if cask.version&.latest?
       return if (url = cask.url).nil?
       return if block_url_offline?
-      return if cask.livecheckable?
+      return if cask.livecheck_defined?
       return if livecheck_result == :auto_detected
 
       add_livecheck = "please add a livecheck. See #{Formatter.url(LIVECHECK_REFERENCE_URL)}"
@@ -693,7 +693,7 @@ module Cask
     sig { returns(T.nilable(MacOSVersion)) }
     def livecheck_min_os
       return unless online?
-      return unless cask.livecheckable?
+      return unless cask.livecheck_defined?
       return if cask.livecheck.strategy != :sparkle
 
       # `Sparkle` strategy blocks that use the `items` argument (instead of
@@ -924,7 +924,7 @@ module Cask
     sig { void }
     def audit_livecheck_https_availability
       return unless online?
-      return unless cask.livecheckable?
+      return unless cask.livecheck_defined?
       return unless (url = cask.livecheck.url)
       return if url.is_a?(Symbol)
 

--- a/Library/Homebrew/cask/cask.rbi
+++ b/Library/Homebrew/cask/cask.rbi
@@ -44,6 +44,8 @@ module Cask
 
     def livecheck; end
 
+    def livecheck_defined?; end
+
     def livecheckable?; end
 
     def name; end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -95,7 +95,8 @@ module Cask
       :disable_replacement,
       :discontinued?, # TODO: remove once discontinued? is removed (4.5.0)
       :livecheck,
-      :livecheckable?,
+      :livecheck_defined?,
+      :livecheckable?, # TODO: remove once `#livecheckable?` is removed
       :on_system_blocks_exist?,
       :on_system_block_min_os,
       :depends_on_set_in_block?,
@@ -110,7 +111,7 @@ module Cask
     attr_reader :cask, :token, :deprecation_date, :deprecation_reason, :deprecation_replacement, :disable_date,
                 :disable_reason, :disable_replacement, :on_system_block_min_os
 
-    attr_predicate :deprecated?, :disabled?, :livecheckable?, :on_system_blocks_exist?, :depends_on_set_in_block?
+    attr_predicate :deprecated?, :disabled?, :livecheck_defined?, :on_system_blocks_exist?, :depends_on_set_in_block?
 
     def initialize(cask)
       @cask = cask
@@ -431,12 +432,20 @@ module Cask
       @livecheck ||= Livecheck.new(cask)
       return @livecheck unless block
 
-      if !@cask.allow_reassignment && @livecheckable
+      if !@cask.allow_reassignment && @livecheck_defined
         raise CaskInvalidError.new(cask, "'livecheck' stanza may only appear once.")
       end
 
-      @livecheckable = true
+      @livecheck_defined = true
       @livecheck.instance_eval(&block)
+    end
+
+    # Whether the cask contains a `livecheck` block. This is a legacy alias
+    # for `#livecheck_defined?`.
+    sig { returns(T::Boolean) }
+    def livecheckable?
+      # odeprecated "`livecheckable?`", "`livecheck_defined?`"
+      @livecheck_defined == true
     end
 
     # Declare that a cask is no longer functional or supported.

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -44,7 +44,7 @@ module Homebrew
         casks = args.named.to_paths(only: :cask, recurse_tap: true).map { |path| Cask::CaskLoader.load(path) }
 
         unversioned_casks = casks.select do |cask|
-          cask.url&.unversioned? && !cask.livecheckable?
+          cask.url&.unversioned? && !cask.livecheck_defined?
         end
 
         ohai "Unversioned Casks: #{unversioned_casks.count} (#{state.size} cached)"

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -137,7 +137,7 @@ module Homebrew
       def skip_repology?(formula_or_cask)
         return true unless args.repology?
 
-        (ENV["CI"].present? && args.open_pr? && formula_or_cask.livecheckable?) ||
+        (ENV["CI"].present? && args.open_pr? && formula_or_cask.livecheck_defined?) ||
           (formula_or_cask.is_a?(Formula) && formula_or_cask.versioned_formula?)
       end
 
@@ -329,7 +329,7 @@ module Homebrew
               "skipped"
             elsif repology_latest.is_a?(Version) &&
                   repology_latest > current_version_value &&
-                  !loaded_formula_or_cask.livecheckable? &&
+                  !loaded_formula_or_cask.livecheck_defined? &&
                   current_version_value != "latest"
               repology_latest
             end.presence
@@ -490,8 +490,8 @@ module Homebrew
         if repology_latest.is_a?(Version) &&
            repology_latest > current_version.general &&
            repology_latest > new_version.general &&
-           formula_or_cask.livecheckable?
-          puts "#{title_name} was not bumped to the Repology version because it's livecheckable."
+           formula_or_cask.livecheck_defined?
+          puts "#{title_name} was not bumped to the Repology version because it has a `livecheck` block."
         end
         if new_version.blank? || versions_equal ||
            (!new_version.general.is_a?(Version) && !version_info.multiple_versions)

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -64,7 +64,7 @@ module Homebrew
             :mpd.f.recursive_dependencies.reject(&:installed?)
 
             'vlc'.c # => instance of the vlc cask
-            :tsh.c.livecheckable?
+            :tsh.c.livecheck_defined?
           EOS
           return
         end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4179,7 +4179,7 @@ class Formula
     end
 
     # {Livecheck} can be used to check for newer versions of the software.
-    # This method evaluates the DSL specified in the livecheck block of the
+    # This method evaluates the DSL specified in the `livecheck` block of the
     # {Formula} (if it exists) and sets the instance variables of a {Livecheck}
     # object accordingly. This is used by `brew livecheck` to check for newer
     # versions of the software.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -455,6 +455,11 @@ class Formula
   delegate livecheck: :"self.class"
 
   # Is a livecheck specification defined for the software?
+  # @!method livecheck_defined?
+  # @see .livecheck_defined?
+  delegate livecheck_defined?: :"self.class"
+
+  # Is a livecheck specification defined for the software?
   # @!method livecheckable?
   # @see .livecheckable?
   delegate livecheckable?: :"self.class"
@@ -3537,8 +3542,19 @@ class Formula
     # It returns `true` when a `livecheck` block is present in the {Formula}
     # and `false` otherwise.
     sig { returns(T::Boolean) }
+    def livecheck_defined?
+      @livecheck_defined == true
+    end
+
+    # Checks whether a `livecheck` specification is defined or not. This is a
+    # legacy alias for `#livecheck_defined?`.
+    #
+    # It returns `true` when a `livecheck` block is present in the {Formula}
+    # and `false` otherwise.
+    sig { returns(T::Boolean) }
     def livecheckable?
-      @livecheckable == true
+      # odeprecated "`livecheckable?`", "`livecheck_defined?`"
+      @livecheck_defined == true
     end
 
     # Checks whether a service specification is defined or not.
@@ -4183,7 +4199,7 @@ class Formula
     def livecheck(&block)
       return @livecheck unless block
 
-      @livecheckable = true
+      @livecheck_defined = true
       @livecheck.instance_eval(&block)
     end
 

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -37,7 +37,7 @@ class Livecheck
   # Sets the `@referenced_cask_name` instance variable to the provided `String`
   # or returns the `@referenced_cask_name` instance variable when no argument
   # is provided. Inherited livecheck values from the referenced cask
-  # (e.g. regex) can be overridden in the livecheck block.
+  # (e.g. regex) can be overridden in the `livecheck` block.
   sig {
     params(
       # Name of cask to inherit livecheck info from.
@@ -56,7 +56,7 @@ class Livecheck
   # Sets the `@referenced_formula_name` instance variable to the provided
   # `String` or returns the `@referenced_formula_name` instance variable when
   # no argument is provided. Inherited livecheck values from the referenced
-  # formula (e.g. regex) can be overridden in the livecheck block.
+  # formula (e.g. regex) can be overridden in the `livecheck` block.
   sig {
     params(
       # Name of formula to inherit livecheck info from.

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -79,7 +79,7 @@ module Homebrew
       full_name: false,
       debug: false
     )
-      # Check the livecheck block for a formula or cask reference
+      # Check the `livecheck` block for a formula or cask reference
       livecheck = formula_or_cask.livecheck
       livecheck_formula = livecheck.formula
       livecheck_cask = livecheck.cask

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -347,7 +347,7 @@ module Homebrew
           newer_than_upstream: is_newer_than_upstream,
         }.compact
         info[:meta] = {
-          livecheckable: formula_or_cask.livecheckable?,
+          livecheck_defined: formula_or_cask.livecheck_defined?,
         }
         info[:meta][:head_only] = true if formula&.head_only?
         info[:meta].merge!(version_info[:meta]) if version_info.present? && version_info.key?(:meta)
@@ -465,7 +465,7 @@ module Homebrew
       status_hash[:messages] = messages if messages.is_a?(Array)
 
       status_hash[:meta] = {
-        livecheckable: package_or_resource.livecheckable?,
+        livecheck_defined: package_or_resource.livecheck_defined?,
       }
       status_hash[:meta][:head_only] = true if formula&.head_only?
 
@@ -478,7 +478,7 @@ module Homebrew
       package_or_resource_s = info[:resource].present? ? "  " : ""
       package_or_resource_s += "#{Tty.blue}#{info[:formula] || info[:cask] || info[:resource]}#{Tty.reset}"
       package_or_resource_s += " (cask)" if ambiguous_cask
-      package_or_resource_s += " (guessed)" if verbose && !info[:meta][:livecheckable]
+      package_or_resource_s += " (guessed)" if verbose && !info[:meta][:livecheck_defined]
 
       current_s = if info[:version][:newer_than_upstream]
         "#{Tty.red}#{info[:version][:current]}#{Tty.reset}"
@@ -608,7 +608,7 @@ module Homebrew
       formula = formula_or_cask if formula_or_cask.is_a?(Formula)
       cask = formula_or_cask if formula_or_cask.is_a?(Cask::Cask)
 
-      has_livecheckable = formula_or_cask.livecheckable?
+      livecheck_defined = formula_or_cask.livecheck_defined?
       livecheck = formula_or_cask.livecheck
       referenced_livecheck = referenced_formula_or_cask&.livecheck
 
@@ -632,7 +632,7 @@ module Homebrew
         elsif cask
           puts "Cask:             #{cask_name(formula_or_cask, full_name:)}"
         end
-        puts "Livecheckable?:   #{has_livecheckable ? "Yes" : "No"}"
+        puts "livecheck block?: #{livecheck_defined ? "Yes" : "No"}"
         puts "Throttle:         #{livecheck_throttle}" if livecheck_throttle
 
         livecheck_references.each do |ref_formula_or_cask|
@@ -736,7 +736,7 @@ module Homebrew
 
         match_version_map.delete_if do |_match, version|
           next true if version.blank?
-          next false if has_livecheckable
+          next false if livecheck_defined
 
           UNSTABLE_VERSION_KEYWORDS.any? do |rejection|
             version.to_s.include?(rejection)
@@ -839,12 +839,12 @@ module Homebrew
       quiet: false,
       verbose: false
     )
-      has_livecheckable = resource.livecheckable?
+      livecheck_defined = resource.livecheck_defined?
 
       if debug
         puts "\n\n"
         puts "Resource:         #{resource.name}"
-        puts "Livecheckable?:   #{has_livecheckable ? "Yes" : "No"}"
+        puts "livecheck block?: #{livecheck_defined ? "Yes" : "No"}"
       end
 
       resource_version_info = {}
@@ -939,7 +939,7 @@ module Homebrew
 
         match_version_map.delete_if do |_match, version|
           next true if version.blank?
-          next false if has_livecheckable
+          next false if livecheck_defined
 
           UNSTABLE_VERSION_KEYWORDS.any? do |rejection|
             version.to_s.include?(rejection)
@@ -978,7 +978,10 @@ module Homebrew
           },
         }
 
-        resource_version_info[:meta] = { livecheckable: has_livecheckable, url: {} }
+        resource_version_info[:meta] = {
+          livecheck_defined: livecheck_defined,
+          url:               {},
+        }
         if livecheck_url.is_a?(Symbol) && livecheck_url_string
           resource_version_info[:meta][:url][:symbol] = livecheck_url
         end

--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -9,14 +9,14 @@ module Homebrew
       sig {
         params(
           package_or_resource: T.any(Formula, Cask::Cask, Resource),
-          livecheckable:       T::Boolean,
+          livecheck_defined:   T::Boolean,
           full_name:           T::Boolean,
           verbose:             T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
       private_class_method def self.package_or_resource_skip(
         package_or_resource,
-        livecheckable,
+        livecheck_defined,
         full_name: false,
         verbose: false
       )
@@ -32,7 +32,7 @@ module Homebrew
 
         skip_message = if package_or_resource.livecheck.skip_msg.present?
           package_or_resource.livecheck.skip_msg
-        elsif !livecheckable
+        elsif !livecheck_defined
           if stable_from_google_code_archive
             "Stable URL is from Google Code Archive"
           elsif stable_from_internet_archive
@@ -50,19 +50,19 @@ module Homebrew
 
       sig {
         params(
-          formula:        Formula,
-          _livecheckable: T::Boolean,
-          full_name:      T::Boolean,
-          verbose:        T::Boolean,
+          formula:            Formula,
+          _livecheck_defined: T::Boolean,
+          full_name:          T::Boolean,
+          verbose:            T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.formula_head_only(formula, _livecheckable, full_name: false, verbose: false)
+      private_class_method def self.formula_head_only(formula, _livecheck_defined, full_name: false, verbose: false)
         return {} if !formula.head_only? || formula.any_version_installed?
 
         Livecheck.status_hash(
           formula,
           "error",
-          ["HEAD only formula must be installed to be livecheckable"],
+          ["HEAD only formula must be installed to be checkable"],
           full_name:,
           verbose:,
         )
@@ -70,86 +70,86 @@ module Homebrew
 
       sig {
         params(
-          formula:       Formula,
-          livecheckable: T::Boolean,
-          full_name:     T::Boolean,
-          verbose:       T::Boolean,
+          formula:           Formula,
+          livecheck_defined: T::Boolean,
+          full_name:         T::Boolean,
+          verbose:           T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.formula_deprecated(formula, livecheckable, full_name: false, verbose: false)
-        return {} if !formula.deprecated? || livecheckable
+      private_class_method def self.formula_deprecated(formula, livecheck_defined, full_name: false, verbose: false)
+        return {} if !formula.deprecated? || livecheck_defined
 
         Livecheck.status_hash(formula, "deprecated", full_name:, verbose:)
       end
 
       sig {
         params(
-          formula:       Formula,
-          livecheckable: T::Boolean,
-          full_name:     T::Boolean,
-          verbose:       T::Boolean,
+          formula:           Formula,
+          livecheck_defined: T::Boolean,
+          full_name:         T::Boolean,
+          verbose:           T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.formula_disabled(formula, livecheckable, full_name: false, verbose: false)
-        return {} if !formula.disabled? || livecheckable
+      private_class_method def self.formula_disabled(formula, livecheck_defined, full_name: false, verbose: false)
+        return {} if !formula.disabled? || livecheck_defined
 
         Livecheck.status_hash(formula, "disabled", full_name:, verbose:)
       end
 
       sig {
         params(
-          formula:       Formula,
-          livecheckable: T::Boolean,
-          full_name:     T::Boolean,
-          verbose:       T::Boolean,
+          formula:           Formula,
+          livecheck_defined: T::Boolean,
+          full_name:         T::Boolean,
+          verbose:           T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.formula_versioned(formula, livecheckable, full_name: false, verbose: false)
-        return {} if !formula.versioned_formula? || livecheckable
+      private_class_method def self.formula_versioned(formula, livecheck_defined, full_name: false, verbose: false)
+        return {} if !formula.versioned_formula? || livecheck_defined
 
         Livecheck.status_hash(formula, "versioned", full_name:, verbose:)
       end
 
       sig {
         params(
-          cask:          Cask::Cask,
-          livecheckable: T::Boolean,
-          full_name:     T::Boolean,
-          verbose:       T::Boolean,
+          cask:              Cask::Cask,
+          livecheck_defined: T::Boolean,
+          full_name:         T::Boolean,
+          verbose:           T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.cask_deprecated(cask, livecheckable, full_name: false, verbose: false)
-        return {} if !cask.deprecated? || livecheckable
+      private_class_method def self.cask_deprecated(cask, livecheck_defined, full_name: false, verbose: false)
+        return {} if !cask.deprecated? || livecheck_defined
 
         Livecheck.status_hash(cask, "deprecated", full_name:, verbose:)
       end
 
       sig {
         params(
-          cask:          Cask::Cask,
-          livecheckable: T::Boolean,
-          full_name:     T::Boolean,
-          verbose:       T::Boolean,
+          cask:              Cask::Cask,
+          livecheck_defined: T::Boolean,
+          full_name:         T::Boolean,
+          verbose:           T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.cask_disabled(cask, livecheckable, full_name: false, verbose: false)
-        return {} if !cask.disabled? || livecheckable
+      private_class_method def self.cask_disabled(cask, livecheck_defined, full_name: false, verbose: false)
+        return {} if !cask.disabled? || livecheck_defined
 
         Livecheck.status_hash(cask, "disabled", full_name:, verbose:)
       end
 
       sig {
         params(
-          cask:           Cask::Cask,
-          _livecheckable: T::Boolean,
-          full_name:      T::Boolean,
-          verbose:        T::Boolean,
-          extract_plist:  T::Boolean,
+          cask:               Cask::Cask,
+          _livecheck_defined: T::Boolean,
+          full_name:          T::Boolean,
+          verbose:            T::Boolean,
+          extract_plist:      T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
       private_class_method def self.cask_extract_plist(
         cask,
-        _livecheckable,
+        _livecheck_defined,
         full_name: false,
         verbose: false,
         extract_plist: false
@@ -167,28 +167,28 @@ module Homebrew
 
       sig {
         params(
-          cask:          Cask::Cask,
-          livecheckable: T::Boolean,
-          full_name:     T::Boolean,
-          verbose:       T::Boolean,
+          cask:              Cask::Cask,
+          livecheck_defined: T::Boolean,
+          full_name:         T::Boolean,
+          verbose:           T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.cask_version_latest(cask, livecheckable, full_name: false, verbose: false)
-        return {} if !(cask.present? && cask.version&.latest?) || livecheckable
+      private_class_method def self.cask_version_latest(cask, livecheck_defined, full_name: false, verbose: false)
+        return {} if !(cask.present? && cask.version&.latest?) || livecheck_defined
 
         Livecheck.status_hash(cask, "latest", full_name:, verbose:)
       end
 
       sig {
         params(
-          cask:          Cask::Cask,
-          livecheckable: T::Boolean,
-          full_name:     T::Boolean,
-          verbose:       T::Boolean,
+          cask:              Cask::Cask,
+          livecheck_defined: T::Boolean,
+          full_name:         T::Boolean,
+          verbose:           T::Boolean,
         ).returns(T::Hash[Symbol, T.untyped])
       }
-      private_class_method def self.cask_url_unversioned(cask, livecheckable, full_name: false, verbose: false)
-        return {} if !(cask.present? && cask.url&.unversioned?) || livecheckable
+      private_class_method def self.cask_url_unversioned(cask, livecheck_defined, full_name: false, verbose: false)
+        return {} if !(cask.present? && cask.url&.unversioned?) || livecheck_defined
 
         Livecheck.status_hash(cask, "unversioned", full_name:, verbose:)
       end
@@ -232,7 +232,7 @@ module Homebrew
         ).returns(T::Hash[Symbol, T.untyped])
       }
       def self.skip_information(package_or_resource, full_name: false, verbose: false, extract_plist: true)
-        livecheckable = package_or_resource.livecheckable?
+        livecheck_defined = package_or_resource.livecheck_defined?
 
         checks = case package_or_resource
         when Formula
@@ -246,9 +246,9 @@ module Homebrew
         checks.each do |method_name|
           skip_hash = case method_name
           when :cask_extract_plist
-            send(method_name, package_or_resource, livecheckable, full_name:, verbose:, extract_plist:)
+            send(method_name, package_or_resource, livecheck_defined, full_name:, verbose:, extract_plist:)
           else
-            send(method_name, package_or_resource, livecheckable, full_name:, verbose:)
+            send(method_name, package_or_resource, livecheck_defined, full_name:, verbose:)
           end
           return skip_hash if skip_hash.present?
         end

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -142,7 +142,7 @@ class Resource
   end
 
   # {Livecheck} can be used to check for newer versions of the software.
-  # This method evaluates the DSL specified in the livecheck block of the
+  # This method evaluates the DSL specified in the `livecheck` block of the
   # {Resource} (if it exists) and sets the instance variables of a {Livecheck}
   # object accordingly. This is used by `brew livecheck` to check for newer
   # versions of the software.

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -29,7 +29,7 @@ class Resource
     @name = name
     @patches = []
     @livecheck = Livecheck.new(self)
-    @livecheckable = false
+    @livecheck_defined = false
     @insecure = false
     instance_eval(&block) if block
   end
@@ -160,15 +160,28 @@ class Resource
   def livecheck(&block)
     return @livecheck unless block
 
-    @livecheckable = true
+    @livecheck_defined = true
     @livecheck.instance_eval(&block)
   end
 
   # Whether a livecheck specification is defined or not.
-  # It returns true when a `livecheck` block is present in the {Resource} and
-  # false otherwise and is used by livecheck.
+  #
+  # It returns `true` when a `livecheck` block is present in the {Resource}
+  # and `false` otherwise.
+  sig { returns(T::Boolean) }
+  def livecheck_defined?
+    @livecheck_defined == true
+  end
+
+  # Whether a livecheck specification is defined or not. This is a legacy alias
+  # for `#livecheck_defined?`.
+  #
+  # It returns `true` when a `livecheck` block is present in the {Resource}
+  # and `false` otherwise.
+  sig { returns(T::Boolean) }
   def livecheckable?
-    @livecheckable == true
+    # odeprecated "`livecheckable?`", "`livecheck_defined?`"
+    @livecheck_defined == true
   end
 
   def sha256(val)

--- a/Library/Homebrew/rubocops/cask/no_overrides.rb
+++ b/Library/Homebrew/rubocops/cask/no_overrides.rb
@@ -40,7 +40,8 @@ module RuboCop
           method_nodes.select(&:block_type?).each do |node|
             node.child_nodes.each do |child|
               child.each_node(:send) do |send_node|
-                # Skip (nested) livecheck blocks as its `url` is different to a download `url`.
+                # Skip (nested) `livecheck` block as its `url` is different
+                # from a download `url`.
                 next if send_node.method_name == :livecheck || inside_livecheck_defined?(send_node)
                 # Skip string interpolations.
                 if send_node.ancestors.drop_while { |a| !a.begin_type? }.any? { |a| a.dstr_type? || a.regexp_type? }

--- a/Library/Homebrew/rubocops/cask/no_overrides.rb
+++ b/Library/Homebrew/rubocops/cask/no_overrides.rb
@@ -41,7 +41,7 @@ module RuboCop
             node.child_nodes.each do |child|
               child.each_node(:send) do |send_node|
                 # Skip (nested) livecheck blocks as its `url` is different to a download `url`.
-                next if send_node.method_name == :livecheck || inside_livecheck_block?(send_node)
+                next if send_node.method_name == :livecheck || inside_livecheck_defined?(send_node)
                 # Skip string interpolations.
                 if send_node.ancestors.drop_while { |a| !a.begin_type? }.any? { |a| a.dstr_type? || a.regexp_type? }
                   next
@@ -55,15 +55,15 @@ module RuboCop
           names
         end
 
-        def inside_livecheck_block?(node)
-          single_stanza_livecheck_block?(node) || multi_stanza_livecheck_block?(node)
+        def inside_livecheck_defined?(node)
+          single_stanza_livecheck_defined?(node) || multi_stanza_livecheck_defined?(node)
         end
 
-        def single_stanza_livecheck_block?(node)
+        def single_stanza_livecheck_defined?(node)
           node.parent.block_type? && node.parent.method_name == :livecheck
         end
 
-        def multi_stanza_livecheck_block?(node)
+        def multi_stanza_livecheck_defined?(node)
           grandparent_node = node.parent.parent
           node.parent.begin_type? && grandparent_node.block_type? && grandparent_node.method_name == :livecheck
         end

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/dsl.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/dsl.rbi
@@ -16,7 +16,7 @@ class Cask::DSL
   def disabled?; end
 
   sig { returns(T::Boolean) }
-  def livecheckable?; end
+  def livecheck_defined?; end
 
   sig { returns(T::Boolean) }
   def on_system_blocks_exist?; end

--- a/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
@@ -91,6 +91,9 @@ class Formula
   def livecheck(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
+  def livecheck_defined?(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
   def livecheckable?(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -508,13 +508,13 @@ RSpec.describe Cask::Audit, :cask do
       let(:online) { true }
       let(:message) { /Version '[^']*' differs from '[^']*' retrieved by livecheck\./ }
 
-      context "when the Cask has a livecheck block using skip" do
+      context "when the Cask has a `livecheck` block using skip" do
         let(:cask_token) { "livecheck-skip" }
 
         it { is_expected.not_to error_with(message) }
       end
 
-      context "when the Cask has a livecheck block referencing a Cask using skip" do
+      context "when the Cask has a `livecheck` block referencing a Cask using skip" do
         let(:cask_token) { "livecheck-skip-reference" }
 
         it { is_expected.not_to error_with(message) }
@@ -526,7 +526,7 @@ RSpec.describe Cask::Audit, :cask do
         it { is_expected.not_to error_with(message) }
       end
 
-      context "when the Cask has a livecheck block referencing a deprecated Cask" do
+      context "when the Cask has a `livecheck` block referencing a deprecated Cask" do
         let(:cask_token) { "livecheck-deprecated-reference" }
 
         it { is_expected.not_to error_with(message) }
@@ -538,7 +538,7 @@ RSpec.describe Cask::Audit, :cask do
         it { is_expected.not_to error_with(message) }
       end
 
-      context "when the Cask has a livecheck block referencing a disabled Cask" do
+      context "when the Cask has a `livecheck` block referencing a disabled Cask" do
         let(:cask_token) { "livecheck-disabled-reference" }
 
         it { is_expected.not_to error_with(message) }
@@ -550,7 +550,7 @@ RSpec.describe Cask::Audit, :cask do
         it { is_expected.not_to error_with(message) }
       end
 
-      context "when the Cask has a livecheck block referencing a Cask where version is :latest" do
+      context "when the Cask has a `livecheck` block referencing a Cask where version is :latest" do
         let(:cask_token) { "livecheck-version-latest-reference" }
 
         it { is_expected.not_to error_with(message) }
@@ -562,7 +562,7 @@ RSpec.describe Cask::Audit, :cask do
         it { is_expected.not_to error_with(message) }
       end
 
-      context "when the Cask has a livecheck block referencing a Cask with an unversioned url" do
+      context "when the Cask has a `livecheck` block referencing a Cask with an unversioned url" do
         let(:cask_token) { "livecheck-url-unversioned-reference" }
 
         it { is_expected.not_to error_with(message) }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -704,13 +704,13 @@ RSpec.describe Formula do
     expect(f.livecheck.regex).to eq(/test-v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  describe "#livecheckable?" do
+  describe "#livecheck_defined?" do
     specify "no livecheck block defined" do
       f = formula do
         url "https://brew.sh/test-1.0.tbz"
       end
 
-      expect(f.livecheckable?).to be false
+      expect(f.livecheck_defined?).to be false
     end
 
     specify "livecheck block defined" do
@@ -721,7 +721,7 @@ RSpec.describe Formula do
         end
       end
 
-      expect(f.livecheckable?).to be true
+      expect(f.livecheck_defined?).to be true
     end
 
     specify "livecheck references Formula URL" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -705,7 +705,7 @@ RSpec.describe Formula do
   end
 
   describe "#livecheck_defined?" do
-    specify "no livecheck block defined" do
+    specify "no `livecheck` block defined" do
       f = formula do
         url "https://brew.sh/test-1.0.tbz"
       end
@@ -713,7 +713,7 @@ RSpec.describe Formula do
       expect(f.livecheck_defined?).to be false
     end
 
-    specify "livecheck block defined" do
+    specify "`livecheck` block defined" do
       f = formula do
         url "https://brew.sh/test-1.0.tbz"
         livecheck do

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Homebrew::Livecheck do
           status:   "error",
           messages: ["Unable to get versions"],
           meta:     {
-            livecheckable: true,
+            livecheck_defined: true,
           },
         })
     end
@@ -123,7 +123,7 @@ RSpec.describe Homebrew::Livecheck do
           status:   "error",
           messages: ["Unable to get versions"],
           meta:     {
-            livecheckable: true,
+            livecheck_defined: true,
           },
         })
     end

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Homebrew::Livecheck do
   end
 
   describe "::resolve_livecheck_reference" do
-    context "when a formula/cask has a livecheck block without formula/cask methods" do
+    context "when a formula/cask has a `livecheck` block without formula/cask methods" do
       it "returns [nil, []]" do
         expect(livecheck.resolve_livecheck_reference(f)).to eq([nil, []])
         expect(livecheck.resolve_livecheck_reference(c)).to eq([nil, []])

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -178,30 +178,30 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           formula: "test_deprecated",
           status:  "deprecated",
           meta:    {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         disabled:            {
           formula: "test_disabled",
           status:  "disabled",
           meta:    {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         versioned:           {
           formula: "test@0.0.1",
           status:  "versioned",
           meta:    {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         head_only:           {
           formula:  "test_head_only",
           status:   "error",
-          messages: ["HEAD only formula must be installed to be livecheckable"],
+          messages: ["HEAD only formula must be installed to be checkable"],
           meta:     {
-            head_only:     true,
-            livecheckable: false,
+            livecheck_defined: false,
+            head_only:         true,
           },
         },
         gist:                {
@@ -209,7 +209,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           status:   "skipped",
           messages: ["Stable URL is a GitHub Gist"],
           meta:     {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         google_code_archive: {
@@ -217,7 +217,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           status:   "skipped",
           messages: ["Stable URL is from Google Code Archive"],
           meta:     {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         internet_archive:    {
@@ -225,14 +225,14 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           status:   "skipped",
           messages: ["Stable URL is from Internet Archive"],
           meta:     {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         skip:                {
           formula: "test_skip",
           status:  "skipped",
           meta:    {
-            livecheckable: true,
+            livecheck_defined: true,
           },
         },
         skip_with_message:   {
@@ -240,7 +240,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           status:   "skipped",
           messages: ["Not maintained"],
           meta:     {
-            livecheckable: true,
+            livecheck_defined: true,
           },
         },
       },
@@ -249,14 +249,14 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           cask:   "test_deprecated",
           status: "deprecated",
           meta:   {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         disabled:          {
           cask:   "test_disabled",
           status: "disabled",
           meta:   {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         extract_plist:     {
@@ -264,28 +264,28 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           status:   "skipped",
           messages: ["Use `--extract-plist` to enable checking multiple casks with ExtractPlist strategy"],
           meta:     {
-            livecheckable: true,
+            livecheck_defined: true,
           },
         },
         latest:            {
           cask:   "test_latest",
           status: "latest",
           meta:   {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         unversioned:       {
           cask:   "test_unversioned",
           status: "unversioned",
           meta:   {
-            livecheckable: false,
+            livecheck_defined: false,
           },
         },
         skip:              {
           cask:   "test_skip",
           status: "skipped",
           meta:   {
-            livecheckable: true,
+            livecheck_defined: true,
           },
         },
         skip_with_message: {
@@ -293,7 +293,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           status:   "skipped",
           messages: ["Not maintained"],
           meta:     {
-            livecheckable: true,
+            livecheck_defined: true,
           },
         },
       },
@@ -301,21 +301,21 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::skip_information" do
-    context "when a formula without a livecheckable is deprecated" do
+    context "when a formula without a `livecheck` block is deprecated" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:deprecated]))
           .to eq(status_hashes[:formula][:deprecated])
       end
     end
 
-    context "when a formula without a livecheckable is disabled" do
+    context "when a formula without a `livecheck` block is disabled" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:disabled]))
           .to eq(status_hashes[:formula][:disabled])
       end
     end
 
-    context "when a formula without a livecheckable is versioned" do
+    context "when a formula without a `livecheck` block is versioned" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:versioned]))
           .to eq(status_hashes[:formula][:versioned])
@@ -329,21 +329,21 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a formula without a livecheckable has a GitHub Gist stable URL" do
+    context "when a formula without a `livecheck` block has a GitHub Gist stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:gist]))
           .to eq(status_hashes[:formula][:gist])
       end
     end
 
-    context "when a formula without a livecheckable has a Google Code Archive stable URL" do
+    context "when a formula without a `livecheck` block has a Google Code Archive stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:google_code_archive]))
           .to eq(status_hashes[:formula][:google_code_archive])
       end
     end
 
-    context "when a formula without a livecheckable has an Internet Archive stable URL" do
+    context "when a formula without a `livecheck` block has an Internet Archive stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:internet_archive]))
           .to eq(status_hashes[:formula][:internet_archive])
@@ -360,14 +360,14 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a cask without a livecheckable is deprecated" do
+    context "when a cask without a `livecheck` block is deprecated" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:deprecated]))
           .to eq(status_hashes[:cask][:deprecated])
       end
     end
 
-    context "when a cask without a livecheckable is disabled" do
+    context "when a cask without a `livecheck` block is disabled" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:disabled]))
           .to eq(status_hashes[:cask][:disabled])
@@ -381,14 +381,14 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a cask without a livecheckable has `version :latest`" do
+    context "when a cask without a `livecheck` block has `version :latest`" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:latest]))
           .to eq(status_hashes[:cask][:latest])
       end
     end
 
-    context "when a cask without a livecheckable has an unversioned URL" do
+    context "when a cask without a `livecheck` block has an unversioned URL" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:unversioned]))
           .to eq(status_hashes[:cask][:unversioned])
@@ -417,21 +417,21 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
   describe "::referenced_skip_information" do
     let(:original_name) { "original" }
 
-    context "when a formula without a livecheckable is deprecated" do
+    context "when a formula without a `livecheck` block is deprecated" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(formulae[:deprecated], original_name) }
           .to raise_error(RuntimeError, "Referenced formula (test_deprecated) is skipped as deprecated")
       end
     end
 
-    context "when a formula without a livecheckable is disabled" do
+    context "when a formula without a `livecheck` block is disabled" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(formulae[:disabled], original_name) }
           .to raise_error(RuntimeError, "Referenced formula (test_disabled) is skipped as disabled")
       end
     end
 
-    context "when a formula without a livecheckable is versioned" do
+    context "when a formula without a `livecheck` block is versioned" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(formulae[:versioned], original_name) }
           .to raise_error(RuntimeError, "Referenced formula (test@0.0.1) is skipped as versioned")
@@ -445,21 +445,21 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a formula without a livecheckable has a GitHub Gist stable URL" do
+    context "when a formula without a `livecheck` block has a GitHub Gist stable URL" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(formulae[:gist], original_name) }
           .to raise_error(RuntimeError, "Referenced formula (test_gist) is automatically skipped")
       end
     end
 
-    context "when a formula without a livecheckable has a Google Code Archive stable URL" do
+    context "when a formula without a `livecheck` block has a Google Code Archive stable URL" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(formulae[:google_code_archive], original_name) }
           .to raise_error(RuntimeError, "Referenced formula (test_google_code_archive) is automatically skipped")
       end
     end
 
-    context "when a formula without a livecheckable has an Internet Archive stable URL" do
+    context "when a formula without a `livecheck` block has an Internet Archive stable URL" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(formulae[:internet_archive], original_name) }
           .to raise_error(RuntimeError, "Referenced formula (test_internet_archive) is automatically skipped")
@@ -476,14 +476,14 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a cask without a livecheckable is deprecated" do
+    context "when a cask without a `livecheck` block is deprecated" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(casks[:deprecated], original_name) }
           .to raise_error(RuntimeError, "Referenced cask (test_deprecated) is skipped as deprecated")
       end
     end
 
-    context "when a cask without a livecheckable is disabled" do
+    context "when a cask without a `livecheck` block is disabled" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(casks[:disabled], original_name) }
           .to raise_error(RuntimeError, "Referenced cask (test_disabled) is skipped as disabled")
@@ -499,14 +499,14 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a cask without a livecheckable has `version :latest`" do
+    context "when a cask without a `livecheck` block has `version :latest`" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(casks[:latest], original_name) }
           .to raise_error(RuntimeError, "Referenced cask (test_latest) is skipped as latest")
       end
     end
 
-    context "when a cask without a livecheckable has an unversioned URL" do
+    context "when a cask without a `livecheck` block has an unversioned URL" do
       it "errors" do
         expect { skip_conditions.referenced_skip_information(casks[:unversioned], original_name) }
           .to raise_error(RuntimeError, "Referenced cask (test_unversioned) is skipped as unversioned")
@@ -533,7 +533,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::print_skip_information" do
-    context "when a formula without a livecheckable is deprecated" do
+    context "when a formula without a `livecheck` block is deprecated" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:deprecated]) }
           .to output("test_deprecated: deprecated\n").to_stdout
@@ -541,7 +541,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a formula without a livecheckable is disabled" do
+    context "when a formula without a `livecheck` block is disabled" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:disabled]) }
           .to output("test_disabled: disabled\n").to_stdout
@@ -549,7 +549,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a formula without a livecheckable is versioned" do
+    context "when a formula without a `livecheck` block is versioned" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:versioned]) }
           .to output("test@0.0.1: versioned\n").to_stdout
@@ -560,7 +560,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
     context "when a formula is HEAD-only and not installed" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:head_only]) }
-          .to output("test_head_only: HEAD only formula must be installed to be livecheckable\n").to_stdout
+          .to output("test_head_only: HEAD only formula must be installed to be checkable\n").to_stdout
           .and not_to_output.to_stderr
       end
     end
@@ -601,7 +601,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the cask is deprecated without a livecheckable" do
+    context "when the cask is deprecated without a `livecheck` block" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:deprecated]) }
           .to output("test_deprecated: deprecated\n").to_stdout
@@ -609,7 +609,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the cask is disabled without a livecheckable" do
+    context "when the cask is disabled without a `livecheck` block" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:disabled]) }
           .to output("test_disabled: disabled\n").to_stdout
@@ -617,7 +617,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the cask has `version :latest` without a livecheckable" do
+    context "when the cask has `version :latest` without a `livecheck` block" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:latest]) }
           .to output("test_latest: latest\n").to_stdout
@@ -625,7 +625,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the cask has an unversioned URL without a livecheckable" do
+    context "when the cask has an unversioned URL without a `livecheck` block" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:unversioned]) }
           .to output("test_unversioned: unversioned\n").to_stdout

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Livecheck do
       head "https://github.com/Homebrew/brew.git"
     end
   end
-  let(:livecheckable_f) { described_class.new(f.class) }
+  let(:livecheck_f) { described_class.new(f.class) }
 
   let(:c) do
     Cask::CaskLoader.load(+<<-RUBY)
@@ -25,89 +25,89 @@ RSpec.describe Livecheck do
       end
     RUBY
   end
-  let(:livecheckable_c) { described_class.new(c) }
+  let(:livecheck_c) { described_class.new(c) }
 
   describe "#formula" do
     it "returns nil if not set" do
-      expect(livecheckable_f.formula).to be_nil
+      expect(livecheck_f.formula).to be_nil
     end
 
     it "returns the String if set" do
-      livecheckable_f.formula("other-formula")
-      expect(livecheckable_f.formula).to eq("other-formula")
+      livecheck_f.formula("other-formula")
+      expect(livecheck_f.formula).to eq("other-formula")
     end
 
     it "raises a TypeError if the argument isn't a String" do
       expect do
-        livecheckable_f.formula(123)
+        livecheck_f.formula(123)
       end.to raise_error TypeError
     end
   end
 
   describe "#cask" do
     it "returns nil if not set" do
-      expect(livecheckable_c.cask).to be_nil
+      expect(livecheck_c.cask).to be_nil
     end
 
     it "returns the String if set" do
-      livecheckable_c.cask("other-cask")
-      expect(livecheckable_c.cask).to eq("other-cask")
+      livecheck_c.cask("other-cask")
+      expect(livecheck_c.cask).to eq("other-cask")
     end
   end
 
   describe "#regex" do
     it "returns nil if not set" do
-      expect(livecheckable_f.regex).to be_nil
+      expect(livecheck_f.regex).to be_nil
     end
 
     it "returns the Regexp if set" do
-      livecheckable_f.regex(/foo/)
-      expect(livecheckable_f.regex).to eq(/foo/)
+      livecheck_f.regex(/foo/)
+      expect(livecheck_f.regex).to eq(/foo/)
     end
   end
 
   describe "#skip" do
     it "sets @skip to true when no argument is provided" do
-      expect(livecheckable_f.skip).to be true
-      expect(livecheckable_f.instance_variable_get(:@skip)).to be true
-      expect(livecheckable_f.instance_variable_get(:@skip_msg)).to be_nil
+      expect(livecheck_f.skip).to be true
+      expect(livecheck_f.instance_variable_get(:@skip)).to be true
+      expect(livecheck_f.instance_variable_get(:@skip_msg)).to be_nil
     end
 
     it "sets @skip to true and @skip_msg to the provided String" do
-      expect(livecheckable_f.skip("foo")).to be true
-      expect(livecheckable_f.instance_variable_get(:@skip)).to be true
-      expect(livecheckable_f.instance_variable_get(:@skip_msg)).to eq("foo")
+      expect(livecheck_f.skip("foo")).to be true
+      expect(livecheck_f.instance_variable_get(:@skip)).to be true
+      expect(livecheck_f.instance_variable_get(:@skip_msg)).to eq("foo")
     end
   end
 
   describe "#skip?" do
     it "returns the value of @skip" do
-      expect(livecheckable_f.skip?).to be false
+      expect(livecheck_f.skip?).to be false
 
-      livecheckable_f.skip
-      expect(livecheckable_f.skip?).to be true
+      livecheck_f.skip
+      expect(livecheck_f.skip?).to be true
     end
   end
 
   describe "#strategy" do
     it "returns nil if not set" do
-      expect(livecheckable_f.strategy).to be_nil
+      expect(livecheck_f.strategy).to be_nil
     end
 
     it "returns the Symbol if set" do
-      livecheckable_f.strategy(:page_match)
-      expect(livecheckable_f.strategy).to eq(:page_match)
+      livecheck_f.strategy(:page_match)
+      expect(livecheck_f.strategy).to eq(:page_match)
     end
   end
 
   describe "#throttle" do
     it "returns nil if not set" do
-      expect(livecheckable_f.throttle).to be_nil
+      expect(livecheck_f.throttle).to be_nil
     end
 
     it "returns the Integer if set" do
-      livecheckable_f.throttle(10)
-      expect(livecheckable_f.throttle).to eq(10)
+      livecheck_f.throttle(10)
+      expect(livecheck_f.throttle).to eq(10)
     end
   end
 
@@ -115,38 +115,38 @@ RSpec.describe Livecheck do
     let(:url_string) { "https://brew.sh" }
 
     it "returns nil if not set" do
-      expect(livecheckable_f.url).to be_nil
+      expect(livecheck_f.url).to be_nil
     end
 
     it "returns a string when set to a string" do
-      livecheckable_f.url(url_string)
-      expect(livecheckable_f.url).to eq(url_string)
+      livecheck_f.url(url_string)
+      expect(livecheck_f.url).to eq(url_string)
     end
 
     it "returns the URL symbol if valid" do
-      livecheckable_f.url(:head)
-      expect(livecheckable_f.url).to eq(:head)
+      livecheck_f.url(:head)
+      expect(livecheck_f.url).to eq(:head)
 
-      livecheckable_f.url(:homepage)
-      expect(livecheckable_f.url).to eq(:homepage)
+      livecheck_f.url(:homepage)
+      expect(livecheck_f.url).to eq(:homepage)
 
-      livecheckable_f.url(:stable)
-      expect(livecheckable_f.url).to eq(:stable)
+      livecheck_f.url(:stable)
+      expect(livecheck_f.url).to eq(:stable)
 
-      livecheckable_c.url(:url)
-      expect(livecheckable_c.url).to eq(:url)
+      livecheck_c.url(:url)
+      expect(livecheck_c.url).to eq(:url)
     end
 
     it "raises an ArgumentError if the argument isn't a valid Symbol" do
       expect do
-        livecheckable_f.url(:not_a_valid_symbol)
+        livecheck_f.url(:not_a_valid_symbol)
       end.to raise_error ArgumentError
     end
   end
 
   describe "#to_hash" do
     it "returns a Hash of all instance variables" do
-      expect(livecheckable_f.to_hash).to eq(
+      expect(livecheck_f.to_hash).to eq(
         {
           "cask"     => nil,
           "formula"  => nil,

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -65,18 +65,18 @@ RSpec.describe Resource do
   end
 
   describe "#livecheck" do
-    specify "when livecheck block is set" do
+    specify "when `livecheck` block is set" do
       expect(livecheck_resource.livecheck.url).to eq("https://brew.sh/test/releases")
       expect(livecheck_resource.livecheck.regex).to eq(/foo[._-]v?(\d+(?:\.\d+)+)\.t/i)
     end
   end
 
   describe "#livecheck_defined?" do
-    it "returns false if livecheck block is not set in resource" do
+    it "returns false if `livecheck` block is not set in resource" do
       expect(resource.livecheck_defined?).to be false
     end
 
-    specify "livecheck block defined in resources" do
+    specify "`livecheck` block defined in resources" do
       expect(livecheck_resource.livecheck_defined?).to be true
     end
   end

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe Resource do
     end
   end
 
-  describe "#livecheckable?" do
+  describe "#livecheck_defined?" do
     it "returns false if livecheck block is not set in resource" do
-      expect(resource.livecheckable?).to be false
+      expect(resource.livecheck_defined?).to be false
     end
 
     specify "livecheck block defined in resources" do
-      expect(livecheck_resource.livecheckable?).to be true
+      expect(livecheck_resource.livecheck_defined?).to be true
     end
   end
 

--- a/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/regex_parentheses_spec.rb
@@ -5,7 +5,7 @@ require "rubocops/livecheck"
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexParentheses do
   subject(:cop) { described_class.new }
 
-  it "reports an offense when the `regex` call in the livecheck block does not use parentheses" do
+  it "reports an offense when the `regex` call in the `livecheck` block does not use parentheses" do
     expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckRegexParentheses do
     RUBY
   end
 
-  it "reports no offenses when the `regex` call in the livecheck block uses parentheses" do
+  it "reports no offenses when the `regex` call in the `livecheck` block uses parentheses" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"

--- a/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/skip_spec.rb
@@ -5,7 +5,7 @@ require "rubocops/livecheck"
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckSkip do
   subject(:cop) { described_class.new }
 
-  it "reports an offense when a skipped formula's livecheck block contains other information" do
+  it "reports an offense when a skipped formula's `livecheck` block contains other information" do
     expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckSkip do
     RUBY
   end
 
-  it "reports no offenses when a skipped formula's livecheck block contains no other information" do
+  it "reports no offenses when a skipped formula's `livecheck` block contains no other information" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"

--- a/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_provided_spec.rb
@@ -5,7 +5,7 @@ require "rubocops/livecheck"
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
   subject(:cop) { described_class.new }
 
-  it "reports an offense when a `url` is not specified in a livecheck block" do
+  it "reports an offense when a `url` is not specified in a `livecheck` block" do
     expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
     RUBY
   end
 
-  it "reports no offenses when a `url` and `regex` are specified in the livecheck block" do
+  it "reports no offenses when a `url` and `regex` are specified in the `livecheck` block" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlProvided do
     RUBY
   end
 
-  it "reports no offenses when a `url` and `strategy` are specified in the livecheck block" do
+  it "reports no offenses when a `url` and `strategy` are specified in the `livecheck` block" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"

--- a/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
+++ b/Library/Homebrew/test/rubocops/livecheck/url_symbol_spec.rb
@@ -5,7 +5,7 @@ require "rubocops/livecheck"
 RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlSymbol do
   subject(:cop) { described_class.new }
 
-  it "reports an offense when the `url` specified in the livecheck block is identical to a formula URL" do
+  it "reports an offense when the `url` specified in the `livecheck` block is identical to a formula URL" do
     expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::LivecheckUrlSymbol do
     RUBY
   end
 
-  it "reports no offenses when the `url` specified in the livecheck block is not identical to a formula URL" do
+  it "reports no offenses when the `url` specified in the `livecheck` block is not identical to a formula URL" do
     expect_no_offenses(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Formulae, casks, and resources have a `#livecheckable?` method that indicates whether they contain a `livecheck` block. This is intended to be read as "has a livecheckable?", not "is livecheckable?" (as livecheck can find versions for some packages/resources without a `livecheck` block). Unfortunately, correct understanding of this method's behavior [outside of documentation] relies on historical knowledge that few people possess, so this is often confusing to anyone who hasn't been working on livecheck since 2020.

In the olden days, a "livecheckable" was a Ruby file containing a `livecheck` block (originally a hash) with a filename that corresponded to a related formula. The `livecheck` blocks in livecheckable files were integrated into their respective formulae in August 2020, so [first-party] livecheckables ceased to exist at that time. From that point forward, we simply referred to these as `livecheck` blocks.

With that in mind, this clarifies the situation by replacing "livecheckable" language. This includes renaming `#livecheckable?` to `#livecheck_defined?`, replacing usage of "livecheckable" as a noun with "\`livecheck\` block", replacing "livecheckable" as a boolean with "livecheck_defined", and replacing incorrect usage of "livecheckable" as an adjective with "checkable".