### PR TITLE
Fix bottle block generation and audit for arm64 Linux

### DIFF
--- a/Library/Homebrew/bottle_specification.rb
+++ b/Library/Homebrew/bottle_specification.rb
@@ -118,11 +118,12 @@ class BottleSpecification
     tags = collector.tags.sort_by do |tag|
       version = tag.to_macos_version
       # Give `arm64` bottles a higher priority so they are first.
-      priority = (tag.arch == :arm64) ? 2 : 1
+      priority = (tag.arch == :arm64) ? 3 : 2
       "#{priority}.#{version}_#{tag}"
     rescue MacOSVersion::Error
-      # Sort non-macOS tags below macOS tags.
-      "0.#{tag}"
+      # Sort non-macOS tags below macOS tags, and arm64 tags before other tags.
+      priority = (tag.arch == :arm64) ? 1 : 0
+      "#{priority}.#{tag}"
     end
     tags.reverse.map do |tag|
       spec = collector.specification_for(tag)

--- a/Library/Homebrew/rubocops/bottle.rb
+++ b/Library/Homebrew/rubocops/bottle.rb
@@ -149,26 +149,35 @@ module RuboCop
             end
           end
 
-          arm64_nodes = []
-          intel_nodes = []
+          arm64_macos_nodes = []
+          intel_macos_nodes = []
+          arm64_linux_nodes = []
+          intel_linux_nodes = []
 
           sha256_nodes.each do |node|
             version = sha256_bottle_tag node
-            if version.to_s.start_with? "arm64"
-              arm64_nodes << node
+            if version == :arm64_linux
+              arm64_linux_nodes << node
+            elsif version.to_s.start_with?("arm64")
+              arm64_macos_nodes << node
+            elsif version.to_s.end_with?("_linux")
+              intel_linux_nodes << node
             else
-              intel_nodes << node
+              intel_macos_nodes << node
             end
           end
 
-          return if sha256_order(sha256_nodes) == sha256_order(arm64_nodes + intel_nodes)
+          sorted_nodes = arm64_macos_nodes + intel_macos_nodes + arm64_linux_nodes + intel_linux_nodes
+          return if sha256_order(sha256_nodes) == sha256_order(sorted_nodes)
 
           offending_node(bottle_node)
           problem "ARM bottles should be listed before Intel bottles" do |corrector|
             lines = ["bottle do"]
             lines += non_sha256_nodes.map { |node| "    #{node.source}" }
-            lines += arm64_nodes.map { |node| "    #{node.source}" }
-            lines += intel_nodes.map { |node| "    #{node.source}" }
+            lines += arm64_macos_nodes.map { |node| "    #{node.source}" }
+            lines += intel_macos_nodes.map { |node| "    #{node.source}" }
+            lines += arm64_linux_nodes.map { |node| "    #{node.source}" }
+            lines += intel_linux_nodes.map { |node| "    #{node.source}" }
             lines << "  end"
             corrector.replace(bottle_node.source_range, lines.join("\n"))
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before this change, `brew bottle` would add the `:arm64_linux` bottle
lines last. This would make `brew style` complain because it wants the
`arm64_*` bottles listed first.

Let's fix this by retaining the existing style as closely as possible:
- macOS bottles are listed first
- for each OS, arm64 bottles are listed first (just as we do on macOS)

In particular, `brew bottle` will now insert `:arm64_linux` bottle lines
just above the `:x86_64_linux` bottle lines (but still below the macOS
bottle lines).

x86_64 may continue to be a more popular platform on Linux for quite
some time. However, users looking for those bottles can continue to look
in the same place as before this change (i.e., the last line of the
bottle block). Taking this together with the consistency on macOS
mentioned above, I think this is the right way forward here.

For concreteness, here are some examples of bottle blocks before and after
this change.

Before this change, immediately after `brew bottle`:

```ruby
bottle do
  sha256 arm64_sequoia: "1a57e04052f4bae4172d546a7927c645fc29d2ef5fafbec19d08ee1dddc542fb"
  sha256 arm64_sonoma:  "a58cf9af5d04d3d5709b5337f3793586087a79e178da51d1f3978c0c13b8cf34"
  sha256 ventura:       "6d8b90b2cbb31dcb78394c6540f5454cd57232fc309921173814f880e63718f0"
  sha256 x86_64_linux:  "cd5faac2834ba79e39429b9aac99e4f69d6e6023cbb1cbcd0b62e94cfc69bb2a"
  sha256 arm64_linux:   "457d3e9bd0c287483e27f29a488a18c90e1f55be076fc49b07942ef396c419be"
end
```


Before this change, after doing `brew style --fix`:

```ruby
bottle do
  sha256 arm64_sequoia: "1a57e04052f4bae4172d546a7927c645fc29d2ef5fafbec19d08ee1dddc542fb"
  sha256 arm64_sonoma:  "a58cf9af5d04d3d5709b5337f3793586087a79e178da51d1f3978c0c13b8cf34"
  sha256 arm64_linux:   "457d3e9bd0c287483e27f29a488a18c90e1f55be076fc49b07942ef396c419be"
  sha256 ventura:       "6d8b90b2cbb31dcb78394c6540f5454cd57232fc309921173814f880e63718f0"
  sha256 x86_64_linux:  "cd5faac2834ba79e39429b9aac99e4f69d6e6023cbb1cbcd0b62e94cfc69bb2a"
end
```

After this change:

```ruby
bottle do
  sha256 arm64_sequoia: "1a57e04052f4bae4172d546a7927c645fc29d2ef5fafbec19d08ee1dddc542fb"
  sha256 arm64_sonoma:  "a58cf9af5d04d3d5709b5337f3793586087a79e178da51d1f3978c0c13b8cf34"
  sha256 ventura:       "6d8b90b2cbb31dcb78394c6540f5454cd57232fc309921173814f880e63718f0"
  sha256 arm64_linux:   "457d3e9bd0c287483e27f29a488a18c90e1f55be076fc49b07942ef396c419be"
  sha256 x86_64_linux:  "cd5faac2834ba79e39429b9aac99e4f69d6e6023cbb1cbcd0b62e94cfc69bb2a"
end
```

