### PR TITLE
livecheck: Add support for POST requests

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -614,6 +614,7 @@ module Homebrew
       referenced_livecheck = referenced_formula_or_cask&.livecheck
 
       livecheck_url = livecheck.url || referenced_livecheck&.url
+      livecheck_url_options = livecheck.url_options || referenced_livecheck&.url_options
       livecheck_regex = livecheck.regex || referenced_livecheck&.regex
       livecheck_strategy = livecheck.strategy || referenced_livecheck&.strategy
       livecheck_strategy_block = livecheck.strategy_block || referenced_livecheck&.strategy_block
@@ -673,6 +674,7 @@ module Homebrew
           elsif original_url.present? && original_url != "None"
             puts "URL:              #{original_url}"
           end
+          puts "URL Options:      #{livecheck_url_options}" if livecheck_url_options.present?
           puts "URL (processed):  #{url}" if url != original_url
           if strategies.present? && verbose
             puts "Strategies:       #{strategies.map { |s| livecheck_strategy_names[s] }.join(", ")}"
@@ -701,6 +703,7 @@ module Homebrew
 
         strategy_args = {
           regex:         livecheck_regex,
+          url_options:   livecheck_url_options,
           homebrew_curl:,
         }
         # TODO: Set `cask`/`url` args based on the presence of the keyword arg
@@ -807,6 +810,7 @@ module Homebrew
               version_info[:meta][:url][:strategy] = strategy_data[:url]
             end
             version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data[:final_url]
+            version_info[:meta][:url][:options] = livecheck_url_options if livecheck_url_options.present?
             version_info[:meta][:url][:homebrew_curl] = homebrew_curl if homebrew_curl.present?
           end
           version_info[:meta][:strategy] = strategy_name if strategy.present?
@@ -856,6 +860,7 @@ module Homebrew
       livecheck = resource.livecheck
       livecheck_reference = livecheck.formula
       livecheck_url = livecheck.url
+      livecheck_url_options = livecheck.url_options
       livecheck_regex = livecheck.regex
       livecheck_strategy = livecheck.strategy
       livecheck_strategy_block = livecheck.strategy_block
@@ -893,6 +898,7 @@ module Homebrew
           elsif original_url.present? && original_url != "None"
             puts "URL:              #{original_url}"
           end
+          puts "URL Options:      #{livecheck_url_options}" if livecheck_url_options.present?
           puts "URL (processed):  #{url}" if url != original_url
           if strategies.present? && verbose
             puts "Strategies:       #{strategies.map { |s| livecheck_strategy_names[s] }.join(", ")}"
@@ -923,6 +929,7 @@ module Homebrew
           strategy_args = {
             url:,
             regex:         livecheck_regex,
+            url_options:   livecheck_url_options,
             homebrew_curl: false,
           }.compact
 
@@ -1012,6 +1019,7 @@ module Homebrew
             resource_version_info[:meta][:url][:strategy] = strategy_data[:url]
           end
           resource_version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data&.dig(:final_url)
+          resource_version_info[:meta][:url][:options] = livecheck_url_options if livecheck_url_options.present?
         end
         resource_version_info[:meta][:strategy] = strategy_name if strategy.present?
         if strategies.present?

--- a/Library/Homebrew/livecheck/strategy.rbi
+++ b/Library/Homebrew/livecheck/strategy.rbi
@@ -1,0 +1,9 @@
+# typed: strict
+
+module Homebrew
+  module Livecheck
+    module Strategy
+      include Kernel
+    end
+  end
+end

--- a/Library/Homebrew/livecheck/strategy/crate.rb
+++ b/Library/Homebrew/livecheck/strategy/crate.rb
@@ -81,11 +81,11 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
+            unused:           T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
           match_data = { matches: {}, regex:, url: }
           match_data[:cached] = true if provided_content.is_a?(String)
 
@@ -97,7 +97,13 @@ module Homebrew
           content = if provided_content
             provided_content
           else
-            match_data.merge!(Strategy.page_content(match_data[:url], homebrew_curl:))
+            match_data.merge!(
+              Strategy.page_content(
+                match_data[:url],
+                url_options:   unused.fetch(:url_options, {}),
+                homebrew_curl:,
+              ),
+            )
             match_data[:content]
           end
           return match_data unless content

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -74,14 +74,18 @@ module Homebrew
             url:           String,
             regex:         T.nilable(Regexp),
             homebrew_curl: T::Boolean,
-            _unused:       T.untyped,
+            unused:        T.untyped,
             block:         T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, homebrew_curl: false, **unused, &block)
           match_data = { matches: {}, regex:, url: }
 
