### PR TITLE
Fix handling of case-mistyped commands

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -61,6 +61,7 @@ begin
   ENV["PATH"] = path.to_s
 
   require "commands"
+  require "warnings"
 
   internal_cmd = Commands.valid_internal_cmd?(cmd) || Commands.valid_internal_dev_cmd?(cmd) if cmd
 
@@ -96,8 +97,10 @@ begin
       begin
         Homebrew.public_send Commands.method_name(cmd)
       rescue NoMethodError => e
-        case_error = "undefined method `#{cmd.downcase}' for module Homebrew"
-        odie "Unknown command: brew #{cmd}" if e.message == case_error
+        converted_cmd = cmd.downcase.tr("-", "_")
+        case_error = "undefined method `#{converted_cmd}' for module Homebrew"
+        private_method_error = "private method `#{converted_cmd}' called for module Homebrew"
+        odie "Unknown command: brew #{cmd}" if [case_error, private_method_error].include?(e.message)
 
         raise
       end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -8,7 +8,15 @@ module Kernel
   def require?(path)
     return false if path.nil?
 
-    require path
+    if defined?(Warnings)
+      # Work around require warning when done repeatedly:
+      # https://bugs.ruby-lang.org/issues/21091
+      Warnings.ignore(/already initialized constant/, /previous definition of/) do
+        require path
+      end
+    else
+      require path
+    end
     true
   rescue LoadError => e
     # we should raise on syntax errors but not if the file doesn't exist.


### PR DESCRIPTION
- hide warnings when requiring files repeatedly on a case-insensitive filesystem and add reference to Ruby bugs
- add another case to check for command require failures
- also handle commands with `-` in them

Closes https://github.com/Homebrew/brew/pull/19150
Fixes #19125