### PR TITLE
Add a `last_reviewed_date` to docs metadata

### DIFF
--- a/docs/Acceptable-Casks.md
+++ b/docs/Acceptable-Casks.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Acceptable Casks
 
 Some casks should not go in [homebrew/cask](https://github.com/Homebrew/homebrew-cask). But there are additional [Interesting Taps and Forks](Interesting-Taps-and-Forks.md) and anyone can [start their own](How-to-Create-and-Maintain-a-Tap.md)!

--- a/docs/Acceptable-Formulae.md
+++ b/docs/Acceptable-Formulae.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Acceptable Formulae
 
 Some formulae should not go in [homebrew/core](https://github.com/Homebrew/homebrew-core). But there are additional [Interesting Taps and Forks](Interesting-Taps-and-Forks.md) and anyone can [start their own](How-to-Create-and-Maintain-a-Tap.md)!

--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Adding Software to Homebrew
 
 Is your favourite software missing from Homebrew? Then you're the perfect person to resolve this problem.

--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Anonymous Analytics
 
 Homebrew gathers anonymous analytics using InfluxDB. You will be notified the first time you run `brew update` or install Homebrew. Analytics are not enabled until after this notice is shown, to ensure that you can [opt out](Analytics.md#opting-out) without ever sending analytics data.

--- a/docs/Bottles.md
+++ b/docs/Bottles.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Bottles (Binary Packages)
 
 Bottles are produced by installing a formula with `brew install --build-bottle <formula>` and then bottling it with `brew bottle <formula>`. This generates a bottle file in the current directory and outputs the bottle DSL for insertion into the formula file.

--- a/docs/Brew-Livecheck.md
+++ b/docs/Brew-Livecheck.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # `brew livecheck`
 
 The `brew livecheck` command finds the newest version of a formula or cask's software by checking upstream. Livecheck has [strategies](https://rubydoc.brew.sh/Homebrew/Livecheck/Strategy) to identify versions from various sources, such as Git repositories, websites, etc.

--- a/docs/BrewTestBot-For-Maintainers.md
+++ b/docs/BrewTestBot-For-Maintainers.md
@@ -3,6 +3,7 @@ logo: /assets/img/brewtestbot.png
 image: /assets/img/brewtestbot.png
 redirect_from:
   - /Brew-Test-Bot-For-Core-Contributors
+last_review_date: "1970-01-01"
 ---
 
 # BrewTestBot for Maintainers

--- a/docs/BrewTestBot.md
+++ b/docs/BrewTestBot.md
@@ -3,6 +3,7 @@ logo: /assets/img/brewtestbot.png
 image: /assets/img/brewtestbot.png
 redirect_from:
   - /Brew-Test-Bot
+last_review_date: "1970-01-01"
 ---
 
 # BrewTestBot

--- a/docs/Building-Against-Non-Homebrew-Dependencies.md
+++ b/docs/Building-Against-Non-Homebrew-Dependencies.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Building Against Non-Homebrew Dependencies
 
 ## History

--- a/docs/C++-Standard-Libraries.md
+++ b/docs/C++-Standard-Libraries.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # C++ Standard Libraries
 
 There are two C++ standard libraries supported by Apple compilers.

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Cask Cookbook
 
 Each cask is a Ruby block, beginning with a special header line. The cask definition itself is always enclosed in a `do … end` block. Example:

--- a/docs/Checksum_Deprecation.md
+++ b/docs/Checksum_Deprecation.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # MD5 and SHA-1 Deprecation
 
 In early 2015 Homebrew started the process of deprecating _SHA1_ for package

--- a/docs/Common-Issues-for-Core-Contributors.md
+++ b/docs/Common-Issues-for-Core-Contributors.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Common Issues for Maintainers
 
 ## Overview

--- a/docs/Common-Issues.md
+++ b/docs/Common-Issues.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Common Issues
 
 This is a list of commonly encountered problems, known issues, and their solutions.

--- a/docs/Creating-a-Homebrew-Issue.md
+++ b/docs/Creating-a-Homebrew-Issue.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Creating a Homebrew Issue
 
 First, check to make sure your issue is not listed in the [FAQ](FAQ.md) or [Common Issues](Common-Issues.md) and can't otherwise be resolved with the information in the [Tips and Tricks](Tips-N'-Tricks.md) documentation. Next, go through the steps in the [Troubleshooting guide](Troubleshooting.md).

--- a/docs/Custom-GCC-and-cross-compilers.md
+++ b/docs/Custom-GCC-and-cross-compilers.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Custom GCC and Cross Compilers
 
 Homebrew depends on having an up-to-date version of Xcode because it comes with specific versions of build tools, e.g. `clang`. Installing a custom version of GCC or Autotools into your `PATH` has the potential to break lots of compiles so we prefer the Apple- or Homebrew-provided compilers. Cross compilers based on GCC will typically be "keg-only" and therefore not linked into your `PATH` by default, or be prefixed with the target architecture, again to avoid conflicting with Apple or Homebrew compilers.

--- a/docs/Deprecating-Disabling-and-Removing-Casks.md
+++ b/docs/Deprecating-Disabling-and-Removing-Casks.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Deprecating, Disabling and Removing Casks
 
 There are many reasons why casks may be deprecated, disabled or removed. This document explains the differences between each method as well as explaining when one method should be used over another.

--- a/docs/Deprecating-Disabling-and-Removing-Formulae.md
+++ b/docs/Deprecating-Disabling-and-Removing-Formulae.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Deprecating, Disabling and Removing Formulae
 
 There are many reasons why formulae may be deprecated, disabled or removed. This document explains the differences between each method as well as explaining when one method should be used over another.

--- a/docs/External-Commands.md
+++ b/docs/External-Commands.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # External Commands
 
 Homebrew, like Git, supports *external commands*. This lets you create new commands that can be run like:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # FAQ (Frequently Asked Questions)
 
 * Table of Contents

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Formula Cookbook
 
 A *formula* is a package definition written in Ruby. It can be created with `brew create <URL>` where `<URL>` is a zip or tarball, installed with `brew install <formula>`, and debugged with `brew install --debug --verbose <formula>`. Formulae use the [Formula API](https://rubydoc.brew.sh/Formula) which provides various Homebrew-specific helpers.

--- a/docs/Gems,-Eggs-and-Perl-Modules.md
+++ b/docs/Gems,-Eggs-and-Perl-Modules.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Gems, Eggs and Perl Modules
 
 On a fresh macOS installation there are two empty directories for

--- a/docs/Homebrew-Governance-Archives.md
+++ b/docs/Homebrew-Governance-Archives.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Governance Archives
 
 {% assign governance_pages = site.pages | where: "category", "governance-archives" %}

--- a/docs/Homebrew-Governance.md
+++ b/docs/Homebrew-Governance.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Governance
 
 ## 1. Definitions

--- a/docs/Homebrew-Leadership-Responsibilities.md
+++ b/docs/Homebrew-Leadership-Responsibilities.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Leadership Responsibilities
 
 ## Project Leadership Committee

--- a/docs/Homebrew-and-Java.md
+++ b/docs/Homebrew-and-Java.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew and Java
 
 This page describes how Java is handled in Homebrew for users. Prospective formula authors may refer to existing Java-based formulae for examples of how to install packages written in Java via Homebrew, or visit the [Homebrew discussion forum](https://github.com/orgs/Homebrew/discussions) to seek guidance for their specific situation.

--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Python
 
 This page describes how Python is handled in Homebrew for users. See [Python for Formula Authors](Python-for-Formula-Authors.md) for advice on writing formulae to install packages written in Python.

--- a/docs/Homebrew-brew-Maintainer-Guide.md
+++ b/docs/Homebrew-brew-Maintainer-Guide.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew/brew Maintainer Guide
 
 This document describes a few components of the `Homebrew/brew` repository that are useful for maintainers to be aware of, but don't necessarily need to appear in documentation for most users and contributors.

--- a/docs/Homebrew-homebrew-cask-Maintainer-Guide.md
+++ b/docs/Homebrew-homebrew-cask-Maintainer-Guide.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew/homebrew-cask Maintainer Guide
 
 This guide is intended to help maintainers effectively maintain the cask repository. It is meant to be used in conjunction with the more generic [Maintainer Guidelines](Maintainer-Guidelines.md).

--- a/docs/Homebrew-homebrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-homebrew-core-Maintainer-Guide.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew/homebrew-core Maintainer Guide
 
 ## Quick merge checklist

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -5,6 +5,7 @@ redirect_from:
   - /linux
   - /Linux
   - /Linuxbrew
+last_review_date: "1970-01-01"
 ---
 
 # Homebrew on Linux

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # How to Open a Homebrew Pull Request
 
 The following commands are used by Homebrew contributors to set up a fork of Homebrew's Git repository on GitHub, create a new branch and create a GitHub pull request ("PR") for the changes in that branch.

--- a/docs/How-To-Organize-AGM.md
+++ b/docs/How-To-Organize-AGM.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # How To Organize AGM
 
 AGM is our combination of business meeting, yearly work planning session, and opportunity to meet others in our international team in person.

--- a/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
+++ b/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # How to Build Software Outside Homebrew with Homebrew `keg_only` Dependencies
 
 ## What does "keg-only" mean?

--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # How to Create and Maintain a Tap
 
 [Taps](Taps.md) are external sources of Homebrew formulae, casks and/or external commands. They can be created by anyone to provide their own formulae, casks and/or external commands to any Homebrew user.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Installation
 
 Instructions for a supported install of Homebrew are on the [homepage](https://brew.sh).

--- a/docs/Interesting-Taps-and-Forks.md
+++ b/docs/Interesting-Taps-and-Forks.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Interesting Taps and Forks
 
 A [tap](Taps.md) is Homebrew-speak for a Git repository containing additional formulae.

--- a/docs/Kickstarter-Supporters.md
+++ b/docs/Kickstarter-Supporters.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Kickstarter Supporters
 
 This file contains a list of the awesome people who gave £5 or more to [our Kickstarter](https://www.kickstarter.com/projects/homebrew/brew-test-bot).

--- a/docs/License-Guidelines.md
+++ b/docs/License-Guidelines.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # License Guidelines
 
 We only accept formulae that use a [Debian Free Software Guidelines license](https://wiki.debian.org/DFSGLicenses) or are released into the public domain following [DFSG Guidelines on Public Domain software](https://wiki.debian.org/DFSGLicenses#Public_Domain) into `homebrew/core`.

--- a/docs/Linux-CI.md
+++ b/docs/Linux-CI.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Linux CI in `homebrew/core`
 
 We currently use Ubuntu 22.04 for bottling in `homebrew/core`.

--- a/docs/Maintainer-Guidelines.md
+++ b/docs/Maintainer-Guidelines.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Maintainer Guidelines
 
 **This guide is for maintainers.** These special people have **write access** to Homebrew’s repository and help merge the contributions of others. You may find what is written here interesting, but it’s definitely not a beginner’s guide.

--- a/docs/Maintainers-Avoiding-Burnout.md
+++ b/docs/Maintainers-Avoiding-Burnout.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Maintainers: Avoiding Burnout
 
 **This guide is for maintainers.** These special people have **write

--- a/docs/Migrating-A-Formula-To-A-Tap.md
+++ b/docs/Migrating-A-Formula-To-A-Tap.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Migrating a Formula to a Tap
 
 There are times when we may wish to migrate a formula from one tap into another tap. To do this:

--- a/docs/New-Maintainer-Checklist.md
+++ b/docs/New-Maintainer-Checklist.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # New Maintainer Checklist
 
 **Existing maintainers and project leadership uses this guide to invite and onboard new maintainers and project leaders.**

--- a/docs/Node-for-Formula-Authors.md
+++ b/docs/Node-for-Formula-Authors.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Node for Formula Authors
 
 This document explains how to successfully use Node and npm in a Node module based Homebrew formula.

--- a/docs/Prose-Style-Guidelines.md
+++ b/docs/Prose-Style-Guidelines.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Prose Style Guidelines
 
 <!-- vale off -->

--- a/docs/Python-for-Formula-Authors.md
+++ b/docs/Python-for-Formula-Authors.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Python for Formula Authors
 
 This document explains how to successfully use Python in a Homebrew formula.

--- a/docs/Querying-Brew.md
+++ b/docs/Querying-Brew.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Querying `brew`
 
 _In this document we will be using [jq](https://stedolan.github.io/jq/) to parse JSON, available from Homebrew using `brew install jq`._

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ A [GitHub Action](https://github.com/Homebrew/brew/blob/master/.github/workflows
 
 Open <https://docs.brew.sh> in your web browser.
 
-To instead generate the site locally to <http://localhost:4000>, run:
+To instead generate the site locally, available on localhost:4000, run:
 
 ```bash
 cd `brew --repository`/docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Docs
 
 These are the source files for the [Homebrew documentation site](https://docs.brew.sh/).

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Releases
 
 Since Homebrew 1.0.0 most Homebrew users (those who haven't run a `dev-cmd` or set `HOMEBREW_DEVELOPER=1` which is ~99.9% based on analytics data) require tags on the [Homebrew/brew repository](https://github.com/homebrew/brew) in order to receive new versions of Homebrew. There are a few steps in making a new Homebrew release:

--- a/docs/Rename-A-Formula.md
+++ b/docs/Rename-A-Formula.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Renaming a Formula
 
 Sometimes software and formulae need to be renamed. To rename a formula you need to:

--- a/docs/Reproducible-Builds.md
+++ b/docs/Reproducible-Builds.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Reproducible Builds
 
 The Homebrew build environment is designed with [reproducible builds](https://reproducible-builds.org) as a goal where possible. Some convenience tools are also available to formula authors to help achieve deterministic builds.

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # `brew` Shell Completion
 
 Homebrew comes with completion definitions for the `brew` command. Some packages also provide completion definitions for their own programs.

--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Taps (Third-Party Repositories)
 
 The `brew tap` command adds more repositories to the list of formulae that Homebrew tracks, updates,

--- a/docs/Tips-N'-Tricks.md
+++ b/docs/Tips-N'-Tricks.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Tips and Tricks
 
 ## Install previous versions of formulae

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Troubleshooting
 
 **Run `brew update` twice and `brew doctor` (and fix all the warnings) *before* creating an issue!**

--- a/docs/Typechecking.md
+++ b/docs/Typechecking.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Type Checking With Sorbet
 
 The majority of the code in Homebrew is written in Ruby which is a dynamic language. To avail the benefits of static type checking, we have set up Sorbet in our codebase which provides the benefits of static type checking to dynamic languages like Ruby.

--- a/docs/Updating-Software-in-Homebrew.md
+++ b/docs/Updating-Software-in-Homebrew.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Updating Software in Homebrew
 
 Did you find something in Homebrew that wasn't the latest version? You can help yourself and others by submitting a pull request to update the formula.

--- a/docs/Versions.md
+++ b/docs/Versions.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Formulae Versions
 
 [homebrew/core](https://github.com/homebrew/homebrew-core) supports multiple versions of formulae by using a special naming format. For example, the formula for GCC 9 is named `gcc@9.rb` and begins with `class GccAT9 < Formula`.

--- a/docs/Xcode.md
+++ b/docs/Xcode.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Xcode
 
 ## Supported Xcode versions

--- a/docs/governance/2019-membership.md
+++ b/docs/governance/2019-membership.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # 2019 Membership
 
 - @alebcay

--- a/docs/governance/2019-moss-track-iii-grant-nomination.md
+++ b/docs/governance/2019-moss-track-iii-grant-nomination.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Nomination for Mozilla Open Source Support, Track III
 
 ## Solicitation

--- a/docs/governance/2019-plc-minutes.md
+++ b/docs/governance/2019-plc-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Project Leadership Committee Minutes 2019
 
 ## Members

--- a/docs/governance/2020-membership.md
+++ b/docs/governance/2020-membership.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # 2020 Membership
 
 - @alebcay

--- a/docs/governance/2020-plc-minutes.md
+++ b/docs/governance/2020-plc-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Project Leadership Committee Minutes 2020
 
 ## Project Leader

--- a/docs/governance/2021-agm-minutes.md
+++ b/docs/governance/2021-agm-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Annual General Meeting 2021
 
 ## Minutes

--- a/docs/governance/2021-egm-minutes.md
+++ b/docs/governance/2021-egm-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Extraordinary General Meeting 2021
 
 ## 2021-01-14

--- a/docs/governance/2021-membership.md
+++ b/docs/governance/2021-membership.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # 2021 Membership
 
 - @alebcay

--- a/docs/governance/2021-plc-minutes.md
+++ b/docs/governance/2021-plc-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Project Leadership Committee Minutes 2021
 
 ## Project Leader

--- a/docs/governance/2022-agm-minutes.md
+++ b/docs/governance/2022-agm-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Annual General Meeting 2022
 
 ## Minutes

--- a/docs/governance/2022-membership.md
+++ b/docs/governance/2022-membership.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # 2022 Membership
 
 - @alebcay

--- a/docs/governance/2023-agm-minutes.md
+++ b/docs/governance/2023-agm-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Annual General Meeting 2023
 
 ## Minutes

--- a/docs/governance/2024-agm-minutes.md
+++ b/docs/governance/2024-agm-minutes.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Homebrew Annual General Meeting 2024
 
 ## Opening

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Documentation
 
 ## Users

--- a/docs/vale-styles/Homebrew/README.md
+++ b/docs/vale-styles/Homebrew/README.md
@@ -1,3 +1,7 @@
+---
+last_review_date: "1970-01-01"
+---
+
 # Vale Styles
 
 Based on Homebrew's [Prose Style Guidelines](http://docs.brew.sh/Prose-Style-Guidelines.html).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- At the AGM we formed an ad-hoc documentation working group.
- One of our ideas was that we should have a last reviewed date for documentation, so that we can periodically implement a review mechanism (GitHub Actions posts to Slack for a regular documentation outdatedness check?) to track how old docs are and ensure they're still relevant.
- This is a first step towards that goal, by adding a `last_review_date` to the metadata of all docs with a date of earlier than Homebrew's inception because everything needs reviewing so that we start from a good base!
