### PR TITLE
Xorg: Handle nil `:content` value

### DIFF
--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -136,9 +136,11 @@ module Homebrew
             options:,
             &block
           )
+          content = match_data[:content]
+          return match_data if content.blank?
 
           # Cache any new page content
-          @page_data[generated_url] = match_data[:content] unless match_data[:content].empty?
+          @page_data[generated_url] = content unless cached_content
 
           match_data
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `Xorg.find_versions` method was recently updated in https://github.com/Homebrew/brew/pull/19355 to replace `match_data[:content].blank?` with `match_data[:content].empty?` but this is producing an `undefined method 'empty?' for nil` error, as `:content` is not present when `PageMatch.find_versions` uses cached content. This updates `Xorg.find_versions` to handle nil `:content` values in a way that's similar to other `find_versions` methods.

To be clear, we use `#blank?` here instead of `#empty?` not only to handle `nil` values but also to ensure that we don't cache an empty string. I may reevaluate this idea but that's the current approach in `find_versions` methods.

My next PR will add cached content support to all strategies other than `ExtractPlist` and extend test coverage for strategies to 100%, so this code path should be properly exercised after those changes. I wanted to push this quick fix out in the interim time, as a number of checks in the homebrew/core autobump workflow are failing due to this bug.