### PR TITLE
Xorg: Handle archive.mesa3d.org URLs

### DIFF
--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -14,6 +14,7 @@ module Homebrew
       # * `https://www.x.org/archive/individual/lib/libexample-1.2.3.tar.bz2`
       # * `https://ftp.x.org/archive/individual/lib/libexample-1.2.3.tar.bz2`
       # * `https://www.x.org/pub/individual/doc/example-1.2.3.tar.gz`
+      # * `https://xorg.freedesktop.org/archive/individual/util/example-1.2.3.tar.xz`
       #
       # The notable differences between URLs are as follows:
       #
@@ -50,8 +51,10 @@ module Homebrew
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
           ^https?://(?:[^/]+?\.)* # Scheme and any leading subdomains
-          (?:x\.org/(?:[^/]+/)*individual/(?:[^/]+/)*#{MODULE_REGEX.source.strip}
-          |freedesktop\.org/(?:archive|dist|software)/(?:[^/]+/)*#{MODULE_REGEX.source.strip})
+          (?:x\.org/(?:[^/]+/)*individual
+            |freedesktop\.org/(?:archive|dist|software)
+            |archive\.mesa3d\.org)
+          /(?:[^/]+/)*#{MODULE_REGEX.source.strip}
         }ix
 
         # Used to cache page content, so we don't fetch the same pages

--- a/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/xorg_spec.rb
@@ -7,36 +7,46 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
 
   let(:xorg_urls) do
     {
-      app:     "https://www.x.org/archive/individual/app/abc-1.2.3.tar.bz2",
-      font:    "https://www.x.org/archive/individual/font/abc-1.2.3.tar.bz2",
-      lib:     "https://www.x.org/archive/individual/lib/libabc-1.2.3.tar.bz2",
-      ftp_lib: "https://ftp.x.org/archive/individual/lib/libabc-1.2.3.tar.bz2",
-      pub_doc: "https://www.x.org/pub/individual/doc/abc-1.2.3.tar.bz2",
+      app:         "https://www.x.org/archive/individual/app/abc-1.2.3.tar.bz2",
+      font:        "https://www.x.org/archive/individual/font/abc-1.2.3.tar.bz2",
+      lib:         "https://www.x.org/archive/individual/lib/libabc-1.2.3.tar.bz2",
+      ftp_lib:     "https://ftp.x.org/archive/individual/lib/libabc-1.2.3.tar.bz2",
+      pub_doc:     "https://www.x.org/pub/individual/doc/abc-1.2.3.tar.bz2",
+      freedesktop: "https://xorg.freedesktop.org/archive/individual/util/abc-1.2.3.tar.xz",
+      mesa:        "https://archive.mesa3d.org/mesa-1.2.3.tar.xz",
     }
   end
   let(:non_xorg_url) { "https://brew.sh/test" }
 
   let(:generated) do
     {
-      app:     {
+      app:         {
         url:   "https://www.x.org/archive/individual/app/",
         regex: /href=.*?abc[._-]v?(\d+(?:\.\d+)+)\.t/i,
       },
-      font:    {
+      font:        {
         url:   "https://www.x.org/archive/individual/font/",
         regex: /href=.*?abc[._-]v?(\d+(?:\.\d+)+)\.t/i,
       },
-      lib:     {
+      lib:         {
         url:   "https://www.x.org/archive/individual/lib/",
         regex: /href=.*?libabc[._-]v?(\d+(?:\.\d+)+)\.t/i,
       },
-      ftp_lib: {
+      ftp_lib:     {
         url:   "https://ftp.x.org/archive/individual/lib/",
         regex: /href=.*?libabc[._-]v?(\d+(?:\.\d+)+)\.t/i,
       },
-      pub_doc: {
+      pub_doc:     {
         url:   "https://www.x.org/archive/individual/doc/",
         regex: /href=.*?abc[._-]v?(\d+(?:\.\d+)+)\.t/i,
+      },
+      freedesktop: {
+        url:   "https://xorg.freedesktop.org/archive/individual/util/",
+        regex: /href=.*?abc[._-]v?(\d+(?:\.\d+)+)\.t/i,
+      },
+      mesa:        {
+        url:   "https://archive.mesa3d.org/",
+        regex: /href=.*?mesa[._-]v?(\d+(?:\.\d+)+)\.t/i,
       },
     }
   end
@@ -48,6 +58,8 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
       expect(xorg.match?(xorg_urls[:lib])).to be true
       expect(xorg.match?(xorg_urls[:ftp_lib])).to be true
       expect(xorg.match?(xorg_urls[:pub_doc])).to be true
+      expect(xorg.match?(xorg_urls[:freedesktop])).to be true
+      expect(xorg.match?(xorg_urls[:mesa])).to be true
     end
 
     it "returns false for a non-X.Org URL" do
@@ -62,6 +74,8 @@ RSpec.describe Homebrew::Livecheck::Strategy::Xorg do
       expect(xorg.generate_input_values(xorg_urls[:lib])).to eq(generated[:lib])
       expect(xorg.generate_input_values(xorg_urls[:ftp_lib])).to eq(generated[:ftp_lib])
       expect(xorg.generate_input_values(xorg_urls[:pub_doc])).to eq(generated[:pub_doc])
+      expect(xorg.generate_input_values(xorg_urls[:freedesktop])).to eq(generated[:freedesktop])
+      expect(xorg.generate_input_values(xorg_urls[:mesa])).to eq(generated[:mesa])
     end
 
     it "returns an empty hash for a non-X.org URL" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `mesa` formula currently uses a mesa.freedesktop.org/archive/ `stable` URL but it redirects to archive.mesa3d.org. [Upstream links to archive.mesa3d.org](https://docs.mesa3d.org/download.html) as the location to find Mesa releases, so we should update the formula URLs accordingly.

This updates the `Xorg` strategy to be able to handle archive.mesa3d.org URLs, so livecheck will continue to be able to check `mesa` without needing a one-off `livecheck` block. [This would also work for `mesalib-glw` (which has an archive.mesa3d.org `stable` URL) but that formula is deprecated.]