### PR TITLE
clear core tap cache on formula creation

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -220,6 +220,7 @@ module Homebrew
         path = fc.write_formula!
 
         formula = Homebrew.with_no_api_env do
+          CoreTap.instance.clear_cache
           Formula[fc.name]
         end
         PyPI.update_python_resources! formula, ignore_non_pypi_packages: true if args.python?

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -100,9 +100,9 @@ module Homebrew
     sig { params(name: String).returns(String) }
     def latest_versioned_formula(name)
       name_prefix = "#{name}@"
-      Tap.fetch("homebrew/core").formula_names
-         .select { |f| f.start_with?(name_prefix) }
-         .max_by { |v| Gem::Version.new(v.sub(name_prefix, "")) } || "python"
+      CoreTap.instance.formula_names
+             .select { |f| f.start_with?(name_prefix) }
+             .max_by { |v| Gem::Version.new(v.sub(name_prefix, "")) } || "python"
     end
 
     sig { returns(String) }


### PR DESCRIPTION
Addresses inability to find just-created formula, see https://github.com/Homebrew/brew/pull/19244#issuecomment-2646030394 for context.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
