### PR TITLE
chore(formula): raise error if no universal binaries are found to deuniversalize

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2005,6 +2005,8 @@ class Formula
   # If called with no parameters, does this with all compatible
   # universal binaries in a {Formula}'s {Keg}.
   #
+  # Raises an error if no universal binaries are found to deuniversalize.
+  #
   # @api public
   sig { params(targets: T.nilable(T.any(Pathname, String))).void }
   def deuniversalize_machos(*targets)
@@ -2013,6 +2015,8 @@ class Formula
         file.arch == :universal && file.archs.include?(Hardware::CPU.arch)
       end
     end
+
+    raise "No universal binaries found to deuniversalize" if targets.blank?
 
     targets&.each do |target|
       extract_macho_slice_from(Pathname(target), Hardware::CPU.arch)


### PR DESCRIPTION
…

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

relates to:
- https://github.com/Homebrew/homebrew-core/pull/200589
- https://github.com/Homebrew/homebrew-core/pull/200591
- https://github.com/Homebrew/homebrew-core/pull/200593
- https://github.com/Homebrew/homebrew-core/pull/200595

I have also tested out for some node formulae, works good

```
/opt/homebrew/Library/Homebrew/ignorable.rb:27:in `block in raise'
RuntimeError: No universal binaries found to deuniversalize
```