### PR TITLE
fix prerelease check to allow standard release

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -64,7 +64,7 @@ module SharedAudits
 
     return "#{tag} is a GitHub pre-release." if release["prerelease"] && [version, "all", "any"].exclude?(exception)
 
-    if !release["prerelease"] && [version, "any"].exclude?(exception)
+    if !release["prerelease"] && exception && [version, "any"].exclude?(exception)
       return "#{tag} is not a GitHub pre-release but '#{name}' is in the GitHub prerelease allowlist."
     end
 


### PR DESCRIPTION
I think my previous PR broke the version check logic,
- https://github.com/Homebrew/brew/pull/19001

Here is the failed actions
- https://github.com/Homebrew/homebrew-core/actions/runs/12514067679/job/34911068323?pr=202542
- https://github.com/Homebrew/homebrew-core/actions/runs/12514611522/job/34911059619?pr=202532

and noticed that the exception should exist. 😥

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
