### PR TITLE
utils/bottles: correctly normalise bottle tags to aarch64_linux

### DIFF
--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -186,7 +186,7 @@ module Utils
       sig { returns(Symbol) }
       def standardized_arch
         return :x86_64 if [:x86_64, :intel].include? arch
-        return :arm64 if [:arm64, :arm].include? arch
+        return linux? ? :aarch64 : :arm64 if [:arm64, :arm, :aarch64].include? arch
 
         arch
       end


### PR DESCRIPTION
The correct bottle tag on macOS is `arm64_*` and the correct bottle tag on Linux is `aarch64_*`: https://github.com/Homebrew/brew/tree/master/Library/Homebrew/test/support/fixtures/bottles. This already works as is, but let's adjust the normalisation so that it correctly equates the two if running on the opposite OS.

This does not affect anything other than bottle tags. Homebrew always uses `arm64` internally for other operations such as `Hardware::CPU.arch` etc.