### PR TITLE
bundle/brew_services: use HOMEBREW_BREW_FILE.

### DIFF
--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -40,7 +40,7 @@ module Homebrew
       def started_services
         @started_services ||= begin
           states_to_skip = %w[stopped none]
-          Utils.safe_popen_read("brew", "services", "list").lines.filter_map do |line|
+          Utils.safe_popen_read(HOMEBREW_BREW_FILE, "services", "list").lines.filter_map do |line|
             name, state, _plist = line.split(/\s+/)
             next if states_to_skip.include? state
 


### PR DESCRIPTION
This ensures the correct `brew` binary is always used.