### PR TITLE
github_runner_matrix: include arch in Linux job names

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -92,7 +92,7 @@ class GitHubRunnerMatrix
     end
 
     LinuxRunnerSpec.new(
-      name:      "Linux",
+      name:      "Linux #{arch}",
       runner:    linux_runner,
       container: {
         image:   "ghcr.io/homebrew/ubuntu22.04:master",

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe GitHubRunnerMatrix do
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
-          expect(get_runner_names(runner_matrix)).to eq(["Linux"])
+          expect(get_runner_names(runner_matrix)).to eq(["Linux x86_64"])
         end
       end
 
@@ -139,7 +139,7 @@ RSpec.describe GitHubRunnerMatrix do
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
-          expect(get_runner_names(runner_matrix).sort).to eq(["Linux", "macOS #{v}-arm64"])
+          expect(get_runner_names(runner_matrix).sort).to eq(["Linux x86_64", "macOS #{v}-arm64"])
         end
       end
     end
@@ -276,7 +276,7 @@ RSpec.describe GitHubRunnerMatrix do
               allow(Formula).to receive(:all).and_return([testball, testball_depender_linux].map(&:formula))
 
               matrix = described_class.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
-              expect(get_runner_names(matrix)).to eq(["Linux"])
+              expect(get_runner_names(matrix)).to eq(["Linux x86_64"])
             end
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will make it easier to distinguish the two jobs in the GitHub UI.
