### PR TITLE
linux/bundle/skipper: add support for Linux casks.

### DIFF
--- a/Library/Homebrew/extend/os/linux/bundle/skipper.rb
+++ b/Library/Homebrew/extend/os/linux/bundle/skipper.rb
@@ -6,17 +6,30 @@ module OS
     module Bundle
       module Skipper
         module ClassMethods
+          sig { params(entry: Homebrew::Bundle::Dsl::Entry).returns(T::Boolean) }
           def macos_only_entry?(entry)
-            [:cask, :mas].include?(entry.type)
+            entry.type == :mas
           end
 
-          def macos_only_tap?(entry)
-            entry.type == :tap && entry.name == "homebrew/cask"
+          sig { params(entry: Homebrew::Bundle::Dsl::Entry).returns(T::Boolean) }
+          def macos_only_cask?(entry)
+            return false if entry.type != :cask
+
+            cask = ::Cask::CaskLoader.load(entry.name)
+            installer = ::Cask::Installer.new(cask)
+            installer.check_stanza_os_requirements
+
+            true
+          rescue ::Cask::CaskError
+            false
           end
 
           def skip?(entry, silent: false)
-            if macos_only_entry?(entry) || macos_only_tap?(entry)
-              ::Kernel.puts Formatter.warning "Skipping #{entry.type} #{entry.name} (on Linux)" unless silent
+            if macos_only_entry?(entry) || macos_only_cask?(entry)
+              unless silent
+                $stdout.puts Formatter.warning "Skipping #{entry.type} #{entry.name} (unsupported on Linux)"
+              end
+
               true
             else
               super(entry)


### PR DESCRIPTION
Don't unconditionally skip Linux casks but instead check if they are supported on Linux.

Fixes https://github.com/Homebrew/brew/issues/19537