### PR TITLE
bundle/commands/cleanup: correctly handle `.keepme` references.

### DIFF
--- a/Library/Homebrew/bundle/commands/cleanup.rb
+++ b/Library/Homebrew/bundle/commands/cleanup.rb
@@ -106,6 +106,13 @@ module Homebrew
           current_formulae.reject! do |f|
             Homebrew::Bundle::BrewInstaller.formula_in_array?(f[:full_name], kept_formulae)
           end
+
+          # Don't try to uninstall formulae with keepme references
+          current_formulae.reject! do |f|
+            Formula[f[:full_name]].installed_kegs.any? do |keg|
+              keg.keepme_refs.present?
+            end
+          end
           current_formulae.map { |f| f[:full_name] }
         end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3146,8 +3146,7 @@ class Formula
             opoo "Skipping (old) #{keg} due to it being linked" unless quiet
           elsif pinned? && keg == Keg.new(@pin.path.resolved_path)
             opoo "Skipping (old) #{keg} due to it being pinned" unless quiet
-          elsif (keepme = keg/".keepme") && keepme.exist? && keepme.readable? &&
-                (keepme_refs = keepme.readlines.map(&:strip).select { |ref| Pathname(ref).exist? }.presence)
+          elsif (keepme_refs = keg.keepme_refs.presence)
             opoo "Skipping #{keg} as it is needed by #{keepme_refs.join(", ")}" unless quiet
           else
             eligible_for_cleanup << keg

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -95,6 +95,8 @@ class Keg
   PYC_EXTENSIONS = %w[.pyc .pyo].freeze
   LIBTOOL_EXTENSIONS = %w[.la .lai].freeze
 
+  KEEPME_FILE = ".keepme"
+
   # @param path if this is a file in a keg, returns the containing {Keg} object.
   def self.for(path)
     original_path = path
@@ -590,6 +592,14 @@ class Keg
 
       manpage.atomic_write(content)
     end
+  end
+
+  sig { returns(T::Array[String]) }
+  def keepme_refs
+    keepme = path/KEEPME_FILE
+    return [] if !keepme.exist? || !keepme.readable?
+
+    keepme.readlines.select { |ref| File.exist?(ref.strip) }
   end
 
   def binary_executable_or_library_files


### PR DESCRIPTION
Extract the relevant logic from `formula.rb`, moving to `keg.rb` and then use this logic in `bundle/commands/cleanup.rb` to ensure that we don't say we need to uninstall formulae that should be still kept.
