### PR TITLE
Allow callers of `brew bundle check` to filter errors.

### DIFF
--- a/Library/Homebrew/bundle/commands/check.rb
+++ b/Library/Homebrew/bundle/commands/check.rb
@@ -7,9 +7,6 @@ module Homebrew
   module Bundle
     module Commands
       module Check
-        ARROW = "→"
-        FAILURE_MESSAGE = "brew bundle can't satisfy your Brewfile's dependencies."
-
         def self.run(global: false, file: nil, no_upgrade: false, verbose: false)
           output_errors = verbose
           exit_on_first_error = !verbose
@@ -18,10 +15,26 @@ module Homebrew
             exit_on_first_error:, no_upgrade:, verbose:
           )
 
-          if check_result.work_to_be_done
-            puts FAILURE_MESSAGE
+          # Allow callers of `brew bundle check` to specify when they've already
+          # output some formulae errors.
+          check_missing_formulae = ENV.fetch("HOMEBREW_BUNDLE_CHECK_ALREADY_OUTPUT_FORMULAE_ERRORS", "")
+                                      .strip
+                                      .split
 
-            check_result.errors.each { |package| puts "#{ARROW} #{package}" } if output_errors
+          if check_result.work_to_be_done
+            puts "brew bundle can't satisfy your Brewfile's dependencies." if check_missing_formulae.blank?
+
+            if output_errors
+              check_result.errors.each do |error|
+                if (match = error.match(/^Formula (.+) needs to be installed/)) &&
+                   check_missing_formulae.include?(match[1])
+                  next
+                end
+
+                puts "→ #{error}"
+              end
+            end
+
             puts "Satisfy missing dependencies with `brew bundle install`."
             exit 1
           else


### PR DESCRIPTION
If callers of `brew bundle check` have already output some formulae errors, they can set the
`HOMEBREW_BUNDLE_CHECK_ALREADY_OUTPUT_FORMULAE_ERRORS` environment variable to the names of the formulae that have already been output.