### PR TITLE
implement fixes and comments for `DisableComment` rubocop

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -55,6 +55,7 @@ module Cask
         return unless other.class < AbstractArtifact
         return 0 if instance_of?(other.class)
 
+        # TODO: Replace class var @@sort_order with a class instance var.
         @@sort_order ||= [ # rubocop:disable Style/ClassVars
           PreflightBlock,
           # The `uninstall` stanza should be run first, as it may

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -703,6 +703,7 @@ end
 
 # Strategy for extracting local binary packages.
 class LocalBottleDownloadStrategy < AbstractFileDownloadStrategy
+  # TODO: Call `super` here
   def initialize(path) # rubocop:disable Lint/MissingSuper
     @cached_location = path
     extend Pourable

--- a/Library/Homebrew/lazy_object.rb
+++ b/Library/Homebrew/lazy_object.rb
@@ -10,11 +10,9 @@ class LazyObject < Delegator
   end
 
   def __getobj__
-    # rubocop:disable Naming/MemoizedInstanceVariableName
-    return @__delegate__ if defined?(@__delegate__)
+    return @__getobj__ if defined?(@__getobj__)
 
-    @__delegate__ = @__callable__.call
-    # rubocop:enable Naming/MemoizedInstanceVariableName
+    @__getobj__ = @__callable__.call
   end
   private :__getobj__
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -30,6 +30,7 @@ module Homebrew
     _system(cmd, *args, **options)
   end
 
+  # `Module` and `Regexp` are global variables used as types here so they don't need to be imported
   # rubocop:disable Style/GlobalVars
   sig { params(the_module: Module, pattern: Regexp).void }
   def self.inject_dump_stats!(the_module, pattern)


### PR DESCRIPTION
(Sorry I created this PR originally with `gh pr create --fill`, I didn't realise that would create a PR with empty PR body)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR should fix the last of the rubocop violations that are reported after #18842 is merged.