### PR TITLE
dev-cmd/dispatch-build-bottle: support arm64 Linux

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -26,9 +26,11 @@ module Homebrew
         switch "--upload",
                description: "Upload built bottles."
         switch "--linux",
-               description: "Dispatch bottle for Linux (using GitHub runners)."
+               description: "Dispatch bottle for Linux x86_64 (using GitHub runners)."
+        switch "--linux-arm64",
+               description: "Dispatch bottle for Linux arm64 (using GitHub runners)."
         switch "--linux-self-hosted",
-               description: "Dispatch bottle for Linux (using self-hosted runner)."
+               description: "Dispatch bottle for Linux x86_64 (using self-hosted runner)."
         switch "--linux-wheezy",
                description: "Use Debian Wheezy container for building the bottle on Linux."
 
@@ -70,7 +72,11 @@ module Homebrew
           runners << "linux-self-hosted-1"
         end
 
-        raise UsageError, "Must specify `--macos`, `--linux` or `--linux-self-hosted` option." if runners.empty?
+        runners << "ubuntu-22.04-arm" if args.linux_arm64?
+
+        if runners.empty?
+          raise UsageError, "Must specify `--macos`, `--linux`, `--linux-arm64`, or `--linux-self-hosted` option."
+        end
 
         args.named.to_resolved_formulae.each do |formula|
           # Required inputs

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/dispatch_build_bottle.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/dispatch_build_bottle.rbi
@@ -18,6 +18,9 @@ class Homebrew::DevCmd::DispatchBuildBottle::Args < Homebrew::CLI::Args
   def linux?; end
 
   sig { returns(T::Boolean) }
+  def linux_arm64?; end
+
+  sig { returns(T::Boolean) }
   def linux_self_hosted?; end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will make it easier to dispatch bottle builds for arm64 Linux.
