### PR TITLE
livecheck: add Options class

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -179,13 +179,9 @@ class Livecheck
   def url(url = T.unsafe(nil), homebrew_curl: nil, post_form: nil, post_json: nil)
     raise ArgumentError, "Only use `post_form` or `post_json`, not both" if post_form && post_json
 
-    if homebrew_curl || post_form || post_json
-      @options = @options.merge({
-        homebrew_curl:,
-        post_form:,
-        post_json:,
-      }.compact)
-    end
+    @options.homebrew_curl = homebrew_curl unless homebrew_curl.nil?
+    @options.post_form = post_form unless post_form.nil?
+    @options.post_json = post_json unless post_json.nil?
 
     case url
     when nil

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -1,4 +1,4 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
 
 module Homebrew
@@ -30,11 +30,13 @@ module Homebrew
 
       # Returns a `Hash` of all instance variables, using `String` keys.
       sig { returns(T::Hash[String, T.untyped]) }
-      def to_hash = serialize
+      def to_hash
+        T.let(serialize, T::Hash[String, T.untyped])
+      end
 
       # Returns a `Hash` of all instance variables, using `Symbol` keys.
       sig { returns(T::Hash[Symbol, T.untyped]) }
-      def to_h = serialize.transform_keys(&:to_sym)
+      def to_h = to_hash.transform_keys(&:to_sym)
 
       # Returns a new object formed by merging `other` values with a copy of
       # `self`.
@@ -54,10 +56,11 @@ module Homebrew
         Options.new(**new_options)
       end
 
-      sig { params(other: T.untyped).returns(T::Boolean) }
+      sig { params(other: Object).returns(T::Boolean) }
       def ==(other)
-        instance_of?(other.class) &&
-          @homebrew_curl == other.homebrew_curl &&
+        return false unless other.is_a?(Options)
+
+        @homebrew_curl == other.homebrew_curl &&
           @post_form == other.post_form &&
           @post_json == other.post_json
       end
@@ -65,7 +68,7 @@ module Homebrew
 
       # Whether the object has only default values.
       sig { returns(T::Boolean) }
-      def empty? = serialize.empty?
+      def empty? = to_hash.empty?
 
       # Whether the object has any non-default values.
       sig { returns(T::Boolean) }

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -8,34 +8,15 @@ module Homebrew
     #
     # Option values use a `nil` default to indicate that the value has not been
     # set.
-    class Options
+    class Options < T::Struct
       # Whether to use brewed curl.
-      sig { returns(T.nilable(T::Boolean)) }
-      attr_reader :homebrew_curl
+      prop :homebrew_curl, T.nilable(T::Boolean)
 
       # Form data to use when making a `POST` request.
-      sig { returns(T.nilable(T::Hash[Symbol, String])) }
-      attr_reader :post_form
+      prop :post_form, T.nilable(T::Hash[Symbol, String])
 
       # JSON data to use when making a `POST` request.
-      sig { returns(T.nilable(T::Hash[Symbol, String])) }
-      attr_reader :post_json
-
-      # @param homebrew_curl whether to use brewed curl
-      # @param post_form form data to use when making a `POST` request
-      # @param post_json JSON data to use when making a `POST` request
-      sig {
-        params(
-          homebrew_curl: T.nilable(T::Boolean),
-          post_form:     T.nilable(T::Hash[Symbol, String]),
-          post_json:     T.nilable(T::Hash[Symbol, String]),
-        ).void
-      }
-      def initialize(homebrew_curl: nil, post_form: nil, post_json: nil)
-        @homebrew_curl = homebrew_curl
-        @post_form = post_form
-        @post_json = post_json
-      end
+      prop :post_json, T.nilable(T::Hash[Symbol, String])
 
       # Returns a `Hash` of options that are provided as arguments to `url`.
       sig { returns(T::Hash[Symbol, T.untyped]) }
@@ -47,25 +28,13 @@ module Homebrew
         }
       end
 
-      # Returns a `Hash` of all instance variables, using `Symbol` keys.
-      sig { returns(T::Hash[Symbol, T.untyped]) }
-      def to_h
-        {
-          homebrew_curl:,
-          post_form:,
-          post_json:,
-        }
-      end
-
       # Returns a `Hash` of all instance variables, using `String` keys.
       sig { returns(T::Hash[String, T.untyped]) }
