### PR TITLE
formula: update `pour_bottle?` CLT error message

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4286,9 +4286,11 @@ class Formula
         lambda do |_|
           on_macos do
             T.bind(self, PourBottleCheck)
-            reason(+<<~EOS)
-              The bottle needs the Apple Command Line Tools to be installed.
-                You can install them, if desired, with:
+            reason(<<~EOS)
+              The bottle needs the Xcode Command Line Tools to be installed at /Library/Developer/CommandLineTools.
+              Development tools provided by Xcode.app are not sufficient.
+
+              You can install the Xcode Command Line Tools, if desired, with:
                   xcode-select --install
             EOS
             satisfy { MacOS::CLT.installed? }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We have received multiple bug reports from users complaining that `brew`
tells them to install the CLT when they already have Xcode installed.
See, for example, #18976.

Let's try to avoid these issues from being opened by making the error
message more explicit that we require the CLT at a specific location,
and that installing Xcode does not suffice.
