### PR TITLE
tap command: add -f alias to --force flag

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -42,7 +42,7 @@ module Homebrew
         switch "--eval-all",
                description: "Evaluate all the formulae, casks and aliases in the new tap to check validity. " \
                             "Implied if `HOMEBREW_EVAL_ALL` is set."
-        switch "--force",
+        switch "-f", "--force",
                description: "Force install core taps even under API mode."
 
         named_args :tap, max: 2


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Make `brew tap -f` == `brew tap --force`.

* Current behavior is to reject `-f` with `Error: ambiguous option: -f`, however the only conflict is the disabled `--full` flag.
* Improve consistency: `tap` is the only command with a `--force` option that isn't explicitly aliased w/ `-f` (see: `git grep 'switch.*"--force"' Library/Homebrew`)
