### PR TITLE
utils/pypi: remove extra newline when updating resources

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -401,7 +401,8 @@ module PyPI
       end
     end
 
-    resource_section = "#{package_errors}\n#{new_resource_blocks}"
+    package_errors += "\n" if package_errors.present?
+    resource_section = "#{package_errors}#{new_resource_blocks}"
 
     odie "Excluded superfluous packages: #{exclude_packages.join(", ")}" if exclude_packages.any?
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Noticed from our autobump job that this was inserting an extra newline and failing `brew audit`: https://github.com/Homebrew/homebrew-core/actions/runs/13216218939/job/36895781679#step:6:1106
