### PR TITLE
Revert "Restructure .gitignore gem handling"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 **/vendor/bundle/ruby/*/build_info/
 **/vendor/bundle/ruby/*/cache
 **/vendor/bundle/ruby/*/extensions
+**/vendor/bundle/ruby/*/gems/*/*
 **/vendor/bundle/ruby/*/plugins
 **/vendor/bundle/ruby/*/specifications
 
@@ -47,36 +48,104 @@
 # Ignore YARD files
 **/.yardoc
 
-# Ignore gems by default
-**/vendor/bundle/ruby/*/gems/**/*
-
-# Include only the license and lib directories for vendored gems
+# Unignore vendored gems
 !**/vendor/bundle/ruby/*/gems/*/*LICENSE*
 !**/vendor/bundle/ruby/*/gems/*/lib
-
-# Unignore gems needed at runtime:
-!**/vendor/bundle/ruby/*/gems/addressable-*/
-!**/vendor/bundle/ruby/*/gems/base64-*/
-!**/vendor/bundle/ruby/*/gems/bindata-*/
-!**/vendor/bundle/ruby/*/gems/concurrent-ruby-*/
-!**/vendor/bundle/ruby/*/gems/elftools-*/
-!**/vendor/bundle/ruby/*/gems/patchelf-*/
-!**/vendor/bundle/ruby/*/gems/plist-*/
-!**/vendor/bundle/ruby/*/gems/public_suffix-*/
-!**/vendor/bundle/ruby/*/gems/ruby-macho-*/
-!**/vendor/bundle/ruby/*/gems/sorbet-runtime-*/
-!**/vendor/bundle/ruby/*/gems/warning-*/
-
-# Unignore additional paths for selected vendored gems
 !**/vendor/bundle/ruby/*/gems/addressable-*/data
 !**/vendor/bundle/ruby/*/gems/public_suffix-*/data
 
-# Unignore partially included gems where we don't need all files
+# Ignore partially included gems where we don't need all files
+**/vendor/gems/mechanize-*/.*
+**/vendor/gems/mechanize-*/*.md
+**/vendor/gems/mechanize-*/*.rdoc
+**/vendor/gems/mechanize-*/*.gemspec
+**/vendor/gems/mechanize-*/Gemfile
+**/vendor/gems/mechanize-*/Rakefile
+**/vendor/gems/mechanize-*/examples/
+**/vendor/gems/mechanize-*/lib/**/*
 !**/vendor/gems/mechanize-*/lib/mechanize/
 !**/vendor/gems/mechanize-*/lib/mechanize/http/
 !**/vendor/gems/mechanize-*/lib/mechanize/http/content_disposition_parser.rb
 !**/vendor/gems/mechanize-*/lib/mechanize/version.rb
+**/vendor/gems/mechanize-*/test/
 
