### PR TITLE
Use `depot` runners for Mac builds

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -162,7 +162,7 @@ class GitHubRunnerMatrix
                                 macos_version >= OLDEST_GITHUB_ACTIONS_ARM_MACOS_RUNNER
 
       runner, timeout = if use_github_runner && github_runner_available
-        ["macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
+        ["depot-macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
       elsif macos_version >= :monterey
         ["#{version}-arm64#{ephemeral_suffix}", runner_timeout]
       else
@@ -185,7 +185,7 @@ class GitHubRunnerMatrix
                                 macos_version >= OLDEST_GITHUB_ACTIONS_INTEL_MACOS_RUNNER
 
       runner, timeout = if use_github_runner && github_runner_available
-        ["macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
+        ["depot-macos-#{version}", GITHUB_ACTIONS_RUNNER_TIMEOUT]
       else
         ["#{version}-x86_64#{ephemeral_suffix}", runner_timeout]
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Have y'all considered using Depot's runners for your builds? Depot has good pricing for the larger runners and will handle all the ephemeral infrastructure for you. May not be able to cover some of the legacy configurations but worth looking into. We've had a good experience with it, at your PR volume might be worth it.

https://depot.dev/docs/github-actions/runner-types#macos-runners