### PR TITLE
sudo: Elevate priviliges before adding metadata after relocating a ca…

### DIFF
--- a/Library/Homebrew/cask/artifact/relocated.rb
+++ b/Library/Homebrew/cask/artifact/relocated.rb
@@ -89,11 +89,14 @@ module Cask
         altnames = "(#{altnames})"
 
         # Some packages are shipped as u=rx (e.g. Bitcoin Core)
-        command.run!("/bin/chmod", args: ["--", "u+rw", file, file.realpath])
+        command.run!("/bin/chmod",
+                     args: ["--", "u+rw", file, file.realpath],
+                     sudo: !file.writable? || !file.realpath.writable?)
 
         command.run!("/usr/bin/xattr",
                      args:         ["-w", ALT_NAME_ATTRIBUTE, altnames, file],
-                     print_stderr: false)
+                     print_stderr: false,
+                     sudo:         !file.writable?)
       end
 
       def printable_target


### PR DESCRIPTION
…sk, if necessary

Homebrew cannot assume that target location is writable for chmod and xattr.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
