### PR TITLE
cask/download: avoid some checksum warnings.

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -82,8 +82,7 @@ module Cask
 
     sig { override.params(filename: Pathname).void }
     def verify_download_integrity(filename)
-      official_cask_tap = @cask.tap&.official?
-      if @cask.sha256 == :no_check && !official_cask_tap
+      if no_checksum_defined? && !official_cask_tap?
         opoo "No checksum defined for cask '#{@cask}', skipping verification."
         return
       end
@@ -112,6 +111,24 @@ module Cask
       else
         Quarantine.release!(download_path: path)
       end
+    end
+
+    sig { returns(T::Boolean) }
+    def official_cask_tap?
+      tap = @cask.tap
+      return false if tap.blank?
+
+      tap.official?
+    end
+
+    sig { returns(T::Boolean) }
+    def no_checksum_defined?
+      @cask.sha256 == :no_check
+    end
+
+    sig { override.returns(T::Boolean) }
+    def silence_checksum_missing_error?
+      no_checksum_defined? && official_cask_tap?
     end
 
     sig { override.returns(T.nilable(::URL)) }

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -117,6 +117,8 @@ module Downloadable
       filename.verify_checksum(checksum)
     end
   rescue ChecksumMissingError
+    return if silence_checksum_missing_error?
+
     opoo <<~EOS
       Cannot verify integrity of '#{filename.basename}'.
       No checksum was provided.
@@ -131,6 +133,11 @@ module Downloadable
   end
 
   private
+
+  sig { overridable.returns(T::Boolean) }
+  def silence_checksum_missing_error?
+    false
+  end
 
   sig { overridable.returns(T.nilable(URL)) }
   def determine_url


### PR DESCRIPTION
These are always output in CI for e.g. `brew fetch google-chrome` and are completely unactionable by the user.

Ultimately this is not disabling any security checks, it's just changing when a warning is output and unifying the logic with the other similar warning.