### PR TITLE
bundle/installer: add missing require.

### DIFF
--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -8,6 +8,7 @@ require "bundle/mac_app_store_installer"
 require "bundle/whalebrew_installer"
 require "bundle/vscode_extension_installer"
 require "bundle/tap_installer"
+require "bundle/skipper"
 
 module Homebrew
   module Bundle


### PR DESCRIPTION
```console
==> Installing Homebrew dependencies
Error: uninitialized constant Homebrew::Bundle::Skipper
/opt/homebrew/Library/Homebrew/bundle/installer.rb:49:in `block in install'
/opt/homebrew/Library/Homebrew/bundle/installer.rb:20:in `each'
/opt/homebrew/Library/Homebrew/bundle/installer.rb:20:in `install'
/opt/homebrew/Library/Homebrew/bundle/commands/install.rb:14:in `run'
/opt/homebrew/Library/Homebrew/cmd/bundle.rb:168:in `run'
/opt/homebrew/Library/Homebrew/brew.rb:95:in `<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
Error: Process completed with exit code 1.
```