### PR TITLE
diagnostic: allow macFUSE FUSE3 files

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -204,6 +204,7 @@ module Homebrew
         # with a short description of the software they come with.
         allow_list = [
           "libfuse.2.dylib", # MacFuse
+          "libfuse3.*.dylib", # MacFuse
           "libfuse_ino64.2.dylib", # MacFuse
           "libmacfuse_i32.2.dylib", # OSXFuse MacFuse compatibility layer
           "libmacfuse_i64.2.dylib", # OSXFuse MacFuse compatibility layer
@@ -261,6 +262,7 @@ module Homebrew
         # with a short description of the software they come with.
         allow_list = [
           "fuse.pc", # OSXFuse/MacFuse
+          "fuse3.pc", # OSXFuse/MacFuse
           "macfuse.pc", # OSXFuse MacFuse compatibility layer
           "osxfuse.pc", # OSXFuse
           "libntfs-3g.pc", # NTFS-3G
@@ -301,6 +303,7 @@ module Homebrew
         allow_list = [
           "fuse.h", # MacFuse
           "fuse/**/*.h", # MacFuse
+          "fuse3/**/*.h", # MacFuse
           "macfuse/**/*.h", # OSXFuse MacFuse compatibility layer
           "osxfuse/**/*.h", # OSXFuse
           "ntfs/**/*.h", # NTFS-3G


### PR DESCRIPTION
FUSE 3 support was introduced in macFUSE 4.10.0.

Resolves #19650.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
