### PR TITLE
Adds caching proxy example using HOMEBREW_ARTIFACT_DOMAIN

### DIFF
--- a/docs/Tips-N'-Tricks.md
+++ b/docs/Tips-N'-Tricks.md
@@ -121,3 +121,18 @@ If you're using Homebrew on macOS Intel, you should also fix permissions afterwa
 ```sh
 sudo chown -R "${USER}" /usr/local/etc
 ```
+
+## Use a caching proxy or mirror for Homebrew bottles
+
+You can configure Homebrew to retrieve bottles from a caching proxy or mirror.
+
+For example, in JFrog's Artifactory, accessible at `https://artifacts.example.com`,
+configure a new "remote" repository with `homebrew` as the "repository key" and `https://ghcr.io` as the URL.
+
+Then, set these environment variables for Homebrew to retrieve from the caching proxy.
+
+```sh
+export HOMEBREW_ARTIFACT_DOMAIN=https://artifacts.example.com/artifactory/homebrew/
+export HOMEBREW_ARTIFACT_DOMAIN_NO_FALLBACK=1
+export HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN="$(printf 'anonymous:' | base64)"
+```


### PR DESCRIPTION
I brought this up several months ago and got a solution working that's been running on my work machine since early September without failure.

Possible additions:

* A statement expressing any limitations on supporting this configuration
* A statement, perhaps in a comment, limiting the tip to the idea and that it should not be an ever-growing HOWTO for every artifact hosting system.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
