### PR TITLE
Simplify livecheck_find_versions_parameters

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -40,22 +40,11 @@ module Homebrew
       T.must(@livecheck_strategy_names).freeze
     end
 
-    sig { returns(T::Hash[T::Class[T.anything], T::Array[Symbol]]) }
-    private_class_method def self.livecheck_find_versions_parameters
-      return T.must(@livecheck_find_versions_parameters) if defined?(@livecheck_find_versions_parameters)
-
-      # Cache strategy `find_versions` method parameters, to avoid repeating
-      # this work
-      @livecheck_find_versions_parameters = T.let({}, T.nilable(T::Hash[T::Class[T.anything], T::Array[Symbol]]))
-      Strategy.constants.sort.each do |const_symbol|
-        constant = Strategy.const_get(const_symbol)
-        next unless constant.is_a?(Class)
-
-        T.must(@livecheck_find_versions_parameters)[constant] =
-          T::Utils.signature_for_method(constant.method(:find_versions))
-                  &.parameters&.map(&:second)
-      end
-      T.must(@livecheck_find_versions_parameters).freeze
+    sig { params(strategy_class: T::Class[T.anything]).returns(T::Array[Symbol]) }
+    private_class_method def self.livecheck_find_versions_parameters(strategy_class)
+      @livecheck_find_versions_parameters ||= T.let({}, T.nilable(T::Hash[T::Class[T.anything], T::Array[Symbol]]))
+      @livecheck_find_versions_parameters[strategy_class] ||=
+        T::Utils.signature_for_method(strategy_class.method(:find_versions)).parameters.map(&:second)
     end
 
     # Uses `formulae_and_casks_to_check` to identify taps in use other than
@@ -727,7 +716,7 @@ module Homebrew
 
         # Only use arguments that the strategy's `#find_versions` method
         # supports
-        find_versions_parameters = T.must(livecheck_find_versions_parameters[strategy])
+        find_versions_parameters = livecheck_find_versions_parameters(strategy)
         strategy_args = {}
         strategy_args[:cask] = cask if find_versions_parameters.include?(:cask)
         strategy_args[:url] = url if find_versions_parameters.include?(:url)
@@ -953,7 +942,7 @@ module Homebrew
         else
           # Only use arguments that the strategy's `#find_versions` method
           # supports
-          find_versions_parameters = T.must(livecheck_find_versions_parameters[strategy])
+          find_versions_parameters = livecheck_find_versions_parameters(strategy)
           strategy_args = {}
           strategy_args[:url] = url if find_versions_parameters.include?(:url)
           strategy_args[:regex] = livecheck_regex if find_versions_parameters.include?(:regex)

--- a/Library/Homebrew/livecheck/strategy.rbi
+++ b/Library/Homebrew/livecheck/strategy.rbi
@@ -1,9 +1,0 @@
-# typed: strict
-
-module Homebrew
-  module Livecheck
-    module Strategy
-      include Kernel
-    end
-  end
-end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
One possibility for a simpler implementation of `livecheck_find_versions_parameters ` that also does less work, as suggested in https://github.com/Homebrew/brew/pull/19293/files#r1956748748