### PR TITLE
create: show command to install formula for testing

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -233,6 +233,7 @@ module Homebrew
           Please audit and test formula before submitting:
             HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --new #{fc.name}
             HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug #{fc.name}
+            HOMEBREW_NO_INSTALL_FROM_API=1 brew test #{fc.name}
         EOS
         path
       end

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -230,8 +230,9 @@ module Homebrew
         PyPI.update_python_resources! formula, ignore_non_pypi_packages: true if args.python?
 
         puts <<~EOS
-          Please run the following command before submitting:
+          Please audit and test formula before submitting:
             HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --new #{fc.name}
+            HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug #{fc.name}
         EOS
         path
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The command is three clicks away if you know where to look for, but even if you know, it takes a while to discover https://docs.brew.sh/Formula-Cookbook#install-the-formula so showing it directly after create saves some time.