### PR TITLE
test pr (do not merge)

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -372,11 +372,8 @@ class Formula
   def specified_path
     return Homebrew::API::Formula.cached_json_file_path if loaded_from_api?
     return alias_path if alias_path&.exist?
-
     return @unresolved_path if @unresolved_path.exist?
-
     return local_bottle_path if local_bottle_path.presence&.exist?
-
     alias_path || @unresolved_path
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -374,6 +374,7 @@ class Formula
     return alias_path if alias_path&.exist?
     return @unresolved_path if @unresolved_path.exist?
     return local_bottle_path if local_bottle_path.presence&.exist?
+
     alias_path || @unresolved_path
   end
 

--- a/Library/Homebrew/test/bundle/whalebrew_installer_spec.rb
+++ b/Library/Homebrew/test/bundle/whalebrew_installer_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe Homebrew::Bundle::WhalebrewInstaller do
                                                  .and_return(true)
     end
 
+    it "successfully installs an image" do
+      expect(described_class.preinstall("whalebrew/wget")).to be(true)
+      expect { described_class.install("whalebrew/wget") }.not_to raise_error
+    end
+
     context "when the requested image is already installed" do
       before do
         allow(described_class).to receive(:image_installed?).with("whalebrew/wget").and_return(true)
@@ -68,11 +73,6 @@ RSpec.describe Homebrew::Bundle::WhalebrewInstaller do
       it "skips" do
         expect(described_class.preinstall("whalebrew/wget")).to be(false)
       end
-    end
-
-    it "successfully installs an image" do
-      expect(described_class.preinstall("whalebrew/wget")).to be(true)
-      expect { described_class.install("whalebrew/wget") }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
This test sometimes fails on CI runners but I cannot reproduce it on my computer. My (probably not the smartest) idea is that somehow `context "when the requested image is already installed" do` may affect the test below.