### PR TITLE
livecheck: fix parent reference handling

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -895,9 +895,9 @@ module Homebrew
           block_provided:     livecheck_strategy_block.present?,
         )
         strategy = Strategy.from_symbol(livecheck_strategy) || strategies.first
-        next unless strategy
+        next if strategy.blank? && livecheck_reference != :parent
 
-        strategy_name = livecheck_strategy_names(strategy)
+        strategy_name = livecheck_strategy_names(strategy) if strategy.present?
 
         if strategy.respond_to?(:preprocess_url)
           url = strategy.preprocess_url(url)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Do not skip resource check if `strategy` is blank – this prevents proper handling of parent reference livecheck blocks. This is one of the possible fixes and I've confirmed it works, but long term we do plan to refactor the livecheck code to handle resources better (and not rely on looping through URLs).

Spotted by @cho-m in https://github.com/Homebrew/brew/commit/efeff905eb9f79efab776c2cc6c2208f24e7b8ba.