### PR TITLE
linux/hardware/cpu: fix amd_k12 reference

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -98,7 +98,7 @@ module Hardware
         when 0x11
           :amd_k8_k10_hybrid
         when 0x12
-          :amd_k12
+          :amd_k10_llano
         when 0x14
           :bobcat
         when 0x15

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hardware::CPU do
         :amd_k8,
         :amd_k8_k10_hybrid,
         :amd_k10,
-        :amd_k12,
+        :amd_k10_llano,
         :arm,
         :arm_blizzard_avalanche,
         :arm_brava,


### PR DESCRIPTION
AMD K12 was an planned ARM microarchitecture that was cancelled.

Ref: https://en.wikipedia.org/wiki/List_of_AMD_CPU_microarchitectures#Nomenclature

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x ] Have you successfully run `brew tests` with your changes locally?
