### PR TITLE
bundle/commands/exec: run `check` first

### DIFF
--- a/Library/Homebrew/bundle/commands/check.rb
+++ b/Library/Homebrew/bundle/commands/check.rb
@@ -7,7 +7,7 @@ module Homebrew
   module Bundle
     module Commands
       module Check
-        def self.run(global: false, file: nil, no_upgrade: false, verbose: false)
+        def self.run(global: false, file: nil, no_upgrade: false, verbose: false, quiet: false)
           output_errors = verbose
           exit_on_first_error = !verbose
           check_result = Homebrew::Bundle::Checker.check(
@@ -37,9 +37,9 @@ module Homebrew
 
             puts "Satisfy missing dependencies with `brew bundle install`."
             exit 1
-          else
-            puts "The Brewfile's dependencies are satisfied."
           end
+
+          puts "The Brewfile's dependencies are satisfied." unless quiet
         end
       end
     end

--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -48,6 +48,9 @@ module Homebrew
         PATH_LIKE_ENV_REGEX = /.+#{File::PATH_SEPARATOR}/
 
         def self.run(*args, global: false, file: nil, subcommand: "")
+          require "bundle/commands/check"
+          Homebrew::Bundle::Commands::Check.run(global:, file:, quiet: true)
+
           # Cleanup Homebrew's global environment
           HOMEBREW_ENV_CLEANUP.each { |key| ENV.delete(key) }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew bundle exec` can behave wrongly if you haven't done `brew bundle install`
first. Let's run `brew bundle check` first to avoid this.
