### PR TITLE
Add missing utils/service require

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -3,6 +3,7 @@
 
 require "ipaddr"
 require "extend/on_system"
+require "utils/service"
 
 module Homebrew
   # The {Service} class implements the DSL methods used in a formula's


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This was originally added in https://github.com/Homebrew/brew/pull/18865.

```console
$ brew ruby -e 'p "activemq".f.service.to_systemd_unit'
/usr/local/Homebrew/Library/Homebrew/service.rb:458:in `block in to_systemd_unit': uninitialized constant Utils::Service (NameError)
        from /usr/local/Homebrew/Library/Homebrew/service.rb:458:in `map'
        from /usr/local/Homebrew/Library/Homebrew/service.rb:458:in `to_systemd_unit'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11685/lib/types/private/methods/call_validation.rb:278:in `bind_call'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11685/lib/types/private/methods/call_validation.rb:278:in `validate_call'
        from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11685/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
        from -e:1:in `<main>'
```

```console
$ brew ruby -e 'p "activemq".f.service.to_systemd_unit'
"[Unit]\nDescription=Homebrew generated unit for activemq\n\n[Install]\nWantedBy=default.target\n\n[Service]\nType=simple\nExecStart=\"/usr/local/opt/activemq/bin/activemq\" \"console\"\nWorkingDirectory=/usr/local/opt/activemq/libexec\n"
```