### PR TITLE
shims/super/cc: tweak optimisation flag handling for runtime CPU detection builds

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -308,7 +308,10 @@ class Cmd
 
     args << "-w" unless configure?
     args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}"
-    args.concat(optflags) unless runtime_cpu_detection?
+    optflags.each do |optflag|
+      flag = optflag.split("=").first
+      args << optflag if !runtime_cpu_detection? || @args.none? { |arg| arg.start_with?(flag) }
+    end
     args.concat(archflags)
     args << "-std=#{@arg0}" if /c[89]9/.match?(@arg0)
     args << "-g" if debug_symbols?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

~~We need to allow `-mcpu` and `-mtune` flags to avoid breaking builds on~~
~~arm64 macOS. See, for example, Homebrew/homebrew-core#212051.~~

Also, let's reinstate adding our own optimisation flags if the compiler
was not invoked with a conflicting optimisation flag.
