### PR TITLE
formula: don't include DATA patches in initial Git repo

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -148,12 +148,15 @@ class Build
           # https://github.com/Homebrew/homebrew-core/pull/87470
           TZ:                         "UTC0",
         ) do
-          formula.patch
-
           if args.git?
+            formula.selective_patch(is_data: false)
             system "git", "init"
             system "git", "add", "-A"
+            formula.selective_patch(is_data: true)
+          else
+            formula.patch
           end
+
           if args.interactive?
             ohai "Entering interactive mode..."
             puts <<~EOS

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1608,6 +1608,20 @@ class Formula
     patchlist.each(&:apply)
   end
 
+  sig { params(is_data: T::Boolean).void }
+  def selective_patch(is_data: false)
+    patches = patchlist.select { |p| p.is_a?(DATAPatch) == is_data }
+    return if patches.empty?
+
+    patchtype = if is_data
+      "DATA"
+    else
+      "non-DATA"
+    end
+    ohai "Applying #{patchtype} patches"
+    patches.each(&:apply)
+  end
+
   # Yields |self,staging| with current working directory set to the uncompressed tarball
   # where staging is a {Mktemp} staging context.
   sig(:final) {


### PR DESCRIPTION
Currently, existing DATA patches are subsumed into the initial Git repo created by `brew install --git`, which makes creating a new DATA patch after more fixes a tedious and error-prone process.

This PR delays DATA patch processing till after the Git repo is created, so a `git diff` at the end creates a correct and consolidated DATA patch block ready for insertion/replacement, or even migration to a proper remote patch URL.

The difference is clearly seen in `gromgit/fuse/dislocker-mac`, which has both remote and DATA patches.

Before:
```
% brew install -sig dislocker-mac
==> Fetching gromgit/fuse/dislocker-mac
==> Downloading https://github.com/Aorimn/dislocker/commit/2cfbba2c8cc07e529622ba134d0a6982815d2b30.patch?full_index=1
Already downloaded: /Volumes/aho/Library/Caches/Homebrew/downloads/37276859cbebc1711941278db00cd8b25b98d69e15e31e33915a98d01a13febc--2cfbba2c8cc07e529622ba134d0a6982815d2b30.patch
==> Downloading https://github.com/Aorimn/dislocker/archive/refs/tags/v0.7.3.tar.gz
Already downloaded: /Volumes/aho/Library/Caches/Homebrew/downloads/b1ba1098c95535574936051eca45cc472955a5a024b81cc72e1c3b006e1950b3--dislocker-0.7.3.tar.gz
==> Installing dislocker-mac from gromgit/fuse
==> Patching
==> Applying 2cfbba2c8cc07e529622ba134d0a6982815d2b30.patch
Initialized empty Git repository in /private/tmp/dislocker-mac-20250215-35534-8qlxtp/dislocker-0.7.3/.git/
==> Entering interactive mode...
Type `exit` to return and finalize the installation.
Install to this prefix: /opt/homebrew/Cellar/dislocker-mac/0.7.3_2
This directory is now a Git repository. Make your changes and then use:
  git diff | pbcopy
to copy the diff to the clipboard.
% git diff
```

After:
```
% brew install -sig dislocker-mac
==> Fetching gromgit/fuse/dislocker-mac
==> Downloading https://github.com/Aorimn/dislocker/commit/2cfbba2c8cc07e529622ba134d0a6982815d2b30.patch?full_index=1
Already downloaded: /Volumes/aho/Library/Caches/Homebrew/downloads/37276859cbebc1711941278db00cd8b25b98d69e15e31e33915a98d01a13febc--2cfbba2c8cc07e529622ba134d0a6982815d2b30.patch
==> Downloading https://github.com/Aorimn/dislocker/archive/refs/tags/v0.7.3.tar.gz
Already downloaded: /Volumes/aho/Library/Caches/Homebrew/downloads/b1ba1098c95535574936051eca45cc472955a5a024b81cc72e1c3b006e1950b3--dislocker-0.7.3.tar.gz
==> Installing dislocker-mac from gromgit/fuse
==> Applying non-DATA patches
==> Applying 2cfbba2c8cc07e529622ba134d0a6982815d2b30.patch
Initialized empty Git repository in /private/tmp/dislocker-mac-20250215-32462-zh1akh/dislocker-0.7.3/.git/
==> Applying DATA patches
==> Entering interactive mode...
Type `exit` to return and finalize the installation.
Install to this prefix: /opt/homebrew/Cellar/dislocker-mac/0.7.3_2
This directory is now a Git repository. Make your changes and then use:
  git diff | pbcopy
to copy the diff to the clipboard.
% git diff
diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
index bd854d2..9ab137d 100644
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
        # Don't use `-read_only_relocs' here as it seems to only work for 32 bits
        # binaries
        set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-bind_at_load")
-       set (FUSE_LIB osxfuse_i64)
+       set (FUSE_LIB fuse)
 else()
        # Useless warnings when used within Darwin
        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wconversion")
diff --git a/src/dislocker-fuse.c b/src/dislocker-fuse.c
index f93523f..3dd106c 100644
--- a/src/dislocker-fuse.c
+++ b/src/dislocker-fuse.c
@@ -33,11 +33,7 @@

-#ifdef __DARWIN
-# include <osxfuse/fuse.h>
-#else
-# include <fuse.h>
-#endif /* __DARWIN */
+#include <fuse.h>

 /** NTFS virtual partition's name */
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
