### PR TITLE
Zig template and std args

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -40,6 +40,8 @@ module Homebrew
                description: "Create a basic template for a Ruby build."
         switch "--rust",
                description: "Create a basic template for a Rust build."
+        switch "--zig",
+               description: "Create a basic template for a Zig build."
         switch "--no-fetch",
                description: "Homebrew will not download <URL> to the cache and will thus not add its SHA-256 " \
                             "to the formula for you, nor will it check the GitHub API for GitHub projects " \
@@ -58,7 +60,7 @@ module Homebrew
                description: "Ignore errors for disallowed formula names and names that shadow aliases."
 
         conflicts "--autotools", "--cmake", "--crystal", "--go", "--meson", "--node",
-                  "--perl", "--python", "--ruby", "--rust", "--cask"
+                  "--perl", "--python", "--ruby", "--rust", "--zig", "--cask"
         conflicts "--cask", "--HEAD"
         conflicts "--cask", "--set-license"
 
@@ -173,6 +175,8 @@ module Homebrew
           :ruby
         elsif args.rust?
           :rust
+        elsif args.zig?
+          :zig
         end
 
         fc = FormulaCreator.new(

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1946,6 +1946,17 @@ class Formula
     args
   end
 
+  # Standard parameters for zig builds.
+  #
+  # @api public
+  sig {
+    params(prefix:       T.any(String, Pathname),
+           release_mode: String).returns(T::Array[String])
+  }
+  def std_zig_args(prefix: self.prefix, release_mode: "fast")
+    ["--prefix", prefix.to_s, "--release=#{release_mode}", "--summary", "all"]
+  end
+
   # Shared library names according to platform conventions.
   #
   # Optionally specify a `version` to restrict the shared library to a specific
@@ -3029,6 +3040,8 @@ class Formula
         pretty_args -= std_go_args
       when "meson"
         pretty_args -= std_meson_args
+      when "zig"
+        pretty_args -= std_zig_args
       when %r{(^|/)(pip|python)(?:[23](?:\.\d{1,2})?)?$}
         pretty_args -= std_pip_args
       end

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -151,6 +151,8 @@ module Homebrew
           uses_from_macos "ruby"
         <% elsif @mode == :rust %>
           depends_on "rust" => :build
+        <% elsif @mode == :zig %>
+          depends_on "zig" => :build
         <% elsif @mode.nil? %>
           # depends_on "cmake" => :build
         <% end %>
@@ -217,6 +219,8 @@ module Homebrew
             bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
         <% elsif @mode == :rust %>
             system "cargo", "install", *std_cargo_args
+        <% elsif @mode == :zig %>
+            system "zig", "build", *std_zig_args
         <% else %>
             # Remove unrecognized options if they cause configure to fail
             # https://rubydoc.brew.sh/Formula.html#std_configure_args-instance_method


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Standard args and a template for Zig project.

I am not sure what would be the best release mode, I think `fast` is the best option for Homebrew. I also wanted to implicitly include `-fno-rosetta` flag for macOS build but this code fails tests:
```rb
def std_zig_args(prefix: self.prefix, release_mode: "fast")
    args = "--prefix", prefix.to_s, "--release=#{release_mode}", "--summary", "all"
    args << "-fno-rosetta" if OS.mac?
    args
end
```

P.S.: on my machine tests fail on `Homebrew::DevCmd::TapNew` method but it failed even before these changes. Not sure how to fix it, hope it is not related.