### PR TITLE
dev-cmd/tests: disable forcing `brew` wrapper in tests.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -215,6 +215,7 @@ module Homebrew
         ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if args.generic?
         ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
         ENV["HOMEBREW_SORBET_RUNTIME"] = "1"
+        ENV["HOMEBREW_NO_FORCE_BREW_WRAPPER"] = "1"
 
         # TODO: remove this and fix tests when possible.
         ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"


### PR DESCRIPTION
Otherwise, various integration tests will fail under some configurations.
