### PR TITLE
cask/utils: alllow use of @ in cask name

### DIFF
--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -111,9 +111,8 @@ module Cask
     def self.token_from(name)
       name.downcase
           .gsub("+", "-plus-")
-          .gsub("@", "-at-")
           .gsub(/[ _·•]/, "-")
-          .gsub(/[^\w-]/, "")
+          .gsub(/[^\w@-]/, "")
           .gsub(/--+/, "-")
           .delete_prefix("-")
           .delete_suffix("-")

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -17,7 +17,12 @@ RSpec.describe Homebrew::DevCmd::Create do
   end
 
   it "generates valid cask tokens" do
-    t = Cask::Utils.token_from("A Foo@Bar_Baz++!")
-    expect(t).to eq("a-foo-at-bar-baz-plus-plus")
+    t = Cask::Utils.token_from("A FooBar_Baz++!")
+    expect(t).to eq("a-foobar-baz-plus-plus")
+  end
+
+  it "retains @ in cask tokens" do
+    t = Cask::Utils.token_from("test@preview")
+    expect(t).to eq("test@preview")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In `homebrew-cask`, we use the `@` sign in the token to denote a suffix that is either a versioned cask (`foobar@5`), or a cask that follows a particular release branch (`foobar@beta`). We also require that `@` signs are replaced with `-at-` in a general cask token. The `brew create --cask` command currently replaces an `@` with `-at-`, which is the far less common occurrence (there's three casks that include this currently).

I'm proposing we default to the much more common occurrence and retain the `@` (219 casks).

Uncovered in: https://github.com/Homebrew/homebrew-cask/pull/204538#issuecomment-2712629687