### PR TITLE
services: use domain target in `launchctl list` command.

### DIFF
--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -234,7 +234,7 @@ module Homebrew
 
       def status_output_success_type
         @status_output_success_type ||= if System.launchctl?
-          cmd = [System.launchctl.to_s, "list", service_name]
+          cmd = [System.launchctl.to_s, "list", "#{System.domain_target}/#{service_name}"]
           output = Utils.popen_read(*cmd).chomp
           if $CHILD_STATUS.present? && $CHILD_STATUS.success? && output.present?
             success = true


### PR DESCRIPTION
If a service is somehow duplicated across multiple domains, this ensures that the correct output is produced.