### PR TITLE
workflows/docker: run `brew test-bot` on arm64 Linux builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -198,9 +198,9 @@ jobs:
           labels: ${{ needs.generate-tags.outputs.labels }}
 
       - name: Run brew test-bot --only-setup
-        # TODO: Remove this conditional when `brew doctor` no longer throws an error on ARM64 Linux.
-        if: matrix.arch == 'x86_64'
-        run: docker run --rm brew brew test-bot --only-setup
+        run: docker run --env HOMEBREW_ARM64_TESTING --rm brew brew test-bot --only-setup
+        env:
+          HOMEBREW_ARM64_TESTING: 1
 
       - name: Log in to GitHub Packages (BrewTestBot)
         if: fromJSON(steps.attributes.outputs.push)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We can stop `brew doctor` from throwing an error if we set
`HOMEBREW_ARM64_TESTING`.
