### PR TITLE
fix(livecheck/pypi): update to use json endpoint to query version

### DIFF
--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -1,25 +1,30 @@
 # typed: strict
 # frozen_string_literal: true
 
-require "json"
-require "utils/curl"
-
 module Homebrew
   module Livecheck
     module Strategy
-      # The {Pypi} strategy identifies versions of software at pypi.org by
-      # using the JSON API endpoint.
+      # The {Pypi} strategy identifies the newest version of a PyPI package by
+      # checking the JSON API endpoint for the project and using the
+      # `info.version` field from the response.
       #
       # PyPI URLs have a standard format:
+      #   `https://files.pythonhosted.org/packages/<hex>/<hex>/<long_hex>/example-1.2.3.tar.gz`
       #
-      # * `https://files.pythonhosted.org/packages/<hex>/<hex>/<long_hex>/example-1.2.3.tar.gz`
-      #
-      # This method uses the `info.version` field in the JSON response to
-      # determine the latest stable version.
+      # Upstream documentation for the PyPI JSON API can be found at:
+      #   https://docs.pypi.org/api/json/#get-a-project
       #
       # @api public
       class Pypi
         NICE_NAME = "PyPI"
+
+        # The default `strategy` block used to extract version information when
+        # a `strategy` block isn't provided.
+        DEFAULT_BLOCK = T.let(proc do |json|
+          json.dig("info", "version").presence
+        end.freeze, T.proc.params(
+          arg0: T::Hash[String, T.untyped],
+        ).returns(T.nilable(String)))
 
         # The `Regexp` used to extract the package name and suffix (e.g. file
         # extension) from the URL basename.
@@ -46,8 +51,8 @@ module Homebrew
           URL_MATCH_REGEX.match?(url)
         end
 
-        # Extracts the package name from the provided URL and generates the
-        # PyPI JSON API endpoint.
+        # Extracts the package name from the provided URL and uses it to
+        # generate the PyPI JSON API URL for the project.
         #
         # @param url [String] the URL used to generate values
         # @return [Hash]
@@ -58,48 +63,41 @@ module Homebrew
           match = File.basename(url).match(FILENAME_REGEX)
           return values if match.blank?
 
