### PR TITLE
patch: restore output from failed patch

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -150,6 +150,7 @@ class ExternalPatch
       end
     end
   rescue ErrorDuringExecution => e
+    onoe e
     f = resource.owner.owner
     cmd, *args = e.cmd
     raise BuildError.new(f, cmd, args, ENV.to_hash)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before https://github.com/Homebrew/brew/pull/18613, we used `safe_system` which would print stderr by default. After switching to `Utils.safe_popen_write`, stderr/stdout is captured in the exception and discarded.

This had caused some confusion in PRs as the resulting logs don't clearly explain failure.

Current `brew` output looks like:
```
==> Patching
==> Applying b6cf2e7222c24343b868986e867ddb7adad0bf30.patch

READ THIS: https://docs.brew.sh/Troubleshooting
```

With change, the output is shown to user, e.g.
```
==> Patching
==> Applying b6cf2e7222c24343b868986e867ddb7adad0bf30.patch
Error: Failure while executing; `patch -g 0 -f -p1` exited with 1. Here's the output:
patching file 'src/fastnetmon.cpp'
2 out of 2 hunks failed--saving rejects to 'src/fastnetmon.cpp.rej'
patching file 'src/fastnetmon_api_client.cpp'
2 out of 2 hunks failed--saving rejects to 'src/fastnetmon_api_client.cpp.rej'

READ THIS: https://docs.brew.sh/Troubleshooting
```

