### PR TITLE
bundle/commands/exec: check that `Brewfile` is installed with `--check`

### DIFF
--- a/Library/Homebrew/bundle/commands/check.rb
+++ b/Library/Homebrew/bundle/commands/check.rb
@@ -7,7 +7,7 @@ module Homebrew
   module Bundle
     module Commands
       module Check
-        def self.run(global: false, file: nil, no_upgrade: false, verbose: false)
+        def self.run(global: false, file: nil, no_upgrade: false, verbose: false, quiet: false)
           output_errors = verbose
           exit_on_first_error = !verbose
           check_result = Homebrew::Bundle::Checker.check(
@@ -37,9 +37,9 @@ module Homebrew
 
             puts "Satisfy missing dependencies with `brew bundle install`."
             exit 1
-          else
-            puts "The Brewfile's dependencies are satisfied."
           end
+
+          puts "The Brewfile's dependencies are satisfied." unless quiet
         end
       end
     end

--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -13,7 +13,12 @@ module Homebrew
       module Exec
         PATH_LIKE_ENV_REGEX = /.+#{File::PATH_SEPARATOR}/
 
-        def self.run(*args, global: false, file: nil, subcommand: "", services: false)
+        def self.run(*args, global: false, file: nil, subcommand: "", services: false, check: false)
+          if check
+            require "bundle/commands/check"
+            Homebrew::Bundle::Commands::Check.run(global:, file:, quiet: true)
+          end
+
           # Store the old environment so we can check if things were already set
           # before we start mutating it.
           old_env = ENV.to_h

--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -228,28 +228,6 @@ module Homebrew
         when "check"
           require "bundle/commands/check"
           Homebrew::Bundle::Commands::Check.run(global:, file:, no_upgrade:, verbose:)
-        when *BUNDLE_EXEC_COMMANDS
-          named_args = case subcommand
-          when "exec"
-            _subcommand, *named_args = args.named
-            named_args
-          when "sh"
-            preferred_path = Utils::Shell.preferred_path(default: "/bin/bash")
-            notice = unless Homebrew::EnvConfig.no_env_hints?
-              <<~EOS
-                Your shell has been configured to use a build environment from your `Brewfile`.
-                This should help you build stuff.
-                Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
-                When done, type `exit`.
-              EOS
-            end
-            ENV["HOMEBREW_FORCE_API_AUTO_UPDATE"] = nil
-            [Utils::Shell.shell_with_prompt("brew bundle", preferred_path:, notice:)]
-          when "env"
-            ["env"]
-          end
-          require "bundle/commands/exec"
-          Homebrew::Bundle::Commands::Exec.run(*named_args, global:, file:, subcommand:, services: args.services?)
         when "list"
           require "bundle/commands/list"
           Homebrew::Bundle::Commands::List.run(
@@ -290,6 +268,28 @@ module Homebrew
             require "bundle/commands/remove"
             Homebrew::Bundle::Commands::Remove.run(*named_args, type: selected_types.first, global:, file:)
           end
+        when *BUNDLE_EXEC_COMMANDS
+          named_args = case subcommand
+          when "exec"
+            _subcommand, *named_args = args.named
+            named_args
+          when "sh"
+            preferred_path = Utils::Shell.preferred_path(default: "/bin/bash")
+            notice = unless Homebrew::EnvConfig.no_env_hints?
+              <<~EOS
+                Your shell has been configured to use a build environment from your `Brewfile`.
+                This should help you build stuff.
+                Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
+                When done, type `exit`.
+              EOS
+            end
+            ENV["HOMEBREW_FORCE_API_AUTO_UPDATE"] = nil
+            [Utils::Shell.shell_with_prompt("brew bundle", preferred_path:, notice:)]
+          when "env"
+            ["env"]
+          end
+          require "bundle/commands/exec"
+          Homebrew::Bundle::Commands::Exec.run(*named_args, global:, file:, subcommand:, services: args.services?)
         else
           raise UsageError, "unknown subcommand: #{subcommand}"
         end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
@@ -24,6 +24,9 @@ class Homebrew::Cmd::Bundle::Args < Homebrew::CLI::Args
   def casks?; end
 
   sig { returns(T::Boolean) }
+  def check?; end
+
+  sig { returns(T::Boolean) }
   def cleanup?; end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew bundle exec` behaves correctly only after doing `brew bundle install`.

Running `brew bundle check` can be slow, so let's add a `--check` flag
to `brew bundle exec` which will also run `brew bundle check` before
`brew bundle exec` to ensure that the `Brewfile` has been installed
before proceeding.

Alternative to #19636 which makes `--check` the default behaviour. I have a mild
preference for this version since the additional `brew bundle check` makes
`brew bundle env` and `brew bundle exec true` 60% slower.

Another option is to merge #19636 while adding a `--no-check` flag for users who
already know their `Brewfile` is installed and don't want to incur the overhead
of `brew bundle check`.


