### PR TITLE
Bump more Cask RuboCops to Sorbet `typed: strict`

### DIFF
--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -14,16 +14,16 @@ module RuboCop
 
         sig {
           params(
-            method_node:  T.any(RuboCop::AST::SendNode, RuboCop::AST::BlockNode),
+            method_node:  RuboCop::AST::Node,
             all_comments: T::Array[T.any(String, Parser::Source::Comment)],
           ).void
         }
         def initialize(method_node, all_comments)
-          @method_node = T.let(method_node, T.any(RuboCop::AST::SendNode, RuboCop::AST::BlockNode))
+          @method_node = T.let(method_node, RuboCop::AST::Node)
           @all_comments = T.let(all_comments, T::Array[T.any(String, Parser::Source::Comment)])
         end
 
-        sig { returns(T.any(RuboCop::AST::SendNode, RuboCop::AST::BlockNode)) }
+        sig { returns(RuboCop::AST::Node) }
         attr_reader :method_node
         alias stanza_node method_node
 

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -53,8 +53,9 @@ module RuboCop
         sig { returns(Symbol) }
         def stanza_name
           return :on_arch_conditional if arch_variable?
+          return stanza_node.method_node&.method_name if stanza_node.block_type?
 
-          stanza_node.method_name
+          T.cast(stanza_node, RuboCop::AST::SendNode).method_name
         end
 
         sig { returns(T.nilable(T::Array[Symbol])) }

--- a/Library/Homebrew/rubocops/cask/desc.rb
+++ b/Library/Homebrew/rubocops/cask/desc.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         sig { params(stanza: RuboCop::Cask::AST::Stanza).void }
         def on_desc_stanza(stanza)
-          @name = T.let(cask_block.header.cask_token, T.nilable(String))
+          @name = T.let(cask_block&.header&.cask_token, T.nilable(String))
           desc_call = stanza.stanza_node
           audit_desc(:cask, @name, desc_call)
         end

--- a/Library/Homebrew/rubocops/cask/discontinued.rb
+++ b/Library/Homebrew/rubocops/cask/discontinued.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module RuboCop
@@ -11,6 +11,7 @@ module RuboCop
 
         MESSAGE = "Use `deprecate!` instead of `caveats { discontinued }`."
 
+        sig { override.params(stanza_block: RuboCop::Cask::AST::StanzaBlock).void }
         def on_cask_stanza_block(stanza_block)
           stanza_block.stanzas.select(&:caveats?).each do |stanza|
             find_discontinued_method_call(stanza.stanza_node) do |node|

--- a/Library/Homebrew/rubocops/cask/discontinued.rbi
+++ b/Library/Homebrew/rubocops/cask/discontinued.rbi
@@ -6,7 +6,7 @@ module RuboCop
       class Discontinued < Base
         sig {
           params(
-            base_node: T.any(RuboCop::AST::BlockNode, RuboCop::AST::SendNode),
+            base_node: RuboCop::AST::Node,
             block:     T.nilable(T.proc.params(node: RuboCop::AST::SendNode).void),
           ).returns(T::Boolean)
         }
@@ -14,7 +14,7 @@ module RuboCop
 
         sig {
           params(
-            base_node: T.any(RuboCop::AST::BlockNode, RuboCop::AST::SendNode),
+            base_node: RuboCop::AST::Node,
             block:     T.proc.params(node: RuboCop::AST::SendNode).void,
           ).void
         }

--- a/Library/Homebrew/rubocops/cask/discontinued.rbi
+++ b/Library/Homebrew/rubocops/cask/discontinued.rbi
@@ -6,7 +6,7 @@ module RuboCop
       class Discontinued < Base
         sig {
           params(
-            base_node: RuboCop::AST::BlockNode,
+            base_node: T.any(RuboCop::AST::BlockNode, RuboCop::AST::SendNode),
             block:     T.nilable(T.proc.params(node: RuboCop::AST::SendNode).void),
           ).returns(T::Boolean)
         }
@@ -14,7 +14,7 @@ module RuboCop
 
         sig {
           params(
-            base_node: RuboCop::AST::BlockNode,
+            base_node: T.any(RuboCop::AST::BlockNode, RuboCop::AST::SendNode),
             block:     T.proc.params(node: RuboCop::AST::SendNode).void,
           ).void
         }

