### PR TITLE
download_strategy: ignore Content-Length value if zero

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -488,7 +488,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         # - Content-Length value is different than the file's size
         cached_location_valid = if cached_location_valid
           newer_last_modified = last_modified && last_modified > cached_location.mtime
-          different_file_size = file_size && file_size != cached_location.size
+          different_file_size = file_size&.nonzero? && file_size != cached_location.size
           !(newer_last_modified || different_file_size)
         end
 


### PR DESCRIPTION
Follow-up to #19460, which was causing cached items to be invalidated if the server returned a Content-Length of 0.
```
$ curl -I https://github.com/snort3/libdaq/archive/refs/tags/v3.0.19.tar.gz
HTTP/2 302 
server: GitHub.com
date: Thu, 20 Mar 2025 19:24:45 GMT
content-type: text/html; charset=utf-8
content-length: 0
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
location: https://codeload.github.com/snort3/libdaq/tar.gz/refs/tags/v3.0.19
cache-control: max-age=0, private
...
```