### PR TITLE
dev-cmd/tap-new: improve handling of multi-user setups

### DIFF
--- a/Library/Homebrew/utils/uid.rb
+++ b/Library/Homebrew/utils/uid.rb
@@ -15,5 +15,14 @@ module Utils
         Process::Sys.seteuid(original_euid)
       end
     end
+
+    sig { returns(T.nilable(String)) }
+    def self.uid_home
+      require "etc"
+      Etc.getpwuid(Process.uid)&.dir
+    rescue ArgumentError
+      # Cover for misconfigured NSS setups
+      nil
+    end
   end
 end


### PR DESCRIPTION
Homebrew largely operates under the model where EUID == Homebrew owner (proxy) and UID == requesting user.

This cross-user model doesn't really work well with `brew tap-new` which does git commits. This PR fixes it so that it can read the author information of the requesting user.

Known issue (that realistically won't be fixed): on macOS, this will not work with Xcode 14.0 through 14.2. On Linux (or I guess old Homebrew Git installs on macOS too potentially) this will not work with any (potentially distro-patched) system Git <2.39 that have the safe directory changes but didn't backport `-c safe.directory` support. This however isn't a regression from the previous state where it still didn't work anyway, and can be fixed by using Homebrew git.