### PR TITLE
Document pwsh shell completion

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1994,8 +1994,8 @@ class Formula
   end
   private :extract_macho_slice_from
 
-  # Generate shell completions for a formula for `bash`, `zsh`, `fish`, and `pwsh`,
-  # using the formula's executable.
+  # Generate shell completions for a formula for `bash`, `zsh`, `fish`, and
+  # optionally `pwsh` using the formula's executable.
   #
   # ### Examples
   #
@@ -2009,6 +2009,17 @@ class Formula
   # (zsh_completion/"_foo").write Utils.safe_popen_read({ "SHELL" => "zsh" }, bin/"foo", "completions", "zsh")
   # (fish_completion/"foo.fish").write Utils.safe_popen_read({ "SHELL" => "fish" }, bin/"foo",
   #                                                          "completions", "fish")
+  # ```
+  #
+  # If your executable can generate completions for PowerShell,
+  # you must pass ":pwsh" explicitly along with any other supported shells.
+  # This will pass "powershell" as the completion argument.
+  #
+  # ```ruby
+  # generate_completions_from_executable(bin/"foo", "completions", shells: [:bash, :pwsh])
+  #
+  # # translates to
+  # (bash_completion/"foo").write Utils.safe_popen_read({ "SHELL" => "bash" }, bin/"foo", "completions", "bash")
   # (pwsh_completion/"foo").write Utils.safe_popen_read({ "SHELL" => "pwsh" }, bin/"foo",
   #                                                           "completions", "powershell")
   # ```

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -889,6 +889,7 @@ Generally we'd rather you were specific about which files or directories need to
 | **`bash_completion`** | `#{prefix}/etc/bash_completion.d`              | `/opt/homebrew/Cellar/foo/0.1/etc/bash_completion.d` |
 | **`zsh_completion`**  | `#{prefix}/share/zsh/site-functions`           | `/opt/homebrew/Cellar/foo/0.1/share/zsh/site-functions` |
 | **`fish_completion`** | `#{prefix}/share/fish/vendor_completions.d`    | `/opt/homebrew/Cellar/foo/0.1/share/fish/vendor_completions.d` |
+| **`pwsh_completion`** | `#{prefix}/share/pwsh/completions`             | `/opt/homebrew/Cellar/foo/0.1/share/pwsh/completions` |
 | **`etc`**             | `#{HOMEBREW_PREFIX}/etc`                       | `/opt/homebrew/etc` |
 | **`pkgetc`**          | `#{HOMEBREW_PREFIX}/etc/#{name}`               | `/opt/homebrew/etc/foo` |
 | **`var`**             | `#{HOMEBREW_PREFIX}/var`                       | `/opt/homebrew/var` |


### PR DESCRIPTION
Based on discussion in #19408, update the documentation to specify that `:pwsh` must be passed explicitly and that it will translate to a "powershell" argument, as is currently supported by Go's common `github.com/spf13/cobra` module and Rust's common `clap` (with `clap_complete`) crate.
