### PR TITLE
fix(search.rb): fix regex regression in search

### DIFF
--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -69,7 +69,11 @@ module Homebrew
 
       aliases = Formula.alias_full_names
       results = search(Formula.full_names + aliases, string_or_regex).sort
-      results |= Formula.fuzzy_search(string_or_regex).map { |n| Formulary.factory(n).full_name }
+      if string_or_regex.is_a?(String)
+        results |= Formula.fuzzy_search(string_or_regex).map do |n|
+          Formulary.factory(n).full_name
+        end
+      end
 
       results.filter_map do |name|
         formula, canonical_full_name = begin


### PR DESCRIPTION
Fixes a regression in `brew search` which prevented using a regex for the search pattern after strict typing was added to `formula.rb` in commit a81239e. Now performs fuzzy search only if input is a string.

Closes #19397

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
