### PR TITLE
fix(services/list): correctly handle services with an error code

### DIFF
--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -161,14 +161,14 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def pid?
-        pid.present? && !pid.zero?
+        pid.present? && pid.positive?
       end
 
       sig { returns(T::Boolean) }
       def error?
         return false if pid?
 
-        exit_code.present? && exit_code.nonzero?
+        exit_code.present? && !exit_code.zero?
       end
 
       sig { returns(T::Boolean) }


### PR DESCRIPTION
The `brew services list` command was not correctly handling services
that had an error code status.

While the `#zero?` method returns a boolean, the `#nonzero?` method
confusingly returns self or nil. Hence a negated `#zero?` call to check
for a non-zero exit code fixes the error.

While here, `#pid?` method uses a negated `#zero?`, which is not
accurate, as a negative PID value would not be a valid PID. Hence I
changed it to use `#positive?` instead.

The tests for the `#error?` method were marked as needing systemd, but I
saw no obvious reason for that due to how they all use mocked values, so
I removed the systemd requirement.

---

Resolves this error I was getting while the `node_exporter` service had a error status:

```
$ brew services list
Error: Return value: Expected type T::Boolean, got type Integer with value 512
Caller: /opt/homebrew/Library/Homebrew/services/formula_wrapper.rb:277
Definition: /opt/homebrew/Library/Homebrew/services/formula_wrapper.rb:168 (Homebrew::Services::FormulaWrapper#error?)
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/configuration.rb:296:in `call_validation_error_handler_default'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/configuration.rb:303:in `call_validation_error_handler'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:322:in `report_error'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:291:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/services/formula_wrapper.rb:277:in `status_symbol'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation_2_7.rb:59:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation_2_7.rb:59:in `block in create_validator_method_fast0'
/opt/homebrew/Library/Homebrew/services/formula_wrapper.rb:202:in `to_hash'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation_2_7.rb:919:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation_2_7.rb:919:in `block in create_validator_method_medium0'
/opt/homebrew/Library/Homebrew/services/formulae.rb:28:in `map'
/opt/homebrew/Library/Homebrew/services/formulae.rb:28:in `services_list'
/opt/homebrew/Library/Homebrew/services/commands/list.rb:15:in `run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/cmd/services.rb:148:in `run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:95:in `<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The one failure I got locally with `brew tests` was from `test/dev-cmd/tap-new_spec.rb` which seems very unrelated to my fix here:

```
Failures:

  1) Homebrew::DevCmd::TapNew initializes a new tap with a README file and GitHub Actions CI
     Failure/Error:
       expect { brew "tap-new", "homebrew/foo", "--verbose" }
         .to be_a_success
         .and output(%r{homebrew/foo}).to_stdout
         .and not_to_output.to_stderr

          expected #<Proc:0x00000001369baaf0 /opt/homebrew/Library/Homebrew/test/dev-cmd/tap-new_spec.rb:13> to be a success

       ...and:

          expected block to not output to stderr, but output "error: cannot run gpg: No such file or directory\nerror: gpg failed to sign the data:\n(no gpg output)\nfatal: failed to write commit object\nError: Failure while executing; `git commit -m Create\\ homebrew/foo\\ tap` exited with 128.\n"
     # ./test/dev-cmd/tap-new_spec.rb:13:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:50:in `block (2 levels) in <top (required)>'
```