### PR TITLE
popen: get correct cmd name on error

### DIFF
--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -51,13 +51,18 @@ module Utils
         yield pipe
       else
         options[:err] ||= File::NULL unless ENV["HOMEBREW_STDERR"]
+        cmd = if args[0].is_a? Hash
+          args[1]
+        else
+          args[0]
+        end
         begin
           exec(*args, options)
         rescue Errno::ENOENT
-          $stderr.puts "brew: command not found: #{args[0]}" if options[:err] != :close
+          $stderr.puts "brew: command not found: #{cmd}" if options[:err] != :close
           exit! 127
         rescue SystemCallError
-          $stderr.puts "brew: exec failed: #{args[0]}" if options[:err] != :close
+          $stderr.puts "brew: exec failed: #{cmd}" if options[:err] != :close
           exit! 1
         end
       end


### PR DESCRIPTION
Blindly using args[0] misleads users when an env is passed.

Before:
```
==> go build -ldflags=-s -w -X main.version=1.64.8 -X main.commit=8b37f14 -X main.date=2025-03-17T16:54:02Z ./cmd/golangci-lint
brew: command not found: {"SHELL"=>"bash"}
Error: Failure while executing; `\{\"SHELL\"=\>\"bash\"\} /opt/homebrew/Cellar/golangci-lint@1/1.64.8/bin/golangci-lint completion bash` exited with 127. Here's the output:
```
After:
```
==> go build -ldflags=-s -w -X main.version=1.64.8 -X main.commit=8b37f14 -X main.date=2025-03-17T16:54:02Z ./cmd/golangci-lint
brew: command not found: /opt/homebrew/Cellar/golangci-lint@1/1.64.8/bin/golangci-lint
Error: Failure while executing; `\{\"SHELL\"=\>\"bash\"\} /opt/homebrew/Cellar/golangci-lint@1/1.64.8/bin/golangci-lint completion bash` exited with 127. Here's the output:
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
