### PR TITLE
cask/artifact/installer: don't reset uid if sudo is used.

### DIFF
--- a/Library/Homebrew/cask/artifact/installer.rb
+++ b/Library/Homebrew/cask/artifact/installer.rb
@@ -30,7 +30,7 @@ module Cask
             env:       { "PATH" => PATH.new(
               HOMEBREW_PREFIX/"bin", HOMEBREW_PREFIX/"sbin", ENV.fetch("PATH")
             ) },
-            reset_uid: true,
+            reset_uid: !args[:sudo],
           )
         end
       end


### PR DESCRIPTION
This fixes handling `sudo` and EUID when using certain `script` commands on casks e.g. adobe-creative-cloud.