### PR TITLE
dev-cmd/livecheck: improve error message when all formulae are autobumped

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -92,6 +92,7 @@ module Homebrew
           end
         end
 
+        skipped_autobump = T.let(false, T::Boolean)
         if skip_autobump?
           autobump_lists = {}
 
@@ -105,10 +106,11 @@ module Homebrew
             end
 
             name = formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
-            if autobump_lists[tap].include?(name)
-              odebug "Skipping #{name} as it is autobumped in #{tap}."
-              true
-            end
+            next unless autobump_lists[tap].include?(name)
+
+            odebug "Skipping #{name} as it is autobumped in #{tap}."
+            skipped_autobump = true
+            true
           end
         end
 
@@ -116,7 +118,8 @@ module Homebrew
           formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
         end
 
-        raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank?
+        raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank? && !skipped_autobump
+        return if formulae_and_casks_to_check.blank?
 
         options = {
           json:                 args.json?,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When all formulae provided to `livecheck` are in `autobump.txt`, we get an uninterpretable error message, which does not help diagnose what's going on:
```
➜  Homebrew git:(master) brew lc prestodb
Usage: brew livecheck, lc [options] [formula|cask ...]

Check for newer versions of formulae and/or casks from upstream. If no formula
or cask argument is passed, the list of formulae and casks to check is taken
from HOMEBREW_LIVECHECK_WATCHLIST or ~/.homebrew/livecheck_watchlist.txt.

      --full-name                  Print formulae and casks with fully-qualified
                                   names.
      --tap                        Check formulae and casks within the given
                                   tap, specified as user/repo.
      --eval-all                   Evaluate all available formulae and casks,
                                   whether installed or not, to check them.
      --installed                  Check formulae and casks that are currently
                                   installed.
      --newer-only                 Show the latest version only if it's newer
                                   than the formula/cask.
      --json                       Output information in JSON format.
  -r, --resources                  Also check resources for formulae.
  -q, --quiet                      Suppress warnings, don't print a progress bar
                                   for JSON output.
      --formula, --formulae        Only check formulae.
      --cask, --casks              Only check casks.
      --extract-plist              Enable checking multiple casks with
                                   ExtractPlist strategy.
      --autobump                   Include packages that are autobumped by
                                   BrewTestBot. By default these are skipped.
  -d, --debug                      Display any debugging information.
  -v, --verbose                    Make some output more verbose.
  -h, --help                       Show this message.

Error: Invalid usage: No formulae or casks to check.
```

This PR attempts to improve the messaging:
```
➜  Homebrew git:(livecheck-error) brew lc prestodb
➜  Homebrew git:(livecheck-error) brew lc -d prestodb
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading prestodb
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::NullLoader): loading prestodb
==> Skipping prestodb as it is autobumped in homebrew/core.
```

The "skip" message only appears when using `--debug` but there is definitely a case to be made for printing it regardless, or a summary that all provided formulae were ignored.