### PR TITLE
Document stderr redirection for shell_output tests

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -334,6 +334,14 @@ test do
 end
 ```
 
+* If the binary only writes to `stderr`, you can redirect `stderr` to `stdout` for assertions with `shell_output`. For example:
+
+```ruby
+test do
+  assert_match "Output on stderr", shell_output("#{bin}/formula-program 2>&1", 2)
+end
+```
+
 ### Manuals
 
 Homebrew expects to find manual pages in `#{prefix}/share/man/...`, and not in `#{prefix}/man/...`.


### PR DESCRIPTION
As discussed in https://github.com/Homebrew/homebrew-core/pull/204366, this documents the specific case, where your program writes an error to stderr that needs to be checked in a test (e.g., using `assert_match` and `shell_output`):
* https://github.com/Homebrew/brew/issues/5149