### PR TITLE
cmd/update: avoid switching developers to `stable` branch

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -375,7 +375,7 @@ EOS
 
   if [[ -z "${HOMEBREW_UPDATE_TO_TAG}" ]]
   then
-    if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEV_CMD_RUN}" ]] && [[ -n "${HOMEBREW_NO_INSTALL_CLEANUP}" ]]
+    if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEV_CMD_RUN}" ]]
     then
       export HOMEBREW_NO_UPDATE_CLEANUP="1"
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Checking for `HOMEBREW_NO_INSTALL_CLEANUP` was added in #18825, but this
breaks developers by switching them to the stable branch.

Setting `HOMEBREW_NO_UPDATE_CLEANUP` when `HOMEBREW_NO_INSTALL_CLEANUP`
is set seems like a relatively recent addition, so I don't think it
hurts to just remove it. We can add it back (correctly) if there are
users that need it.