-      def to_hash
-        {
-          "homebrew_curl" => @homebrew_curl,
-          "post_form"     => @post_form,
-          "post_json"     => @post_json,
-        }
-      end
+      def to_hash = serialize
+
+      # Returns a `Hash` of all instance variables, using `Symbol` keys.
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      def to_h = serialize.transform_keys(&:to_sym)
 
       # Returns a new object formed by merging `other` values with a copy of
       # `self`.
@@ -78,7 +47,7 @@ module Homebrew
         return dup if other.empty?
 
         this_hash = to_h
-        other_hash = other.is_a?(Options) ? other.to_h.compact : other
+        other_hash = other.is_a?(Options) ? other.to_h : other
         return dup if this_hash == other_hash
 
         new_options = this_hash.merge(other_hash)
@@ -96,15 +65,11 @@ module Homebrew
 
       # Whether the object has only default values.
       sig { returns(T::Boolean) }
-      def empty?
-        @homebrew_curl.nil? && @post_form.nil? && @post_json.nil?
-      end
+      def empty? = serialize.empty?
 
       # Whether the object has any non-default values.
       sig { returns(T::Boolean) }
-      def present?
-        !@homebrew_curl.nil? || !@post_form.nil? || !@post_json.nil?
-      end
+      def present? = !empty?
     end
   end
 end

--- a/Library/Homebrew/livecheck/options.rb
+++ b/Library/Homebrew/livecheck/options.rb
@@ -1,0 +1,110 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  module Livecheck
+    # Options to modify livecheck's behavior. These primarily come from
+    # `livecheck` blocks but they can also be set by livecheck at runtime.
+    #
+    # Option values use a `nil` default to indicate that the value has not been
+    # set.
+    class Options
+      # Whether to use brewed curl.
+      sig { returns(T.nilable(T::Boolean)) }
+      attr_reader :homebrew_curl
+
+      # Form data to use when making a `POST` request.
+      sig { returns(T.nilable(T::Hash[Symbol, String])) }
+      attr_reader :post_form
+
+      # JSON data to use when making a `POST` request.
+      sig { returns(T.nilable(T::Hash[Symbol, String])) }
+      attr_reader :post_json
+
+      # @param homebrew_curl whether to use brewed curl
+      # @param post_form form data to use when making a `POST` request
+      # @param post_json JSON data to use when making a `POST` request
+      sig {
+        params(
+          homebrew_curl: T.nilable(T::Boolean),
+          post_form:     T.nilable(T::Hash[Symbol, String]),
+          post_json:     T.nilable(T::Hash[Symbol, String]),
+        ).void
+      }
+      def initialize(homebrew_curl: nil, post_form: nil, post_json: nil)
+        @homebrew_curl = homebrew_curl
+        @post_form = post_form
+        @post_json = post_json
+      end
+
+      # Returns a `Hash` of options that are provided as arguments to `url`.
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      def url_options
+        {
+          homebrew_curl:,
+          post_form:,
+          post_json:,
+        }
+      end
+
+      # Returns a `Hash` of all instance variables, using `Symbol` keys.
+      sig { returns(T::Hash[Symbol, T.untyped]) }
+      def to_h
+        {
+          homebrew_curl:,
+          post_form:,
+          post_json:,
+        }
+      end
+
+      # Returns a `Hash` of all instance variables, using `String` keys.
+      sig { returns(T::Hash[String, T.untyped]) }
+      def to_hash
+        {
+          "homebrew_curl" => @homebrew_curl,
+          "post_form"     => @post_form,
+          "post_json"     => @post_json,
+        }
+      end
+
+      # Returns a new object formed by merging `other` values with a copy of
+      # `self`.
+      #
+      # `nil` values are removed from `other` before merging if it is an
+      # `Options` object, as these are unitiailized values. This ensures that
+      # existing values in `self` aren't unexpectedly overwritten with defaults.
+      sig { params(other: T.any(Options, T::Hash[Symbol, T.untyped])).returns(Options) }
+      def merge(other)
+        return dup if other.empty?
+
+        this_hash = to_h
+        other_hash = other.is_a?(Options) ? other.to_h.compact : other
+        return dup if this_hash == other_hash
+
+        new_options = this_hash.merge(other_hash)
+        Options.new(**new_options)
+      end
+
+      sig { params(other: T.untyped).returns(T::Boolean) }
+      def ==(other)
+        instance_of?(other.class) &&
+          @homebrew_curl == other.homebrew_curl &&
+          @post_form == other.post_form &&
+          @post_json == other.post_json
+      end
+      alias eql? ==
+
+      # Whether the object has only default values.
+      sig { returns(T::Boolean) }
+      def empty?
+        @homebrew_curl.nil? && @post_form.nil? && @post_json.nil?
+      end
+
+      # Whether the object has any non-default values.
+      sig { returns(T::Boolean) }
+      def present?
+        !@homebrew_curl.nil? || !@post_form.nil? || !@post_json.nil?
+      end
+    end
+  end
+end

