### PR TITLE
Fix it so upgrade from previous versions actually works

### DIFF
--- a/package/scripts/preinstall
+++ b/package/scripts/preinstall
@@ -21,14 +21,21 @@ subdirs=(
   ".git"
   "Library/Homebrew"
 )
-if [[ $(uname -m) == "x86_64" ]]; then
+
+arch=$(/usr/bin/uname -m)
+
+if [[ ${arch} == "x86_64" ]]
+then
   brew_dir="/usr/local/Homebrew"
 else
   brew_dir="/opt/homebrew"
 fi
-for subdir in $subdirs; do
-  if [[ -d "$brew_dir/$subdir" ]]; then
-    echo "Deleting $brew_dir/$subdir for clean upgrade..."
-    /bin/rm -rf $brew_dir/$subdir
+
+for subdir in "${subdirs[@]}"
+do
+  if [[ -d "${brew_dir}/${subdir}" ]]
+  then
+    echo "Deleting ${brew_dir}/${subdir} for clean upgrade..."
+    /bin/rm -rf "${brew_dir:?}"/"${subdir}"
   fi
 done

--- a/package/scripts/preinstall
+++ b/package/scripts/preinstall
@@ -28,7 +28,7 @@ else
 fi
 for subdir in $subdirs; do
   if [[ -d "$brew_dir/$subdir" ]]; then
-	  echo "Deleting $brew_dir/$subdir for clean upgrade..."
-	  /bin/rm -rf $brew_dir/$subdir
+    echo "Deleting $brew_dir/$subdir for clean upgrade..."
+    /bin/rm -rf $brew_dir/$subdir
   fi
 done

--- a/package/scripts/preinstall
+++ b/package/scripts/preinstall
@@ -15,3 +15,20 @@ then
 else
   exit 0
 fi
+
+# Clean up subdirs so that there's a clean upgrade from previous brew versions
+subdirs=(
+  ".git"
+  "Library/Homebrew"
+)
+if [[ $(uname -m) == "x86_64" ]]; then
+  brew_dir="/usr/local/Homebrew"
+else
+  brew_dir="/opt/homebrew"
+fi
+for subdir in $subdirs; do
+  if [[ -d "$brew_dir/$subdir" ]]; then
+	  echo "Deleting $brew_dir/$subdir for clean upgrade..."
+	  /bin/rm -rf $brew_dir/$subdir
+  fi
+done


### PR DESCRIPTION
Unless you delete these subdirectories before installing, Brew will still report the old version as being installed.

Fixes this issue: [Mac installer packages do not upgrade Homebrew from older versions](https://github.com/Homebrew/brew/issues/19287)