### PR TITLE
dev-cmd/bump-formula-pr: automatically bump matched-version resources

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -466,7 +466,7 @@ module Homebrew
       sig {
         params(
           formula: Formula,
-          version: T.nilable(String),
+          version: String,
         ).void
       }
       def update_matching_version_resources!(formula, version:)
@@ -507,7 +507,7 @@ module Homebrew
             end\s
           /x
 
-          leading_spaces = formula.path.read.match(/^([ ]+)resource "#{resource.name}"/).captures.first
+          leading_spaces = T.must(formula.path.read.match(/^([ ]+)resource "#{resource.name}"/)).captures.first
           new_resource_block = <<~EOS
             #{leading_spaces}resource "#{resource.name}" do
             #{leading_spaces}  url "#{new_url}"#{new_mirrors.map { |m| "\n#{leading_spaces}  mirror \"#{m}\"" }.join}

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -346,12 +346,17 @@ module Homebrew
                                                             install_dependencies:     args.install_dependencies?,
                                                             silent:                   args.quiet?,
                                                             ignore_non_pypi_packages: true
+
+          update_matching_version_resources! formula,
+                                             version: new_formula_version.to_s
         end
 
         run_audit(formula, alias_rename, old_contents)
 
         pr_message = "Created with `brew bump-formula-pr`."
-        if resources_checked.nil? && formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") }
+        if resources_checked.nil? && formula.resources.any? do |resource|
+          resource.livecheck.formula != :parent && !resource.name.start_with?("homebrew-")
+        end
           pr_message += <<~EOS
 
 
@@ -441,17 +446,83 @@ module Homebrew
       end
 
       sig {
-        params(formula: Formula, new_version: T.nilable(String), url: String,
+        params(formula_or_resource: T.any(Formula, Resource), new_version: T.nilable(String), url: String,
                specs: String).returns(T::Array[T.untyped])
       }
-      def fetch_resource_and_forced_version(formula, new_version, url, **specs)
+      def fetch_resource_and_forced_version(formula_or_resource, new_version, url, **specs)
         resource = Resource.new
         resource.url(url, **specs)
-        resource.owner = Resource.new(formula.name)
+        resource.owner = if formula_or_resource.is_a?(Formula)
+          Resource.new(formula_or_resource.name)
+        else
+          Resource.new(formula_or_resource.owner.name)
+        end
         forced_version = new_version && new_version != resource.version.to_s
         resource.version(new_version) if forced_version
         odie "Couldn't identify version, specify it using `--version=`." if resource.version.blank?
         [resource.fetch, forced_version]
+      end
+
+      sig {
+        params(
+          formula: Formula,
+          version: T.nilable(String),
+        ).void
+      }
+      def update_matching_version_resources!(formula, version:)
+        formula.resources.select { |r| r.livecheck.formula == :parent }.each do |resource|
+          new_url = update_url(resource.url, resource.version.to_s, version)
+
+          if new_url == resource.url
+            opoo <<~EOS
+              You need to bump resource "#{resource.name}" manually since the new URL
+              and old URL are both:
+                #{new_url}
+            EOS
+            next
+          end
+
+          new_mirrors = resource.mirrors.map do |mirror|
+            update_url(mirror, resource.version.to_s, version)
+          end
+          resource_path, forced_version = fetch_resource_and_forced_version(resource, version, new_url)
+          Utils::Tar.validate_file(resource_path)
+          new_hash = resource_path.sha256
+
+          inreplace_regex = /
+            [ ]+resource\ "#{resource.name}"\ do\s+
+              url\ .*\s+
+              (mirror\ .*\s+)*
+              sha256\ .*\s+
+              (version\ .*\s+)?
+              (\#.*\s+)*
+              livecheck\ do\s+
+                formula\ :parent\s+
+              end\s+
+              ((\#.*\s+)*
+              patch\ (.*\ )?do\s+
+                url\ .*\s+
+                sha256\ .*\s+
+              end\s+)*
+            end\s
+          /x
+
+          leading_spaces = formula.path.read.match(/^([ ]+)resource "#{resource.name}"/).captures.first
+          new_resource_block = <<~EOS
+            #{leading_spaces}resource "#{resource.name}" do
+            #{leading_spaces}  url "#{new_url}"#{new_mirrors.map { |m| "\n#{leading_spaces}  mirror \"#{m}\"" }.join}
+            #{leading_spaces}  sha256 "#{new_hash}"
+            #{forced_version ? "#{leading_spaces}  version \"#{version}\"\n" : ""}
+            #{leading_spaces}  livecheck do
+            #{leading_spaces}    formula :parent
+            #{leading_spaces}  end
+            #{leading_spaces}end
+          EOS
+
+          Utils::Inreplace.inreplace formula.path do |s|
+            s.sub! inreplace_regex, new_resource_block
+          end
+        end
       end
 
       sig { params(formula: Formula, contents: T.nilable(String)).returns(Version) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR allows `bump-formula-pr` to autobump resources with a livecheck block referencing the parent formula (see #19040). I haven't added tests because it seems like there are no tests anyway for `bump-formula-pr`, but I've tested that this feature works as intended on a couple formula such as:
* `prestodb`: "run of the mill" resource
* `audacious`: resource is within a `stable` block
* `erlang`: resource has mirror URLs, other non-matched resources exist
* `clang-format`: multiple such resources

Will do some more testing in a while with other formulae. Where this will not work is when the resource URL encodes the resource version in an atypical way, e.g., `4_2_2` instead of `4.2.2` – the command will warn the user to bump such resources manually. Note that `bump-formula-pr` doesn't work with such URLs/version encodings either.

The current `inreplace_regex` will also not work when a resource contains a `patch :DATA` patch, e.g., currently `bctoolbox` in `ortp`. This will have to be deal with separately or such resources skipped.