-          headers = Strategy.page_headers(url, homebrew_curl:)
+          headers = Strategy.page_headers(
+            url,
+            url_options:   unused.fetch(:url_options, {}),
+            homebrew_curl:,
+          )
 
           # Merge the headers from all responses into one hash
           merged_headers = headers.reduce(&:merge)

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -102,11 +102,11 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
+            unused:           T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
@@ -116,7 +116,13 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
+            match_data.merge!(
+              Strategy.page_content(
+                url,
+                url_options:   unused.fetch(:url_options, {}),
+                homebrew_curl:,
+              ),
+            )
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -85,11 +85,11 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
+            unused:           T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
           if regex.blank? && block.blank?
             raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a regex or `strategy` block"
           end
@@ -101,7 +101,13 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
+            match_data.merge!(
+              Strategy.page_content(
+                url,
+                url_options:   unused.fetch(:url_options, {}),
+                homebrew_curl:,
+              ),
+            )
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -217,13 +217,13 @@ module Homebrew
         # @return [Hash]
         sig {
           params(
-            url:     String,
-            regex:   T.nilable(Regexp),
-            _unused: T.untyped,
-            block:   T.nilable(Proc),
+            url:    String,
+            regex:  T.nilable(Regexp),
+            unused: T.untyped,
+            block:  T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **_unused, &block)
+        def self.find_versions(url:, regex: nil, **unused, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
@@ -231,7 +231,12 @@ module Homebrew
 
           match_data = { matches: {}, regex:, url: }
 
-          match_data.merge!(Strategy.page_content(url))
+          match_data.merge!(
+            Strategy.page_content(
+              url,
+              url_options: unused.fetch(:url_options, {}),
+            ),
+          )
           content = match_data.delete(:content)
           return match_data if content.blank?
 

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -214,16 +214,18 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp, nil] a regex for use in a strategy block
+        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:           String,
+            regex:         T.nilable(Regexp),
+            homebrew_curl: T::Boolean,
+            unused:        T.untyped,
+            block:         T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, homebrew_curl: false, **unused, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
@@ -234,7 +236,8 @@ module Homebrew
           match_data.merge!(
             Strategy.page_content(
               url,
-              url_options: unused.fetch(:url_options, {}),
+              url_options:   unused.fetch(:url_options, {}),
+              homebrew_curl:,
             ),
           )
           content = match_data.delete(:content)

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -142,11 +142,11 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
+            unused:           T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
@@ -156,7 +156,13 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
+            match_data.merge!(
+              Strategy.page_content(
+                url,
+                url_options:   unused.fetch(:url_options, {}),
+                homebrew_curl:,
+              ),
+            )
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/yaml.rb
+++ b/Library/Homebrew/livecheck/strategy/yaml.rb
@@ -102,11 +102,11 @@ module Homebrew
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
             homebrew_curl:    T::Boolean,
-            _unused:          T.untyped,
+            unused:           T.untyped,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **_unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
           raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
@@ -116,7 +116,13 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(Strategy.page_content(url, homebrew_curl:))
+            match_data.merge!(
+              Strategy.page_content(
+                url,
+                url_options:   unused.fetch(:url_options, {}),
+                homebrew_curl:,
+              ),
+            )
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -5,6 +5,102 @@ require "livecheck/strategy"
 RSpec.describe Homebrew::Livecheck::Strategy do
   subject(:strategy) { described_class }
 
+  let(:url) { "https://brew.sh/" }
+  let(:redirection_url) { "https://brew.sh/redirection" }
+
+  let(:post_hash) do
+    {
+      "empty"   => "",
+      "boolean" => "true",
+      "number"  => "1",
+      "string"  => "a + b = c",
+    }
+  end
+  let(:post_hash_symbol_keys) do
+    {
+      empty:   "",
+      boolean: "true",
+      number:  "1",
+      string:  "a + b = c",
+    }
+  end
+  let(:form_string) { "empty=&boolean=true&number=1&string=a+%2B+b+%3D+c" }
+  let(:json_string) { '{"empty":"","boolean":"true","number":"1","string":"a + b = c"}' }
+
+  let(:response_hash) do
+    response_hash = {}
+
+    response_hash[:ok] = {
+      status_code: "200",
+      status_text: "OK",
+      headers:     {
+        "cache-control"  => "max-age=604800",
+        "content-type"   => "text/html; charset=UTF-8",
+        "date"           => "Wed, 1 Jan 2020 01:23:45 GMT",
+        "expires"        => "Wed, 31 Jan 2020 01:23:45 GMT",
+        "last-modified"  => "Thu, 1 Jan 2019 01:23:45 GMT",
+        "content-length" => "123",
+      },
+    }
+
+    response_hash[:redirection] = {
+      status_code: "301",
+      status_text: "Moved Permanently",
+      headers:     {
+        "cache-control"  => "max-age=604800",
+        "content-type"   => "text/html; charset=UTF-8",
+        "date"           => "Wed, 1 Jan 2020 01:23:45 GMT",
+        "expires"        => "Wed, 31 Jan 2020 01:23:45 GMT",
+        "last-modified"  => "Thu, 1 Jan 2019 01:23:45 GMT",
+        "content-length" => "123",
+        "location"       => redirection_url,
+      },
+    }
+
+    response_hash
+  end
+
+  let(:body) do
+    <<~HTML
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>Thank you!</title>
+        </head>
+        <body>
+          <h1>Download</h1>
+          <p>This download link could have been made publicly available in a reasonable fashion but we appreciate that you jumped through the hoops that we carefully set up!: <a href="https://brew.sh/example-1.2.3.tar.gz">Example v1.2.3</a></p>
+          <p>The current legacy version is: <a href="https://brew.sh/example-0.1.2.tar.gz">Example v0.1.2</a></p>
+        </body>
+      </html>
+    HTML
+  end
+
+  let(:response_text) do
+    response_text = {}
+
+    response_text[:ok] = <<~EOS
+      HTTP/1.1 #{response_hash[:ok][:status_code]} #{response_hash[:ok][:status_text]}\r
+      Cache-Control: #{response_hash[:ok][:headers]["cache-control"]}\r
+      Content-Type: #{response_hash[:ok][:headers]["content-type"]}\r
+      Date: #{response_hash[:ok][:headers]["date"]}\r
+      Expires: #{response_hash[:ok][:headers]["expires"]}\r
+      Last-Modified: #{response_hash[:ok][:headers]["last-modified"]}\r
+      Content-Length: #{response_hash[:ok][:headers]["content-length"]}\r
+      \r
+      #{body.rstrip}
+    EOS
+
+    response_text[:redirection_to_ok] = response_text[:ok].sub(
+      "HTTP/1.1 #{response_hash[:ok][:status_code]} #{response_hash[:ok][:status_text]}\r",
+      "HTTP/1.1 #{response_hash[:redirection][:status_code]} #{response_hash[:redirection][:status_text]}\r\n" \
+      "Location: #{response_hash[:redirection][:headers]["location"]}\r",
+    )
+
+    response_text
+  end
+
   describe "::from_symbol" do
     it "returns the Strategy module represented by the Symbol argument" do
       expect(strategy.from_symbol(:page_match)).to eq(Homebrew::Livecheck::Strategy::PageMatch)
@@ -27,6 +123,113 @@ RSpec.describe Homebrew::Livecheck::Strategy do
             [Homebrew::Livecheck::Strategy::Sourceforge, Homebrew::Livecheck::Strategy::PageMatch],
           )
       end
