### PR TITLE
fix: Allow Formula.url with no args to get url

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -67,7 +67,7 @@ class DependencyCollector
   def cache_key(spec)
     if spec.is_a?(Resource)
       if spec.download_strategy <= CurlDownloadStrategy
-        return "#{spec.download_strategy}#{File.extname(spec.url).split("?").first}"
+        return "#{spec.download_strategy}#{File.extname(T.must(spec.url)).split("?").first}"
       end
 
       return spec.download_strategy

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -156,7 +156,7 @@ module Homebrew
         new_hash = args.sha256
         new_tag = args.tag
         new_revision = args.revision
-        old_url = formula_spec.url
+        old_url = T.must(formula_spec.url)
         old_tag = formula_spec.specs[:tag]
         old_formula_version = formula_version(formula)
         old_version = old_formula_version.to_s
@@ -234,7 +234,7 @@ module Homebrew
         replacement_pairs += if new_url_hash.present?
           [
             [
-              /#{Regexp.escape(formula_spec.url)}/,
+              /#{Regexp.escape(T.must(formula_spec.url))}/,
               new_url,
             ],
             [
@@ -256,7 +256,7 @@ module Homebrew
         elsif new_url.present?
           [
             [
-              /#{Regexp.escape(formula_spec.url)}/,
+              /#{Regexp.escape(T.must(formula_spec.url))}/,
               new_url,
             ],
             [

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -12,7 +12,7 @@ module Downloadable
   abstract!
   requires_ancestor { Kernel }
 
-  sig { overridable.returns(T.nilable(URL)) }
+  sig { overridable.returns(T.any(NilClass, String, URL)) }
   attr_reader :url
 
   sig { overridable.returns(T.nilable(Checksum)) }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3650,8 +3650,8 @@ class Formula
     # ```
     #
     # @api public
-    sig { params(val: String, specs: T::Hash[Symbol, T.any(String, Symbol)]).void }
-    def url(val, specs = {}) = stable.url(val, specs)
+    sig { params(val: String, specs: T::Hash[Symbol, T.anything]).returns(String) }
+    def url(val = T.unsafe(nil), specs = {}) = stable.url(val, specs)
 
     # The version string for the {.stable} version of the formula.
     # The version is autodetected from the URL and/or tag so only needs to be

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -186,6 +186,7 @@ class Resource
     @checksum = Checksum.new(val)
   end
 
+  sig { override.params(val: T.nilable(String), specs: T.anything).returns(T.nilable(String)) }
   def url(val = nil, **specs)
     return @url&.to_s if val.nil?
 
@@ -198,6 +199,7 @@ class Resource
     @url = URL.new(val, specs)
     @downloader = nil
     @download_strategy = @url.download_strategy
+    @url.to_s
   end
 
   sig { override.params(val: T.nilable(T.any(String, Version))).returns(T.nilable(Version)) }
@@ -239,6 +241,7 @@ class Resource
 
   def determine_url_mirrors
     extra_urls = []
+    url = T.must(self.url)
 
     # glibc-bootstrap
     if url.start_with?("https://github.com/Homebrew/glibc-bootstrap/releases/download")

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -9,7 +9,7 @@ module Homebrew
     attr_reader :downloadable
     private :downloadable
 
-    sig { override.returns(T.nilable(URL)) }
+    sig { override.returns(T.any(NilClass, String, URL)) }
     def url = downloadable.url
 
     sig { override.returns(T.nilable(Checksum)) }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -102,11 +102,13 @@ class SoftwareSpec
     patches.each { |p| p.owner = self }
   end
 
+  sig { override.params(val: T.nilable(String), specs: T::Hash[Symbol, T.anything]).returns(T.nilable(String)) }
   def url(val = nil, specs = {})
-    return @resource.url if val.nil?
-
-    @resource.url(val, **specs)
-    dependency_collector.add(@resource)
+    if val
+      @resource.url(val, **specs)
+      dependency_collector.add(@resource)
+    end
+    @resource.url
   end
 
   def bottle_defined?

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -535,6 +535,14 @@ RSpec.describe Formula do
     end
   end
 
+  specify ".url" do
+    f = formula do
+      url "foo-1.0"
+    end
+
+    expect(f.class.url).to eq("foo-1.0")
+  end
+
   specify "spec integration" do
     f = formula do
       homepage "https://brew.sh"

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -285,7 +285,7 @@ module PyPI
       url = if stable.specs[:tag].present?
         "git+#{stable.url}@#{stable.specs[:tag]}"
       else
-        stable.url
+        T.must(stable.url)
       end
       Package.new(url, is_url: true, python_name:)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Resolves https://github.com/Homebrew/brew/issues/19505 by fixing the regression of undocumented Formula.url properties:
- `Formula.url` with no args now returns the url (variation on the example.txt contents in the linked issue)
- `Formual.url` now allows for additional `specs` value types` (see example2.txt in the linked issue)