### PR TITLE
cask/cask: ensure plist is readable before reading.

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -515,7 +515,7 @@ module Cask
     sig { returns(T.nilable(Homebrew::BundleVersion)) }
     def bundle_version
       @bundle_version ||= if (bundle = artifacts.find { |a| a.is_a?(Artifact::App) }&.target) &&
-                             (plist = Pathname("#{bundle}/Contents/Info.plist")) && plist.exist?
+                             (plist = Pathname("#{bundle}/Contents/Info.plist")) && plist.exist? && plist.readable?
         Homebrew::BundleVersion.from_info_plist(plist)
       end
     end


### PR DESCRIPTION
If we don't have permissions to read it, this will raise an exception even although this whole call chain is very tolerant of nil values.