### PR TITLE
livecheck: restrict POST hashes to symbol keys

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -170,8 +170,8 @@ class Livecheck
     params(
       # URL to check for version information.
       url:       T.any(String, Symbol),
-      post_form: T.nilable(T::Hash[T.any(String, Symbol), String]),
-      post_json: T.nilable(T::Hash[T.any(String, Symbol), String]),
+      post_form: T.nilable(T::Hash[Symbol, String]),
+      post_json: T.nilable(T::Hash[Symbol, String]),
     ).returns(T.nilable(T.any(String, Symbol)))
   }
   def url(url = T.unsafe(nil), post_form: nil, post_json: nil)

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -172,8 +172,8 @@ module Homebrew
       # @return [Array]
       sig {
         params(
-          post_form: T.nilable(T::Hash[T.any(String, Symbol), String]),
-          post_json: T.nilable(T::Hash[T.any(String, Symbol), String]),
+          post_form: T.nilable(T::Hash[Symbol, String]),
+          post_json: T.nilable(T::Hash[Symbol, String]),
         ).returns(T::Array[String])
       }
       def self.post_args(post_form: nil, post_json: nil)

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -10,14 +10,6 @@ RSpec.describe Homebrew::Livecheck::Strategy do
 
   let(:post_hash) do
     {
-      "empty"   => "",
-      "boolean" => "true",
-      "number"  => "1",
-      "string"  => "a + b = c",
-    }
-  end
-  let(:post_hash_symbol_keys) do
-    {
       empty:   "",
       boolean: "true",
       number:  "1",
@@ -154,7 +146,6 @@ RSpec.describe Homebrew::Livecheck::Strategy do
   describe "::post_args" do
     it "returns an array including `--data` and an encoded form data string" do
       expect(strategy.post_args(post_form: post_hash)).to eq(["--data", form_string])
-      expect(strategy.post_args(post_form: post_hash_symbol_keys)).to eq(["--data", form_string])
 
       # If both `post_form` and `post_json` are present, only `post_form` will
       # be used.
@@ -163,7 +154,6 @@ RSpec.describe Homebrew::Livecheck::Strategy do
 
     it "returns an array including `--json` and a JSON string" do
       expect(strategy.post_args(post_json: post_hash)).to eq(["--json", json_string])
-      expect(strategy.post_args(post_json: post_hash_symbol_keys)).to eq(["--json", json_string])
     end
 
     it "returns an empty array if `post_form` value is blank" do

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -29,10 +29,10 @@ RSpec.describe Livecheck do
 
   let(:post_hash) do
     {
-      "empty"   => "",
-      "boolean" => "true",
-      "number"  => "1",
-      "string"  => "a + b = c",
+      empty:   "",
+      boolean: "true",
+      number:  "1",
+      string:  "a + b = c",
     }
   end
 

--- a/docs/Brew-Livecheck.md
+++ b/docs/Brew-Livecheck.md
@@ -119,8 +119,8 @@ Some checks require making a `POST` request and that can be accomplished by addi
 ```ruby
 livecheck do
   url "https://example.com/download.php", post_form: {
-    "Name"   => "",
-    "E-mail" => "",
+    Name:     "",
+    "E-mail": "",
   }
   regex(/href=.*?example[._-]v?(\d+(?:\.\d+)+)\.t/i)
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I initially set the type for livecheck's `post_form` and `post_json` hashes to allow either a string or symbol key. I used string keys in the documentation, as there will inevitably be some form field names that would pose a problem for symbols (e.g., `E-mail` uses a hyphen, `1twothree` starts with a digit, etc.). However, I remembered that we can simply use quote symbols like `:"E-mail"` to handle these situations, as they have the flexibility of a string while still being a symbol.

With that in mind, this updates related type signatures to only allow symbol keys and updates documentation and tests accordingly. The documentation example contains a hyphenated form field, so it demonstrates how to handle names that don't work as a bare symbol.