### PR TITLE
create: check that downloaded URL is actually archive

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -84,7 +84,9 @@ module Homebrew
           r.owner = self
           filepath = r.fetch
           html_doctype_prefix = "<!doctype html"
-          raise "Downloaded URL is not archive" if File.read(filepath, html_doctype_prefix.length).downcase.start_with?(html_doctype_prefix)
+          if File.read(filepath, html_doctype_prefix.length).downcase.start_with?(html_doctype_prefix)
+            raise "Downloaded URL is not archive"
+          end
 
           @sha256 = filepath.sha256
         end

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -82,7 +82,10 @@ module Homebrew
           r = Resource.new
           r.url(@url)
           r.owner = self
-          @sha256 = r.fetch.sha256 if r.download_strategy == CurlDownloadStrategy
+          filepath = r.fetch
+          raise "Downloaded URL is not archive" if File.read(filepath, 100).strip.start_with?("<!DOCTYPE html>")
+
+          @sha256 = filepath.sha256
         end
 
         if @github

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -83,7 +83,8 @@ module Homebrew
           r.url(@url)
           r.owner = self
           filepath = r.fetch
-          raise "Downloaded URL is not archive" if File.read(filepath, 100).strip.start_with?("<!DOCTYPE html>")
+          html_doctype_prefix = "<!doctype html"
+          raise "Downloaded URL is not archive" if File.read(filepath, html_doctype_prefix.length).downcase.start_with?(html_doctype_prefix)
 
           @sha256 = filepath.sha256
         end


### PR DESCRIPTION
My common mistake is to specify release URL, like

    brew crate https://github.com/hugelgupf/p9/releases/tag/v0.3.0

which gives unpacking errors later. It should be archive instead

    brew create https://github.com/hugelgupf/p9/archive/refs/tags/v0.3.0.tar.gz

Ideally we can try to autodetect the archive from release page, but erroring out if downloaded file is HTML page should be handy for early spotting other URL mistakes too.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
