### PR TITLE
Add rebottling documentation in BrewTestBot-For-Maintainers.md

### DIFF
--- a/docs/BrewTestBot-For-Maintainers.md
+++ b/docs/BrewTestBot-For-Maintainers.md
@@ -32,3 +32,13 @@ If a pull request needs its commit messages changed in a way that autosquash doe
 1. Ensure that bottles have built successfully.
 2. Run `brew pr-pull 12345` where `12345` is the pull request number (or URL).
 3. Amend any relevant commits if needed, then run `git push` to push the commits to the pull request.
+
+## Rebottling
+
+If a formula needs rebottling for any reasons within homebrew-core:
+
+1. Navigate to the homebrew-core github page.
+2. Click on the "Actions" tab.
+3. Click on the "Dispatch rebottle" workflow on the left of the page.
+4. Click on the "Run workflow" button on the right of the page.
+5. Fill out any necessary fields.

--- a/docs/BrewTestBot-For-Maintainers.md
+++ b/docs/BrewTestBot-For-Maintainers.md
@@ -35,7 +35,7 @@ If a pull request needs its commit messages changed in a way that autosquash doe
 
 ## Rebottling
 
-If a formula needs rebottling for any reasons within homebrew-core:
+If a formula in homebrew-core needs rebottling for any reason:
 
 1. Navigate to the homebrew-core github page.
 2. Click on the "Actions" tab.

--- a/docs/BrewTestBot-For-Maintainers.md
+++ b/docs/BrewTestBot-For-Maintainers.md
@@ -37,8 +37,6 @@ If a pull request needs its commit messages changed in a way that autosquash doe
 
 If a formula in homebrew-core needs rebottling for any reason:
 
-1. Navigate to the homebrew-core github page.
-2. Click on the "Actions" tab.
-3. Click on the "Dispatch rebottle" workflow on the left of the page.
-4. Click on the "Run workflow" button on the right of the page.
-5. Fill out any necessary fields.
+1. Navigate to [homebrew-core's rebottling workflow page](https://github.com/Homebrew/homebrew-core/actions/workflows/dispatch-rebottle.yml)
+2. Click on the "Run workflow" button on the right of the page.
+3. Fill out any necessary fields.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The rebottling process didn't have any documentation.