### PR TITLE
Remove OpenStruct from CLI::Args

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -408,10 +408,6 @@ Style/NumericLiterals:
 Style/OpenStructUse:
   Exclude:
     - "Taps/**/*"
-    # TODO: This is a pre-existing violation and should be corrected
-    #   to define methods so that call sites can be type-checked.
-    - "Homebrew/cli/args.rb"
-    - "Homebrew/cli/args.rbi"
 
 Style/OptionalBooleanParameter:
   AllowedMethods:

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -42,6 +42,8 @@ module Cask
 
     sig { params(args: Homebrew::CLI::Args).returns(T.attached_class) }
     def self.from_args(args)
+      # FIXME: T.unsafe is a workaround for methods that are only defined when `cask_options`
+      # is invoked on the parser. (These could be captured by a DSL compiler instead.)
       args = T.unsafe(args)
       new(explicit: {
         appdir:               args.appdir,

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -50,25 +50,25 @@ module Homebrew
       end
 
       sig { returns(T.nilable(String)) }
-      def arch = nil
+      def arch = table[:arch]
 
       sig { returns(T::Boolean) }
-      def build_bottle? = false
+      def build_bottle? = table[:build_bottle?] || false
 
       sig { returns(T::Boolean) }
-      def build_from_source? = false
+      def build_from_source? = table[:build_from_source?] || false
 
       sig { returns(T::Boolean) }
-      def force_bottle? = false
+      def force_bottle? = table[:force_bottle?] || false
 
       sig { returns(T::Boolean) }
-      def HEAD? = false
+      def HEAD? = table[:HEAD?] || false
 
       sig { returns(T::Boolean) }
-      def include_test? = false
+      def include_test? = table[:include_test?] || false
 
       sig { returns(T.nilable(String)) }
-      def os = nil
+      def os = table[:os]
 
       sig { params(_blk: T.untyped).returns(T.untyped) }
       def tap(&_blk)

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -70,6 +70,13 @@ module Homebrew
       sig { returns(T.nilable(String)) }
       def os = nil
 
+      sig { params(_blk: T.untyped).returns(T.untyped) }
+      def tap(&_blk)
+        return super if block_given? # Object#tap
+
+        @table[:tap]
+      end
+
       sig { params(processed_options: OptionsType).void }
       def freeze_processed_options!(processed_options)
         # Reset cache values reliant on processed_options

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -55,7 +55,7 @@ module Homebrew
         @table[name] = value
       end
 
-      sig { params(_blk: T.nilable(T.proc.params(x: T.untyped).void)).returns(T.untyped) }
+      sig { override.params(_blk: T.nilable(T.proc.params(x: T.untyped).void)).returns(T.untyped) }
       def tap(&_blk)
         return super if block_given? # Object#tap
 

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -180,8 +180,7 @@ module Homebrew
           elsif @table[flag].instance_of? Array
             "#{option}=#{@table[flag].join(",")}"
           end
-        end
-        @cli_args.freeze
+        end.freeze
       end
     end
   end

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -14,6 +14,9 @@ module Homebrew
       sig { returns(T::Array[String]) }
       attr_reader :options_only, :flags_only, :remaining
 
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      attr_accessor :table
+
       sig { void }
       def initialize
         require "cli/named_args"
@@ -56,13 +59,7 @@ module Homebrew
       def build_from_source? = false
 
       sig { returns(T::Boolean) }
-      def cask? = false
-
-      sig { returns(T::Boolean) }
       def force_bottle? = false
-
-      # Defined in extend/os:
-      # def formula; end
 
       sig { returns(T::Boolean) }
       def HEAD? = false
@@ -128,9 +125,11 @@ module Homebrew
 
       sig { returns(T.nilable(Symbol)) }
       def only_formula_or_cask
-        if formula? && !cask?
+        return if !respond_to?(:formula?) && !respond_to?(:cask?)
+
+        if T.unsafe(self).formula? && !T.unsafe(self).cask?
           :formula
-        elsif cask? && !formula?
+        elsif T.unsafe(self).cask? && !T.unsafe(self).formula?
           :cask
         end
       end
@@ -191,7 +190,8 @@ module Homebrew
           elsif @table[flag].instance_of? Array
             "#{option}=#{@table[flag].join(",")}"
           end
-        end.freeze
+        end
+        @cli_args.freeze
       end
     end
   end

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -56,7 +56,13 @@ module Homebrew
       def build_from_source? = false
 
       sig { returns(T::Boolean) }
+      def cask? = false
+
+      sig { returns(T::Boolean) }
       def force_bottle? = false
+
+      # Defined in extend/os:
+      # def formula; end
 
       sig { returns(T::Boolean) }
       def HEAD? = false
@@ -122,9 +128,9 @@ module Homebrew
 
       sig { returns(T.nilable(Symbol)) }
       def only_formula_or_cask
-        if invoke_if_respond_to(:formula?) && !invoke_if_respond_to(:cask?)
+        if formula? && !cask?
           :formula
-        elsif invoke_if_respond_to(:cask?) && !invoke_if_respond_to(:formula?)
+        elsif cask? && !formula?
           :cask
         end
       end

--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -14,30 +14,6 @@ class Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def quiet?; end
 
-  sig { returns(T::Array[String]) }
-  def remaining; end
-
   sig { returns(T::Boolean) }
   def verbose?; end
-
-  # FIXME: The methods below are not defined by Args, but are valid because Args inherits from OpenStruct
-  # We should instead be using type guards to check if the method is defined on the object before calling it
-
-  sig { returns(T.nilable(String)) }
-  def arch; end
-
-  sig { returns(T::Boolean) }
-  def build_from_source?; end
-
-  sig { returns(T::Boolean) }
-  def cask?; end
-
-  sig { returns(T::Boolean) }
-  def formula?; end
-
-  sig { returns(T::Boolean) }
-  def include_test?; end
-
-  sig { returns(T.nilable(String)) }
-  def os; end
 end

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -393,10 +393,7 @@ module Homebrew
         end
 
         unless ignore_invalid_options
-          unless @is_dev_cmd
-            set_default_options
-            validate_options
-          end
+          validate_options unless @is_dev_cmd
           check_constraint_violations
           check_named_args(named_args)
         end
@@ -415,9 +412,6 @@ module Homebrew
 
         @args
       end
-
-      sig { void }
-      def set_default_options; end
 
       sig { void }
       def validate_options; end

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -404,7 +404,10 @@ module Homebrew
         end
 
         unless ignore_invalid_options
-          validate_options unless @is_dev_cmd
+          unless @is_dev_cmd
+            set_default_options
+            validate_options
+          end
           check_constraint_violations
           check_named_args(named_args)
         end
@@ -423,6 +426,9 @@ module Homebrew
 
         @args
       end
+
+      sig { void }
+      def set_default_options; end
 
       sig { void }
       def validate_options; end

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -288,12 +288,12 @@ module Homebrew
 
       sig { params(name: Symbol, value: T.untyped).void }
       def set_args_method(name, value)
-        @args.table[name] = value
+        @args.set_arg(name, value)
         return if @args.respond_to?(name)
 
         @args.define_singleton_method(name) do
-          T.bind(self, Args)
-          table.fetch(name)
+          # We cannot reference the ivar directly due to https://github.com/sorbet/sorbet/issues/8106
+          instance_variable_get(:@table).fetch(name)
         end
       end
 

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -108,7 +108,7 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def search_package_manager
-        package_manager = PACKAGE_MANAGERS.find { |name,| args[:"#{name}?"] }
+        package_manager = PACKAGE_MANAGERS.find { |name,| args.public_send(:"#{name}?") }
         return false if package_manager.nil?
 
         _, url = package_manager

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -125,7 +125,7 @@ module Homebrew
 
         audit_formulae, audit_casks = Homebrew.with_no_api_env do # audit requires full Ruby source
           if args.tap
-            Tap.fetch(T.must(args.tap)).then do |tap|
+            Tap.fetch(args.tap).then do |tap|
               [
                 tap.formula_files.map { |path| Formulary.factory(path) },
                 tap.cask_files.map { |path| Cask::CaskLoader.load(path) },

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -86,7 +86,7 @@ module Homebrew
               Formulary.factory(qualified_name)
             end
           elsif args.tap
-            tap = Tap.fetch(T.must(args.tap))
+            tap = Tap.fetch(args.tap)
             raise UsageError, "`--tap` requires `--auto` for official taps." if tap.official?
 
             formulae = args.cask? ? [] : tap.formula_files.map { |path| Formulary.factory(path) }

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -60,7 +60,7 @@ module Homebrew
 
         formulae_and_casks_to_check = Homebrew.with_no_api_env do
           if args.tap
-            tap = Tap.fetch(T.must(args.tap))
+            tap = Tap.fetch(args.tap)
             formulae = args.cask? ? [] : tap.formula_files.map { |path| Formulary.factory(path) }
             casks = args.formula? ? [] : tap.cask_files.map { |path| Cask::CaskLoader.load(path) }
             formulae + casks

--- a/Library/Homebrew/extend/os/linux/cli/parser.rb
+++ b/Library/Homebrew/extend/os/linux/cli/parser.rb
@@ -10,14 +10,8 @@ module OS
         requires_ancestor { Homebrew::CLI::Parser }
 
         sig { void }
-        def set_default_options
-          args.define_singleton_method(:formula?) { true } if args.respond_to?(:formula?)
-        end
-
-        sig { void }
         def validate_options
-          return unless args.respond_to?(:cask?)
-          return unless T.unsafe(args).cask?
+          return unless args.cask?
 
           # NOTE: We don't raise an error here because we don't want
           #       to print the help page or a stack trace.

--- a/Library/Homebrew/extend/os/linux/cli/parser.rb
+++ b/Library/Homebrew/extend/os/linux/cli/parser.rb
@@ -11,13 +11,13 @@ module OS
 
         sig { void }
         def set_default_options
-          args["formula?"] = true if args.respond_to?(:formula?)
+          args.define_singleton_method(:formula?) { true } if args.respond_to?(:formula?)
         end
 
         sig { void }
         def validate_options
           return unless args.respond_to?(:cask?)
-          return unless args.cask?
+          return unless T.unsafe(args).cask?
 
           # NOTE: We don't raise an error here because we don't want
           #       to print the help page or a stack trace.

--- a/Library/Homebrew/extend/os/linux/cli/parser.rb
+++ b/Library/Homebrew/extend/os/linux/cli/parser.rb
@@ -10,8 +10,14 @@ module OS
         requires_ancestor { Homebrew::CLI::Parser }
 
         sig { void }
+        def set_default_options
+          args.table[:formula?] = true if args.respond_to?(:formula?)
+        end
+
+        sig { void }
         def validate_options
-          return unless args.cask?
+          return unless args.respond_to?(:cask?)
+          return unless T.unsafe(self).args.cask?
 
           # NOTE: We don't raise an error here because we don't want
           #       to print the help page or a stack trace.

--- a/Library/Homebrew/extend/os/linux/cli/parser.rb
+++ b/Library/Homebrew/extend/os/linux/cli/parser.rb
@@ -11,7 +11,7 @@ module OS
 
         sig { void }
         def set_default_options
-          args.table[:formula?] = true if args.respond_to?(:formula?)
+          args.table[:formula?] = true
         end
 
         sig { void }

--- a/Library/Homebrew/extend/os/linux/cli/parser.rb
+++ b/Library/Homebrew/extend/os/linux/cli/parser.rb
@@ -11,7 +11,7 @@ module OS
 
         sig { void }
         def set_default_options
-          args.table[:formula?] = true
+          args.set_arg(:formula?, true)
         end
 
         sig { void }

--- a/Library/Homebrew/extend/os/parser.rb
+++ b/Library/Homebrew/extend/os/parser.rb
@@ -2,3 +2,12 @@
 # frozen_string_literal: true
 
 require "extend/os/linux/cli/parser" if OS.linux?
+
+module Homebrew
+  module CLI
+    class Args
+      sig { returns(T::Boolean) }
+      def formula? = OS.linux?
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/parser.rb
+++ b/Library/Homebrew/extend/os/parser.rb
@@ -2,12 +2,3 @@
 # frozen_string_literal: true
 
 require "extend/os/linux/cli/parser" if OS.linux?
-
-module Homebrew
-  module CLI
-    class Args
-      sig { returns(T::Boolean) }
-      def formula? = OS.linux?
-    end
-  end
-end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/tap_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/tap_cmd.rbi
@@ -20,7 +20,7 @@ class Homebrew::Cmd::TapCmd::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def force?; end
 
-  sig { returns(T.nilable(String)) }
+  sig { returns(T::Boolean) }
   def force_auto_update?; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/audit.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/audit.rbi
@@ -71,7 +71,7 @@ class Homebrew::DevCmd::Audit::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(String)) }
   def os; end
 
-  sig { returns(T.nilable(String)) }
+  sig { returns(T::Boolean) }
   def signing?; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/audit.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/audit.rbi
@@ -80,9 +80,6 @@ class Homebrew::DevCmd::Audit::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def strict?; end
 
-  sig { returns(T.nilable(String)) }
-  def tap; end
-
   sig { returns(T::Boolean) }
   def token_conflicts?; end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
@@ -49,7 +49,4 @@ class Homebrew::DevCmd::Bump::Args < Homebrew::CLI::Args
 
   sig { returns(T.nilable(String)) }
   def start_with; end
-
-  sig { returns(T.nilable(String)) }
-  def tap; end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/create.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/create.rbi
@@ -64,7 +64,4 @@ class Homebrew::DevCmd::Create::Args < Homebrew::CLI::Args
 
   sig { returns(T.nilable(String)) }
   def set_version; end
-
-  sig { returns(T.nilable(String)) }
-  def tap; end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/dispatch_build_bottle.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/dispatch_build_bottle.rbi
@@ -27,9 +27,6 @@ class Homebrew::DevCmd::DispatchBuildBottle::Args < Homebrew::CLI::Args
   def macos; end
 
   sig { returns(T.nilable(String)) }
-  def tap; end
-
-  sig { returns(T.nilable(String)) }
   def timeout; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/livecheck_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/livecheck_cmd.rbi
@@ -46,7 +46,4 @@ class Homebrew::DevCmd::LivecheckCmd::Args < Homebrew::CLI::Args
 
   sig { returns(T::Boolean) }
   def resources?; end
-
-  sig { returns(T.nilable(String)) }
-  def tap; end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/pr_automerge.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/pr_automerge.rbi
@@ -21,9 +21,6 @@ class Homebrew::DevCmd::PrAutomerge::Args < Homebrew::CLI::Args
   def publish?; end
 
   sig { returns(T.nilable(String)) }
-  def tap; end
-
-  sig { returns(T.nilable(String)) }
   def with_label; end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/pr_publish.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/pr_publish.rbi
@@ -24,8 +24,5 @@ class Homebrew::DevCmd::PrPublish::Args < Homebrew::CLI::Args
   def message; end
 
   sig { returns(T.nilable(String)) }
-  def tap; end
-
-  sig { returns(T.nilable(String)) }
   def workflow; end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/pr_pull.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/pr_pull.rbi
@@ -65,9 +65,6 @@ class Homebrew::DevCmd::PrPull::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(String)) }
   def root_url_using; end
 
