### PR TITLE
cmd/list: fix duplicate casks when symlinks exist

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -214,7 +214,15 @@ module Homebrew
       sig { void }
       def list_casks
         casks = if args.no_named?
-          Cask::Caskroom.casks
+          cask_paths = Cask::Caskroom.path.children.map do |path|
+            if path.symlink?
+              real_path = path.realpath
+              real_path.basename.to_s
+            else
+              path.basename.to_s
+            end
+          end.uniq
+          cask_paths.map { |name| Cask::CaskLoader.load(name) }
         else
           filtered_args = args.named.dup.delete_if do |n|
             Homebrew.failed = true unless Cask::Caskroom.path.join(n).exist?


### PR DESCRIPTION
When a cask is renamed (e.g. logi-options-plus to logi-options+), Homebrew creates a symlink in the Caskroom directory. Currently, `brew list --cask` shows both the original and symlinked cask as separate entries. This patch modifies the listing logic to resolve symlinks and show only unique casks.

Fixes #18849

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
