### PR TITLE
cask/artifact/abstract_uninstall: handle sudo trashed paths correctly

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -468,9 +468,7 @@ module Cask
         trashed = trashed.split(":")
         untrashable = untrashable.split(":")
 
-        return trashed, untrashable if untrashable.empty?
-
-        untrashable.delete_if do |path|
+        trashed_with_permissions, untrashable = untrashable.partition do |path|
           Utils.gain_permissions(path, ["-R"], SystemCommand) do
             system_command! HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift",
                             args:         [path],
@@ -481,6 +479,10 @@ module Cask
         rescue
           false
         end
+
+        trashed += trashed_with_permissions
+
+        return trashed, untrashable if untrashable.empty?
 
         opoo "The following files could not be trashed, please do so manually:"
         $stderr.puts untrashable


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This showed a confusing message when the trash path was able to be deleted using sudo since the untrashable array was updated but the check was higher up for returning early.

```
==> Trashing files:
/Users/Shared/Maxon
/Users/Shared/Red Giant
~/Library/Application Support/Maxon
~/Library/Application Support/Red Giant
~/Library/Caches/net.maxon.app-manager
~/Library/Preferences/Maxon
~/Library/Preferences/net.maxon.app-manager.plist
~/Library/Saved Application State/net.maxon.app-manager.savedState
==> Using sudo to gain ownership of path '/Users/Shared/Maxon'
==> Using sudo to gain ownership of path '/Users/Shared/Red Giant'
Warning: The following files could not be trashed, please do so manually:
==> Removing all staged versions of Cask 'maxon'
```

The warning about files not getting trashed should only be shown if some files didn't get trashed.

Fixes https://github.com/Homebrew/brew/issues/18901