--- a/Library/Homebrew/rubocops/cask/extend/node.rb
+++ b/Library/Homebrew/rubocops/cask/extend/node.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module RuboCop
@@ -20,6 +20,7 @@ module RuboCop
         (on_system_block? && each_ancestor.any?(&:cask_block?)) || false
       end
 
+      sig { returns(T::Boolean) }
       def stanza?
         return true if arch_variable?
 
@@ -30,10 +31,12 @@ module RuboCop
         end
       end
 
+      sig { returns(T::Boolean) }
       def heredoc?
         loc.is_a?(Parser::Source::Map::Heredoc)
       end
 
+      sig { returns(Parser::Source::Range) }
       def location_expression
         base_expression = loc.expression
         descendants.select(&:heredoc?).reduce(base_expression) do |expr, node|

--- a/Library/Homebrew/rubocops/cask/homepage_url_styling.rb
+++ b/Library/Homebrew/rubocops/cask/homepage_url_styling.rb
@@ -20,7 +20,7 @@ module RuboCop
         sig { params(stanza: RuboCop::Cask::AST::Stanza).void }
         def on_homepage_stanza(stanza)
           @name = T.let(cask_block&.header&.cask_token, T.nilable(String))
-          desc_call = stanza.stanza_node
+          desc_call = T.cast(stanza.stanza_node, RuboCop::AST::SendNode)
           url_node = desc_call.first_argument
 
           url = if url_node.dstr_type?

--- a/Library/Homebrew/rubocops/cask/homepage_url_styling.rb
+++ b/Library/Homebrew/rubocops/cask/homepage_url_styling.rb
@@ -19,7 +19,7 @@ module RuboCop
 
         sig { params(stanza: RuboCop::Cask::AST::Stanza).void }
         def on_homepage_stanza(stanza)
-          @name = T.let(cask_block.header.cask_token, T.nilable(String))
+          @name = T.let(cask_block&.header&.cask_token, T.nilable(String))
           desc_call = stanza.stanza_node
           url_node = desc_call.first_argument
 

--- a/Library/Homebrew/rubocops/cask/mixin/on_desc_stanza.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/on_desc_stanza.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module RuboCop
@@ -9,8 +9,9 @@ module RuboCop
         extend Forwardable
         include CaskHelp
 
+        sig { override.params(cask_block: T.nilable(RuboCop::Cask::AST::CaskBlock)).void }
         def on_cask(cask_block)
-          @cask_block = cask_block
+          @cask_block = T.let(cask_block, T.nilable(RuboCop::Cask::AST::CaskBlock))
 
           toplevel_stanzas.select(&:desc?).each do |stanza|
             on_desc_stanza(stanza)
@@ -19,6 +20,7 @@ module RuboCop
 
         private
 
+        sig { returns(T.nilable(RuboCop::Cask::AST::CaskBlock)) }
         attr_reader :cask_block
 
         def_delegators :cask_block,

--- a/Library/Homebrew/rubocops/cask/mixin/on_homepage_stanza.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/on_homepage_stanza.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 module RuboCop
@@ -9,8 +9,9 @@ module RuboCop
         extend Forwardable
         include CaskHelp
 
+        sig { override.params(cask_block: T.nilable(RuboCop::Cask::AST::CaskBlock)).void }
         def on_cask(cask_block)
-          @cask_block = cask_block
+          @cask_block = T.let(cask_block, T.nilable(RuboCop::Cask::AST::CaskBlock))
 
           toplevel_stanzas.select(&:homepage?).each do |stanza|
             on_homepage_stanza(stanza)
@@ -19,6 +20,7 @@ module RuboCop
 
         private
 
+        sig { returns(T.nilable(RuboCop::Cask::AST::CaskBlock)) }
         attr_reader :cask_block
 
         def_delegators :cask_block,

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -26,7 +26,7 @@ module RuboCop
           return if (on_blocks = on_system_methods(cask_stanzas)).none?
 
           on_blocks.map(&:method_node).select(&:block_type?).each do |on_block|
-            stanzas = inner_stanzas(on_block, processed_source.comments)
+            stanzas = inner_stanzas(T.cast(on_block, RuboCop::AST::BlockNode), processed_source.comments)
             add_offenses(stanzas)
           end
         end

