### PR TITLE
workflows/docker: continue to deploy `master` images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,9 @@ name: Docker
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
   merge_group:
   release:
     types:
@@ -74,7 +77,7 @@ jobs:
                 "homebrew/brew:latest"
               )
             fi
-          elif [[ "${GITHUB_EVENT_NAME}" == "merge_group" &&
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" &&
                   "${GITHUB_REF}" == "refs/heads/master" &&
                   "${{ matrix.version }}" == "22.04" ]]; then
             tags+=(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I noticed that `master` images have not been updated since #18912:

```console
$ docker run --pull=always --rm -it homebrew/brew:master brew --version
master: Pulling from homebrew/brew
Digest: sha256:3812ffd9b728ce3d96a2a362ef33bed420d1dc73c7d96c93a8f8d2d4f10e6281
Status: Image is up to date for homebrew/brew:master
Homebrew 4.4.11-6-geae8d1b
Homebrew/homebrew-core (git revision 9610909d254; last commit 2024-12-10)
```

That is due to images no longer being built on `master` pushes. This change restores the previous behaviour.