-  sig { returns(T.nilable(String)) }
-  def tap; end
-
   sig { returns(T::Boolean) }
   def warn_on_upload_failure?; end
 

--- a/Library/Homebrew/test/abstract_command_spec.rb
+++ b/Library/Homebrew/test/abstract_command_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Homebrew::AbstractCommand do
       end
 
       it "allows access to args" do
-        expect(TestCat.new(["--bar", "baz"]).args[:bar]).to eq("baz")
+        expect(TestCat.new(["--bar", "baz"]).args.bar).to eq("baz")
       end
 
       it "raises on invalid args" do

--- a/Library/Homebrew/test/cask/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/upgrade_spec.rb
@@ -19,7 +19,11 @@ RSpec.describe Cask::Upgrade, :cask do
   let(:renamed_app) { Cask::CaskLoader.load("renamed-app") }
   let(:renamed_app_old_path) { renamed_app.config.appdir.join("OldApp.app") }
   let(:renamed_app_new_path) { renamed_app.config.appdir.join("NewApp.app") }
-  let(:args) { Homebrew::CLI::Args.new }
+  let(:args) do
+    parser = Homebrew::CLI::Parser.new(Homebrew::Cmd::Brew)
+    parser.cask_options
+    parser.args
+  end
 
   before do
     installed.each do |cask|

