### PR TITLE
Fix return type of Formula.build

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3703,7 +3703,7 @@ class Formula
     sig { params(block: T.proc.bind(BottleSpecification).void).void }
     def bottle(&block) = stable.bottle(&block)
 
-    sig { returns(String) }
+    sig { returns(BuildOptions) }
     def build = stable.build
 
     # Get the `BUILD_FLAGS` from the formula's namespace set in `Formulary::load_formula`.

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -549,6 +549,7 @@ RSpec.describe Formula do
     expect(f.homepage).to eq("https://brew.sh")
     expect(f.version).to eq(Version.new("0.1"))
     expect(f).to be_stable
+    expect(f.build).to be_a(BuildOptions)
     expect(f.stable.version).to eq(Version.new("0.1"))
     expect(f.head.version).to eq(Version.new("HEAD"))
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Resolves https://github.com/d12frosted/homebrew-emacs-plus/issues/787