### PR TITLE
env_config: Improve the deprecated envvar message

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -527,9 +527,8 @@ module Homebrew
 
           falsy_values = %w[false no off nil 0]
           if falsy_values.include?(env_value&.downcase)
-            odeprecated "#{env}=#{env_value}", <<~EOS
-              If you wish to enable #{env}, #{env}=1
-              If you wish to disable #{env}, #{env}=
+            odeprecated "#{env}=#{env_value}", <<~EOS.chomp
+              #{env}=1 to enable and #{env}= (an empty value) to disable
             EOS
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before:

```
❯ HOMEBREW_NO_ANALYTICS=0 brew formula-analytics --days-ago=2
Error: Calling HOMEBREW_NO_ANALYTICS=0 is deprecated! Use If you wish to enable HOMEBREW_NO_ANALYTICS, use HOMEBREW_NO_ANALYTICS=1
If you wish to disable HOMEBREW_NO_ANALYTICS, use HOMEBREW_NO_ANALYTICS= instead.
```

After:

```
❯ HOMEBREW_NO_ANALYTICS=0 brew formula-analytics --days-ago=2
Error: Calling HOMEBREW_NO_ANALYTICS=0 is deprecated! Use HOMEBREW_NO_ANALYTICS=1 to enable and HOMEBREW_NO_ANALYTICS= (an empty value) to disable instead.
```
