### PR TITLE
Fix fetch for Intel Sequoia

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -160,7 +160,7 @@ module Homebrew
                     bottle_tag = if (bottle_tag = args.bottle_tag&.to_sym)
                       Utils::Bottles::Tag.from_symbol(bottle_tag)
                     else
-                      Utils::Bottles::Tag.new(system: os, arch:)
+                      Utils::Bottles.tag
                     end
 
                     bottle = formula.bottle_for_tag(bottle_tag)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes #19060. On Intel Sequoia, `brew install` install from Sonoma bottles as expected, but `brew fetch` gives errors due to lack of a `sequoia:` bottle. I'm not sure how exactly the formula installer resolves the bottle tag, but I just took a look at the function that's called and copied it over to the fetch command, and it worked: https://github.com/Homebrew/brew/blob/1e91082d67661715656915372a6a7d9b1868668e/Library/Homebrew/formula_installer.rb#L218
