### PR TITLE
Cask: skip livecheck https audit for POST requests

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -950,6 +950,9 @@ module Cask
       return unless (url = cask.livecheck.url)
       return if url.is_a?(Symbol)
 
+      options = cask.livecheck.options
+      return if options.post_form || options.post_json
+
       validate_url_for_https_availability(
         url, "livecheck URL",
         check_content: true,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We recently added `POST` request support to livecheck but related cask checks are failing the `livecheck_https_availability` audit (e.g., https://github.com/Homebrew/homebrew-cask/pull/204094) because it calls `validate_url_for_https_availability` which calls `Utils::Curl.curl_check_http_content` and that checks the URL using a `GET` request. Adding `POST` request support to all of those methods will take some work, so this adds a guard to skip the audit if the `livecheck` block uses `post_form` or `post_json`. This isn't ideal but it will allow us to add these `livecheck` blocks in the interim time.