### PR TITLE
bundle/cask_installer: remove debugging output.

### DIFF
--- a/Library/Homebrew/bundle/cask_installer.rb
+++ b/Library/Homebrew/bundle/cask_installer.rb
@@ -33,8 +33,6 @@ module Homebrew
 
         full_name = options.fetch(:full_name, name)
 
-        p [:installed_casks, installed_casks]
-        p [:upgrading?, upgrading?(no_upgrade, name, options)]
         install_result = if installed_casks.include?(name) && upgrading?(no_upgrade, name, options)
           status = "#{options[:greedy] ? "may not be" : "not"} up-to-date"
           puts "Upgrading #{name} cask. It is installed but #{status}." if verbose


### PR DESCRIPTION
This was accidentally left in but should have been removed.