### PR TITLE
update prerelease check to allow standard release

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -56,17 +56,13 @@ module SharedAudits
     release = github_release_data(user, repo, tag)
     return unless release
 
-    exception, name, version = if formula
-      [formula.tap&.audit_exception(:github_prerelease_allowlist, formula.name), formula.name, formula.version]
+    exception, version = if formula
+      [formula.tap&.audit_exception(:github_prerelease_allowlist, formula.name), formula.version]
     elsif cask
-      [cask.tap&.audit_exception(:github_prerelease_allowlist, cask.token), cask.token, cask.version]
+      [cask.tap&.audit_exception(:github_prerelease_allowlist, cask.token), cask.version]
     end
 
     return "#{tag} is a GitHub pre-release." if release["prerelease"] && [version, "all"].exclude?(exception)
-
-    if !release["prerelease"] && exception
-      return "#{tag} is not a GitHub pre-release but '#{name}' is in the GitHub prerelease allowlist."
-    end
 
     "#{tag} is a GitHub draft." if release["draft"]
   end

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -56,13 +56,17 @@ module SharedAudits
     release = github_release_data(user, repo, tag)
     return unless release
 
-    exception, version = if formula
-      [formula.tap&.audit_exception(:github_prerelease_allowlist, formula.name), formula.version]
+    exception, name, version = if formula
+      [formula.tap&.audit_exception(:github_prerelease_allowlist, formula.name), formula.name, formula.version]
     elsif cask
-      [cask.tap&.audit_exception(:github_prerelease_allowlist, cask.token), cask.version]
+      [cask.tap&.audit_exception(:github_prerelease_allowlist, cask.token), cask.token, cask.version]
     end
 
-    return "#{tag} is a GitHub pre-release." if release["prerelease"] && [version, "all"].exclude?(exception)
+    return "#{tag} is a GitHub pre-release." if release["prerelease"] && [version, "all", "any"].exclude?(exception)
+
+    if !release["prerelease"] && [version, "any"].exclude?(exception)
+      return "#{tag} is not a GitHub pre-release but '#{name}' is in the GitHub prerelease allowlist."
+    end
 
     "#{tag} is a GitHub draft." if release["draft"]
   end


### PR DESCRIPTION
When a formula or cask is written on the `github_prerelease_allowlist.json`, prerelease is allowed but interestingly it prohibits regular release. I think this should be also allowed too.

Here is an example.
- https://github.com/Homebrew/homebrew-cask/pull/193893

`utm@beta` cask has a version `4.6.1` but `utm` is now `4.6.3`. On my thought,  `beta`  branch should always have more up to date version than the normal branch and so it should be `4.6.3` not `4.6.1`.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
