### PR TITLE
github_runner_matrix: restore self-hosted Linux timeout

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -73,6 +73,7 @@ class GitHubRunnerMatrix
   private
 
   SELF_HOSTED_LINUX_RUNNER = "linux-self-hosted-1"
+  SELF_HOSTED_LINUX_TIMEOUT = 4320 # 72 hours
   # ARM macOS timeout, keep this under 1/2 of GitHub's job execution time limit for self-hosted runners.
   # https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#usage-limits
   GITHUB_ACTIONS_LONG_TIMEOUT = 2160 # 36 hours
@@ -90,7 +91,7 @@ class GitHubRunnerMatrix
         options: "--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED",
       },
       workdir:   "/github/home",
-      timeout:   GITHUB_ACTIONS_LONG_TIMEOUT,
+      timeout:   SELF_HOSTED_LINUX_TIMEOUT,
       cleanup:   linux_runner == SELF_HOSTED_LINUX_RUNNER,
     )
   end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Needed to do a full run for some Linux-only formulae.

Once we confirm no linkage after full run, we can consider switching some Linux-only formulae to use `CI-skip-recursive-dependents`.