### PR TITLE
Correctly handle missing homepage in GitHub API response

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -93,7 +93,7 @@ module Homebrew
 
         if @github
           @desc = @github["description"]
-          @homepage = if @github["homepage"].nil?
+          @homepage = if @github["homepage"].blank?
             "https://github.com/#{@github["full_name"]}"
           else
             @github["homepage"]

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -93,7 +93,7 @@ module Homebrew
 
         if @github
           @desc = @github["description"]
-          @homepage = if @github["homepage"].to_s.empty?
+          @homepage = if @github["homepage"].nil?
             "https://github.com/#{@github["full_name"]}"
           else
             @github["homepage"]

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -93,7 +93,7 @@ module Homebrew
 
         if @github
           @desc = @github["description"]
-          @homepage = if @github["homepage"].empty?
+          @homepage = if @github["homepage"].to_s.empty?
             "https://github.com/#{@github["full_name"]}"
           else
             @github["homepage"]

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -93,11 +93,7 @@ module Homebrew
 
         if @github
           @desc = @github["description"]
-          @homepage = if @github["homepage"].blank?
-            "https://github.com/#{@github["full_name"]}"
-          else
-            @github["homepage"]
-          end
+          @homepage = @github["homepage"].presence || "https://github.com/#{@github["full_name"]}"
           @license = @github["license"]["spdx_id"] if @github["license"]
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In #19623, the homepage in the GitHub repo info was checked with `empty?`, but I found that the API returns `null` for a missing homepage, which in Ruby seems to be treated as `nil`, so calling `empty?` on it fails if not set.