### PR TITLE
os/mac/pkgconfig/15: update expat version for 15.2

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/15/expat.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/15/expat.pc
@@ -5,7 +5,7 @@ libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: expat
-Version: 2.6.1
+Version: 2.6.3
 Description: expat XML parser
 URL: https://libexpat.github.io/
 Libs: -L${libdir} -lexpat


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Saw failure in another PR probably from https://github.com/actions/runner-images/commit/45226c1116cdb863fcc3804d00c9aaaedb270b52

---

```console
❯ grep VERSION /Library/Developer/CommandLineTools/SDKs/MacOSX15.2.sdk/usr/include/expat_config.h
#define PACKAGE_VERSION "2.6.3"
#define VERSION "2.6.3"
```