### PR TITLE
refactor: move nil check inside demodulize

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -31,7 +31,7 @@ module Homebrew
     sig { params(strategy_class: T::Class[T.anything]).returns(String) }
     private_class_method def self.livecheck_strategy_names(strategy_class)
       @livecheck_strategy_names ||= T.let({}, T.nilable(T::Hash[T::Class[T.anything], String]))
-      @livecheck_strategy_names[strategy_class] ||= Utils.demodulize(T.must(strategy_class.name))
+      @livecheck_strategy_names[strategy_class] ||= Utils.demodulize(strategy_class.name)
     end
 
     # Uses `formulae_and_casks_to_check` to identify taps in use other than

--- a/Library/Homebrew/livecheck/strategy/electron_builder.rb
+++ b/Library/Homebrew/livecheck/strategy/electron_builder.rb
@@ -47,7 +47,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, provided_content: nil, **unused, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
-                  "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
+                  "#{Utils.demodulize(name)} only supports a regex when using a `strategy` block"
           end
 
           Yaml.find_versions(

--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -92,11 +92,9 @@ module Homebrew
         def self.find_versions(cask:, url: nil, regex: nil, **_unused, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
-                  "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
+                  "#{Utils.demodulize(name)} only supports a regex when using a `strategy` block"
           end
-          unless T.unsafe(cask)
-            raise ArgumentError, "The #{Utils.demodulize(T.must(name))} strategy only supports casks."
-          end
+          raise ArgumentError, "The #{Utils.demodulize(name)} strategy only supports casks." unless T.unsafe(cask)
 
           match_data = { matches: {}, regex:, url: }
 

--- a/Library/Homebrew/livecheck/strategy/json.rb
+++ b/Library/Homebrew/livecheck/strategy/json.rb
@@ -107,7 +107,7 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
-          raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
+          raise ArgumentError, "#{Utils.demodulize(name)} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
           return match_data if url.blank? || block.blank?

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -91,7 +91,7 @@ module Homebrew
         }
         def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
           if regex.blank? && block.blank?
-            raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a regex or `strategy` block"
+            raise ArgumentError, "#{Utils.demodulize(name)} requires a regex or `strategy` block"
           end
 
           match_data = { matches: {}, regex:, url: }

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -228,7 +228,7 @@ module Homebrew
         def self.find_versions(url:, regex: nil, homebrew_curl: false, **unused, &block)
           if regex.present? && block.blank?
             raise ArgumentError,
-                  "#{Utils.demodulize(T.must(name))} only supports a regex when using a `strategy` block"
+                  "#{Utils.demodulize(name)} only supports a regex when using a `strategy` block"
           end
 
           match_data = { matches: {}, regex:, url: }

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -147,7 +147,7 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
-          raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
+          raise ArgumentError, "#{Utils.demodulize(name)} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
           return match_data if url.blank? || block.blank?

--- a/Library/Homebrew/livecheck/strategy/yaml.rb
+++ b/Library/Homebrew/livecheck/strategy/yaml.rb
@@ -107,7 +107,7 @@ module Homebrew
           ).returns(T::Hash[Symbol, T.untyped])
         }
         def self.find_versions(url:, regex: nil, provided_content: nil, homebrew_curl: false, **unused, &block)
-          raise ArgumentError, "#{Utils.demodulize(T.must(name))} requires a `strategy` block" if block.blank?
+          raise ArgumentError, "#{Utils.demodulize(name)} requires a `strategy` block" if block.blank?
 
           match_data = { matches: {}, regex:, url: }
           return match_data if url.blank? || block.blank?

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -30,6 +30,10 @@ RSpec.describe Utils do
       expect(described_class.demodulize("")).to eq("")
       expect(described_class.demodulize("::")).to eq("")
     end
+
+    it "raise an ArgumentError when passed nil" do
+      expect { described_class.demodulize(nil) }.to raise_error(ArgumentError)
+    end
   end
 
   specify ".parse_author!" do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -97,8 +97,11 @@ module Utils
   # See also #deconstantize.
   # @see https://github.com/rails/rails/blob/b0dd7c7/activesupport/lib/active_support/inflector/methods.rb#L230-L245
   #   `ActiveSupport::Inflector.demodulize`
-  sig { params(path: String).returns(String) }
+  # @raise [ArgumentError] if the provided path is nil
+  sig { params(path: T.nilable(String)).returns(String) }
   def self.demodulize(path)
+    raise ArgumentError, "No constant path provided" if path.nil?
+
     if (i = path.rindex("::"))
       T.must(path[(i + 2)..])
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I noticed we could shed some `T.must` use by moving the `nil` check inside the method. (This helps absolve some of the sins of https://github.com/Homebrew/brew/pull/19323)