### PR TITLE
Add implicit macOS dependency to casks without explicit `depends_on` stanza

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -114,6 +114,7 @@ module Cask
       return unless @block
 
       @dsl.instance_eval(&@block)
+      @dsl.add_implicit_macos_dependency
       @dsl.language_eval
     end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -370,6 +370,13 @@ module Cask
       @depends_on
     end
 
+    # @api private
+    def add_implicit_macos_dependency
+      return if @depends_on.present? && @depends_on.macos.present?
+
+      depends_on macos: ">= :#{MacOSVersion::SYMBOLS.key MacOSVersion::SYMBOLS.values.min}"
+    end
+
     # Declare conflicts that keep a cask from installing or working correctly.
     #
     # @api public

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -76,7 +76,12 @@
   "depends_on": {
     "cask": [
       "something"
-    ]
+    ],
+    "macos": {
+      ">=": [
+        "10.11"
+      ]
+    }
   },
   "conflicts_with": {
     "formula": [


### PR DESCRIPTION
This PR adds an explicit `depends_on macos` line to any cask that does not have a `depends_on macos` line already.

See <https://github.com/Homebrew/brew/pull/19121>

CC: @SMillerDev, @bevanjkay

---

Note: right now this is kind of useless because there's no way to _not_ apply the macOS depndency, but once we add a way to say that a cask works on Linux, we should include a check for that here.

I've left this as a draft for now until that is added. Feel free, also, to take this commit into #19121 if it makes sense to do this over there
