### PR TITLE
livecheck: allow parent formula reference in resources

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -60,14 +60,14 @@ class Livecheck
   sig {
     params(
       # Name of formula to inherit livecheck info from.
-      formula_name: String,
-    ).returns(T.nilable(String))
+      formula_name: T.any(String, Symbol),
+    ).returns(T.nilable(T.any(String, Symbol)))
   }
   def formula(formula_name = T.unsafe(nil))
     case formula_name
     when nil
       @referenced_formula_name
-    when String
+    when String, :parent
       @referenced_formula_name = formula_name
     end
   end

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -54,9 +54,9 @@ class Livecheck
   end
 
   # Sets the `@referenced_formula_name` instance variable to the provided
-  # `String` or returns the `@referenced_formula_name` instance variable when
-  # no argument is provided. Inherited livecheck values from the referenced
-  # formula (e.g. regex) can be overridden in the `livecheck` block.
+  # `String`/`Symbol` or returns the `@referenced_formula_name` instance
+  # variable when no argument is provided. Inherited livecheck values from the
+  # referenced formula (e.g. regex) can be overridden in the `livecheck` block.
   sig {
     params(
       # Name of formula to inherit livecheck info from.

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -670,14 +670,14 @@ module Homebrew
           if livecheck_url.is_a?(Symbol)
             # This assumes the URL symbol will fit within the available space
             puts "URL (#{livecheck_url}):".ljust(18, " ") + original_url
-          else
+          elsif original_url.present? && original_url != "None"
             puts "URL:              #{original_url}"
           end
           puts "URL (processed):  #{url}" if url != original_url
           if strategies.present? && verbose
             puts "Strategies:       #{strategies.map { |s| livecheck_strategy_names[s] }.join(", ")}"
           end
-          puts "Strategy:         #{strategy.blank? ? "None" : strategy_name}"
+          puts "Strategy:         #{strategy_name}" if strategy.present?
           puts "Regex:            #{livecheck_regex.inspect}" if livecheck_regex.present?
         end
 
@@ -798,17 +798,18 @@ module Homebrew
             end
           end
 
-          version_info[:meta][:url] = {}
-          version_info[:meta][:url][:symbol] = livecheck_url if livecheck_url.is_a?(Symbol) && livecheck_url_string
-          version_info[:meta][:url][:original] = original_url
-          version_info[:meta][:url][:processed] = url if url != original_url
-          if strategy_data[:url].present? && strategy_data[:url] != url
-            version_info[:meta][:url][:strategy] = strategy_data[:url]
+          if url != "None"
+            version_info[:meta][:url] = {}
+            version_info[:meta][:url][:symbol] = livecheck_url if livecheck_url.is_a?(Symbol) && livecheck_url_string
+            version_info[:meta][:url][:original] = original_url
+            version_info[:meta][:url][:processed] = url if url != original_url
+            if strategy_data[:url].present? && strategy_data[:url] != url
+              version_info[:meta][:url][:strategy] = strategy_data[:url]
+            end
+            version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data[:final_url]
+            version_info[:meta][:url][:homebrew_curl] = homebrew_curl if homebrew_curl.present?
           end
-          version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data[:final_url]
-          version_info[:meta][:url][:homebrew_curl] = homebrew_curl if homebrew_curl.present?
-
-          version_info[:meta][:strategy] = strategy.present? ? strategy_name : nil
+          version_info[:meta][:strategy] = strategy_name if strategy.present?
           version_info[:meta][:strategies] = strategies.map { |s| livecheck_strategy_names[s] } if strategies.present?
           version_info[:meta][:regex] = regex.inspect if regex.present?
           version_info[:meta][:cached] = true if strategy_data[:cached] == true
@@ -889,14 +890,14 @@ module Homebrew
           if livecheck_url.is_a?(Symbol)
             # This assumes the URL symbol will fit within the available space
             puts "URL (#{livecheck_url}):".ljust(18, " ") + original_url
-          else
+          elsif original_url.present? && original_url != "None"
             puts "URL:              #{original_url}"
           end
           puts "URL (processed):  #{url}" if url != original_url
           if strategies.present? && verbose
             puts "Strategies:       #{strategies.map { |s| livecheck_strategy_names[s] }.join(", ")}"
           end
-          puts "Strategy:         #{strategy.blank? ? "None" : strategy_name}"
+          puts "Strategy:         #{strategy_name}" if strategy.present?
           puts "Regex:            #{livecheck_regex.inspect}" if livecheck_regex.present?
           if livecheck_reference == :parent
             puts "Formula Ref:      #{full_name ? resource.owner.full_name : resource.owner.name} (parent)"
@@ -998,7 +999,7 @@ module Homebrew
         }
         if livecheck_reference == :parent
           resource_version_info[:meta][:references] =
-            [{ formula: full_name ? resource.owner.full_name : resource.owner.name }]
+            [{ formula: full_name ? resource.owner.full_name : resource.owner.name, symbol: :parent }]
         end
         if url != "None"
           resource_version_info[:meta][:url] = {}
@@ -1012,7 +1013,7 @@ module Homebrew
           end
           resource_version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data&.dig(:final_url)
         end
-        resource_version_info[:meta][:strategy] = strategy.present? ? strategy_name : nil
+        resource_version_info[:meta][:strategy] = strategy_name if strategy.present?
         if strategies.present?
           resource_version_info[:meta][:strategies] = strategies.map { |s| livecheck_strategy_names[s] }
         end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -995,22 +995,23 @@ module Homebrew
 
         resource_version_info[:meta] = {
           livecheck_defined: livecheck_defined,
-          url:               {},
         }
-        if livecheck_reference.presence == :parent
+        if livecheck_reference == :parent
           resource_version_info[:meta][:references] =
-            { formula: full_name ? resource.owner.full_name : resource.owner.name }
-          resource_version_info[:meta][:references][:parent] = true
+            [{ formula: full_name ? resource.owner.full_name : resource.owner.name }]
         end
-        if livecheck_url.is_a?(Symbol) && livecheck_url_string
-          resource_version_info[:meta][:url][:symbol] = livecheck_url
+        if url != "None"
+          resource_version_info[:meta][:url] = {}
+          if livecheck_url.is_a?(Symbol) && livecheck_url_string
+            resource_version_info[:meta][:url][:symbol] = livecheck_url
+          end
+          resource_version_info[:meta][:url][:original] = original_url
+          resource_version_info[:meta][:url][:processed] = url if url != original_url
+          if strategy_data&.dig(:url).present? && strategy_data[:url] != url
+            resource_version_info[:meta][:url][:strategy] = strategy_data[:url]
+          end
+          resource_version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data&.dig(:final_url)
         end
-        resource_version_info[:meta][:url][:original] = original_url if livecheck_reference != :parent
-        resource_version_info[:meta][:url][:processed] = url if url != original_url
-        if strategy_data&.dig(:url).present? && strategy_data[:url] != url
-          resource_version_info[:meta][:url][:strategy] = strategy_data[:url]
-        end
-        resource_version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data&.dig(:final_url)
         resource_version_info[:meta][:strategy] = strategy.present? ? strategy_name : nil
         if strategies.present?
           resource_version_info[:meta][:strategies] = strategies.map { |s| livecheck_strategy_names[s] }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a new `livecheck` strategy, `FormulaLatest`. This will be used in formulae where the latest versions of the resources are identical to the latest version of the formula itself. For example, consider the resource `presto-cli` in `prestodb`:
```ruby
  resource "presto-cli" do
    ...

    livecheck do
      strategy :formula_latest
    end
  end
```
This gives:
```console
➜  homebrew-core git:(master) ✗ brew lc -dvr --autobump prestodb
...

Resource:         presto-cli
livecheck block?: Yes

URL:              None
Strategies:       FormulaLatest
Strategy:         FormulaLatest
Cached?:          Yes

Matched Versions:
0.290 => #<Version:0x0000000103d81338 @version="0.290", @detected_from_url=false>

prestodb: 0.290 ==> 0.290
  presto-cli: 0.290 ==> 0.290
```

Once this is merged, I'll work on automatically updating such resources when `brew bump` is used.