### PR TITLE
Fix `HOMEBREW_*BREW_WRAPPER` behaviour

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -182,8 +182,9 @@ esac
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/helpers.sh"
 
 # Require HOMEBREW_BREW_WRAPPER to be set if HOMEBREW_FORCE_BREW_WRAPPER is set
-# for all non-trivial commands (i.e. not run above).
-if [[ -n "${HOMEBREW_FORCE_BREW_WRAPPER}" ]]
+# (and HOMEBREW_NO_FORCE_BREW_WRAPPER is not set) for all non-trivial commands
+# (i.e. not defined above this line e.g. formulae or --cellar).
+if [[ -z "${HOMEBREW_NO_FORCE_BREW_WRAPPER:-}" && -n "${HOMEBREW_FORCE_BREW_WRAPPER:-}" ]]
 then
   if [[ -z "${HOMEBREW_BREW_WRAPPER:-}" ]]
   then
@@ -195,7 +196,7 @@ but HOMEBREW_BREW_WRAPPER was unset. This indicates that you are running
 directly but should instead run
   ${HOMEBREW_FORCE_BREW_WRAPPER}
 EOS
-  elif [[ "${HOMEBREW_FORCE_BREW_WRAPPER:-}" != "${HOMEBREW_BREW_WRAPPER:-}" ]]
+  elif [[ "${HOMEBREW_FORCE_BREW_WRAPPER}" != "${HOMEBREW_BREW_WRAPPER}" ]]
   then
     odie <<EOS
 HOMEBREW_FORCE_BREW_WRAPPER was set to

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -376,6 +376,10 @@ module Homebrew
         description: "If set, do not print any hints about changing Homebrew's behaviour with environment variables.",
         boolean:     true,
       },
+      HOMEBREW_NO_FORCE_BREW_WRAPPER:            {
+        description: "If set, disables `HOMEBREW_FORCE_BREW_WRAPPER` behaviour, even if set.",
+        boolean:     true,
+      },
       HOMEBREW_NO_GITHUB_API:                    {
         description: "If set, do not use the GitHub API, e.g. for searches or fetching relevant issues " \
                      "after a failed install.",

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -142,8 +142,8 @@ module Homebrew::EnvConfig
     sig { returns(T::Boolean) }
     def force_api_auto_update?; end
 
-    sig { returns(T::Boolean) }
-    def force_brew_wrapper?; end
+    sig { returns(T.nilable(::String)) }
+    def force_brew_wrapper; end
 
     sig { returns(T::Boolean) }
     def force_brewed_ca_certificates?; end
@@ -237,6 +237,9 @@ module Homebrew::EnvConfig
 
     sig { returns(T::Boolean) }
     def no_env_hints?; end
+
+    sig { returns(T::Boolean) }
+    def no_force_brew_wrapper?; end
 
     sig { returns(T::Boolean) }
     def no_github_api?; end


### PR DESCRIPTION
- handle reading from variables that may not be defined yet
- fix incorrect `env_config.rbi` file entry
- avoid unnecessary handling of defined variables
- add `HOMEBREW_NO_FORCE_BREW_WRAPPER` to disable `HOMEBREW_FORCE_BREW_WRAPPER` functionality if needed