### PR TITLE
rmdir: ignore unreadable path errors

### DIFF
--- a/Library/Homebrew/cask/utils/rmdir.sh
+++ b/Library/Homebrew/cask/utils/rmdir.sh
@@ -26,7 +26,7 @@ do
 
     # Some packages leave broken symlinks around; we clean them out before
     # attempting to `rmdir` to prevent extra cruft from accumulating.
-    /usr/bin/find -f "${path}" -- -mindepth 1 -maxdepth 1 -type l ! -exec /bin/test -e {} \; -delete
+    /usr/bin/find -f "${path}" -- -mindepth 1 -maxdepth 1 -type l ! -exec /bin/test -e {} \; -delete || true
   elif ! ${symlink} && [[ ! -e "${path}" ]]
   then
     # Skip paths that don't exists and aren't a broken symlink.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
xref. https://github.com/orgs/Homebrew/discussions/6002, fixes https://github.com/Homebrew/homebrew-cask/issues/204284

When uninstalling a cask that was installed via a .pkg installer, the cask uninstaller's `rmdir.sh` will attempt to find orphaned symlinks in any [non-system paths](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cask/macos.rb#L6). So if files were installed in `/var/db`, as is done by `santa`, `rmdir.sh`'s run of `find` in that path will fail when it attempts to query the `DifferentialPrivacy`, which seems to have some super-special invisibility cloak over it.
```
$ find /var/db -mindepth 1 -maxdepth 1 -type l
find: /var/db/DifferentialPrivacy: Operation not permitted
```
Adding `|| true` suppresses errors from `find`, which allows casks like `santa` to be uninstalled.

Before:
```
$ brew uninstall --cask santa
==> Uninstalling Cask santa
==> Removing launchctl service com.northpolesec.santa
Password:
==> Removing launchctl service com.northpolesec.santa.bundleservice
==> Removing launchctl service com.northpolesec.santa.metricservice
==> Removing launchctl service com.northpolesec.santa.syncservice
==> Removing launchctl service com.northpolesec.santad
==> Unloading kernel extension com.northpolesec.santa-driver
Executing: /usr/bin/kmutil showloaded --list-only --bundle-identifier com.northpolesec.santa-driver
No variant specified, falling back to release
Can't record kext in identifier lookup dictionary; no identifier.
Can't record kext in identifier lookup dictionary; no identifier.
==> Uninstalling packages with sudo; the password may be necessary:
com.northpolesec.santa
find: /var/db/DifferentialPrivacy: Operation not permitted
Error: Failure while executing; `/usr/bin/sudo -u root -E -- /usr/bin/xargs -0 -- /opt/homebrew/Library/Homebrew/cask/utils/rmdir.sh` exited with 1. Here's the output:
find: /var/db/DifferentialPrivacy: Operation not permitted
```

After:
```
$ brew uninstall --cask santa
==> Uninstalling Cask santa
==> Removing launchctl service com.northpolesec.santa
Password:
==> Removing launchctl service com.northpolesec.santa.bundleservice
==> Removing launchctl service com.northpolesec.santa.metricservice
==> Removing launchctl service com.northpolesec.santa.syncservice
==> Removing launchctl service com.northpolesec.santad
==> Unloading kernel extension com.northpolesec.santa-driver
Executing: /usr/bin/kmutil showloaded --list-only --bundle-identifier com.northpolesec.santa-driver
No variant specified, falling back to release
Can't record kext in identifier lookup dictionary; no identifier.
Can't record kext in identifier lookup dictionary; no identifier.
==> Uninstalling packages with sudo; the password may be necessary:
com.northpolesec.santa
find: /var/db/DifferentialPrivacy: Operation not permitted
==> Removing files:
/Applications/Santa.app
/usr/local/bin/santactl
==> Purging files for version 2025.2 of Cask santa
```