### PR TITLE
dependabot: update github-actions weekly.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     allow:
       - dependency-type: all
     # The actions in triage-issues.yml are updated in the Homebrew/.github repo


### PR DESCRIPTION
This should reduce the amount of PR spam we get.

If there's critical vulnerabilities: they will be updated more often.