### PR TITLE
Add `HOMEBREW_FORCE_API_AUTO_UPDATE`

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -60,7 +60,7 @@ module Homebrew
       skip_download = target.exist? &&
                       !target.empty? &&
                       (!Homebrew.auto_update_command? ||
-                        Homebrew::EnvConfig.no_auto_update? ||
+                        (Homebrew::EnvConfig.no_auto_update? && !Homebrew::EnvConfig.force_api_auto_update?) ||
                       ((Time.now - stale_seconds) < target.mtime))
       skip_download ||= Homebrew.running_as_root_but_not_owned_by_root?
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -223,6 +223,10 @@ module Homebrew
                      "e.g. `brew install ./package.rb`.",
         boolean:     true,
       },
+      HOMEBREW_FORCE_API_AUTO_UPDATE:            {
+        description: "If set, update the Homebrew API formula or cask data even if `HOMEBREW_NO_AUTO_UPDATE` is set.",
+        boolean:     true,
+      },
       HOMEBREW_FORCE_BREWED_CA_CERTIFICATES:     {
         description: "If set, always use a Homebrew-installed `ca-certificates` rather than the system version. " \
                      "Automatically set if the system version is too old.",

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -137,6 +137,9 @@ module Homebrew::EnvConfig
     def forbidden_taps; end
 
     sig { returns(T::Boolean) }
+    def force_api_auto_update?; end
+
+    sig { returns(T::Boolean) }
     def force_brewed_ca_certificates?; end
 
     sig { returns(T::Boolean) }


### PR DESCRIPTION
If set, this will update the Homebrew API formula or cask data even if `HOMEBREW_NO_AUTO_UPDATE` is set.

This is useful in cases where you want to update the cached API data but don't want to update Homebrew itself.