### PR TITLE
bundle: use HOMEBREW_BUNDLE_FORMULA_VERSION_* for formula version.

### DIFF
--- a/Library/Homebrew/bundle.rb
+++ b/Library/Homebrew/bundle.rb
@@ -88,7 +88,9 @@ module Homebrew
           formula_versions = {}
 
           ENV.each do |key, value|
-            match = key.match(/^HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_(.+)$/)
+            match = key.match(/^HOMEBREW_BUNDLE_FORMULA_VERSION_(.+)$/)
+            # odeprecated: get rid of this in Homebrew >=4.5
+            match ||= key.match(/^HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_(.+)$/)
             next if match.blank?
 
             formula_name = match[1]

--- a/Library/Homebrew/test/bundle/commands/exec_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/exec_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Homebrew::Bundle::Commands::Exec do
         openssl_version = "1.1.1"
         ENV["PATH"] = "/opt/homebrew/opt/openssl/bin:/usr/bin:/bin"
         ENV["MANPATH"] = "/opt/homebrew/opt/openssl/man"
-        ENV["HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_OPENSSL"] = openssl_version
+        ENV["HOMEBREW_BUNDLE_FORMULA_VERSION_OPENSSL"] = openssl_version
         allow(described_class).to receive(:which).and_return(Pathname("/usr/bin/bundle"))
         described_class.run("bundle", "install")
         expect(ENV.fetch("PATH")).to include("/Cellar/openssl/1.1.1/bin")


### PR DESCRIPTION
As this variable is no longer just used for `brew bundle exec`.