### PR TITLE
Change default temp on Linux to /var/tmp.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -65,7 +65,7 @@ else
   CACHE_HOME="${HOMEBREW_XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_DEFAULT_CACHE="${CACHE_HOME}/Homebrew"
   HOMEBREW_DEFAULT_LOGS="${CACHE_HOME}/Homebrew/Logs"
-  HOMEBREW_DEFAULT_TEMP="/tmp"
+  HOMEBREW_DEFAULT_TEMP="/var/tmp"
 fi
 
 realpath() {

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -457,7 +457,7 @@ module Homebrew
                       "different volumes, as macOS has trouble moving symlinks across volumes when the target " \
                       "does not yet exist. This issue typically occurs when using FileVault or custom SSD " \
                       "configurations.",
-        default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
+        default_text: "macOS: `/private/tmp`, Linux: `/var/tmp`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
       HOMEBREW_UPDATE_TO_TAG:                    {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4102,7 +4102,7 @@ command execution e.g. `$(cat file)`.
   the target does not yet exist. This issue typically occurs when using
   FileVault or custom SSD configurations.
   
-  *Default:* macOS: `/private/tmp`, Linux: `/tmp`.
+  *Default:* macOS: `/private/tmp`, Linux: `/var/tmp`.
 
 `HOMEBREW_UPDATE_TO_TAG`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2687,7 +2687,7 @@ If set in Homebrew\[u2019]s system\-wide environment file (\fB/etc/homebrew/brew
 Use this path as the temporary directory for building packages\. Changing this may be needed if your system temporary directory and Homebrew prefix are on different volumes, as macOS has trouble moving symlinks across volumes when the target does not yet exist\. This issue typically occurs when using FileVault or custom SSD configurations\.
 .RS
 .P
-\fIDefault:\fP macOS: \fB/private/tmp\fP, Linux: \fB/tmp\fP\&\.
+\fIDefault:\fP macOS: \fB/private/tmp\fP, Linux: \fB/var/tmp\fP\&\.
 .RE
 .TP
 \fBHOMEBREW_UPDATE_TO_TAG\fP


### PR DESCRIPTION
Previously, the default temporary directory was /tmp on Linux and /private/tmp on macOS. On many Linux distros, including at least Fedora, /tmp is stored in RAM. This diverges from the behavior on macOS and has led to bugs, most notably the inability to install large bottles on memory-limited machines.

This fixes #19037.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Please let me know if there's anything else I need to change.