### PR TITLE
service: end systemd configs with a new line

### DIFF
--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -718,7 +718,7 @@ RSpec.describe Homebrew::Service do
 
       unit = f.service.to_systemd_unit
       std_path = "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
-      unit_expect = <<~EOS
+      unit_expect = <<~SYSTEMD
         [Unit]
         Description=Homebrew generated unit for formula_name
 
@@ -737,8 +737,8 @@ RSpec.describe Homebrew::Service do
         StandardError=append:#{HOMEBREW_PREFIX}/var/log/beanstalkd.error.log
         Environment="PATH=#{std_path}"
         Environment="FOO=BAR"
-      EOS
-      expect(unit).to eq(unit_expect.strip)
+      SYSTEMD
+      expect(unit).to eq(unit_expect)
     end
 
     it "returns valid partial oneshot unit" do
@@ -751,7 +751,7 @@ RSpec.describe Homebrew::Service do
       end
 
       unit = f.service.to_systemd_unit
-      unit_expect = <<~EOS
+      unit_expect = <<~SYSTEMD
         [Unit]
         Description=Homebrew generated unit for formula_name
 
@@ -761,8 +761,8 @@ RSpec.describe Homebrew::Service do
         [Service]
         Type=oneshot
         ExecStart=#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd
-      EOS
-      expect(unit).to eq(unit_expect.strip)
+      SYSTEMD
+      expect(unit).to eq(unit_expect)
     end
 
     it "expands paths" do
@@ -774,7 +774,7 @@ RSpec.describe Homebrew::Service do
       end
 
       unit = f.service.to_systemd_unit
-      unit_expect = <<~EOS
+      unit_expect = <<~SYSTEMD
         [Unit]
         Description=Homebrew generated unit for formula_name
 
@@ -785,8 +785,8 @@ RSpec.describe Homebrew::Service do
         Type=simple
         ExecStart=#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd
         WorkingDirectory=#{Dir.home}
-      EOS
-      expect(unit).to eq(unit_expect.strip)
+      SYSTEMD
+      expect(unit).to eq(unit_expect)
     end
   end
 
@@ -801,7 +801,7 @@ RSpec.describe Homebrew::Service do
       end
 
       unit = f.service.to_systemd_timer
-      unit_expect = <<~EOS
+      unit_expect = <<~SYSTEMD
         [Unit]
         Description=Homebrew generated timer for formula_name
 
@@ -811,8 +811,8 @@ RSpec.describe Homebrew::Service do
         [Timer]
         Unit=homebrew.formula_name
         OnUnitActiveSec=5
-      EOS
-      expect(unit).to eq(unit_expect.strip)
+      SYSTEMD
+      expect(unit).to eq(unit_expect)
     end
 
     it "returns valid partial timer" do
@@ -824,7 +824,7 @@ RSpec.describe Homebrew::Service do
       end
 
       unit = f.service.to_systemd_timer
-      unit_expect = <<~EOS
+      unit_expect = <<~SYSTEMD
         [Unit]
         Description=Homebrew generated timer for formula_name
 
@@ -833,7 +833,8 @@ RSpec.describe Homebrew::Service do
 
         [Timer]
         Unit=homebrew.formula_name
-      EOS
+
+      SYSTEMD
       expect(unit).to eq(unit_expect)
     end
 
@@ -872,7 +873,7 @@ RSpec.describe Homebrew::Service do
         end
 
         unit = f.service.to_systemd_timer
-        unit_expect = <<~EOS
+        unit_expect = <<~SYSTEMD
           [Unit]
           Description=Homebrew generated timer for formula_name
 
@@ -883,8 +884,8 @@ RSpec.describe Homebrew::Service do
           Unit=homebrew.formula_name
           Persistent=true
           OnCalendar=#{calendar}
-        EOS
-        expect(unit).to eq(unit_expect.chomp)
+        SYSTEMD
+        expect(unit).to eq(unit_expect)
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

systemd configs, like all UNIX text files, should end with a new line.
