### PR TITLE
formula_auditor: avoid `pkg-config` dependency in core tap

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -363,8 +363,7 @@ module Homebrew
 
           # we want to allow uses_from_macos for aliases but not bare dependencies.
           # we also allow `pkg-config` for backwards compatibility in external taps.
-          # TODO: after migrating all `pkg-config` usage to `pkgconf`, do not allow `pkg-config` in core tap
-          if self.class.aliases.include?(dep.name) && !dep.uses_from_macos? && dep.name != "pkg-config"
+          if self.class.aliases.include?(dep.name) && !dep.uses_from_macos? && (dep.name != "pkg-config" || @core_tap)
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As we should use the actual dependency `pkgconf` rather than the alias.

Almost ready:
* https://github.com/Homebrew/homebrew-core/pull/199271
* https://github.com/Homebrew/homebrew-core/pull/199382
* https://github.com/Homebrew/homebrew-core/pull/199241
* https://github.com/Homebrew/homebrew-core/pull/199243