### PR TITLE
fix: DownloadStrategy meta params should be untyped

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1219,7 +1219,7 @@ end
 #
 # @api public
 class GitHubGitDownloadStrategy < GitDownloadStrategy
-  sig { params(url: String, name: String, version: T.nilable(Version), meta: T::Hash[Symbol, T.untyped]).void }
+  sig { params(url: String, name: String, version: T.nilable(Version), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @version = T.let(version, T.nilable(Version))
@@ -1371,10 +1371,7 @@ end
 #
 # @api public
 class MercurialDownloadStrategy < VCSDownloadStrategy
-  sig {
-    params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T::Hash[Symbol, T.untyped])
-      .void
-  }
+  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @url = T.let(@url.sub(%r{^hg://}, ""), String)
@@ -1462,10 +1459,7 @@ end
 #
 # @api public
 class BazaarDownloadStrategy < VCSDownloadStrategy
-  sig {
-    params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T::Hash[Symbol, T.untyped])
-      .void
-  }
+  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @url = T.let(@url.sub(%r{^bzr://}, ""), String)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I should really know better than to type double splats as hashes 😞 

Resolves https://github.com/Homebrew/brew/pull/19475#issuecomment-2726010452