### PR TITLE
cask/info: send missing args after removing openstruct

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "cmd/info"
 
 module Cask
   class Info

--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -31,12 +31,12 @@ module Cask
       output
     end
 
-    sig { params(cask: Cask).void }
-    def self.info(cask)
+    sig { params(cask: Cask, args: Homebrew::Cmd::Info::Args).void }
+    def self.info(cask, args:)
       puts get_info(cask)
 
       require "utils/analytics"
-      ::Utils::Analytics.cask_output(cask, args: Homebrew::CLI::Args.new)
+      ::Utils::Analytics.cask_output(cask, args:)
     end
 
     sig { params(cask: Cask).returns(String) }

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -382,7 +382,7 @@ module Homebrew
       def info_cask(cask)
         require "cask/info"
 
-        Cask::Info.info(cask)
+        Cask::Info.info(cask, args:)
       end
     end
   end

--- a/Library/Homebrew/test/cask/info_spec.rb
+++ b/Library/Homebrew/test/cask/info_spec.rb
@@ -3,6 +3,8 @@
 require "utils"
 
 RSpec.describe Cask::Info, :cask do
+  let(:args) { instance_double(Homebrew::Cmd::Info::Args) }
+
   before do
     # Prevent unnecessary network requests in `Utils::Analytics.cask_output`
     ENV["HOMEBREW_NO_ANALYTICS"] = "1"
@@ -10,7 +12,7 @@ RSpec.describe Cask::Info, :cask do
 
   it "displays some nice info about the specified Cask" do
     expect do
-      described_class.info(Cask::CaskLoader.load("local-transmission"))
+      described_class.info(Cask::CaskLoader.load("local-transmission"), args:)
     end.to output(<<~EOS).to_stdout
       ==> local-transmission: 2.61
       https://transmissionbt.com/
@@ -27,7 +29,7 @@ RSpec.describe Cask::Info, :cask do
 
   it "prints cask dependencies if the Cask has any" do
     expect do
-      described_class.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"))
+      described_class.info(Cask::CaskLoader.load("with-depends-on-cask-multiple"), args:)
     end.to output(<<~EOS).to_stdout
       ==> with-depends-on-cask-multiple: 1.2.3
       https://brew.sh/with-depends-on-cask-multiple
@@ -46,7 +48,7 @@ RSpec.describe Cask::Info, :cask do
 
   it "prints cask and formulas dependencies if the Cask has both" do
     expect do
-      described_class.info(Cask::CaskLoader.load("with-depends-on-everything"))
+      described_class.info(Cask::CaskLoader.load("with-depends-on-everything"), args:)
     end.to output(<<~EOS).to_stdout
       ==> with-depends-on-everything: 1.2.3
       https://brew.sh/with-depends-on-everything
@@ -65,7 +67,7 @@ RSpec.describe Cask::Info, :cask do
 
   it "prints auto_updates if the Cask has `auto_updates true`" do
     expect do
-      described_class.info(Cask::CaskLoader.load("with-auto-updates"))
+      described_class.info(Cask::CaskLoader.load("with-auto-updates"), args:)
     end.to output(<<~EOS).to_stdout
       ==> with-auto-updates: 1.0 (auto_updates)
       https://brew.sh/autoupdates
@@ -82,7 +84,7 @@ RSpec.describe Cask::Info, :cask do
 
   it "prints caveats if the Cask provided one" do
     expect do
-      described_class.info(Cask::CaskLoader.load("with-caveats"))
+      described_class.info(Cask::CaskLoader.load("with-caveats"), args:)
     end.to output(<<~EOS).to_stdout
       ==> with-caveats: 1.2.3
       https://brew.sh/
@@ -109,7 +111,7 @@ RSpec.describe Cask::Info, :cask do
 
   it 'does not print "Caveats" section divider if the caveats block has no output' do
     expect do
