### PR TITLE
fix: ignore broken kegs during gcc linkage test

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -143,7 +143,14 @@ module OS
           return if gcc_dependents.empty?
 
           badly_linked = gcc_dependents.select do |dependent|
-            keg = Keg.new(dependent.prefix)
+            dependent_prefix = dependent.any_installed_prefix
+            # Keg.new() may raise an error if it is not a directory.
+            # As the result `brew doctor` may display `Error: <keg> is not a directory`
+            # instead of proper `doctor` information.
+            # There are other checks that test that, we can skip broken kegs.
+            next if dependent_prefix.nil? || !dependent_prefix.exist? || !dependent_prefix.directory?
+
+            keg = Keg.new(dependent_prefix)
             keg.binary_executable_or_library_files.any? do |binary|
               paths = binary.rpaths
               versioned_linkage = paths.any? { |path| path.match?(%r{lib/gcc/\d+$}) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If my theory is correct, this pr should close #19500 but unfortunately I cannot test it. If someone uses Linux, please, apply this patch, delete a few kegs manually (directories like `$HOMEBREW_PREFIX/Cellar/<formula>/<version>` and try to run `brew doctor`