### PR TITLE
extend/os/linux/cask/installer: make `check_stanza_os_requirements` non-private

### DIFF
--- a/Library/Homebrew/extend/os/linux/cask/installer.rb
+++ b/Library/Homebrew/extend/os/linux/cask/installer.rb
@@ -29,8 +29,6 @@ module OS
           ::Cask::Artifact::Vst3Plugin,
         ].freeze
 
-        private
-
         sig { void }
         def check_stanza_os_requirements
           return unless artifacts.any? do |artifact|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The method it overrides is not `private`, so it doesn't seem like this
should be private. This causes errors when using `brew bundle` on Linux
with a `Brewfile` that contains `cask` entries.
