### PR TITLE
bundle/exec: fix command `PATH` lookup

### DIFF
--- a/Library/Homebrew/test/bundle/commands/exec_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/exec_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Homebrew::Bundle::Commands::Exec do
 
     it "prepends the path of the requested command to PATH before running" do
       expect(described_class).to receive(:exec).with("bundle", "install").and_return(nil)
-      expect(described_class).to receive(:which).and_return(Pathname("/usr/local/bin/bundle"))
+      expect(described_class).to receive(:which).twice.and_return(Pathname("/usr/local/bin/bundle"))
       allow(ENV).to receive(:prepend_path).with(any_args).and_call_original
       expect(ENV).to receive(:prepend_path).with("PATH", "/usr/local/bin").once.and_call_original
       described_class.run("bundle", "install")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We are checking `PATH` for the command too early, since the code below
it mutates `PATH`.

Let's defer the check to later to fix this.
