### PR TITLE
curl_headers: Handle POST requests

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -178,7 +178,7 @@ module Homebrew
         ).returns(T::Array[String])
       }
       def self.post_args(post_form: nil, post_json: nil)
-        if post_form.present?
+        args = if post_form.present?
           require "uri"
           ["--data", URI.encode_www_form(post_form)]
         elsif post_json.present?
@@ -187,6 +187,12 @@ module Homebrew
         else
           []
         end
+
+        if (content_length = args[1]&.length)
+          args << "--header" << "Content-Length: #{content_length}"
+        end
+
+        args
       end
 
       # Collects HTTP response headers, starting with the provided URL.

--- a/Library/Homebrew/test/livecheck/strategy_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy_spec.rb
@@ -144,16 +144,22 @@ RSpec.describe Homebrew::Livecheck::Strategy do
   end
 
   describe "::post_args" do
+    let(:form_string_content_length) { "Content-Length: #{form_string.length}" }
+    let(:json_string_content_length) { "Content-Length: #{json_string.length}" }
+
     it "returns an array including `--data` and an encoded form data string" do
-      expect(strategy.post_args(post_form: post_hash)).to eq(["--data", form_string])
+      expect(strategy.post_args(post_form: post_hash))
+        .to eq(["--data", form_string, "--header", form_string_content_length])
 
       # If both `post_form` and `post_json` are present, only `post_form` will
       # be used.
-      expect(strategy.post_args(post_form: post_hash, post_json: post_hash)).to eq(["--data", form_string])
+      expect(strategy.post_args(post_form: post_hash, post_json: post_hash))
+        .to eq(["--data", form_string, "--header", form_string_content_length])
     end
 
     it "returns an array including `--json` and a JSON string" do
-      expect(strategy.post_args(post_json: post_hash)).to eq(["--json", json_string])
+      expect(strategy.post_args(post_json: post_hash))
+        .to eq(["--json", json_string, "--header", json_string_content_length])
     end
 
     it "returns an empty array if `post_form` value is blank" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Livecheck::Strategy.page_headers` uses `Utils::Curl.curl_headers` but the method only handles `HEAD` and `GET` requests. I recently added `POST` support to livecheck but forgot to update `curl_headers` in the process, so `livecheck` blocks using the `HeaderMatch` strategy along with `post_form` or `post_json` will fail because curl doesn't allow both `--head` and `--data`/`--json` arguments (e.g., https://github.com/Homebrew/homebrew-cask/pull/204216).

This addresses the issue by updating `curl_headers` to handle `POST` requests and skip the `GET` retry logic.

-----

The aforementioned `effect-house` PR also demonstrated that some servers will return an unexpected response if a `Content-Length` header isn't included in the `POST` request, so this adds the header to the `post_args` array when `post_form` or `post_json` are used.