+    end
+  end
+
+  describe "::post_args" do
+    it "returns an array including `--data` and an encoded form data string" do
+      expect(strategy.post_args(post_form: post_hash)).to eq(["--data", form_string])
+      expect(strategy.post_args(post_form: post_hash_symbol_keys)).to eq(["--data", form_string])
+
+      # If both `post_form` and `post_json` are present, only `post_form` will
+      # be used.
+      expect(strategy.post_args(post_form: post_hash, post_json: post_hash)).to eq(["--data", form_string])
+    end
+
+    it "returns an array including `--json` and a JSON string" do
+      expect(strategy.post_args(post_json: post_hash)).to eq(["--json", json_string])
+      expect(strategy.post_args(post_json: post_hash_symbol_keys)).to eq(["--json", json_string])
+    end
+
+    it "returns an empty array if `post_form` value is blank" do
+      expect(strategy.post_args(post_form: {})).to eq([])
+    end
+
+    it "returns an empty array if `post_json` value is blank" do
+      expect(strategy.post_args(post_json: {})).to eq([])
+    end
+
+    it "returns an empty array if hash argument doesn't have a `post_form` or `post_json` value" do
+      expect(strategy.post_args).to eq([])
+    end
+  end
+
+  describe "::page_headers" do
+    let(:responses) { [response_hash[:ok]] }
+
+    it "returns headers from fetched content" do
+      allow(strategy).to receive(:curl_headers).and_return({ responses:, body: })
+
+      expect(strategy.page_headers(url)).to eq([responses.first[:headers]])
+    end
+
+    it "handles `post_form` `url` options" do
+      allow(strategy).to receive(:curl_headers).and_return({ responses:, body: })
+
+      expect(strategy.page_headers(url, url_options: { post_form: post_hash }))
+        .to eq([responses.first[:headers]])
+    end
+
+    it "returns an empty array if `curl_headers` only raises an `ErrorDuringExecution` error" do
+      allow(strategy).to receive(:curl_headers).and_raise(ErrorDuringExecution.new([], status: 1))
+
+      expect(strategy.page_headers(url)).to eq([])
+    end
+  end
+
+  describe "::page_content" do
+    let(:curl_version) { Version.new("8.7.1") }
+    let(:success_status) { instance_double(Process::Status, success?: true, exitstatus: 0) }
+
+    it "returns hash including fetched content" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])
+
+      expect(strategy.page_content(url)).to eq({ content: body })
+    end
+
+    it "handles `post_form` `url` option" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])
+
+      expect(strategy.page_content(url, url_options: { post_form: post_hash })).to eq({ content: body })
+    end
+
+    it "handles `post_json` `url` option" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])
+
+      expect(strategy.page_content(url, url_options: { post_json: post_hash })).to eq({ content: body })
+    end
+
+    it "returns error `messages` from `stderr` in the return hash on failure when `stderr` is not `nil`" do
+      error_message = "curl: (6) Could not resolve host: brew.sh"
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow(strategy).to receive(:curl_output).and_return([
+        nil,
+        error_message,
+        instance_double(Process::Status, success?: false, exitstatus: 6),
+      ])
+
+      expect(strategy.page_content(url)).to eq({ messages: [error_message] })
+    end
+
+    it "returns default error `messages` in the return hash on failure when `stderr` is `nil`" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow(strategy).to receive(:curl_output).and_return([
+        nil,
+        nil,
+        instance_double(Process::Status, success?: false, exitstatus: 1),
+      ])
+
+      expect(strategy.page_content(url)).to eq({ messages: ["cURL failed without a detectable error"] })
+    end
+
+    it "returns hash including `final_url` if it differs from initial `url`" do
+      allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
+      allow(strategy).to receive(:curl_output).and_return([response_text[:redirection_to_ok], nil, success_status])
+
+      expect(strategy.page_content(url)).to eq({ content: body, final_url: redirection_url })
     end
   end
 

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe Livecheck do
   end
   let(:livecheck_c) { described_class.new(c) }
 
