### PR TITLE
rubocops/cask/stanza_order: Ensure `arch` and `os` are adjacent

### DIFF
--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -20,7 +20,7 @@ module RuboCop
 
       STANZA_GROUPS = T.let(
         [
-          [:arch, :on_arch_conditional],
+          [:arch, :on_arch_conditional, :os],
           [:version, :sha256],
           ON_SYSTEM_METHODS_STANZA_ORDER,
           [:language],

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe RuboCop::Cop::Cask::StanzaGrouping, :config do
       cask 'foo' do
         arch arm: "arm64", intel: "x86_64"
         folder = on_arch_conditional arm: "darwin-arm64", intel: "darwin"
+        os macos: ">= :big_sur"
 
         version :latest
         sha256 :no_check

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
   it "reports an offense when an `arch` stanza is out of order" do
     expect_offense <<~CASK
       cask 'foo' do
+        os macos: ">= :big_sur"
+        ^^^^^^^^^^^^^^^^^^^^^^^ `os` stanza out of order
         version :latest
         ^^^^^^^^^^^^^^^ `version` stanza out of order
         sha256 :no_check
@@ -56,6 +58,7 @@ RSpec.describe RuboCop::Cop::Cask::StanzaOrder, :config do
     expect_correction <<~CASK
       cask 'foo' do
         arch arm: "arm", intel: "x86_64"
+        os macos: ">= :big_sur"
         version :latest
         sha256 :no_check
       end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-os.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-os.rb
@@ -1,6 +1,6 @@
 cask "sha256-os" do
-  os macos: "darwin", linux: "linux"
   arch arm: "arm", intel: "intel"
+  os macos: "darwin", linux: "linux"
 
   version "1.2.3"
   sha256 arm:          "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Because @p-linnane wanted this to be codified.