### PR TITLE
attestation: handle multiple subjects

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -168,6 +168,8 @@ module Homebrew
       # As of 2024-12-04 GitHub's Artifact Attestation feature can put multiple subjects
       # in a single attestation, so we check every subject in each attestation
       # and select the first attestation with a matching subject.
+      # In particular, this happens with v2.0.0 and later of the
+      # `actions/attest-build-provenance` action.
       subject = bottle.filename.to_s if subject.blank?
 
       attestation = if bottle.tag.to_sym == :all

--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -164,7 +164,10 @@ module Homebrew
 
       # `gh attestation verify` returns a JSON array of one or more results,
       # for all attestations that match the input's digest. We want to additionally
-      # filter these down to just the attestation whose subject matches the bottle's name.
+      # filter these down to just the attestation whose subject(s) contain the bottle's name.
+      # As of 2024-12-04 GitHub's Artifact Attestation feature can put multiple subjects
+      # in a single attestation, so we check every subject in each attestation
+      # and select the first attestation with a matching subject.
       subject = bottle.filename.to_s if subject.blank?
 
       attestation = if bottle.tag.to_sym == :all
@@ -175,12 +178,15 @@ module Homebrew
         # This is sound insofar as the signature has already been verified. However,
         # longer term, we should also directly attest to `:all`-tagged bottles.
         attestations.find do |a|
-          actual_subject = a.dig("verificationResult", "statement", "subject", 0, "name")
-          actual_subject.start_with? "#{bottle.filename.name}--#{bottle.filename.version}"
+          candidate_subjects = a.dig("verificationResult", "statement", "subject")
+          candidate_subjects.any? do |candidate|
+            candidate["name"].start_with? "#{bottle.filename.name}--#{bottle.filename.version}"
+          end
         end
       else
         attestations.find do |a|
-          a.dig("verificationResult", "statement", "subject", 0, "name") == subject
+          candidate_subjects = a.dig("verificationResult", "statement", "subject")
+          candidate_subjects.any? { |candidate| candidate["name"] == subject }
         end
       end
 

--- a/Library/Homebrew/test/attestation_spec.rb
+++ b/Library/Homebrew/test/attestation_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe Homebrew::Attestation do
                       } },
                     ]))
   end
+  let(:fake_result_json_resp_multi_subject) do
+    instance_double(SystemCommand::Result,
+                    stdout: JSON.dump([
+                      { verificationResult: {
+                        verifiedTimestamps: [{ timestamp: "2024-03-13T00:00:00Z" }],
+                        statement:          { subject: [{ name: "nonsense" }, { name: fake_bottle_filename.to_s }] },
+                      } },
+                    ]))
+  end
   let(:fake_result_json_resp_backfill) do
     digest = Digest::SHA256.hexdigest(fake_bottle_url)
     instance_double(SystemCommand::Result,
@@ -230,6 +239,17 @@ RSpec.describe Homebrew::Attestation do
               env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
               print_stderr: false, chdir: HOMEBREW_TEMP)
         .and_return(fake_result_json_resp)
+
+      described_class.check_core_attestation fake_bottle
+    end
+
+    it "calls gh with args for homebrew-core and handles a multi-subject attestation" do
+      expect(described_class).to receive(:system_command!)
+        .with(fake_gh, args: ["attestation", "verify", cached_download, "--repo",
+                              described_class::HOMEBREW_CORE_REPO, "--format", "json"],
+              env: { "GH_TOKEN" => fake_gh_creds, "GH_HOST" => "github.com" }, secrets: [fake_gh_creds],
+              print_stderr: false, chdir: HOMEBREW_TEMP)
+        .and_return(fake_result_json_resp_multi_subject)
 
       described_class.check_core_attestation fake_bottle
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

GitHub's Artifact Attestations feature began putting multiple subjects in a single bundle yesterday. This broke our assumption that each attestation has only one subject. To fix this, we generalize our search of the attestation's subject from just the first subject name to any name in the subject set.

This should fix the behavior observed in https://github.com/Homebrew/homebrew-core/issues/177384#issuecomment-2521141910 and below.

See also: https://github.blog/changelog/2024-12-04-artifact-attestations-now-support-multiple-subjects/