### PR TITLE
tests: add missing :needs_network argument

### DIFF
--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Homebrew::Cmd::Desc do
       .and not_to_output.to_stderr
   end
 
-  it "successfully searches without --eval-all, with API", :integration_test do
+  it "successfully searches without --eval-all, with API", :integration_test, :needs_network do
     setup_test_formula "testball"
 
     expect { brew "desc", "--search", "testball", "HOMEBREW_NO_INSTALL_FROM_API" => nil }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I was recently running `brew tests` without `--online` and I noticed that there was still one formulae.brew.sh request. I narrowed it down to a `brew desc` test, so this adds `:needs_network` to that test. As expected, `brew tests` doesn't make any network requests after this change unless `--online` is used.