### PR TITLE
std_go_args: add `-tags` flag

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1820,10 +1820,12 @@ class Formula
       output:  T.any(String, Pathname),
       ldflags: T.nilable(T.any(String, T::Array[String])),
       gcflags: T.nilable(T.any(String, T::Array[String])),
+      tags:    T.nilable(T.any(String, T::Array[String])),
     ).returns(T::Array[String])
   }
-  def std_go_args(output: bin/name, ldflags: nil, gcflags: nil)
+  def std_go_args(output: bin/name, ldflags: nil, gcflags: nil, tags: nil)
     args = ["-trimpath", "-o=#{output}"]
+    args += ["-tags=#{Array(tags).join(" ")}"] if tags
     args += ["-ldflags=#{Array(ldflags).join(" ")}"] if ldflags
     args += ["-gcflags=#{Array(gcflags).join(" ")}"] if gcflags
     args

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -517,7 +517,7 @@ The `std_*_args` methods, as well as the arguments they pass, are:
 "-o=#{output}"
 ```
 
-It also provides a convenient way to set `-ldflags` and `-gcflags`, see examples: [`babelfish`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/b/babelfish.rb) and [`wazero`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/w/wazero.rb) formulae.
+It also provides a convenient way to set `-ldflags`, `-gcflags`, and `-tags`, see examples: [`babelfish`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/b/babelfish.rb) and [`wazero`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/w/wazero.rb) formulae.
 
 #### `std_meson_args`
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~~ (no needed)
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
A convenient way to set `-tags` flag with multiple values in std_go_args