### PR TITLE
linux/bundle/skipper: fix skipper logic.

### DIFF
--- a/Library/Homebrew/extend/os/linux/bundle/skipper.rb
+++ b/Library/Homebrew/extend/os/linux/bundle/skipper.rb
@@ -22,9 +22,9 @@ module OS
             installer = ::Cask::Installer.new(cask)
             installer.check_stanza_os_requirements
 
-            true
-          rescue ::Cask::CaskError
             false
+          rescue ::Cask::CaskError
+            true
           end
 
           def skip?(entry, silent: false)


### PR DESCRIPTION
This should have been reversed in https://github.com/Homebrew/brew/pull/19599 to work as expected on Linux.

Lesson learned that I shouldn't be relying on using macOS and our CI testing for tests like this to work 🤦🏻.

Commit verified because did this on WSL where I don't have GPG signing working yet.