### PR TITLE
dev-cmd/bottle: check for prefix when not /usr/local

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -559,7 +559,7 @@ module Homebrew
 
             ohai "Detecting if #{local_filename} is relocatable..." if bottle_path.size > 1 * 1024 * 1024
 
-            prefix_check = if Homebrew.default_prefix?(prefix)
+            prefix_check = if prefix == HOMEBREW_DEFAULT_PREFIX
               File.join(prefix, "opt")
             else
               prefix


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes incorrectly marking bottles as relocatable, e.g.

https://github.com/Homebrew/homebrew-core/blob/425d4ea43d36e7d03ce894268dd42aef5236bb54/Formula/p/pkgconf.rb#L34-L36

This cannot be done for `/usr/local` as it is used outside Homebrew. Other default prefixes are Homebrew-specific.