-      described_class.info(Cask::CaskLoader.load("with-conditional-caveats"))
+      described_class.info(Cask::CaskLoader.load("with-conditional-caveats"), args:)
     end.to output(<<~EOS).to_stdout
       ==> with-conditional-caveats: 1.2.3
       https://brew.sh/
@@ -126,7 +128,7 @@ RSpec.describe Cask::Info, :cask do
 
   it "prints languages specified in the Cask" do
     expect do
-      described_class.info(Cask::CaskLoader.load("with-languages"))
+      described_class.info(Cask::CaskLoader.load("with-languages"), args:)
     end.to output(<<~EOS).to_stdout
       ==> with-languages: 1.2.3
       https://brew.sh/
@@ -145,7 +147,7 @@ RSpec.describe Cask::Info, :cask do
 
   it 'does not print "Languages" section divider if the languages block has no output' do
     expect do
-      described_class.info(Cask::CaskLoader.load("without-languages"))
+      described_class.info(Cask::CaskLoader.load("without-languages"), args:)
     end.to output(<<~EOS).to_stdout
       ==> without-languages: 1.2.3
       https://brew.sh/
@@ -173,7 +175,7 @@ RSpec.describe Cask::Info, :cask do
       expect(Cask::Tab).to receive(:for_cask).with(cask).and_return(tab)
 
       expect do
-        described_class.info(cask)
+        described_class.info(cask, args:)
       end.to output(<<~EOS).to_stdout
         ==> local-transmission: 2.61
         https://transmissionbt.com/


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This should fix #18915 and is an attempt to fix forward so we don't have to rollback https://github.com/Homebrew/brew/pull/18847 since this seems like a minor issue.

This seems like it was a bug before the recent change to remove OpenStruct from `Homebrew::CLI::Args` but it was failing silently before. Now we pass the args to the `Cask::Info.info` method so that when they eventually reach the `Utils::Analytics.output_analytics` method they are present as expected.

Note that this error requires `HOMEBREW_NO_ANALYTICS` to not be set and `--verbose` to be passed along with `brew info CASK`.

Example error fragment:
```console
$ set -e HOMEBREW_NO_ANALYTICS
$ brew info iterm2 --cask --verbose
==> iterm2: 3.5.10 (auto_updates)
https://iterm2.com/
Installed
/usr/local/Caskroom/iterm2/3.5.4 (91.7MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/i/iterm2.rb
==> Name
iTerm2
==> Description
Terminal emulator as alternative to Apple's Terminal app
==> Artifacts
iTerm.app (App)
Error: undefined method `analytics?' for an instance of Homebrew::CLI::Args
/usr/local/Homebrew/Library/Homebrew/utils/analytics.rb:248:in `output_analytics'
/usr/local/Homebrew/Library/Homebrew/utils/analytics.rb:342:in `cask_output'
/usr/local/Homebrew/Library/Homebrew/cask/info.rb:39:in `info'
...
```

Expected output:

```console
$ brew info iterm2 --cask --verbose
==> iterm2: 3.5.10 (auto_updates)
https://iterm2.com/
Installed
/usr/local/Caskroom/iterm2/3.5.4 (91.7MB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/i/iterm2.rb
==> Name
iTerm2
==> Description
Terminal emulator as alternative to Apple's Terminal app
==> Artifacts
iTerm.app (App)
==> Analytics
==> install (30 days)
Index | Name (with options)                                                                          |  Count |  Percent
-----:|----------------------------------------------------------------------------------------------|-------:|--------:
1     | iterm2                                                                                       | 27,977 |  100.00%
==> install (90 days)
Index | Name (with options)                                                                          |  Count |  Percent
-----:|----------------------------------------------------------------------------------------------|-------:|--------:
1     | iterm2                                                                                       | 75,134 |  100.00%
==> install (365 days)
Index | Name (with options)                                                                         |   Count |  Percent
-----:|---------------------------------------------------------------------------------------------|--------:|--------:
1     | iterm2                                                                                      | 287,267 |  100.00%
```