### PR TITLE
extend/ENV/super: always set PKG_CONFIG_LIBDIR

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -65,7 +65,7 @@ module Superenv
     self["RUSTFLAGS"] = Hardware.rustflags_target_cpu(effective_arch)
     self["PATH"] = determine_path
     self["PKG_CONFIG_PATH"] = determine_pkg_config_path
-    self["PKG_CONFIG_LIBDIR"] = determine_pkg_config_libdir
+    self["PKG_CONFIG_LIBDIR"] = determine_pkg_config_libdir || ""
     self["HOMEBREW_CCCFG"] = determine_cccfg
     self["HOMEBREW_OPTIMIZATION_LEVEL"] = "Os"
     self["HOMEBREW_BREW_FILE"] = HOMEBREW_BREW_FILE.to_s


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Setting PKG_CONFIG_LIBDIR overrides compiled default. This helps reduce opportunistic linkage when pkg-config call finds modules installed on system but not included in a formula's dependency tree.

---

The default on Linux is:
* `#{HOMEBREW_PREFIX}/lib/pkgconfig`
* `#{HOMEBREW_PREFIX}/share/pkgconfig`
* `#{HOMEBREW_LIBRARY}/Homebrew/os/linux/pkgconfig`

Removing first 2 are needed to avoid opportunistic linkage. The final path doesn't exist.

On macOS, PKG_CONFIG_LIBDIR is:
https://github.com/Homebrew/brew/blob/e9b0285c14c77fb2ed22ad831bb727ee9ae5abd7/Library/Homebrew/extend/os/mac/extend/ENV/super.rb#L29