### PR TITLE
bundle/brew_installer: strip revision number from version file.

### DIFF
--- a/Library/Homebrew/bundle/brew_installer.rb
+++ b/Library/Homebrew/bundle/brew_installer.rb
@@ -61,11 +61,12 @@ module Homebrew
 
           if result && @version_file.present?
             # Use the version from the environment if it hasn't changed.
+            # Strip the revision number because it's not part of the non-Homebrew version.
             version = if !changed? && (env_version = Bundle.formula_versions_from_env[@name])
               env_version
             else
               Formula[@full_name].version.to_s
-            end
+            end.sub(/_\d+$/, "")
             version_path = Pathname.new(@version_file)
             version_path.write("#{version}\n")
 

--- a/Library/Homebrew/bundle/brew_installer.rb
+++ b/Library/Homebrew/bundle/brew_installer.rb
@@ -63,10 +63,10 @@ module Homebrew
             # Use the version from the environment if it hasn't changed.
             # Strip the revision number because it's not part of the non-Homebrew version.
             version = if !changed? && (env_version = Bundle.formula_versions_from_env[@name])
-              env_version
+              PkgVersion.parse(env_version).version
             else
-              Formula[@full_name].version.to_s
-            end.sub(/_\d+$/, "")
+              Formula[@full_name].version
+            end.to_s
             version_path = Pathname.new(@version_file)
             version_path.write("#{version}\n")
 


### PR DESCRIPTION
This doesn't make sense for consumption outside of Homebrew.