### PR TITLE
Fix "can't modify frozen String" error

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4216,7 +4216,7 @@ class Formula
         lambda do |_|
           on_macos do
             T.bind(self, PourBottleCheck)
-            reason(<<~EOS)
+            reason(+<<~EOS)
               The bottle needs the Xcode Command Line Tools to be installed at /Library/Developer/CommandLineTools.
               Development tools provided by Xcode.app are not sufficient.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix "can't modify frozen String" error if bottle requires Command Line Tools when installing/updating several packages, which causes install/update process failure. The plus was here to concatenate errors until the commit https://github.com/Homebrew/brew/commit/9abfafbd408e6f2b4a0f4fc84c2970687df3a459

> Error: can't modify frozen String: "The bottle needs the Xcode Command Line Tools to be installed at /Library/Developer/CommandLineTools.\nDevelopment tools provided by Xcode.app are not sufficient.\n\nYou can install the Xcode Command Line Tools, if desired, with:\n    xcode-select --install\n"