### PR TITLE
formula: allow :no_check for sha256 in sorbet types

### DIFF
--- a/Library/Homebrew/checksum.rb
+++ b/Library/Homebrew/checksum.rb
@@ -5,12 +5,12 @@
 class Checksum
   extend Forwardable
 
-  sig { returns(String) }
+  sig { returns(T.any(String, Symbol)) }
   attr_reader :hexdigest
 
-  sig { params(hexdigest: String).void }
+  sig { params(hexdigest: T.any(String, Symbol)).void }
   def initialize(hexdigest)
-    @hexdigest = T.let(hexdigest.downcase, String)
+    @hexdigest = T.let(hexdigest.downcase, T.any(String, Symbol))
   end
 
   delegate [:empty?, :to_s, :length, :[]] => :@hexdigest

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3669,7 +3669,7 @@ class Formula
     # ```
     #
     # @api public
-    sig { params(val: String).void }
+    sig { params(val: T.any(String, Symbol)).void }
     def sha256(val) = stable.sha256(val)
 
     # Adds a {.bottle} {SoftwareSpec}.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

There are some formulae that have `sha256 :no_check` (in private taps).
This works fine when sorbet is disabled, but when it is enabled we get
type errors as only a String is expected.

I copied the types from the Cask definition at
https://github.com/Homebrew/brew/blob/9a3451ee950dd50e0fc3fb1a0092a519ef6d9736/Library/Homebrew/cask/dsl.rb#L323
, to the point where `brew info --json=v2 <formula>` started to pass.