### PR TITLE
tap command: correct helptext for --repair

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -38,7 +38,8 @@ module Homebrew
         switch "--custom-remote",
                description: "Install or change a tap with a custom remote. Useful for mirrors."
         switch "--repair",
-               description: "Migrate tapped formulae from symlink-based to directory-based structure."
+               description: "Add missing symlinks to tap manpages and shell completions. Correct git remote " \
+                            "refs for any taps where upstream HEAD branch has been renamed."
         switch "--eval-all",
                description: "Evaluate all the formulae, casks and aliases in the new tap to check validity. " \
                             "Implied if `$HOMEBREW_EVAL_ALL` is set."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Current helptext describes original functionality of `brew tap --repair`, which was removed in 56cb3325a. Replace this with decription of current functionality.