### PR TITLE
utils/github: handle over 30 changed files

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -675,7 +675,11 @@ module GitHub
   end
 
   def self.get_pull_request_changed_files(tap_remote_repo, pull_request)
-    API.open_rest(url_to("repos", tap_remote_repo, "pulls", pull_request, "files"))
+    files = []
+    API.paginate_rest(url_to("repos", tap_remote_repo, "pulls", pull_request, "files")) do |result|
+      files.concat(result)
+    end
+    files
   end
 
   private_class_method def self.add_auth_token_to_url!(url)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related to issue seen while working on https://github.com/Homebrew/homebrew-core/pull/198115 and temporary alternative CODEOWNERS in https://github.com/Homebrew/homebrew-core/pull/201069

Before
```ruby
brew(main):001> GitHub.get_pull_request_changed_files("Homebrew/homebrew-core", 198115).size
=> 30
brew(main):002> GitHub.get_pull_request_changed_files("Homebrew/homebrew-core", 198115).last["filename"]
=> "Formula/l/leela-zero.rb"
```

After
```ruby
brew(main):001> GitHub.get_pull_request_changed_files("Homebrew/homebrew-core", 198115).size
=> 77
brew(main):002> GitHub.get_pull_request_changed_files("Homebrew/homebrew-core", 198115).last["filename"]
=> "Formula/z/znc.rb"
```