### PR TITLE
WIP: create lightweight internal JSON API

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -33,7 +33,7 @@ module Homebrew
         raise TapUnavailableError, tap.name unless tap.installed?
 
         unless args.dry_run?
-          directories = ["_data/cask", "api/cask", "api/cask-source", "cask", "api/internal/v3"].freeze
+          directories = ["_data/cask", "api/cask", "api/cask-source", "cask", "api/internal"].freeze
           FileUtils.rm_rf directories
           FileUtils.mkdir_p directories
         end
@@ -63,7 +63,7 @@ module Homebrew
           end
 
           homebrew_cask_tap_json = JSON.generate(tap.to_internal_api_hash)
-          File.write("api/internal/v3/homebrew-cask.json", homebrew_cask_tap_json) unless args.dry_run?
+          File.write("api/internal/homebrew-cask.json", homebrew_cask_tap_json) unless args.dry_run?
           canonical_json = JSON.pretty_generate(tap.cask_renames)
           File.write("_data/cask_canonical.json", "#{canonical_json}\n") unless args.dry_run?
         end

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -32,7 +32,7 @@ module Homebrew
         raise TapUnavailableError, tap.name unless tap.installed?
 
         unless args.dry_run?
-          directories = ["_data/formula", "api/formula", "formula", "api/internal/v3"]
+          directories = ["_data/formula", "api/formula", "formula", "api/internal"]
           FileUtils.rm_rf directories + ["_data/formula_canonical.json"]
           FileUtils.mkdir_p directories
         end
@@ -60,8 +60,10 @@ module Homebrew
             raise
           end
 
-          homebrew_core_tap_json = JSON.generate(tap.to_internal_api_hash)
-          File.write("api/internal/v3/homebrew-core.json", homebrew_core_tap_json) unless args.dry_run?
+          tap.to_internal_api_hashes.each do |os_arch, hash|
+            File.write("api/internal/homebrew-core.#{os_arch}.json", JSON.generate(hash)) unless args.dry_run?
+          end
+
           canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
           File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
         end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2572,6 +2572,21 @@ class Formula
     hsh
   end
 
+  def to_bottle_manifest_hashes
+    OnSystem::ALL_OS_ARCH_COMBINATIONS.filter_map do |os, arch|
+      bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
+      next unless bottle_tag.valid_combination?
+
+      hash = {
+        "name"        => name,
+        "pkg_version" => pkg_version.to_s,
+        "sha256"      => bottle_hash["files"][bottle_tag.to_sym]&.fetch("sha256"),
+      }
+
+      [bottle_tag.to_s, hash]
+    end.to_h
+  end
+
   def to_internal_api_hash
     api_hash = {
       "desc"                 => desc,


### PR DESCRIPTION
This PR starts to create a new internal API per <https://github.com/Homebrew/brew/issues/19204>. These files are sharded by OS/arch, and contain the tap's formula renames, tap migrations, etc. The only information it contains about each individual formula is the name, `pkg_version`, and bottle hash.

Known to-dos (just for my own notes, some of these will probably end up being in separate PRs):

- Include the bottle rebuild in the formula information (needed to download the correct bottle manifest)
- Actually write the necessary data to the manifest
- Figure out where in the formula load process to download the manifest
- Cleanup existing API v3 code, as it's mostly being replaced by this new strategy

This PR is a work-in-progress, I'm just uploading it so other people can mess around with the code I started to write at the AGM. _Anyone, please feel free to push commits or supercede this PR!_