### PR TITLE
sorbet/config: handle some homebrew-bundle cases.

### DIFF
--- a/Library/Homebrew/sorbet/config
+++ b/Library/Homebrew/sorbet/config
@@ -2,8 +2,10 @@
 --enable-experimental-requires-ancestor
 --ignore=/vendor/bundle
 --ignore=/vendor/gems
+--ignore=/vendor/ruby
 --ignore=/vendor/portable-ruby
 --ignore=/test/.gem
+--ignore=/spec/stub
 --ignore=Formula
 --ignore=Casks
 --suppress-error-code=7019


### PR DESCRIPTION
- need to ignore `vendor/ruby` because there can be gems in there
- need to ignore `spec/stub` because it's defining RSpec-only stub methods that aren't used outside of RSpec and don't have the same e.g. signatures.