### PR TITLE
shims/super/cc: handle double dash in args

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -40,7 +40,9 @@ class Cmd
 
   def initialize(arg0, args)
     @arg0 = arg0
-    @args = args.freeze
+    split_args = split_args_at_double_dash(args)
+    @args = split_args[0].freeze
+    @positional_args = split_args[1].freeze
     @config = ENV.fetch("HOMEBREW_CCCFG", "")
     @prefix = ENV["HOMEBREW_PREFIX"]
     @cellar = ENV["HOMEBREW_CELLAR"]
@@ -55,6 +57,15 @@ class Cmd
     @formula_buildpath = ENV["HOMEBREW_FORMULA_BUILDPATH"]
     # matches opt or cellar prefix and formula name
     @keg_regex = %r{(#{Regexp.escape(opt)}|#{Regexp.escape(cellar)})/([\w+-.@]+)}
+  end
+
+  def split_args_at_double_dash(args)
+    double_dash_index = args.find_index("--")
+    if double_dash_index
+      [args[...double_dash_index], args[double_dash_index..]]
+    else
+      [args, []]
+    end
   end
 
   def mode
@@ -130,7 +141,7 @@ class Cmd
       end
     end
 
-    case mode
+    optional_args = case mode
     when :ccld
       cflags + args + cppflags + ldflags
     when :cxxld
@@ -146,6 +157,8 @@ class Cmd
     when :ld
       ldflags + args
     end
+
+    optional_args + @positional_args
   end
 
   def refurbished_args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `cc` shim currently does not handle invocations where `--` is passed as an argument, which (conventionally) indicates that all following arguments be treated as positional (non-optional) arguments. As a result, any refurbished args may get appended after the `--` where they are erroneously treated as input file paths:

```
clang: error: no such file or directory: '-isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk'
clang: error: no such file or directory: '--sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk'; did you mean '--sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk'?
clang: error: no such file or directory: '-isystem/opt/homebrew/include'
clang: error: no such file or directory: '-isystem/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers'
clang: error: no such file or directory: '-L/opt/homebrew/lib'
clang: error: no such file or directory: '-L/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries'
clang: error: no such file or directory: '-Wl,-headerpad_max_install_names'
```

This kind of error was encountered in the wild in some core PRs, e.g. https://github.com/Homebrew/homebrew-core/pull/203929, https://github.com/Homebrew/homebrew-core/pull/203934, https://github.com/Homebrew/homebrew-core/pull/203932, https://github.com/Homebrew/homebrew-core/pull/203944.

This pull request ensures that any modifications to the arguments are applied before the `--` (if `--` is present).

Before:

```
clang called with: -- test.c
superenv added:    -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -isystem/opt/homebrew/include -isystem/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -L/opt/homebrew/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries -Wl,-headerpad_max_install_names
superenv executed: clang -- test.c -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -isystem/opt/homebrew/include -isystem/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -L/opt/homebrew/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries -Wl,-headerpad_max_install_names
```

After:

```
clang called with: -- test.c
superenv added:    -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -isystem/opt/homebrew/include -isystem/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -L/opt/homebrew/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries -Wl,-headerpad_max_install_names
superenv executed: clang -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -isystem/opt/homebrew/include -isystem/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -L/opt/homebrew/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries -Wl,-headerpad_max_install_names -- test.c
```