### PR TITLE
cask/url: remove arch placeholder when checking if unversioned

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -267,6 +267,7 @@ module Cask
 
       return false unless interpolated_url
 
+      interpolated_url = interpolated_url.gsub(/\#{\s*arch\s*}/, "")
       interpolated_url = interpolated_url.gsub(/\#{\s*version\s*\.major\s*}/, "") if ignore_major_version
 
       interpolated_url.exclude?('#{')


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This prevents casks whose `url` contains only `#{arch}` from passing `audit_sha256_no_check_if_unversioned`.

Examples: https://github.com/Homebrew/homebrew-cask/pull/201002, https://github.com/Homebrew/homebrew-cask/pull/201056 and https://github.com/Homebrew/homebrew-cask/pull/201064