### PR TITLE
dev-cmd/bump-*: only warn on duplicate PRs for official taps.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -259,8 +259,9 @@ module Homebrew
 
         file = cask.sourcefile_path.relative_path_from(cask.tap.path).to_s
         quiet = args.quiet?
+        official_tap = cask.tap.official?
         GitHub.check_for_duplicate_pull_requests(cask.token, tap_remote_repo,
-                                                 state: "open", file:, quiet:)
+                                                 state: "open", file:, quiet:, official_tap:)
 
         # if we haven't already found open requests, try for an exact match across all pull requests
         new_version.instance_variables.each do |version_type|
@@ -268,7 +269,8 @@ module Homebrew
           next if version_type_version.blank?
 
           version = shortened_version(version_type_version, cask:)
-          GitHub.check_for_duplicate_pull_requests(cask.token, tap_remote_repo, version:, file:, quiet:)
+          GitHub.check_for_duplicate_pull_requests(cask.token, tap_remote_repo, version:,
+                                                   file:, quiet:, official_tap:)
         end
       end
 

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -550,8 +550,9 @@ module Homebrew
           formula.name, tap_remote_repo,
           version:,
           state:,
-          file:    formula.path.relative_path_from(tap.path).to_s,
-          quiet:   args.quiet?
+          file:         formula.path.relative_path_from(tap.path).to_s,
+          quiet:        args.quiet?,
+          official_tap: tap.official?
         )
       end
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -635,9 +635,11 @@ module GitHub
       quiet:           T::Boolean,
       state:           T.nilable(String),
       version:         T.nilable(String),
+      official_tap:    T::Boolean,
     ).void
   }
-  def self.check_for_duplicate_pull_requests(name, tap_remote_repo, file:, quiet: false, state: nil, version: nil)
+  def self.check_for_duplicate_pull_requests(name, tap_remote_repo, file:, quiet: false, state: nil,
+                                             version: nil, official_tap: true)
     pull_requests = fetch_pull_requests(name, tap_remote_repo, state:, version:)
 
     pull_requests.select! do |pr|
@@ -657,7 +659,9 @@ module GitHub
       Manually open these PRs if you are sure that they are not duplicates (and tell us that in the PR).
     EOS
 
-    if version
+    if !official_tap
+      opoo duplicates_message
+    elsif version
       odie <<~EOS
         #{duplicates_message.chomp}
         #{error_message}


### PR DESCRIPTION
The default behaviour is too strict for unofficial taps. We can still warn elsewhere but, given the potential for false positives, let's loosen things a bit.