### PR TITLE
livecheck: refactor HEAD-only formula handling

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -287,6 +287,7 @@ module Cask
     #
     # @see DSL::Version
     # @api public
+    sig { params(arg: T.nilable(T.any(String, Symbol))).returns(T.nilable(DSL::Version)) }
     def version(arg = nil)
       set_unique_stanza(:version, arg.nil?) do
         if !arg.is_a?(String) && arg != :latest

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2403,6 +2403,7 @@ class Formula
 
   # Returns the {PkgVersion} for this formula if it is installed.
   # If not, return `nil`.
+  sig { returns(T.nilable(PkgVersion)) }
   def any_installed_version
     any_installed_keg&.version
   end

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -388,6 +388,7 @@ class Keg
     (path/"share/emacs/site-lisp"/name).children.any? { |f| ELISP_EXTENSIONS.include? f.extname }
   end
 
+  sig { returns(PkgVersion) }
   def version
     require "pkg_version"
     PkgVersion.parse(path.basename.to_s)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -14,6 +14,7 @@ module Homebrew
   # for formulae.
   module Livecheck
     NO_CURRENT_VERSION_MSG = "Unable to identify current version"
+    NO_VERSIONS_MSG = "Unable to get versions"
 
     UNSTABLE_VERSION_KEYWORDS = T.let(%w[
       alpha
@@ -298,7 +299,7 @@ module Homebrew
                 verbose:,
               )
               if res_version_info.empty?
-                status_hash(resource, "error", ["Unable to get versions"], verbose:)
+                status_hash(resource, "error", [NO_VERSIONS_MSG], verbose:)
               else
                 res_version_info
               end
@@ -308,13 +309,12 @@ module Homebrew
         end
 
         if latest.blank?
-          no_versions_msg = "Unable to get versions"
-          raise Livecheck::Error, no_versions_msg unless json
+          raise Livecheck::Error, NO_VERSIONS_MSG unless json
           next if quiet
 
           next version_info if version_info.is_a?(Hash) && version_info[:status] && version_info[:messages]
 
-          latest_info = status_hash(formula_or_cask, "error", [no_versions_msg], full_name: use_full_name,
+          latest_info = status_hash(formula_or_cask, "error", [NO_VERSIONS_MSG], full_name: use_full_name,
                                                                                  verbose:)
           if check_for_resources
             unless verbose
@@ -995,7 +995,7 @@ module Homebrew
         res_current = T.must(resource.version)
         res_latest = Version.new(match_version_map.values.max_by { |v| LivecheckVersion.create(resource, v) })
 
-        return status_hash(resource, "error", ["Unable to get versions"], verbose:) if res_latest.blank?
+        return status_hash(resource, "error", [NO_VERSIONS_MSG], verbose:) if res_latest.blank?
 
         is_outdated = res_current < res_latest
         is_newer_than_upstream = res_current > res_latest


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The existing code for handling a `HEAD`-only formula involves two return values that can be `nil` but this isn't apparent because the related methods aren't typed. This adds type signatures to the methods and updates the livecheck code to account for `nil` return values (making it clear which methods can return `nil`). This addresses `T.must` usage in the same code in https://github.com/Homebrew/brew/pull/19323.

Besides that, this also extracts the "Unable to get versions" error message into a constant, like `NO_CURRENT_VERSION_MSG`.