### PR TITLE
cmd/*env-sync: add `HOMEBREW_ENV_SYNC_STRICT` mode.

### DIFF
--- a/Library/Homebrew/cmd/rbenv-sync.rb
+++ b/Library/Homebrew/cmd/rbenv-sync.rb
@@ -55,13 +55,23 @@ module Homebrew
         minor_version = version.minor.to_i
         patch_version = version.patch.to_i || 0
 
-        (0..patch_version).each do |patch|
+        patch_version_range = if Homebrew::EnvConfig.env_sync_strict?
+          # Only create symlinks for the exact installed patch version.
+          # e.g. 3.4.0 => 3.4.0
+          [patch_version]
+        else
+          # Create folder symlinks for all patch versions to the latest patch version
+          # e.g. 3.4.0 => 3.4.2
+          0..patch_version
+        end
+
+        patch_version_range.each do |patch|
           link_path = rbenv_versions/"#{major_version}.#{minor_version}.#{patch}"
           # Don't clobber existing user installations.
           next if link_path.exist? && !link_path.symlink?
 
           FileUtils.rm_f link_path
-          FileUtils.ln_sf path, link_path
+          FileUtils.ln_s path, link_path
         end
       end
     end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -195,6 +195,10 @@ module Homebrew
                       "editors will do strange things in this case.",
         default_text: "`$EDITOR` or `$VISUAL`.",
       },
+      HOMEBREW_ENV_SYNC_STRICT:                  {
+        description: "If set, `brew *env-sync` will only sync the exact installed versions of formulae.",
+        boolean:     true,
+      },
       HOMEBREW_EVAL_ALL:                         {
         description: "If set, `brew` commands evaluate all formulae and casks, executing their arbitrary code, by " \
                      "default without requiring `--eval-all`. Required to cache formula and cask descriptions.",

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -116,6 +116,9 @@ module Homebrew::EnvConfig
     def editor; end
 
     sig { returns(T::Boolean) }
+    def env_sync_strict?; end
+
+    sig { returns(T::Boolean) }
     def eval_all?; end
 
     sig { returns(Integer) }


### PR DESCRIPTION
If this variable is set, `brew *env-sync` will only sync the exact installed versions of formulae rather than all the patch (or, for node, minor and patch) versions.