### PR TITLE
cleanup: fix handling of bottle manifest rebuilds.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -151,6 +151,12 @@ module Homebrew
           formula_excluded_versions_from_cleanup = excluded_versions_from_cleanup(formula)
           return false if formula_excluded_versions_from_cleanup.include?(version.to_s)
 
+          if pathname.to_s.include?("_bottle_manifest")
+            excluded_version = version.to_s
+            excluded_version.sub!(/-\d+$/, "")
+            return false if formula_excluded_versions_from_cleanup.include?(excluded_version)
+          end
+
           # We can't determine an installed rebuild and parsing manifest version cannot be reliably done.
           return false unless formula.latest_version_installed?
 


### PR DESCRIPTION
We need to handle these slightly different as otherwise they can be cleaned up incorrectly.