### PR TITLE
devcontainer/on-create-command: fix permissions harder.

### DIFF
--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -3,6 +3,7 @@ set -e
 
 # fix permissions so Homebrew and Bundler don't complain
 sudo chmod -R g-w,o-w /home/linuxbrew
+sudo chmod +t -R /home/linuxbrew/
 
 # everything below is too slow to do unless prebuilding so skip it
 CODESPACES_ACTION_NAME="$(jq --raw-output '.ACTION_NAME' /workspaces/.codespaces/shared/environment-variables.json)"


### PR DESCRIPTION
This `chmod -t` seems to fix things on other Codespaces so let's try it here too.