+  let(:post_hash) do
+    {
+      "empty"   => "",
+      "boolean" => "true",
+      "number"  => "1",
+      "string"  => "a + b = c",
+    }
+  end
+
   describe "#formula" do
     it "returns nil if not set" do
       expect(livecheck_f.formula).to be_nil
@@ -137,9 +146,21 @@ RSpec.describe Livecheck do
       expect(livecheck_c.url).to eq(:url)
     end
 
+    it "sets `url_options` when provided" do
+      post_args = { post_form: post_hash }
+      livecheck_f.url(url_string, **post_args)
+      expect(livecheck_f.url_options).to eq(post_args)
+    end
+
     it "raises an ArgumentError if the argument isn't a valid Symbol" do
       expect do
         livecheck_f.url(:not_a_valid_symbol)
+      end.to raise_error ArgumentError
+    end
+
+    it "raises an ArgumentError if both `post_form` and `post_json` arguments are provided" do
+      expect do
+        livecheck_f.url(:stable, post_form: post_hash, post_json: post_hash)
       end.to raise_error ArgumentError
     end
   end
@@ -148,14 +169,15 @@ RSpec.describe Livecheck do
     it "returns a Hash of all instance variables" do
       expect(livecheck_f.to_hash).to eq(
         {
-          "cask"     => nil,
-          "formula"  => nil,
-          "regex"    => nil,
-          "skip"     => false,
-          "skip_msg" => nil,
-          "strategy" => nil,
-          "throttle" => nil,
-          "url"      => nil,
+          "cask"        => nil,
+          "formula"     => nil,
+          "regex"       => nil,
+          "skip"        => false,
+          "skip_msg"    => nil,
+          "strategy"    => nil,
+          "throttle"    => nil,
+          "url"         => nil,
+          "url_options" => nil,
         },
       )
     end

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -99,13 +99,23 @@ RSpec.describe Livecheck do
   end
 
   describe "#strategy" do
+    block = proc { |page, regex| page.scan(regex).map { |match| match[0].tr("_", ".") } }
+
     it "returns nil if not set" do
       expect(livecheck_f.strategy).to be_nil
