### PR TITLE
Restructure .gitignore gem handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@
 **/vendor/bundle/ruby/*/build_info/
 **/vendor/bundle/ruby/*/cache
 **/vendor/bundle/ruby/*/extensions
-**/vendor/bundle/ruby/*/gems/*/*
 **/vendor/bundle/ruby/*/plugins
 **/vendor/bundle/ruby/*/specifications
 
@@ -48,104 +47,36 @@
 # Ignore YARD files
 **/.yardoc
 
-# Unignore vendored gems
+# Ignore gems by default
+**/vendor/bundle/ruby/*/gems/**/*
+
+# Include only the license and lib directories for vendored gems
 !**/vendor/bundle/ruby/*/gems/*/*LICENSE*
 !**/vendor/bundle/ruby/*/gems/*/lib
+
+# Unignore gems needed at runtime:
+!**/vendor/bundle/ruby/*/gems/addressable-*/
+!**/vendor/bundle/ruby/*/gems/base64-*/
+!**/vendor/bundle/ruby/*/gems/bindata-*/
+!**/vendor/bundle/ruby/*/gems/concurrent-ruby-*/
+!**/vendor/bundle/ruby/*/gems/elftools-*/
+!**/vendor/bundle/ruby/*/gems/patchelf-*/
+!**/vendor/bundle/ruby/*/gems/plist-*/
+!**/vendor/bundle/ruby/*/gems/public_suffix-*/
+!**/vendor/bundle/ruby/*/gems/ruby-macho-*/
+!**/vendor/bundle/ruby/*/gems/sorbet-runtime-*/
+!**/vendor/bundle/ruby/*/gems/warning-*/
+
+# Unignore additional paths for selected vendored gems
 !**/vendor/bundle/ruby/*/gems/addressable-*/data
 !**/vendor/bundle/ruby/*/gems/public_suffix-*/data
 
-# Ignore partially included gems where we don't need all files
-**/vendor/gems/mechanize-*/.*
-**/vendor/gems/mechanize-*/*.md
-**/vendor/gems/mechanize-*/*.rdoc
-**/vendor/gems/mechanize-*/*.gemspec
-**/vendor/gems/mechanize-*/Gemfile
-**/vendor/gems/mechanize-*/Rakefile
-**/vendor/gems/mechanize-*/examples/
-**/vendor/gems/mechanize-*/lib/**/*
+# Unignore partially included gems where we don't need all files
 !**/vendor/gems/mechanize-*/lib/mechanize/
 !**/vendor/gems/mechanize-*/lib/mechanize/http/
 !**/vendor/gems/mechanize-*/lib/mechanize/http/content_disposition_parser.rb
 !**/vendor/gems/mechanize-*/lib/mechanize/version.rb
-**/vendor/gems/mechanize-*/test/
 
