### PR TITLE
update-maintainers: ignore accents when sorting names

### DIFF
--- a/Library/Homebrew/dev-cmd/update-maintainers.rb
+++ b/Library/Homebrew/dev-cmd/update-maintainers.rb
@@ -35,7 +35,7 @@ module Homebrew
         members.each do |group, hash|
           hash.replace(hash.slice(*public_members))
           hash.each { |login, name| hash[login] = "[#{name}](https://github.com/#{login})" }
-          sentences[group] = hash.values.sort.to_sentence
+          sentences[group] = hash.values.sort_by { |s| s.unicode_normalize(:nfd).gsub(/\P{L}+/, "") }.to_sentence
         end
 
         readme = HOMEBREW_REPOSITORY/"README.md"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Currently, accented characters are sorted after the non-accented alphabet, which is why "Štefan Baebler" ends up at the end of the list. This change sorts the list of names on each letter's non-accented variant instead.