### PR TITLE
cask: fewer GitHub Actions warnings.

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -82,7 +82,8 @@ module Cask
 
     sig { override.params(filename: Pathname).void }
     def verify_download_integrity(filename)
-      if @cask.sha256 == :no_check
+      official_cask_tap = @cask.tap&.official?
+      if @cask.sha256 == :no_check && !official_cask_tap
         opoo "No checksum defined for cask '#{@cask}', skipping verification."
         return
       end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -107,7 +107,8 @@ module Cask
       backup if force? && @cask.staged_path.exist? && @cask.metadata_versioned_path.exist?
 
       oh1 "Installing Cask #{Formatter.identifier(@cask)}"
-      opoo "macOS's Gatekeeper has been disabled for this Cask" unless quarantine?
+      # GitHub Actions globally disables Gatekeeper.
+      opoo "macOS's Gatekeeper has been disabled for this Cask" if !quarantine? && !GitHub::Actions.env_set?
       stage
 
       @cask.config = @cask.default_config.merge(old_config)

--- a/Library/Homebrew/test/cask/download_spec.rb
+++ b/Library/Homebrew/test/cask/download_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Cask::Download, :cask do
   describe "#verify_download_integrity" do
     subject(:verification) { described_class.new(cask).verify_download_integrity(downloaded_path) }
 
-    let(:cask) { instance_double(Cask::Cask, token: "cask", sha256: expected_sha256) }
+    let(:tap) { nil }
+    let(:cask) { instance_double(Cask::Cask, token: "cask", sha256: expected_sha256, tap:) }
     let(:cafebabe) { "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe" }
     let(:deadbeef) { "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" }
     let(:computed_sha256) { cafebabe }
@@ -17,8 +18,16 @@ RSpec.describe Cask::Download, :cask do
     context "when the expected checksum is :no_check" do
       let(:expected_sha256) { :no_check }
 
-      it "skips the check" do
+      it "warns about skipping the check" do
         expect { verification }.to output(/skipping verification/).to_stderr
+      end
+
+      context "with an official tap" do
+        let(:tap) { CoreCaskTap.instance }
+
+        it "does not warn about skipping the check" do
+          expect { verification }.not_to output(/skipping verification/).to_stderr
+        end
       end
     end
 


### PR DESCRIPTION
- don't care about no checksums being defined for official casks
- don't complain about Gatekeeper being disabled on GitHub Actions as it's been globally disabled by the GitHub Actions team