### PR TITLE
Pypi: Restore regex support

### DIFF
--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -58,8 +58,10 @@ module Homebrew
         end
 
         # Parses JSON text and identifies versions using a `strategy` block.
-        # If a regex is provided, it will be passed as the second argument to
-        # the  `strategy` block (after the parsed JSON data).
+        # If the block has two parameters, the parsed JSON data will be used as
+        # the first argument and the regex (if any) will be the second.
+        # Otherwise, only the parsed JSON data will be passed to the block.
+        #
         # @param content [String] the JSON text to parse and check
         # @param regex [Regexp, nil] a regex used for matching versions in the
         #   content
@@ -77,10 +79,8 @@ module Homebrew
           json = parse_json(content)
           return [] if json.blank?
 
-          block_return_value = if regex.present?
+          block_return_value = if block.arity == 2
             yield(json, regex)
-          elsif block.arity == 2
-            raise "Two arguments found in `strategy` block but no regex provided."
           else
             yield(json)
           end

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -20,10 +20,14 @@ module Homebrew
 
         # The default `strategy` block used to extract version information when
         # a `strategy` block isn't provided.
-        DEFAULT_BLOCK = T.let(proc do |json|
-          json.dig("info", "version").presence
+        DEFAULT_BLOCK = T.let(proc do |json, regex|
+          version = json.dig("info", "version")
+          next if version.blank?
+
+          regex ? version[regex, 1] : version
         end.freeze, T.proc.params(
-          arg0: T::Hash[String, T.untyped],
+          json:  T::Hash[String, T.untyped],
+          regex: T.nilable(Regexp),
         ).returns(T.nilable(String)))
 
         # The `Regexp` used to extract the package name and suffix (e.g. file

--- a/Library/Homebrew/test/livecheck/strategy/json_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/json_spec.rb
@@ -107,11 +107,6 @@ RSpec.describe Homebrew::Livecheck::Strategy::Json do
       expect(json.versions_from_content(content_simple, regex) { next }).to eq([])
     end
 
-    it "errors if a block uses two arguments but a regex is not given" do
-      expect { json.versions_from_content(content_simple) { |json, regex| json["version"][regex, 1] } }
-        .to raise_error("Two arguments found in `strategy` block but no regex provided.")
-    end
-
     it "errors on an invalid return type from a block" do
       expect { json.versions_from_content(content_simple, regex) { 123 } }
         .to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to https://github.com/Homebrew/brew/pull/18895. We recently updated the `Pypi` strategy to use the PyPI JSON API and the default strategy behavior no longer relies on a regex, so the initial implementation didn't include regex handling. This restores support for a `livecheck` block regex by updating the `DEFAULT_BLOCK` logic to handle an optional regex. This allows us to use a regex to omit parts of the `info.version` value without having to duplicate the default block logic in a `strategy` block only to use a regex.

This isn't currently necessary for any existing formulae using the `Pypi` strategy but we have a few that needed a custom regex with the previous strategy approach, so they may need this functionality in the future. Besides that, restoring regex support to `Pypi` ensures that `livecheck`/`strategy` blocks work in a fairly consistent manner across strategies.

To allow this, it was necessary to remove the check in `Json::versions_from_content` that raises an error if the block has two parameters but `regex` is `nil`. The regex parameter in `Pypi::DEFAULT_BLOCK` is optional and the block body handles a `nil` regex value, so that applies here. Unfortunately, we can't use `regex = nil` in the `DEFAULT_BLOCK` parameters because Sorbet treats all `Proc` parameters as required (from [the Sorbet `Proc` documentation](https://sorbet.org/docs/procs): "At present, all parameters are assumed to be required positional parameters—`T.proc` types cannot declare optional nor keyword parameters.").

Alternatively, we could keep `Json::versions_from_content` and `DEFAULT_BLOCK` as is and add a `Pypi::DEFAULT_BLOCK_WITH_REGEX` variant that accepts a regex, using the latter when regex isn't `nil`. We would achieve the same goal either way but I figured modifying `DEFAULT_BLOCK` was maybe a bit cleaner.