--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "rubocops/shared/url_helper"
@@ -24,6 +24,7 @@ module RuboCop
         include OnUrlStanza
         include UrlHelper
 
+        sig { params(stanza: RuboCop::Cask::AST::Stanza).void }
         def on_url_stanza(stanza)
           if stanza.stanza_node.block_type?
             if cask_tap == "homebrew-cask"

--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -33,8 +33,9 @@ module RuboCop
             return
           end
 
-          url_stanza = stanza.stanza_node.first_argument
-          hash_node = stanza.stanza_node.last_argument
+          stanza_node = T.cast(stanza.stanza_node, RuboCop::AST::SendNode)
+          url_stanza = stanza_node.first_argument
+          hash_node = stanza_node.last_argument
 
           audit_url(:cask, [stanza.stanza_node], [], livecheck_url: false)
 

--- a/Library/Homebrew/rubocops/cask/url_legacy_comma_separators.rb
+++ b/Library/Homebrew/rubocops/cask/url_legacy_comma_separators.rb
@@ -14,9 +14,9 @@ module RuboCop
 
         sig { override.params(stanza: RuboCop::Cask::AST::Stanza).void }
         def on_url_stanza(stanza)
-          return if stanza.stanza_node.type == :block
+          return if stanza.stanza_node.block_type?
 
-          url_node = stanza.stanza_node.first_argument
+          url_node = T.cast(stanza.stanza_node, RuboCop::AST::SendNode).first_argument
 
           legacy_comma_separator_pattern = /version\.(before|after)_comma/
 

--- a/Library/Homebrew/rubocops/cask/variables.rb
+++ b/Library/Homebrew/rubocops/cask/variables.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "forwardable"
@@ -26,8 +26,9 @@ module RuboCop
         extend AutoCorrector
         include CaskHelp
 
+        sig { override.params(cask_block: RuboCop::Cask::AST::CaskBlock).void }
         def on_cask(cask_block)
-          @cask_block = cask_block
+          @cask_block = T.let(cask_block, T.nilable(RuboCop::Cask::AST::CaskBlock))
           add_offenses
         end
 
@@ -35,6 +36,7 @@ module RuboCop
 
         def_delegator :@cask_block, :cask_node
 
+        sig { void }
         def add_offenses
           variable_assignment(cask_node) do |node, var_name, arch_condition, true_node, false_node|
             arm_node, intel_node = if arch_condition == :arm?
@@ -59,10 +61,11 @@ module RuboCop
           end
         end
 
+        sig { params(node: RuboCop::AST::Node).returns(T::Boolean) }
         def blank_node?(node)
           case node.type
           when :str
-            node.value.empty?
+            node.str_content.empty?
           when :nil
             true
           else

--- a/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cask/ast/stanza.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/rubo_cop/cask/ast/stanza.rbi
@@ -6,18 +6,186 @@
 
 
 class RuboCop::Cask::AST::Stanza
+  sig { returns(T::Boolean) }
+  def app?; end
+
+  sig { returns(T::Boolean) }
+  def appcast?; end
+
+  sig { returns(T::Boolean) }
+  def arch?; end
+
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
   def arch_variable?(*args, &block); end
