### PR TITLE
automatically repair tap with renamed main branch

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -259,19 +259,6 @@ module Homebrew
         link_completions_manpages_and_docs
         Tap.installed.each(&:link_completions_and_manpages)
 
-        failed_fetch_dirs = ENV["HOMEBREW_MISSING_REMOTE_REF_DIRS"]&.split("\n")
-        if failed_fetch_dirs.present?
-          failed_fetch_taps = failed_fetch_dirs.map { |dir| Tap.from_path(dir) }
-
-          ofail <<~EOS
-            Some taps failed to update!
-            The following taps can not read their remote branches:
-              #{failed_fetch_taps.join("\n  ")}
-            This is happening because the remote branch was renamed or deleted.
-            Reset taps to point to the correct remote branches by running `brew tap --repair`
-          EOS
-        end
-
         return if new_tag.blank? || new_tag == old_tag || args.quiet?
 
         puts

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -522,8 +522,6 @@ EOS
     echo "HOMEBREW_BREW_GIT_REMOTE set: using ${HOMEBREW_BREW_GIT_REMOTE} as the Homebrew/brew Git remote."
     git remote set-url origin "${HOMEBREW_BREW_GIT_REMOTE}"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    git fetch --force --tags origin
-    SKIP_FETCH_BREW_REPOSITORY=1
   fi
 
   if [[ -d "${HOMEBREW_CORE_REPOSITORY}" ]] &&
@@ -541,8 +539,6 @@ EOS
     echo "HOMEBREW_CORE_GIT_REMOTE set: using ${HOMEBREW_CORE_GIT_REMOTE} as the Homebrew/homebrew-core Git remote."
     git remote set-url origin "${HOMEBREW_CORE_GIT_REMOTE}"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    git fetch --force origin refs/heads/master:refs/remotes/origin/master
-    SKIP_FETCH_CORE_REPOSITORY=1
   fi
 
   safe_cd "${HOMEBREW_REPOSITORY}"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -260,7 +260,7 @@ merge_or_rebase() {
 Could not 'git stash' in ${DIR}!
 Please stash/commit manually if you need to keep your changes or, if not, run:
   cd ${DIR}
-  git reset --hard origin/master
+  git reset --hard origin/${UPSTREAM_DEFAULT_BRANCH}
 EOS
     fi
     git reset --hard "${QUIET_ARGS[@]}"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -213,11 +213,13 @@ merge_or_rebase() {
   local DIR
   local TAP_VAR
   local UPSTREAM_BRANCH
+  local UPSTREAM_DEFAULT_BRANCH
 
   DIR="$1"
   cd "${DIR}" || return
   TAP_VAR="$2"
   UPSTREAM_BRANCH="$3"
+  UPSTREAM_DEFAULT_BRANCH="${UPSTREAM_BRANCH}"
   unset STASHED
 
   trap reset_on_interrupt SIGINT
@@ -276,10 +278,10 @@ EOS
     then
       git checkout --force "${UPSTREAM_BRANCH}" "${QUIET_ARGS[@]}"
     else
-      if [[ -n "${UPSTREAM_TAG}" && "${UPSTREAM_BRANCH}" != "master" ]] &&
-         [[ "${INITIAL_BRANCH}" != "master" ]]
+      if [[ -n "${UPSTREAM_TAG}" && "${UPSTREAM_BRANCH}" != "${UPSTREAM_DEFAULT_BRANCH}" ]] &&
+         [[ "${INITIAL_BRANCH}" != "${UPSTREAM_DEFAULT_BRANCH}" ]]
       then
-        git branch --force "master" "origin/master" "${QUIET_ARGS[@]}"
+        git branch --force "${UPSTREAM_DEFAULT_BRANCH}" "origin/${UPSTREAM_DEFAULT_BRANCH}" "${QUIET_ARGS[@]}"
       fi
 
       git checkout --force -B "${UPSTREAM_BRANCH}" "${REMOTE_REF}" "${QUIET_ARGS[@]}"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -927,7 +927,6 @@ EOS
   # shellcheck disable=SC2031
   if [[ -n "${HOMEBREW_UPDATED}" ]] ||
      [[ -n "${HOMEBREW_UPDATE_FAILED}" ]] ||
-     [[ -n "${HOMEBREW_MISSING_REMOTE_REF_DIRS}" ]] ||
      [[ -n "${HOMEBREW_UPDATE_FORCE}" ]] ||
      [[ -n "${HOMEBREW_MIGRATE_LINUXBREW_FORMULAE}" ]] ||
      [[ -d "${HOMEBREW_LIBRARY}/LinkedKegs" ]] ||


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When fetching git repos, automatically correct local branch name if we find the remote HEAD was renamed.

----
_Completely reworked PR; to the point that my original comment doesn't make sense anymore. Original comment follows._

First step to fixing #17296.

We already have robust support for both detecting and fixing taps with renamed upstream HEAD. This puts those two together.

- support repairing one tap at a time with `brew tap --repair foo/bar`
- in `update.sh`, run `brew tap --repair` on any taps where we detect renamed upstream HEAD
- surpress git errors on first `git fetch` attempt, only if we detect rename
- after `brew tap --repair`, retry `git fetch`