--- a/Library/Homebrew/livecheck/strategy.rbi
+++ b/Library/Homebrew/livecheck/strategy.rbi
@@ -1,9 +1,0 @@
-# typed: strict
-
-module Homebrew
-  module Livecheck
-    module Strategy
-      include Kernel
-    end
-  end
-end

--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -85,19 +85,25 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(
+            url:     generated[:url],
+            regex:   regex || generated[:regex],
+            options:,
+            &block
+          )
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -93,19 +93,25 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(
+            url:     generated[:url],
+            regex:   regex || generated[:regex],
+            options:,
+            &block
+          )
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -72,19 +72,25 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(
+            url:     generated[:url],
+            regex:   regex || generated[:regex],
+            options:,
+            &block
+          )
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/crate.rb
+++ b/Library/Homebrew/livecheck/strategy/crate.rb
@@ -73,19 +73,18 @@ module Homebrew
         # @param regex [Regexp, nil] a regex for matching versions in content
         # @param provided_content [String, nil] content to check instead of
         #   fetching
-        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            homebrew_curl:    T::Boolean,
-            unused:           T.untyped,
+            options:          Options,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, options: Options.new, &block)
           match_data = { matches: {}, regex:, url: }
           match_data[:cached] = true if provided_content.is_a?(String)
 
@@ -97,13 +96,7 @@ module Homebrew
           content = if provided_content
             provided_content
           else
-            match_data.merge!(
-              Strategy.page_content(
-                match_data[:url],
-                url_options:   unused.fetch(:url_options, {}),
-                homebrew_curl:,
-              ),
-            )
+            match_data.merge!(Strategy.page_content(match_data[:url], options:))
             match_data[:content]
           end
           return match_data unless content

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -34,17 +34,18 @@ module Homebrew
         # @param regex [Regexp, nil] a regex used for matching versions
         # @param provided_content [String, nil] content to use in place of
         #   fetching via `Strategy#page_content`
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            unused:           T.untyped,
+            options:          Options,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, options: Options.new, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(name)} only supports a regex when using a `strategy` block"
@@ -54,7 +55,7 @@ module Homebrew
             url:,
             regex:,
             provided_content:,
-            **unused,
+            options:,
             &block || proc { |yaml| yaml["version"] }
           )
         end

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -79,17 +79,18 @@ module Homebrew
         # @param url [String, nil] an alternative URL to check for version
         #   information
         # @param regex [Regexp, nil] a regex for use in a strategy block
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             cask:    Cask::Cask,
             url:     T.nilable(String),
             regex:   T.nilable(Regexp),
-            _unused: T.untyped,
+            options: Options,
             block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(cask:, url: nil, regex: nil, **_unused, &block)
+        def self.find_versions(cask:, url: nil, regex: nil, options: Options.new, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(name)} only supports a regex when using a `strategy` block"

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -186,16 +186,17 @@ module Homebrew
         #
         # @param url [String] the URL of the Git repository to check
         # @param regex [Regexp, nil] a regex used for matching versions
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:     String,
             regex:   T.nilable(Regexp),
-            _unused: T.untyped,
+            options: Options,
             block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **_unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           match_data = { matches: {}, regex:, url: }
 
           tags_data = tag_info(url, regex)

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -70,16 +70,17 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:     String,
             regex:   Regexp,
-            _unused: T.untyped,
+            options: Options,
             block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: GithubReleases::DEFAULT_REGEX, **_unused, &block)
+        def self.find_versions(url:, regex: GithubReleases::DEFAULT_REGEX, options: Options.new, &block)
           match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)

--- a/Library/Homebrew/livecheck/strategy/github_releases.rb
+++ b/Library/Homebrew/livecheck/strategy/github_releases.rb
@@ -124,16 +124,17 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:     String,
             regex:   Regexp,
