### PR TITLE
livecheck: fix type error for github formulae

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1219,7 +1219,7 @@ end
 #
 # @api public
 class GitHubGitDownloadStrategy < GitDownloadStrategy
-  sig { params(url: String, name: String, version: T.nilable(Version), meta: T::Hash[Symbol, T.untyped]).void }
+  sig { params(url: String, name: String, version: T.nilable(Version), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @version = T.let(version, T.nilable(Version))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Recent download strategy refactor (#19475) broke livecheck for all GitHub formulae, examples:
https://github.com/Homebrew/homebrew-core/actions/runs/13866807187/job/38807549816?pr=210974#step:4:46
https://github.com/Homebrew/homebrew-core/actions/runs/13866759236/job/38807498516?pr=210970#step:4:45
https://github.com/Homebrew/homebrew-core/actions/runs/13866741068/job/38807546599?pr=210968#step:4:45

This change fixes it