### PR TITLE
cmd/update-reset: remove .git/describe-cache.

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -86,6 +86,7 @@ homebrew-update-reset() {
       head="${head#refs/remotes/origin/}"
       git -C "${DIR}" checkout --force -B "${head}" origin/HEAD
     fi
+    rm -rf "${DIR}/.git/describe-cache"
     echo
   done
 }


### PR DESCRIPTION
As this is a cache and can potentially be incorrect, let's allow this way of cleaning it up.