-            _unused: T.untyped,
+            options: Options,
             block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: DEFAULT_REGEX, **_unused, &block)
+        def self.find_versions(url:, regex: DEFAULT_REGEX, options: Options.new, &block)
           match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -74,22 +74,23 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
           version_data = PageMatch.find_versions(
-            url:   generated[:url],
-            regex: regex || generated[:regex],
-            **unused,
+            url:     generated[:url],
+            regex:   regex || generated[:regex],
+            options:,
             &block
           )
 

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -84,19 +84,25 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(
+            url:     generated[:url],
+            regex:   regex || generated[:regex],
+            options:,
+            &block
+          )
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -70,19 +70,25 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(
+            url:     generated[:url],
+            regex:   regex || generated[:regex],
+            options:,
+            &block
+          )
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -67,25 +67,20 @@ module Homebrew
         #
         # @param url [String] the URL to fetch
         # @param regex [Regexp, nil] a regex used for matching versions
-        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:           String,
-            regex:         T.nilable(Regexp),
-            homebrew_curl: T::Boolean,
-            unused:        T.untyped,
-            block:         T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, homebrew_curl: false, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           match_data = { matches: {}, regex:, url: }
 
-          headers = Strategy.page_headers(
-            url,
-            url_options:   unused.fetch(:url_options, {}),
-            homebrew_curl:,
-          )
+          headers = Strategy.page_headers(url, options:)
 
           # Merge the headers from all responses into one hash
           merged_headers = headers.reduce(&:merge)

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -94,19 +94,18 @@ module Homebrew
         # @param regex [Regexp, nil] a regex used for matching versions
         # @param provided_content [String, nil] page content to use in place of
         #   fetching via `Strategy#page_content`
-        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            homebrew_curl:    T::Boolean,
-            unused:           T.untyped,
+            options:          Options,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, options: Options.new, &block)
           raise ArgumentError, "#{Utils.demodulize(name)} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
@@ -116,13 +115,7 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(
-              Strategy.page_content(
-                url,
-                url_options:   unused.fetch(:url_options, {}),
-                homebrew_curl:,
-              ),
-            )
+            match_data.merge!(Strategy.page_content(url, options:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -67,19 +67,25 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  Regexp,
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   Regexp,
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: DEFAULT_REGEX, **unused, &block)
+        def self.find_versions(url:, regex: DEFAULT_REGEX, options: Options.new, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex:, **unused, &block)
+          PageMatch.find_versions(
+            url:     generated[:url],
+            regex:,
+            options:,
+            &block
+          )
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -65,19 +65,25 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
-          PageMatch.find_versions(url: generated[:url], regex: regex || generated[:regex], **unused, &block)
+          PageMatch.find_versions(
+            url:     generated[:url],
+            regex:   regex || generated[:regex],
+            options:,
+            &block
+          )
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -77,19 +77,18 @@ module Homebrew
         # @param regex [Regexp, nil] a regex used for matching versions
         # @param provided_content [String, nil] page content to use in place of
         #   fetching via `Strategy#page_content`
-        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            homebrew_curl:    T::Boolean,
-            unused:           T.untyped,
+            options:          Options,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, options: Options.new, &block)
           if regex.blank? && block.blank?
             raise ArgumentError, "#{Utils.demodulize(name)} requires a regex or `strategy` block"
           end
@@ -101,13 +100,7 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(
-              Strategy.page_content(
-                url,
-                url_options:   unused.fetch(:url_options, {}),
-                homebrew_curl:,
-              ),
-            )
+            match_data.merge!(Strategy.page_content(url, options:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -79,17 +79,18 @@ module Homebrew
         # @param regex [Regexp] a regex used for matching versions in content
         # @param provided_content [String, nil] content to check instead of
         #   fetching
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            unused:           T.untyped,
+            options:          Options,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, options: Options.new, &block)
           match_data = { matches: {}, regex:, url: }
 
           generated = generate_input_values(url)
@@ -99,7 +100,7 @@ module Homebrew
             url:              generated[:url],
             regex:,
             provided_content:,
-            **unused,
+            options:,
             &block || DEFAULT_BLOCK
           )
         end

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -84,22 +84,23 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
 
           PageMatch.find_versions(
-            url:   generated[:url] || url,
-            regex: regex || generated[:regex],
-            **unused,
+            url:     generated[:url] || url,
+            regex:   regex || generated[:regex],
+            options:,
             &block
           )
         end

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -214,18 +214,17 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp, nil] a regex for use in a strategy block
-        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:           String,
-            regex:         T.nilable(Regexp),
-            homebrew_curl: T::Boolean,
-            unused:        T.untyped,
-            block:         T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, homebrew_curl: false, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
                   "#{Utils.demodulize(name)} only supports a regex when using a `strategy` block"