-          package_name = T.must(match[:package_name]).gsub(/[_-]/, "-")
-          values[:url] = "https://pypi.org/project/#{package_name}/#files"
-          values[:regex] = %r{href=.*?/packages.*?/#{package_name}[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i
+          values[:url] = "https://pypi.org/pypi/#{T.must(match[:package_name]).gsub(/%20|_/, "-")}/json"
 
           values
         end
 
-        # Fetches the latest version of the package from the PyPI JSON API.
+        # Generates a PyPI JSON API URL for the project and identifies new
+        # versions using {Json#find_versions} with a block.
         #
         # @param url [String] the URL of the content to check
-        # @param regex [Regexp] a regex used for matching versions in content (optional)
+        # @param regex [Regexp] a regex used for matching versions in content
+        # @param provided_content [String, nil] content to check instead of
+        #   fetching
         # @return [Hash]
         sig {
           params(
-            url:     String,
-            regex:   T.nilable(Regexp),
-            _unused: T.untyped,
-            _block:  T.nilable(Proc),
+            url:              String,
+            regex:            T.nilable(Regexp),
+            provided_content: T.nilable(String),
+            unused:           T.untyped,
+            block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **_unused, &_block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, **unused, &block)
           match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)
           return match_data if generated.blank?
 
-          match_data[:url] = generated[:url]
-
-          # Parse JSON and get the latest version
-          begin
-            response = Utils::Curl.curl_output(generated[:url])
-            data = JSON.parse(response.stdout, symbolize_names: true)
-            latest_version = data.dig(:info, :version)
-          rescue => e
-            puts "Error fetching version from PyPI: #{e.message}"
-            return {}
-          end
-
-          # Return the version if found
-          return {} if latest_version.blank?
-
-          { matches: { latest_version => Version.new(latest_version) } }
+          Json.find_versions(
+            url:              generated[:url],
+            regex:,
+            provided_content:,
+            **unused,
+            &block || DEFAULT_BLOCK
+          )
         end
       end
     end

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -8,10 +8,40 @@ RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
   let(:pypi_url) { "https://files.pythonhosted.org/packages/ab/cd/efg/example-package-1.2.3.tar.gz" }
   let(:non_pypi_url) { "https://brew.sh/test" }
 
+  let(:regex) { /^v?(\d+(?:\.\d+)+)$/i }
+
   let(:generated) do
     {
       url: "https://pypi.org/pypi/example-package/json",
     }
+  end
+
+  # This is a limited subset of a PyPI JSON API response object, for the sake
+  # of testing.
+  let(:content) do
+    <<~JSON
+      {
+        "info": {
+          "version": "1.2.3"
+        }
+      }
+    JSON
+  end
+
+  let(:matches) { ["1.2.3"] }
+
+  let(:find_versions_return_hash) do
+    {
+      matches: {
+        "1.2.3" => Version.new("1.2.3"),
+      },
+      regex:   nil,
+      url:     generated[:url],
+    }
+  end
+
+  let(:find_versions_cached_return_hash) do
+    find_versions_return_hash.merge({ cached: true })
   end
 
   describe "::match?" do
@@ -31,6 +61,61 @@ RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
 
     it "returns an empty hash for a non-PyPI URL" do
       expect(pypi.generate_input_values(non_pypi_url)).to eq({})
+    end
+  end
+
+  describe "::find_versions" do
+    let(:match_data) do
+      cached = {
+        matches: matches.to_h { |v| [v, Version.new(v)] },
+        regex:   nil,
+        url:     generated[:url],
+        cached:  true,
+      }
+
+      {
+        cached:,
+        cached_default: cached.merge({ matches: {} }),
+      }
+    end
+
+    it "finds versions in provided content" do
+      expect(pypi.find_versions(url: pypi_url, provided_content: content))
+        .to eq(match_data[:cached])
+    end
+
+    it "finds versions in provided content using a block" do
+      # NOTE: We only use a regex here to make sure it can be passed into the
+      # block, if necessary.
+      expect(pypi.find_versions(url: pypi_url, regex:, provided_content: content) do |json, regex|
+        match = json.dig("info", "version")&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end).to eq(match_data[:cached].merge({ regex: }))
+
+      expect(pypi.find_versions(url: pypi_url, provided_content: content) do |json|
+        json.dig("info", "version").presence
+      end).to eq(match_data[:cached])
+    end
+
+    it "returns default match_data when block doesn't return version information" do
+      expect(pypi.find_versions(url: pypi_url, provided_content: '{"info":{"version":""}}'))
+        .to eq(match_data[:cached_default])
+      expect(pypi.find_versions(url: pypi_url, provided_content: '{"other":true}'))
+        .to eq(match_data[:cached_default])
+    end
+
+    it "returns default match_data when url is blank" do
+      expect(pypi.find_versions(url: "") { "1.2.3" })
+        .to eq({ matches: {}, regex: nil, url: "" })
+    end
+
+    it "returns default match_data when content is blank" do
+      expect(pypi.find_versions(url: pypi_url, provided_content: "{}") { "1.2.3" })
+        .to eq(match_data[:cached_default])
+      expect(pypi.find_versions(url: pypi_url, provided_content: "") { "1.2.3" })
+        .to eq(match_data[:cached_default])
     end
   end
 end

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
   let(:generated) do
     {
       url:   "https://pypi.org/project/example-package/#files",
-      regex: %r{href=.*?/packages.*?/example[_-]package[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i,
+      regex: %r{href=.*?/packages.*?/example-package[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i,
     }
   end
 

--- a/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/pypi_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::Pypi do
 
   let(:generated) do
     {
-      url:   "https://pypi.org/project/example-package/#files",
-      regex: %r{href=.*?/packages.*?/example-package[._-]v?(\d+(?:\.\d+)*(?:[._-]post\d+)?)\.t}i,
+      url: "https://pypi.org/pypi/example-package/json",
     }
   end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Right now, pypi strategy is crawling the page for checking the latest version, but we should just use json to find out the latest version.

```
$ curl -s https://pypi.org/pypi/mkvtomp4/json | jq -r '.info.version'
2.0
```
