### PR TITLE
dev-cmd/unbottled: fix module resolution error

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -239,7 +239,7 @@ module Homebrew
               when XcodeRequirement
                 next true unless r.version
 
-                Version.new(MacOS::Xcode.latest_version(macos: macos_version)) >= r.version
+                Version.new(::OS::Mac::Xcode.latest_version(macos: macos_version)) >= r.version
               when ArchRequirement
                 r.arch == @bottle_tag.arch
               else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Fixes #18993

The problem here was that it was unable to find the correct namespace.

It assumed the `MacOS` module was below the `Homebrew::DevCmd::Unbottled` class.

### Before

```sh
kevinrobell@kevinrobell-iMac ~ [1]> brew unbottled --tag arm64_sequoia --dependents -v vtk
==> Populating dependency tree...
==> :arm64_sequoia bottle status
Error: uninitialized constant Homebrew::DevCmd::Unbottled::MacOS
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:242:in `block (2 levels) in output_unbottled'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/set.rb:501:in `each_key'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/set.rb:501:in `each'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/delegate.rb:87:in `all?'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/delegate.rb:87:in `method_missing'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:233:in `block in output_unbottled'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:214:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:214:in `output_unbottled'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:107:in `block in run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/simulate_system.rb:29:in `with'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:67:in `run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

I tried just adding `::Macos...` and that also caused an error because it seems like the `MacOs = OS::Mac` code had not been loaded.

```sh
kevinrobell@kevinrobell-iMac ~ [1]> brew unbottled --tag arm64_sequoia --dependents -v vtk
==> Populating dependency tree...
==> :arm64_sequoia bottle status
Error: uninitialized constant MacOS
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:242:in `block (2 levels) in output_unbottled'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/set.rb:501:in `each_key'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/set.rb:501:in `each'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/delegate.rb:87:in `all?'
/home/kevinrobell/.asdf/installs/ruby/3.3.6/lib/ruby/3.3.0/delegate.rb:87:in `method_missing'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:233:in `block in output_unbottled'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:214:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:214:in `output_unbottled'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:107:in `block in run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/simulate_system.rb:29:in `with'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:67:in `run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/call_validation.rb:278:in `validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11711/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

### After

```sh
kevinrobell@kevinrobell-iMac ~ [1]> brew unbottled --tag arm64_sequoia --dependents -v vtk ==> Populating dependency tree...
==> :arm64_sequoia bottle status
vtk: doesn't support this macOS
```