### PR TITLE
linux/bundle/skipper: add missing requires.

### DIFF
--- a/Library/Homebrew/extend/os/linux/bundle/skipper.rb
+++ b/Library/Homebrew/extend/os/linux/bundle/skipper.rb
@@ -1,6 +1,9 @@
 # typed: true # rubocop:todo Sorbet/StrictSigil
 # frozen_string_literal: true
 
+require "cask/cask_loader"
+require "cask/installer"
+
 module OS
   module Linux
     module Bundle


### PR DESCRIPTION
This was missing in https://github.com/Homebrew/brew/pull/19599 but showed up in a runtime test.