+
+  sig { returns(T::Boolean) }
+  def artifact?; end
+
+  sig { returns(T::Boolean) }
+  def audio_unit_plugin?; end
+
+  sig { returns(T::Boolean) }
+  def auto_updates?; end
+
+  sig { returns(T::Boolean) }
+  def binary?; end
+
+  sig { returns(T::Boolean) }
+  def caveats?; end
+
+  sig { returns(T::Boolean) }
+  def colorpicker?; end
+
+  sig { returns(T::Boolean) }
+  def conflicts_with?; end
+
+  sig { returns(T::Boolean) }
+  def container?; end
+
+  sig { returns(T::Boolean) }
+  def depends_on?; end
+
+  sig { returns(T::Boolean) }
+  def desc?; end
+
+  sig { returns(T::Boolean) }
+  def dictionary?; end
+
+  sig { returns(T::Boolean) }
+  def font?; end
+
+  sig { returns(T::Boolean) }
+  def homepage?; end
+
+  sig { returns(T::Boolean) }
+  def input_method?; end
+
+  sig { returns(T::Boolean) }
+  def installer?; end
+
+  sig { returns(T::Boolean) }
+  def internet_plugin?; end
+
+  sig { returns(T::Boolean) }
+  def keyboard_layout?; end
+
+  sig { returns(T::Boolean) }
+  def language?; end
+
+  sig { returns(T::Boolean) }
+  def livecheck?; end
+
+  sig { returns(T::Boolean) }
+  def manpage?; end
+
+  sig { returns(T::Boolean) }
+  def mdimporter?; end
+
+  sig { returns(T::Boolean) }
+  def name?; end
+
+  sig { returns(T::Boolean) }
+  def on_arch_conditional?; end
+
+  sig { returns(T::Boolean) }
+  def on_arm?; end
+
+  sig { returns(T::Boolean) }
+  def on_big_sur?; end
+
+  sig { returns(T::Boolean) }
+  def on_catalina?; end
+
+  sig { returns(T::Boolean) }
+  def on_el_capitan?; end
+
+  sig { returns(T::Boolean) }
+  def on_high_sierra?; end
+
+  sig { returns(T::Boolean) }
+  def on_intel?; end
+
+  sig { returns(T::Boolean) }
+  def on_mojave?; end
+
+  sig { returns(T::Boolean) }
+  def on_monterey?; end
+
+  sig { returns(T::Boolean) }
+  def on_sequoia?; end
+
+  sig { returns(T::Boolean) }
+  def on_sierra?; end
+
+  sig { returns(T::Boolean) }
+  def on_sonoma?; end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
   def on_system_block?(*args, &block); end
 
+  sig { returns(T::Boolean) }
+  def on_ventura?; end
+
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def parent_node(*args, &block); end
+
+  sig { returns(T::Boolean) }
+  def pkg?; end
+
+  sig { returns(T::Boolean) }
+  def postflight?; end
+
+  sig { returns(T::Boolean) }
+  def preflight?; end
+
+  sig { returns(T::Boolean) }
+  def prefpane?; end
+
+  sig { returns(T::Boolean) }
+  def qlplugin?; end
+
+  sig { returns(T::Boolean) }
+  def screen_saver?; end
+
+  sig { returns(T::Boolean) }
+  def service?; end
+
+  sig { returns(T::Boolean) }
+  def sha256?; end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def source(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def source_with_comments(*args, &block); end
+
+  sig { returns(T::Boolean) }
+  def stage_only?; end
+
+  sig { returns(T::Boolean) }
+  def suite?; end
+
+  sig { returns(T::Boolean) }
+  def uninstall?; end
+
+  sig { returns(T::Boolean) }
+  def uninstall_postflight?; end
+
+  sig { returns(T::Boolean) }
+  def uninstall_preflight?; end
+
+  sig { returns(T::Boolean) }
+  def url?; end
+
+  sig { returns(T::Boolean) }
+  def version?; end
+
+  sig { returns(T::Boolean) }
+  def vst3_plugin?; end
+
+  sig { returns(T::Boolean) }
+  def vst_plugin?; end
+
+  sig { returns(T::Boolean) }
+  def zap?; end
 end

--- a/Library/Homebrew/sorbet/tapioca/compilers/rubocop_cask_ast_stanza.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/rubocop_cask_ast_stanza.rb
@@ -1,0 +1,26 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "method_source"
+require "rubocop"
+require_relative "../../../rubocops"
+
+module Tapioca
+  module Compilers
+    class Stanza < Tapioca::Dsl::Compiler
+      ConstantType = type_member { { fixed: Module } }
+
+      sig { override.returns(T::Enumerable[Module]) }
+      def self.gather_constants = [::RuboCop::Cask::AST::Stanza]
+
+      sig { override.void }
+      def decorate
+        root.create_module(T.must(constant.name)) do |mod|
+          ::RuboCop::Cask::Constants::STANZA_ORDER.each do |stanza|
+            mod.create_method("#{stanza}?", return_type: "T::Boolean", class_method: false)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Part of https://github.com/Homebrew/brew/issues/17297.
- This includes a new Tapioca compiler for `RuboCop::Cask::AST::Stanza` dynamic methods like `caveats?`.
