### PR TITLE
dev-cmd/prof: fix `vernier` invocation

### DIFF
--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -50,7 +50,7 @@ module Homebrew
         elsif args.vernier?
           output_filename = "prof/vernier.json"
           Process::UID.change_privilege(Process.euid) if Process.euid != Process.uid
-          safe_system "vernier", "run", "--output=#{output_filename}", "--allocation_sample_rate=500", "--",
+          safe_system "vernier", "run", "--output=#{output_filename}", "--allocation_interval=500", "--",
                       RUBY_PATH, brew_rb, *args.named
           ohai "Profiling complete!"
           puts "Upload the results from #{output_filename} to:"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`--allocation_sample_rate` was renamed to `--allocation_interval` in https://github.com/jhawthorn/vernier/commit/8ffadb304f0262f7ede9f590eacefa1453b26909
