### PR TITLE
diagnostic: elide stray filenames in subdirs

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -188,11 +188,14 @@ module Homebrew
         files = Dir.chdir(dir) do
           (Dir.glob(pattern) - Dir.glob(allow_list))
             .select { |f| File.file?(f) && !File.symlink?(f) }
-            .map { |f| File.join(dir, f) }
+            .map do |f|
+              f.sub!(%r{/.*}, "/...") unless @verbose
+              File.join(dir, f)
+            end
         end
         return if files.empty?
 
-        inject_file_list(files.sort, message)
+        inject_file_list(files.sort.uniq, message)
       end
 
       def check_for_stray_dylibs

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -189,13 +189,14 @@ module Homebrew
           (Dir.glob(pattern) - Dir.glob(allow_list))
             .select { |f| File.file?(f) && !File.symlink?(f) }
             .map do |f|
-              f.sub!(%r{/.*}, "/...") unless @verbose
+              f.sub!(%r{/.*}, "/*") unless @verbose
               File.join(dir, f)
             end
+            .sort.uniq
         end
         return if files.empty?
 
-        inject_file_list(files.sort.uniq, message)
+        inject_file_list(files, message)
       end
 
       def check_for_stray_dylibs


### PR DESCRIPTION
Usually, the subdirectory name is sufficient info, and the full file list is just noise.

This reduces `brew doctor` output clutter, making it easier for user to paste, and maintainers to parse.

Before:
```
$ brew doctor
[...]
Unexpected header files:
  /usr/local/include/node/cppgc/allocation.h
  /usr/local/include/node/cppgc/common.h
  /usr/local/include/node/cppgc/custom-space.h
  /usr/local/include/node/cppgc/garbage-collected.h
  /usr/local/include/node/cppgc/heap.h
  /usr/local/include/node/cppgc/internal/accessors.h
  /usr/local/include/node/cppgc/internal/api-constants.h
  /usr/local/include/node/cppgc/internal/compiler-specific.h
  /usr/local/include/node/cppgc/internal/finalizer-trait.h
  /usr/local/include/node/cppgc/internal/gc-info.h
  /usr/local/include/node/cppgc/internal/logging.h
  /usr/local/include/node/cppgc/internal/persistent-node.h
  /usr/local/include/node/cppgc/internal/pointer-policies.h
  /usr/local/include/node/cppgc/internal/prefinalizer-handler.h
[about 500 more files]
```
After:
```
$ brew doctor
Unexpected header files:
  /usr/local/include/node/*
```
The full list of stray files can still be viewed with `brew doctor -v`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
