### PR TITLE
pr-upload: fix `--warn-on-upload-failure` functionality

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -260,6 +260,8 @@ class GitHubPackages
     # We run the preupload check twice to prevent TOCTOU bugs.
     result = preupload_check(user, token, skopeo, formula_full_name, bottle_hash,
                              keep_old:, dry_run:, warn_on_error:)
+    # Skip upload if preupload check returned early.
+    return if result.nil?
 
     formula_name, org, repo, version, rebuild, version_rebuild, image_name, image_uri, keep_old = *result
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

To reproduce: `brew pr-upload --no-commit --warn-on-upload-failure` in a directory with a few bottles where at least one is already uploaded to GitHub Packages.

For bottle uploads that would be skipped due to preupload_check warning about skipped uploads and returning early, the old code errored out due to JSON schema validation failure since the upload was allowed to resume:

    "error"=>"value at /manifests/0/annotations/org.opencontainers.image.ref.name is not a string"

This change ensures that the upload is actually skipped if preupload_check returns no result.

