### PR TITLE
generate-man-completions: also fail if only date changed

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-man-completions.rb
+++ b/Library/Homebrew/dev-cmd/generate-man-completions.rb
@@ -28,10 +28,13 @@ module Homebrew
         Completions.update_shell_completions!
 
         diff = system_command "git", args: [
-          "-C", HOMEBREW_REPOSITORY, "diff", "--exit-code", "docs/Manpage.md", "manpages", "completions"
+          "-C", HOMEBREW_REPOSITORY,
+          "diff", "--shortstat", "--patch", "--exit-code", "docs/Manpage.md", "manpages", "completions"
         ]
         if diff.status.success?
           ofail "No changes to manpage or completions."
+        elsif /1 file changed, 1 insertion\(\+\), 1 deletion\(-\).*-\.TH "BREW" "1" "\w+ \d+"/m.match?(diff.stdout)
+          ofail "No changes to manpage or completions other than the date."
         else
           puts "Manpage and completions updated."
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The original `ronn`-based manpage generator would backdate the generated date if the target file existed. That was dropped when `ronn` was replaced with Kramdown in #16868. This change restores the idea by having `generate-man-completions` also fail if there are no changes or only the date is changed, which should eliminate the monthly automated date-updating PRs like #18846.