### PR TITLE
Add `version_file:` DSL to `Brewfile`

### DIFF
--- a/Library/Homebrew/bundle.rb
+++ b/Library/Homebrew/bundle.rb
@@ -82,6 +82,34 @@ module Homebrew
 
         return_value
       end
+
+      def formula_versions_from_env
+        @formula_versions_from_env ||= begin
+          formula_versions = {}
+
+          ENV.each do |key, value|
+            match = key.match(/^HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_(.+)$/)
+            next if match.blank?
+
+            formula_name = match[1]
+            next if formula_name.blank?
+
+            ENV.delete(key)
+            formula_versions[formula_name.downcase] = value
+          end
+
+          formula_versions
+        end
+      end
+
+      sig { void }
+      def reset!
+        @mas_installed = nil
+        @vscode_installed = nil
+        @whalebrew_installed = nil
+        @cask_installed = nil
+        @formula_versions_from_env = nil
+      end
     end
   end
 end

--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -108,18 +108,7 @@ module Homebrew
           end
 
           # Replace the formula versions from the environment variables
-          formula_versions = {}
-          ENV.each do |key, value|
-            match = key.match(/^HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_(.+)$/)
-            next if match.blank?
-
-            formula_name = match[1]
-            next if formula_name.blank?
-
-            ENV.delete(key)
-            formula_versions[formula_name.downcase] = value
-          end
-          formula_versions.each do |formula_name, formula_version|
+          Bundle.formula_versions_from_env.each do |formula_name, formula_version|
             ENV.each do |key, value|
               opt = %r{/opt/#{formula_name}([/:$])}
               next unless value.match(opt)

--- a/Library/Homebrew/test/bundle/commands/exec_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/exec_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Homebrew::Bundle::Commands::Exec do
     context "with valid command setup" do
       before do
         allow(described_class).to receive(:exec).and_return(nil)
+        Homebrew::Bundle.reset!
       end
 
       it "does not raise an error" do

--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -40,6 +40,8 @@ brew "mysql@5.6", restart_service: :changed, link: true, conflicts_with: ["mysql
 # 'brew install' and run a command if installer or upgraded.
 brew "postgresql@16",
      postinstall: "${HOMEBREW_PREFIX}/opt/postgresql@16/bin/postgres -D ${HOMEBREW_PREFIX}/var/postgresql@16"
+# 'brew install' and write the installed version to the '.ruby-version' file.
+brew "ruby", version_file: ".ruby-version"
 # install only on specified OS
 brew "gnupg" if OS.mac?
 brew "glibc" if OS.linux?


### PR DESCRIPTION
This allows writing to e.g. `.ruby-version` files directly from the `Brewfile`, making it easy to keep these versions in sync.