### PR TITLE
Dockerfile: remove `sudo`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,9 @@ RUN apt-get update \
   && localedef -i en_US -f UTF-8 en_US.UTF-8 \
   && useradd -u "${USER_ID}" --create-home --shell /bin/bash --user-group linuxbrew \
   && echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers \
-  && su - linuxbrew -c 'mkdir ~/.linuxbrew'
+  && su - linuxbrew -c 'mkdir ~/.linuxbrew' \
+  && apt-get remove --purge -y sudo \
+  && apt-get autoremove --purge -y
 
 USER linuxbrew
 COPY --chown=linuxbrew:linuxbrew . /home/linuxbrew/.linuxbrew/Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Homebrew on Linux is designed to be able to run without `sudo`. We
should leave it out of our Docker containers to make sure we're not
relying on it anywhere.
