### PR TITLE
update.sh: reject unknown long opts

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -352,7 +352,11 @@ homebrew-update() {
         HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH=1
         ;;
       --auto-update) export HOMEBREW_UPDATE_AUTO=1 ;;
-      --*) ;;
+      --*)
+        onoe "Unknown option: ${option}"
+        brew help update
+        exit 1
+        ;;
       -*)
         [[ "${option}" == *v* ]] && HOMEBREW_VERBOSE=1
         [[ "${option}" == *q* ]] && HOMEBREW_QUIET=1


### PR DESCRIPTION
I accidentally typed `brew update --greedy` instead of `brew upgrade --greedy` and got some strange output.

This fix causes unrecognized long options to throw a usage message and exit like all the other subcommands.

Before:
```
% brew update --greedy
==> Updating Homebrew...
Usage: brew update-report [--auto-update] [--force]

The Ruby implementation of brew update. Never called manually.
[...]
```

After:
```
% brew update --greedy
Error: Unrecognized option '--greedy'
Usage: brew update, up [options]

Fetch the newest version of Homebrew and all formulae from GitHub using git(1)
and perform any necessary migrations.
[...]
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
