### PR TITLE
os/linux/diagnostic: skip error on arm64 when `HOMEBREW_ARM64_TESTING` is set

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -74,7 +74,8 @@ module OS
         end
 
         def check_supported_architecture
-          return if Hardware::CPU.arch == :x86_64
+          return if Hardware::CPU.intel?
+          return if Homebrew::EnvConfig.developer? && ENV["HOMEBREW_ARM64_TESTING"].present? && Hardware::CPU.arm?
 
           <<~EOS
             Your CPU architecture (#{Hardware::CPU.arch}) is not supported. We only support


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This[^1] will enable us to start testing arm64 bottle builds in
Homebrew/core when this environment variable is set.

[^1]: Along with some tweaks to the `dispatch-build-bottle` workflow.
