### PR TITLE
docs: Remove misused YARD directives

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3432,8 +3432,6 @@ class Formula
     # ```ruby
     # allow_network_access! [:build, :test]
     # ```
-    #
-    # @!attribute [w] allow_network_access!
     sig { params(phases: T.any(Symbol, T::Array[Symbol])).void }
     def allow_network_access!(phases = [])
       phases_array = Array(phases)
@@ -3466,8 +3464,6 @@ class Formula
     # ```ruby
     # deny_network_access! [:build, :test]
     # ```
-    #
-    # @!attribute [w] deny_network_access!
     sig { params(phases: T.any(Symbol, T::Array[Symbol])).void }
     def deny_network_access!(phases = [])
       phases_array = Array(phases)
@@ -3740,7 +3736,6 @@ class Formula
       T.must(@stable).instance_eval(&block)
     end
 
-    # @!attribute [w] head
     # Adds a {.head} {SoftwareSpec}.
     # This can be installed by passing the `--HEAD` option to allow
     # installing software directly from a branch of a version-control repository.

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -155,8 +155,6 @@ class Resource
   #   regex /foo-(\d+(?:\.\d+)+)\.tar/
   # end
   # ```
-  #
-  # @!attribute [w] livecheck
   def livecheck(&block)
     return @livecheck unless block
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`@!attribute` is [intended](https://www.rubydoc.info/gems/yard/file/docs/Tags.md#attribute) to inject implicit `attr_*` methods. I removed the directives where they do no represent attribute writers (e.g. they are set with `head "https://example.com/.git"` not `head = "https://example.com/.git"`