### PR TITLE
sorbet: Add an RBI file for `PyCall`

### DIFF
--- a/Library/Homebrew/sorbet/rbi/pycall-setup.rbi
+++ b/Library/Homebrew/sorbet/rbi/pycall-setup.rbi
@@ -1,0 +1,14 @@
+# typed: true # rubocop:disable Sorbet/StrictSigil
+
+module InfluxDBClient3; end
+
+# This is required for  the `formula-analytics` tap's usage of `PyCall`.
+module PyCall
+  module Import
+    def self.pyfrom(*args); end
+
+    def self.import(*args); end
+  end
+
+  class PyError; end # rubocop:disable Lint/EmptyClass
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/17297.
- Companion PR to https://github.com/Homebrew/homebrew-formula-analytics/pull/538.
- This is used in `Homebrew/formula-analytics` to import Python modules, specifically the InfluxDB client we need.
- Sorbet complained that it couldn‘t find the `PyCall` reference:

```
/opt/homebrew/Library/Taps/homebrew/homebrew-formula-analytics/lib/pycall-setup.rb:7: Unable to resolve constant PyCall https://srb.help/5002
     7 |  extend PyCall::Import

```