### PR TITLE
don't crash on incorrectly capitalized commands

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -94,12 +94,12 @@ begin
       command_instance.run
     else
       begin
-        Homebrew.public_send Commands.method_name(cmd)
-      rescue NoMethodError => e
-        case_error = "undefined method `#{cmd.downcase}' for module Homebrew"
-        odie "Unknown command: brew #{cmd}" if e.message == case_error
-
-        raise
+        method_name = Commands.method_name(cmd)
+        if Homebrew.respond_to? method_name
+          Homebrew.public_send method_name
+        else
+          odie "Unknown command: brew #{cmd}"
+        end
       end
     end
   elsif (path = Commands.external_ruby_cmd_path(cmd))


### PR DESCRIPTION
Fixes #19125 (partially?). This prevents the crash + stack trace that was occuring, but does not address the warnings, which have a separate cause.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
