### PR TITLE
Refactor Livecheck::Strategy to remove module_function use

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -12,8 +12,6 @@ module Homebrew
     module Strategy
       extend Utils::Curl
 
-      module_function
-
       # {Strategy} priorities informally range from 1 to 10, where 10 is the
       # highest priority. 5 is the default priority because it's roughly in
       # the middle of this range. Strategies with a priority of 0 (or lower)
@@ -98,7 +96,7 @@ module Homebrew
       # loaded, otherwise livecheck won't be able to use them.
       # @return [Hash]
       sig { returns(T::Hash[Symbol, T.untyped]) }
-      def strategies
+      def self.strategies
         @strategies ||= T.let(Strategy.constants.sort.each_with_object({}) do |const_symbol, hash|
           constant = Strategy.const_get(const_symbol)
           next unless constant.is_a?(Class)
@@ -116,7 +114,7 @@ module Homebrew
       #   `Symbol` (e.g. `:page_match`)
       # @return [Class, nil]
       sig { params(symbol: T.nilable(Symbol)).returns(T.untyped) }
-      def from_symbol(symbol)
+      def self.from_symbol(symbol)
         strategies[symbol] if symbol.present?
       end
 
@@ -138,7 +136,7 @@ module Homebrew
           block_provided:     T::Boolean,
         ).returns(T::Array[T.untyped])
       }
-      def from_url(url, livecheck_strategy: nil, regex_provided: false, block_provided: false)
+      def self.from_url(url, livecheck_strategy: nil, regex_provided: false, block_provided: false)
         usable_strategies = strategies.select do |strategy_symbol, strategy|
           if strategy == PageMatch
             # Only treat the strategy as usable if the `livecheck` block
@@ -178,7 +176,7 @@ module Homebrew
           post_json: T.nilable(T::Hash[T.any(String, Symbol), String]),
         ).returns(T::Array[String])
       }
-      def post_args(post_form: nil, post_json: nil)
+      def self.post_args(post_form: nil, post_json: nil)
         if post_form.present?
           require "uri"
           ["--data", URI.encode_www_form(post_form)]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We discovered that the sorbet runtime does not enforce the static version of `module_function` methods: https://github.com/sorbet/sorbet/issues/8531

I'm already not a fan of `module_function` (I'd rather see a single, consistent API in use, not to mention the long tail of subtle bugs like these that I've come across over the years), so I refactored this file to use the static implementations only (which is consistent with how it's used, at least in tests).