### PR TITLE
Disable parallel for small test coverage runs

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -3,6 +3,7 @@
 
 require "abstract_command"
 require "fileutils"
+require "hardware"
 require "system_command"
 
 module Homebrew
@@ -75,7 +76,13 @@ module Homebrew
             end
           end
 
-          parallel = false if args.profile
+          # We use `ParallelTests.last_process?` in `test/spec_helper.rb` to
+          # handle SimpleCov output but, due to how the method is implemented,
+          # it doesn't work as expected if the number of processes is greater
+          # than one but lower than the number of CPU cores in the execution
+          # environment. Coverage information isn't saved in that scenario,
+          # so we disable parallel testing as a workaround in this case.
+          parallel = false if args.profile || (args.coverage? && files.length < Hardware::CPU.cores)
 
           parallel_rspec_log_name = "parallel_runtime_rspec"
           parallel_rspec_log_name = "#{parallel_rspec_log_name}.generic" if args.generic?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew tests --coverage` can fail to produce coverage information when run on a small number of tests (e.g., `--only utils/curl`). We use `ParallelTests::last_process?` in `tests/spec_helper.rb` to handle the SimpleCov output but due to the way the method is implemented, it doesn't work as expected if the number of processes is greater than one but lower than the number of cores.

For example, this is the current output for a small run (no coverage generated):

```
$ brew tests --only utils/curl --coverage
Randomized with seed 26057
1 process for 1 spec, ~ 1 spec per process
.........................................



Took 0 seconds
```

This is the output with this change (coverage generated as expected):

```
$ brew tests --only utils/curl --coverage
Randomized with seed 9280
Run options: exclude {:needs_linux=>true, :needs_network=>true, :needs_ci=>true, :needs_svn=>true}

Randomized with seed 9280
.........................................

Finished in 0.10351 seconds (files took 0.56166 seconds to load)
41 examples, 0 failures

Randomized with seed 9280

Coverage report generated for brew:80041 to /opt/homebrew/Library/Homebrew/test/coverage.
Line Coverage: 17.05% (8454 / 49580)
Branch Coverage: 2.32% (204 / 8797)
Coverage report generated for brew:80041 to /opt/homebrew/Library/Homebrew/test/coverage/coverage.xml. 8454 / 49580 LOC (17.05%) covered; 204 / 8797 BC (2.32%) covere
```

I tried to address this through changes to  `spec_helper.rb` and/or changes to `ParallelTests` but didn't meet with any success.

This works around the issue by disabling parallel test execution when the `--coverage` option is used and the number of files to be tested is lower than the number of CPU cores. I've been using this workaround for months and it works as expected on my machine (M1 Pro and now M4 Pro).