### PR TITLE
tab: add `bottle_rebuild` to `runtime_dependencies`.

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -100,9 +100,10 @@ class AbstractTab
       "full_name"         => formula.full_name,
       "version"           => formula.version.to_s,
       "revision"          => formula.revision,
+      "bottle_rebuild"    => formula.bottle&.rebuild,
       "pkg_version"       => formula.pkg_version.to_s,
       "declared_directly" => declared_deps.include?(formula.full_name),
-    }
+    }.compact
   end
   private_class_method :formula_to_dep_hash
 


### PR DESCRIPTION
It can be useful to know, if a formula's dependencies were installed from a bottle, what rebuild of the bottle was used for debugging.