### PR TITLE
github/workflows: use merge_group instead of push events.

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -2,8 +2,6 @@ name: actionlint
 
 on:
   push:
-    branches:
-      - master
     paths:
       - '.github/workflows/*.ya?ml'
       - '.github/actionlint.yaml'
@@ -11,7 +9,6 @@ on:
     paths:
       - '.github/workflows/*.ya?ml'
       - '.github/actionlint.yaml'
-  merge_group:
 
 env:
   HOMEBREW_DEVELOPER: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,6 @@ name: Docker
 
 on:
   pull_request:
-  push:
-    branches:
-      - master
   merge_group:
   release:
     types:
@@ -75,7 +72,7 @@ jobs:
                 "homebrew/brew:latest"
               )
             fi
-          elif [[ "${GITHUB_EVENT_NAME}" == "push" &&
+          elif [[ "${GITHUB_EVENT_NAME}" == "merge_group" &&
                   "${GITHUB_REF}" == "refs/heads/master" &&
                   "${{ matrix.version }}" == "22.04" ]]; then
             tags+=(

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,6 @@
 name: Documentation CI
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
   merge_group:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
   merge_group:
 


### PR DESCRIPTION
We're currently doing both which doubles the number of jobs we end up running for commits on `master`.