-# Ignore dependencies we don't wish to vendor
-**/vendor/bundle/ruby/*/gems/ast-*/
-**/vendor/bundle/ruby/*/gems/benchmark-*/
-**/vendor/bundle/ruby/*/gems/bigdecimal-*/
-**/vendor/bundle/ruby/*/gems/bootsnap-*/
-**/vendor/bundle/ruby/*/gems/bundler-*/
-**/vendor/bundle/ruby/*/gems/byebug-*/
-**/vendor/bundle/ruby/*/gems/coderay-*/
-**/vendor/bundle/ruby/*/gems/colorize-*/
-**/vendor/bundle/ruby/*/gems/commander-*/
-**/vendor/bundle/ruby/*/gems/diff-lcs-*/
-**/vendor/bundle/ruby/*/gems/docile-*/
-**/vendor/bundle/ruby/*/gems/ecma-re-validator-*/
-**/vendor/bundle/ruby/*/gems/erubi-*/
-**/vendor/bundle/ruby/*/gems/hana-*/
-**/vendor/bundle/ruby/*/gems/highline-*/
-**/vendor/bundle/ruby/*/gems/jaro_winkler-*/
-**/vendor/bundle/ruby/*/gems/json-*/
-**/vendor/bundle/ruby/*/gems/json_schemer-*/
-**/vendor/bundle/ruby/*/gems/kramdown-*/
-**/vendor/bundle/ruby/*/gems/language_server-protocol-*/
-**/vendor/bundle/ruby/*/gems/logger-*/
-**/vendor/bundle/ruby/*/gems/method_source-*/
-**/vendor/bundle/ruby/*/gems/mini_portile2-*/
-**/vendor/bundle/ruby/*/gems/minitest-*/
-**/vendor/bundle/ruby/*/gems/msgpack-*/
-**/vendor/bundle/ruby/*/gems/netrc-*/
-**/vendor/bundle/ruby/*/gems/ntlm-http-*/
-**/vendor/bundle/ruby/*/gems/parallel-*/
-**/vendor/bundle/ruby/*/gems/parallel_tests-*/
-**/vendor/bundle/ruby/*/gems/parlour-*/
-**/vendor/bundle/ruby/*/gems/parser-*/
-**/vendor/bundle/ruby/*/gems/powerpack-*/
-**/vendor/bundle/ruby/*/gems/prettier_print-*/
-**/vendor/bundle/ruby/*/gems/prism-*/
-**/vendor/bundle/ruby/*/gems/psych-*/
-**/vendor/bundle/ruby/*/gems/pry-*/
-**/vendor/bundle/ruby/*/gems/racc-*/
-**/vendor/bundle/ruby/*/gems/rainbow-*/
-**/vendor/bundle/ruby/*/gems/rbi-*/
-**/vendor/bundle/ruby/*/gems/rbs-*/
-**/vendor/bundle/ruby/*/gems/rdoc-*/
-**/vendor/bundle/ruby/*/gems/redcarpet-*/
-**/vendor/bundle/ruby/*/gems/regexp_parser-*/
-**/vendor/bundle/ruby/*/gems/rexml-*/
-**/vendor/bundle/ruby/*/gems/rspec-*/
-**/vendor/bundle/ruby/*/gems/rspec-core-*/
-**/vendor/bundle/ruby/*/gems/rspec-expectations-*/
-**/vendor/bundle/ruby/*/gems/rspec_junit_formatter-*/
-**/vendor/bundle/ruby/*/gems/rspec-mocks-*/
-**/vendor/bundle/ruby/*/gems/rspec-retry-*/
-**/vendor/bundle/ruby/*/gems/rspec-support-*/
-**/vendor/bundle/ruby/*/gems/rspec-sorbet-*/
-**/vendor/bundle/ruby/*/gems/rubocop-*/
-**/vendor/bundle/ruby/*/gems/ruby-lsp-*/
-**/vendor/bundle/ruby/*/gems/ruby-prof-*/
-**/vendor/bundle/ruby/*/gems/ruby-progressbar-*/
-**/vendor/bundle/ruby/*/gems/simplecov-*/
-**/vendor/bundle/ruby/*/gems/simplecov-html-*/
-**/vendor/bundle/ruby/*/gems/simplecov_json_formatter-*/
-**/vendor/bundle/ruby/*/gems/simpleidn-*/
-**/vendor/bundle/ruby/*/gems/sorbet-*/
-!**/vendor/bundle/ruby/*/gems/sorbet-runtime-*/
-**/vendor/bundle/ruby/*/gems/spoom-*/
-**/vendor/bundle/ruby/*/gems/stackprof-*/
-**/vendor/bundle/ruby/*/gems/strscan-*/
-**/vendor/bundle/ruby/*/gems/syntax_tree-*/
-**/vendor/bundle/ruby/*/gems/tapioca-*/
-**/vendor/bundle/ruby/*/gems/thor-*/
-**/vendor/bundle/ruby/*/gems/unicode-display_width-*/
-**/vendor/bundle/ruby/*/gems/unicode-emoji-*/
-**/vendor/bundle/ruby/*/gems/unparser-*/
-**/vendor/bundle/ruby/*/gems/uri_template-*/
-**/vendor/bundle/ruby/*/gems/vernier-*/
-**/vendor/bundle/ruby/*/gems/webrobots-*/
-**/vendor/bundle/ruby/*/gems/yard-*/
-**/vendor/bundle/ruby/*/gems/yard-sorbet-*/
 **/vendor/cache/
 **/vendor/specifications/
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
The current structure of `.gitignore`  requires gems to be explicitly ignored. I've found this approach has a few issues:

- [Failures](https://github.com/Homebrew/brew/actions/runs/12719887056/job/35460770945#step:8:70) when dependencies change are confusing
- Cruft accumulates when gems are no longer in the `Gemfile.lock` dependency tree (`bootsnap`, `byebug`, `colorize` appear to be just a few)
- The [list](https://github.com/Homebrew/brew/tree/master/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems) of gems to vendor is much more concise.

There's a potential new failure mode here: if a vendored gem adds a new dependency, that transitive dependency will need to be added to the `.gitignore`. I _think_ CI will catch that, though I'm not positive.

I tested this by adding gems to the unignore list (e.g. `!**/vendor/bundle/ruby/*/gems/yard-sorbet-*/`) to verify that they become un-ignored (as well as verifying that previously ignored gems were not included in untracked files by git).