### PR TITLE
bin/brew: don't allow unbound variables.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,4 +1,4 @@
-#!/bin/bash -p
+#!/bin/bash -pu
 set -u
 
 # Fail fast with concise message when not using bash


### PR DESCRIPTION
This can fail for users using `bash -u` or `set -u` in their shell so let's try to be stricter here for both them and us.

Related to https://github.com/Homebrew/brew/pull/19061