--- a/Library/Homebrew/test/sorbet/tapioca/compilers/args_spec.rb
+++ b/Library/Homebrew/test/sorbet/tapioca/compilers/args_spec.rb
@@ -18,36 +18,19 @@ RSpec.describe Tapioca::Compilers::Args do
 
   describe "#args_table" do
     it "returns a mapping of list args to default values" do
-      expect(compiler.args_table(list_parser).keys).to contain_exactly(
-        :"1?", :built_from_source?, :cask?, :casks?, :d?, :debug?,
-        :formula?, :formulae?, :full_name?, :h?, :help?,
-        :installed_as_dependency?, :installed_on_request?, :l?,
-        :multiple?, :pinned?, :poured_from_bottle?, :q?, :quiet?,
-        :r?, :t?, :v?, :verbose?, :versions?
+      expect(compiler.args_table(list_parser)).to contain_exactly(
+        :"1?", :built_from_source?, :cask?, :casks?, :d?, :debug?, :formula?, :formulae?, :full_name?, :h?, :help?,
+        :installed_as_dependency?, :installed_on_request?, :l?, :multiple?, :pinned?, :poured_from_bottle?, :q?,
+        :quiet?, :r?, :t?, :v?, :verbose?, :versions?
       )
     end
 
     it "returns a mapping of update-python-resources args to default values" do
-      expect(compiler.args_table(update_python_resources_parser)).to eq({
-        d?:                        false,
-        debug?:                    false,
-        exclude_packages:          nil,
-        extra_packages:            nil,
-        h?:                        false,
-        help?:                     false,
-        ignore_non_pypi_packages?: false,
-        install_dependencies?:     false,
-        p?:                        false,
-        package_name:              nil,
-        print_only?:               false,
-        q?:                        false,
-        quiet?:                    false,
-        s?:                        false,
-        silent?:                   false,
-        v?:                        false,
-        verbose?:                  false,
-        version:                   nil,
-      })
+      expect(compiler.args_table(update_python_resources_parser)).to contain_exactly(
+        :d?, :debug?, :exclude_packages, :extra_packages, :h?, :help?, :ignore_non_pypi_packages?,
+        :install_dependencies?, :p?, :package_name, :print_only?, :q?, :quiet?, :s?, :silent?, :v?, :verbose?,
+        :version
+      )
     end
   end
 
@@ -65,15 +48,15 @@ RSpec.describe Tapioca::Compilers::Args do
     let(:comma_arrays) { compiler.comma_arrays(update_python_resources_parser) }
 
     it "returns the correct type for switches" do
-      expect(compiler.get_return_type(:silent?, false, comma_arrays)).to eq("T::Boolean")
+      expect(compiler.get_return_type(:silent?, comma_arrays)).to eq("T::Boolean")
     end
 
     it "returns the correct type for flags" do
-      expect(compiler.get_return_type(:package_name, nil, comma_arrays)).to eq("T.nilable(String)")
+      expect(compiler.get_return_type(:package_name, comma_arrays)).to eq("T.nilable(String)")
     end
 
     it "returns the correct type for comma_arrays" do
-      expect(compiler.get_return_type(:extra_packages, nil, comma_arrays)).to eq("T.nilable(T::Array[String])")
+      expect(compiler.get_return_type(:extra_packages, comma_arrays)).to eq("T.nilable(T::Array[String])")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Resolves https://github.com/Homebrew/brew/issues/18777

- Retains the `@table` attr that OpenStruct used, but it is now exclusively for args (not metadata like `named` and `remaining`). I'm open to renaming the attr.
- `missing_method` dispatch is removed, only defined methods are allowed
- A generic `set_arg` method is provided, to allow setting args from the parser. There is no corresponding getter, because I want to encourage explicit invocations. The usual ruby escape hatches (e.g. `instance_variable_get`) are available if needed 😞.
- Within the args class, I've replaced arg lookup methods with `@table` lookups, because the methods aren't necessarily defined. It's a bit of an eyesore, but IMO preferable to defining them unnecessarily, or using `respond_to?` guards.