### PR TITLE
Support `--file` for `brew services run`

### DIFF
--- a/Library/Homebrew/cmd/services.rb
+++ b/Library/Homebrew/cmd/services.rb
@@ -32,7 +32,7 @@ module Homebrew
           [`sudo`] `brew services info` (<formula>|`--all`|`--json`):
           List all managed services for the current user (or root).
 
-          [`sudo`] `brew services run` (<formula>|`--all`):
+          [`sudo`] `brew services run` (<formula>|`--all`|`--file=`):
           Run the service <formula> without registering to launch at login (or boot).
 
           [`sudo`] `brew services start` (<formula>|`--all`|`--file=`):
@@ -105,10 +105,15 @@ module Homebrew
         end
 
         if args.file
-          if Homebrew::Services::Commands::Start::TRIGGERS.exclude?(subcommand)
+          file_commands = [
+            *Homebrew::Services::Commands::Start::TRIGGERS,
+            *Homebrew::Services::Commands::Run::TRIGGERS,
+          ]
+          if file_commands.exclude?(subcommand)
             raise UsageError, "The `#{subcommand}` subcommand does not accept the --file= argument!"
           elsif args.all?
-            raise UsageError, "The start subcommand does not accept the --all and --file= arguments at the same time!"
+            raise UsageError,
+                  "The `#{subcommand}` subcommand does not accept the --all and --file= arguments at the same time!"
           end
         end
 
@@ -153,7 +158,7 @@ module Homebrew
         when *Homebrew::Services::Commands::Restart::TRIGGERS
           Homebrew::Services::Commands::Restart.run(targets, verbose: args.verbose?)
         when *Homebrew::Services::Commands::Run::TRIGGERS
-          Homebrew::Services::Commands::Run.run(targets, verbose: args.verbose?)
+          Homebrew::Services::Commands::Run.run(targets, args.file, verbose: args.verbose?)
         when *Homebrew::Services::Commands::Start::TRIGGERS
           Homebrew::Services::Commands::Start.run(targets, args.file, verbose: args.verbose?)
         when *Homebrew::Services::Commands::Stop::TRIGGERS

--- a/Library/Homebrew/services/commands/run.rb
+++ b/Library/Homebrew/services/commands/run.rb
@@ -9,10 +9,16 @@ module Homebrew
       module Run
         TRIGGERS = ["run"].freeze
 
-        sig { params(targets: T::Array[Services::FormulaWrapper], verbose: T::Boolean).void }
-        def self.run(targets, verbose:)
+        sig {
+          params(
+            targets:      T::Array[Services::FormulaWrapper],
+            custom_plist: T.nilable(String),
+            verbose:      T::Boolean,
+          ).void
+        }
+        def self.run(targets, custom_plist, verbose:)
           Services::Cli.check(targets)
-          Services::Cli.run(targets, verbose:)
+          Services::Cli.run(targets, custom_plist, verbose:)
         end
       end
     end

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -83,6 +83,13 @@ RSpec.describe Homebrew::Services::Cli do
   end
 
   describe "#run" do
+    it "checks missing file causes error" do
+      expect(Homebrew::Services::System).not_to receive(:root?)
+      expect do
+        services_cli.start(["service_name"], "/non/existent/path")
+      end.to raise_error(UsageError, "Invalid usage: Provided service file does not exist")
+    end
+
     it "checks empty targets cause no error" do
       expect(Homebrew::Services::System).not_to receive(:root?)
       services_cli.run([])
@@ -225,6 +232,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_name:     "service.name",
             service_startup?: false,
           ),
+          nil,
           enable: false,
         )
       end.to output("==> Successfully ran `name` (label: service.name)\n").to_stdout
@@ -242,6 +250,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_name:     "service.name",
             service_startup?: true,
           ),
+          nil,
           enable: false,
         )
       end.to output("==> Successfully ran `name` (label: service.name)\n").to_stdout
@@ -261,6 +270,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_startup?: false,
             service_file:     instance_double(Pathname, exist?: false),
           ),
+          nil,
           enable: false,
         )
       end.to output("==> Successfully ran `name` (label: service.name)\n").to_stdout
@@ -280,6 +290,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_startup?: false,
             dest:             instance_double(Pathname, exist?: true),
           ),
+          nil,
           enable: false,
         )
       end.to output("==> Successfully ran `name` (label: service.name)\n").to_stdout
@@ -299,6 +310,7 @@ RSpec.describe Homebrew::Services::Cli do
             service_startup?: false,
             dest:             instance_double(Pathname, exist?: true),
           ),
+          nil,
           enable: true,
         )
       end.to output("==> Successfully started `name` (label: service.name)\n").to_stdout


### PR DESCRIPTION
Like `brew services start --file` except it's not sticky (i.e. it doesn't install the file, on macOS at least).