@@ -233,13 +232,7 @@ module Homebrew
 
           match_data = { matches: {}, regex:, url: }
 
-          match_data.merge!(
-            Strategy.page_content(
-              url,
-              url_options:   unused.fetch(:url_options, {}),
-              homebrew_curl:,
-            ),
-          )
+          match_data.merge!(Strategy.page_content(url, options:))
           content = match_data.delete(:content)
           return match_data if content.blank?
 

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -134,19 +134,18 @@ module Homebrew
         # @param regex [Regexp, nil] a regex used for matching versions
         # @param provided_content [String, nil] page content to use in place of
         #   fetching via `Strategy#page_content`
-        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            homebrew_curl:    T::Boolean,
-            unused:           T.untyped,
+            options:          Options,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, options: Options.new, &block)
           raise ArgumentError, "#{Utils.demodulize(name)} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
@@ -156,13 +155,7 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(
-              Strategy.page_content(
-                url,
-                url_options:   unused.fetch(:url_options, {}),
-                homebrew_curl:,
-              ),
-            )
+            match_data.merge!(Strategy.page_content(url, options:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -109,16 +109,17 @@ module Homebrew
         #
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
-            url:    String,
-            regex:  T.nilable(Regexp),
-            unused: T.untyped,
-            block:  T.nilable(Proc),
+            url:     String,
+            regex:   T.nilable(Regexp),
+            options: Options,
+            block:   T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, **unused, &block)
+        def self.find_versions(url:, regex: nil, options: Options.new, &block)
           generated = generate_input_values(url)
           generated_url = generated[:url]
 
@@ -128,7 +129,7 @@ module Homebrew
             url:              generated_url,
             regex:            regex || generated[:regex],
             provided_content: cached_content,
-            **unused,
+            options:,
             &block
           )
 

--- a/Library/Homebrew/livecheck/strategy/yaml.rb
+++ b/Library/Homebrew/livecheck/strategy/yaml.rb
@@ -94,19 +94,18 @@ module Homebrew
         # @param regex [Regexp, nil] a regex used for matching versions
         # @param provided_content [String, nil] page content to use in place of
         #   fetching via `Strategy#page_content`
-        # @param homebrew_curl [Boolean] whether to use brewed curl with the URL
+        # @param options [Options] options to modify behavior
         # @return [Hash]
         sig {
           params(
             url:              String,
             regex:            T.nilable(Regexp),
             provided_content: T.nilable(String),
-            homebrew_curl:    T::Boolean,
-            unused:           T.untyped,
+            options:          Options,
             block:            T.nilable(Proc),
           ).returns(T::Hash[Symbol, T.untyped])
         }
-        def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
+        def self.find_versions(url:, regex: nil, provided_content: nil, options: Options.new, &block)
           raise ArgumentError, "#{Utils.demodulize(name)} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
@@ -116,13 +115,7 @@ module Homebrew
             match_data[:cached] = true
             provided_content
           else
-            match_data.merge!(
-              Strategy.page_content(
-                url,
-                url_options:   unused.fetch(:url_options, {}),
-                homebrew_curl:,
-              ),
-            )
+            match_data.merge!(Strategy.page_content(url, options:))
             match_data[:content]
           end
           return match_data if content.blank?

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -86,6 +86,22 @@ RSpec.describe Homebrew::Livecheck do
     end
   end
 
+  describe "::livecheck_find_versions_parameters" do
+    context "when provided with a strategy class" do
+      it "returns demodulized class name" do
+        page_match_parameters = T::Utils.signature_for_method(
+          Homebrew::Livecheck::Strategy::PageMatch.method(:find_versions),
+        ).parameters.map(&:second)
+
+        # We run this twice with the same argument to exercise the caching logic
+        expect(livecheck.send(:livecheck_find_versions_parameters, Homebrew::Livecheck::Strategy::PageMatch))
+          .to eq(page_match_parameters)
+        expect(livecheck.send(:livecheck_find_versions_parameters, Homebrew::Livecheck::Strategy::PageMatch))
+          .to eq(page_match_parameters)
+      end
+    end
+  end
+
   describe "::resolve_livecheck_reference" do
     context "when a formula/cask has a `livecheck` block without formula/cask methods" do
       it "returns [nil, []]" do

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -39,21 +39,19 @@ RSpec.describe Homebrew::Livecheck::Options do
 
   describe "#to_h" do
     it "returns a Hash of all instance variables" do