+      expect(livecheck_f.strategy_block).to be_nil
     end
 
     it "returns the Symbol if set" do
       livecheck_f.strategy(:page_match)
       expect(livecheck_f.strategy).to eq(:page_match)
+      expect(livecheck_f.strategy_block).to be_nil
+    end
+
+    it "sets `strategy_block` when provided" do
+      livecheck_f.strategy(:page_match, &block)
+      expect(livecheck_f.strategy).to eq(:page_match)
+      expect(livecheck_f.strategy_block).to eq(block)
     end
   end
 

--- a/docs/Brew-Livecheck.md
+++ b/docs/Brew-Livecheck.md
@@ -112,6 +112,24 @@ end
 
 The referenced formula/cask should be in the same tap, as a reference to a formula/cask from another tap will generate an error if the user doesn't already have it tapped.
 
+### `POST` requests
+
+Some checks require making a `POST` request and that can be accomplished by adding a `post_form` or `post_json` option to a `livecheck` block `url`.
+
+```ruby
+livecheck do
+  url "https://example.com/download.php", post_form: {
+    "Name"   => "",
+    "E-mail" => "",
+  }
+  regex(/href=.*?example[._-]v?(\d+(?:\.\d+)+)\.t/i)
+end
+```
+
+`post_form` is used for form data and `post_json` is used for JSON data. livecheck will encode the provided hash value to the appropriate format before making the request.
+
+`POST` support only applies to strategies that use `Strategy::page_headers` or `::page_content` (directly or indirectly), so it does not apply to `ExtractPlist`, `Git`, `GithubLatest`, `GithubReleases`, etc.
+
 ### `strategy` blocks
 
 If the upstream version format needs to be manipulated to match the formula/cask format, a `strategy` block can be used instead of a `regex`.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

livecheck currently doesn't support `POST` requests but it wasn't entirely clear how best to handle that. I initially approached it as a `Post` strategy but unfortunately that would have required us to handle response body parsing (e.g., JSON, XML, etc.) in some fashion. We could borrow some of the logic from related strategies but we would still be stuck having to update `Post` whenever we add a strategy for a new format.

Instead, this implements `POST` support by borrowing ideas from the `using: :post` and `data` `url` options found in formulae. This uses a `post_form` option to handle form data and `post_json` to handle JSON data, encoding the hash argument for each into the appropriate format. The presence of either option means that curl will use a `POST` request.

With this approach, we can make a `POST` request using any strategy that calls `Strategy::page_headers` or `::page_content` (directly or indirectly) and everything else works the same as usual. The only change needed in related strategies was to pass the options through to the `Strategy` methods.

For example, if we need to parse a JSON response from a `POST` request, we add a `post_data` or `post_json` hash to the `livecheck` block `url` and use `strategy :json` with a `strategy` block. This leans on existing patterns that we're already familiar with and shouldn't require any notable maintenance burden when adding new strategies, so it seems like a better approach than a `Post` strategy.

Related to https://github.com/Homebrew/brew/issues/19203.

-----

If you want to test this, one of the formulae on my list that require `POST` is `ltl2ba` and the related `livecheck` block looks like this:

```diff
diff --git a/Formula/l/ltl2ba.rb b/Formula/l/ltl2ba.rb
index c81e88e7ce2c5f59b43e881d2e3ff6279213091c..f21c3c2fc8993d9767ce5aea5225709b5fd29bb9 100644
--- a/Formula/l/ltl2ba.rb
+++ b/Formula/l/ltl2ba.rb
@@ -6,6 +6,17 @@ class Ltl2ba < Formula
   sha256 "912877cb2929cddeadfd545a467135a2c61c507bbd5ae0edb695f8b5af7ce9af"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "http://www.lsv.fr/~gastin/ltl2ba/download.php", post_form: {
+      "Name"        => "",
+      "Institution" => "",
+      "Country"     => "",
+      "E-mail"      => "",
+      "getltl2ba"   => "Get LTL2BA",
+    }
+    regex(/href=.*?ltl2ba[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "18b178bd47a42ca3c5ab755e80cb5ec5a087807c1bef4fc064aa97a3ff18d76a"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5527191de9afab610f9d220b2c62ceed062df2e5e2c99b1743381c57067b9535"
```

The `post_form`/`post_json` value is expected to be a hash (with symbol or string keys), as in the above `ltl2ba` example. The `Strategy::post_args` method will take care of encoding the hash into the appropriate format (e.g., `Name=&Institution=&Country=&E-mail=&getltl2ba=Get LTL2BA` for form data or `{"Name":"","Institution":"","Country":"","E-mail":"","getltl2ba":"Get LTL2BA"}` for JSON).