### PR TITLE
HOMEBREW_SYSTEM_ENV configurable from /etc/homebrew/brew.env

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -132,11 +132,16 @@ export_homebrew_env_file() {
 
 # First, load the system-wide configuration.
 unset SYSTEM_ENV_TAKES_PRIORITY
+
+if [[ -f "/etc/homebrew/brew.env" ]]
+then
+  # Initial load of homebrew system env
+  export_homebrew_env_file "/etc/homebrew/brew.env"
+fi
+
 if [[ -n "${HOMEBREW_SYSTEM_ENV_TAKES_PRIORITY-}" ]]
 then
   SYSTEM_ENV_TAKES_PRIORITY="1"
-else
-  export_homebrew_env_file "/etc/homebrew/brew.env"
 fi
 
 # Next, load the prefix configuration
@@ -152,7 +157,7 @@ fi
 
 export_homebrew_env_file "${HOMEBREW_USER_CONFIG_HOME}/brew.env"
 
-# If the system configuration takes priority, load it last.
+# If the system configuration takes priority, reload it last.
 if [[ -n "${SYSTEM_ENV_TAKES_PRIORITY-}" ]]
 then
   export_homebrew_env_file "/etc/homebrew/brew.env"


### PR DESCRIPTION
Restoring behaviour from initial implementation.

Related to bug #18925 

can be configured in the /etc/homebrew/brew.env file and override configuration in other files

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
