### PR TITLE
Skip homepage audit for `www.gnu.org` and `www.nongnu.org` on GitHub runners

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -563,6 +563,15 @@ module Homebrew
 
       return unless DevelopmentTools.curl_handles_most_https_certificates?
 
+      # Skip gnu.org and nongnu.org audit on GitHub runners
+      # See issue: https://github.com/Homebrew/homebrew-core/issues/206757
+      gnu_homepages = [
+        %r{https://www\.gnu\.org/.+},
+        %r{https://www\.nongnu\.org/.+},
+      ]
+
+      return if gnu_homepages.any?(&homepage.method(:match?)) && ENV["HOMEBREW_GITHUB_HOSTED_RUNNER"]
+
       use_homebrew_curl = [:stable, :head].any? do |spec_name|
         next false unless (spec = formula.send(spec_name))
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -565,12 +565,7 @@ module Homebrew
 
       # Skip gnu.org and nongnu.org audit on GitHub runners
       # See issue: https://github.com/Homebrew/homebrew-core/issues/206757
-      gnu_homepages = [
-        %r{https://www\.gnu\.org/.+},
-        %r{https://www\.nongnu\.org/.+},
-      ]
-
-      return if gnu_homepages.any?(&homepage.method(:match?)) && ENV["HOMEBREW_GITHUB_HOSTED_RUNNER"]
+      return if homepage.match?(%r{^https?://www\.(?:non)?gnu\.org/.+}) && ENV["HOMEBREW_GITHUB_HOSTED_RUNNER"]
 
       use_homebrew_curl = [:stable, :head].any? do |spec_name|
         next false unless (spec = formula.send(spec_name))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Related issue: Homebrew/homebrew-core#206757

There are a lot of formulae in the core repository that have `www.gnu.org` and `www.nongnu.org` homepages (`grep -o -n "www\.gnu\.org" -r . | cut -d : -f 1 | uniq -c | wc -l` gives 119 entries). Admins do not want to unblock GitHub infrastructure (https://savannah.nongnu.org/support/index.php?111187), so I think it would be better skip this check on Linux (this audit error doesn't occur on macs). If the homepage has a problem it'll be caught during tests on macOS