### PR TITLE
workflows/docs: enable merge queue/group jobs.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
This should allow us to make use of the GitHub merge queue to ensure that we're not merging outdated code (or breaking `master`) but avoiding the need to continually merge into/rebase PR branches.

This should be safe to merge as-is as is essentially a no-op without the merge queue enabled.