+# Ignore dependencies we don't wish to vendor
+**/vendor/bundle/ruby/*/gems/ast-*/
+**/vendor/bundle/ruby/*/gems/benchmark-*/
+**/vendor/bundle/ruby/*/gems/bigdecimal-*/
+**/vendor/bundle/ruby/*/gems/bootsnap-*/
+**/vendor/bundle/ruby/*/gems/bundler-*/
+**/vendor/bundle/ruby/*/gems/byebug-*/
+**/vendor/bundle/ruby/*/gems/coderay-*/
+**/vendor/bundle/ruby/*/gems/colorize-*/
+**/vendor/bundle/ruby/*/gems/commander-*/
+**/vendor/bundle/ruby/*/gems/diff-lcs-*/
+**/vendor/bundle/ruby/*/gems/docile-*/
+**/vendor/bundle/ruby/*/gems/ecma-re-validator-*/
+**/vendor/bundle/ruby/*/gems/erubi-*/
+**/vendor/bundle/ruby/*/gems/hana-*/
+**/vendor/bundle/ruby/*/gems/highline-*/
+**/vendor/bundle/ruby/*/gems/jaro_winkler-*/
+**/vendor/bundle/ruby/*/gems/json-*/
+**/vendor/bundle/ruby/*/gems/json_schemer-*/
+**/vendor/bundle/ruby/*/gems/kramdown-*/
+**/vendor/bundle/ruby/*/gems/language_server-protocol-*/
+**/vendor/bundle/ruby/*/gems/logger-*/
+**/vendor/bundle/ruby/*/gems/method_source-*/
+**/vendor/bundle/ruby/*/gems/mini_portile2-*/
+**/vendor/bundle/ruby/*/gems/minitest-*/
+**/vendor/bundle/ruby/*/gems/msgpack-*/
+**/vendor/bundle/ruby/*/gems/netrc-*/
+**/vendor/bundle/ruby/*/gems/ntlm-http-*/
+**/vendor/bundle/ruby/*/gems/parallel-*/
+**/vendor/bundle/ruby/*/gems/parallel_tests-*/
+**/vendor/bundle/ruby/*/gems/parlour-*/
+**/vendor/bundle/ruby/*/gems/parser-*/
+**/vendor/bundle/ruby/*/gems/powerpack-*/
+**/vendor/bundle/ruby/*/gems/prettier_print-*/
+**/vendor/bundle/ruby/*/gems/prism-*/
+**/vendor/bundle/ruby/*/gems/psych-*/
+**/vendor/bundle/ruby/*/gems/pry-*/
+**/vendor/bundle/ruby/*/gems/racc-*/
+**/vendor/bundle/ruby/*/gems/rainbow-*/
+**/vendor/bundle/ruby/*/gems/rbi-*/
+**/vendor/bundle/ruby/*/gems/rbs-*/
+**/vendor/bundle/ruby/*/gems/rdoc-*/
+**/vendor/bundle/ruby/*/gems/redcarpet-*/
+**/vendor/bundle/ruby/*/gems/regexp_parser-*/
+**/vendor/bundle/ruby/*/gems/rexml-*/
+**/vendor/bundle/ruby/*/gems/rspec-*/
+**/vendor/bundle/ruby/*/gems/rspec-core-*/
+**/vendor/bundle/ruby/*/gems/rspec-expectations-*/
+**/vendor/bundle/ruby/*/gems/rspec_junit_formatter-*/
+**/vendor/bundle/ruby/*/gems/rspec-mocks-*/
+**/vendor/bundle/ruby/*/gems/rspec-retry-*/
+**/vendor/bundle/ruby/*/gems/rspec-support-*/
+**/vendor/bundle/ruby/*/gems/rspec-sorbet-*/
+**/vendor/bundle/ruby/*/gems/rubocop-*/
+**/vendor/bundle/ruby/*/gems/ruby-lsp-*/
+**/vendor/bundle/ruby/*/gems/ruby-prof-*/
+**/vendor/bundle/ruby/*/gems/ruby-progressbar-*/
+**/vendor/bundle/ruby/*/gems/simplecov-*/
+**/vendor/bundle/ruby/*/gems/simplecov-html-*/
+**/vendor/bundle/ruby/*/gems/simplecov_json_formatter-*/
+**/vendor/bundle/ruby/*/gems/simpleidn-*/
+**/vendor/bundle/ruby/*/gems/sorbet-*/
+!**/vendor/bundle/ruby/*/gems/sorbet-runtime-*/
+**/vendor/bundle/ruby/*/gems/spoom-*/
+**/vendor/bundle/ruby/*/gems/stackprof-*/
+**/vendor/bundle/ruby/*/gems/strscan-*/
+**/vendor/bundle/ruby/*/gems/syntax_tree-*/
+**/vendor/bundle/ruby/*/gems/tapioca-*/
+**/vendor/bundle/ruby/*/gems/thor-*/
+**/vendor/bundle/ruby/*/gems/unicode-display_width-*/
+**/vendor/bundle/ruby/*/gems/unicode-emoji-*/
+**/vendor/bundle/ruby/*/gems/unparser-*/
+**/vendor/bundle/ruby/*/gems/uri_template-*/
+**/vendor/bundle/ruby/*/gems/vernier-*/
+**/vendor/bundle/ruby/*/gems/webrobots-*/
+**/vendor/bundle/ruby/*/gems/yard-*/
+**/vendor/bundle/ruby/*/gems/yard-sorbet-*/
 **/vendor/cache/
 **/vendor/specifications/
 


### PR DESCRIPTION
Reverts Homebrew/brew#19106

This is causing CI failures and has broken the Vendor Gems workflow. Reverting to unblock CI.