### PR TITLE
`brew bundle env`: quote values correctly. 

### DIFF
--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -142,7 +142,7 @@ module Homebrew
 
           if subcommand == "env"
             ENV.each do |key, value|
-              puts "export #{key}=\"#{value}\""
+              puts "export #{key}=\"#{Utils::Shell.sh_quote(value)}\""
             end
             return
           end


### PR DESCRIPTION
Otherwise, certain output will break the script when `eval`ed.