### PR TITLE
Remove unused `unused` params in livecheck strategies

### DIFF
--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -88,16 +88,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -96,16 +96,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -75,16 +75,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/crate.rb
+++ b/Library/Homebrew/livecheck/strategy/crate.rb
@@ -81,11 +81,10 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, &block)
           match_data = { matches: {}, regex:, url: }
           match_data[:cached] = true if provided_content.is_a?(String)
 

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -40,11 +40,10 @@ module Homebrew
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            unused:           T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
@@ -54,7 +53,6 @@ module Homebrew
             url:,
             regex:,
             provided_content:,
-            **unused,
             &block || proc { |yaml| yaml["version"] }
           )
         end

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -82,14 +82,13 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            cask:    Cask::Cask,
-            url:     T.nilable(String),
-            regex:   T.nilable(Regexp),
-            _unused: T.untyped,
-            block:   T.nilable(Proc),
+            cask:  Cask::Cask,
+            url:   T.nilable(String),
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(cask:, url: nil, regex: nil, **_unused, &block)
+        def self.find_versions(cask:, url: nil, regex: nil, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -189,13 +189,12 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:     String,
-            regex:   T.nilable(Regexp),
-            _unused: T.untyped,
-            block:   T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **_unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           match_data = { matches: {}, regex:, url: }
 
           tags_data = tag_info(url, regex)

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -73,13 +73,12 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:     String,
-            regex:   Regexp,
-            _unused: T.untyped,
-            block:   T.nilable(Proc),
+            url:   String,
+            regex: Regexp,
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: GithubReleases::DEFAULT_REGEX, **_unused, &block)
+        def self.find_versions(url:, regex: GithubReleases::DEFAULT_REGEX, &block)
           match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)

--- a/Library/Homebrew/livecheck/strategy/github_releases.rb
+++ b/Library/Homebrew/livecheck/strategy/github_releases.rb
@@ -127,13 +127,12 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:     String,
-            regex:   Regexp,
-            _unused: T.untyped,
-            block:   T.nilable(Proc),
+            url:   String,
+            regex: Regexp,
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: DEFAULT_REGEX, **_unused, &block)
+        def self.find_versions(url:, regex: DEFAULT_REGEX, &block)
           match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -77,19 +77,17 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
           version_data = PageMatch.find_versions(
             url:   generated[:url],
             regex: regex || generated[:regex],
-            **unused,
             &block
           )
 

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -87,16 +87,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -73,16 +73,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -74,11 +74,10 @@ module Homebrew
             url:           String,
             regex:         T.nilable(Regexp),
             homebrew_curl: T::Boolean,
-            _unused:       T.untyped,
             block:         T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, homebrew_curl: false, &block)
           match_data = { matches: {}, regex:, url: }
 
           headers = Strategy.page_headers(url, homebrew_curl:)

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -102,11 +102,10 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -70,16 +70,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  Regexp,
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: Regexp,
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: DEFAULT_REGEX, **unused, &block)
+        def self.find_versions(url:, regex: DEFAULT_REGEX, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex:, **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex:, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -68,16 +68,15 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -85,11 +85,10 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, &block)
           if regex.blank? && block.blank?
             raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a regex or `strategy` block"
           end

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -85,11 +85,10 @@ module Homebrew
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            unused:           T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, &block)
           match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)
@@ -99,7 +98,6 @@ module Homebrew
             url:              generated[:url],
             regex:,
             provided_content:,
-            **unused,
             &block || DEFAULT_BLOCK
           )
         end

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -87,19 +87,17 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
 
           PageMatch.find_versions(
             url:   generated[:url] || url,
             regex: regex || generated[:regex],
-            **unused,
             &block
           )
         end

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -217,13 +217,12 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:     String,
-            regex:   T.nilable(Regexp),
-            _unused: T.untyped,
-            block:   T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **_unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -142,11 +142,10 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -112,13 +112,12 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:   String,
+            regex: T.nilable(Regexp),
+            block: T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, &block)
           generated = generate_input_values(url)
           generated_url = generated[:url]
 
@@ -128,7 +127,6 @@ module Homebrew
             url:              generated_url,
             regex:            regex || generated[:regex],
             provided_content: cached_content,
-            **unused,
             &block
           )
 

--- a/Library/Homebrew/livecheck/strategy/yaml.rb
+++ b/Library/Homebrew/livecheck/strategy/yaml.rb
@@ -102,11 +102,10 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I'm not sure if this is here for backcompat reasons, but it passes tests/typecheck locally to remove them. (If it is necessary, maybe we can add tests to ensure compatibility.)

(In case it's helpful, originally introduced in https://github.com/Homebrew/brew/pull/11854 )