### PR TITLE
Fix type error in DependenciesHelpers#dependents

### DIFF
--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -66,9 +66,11 @@ module DependenciesHelpers
   end
 
   sig {
-    params(dependables: T.any(Dependencies, Requirements), ignores: T::Array[Symbol],
-           includes: T::Array[Symbol])
-      .returns(T::Array[T.any(Dependency, Requirement)])
+    params(
+      dependables: T.any(Dependencies, Requirements, T::Array[Dependency], T::Array[Requirement]),
+      ignores:     T::Array[Symbol],
+      includes:    T::Array[Symbol],
+    ).returns(T::Array[T.any(Dependency, Requirement)])
   }
   def select_includes(dependables, ignores, includes)
     dependables.select do |dep|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
There some inconsistency in how we use `Dependencies`/`Requirements` vs. arrays of `Dependency`/`Requirement`. For now, we'll just update the `sig` to fix https://github.com/Homebrew/brew/pull/19314#issuecomment-2667487594.