-      expect(options.new.to_h).to eq({
-        homebrew_curl: nil,
-        post_form:     nil,
-        post_json:     nil,
-      })
+      # `T::Struct.serialize` omits `nil` values
+      expect(options.new.to_h).to eq({})
+
+      expect(options.new(**args).to_h).to eq(args)
     end
   end
 
   describe "#to_hash" do
     it "returns a Hash of all instance variables, using String keys" do
-      expect(options.new.to_hash).to eq({
-        "homebrew_curl" => nil,
-        "post_form"     => nil,
-        "post_json"     => nil,
-      })
+      # `T::Struct.serialize` omits `nil` values
+      expect(options.new.to_hash).to eq({})
+
+      expect(options.new(**args).to_hash).to eq(args.transform_keys(&:to_s))
     end
   end
 
@@ -64,6 +62,8 @@ RSpec.describe Homebrew::Livecheck::Options do
       expect(options.new(**args).merge(options.new(**other_args)))
         .to eq(options.new(**merged_hash))
       expect(options.new(**args).merge(args))
+        .to eq(options.new(**args))
+      expect(options.new(**args).merge({}))
         .to eq(options.new(**args))
     end
   end
@@ -81,6 +81,10 @@ RSpec.describe Homebrew::Livecheck::Options do
 
     it "returns false if any instance variables differ" do
       expect(options.new == options.new(**args)).to be false
+    end
+
+    it "returns false if other object is not the same class" do
+      expect(options.new == :other).to be false
     end
   end
 

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe Homebrew::Livecheck::Options do
   end
   let(:merged_hash) { args.merge(other_args) }
 
