### PR TITLE
utils: add check_binary_linkage function

### DIFF
--- a/Library/Homebrew/test/utils/linkage_spec.rb
+++ b/Library/Homebrew/test/utils/linkage_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "utils/linkage"
+
+RSpec.describe Utils do
+  [:needs_macos, :needs_linux].each do |needs_os|
+    describe "::binary_linked_to_library?", needs_os do
+      suffix = OS.mac? ? ".dylib" : ".so"
+
+      before do
+        mktmpdir do |dir|
+          (dir/"foo.h").write "void foo();"
+          (dir/"foo.c").write <<~C
+            #include <stdio.h>
+            #include "foo.h"
+            void foo() { printf("foo\\\\n"); }
+          C
+          (dir/"bar.c").write <<~C
+            #include <stdio.h>
+            void bar() { printf("bar\\\\n"); }
+          C
+          (dir/"test.c").write <<~C
+            #include "foo.h"
+            int main() { foo(); return 0; }
+          C
+
+          system "cc", "-c", "-fpic", dir/"foo.c", "-o", dir/"foo.o"
+          system "cc", "-c", "-fpic", dir/"bar.c", "-o", dir/"bar.o"
+          dll_flag = OS.mac? ? "-dynamiclib" : "-shared"
+          (HOMEBREW_PREFIX/"lib").mkdir
+          system "cc", dll_flag, "-o", HOMEBREW_PREFIX/"lib/libbrewfoo#{suffix}", dir/"foo.o"
+          system "cc", dll_flag, "-o", HOMEBREW_PREFIX/"lib/libbrewbar#{suffix}", dir/"bar.o"
+          rpath_flag = "-Wl,-rpath,#{HOMEBREW_PREFIX}/lib" if OS.linux?
+          system "cc", "-o", dir/"brewtest", dir/"test.c", *rpath_flag, "-L#{HOMEBREW_PREFIX/"lib"}", "-lbrewfoo"
+          (HOMEBREW_PREFIX/"bin").install dir/"brewtest"
+        end
+      end
+
+      it "returns true if the binary is linked to the library" do
+        result = described_class.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest",
+                                                           HOMEBREW_PREFIX/"lib/libbrewfoo#{suffix}")
+        expect(result).to be true
+      end
+
+      it "returns false if the binary is not linked to the library" do
+        result = described_class.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest",
+                                                           HOMEBREW_PREFIX/"lib/libbrewbar#{suffix}")
+        expect(result).to be false
+      end
+    end
+  end
+end

--- a/Library/Homebrew/utils/linkage.rb
+++ b/Library/Homebrew/utils/linkage.rb
@@ -1,0 +1,15 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Utils
+  sig {
+    params(binary: T.any(String, Pathname), library: T.any(String, Pathname)).returns(T::Boolean)
+  }
+  def self.binary_linked_to_library?(binary, library)
+    Pathname.new(binary).dynamically_linked_libraries.any? do |dll|
+      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
+
+      File.realpath(dll) == File.realpath(Pathname.new(library))
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds `Utils::check_binary_linkage`, which is a helper-function that is already used in [some (primarily Rust-based) formulae](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-core%20def%20check_binary_linkage&type=code).

The function is more or less copied verbatim, except types are loosened to accept `String` or `Pathname`. An optional `prefix` parameter can also be set to change the filtering behavior - this flag really only exists because we have to tweak the filtering behavior a bit in the test. Maybe we can just not do any filtering and that'll be fine - but for now I've kept it as close to the original as possible.

Open to suggestions all around, but I'm a bit extra miffed about:
- Where would be the best place to put this file, and the file name. There didn't appear to be another file in `utils` that seemed like a good place, so I created a new one.
- The tests still feel a bit clunky to me and I think there's probably room for improvement. Note that we set `prefix` in invocations to `Utils::check_binary_linkage` because in the test environment, [`HOMEBREW_CELLAR` is a sibling to `HOMEBREW_PREFIX`, not a child](https://github.com/Homebrew/brew/blob/637fd5be9dc1e84a170f347a43836de82802df1c/Library/Homebrew/test/support/lib/startup/config.rb#L34), so filtering on `HOMEBREW_PREFIX` will exclude all the libraries in `HOMEBREW_CELLAR`, unlike in a real Homebrew installation where the cellar is in `HOMEBREW_PREFIX/"Cellar"`.