### PR TITLE
utils/pypi: warn when `pypi_info` fails due to missing sources

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -86,7 +86,10 @@ module PyPI
         end
       end
 
-      return if dist.nil?
+      if dist.nil?
+        onoe "#{name} exists on PyPI but lacks a suitable source distribution"
+        return
+      end
 
       @pypi_info = [
         PyPI.normalize_python_package(json["info"]["name"]), dist["url"],


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

One of the more oblique ways in which the Python-focused dev commands can fail is when PyPI *does* contain a given `project==version`, but that version is missing a source distribution (or equivalent wheel). This typically happens either due to maintainer error (in which case we typically ping the upstream to fix it) or because the package is actually proprietary, in which case it isn't suitable for use with homebrew-core formulae.

This PR is a tiny PR to add an additional error message in that oblique case: it doesn't fix the underlying problem (since the underlying problem is a data problem with the resource being fetched), but it will hopefully make the output of `brew update-python-resources` and similar slightly more helpful to developers.

See https://github.com/Homebrew/brew/issues/19240 for context.