+  let(:base_options) { options.new(**args) }
+  let(:other_options) { options.new(**other_args) }
+  let(:merged_options) { options.new(**merged_hash) }
+
   describe "#url_options" do
     it "returns a Hash of the options that are provided as arguments to the `url` DSL method" do
       expect(options.new.url_options).to eq({
@@ -65,6 +69,40 @@ RSpec.describe Homebrew::Livecheck::Options do
         .to eq(options.new(**args))
       expect(options.new(**args).merge({}))
         .to eq(options.new(**args))
+    end
+  end
+
+  describe "#merge!" do
+    it "merges values from `other` into `self` and returns `self`" do
+      o1 = options.new(**args)
+      expect(o1.merge!(other_options)).to eq(merged_options)
+      expect(o1).to eq(merged_options)
+
+      o2 = options.new(**args)
+      expect(o2.merge!(other_args)).to eq(merged_options)
+      expect(o2).to eq(merged_options)
+
+      o3 = options.new(**args)
+      expect(o3.merge!(base_options)).to eq(base_options)
+      expect(o3).to eq(base_options)
+
+      o4 = options.new(**args)
+      expect(o4.merge!(args)).to eq(base_options)
+      expect(o4).to eq(base_options)
+
+      o5 = options.new(**args)
+      expect(o5.merge!(options.new)).to eq(base_options)
+      expect(o5).to eq(base_options)
+
+      o6 = options.new(**args)
+      expect(o6.merge!({})).to eq(base_options)
+      expect(o6).to eq(base_options)
+    end
+
+    it "skips over hash values without a corresponding Options value" do
+      o1 = options.new(**args)
+      expect(o1.merge!({ nonexistent: true })).to eq(base_options)
+      expect(o1).to eq(base_options)
     end
   end
 

--- a/Library/Homebrew/test/livecheck/options_spec.rb
+++ b/Library/Homebrew/test/livecheck/options_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "livecheck/options"
+
+RSpec.describe Homebrew::Livecheck::Options do
+  subject(:options) { described_class }
+
+  let(:post_hash) do
+    {
+      empty:   "",
+      boolean: "true",
+      number:  "1",
+      string:  "a + b = c",
+    }
+  end
+  let(:args) do
+    {
+      homebrew_curl: true,
+      post_form:     post_hash,
+      post_json:     post_hash,
+    }
+  end
+  let(:other_args) do
+    {
+      post_form: { something: "else" },
+    }
+  end
+  let(:merged_hash) { args.merge(other_args) }
+
+  describe "#url_options" do
+    it "returns a Hash of the options that are provided as arguments to the `url` DSL method" do
+      expect(options.new.url_options).to eq({
+        homebrew_curl: nil,
+        post_form:     nil,
+        post_json:     nil,
+      })
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a Hash of all instance variables" do
+      expect(options.new.to_h).to eq({
+        homebrew_curl: nil,
+        post_form:     nil,
+        post_json:     nil,
+      })
+    end
+  end
+
+  describe "#to_hash" do
+    it "returns a Hash of all instance variables, using String keys" do
+      expect(options.new.to_hash).to eq({
+        "homebrew_curl" => nil,
+        "post_form"     => nil,
+        "post_json"     => nil,
+      })
+    end
+  end
+
+  describe "#merge" do
+    it "returns an Options object with merged values" do
+      expect(options.new(**args).merge(other_args))
+        .to eq(options.new(**merged_hash))
+      expect(options.new(**args).merge(options.new(**other_args)))
+        .to eq(options.new(**merged_hash))
+      expect(options.new(**args).merge(args))
+        .to eq(options.new(**args))
+    end
+  end
+
+  describe "#==" do
+    it "returns true if all instance variables are the same" do
+      obj_with_args1 = options.new(**args)
+      obj_with_args2 = options.new(**args)
+      expect(obj_with_args1 == obj_with_args2).to be true
+
+      default_obj1 = options.new
+      default_obj2 = options.new
+      expect(default_obj1 == default_obj2).to be true
+    end
+
+    it "returns false if any instance variables differ" do
+      expect(options.new == options.new(**args)).to be false
+    end
+  end
+
+  describe "#empty?" do
+    it "returns true if object has only default values" do
+      expect(options.new.empty?).to be true
+    end
+
+    it "returns false if object has any non-default values" do
+      expect(options.new(**args).empty?).to be false
+    end
+  end
+
+  describe "#present?" do
+    it "returns false if object has only default values" do
+      expect(options.new.present?).to be false
+    end
+
+    it "returns true if object has any non-default values" do
+      expect(options.new(**args).present?).to be true
+    end
+  end
+end

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -181,8 +181,12 @@ RSpec.describe Homebrew::Livecheck::Strategy do
     it "handles `post_form` `url` options" do
       allow(strategy).to receive(:curl_headers).and_return({ responses:, body: })
 
-      expect(strategy.page_headers(url, url_options: { post_form: post_hash }))
-        .to eq([responses.first[:headers]])
+      expect(
+        strategy.page_headers(
+          url,
+          options: Homebrew::Livecheck::Options.new(post_form: post_hash),
+        ),
+      ).to eq([responses.first[:headers]])
     end
 
     it "returns an empty array if `curl_headers` only raises an `ErrorDuringExecution` error" do
@@ -207,14 +211,24 @@ RSpec.describe Homebrew::Livecheck::Strategy do
       allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
       allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])
 
-      expect(strategy.page_content(url, url_options: { post_form: post_hash })).to eq({ content: body })
+      expect(
+        strategy.page_content(
+          url,
+          options: Homebrew::Livecheck::Options.new(post_form: post_hash),
+        ),
+      ).to eq({ content: body })
     end
 
     it "handles `post_json` `url` option" do
       allow_any_instance_of(Utils::Curl).to receive(:curl_version).and_return(curl_version)
       allow(strategy).to receive(:curl_output).and_return([response_text[:ok], nil, success_status])
 
-      expect(strategy.page_content(url, url_options: { post_json: post_hash })).to eq({ content: body })
+      expect(
+        strategy.page_content(
+          url,
+          options: Homebrew::Livecheck::Options.new(post_json: post_hash),
+        ),
+      ).to eq({ content: body })
     end
 
     it "returns error `messages` from `stderr` in the return hash on failure when `stderr` is not `nil`" do

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -156,10 +156,17 @@ RSpec.describe Livecheck do
       expect(livecheck_c.url).to eq(:url)
     end
 
