### PR TITLE
dev-cmd/edit: Actionable message about no API install

### DIFF
--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -71,7 +71,7 @@ module Homebrew
              break if Homebrew::EnvConfig.no_env_hints?
 
              is_formula = core_formula_path?(path)
-             (is_formula || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))
+             is_formula || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path)
            end
           from_source = " --build-from-source" if is_formula
           puts <<~EOS

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -64,8 +64,7 @@ module Homebrew
         exec_editor(*paths)
 
         is_formula = T.let(false, T::Boolean)
-        show_hint = !Homebrew::EnvConfig.no_env_hints?
-        if show_hint && paths.any? do |path|
+        if !Homebrew::EnvConfig.no_env_hints? && paths.any? do |path|
              next if path == "--project"
 
              is_formula = core_formula_path?(path)

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -70,9 +70,8 @@ module Homebrew
              !Homebrew::EnvConfig.no_env_hints? &&
              (core_formula_path?(path) || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))
            end
-          opoo <<~EOS
-            `brew install` ignores locally edited casks and formulae if
-            HOMEBREW_NO_INSTALL_FROM_API is not set.
+          ohai "To test your local edits, run:", <<~EOS
+            HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug #{args.named.join(" ")}
           EOS
         end
       end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -64,19 +64,18 @@ module Homebrew
         exec_editor(*paths)
 
         is_formula = T.let(false, T::Boolean)
-        if paths.any? do |path|
+        show_hint = !Homebrew::EnvConfig.no_env_hints?
+        if show_hint && paths.any? do |path|
              next if path == "--project"
-
-             break if Homebrew::EnvConfig.no_install_from_api?
-             break if Homebrew::EnvConfig.no_env_hints?
 
              is_formula = core_formula_path?(path)
              is_formula || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path)
            end
           from_source = " --build-from-source" if is_formula
+          no_api = "HOMEBREW_NO_INSTALL_FROM_API=1 " unless Homebrew::EnvConfig.no_install_from_api?
           puts <<~EOS
             To test your local edits, run:
-              HOMEBREW_NO_INSTALL_FROM_API=1 brew install#{from_source} --verbose --debug #{args.named.join(" ")}
+              #{no_api}brew install#{from_source} --verbose --debug #{args.named.join(" ")}
           EOS
         end
       end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -70,8 +70,9 @@ module Homebrew
              !Homebrew::EnvConfig.no_env_hints? &&
              (core_formula_path?(path) || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))
            end
-          ohai "To test your local edits, run:", <<~EOS
-            HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug #{args.named.join(" ")}
+          puts <<~EOS
+            To test your local edits, run:
+              HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug #{args.named.join(" ")}
           EOS
         end
       end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -63,16 +63,24 @@ module Homebrew
 
         exec_editor(*paths)
 
+        is_formula = false
+        is_cask = false
+        is_tap = false
         if paths.any? do |path|
              next if path == "--project"
 
+             is_formula = core_formula_path?(path)
+             is_cask = core_cask_path?(path)
+             is_tap = core_formula_tap?(path) || core_cask_tap?(path)
+
              !Homebrew::EnvConfig.no_install_from_api? &&
              !Homebrew::EnvConfig.no_env_hints? &&
-             (core_formula_path?(path) || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))
+             (is_formula || is_cask || is_tap)
            end
+          from_source = "--build-from-source" if is_formula
           puts <<~EOS
             To test your local edits, run:
-              HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug #{args.named.join(" ")}
+              HOMEBREW_NO_INSTALL_FROM_API=1 brew install #{from_source} --verbose --debug #{args.named.join(" ")}
           EOS
         end
       end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -63,9 +63,9 @@ module Homebrew
 
         exec_editor(*paths)
 
-        is_formula = false
-        is_cask = false
-        is_tap = false
+        is_formula = T.let(false, T::Boolean)
+        is_cask = T.let(false, T::Boolean)
+        is_tap = T.let(false, T::Boolean)
         if paths.any? do |path|
              next if path == "--project"
 

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -64,23 +64,19 @@ module Homebrew
         exec_editor(*paths)
 
         is_formula = T.let(false, T::Boolean)
-        is_cask = T.let(false, T::Boolean)
-        is_tap = T.let(false, T::Boolean)
         if paths.any? do |path|
              next if path == "--project"
 
-             is_formula = core_formula_path?(path)
-             is_cask = core_cask_path?(path)
-             is_tap = core_formula_tap?(path) || core_cask_tap?(path)
+             break if Homebrew::EnvConfig.no_install_from_api?
+             break if Homebrew::EnvConfig.no_env_hints?
 
-             !Homebrew::EnvConfig.no_install_from_api? &&
-             !Homebrew::EnvConfig.no_env_hints? &&
-             (is_formula || is_cask || is_tap)
+             is_formula = core_formula_path?(path)
+             (is_formula || core_cask_path?(path) || core_formula_tap?(path) || core_cask_tap?(path))
            end
-          from_source = "--build-from-source" if is_formula
+          from_source = " --build-from-source" if is_formula
           puts <<~EOS
             To test your local edits, run:
-              HOMEBREW_NO_INSTALL_FROM_API=1 brew install #{from_source} --verbose --debug #{args.named.join(" ")}
+              HOMEBREW_NO_INSTALL_FROM_API=1 brew install#{from_source} --verbose --debug #{args.named.join(" ")}
           EOS
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before:
```sh
Warning: `brew install` ignores locally edited casks and formulae if
HOMEBREW_NO_INSTALL_FROM_API is not set.
```
After:
```sh
==> To test your local edits, run:
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug p9ufs
```