### PR TITLE
formula_creator: depend on latest python

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -97,6 +97,14 @@ module Homebrew
       path
     end
 
+    sig { params(name: String).returns(String) }
+    def latest_versioned_formula(name)
+      name_prefix = "#{name}@"
+      Tap.fetch("homebrew/core").formula_names
+         .select { |f| f.start_with?(name_prefix) }
+         .max_by { |v| Gem::Version.new(v.sub(name_prefix, "")) } || "python"
+    end
+
     sig { returns(String) }
     def template
       # FIXME: https://github.com/errata-ai/vale/issues/818
@@ -138,7 +146,7 @@ module Homebrew
         <% elsif @mode == :perl %>
           uses_from_macos "perl"
         <% elsif @mode == :python %>
-          depends_on "python@x.y"
+          depends_on "#{latest_versioned_formula("python")}"
         <% elsif @mode == :ruby %>
           uses_from_macos "ruby"
         <% elsif @mode == :rust %>


### PR DESCRIPTION
Followup to #19173, which causes `brew create` to error out on the literal `python@x.y` dependency.

Related to #19240.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