-    it "sets `url_options` when provided" do
-      post_args = { post_form: post_hash }
-      livecheck_f.url(url_string, **post_args)
-      expect(livecheck_f.url_options).to eq(post_args)
+    it "sets `url` options when provided" do
+      # This test makes sure that we can set multiple options at once and
+      # options from subsequent `url` calls are merged with existing values
+      # (i.e. existing values aren't reset to `nil`). [We only call `url` once
+      # in a `livecheck` block but this should technically work due to how it's
+      # implemented.]
+      livecheck_f.url(url_string, homebrew_curl: true, post_form: post_hash)
+      livecheck_f.url(url_string, post_json: post_hash)
+      expect(livecheck_f.options.homebrew_curl).to be(true)
+      expect(livecheck_f.options.post_form).to eq(post_hash)
+      expect(livecheck_f.options.post_json).to eq(post_hash)
     end
 
     it "raises an ArgumentError if the argument isn't a valid Symbol" do
@@ -179,15 +186,15 @@ RSpec.describe Livecheck do
     it "returns a Hash of all instance variables" do
       expect(livecheck_f.to_hash).to eq(
         {
-          "cask"        => nil,
-          "formula"     => nil,
-          "regex"       => nil,
-          "skip"        => false,
-          "skip_msg"    => nil,
-          "strategy"    => nil,
-          "throttle"    => nil,
-          "url"         => nil,
-          "url_options" => nil,
+          "options"  => Homebrew::Livecheck::Options.new.to_hash,
+          "cask"     => nil,
+          "formula"  => nil,
+          "regex"    => nil,
+          "skip"     => false,
+          "skip_msg" => nil,
+          "strategy" => nil,
+          "throttle" => nil,
+          "url"      => nil,
         },
       )
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a `Livecheck::Options` class, which is intended to house various configuration options that are set in `livecheck` blocks, conditionally set by livecheck at runtime, etc. The general idea is that when we add features involving configurations options (e.g., for livecheck, strategies, curl, etc.), we can make changes to `Options` without needing to modify parameters for strategy `find_versions` methods, `Strategy` methods like `page_headers` and `page_content`, etc. This is something that I've been trying to improve over the years and `Options` should help to reduce maintenance overhead in this area while also strengthening type signatures.

`Options` replaces the existing `homebrew_curl` option (which related strategies pass to `Strategy` methods and on to `curl_args`) and the new `url_options` (which contains `post_form` or `post_json` values that are used to make `POST` requests). I recently added `url_options` as a temporary way of enabling `POST` support without `Options` but this restores the original `Options`-based implementation.

Along the way, I added a `homebrew_curl` parameter to the `url` DSL method, allowing us to set an explicit value in `livecheck` blocks. This is something that we've needed in some cases but I also intend to replace implicit/inferred `homebrew_curl` usage with explicit values in `livecheck` blocks once this is available for use. My intention is to eventually remove the implicit behavior and only rely on explicit values. That will align with how `homebrew_curl` options work for other URLs and makes the behavior clear just from looking at the formula/cask file.

Lastly, this removes the `unused` rest parameter from `find_versions` methods. I originally added `unused` as a way of handling parameters that some `find_versions` methods have but others don't (e.g., `cask` in `ExtractPlist`), as this allowed us to pass various arguments to `find_versions` methods without worrying about whether a particular parameter is available. This isn't an ideal solution and I originally wanted to handle this situation by only passing expected arguments to `find_versions` methods but there was a technical issue standing in the way. I recently found an answer to the issue, so this also replaces the existing `ExtractPlist` special case with generic logic that checks the parameters for a strategy's `find_versions` method and only passes expected arguments.

Replacing the aforementioned `find_versions` parameters with `Options` ensures that the remaining parameters are consistent across strategies and any differences are handled by this new logic. Outside of `ExtractPlist`, the only other difference is that some `find_versions` methods have a `provided_content` parameter but that's currently only used by tests (though it's intended for caching support in the future). I will be renaming that parameter to `content` in an upcoming PR and expanding it to the other strategies, which should make them all consistent outside of `ExtractPlist`.

-----

If you'd like to see what it looks like to implement a new configuration option, here's a commit from my upcoming PR to add a `user_agent` option: https://github.com/Homebrew/brew/commit/a7598a1d7af7e84fcf99e57bb2e2a1d487a45222 (the branch is [livecheck/add-user_agent-option](https://github.com/Homebrew/brew/tree/livecheck/add-user_agent-option)). The initial implementation of `Options` required a number of changes when adding a new option but the current `T::Struct` setup makes things fairly reasonable.