### PR TITLE
livecheck: refactor livecheck_strategy_names

### DIFF
--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe Homebrew::Livecheck do
     RUBY
   end
 
+  describe "::livecheck_strategy_names" do
+    context "when provided with a strategy class" do
+      it "returns demodulized class name" do
+        # We run this twice with the same argument to exercise the caching logic
+        expect(livecheck.send(:livecheck_strategy_names, Homebrew::Livecheck::Strategy::PageMatch)).to eq("PageMatch")
+        expect(livecheck.send(:livecheck_strategy_names, Homebrew::Livecheck::Strategy::PageMatch)).to eq("PageMatch")
+      end
+    end
+  end
+
   describe "::resolve_livecheck_reference" do
     context "when a formula/cask has a `livecheck` block without formula/cask methods" do
       it "returns [nil, []]" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This refactors the `livecheck_strategy_names` method to align with Doug's `livecheck_find_versions_parameters` implementation in https://github.com/Homebrew/brew/pull/19312 (which is currently part of the `Options` PR).