### PR TITLE
install.rb: add "no" in `--ask` output

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -381,7 +381,7 @@ module Homebrew
       end
 
       def ask_input
-        ohai "Do you want to proceed with the installation? [Y/y/yes/N/n]"
+        ohai "Do you want to proceed with the installation? [Y/y/yes/N/n/no]"
         accepted_inputs = %w[y yes]
         declined_inputs = %w[n no]
         loop do


### PR DESCRIPTION
- improves https://github.com/Homebrew/brew/pull/19254

Added "/no" for consistency with "Y/y/yes".

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
