### PR TITLE
formula: conditionally use executable name as completion name

### DIFF
--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1897,9 +1897,9 @@ RSpec.describe Formula do
 
     it "generates completion scripts" do
       f.brew { f.install }
-      expect(f.bash_completion/"testball").to be_a_file
-      expect(f.zsh_completion/"_testball").to be_a_file
-      expect(f.fish_completion/"testball.fish").to be_a_file
+      expect(f.bash_completion/"foo").to be_a_file
+      expect(f.zsh_completion/"_foo").to be_a_file
+      expect(f.fish_completion/"foo.fish").to be_a_file
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In most cases, when running `generate_completions_from_executable` with a formula's `bin`/`sbin` executable, the resulting completion is usually intended for the executable itself.

From a quick glance, this should avoid majority of `base_name` overrides in Homebrew/core. Formulae that use `register-python-argcomplete` may still need an override (e.g. `azure-cli`, `commitizen`)

---

For non-`bin`/`sbin` executables, the original default of formula name is used as these have higher chance of being an intermediary/helper executable, e.g. `libexec/"bin/register-python-argcomplete"` (`azure-cli`) or a helper `go` script (`caddy`)