### PR TITLE
Fix usage of `Tab#installed_(on_request|as_dependency)`

### DIFF
--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -41,12 +41,12 @@ module Homebrew
 
       sig { params(formula: Formula).returns(T::Boolean) }
       def installed_on_request?(formula)
-        formula.any_installed_keg&.tab&.installed_on_request
+        formula.any_installed_keg&.tab&.installed_on_request == true
       end
 
       sig { params(formula: Formula).returns(T::Boolean) }
       def installed_as_dependency?(formula)
-        formula.any_installed_keg&.tab&.installed_as_dependency
+        formula.any_installed_keg&.tab&.installed_as_dependency == true
       end
     end
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -800,12 +800,18 @@ on_request: installed_on_request?, options:)
     options |= inherited_options
     options &= df.options
 
+    installed_on_request = if df.any_version_installed? && tab.present? && tab.installed_on_request
+      true
+    else
+      false
+    end
+
     fi = FormulaInstaller.new(
       df,
       options:,
       link_keg:                   keg_had_linked_keg && keg_was_linked,
       installed_as_dependency:    true,
-      installed_on_request:       df.any_version_installed? && tab.present? && tab.installed_on_request,
+      installed_on_request:,
       force_bottle:               false,
       include_test_formulae:      @include_test_formulae,
       build_from_source_formulae: @build_from_source_formulae,

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -25,8 +25,8 @@ module Homebrew
         keg = Keg.new(formula.opt_prefix.resolved_path)
         tab = keg.tab
         link_keg = keg.linked?
-        installed_as_dependency = tab.installed_as_dependency
-        installed_on_request = tab.installed_on_request
+        installed_as_dependency = tab.installed_as_dependency == true
+        installed_on_request = tab.installed_on_request == true
         build_bottle = tab.built_bottle?
         backup keg
       else

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -16,11 +16,13 @@ class AbstractTab
   # Check whether the formula or cask was installed as a dependency.
   #
   # @api internal
+  sig { returns(T.nilable(T::Boolean)) } # TODO: change this to always return a boolean
   attr_accessor :installed_as_dependency
 
   # Check whether the formula or cask was installed on request.
   #
   # @api internal
+  sig { returns(T.nilable(T::Boolean)) } # TODO: change this to always return a boolean
   attr_accessor :installed_on_request
 
   attr_accessor :homebrew_version, :tabfile, :loaded_from_api, :time, :arch, :source, :built_on

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -132,8 +132,8 @@ module Homebrew
       if keg
         tab = keg.tab
         link_keg = keg.linked?
-        installed_as_dependency = tab.installed_as_dependency
-        installed_on_request = tab.installed_on_request
+        installed_as_dependency = tab.installed_as_dependency == true
+        installed_on_request = tab.installed_on_request == true
         build_bottle = tab.built_bottle?
       else
         link_keg = nil


### PR DESCRIPTION
These can return `true`, `false` or `nil` so adjust the signature to note this and fix the call sites to ensure we don't accidentally pass through `nil` values when we shouldn't.

While we're here, make a `TODO` to fix this bad API up in future.

Fixes https://github.com/Homebrew/brew/issues/19076