### PR TITLE
macOS pkg installer: fix existing installation not being upgraded

### DIFF
--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -29,9 +29,9 @@ export HOME="${homebrew_directory}"
 # reset Git repository
 cd "${homebrew_directory}"
 git config --global --add safe.directory "${homebrew_directory}"
-git reset --hard
-git checkout --force master
-git branch | grep -v '\*' | xargs -n 1 git branch --delete --force || true
+git checkout --force -B stable
+git reset --hard "$(git tag --list --sort="-version:refname" | head -n1)"
+git clean -f -d
 rm "${homebrew_directory}/.gitconfig"
 
 # move to /usr/local if on x86_64
@@ -44,8 +44,9 @@ then
 
     export HOME="/usr/local/Homebrew"
     git config --global --add safe.directory /usr/local/Homebrew
+    git -C /usr/local/Homebrew checkout --force -B stable
     git -C /usr/local/Homebrew reset --hard
-    git -C /usr/local/Homebrew checkout --force master
+    git -C /usr/local/Homebrew clean -f -d
     rm /usr/local/Homebrew/.gitconfig
   else
     mkdir -vp /usr/local/bin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Currently when running the macOS installer atop an existing installation, at the point after the installation finishes but before `postinstall` is run, the master branch hasn't had its HEAD advanced to the latest tag yet so the working directory is in a "HEAD detached at {version number}" as though you had run `git checkout {version number}`. This is why `git reset --hard` resets it to the previous tagged version.

This change has `git` find the latest tag (`git tag --list --sort="-version:refname" | head -n1`) and then resets to that tag (`git reset --hard <tag name>`). This also adds a `git clean -f -d` to clear any stray untracked files from the working directory, and no longer purges all branches other than `master`. 

Fixes #19287, alternate to #19354. Tested on both macOS ARM and Intel. 