### PR TITLE
cask/installer: pass more options to cask dependencies

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -424,10 +424,13 @@ on_request: true)
             cask_or_formula,
             adopt:                   adopt?,
             binaries:                binaries?,
-            verbose:                 verbose?,
+            force:                   false,
             installed_as_dependency: true,
             installed_on_request:    false,
-            force:                   false,
+            quarantine:              quarantine?,
+            quiet:                   quiet?,
+            require_sha:             require_sha?,
+            verbose:                 verbose?,
           ).install
         else
           Homebrew::Install.perform_preinstall_checks_once

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -237,14 +237,14 @@ module Homebrew
           new_casks.each do |cask|
             Cask::Installer.new(
               cask,
-              binaries:       args.binaries?,
-              verbose:        args.verbose?,
-              force:          args.force?,
               adopt:          args.adopt?,
-              require_sha:    args.require_sha?,
-              skip_cask_deps: args.skip_cask_deps?,
+              binaries:       args.binaries?,
+              force:          args.force?,
               quarantine:     args.quarantine?,
               quiet:          args.quiet?,
+              require_sha:    args.require_sha?,
+              skip_cask_deps: args.skip_cask_deps?,
+              verbose:        args.verbose?,
             ).install
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Currently, `brew install` will refuse to install a `sha256 :no_check` cask if `--require-sha` is specified, but will happily do so if said cask is a dependency of another cask. Same goes for `--no-quarantine`: it'll skip applying the quarantine attribute only for the dependent cask.

This commit fixes that by passing `require_sha` and `quarantine` when installing dependencies, plus `quiet` which was also missing. (It also reorders the args in a similar `cmd/install.rb` call to match.)