### PR TITLE
docs: Remove aarch64 unsupported note for Homebrew on Linux #1

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -53,7 +53,7 @@ If you're using an older distribution of Linux, installing your first package wi
 
 - **Linux** 3.2 or newer
 - **Glibc** 2.13 or newer
-- **64-bit x86_64** CPU
+- **64-bit x86_64** or **64-bit aarch64** (including Apple Silicon) CPU's
 
 To install build tools, paste at a terminal prompt:
 
@@ -76,9 +76,9 @@ To install build tools, paste at a terminal prompt:
   sudo pacman -S base-devel procps-ng curl file git
   ```
 
-### ARM (unsupported)
+### ARM32 (unsupported)
 
-Homebrew can run on 32-bit ARM (e.g. Raspberry Pi and others) and 64-bit ARM (ARM64, also known as AArch64), but as they lack bottles (binary packages) they are unsupported. Pull requests are welcome to improve the experience on ARM platforms.
+Homebrew can run on 32-bit ARM (e.g. Raspberry Pi and others), but as they lack bottles (binary packages) they are unsupported. Pull requests are welcome to improve the experience on ARM platforms.
 
 You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as we no longer distribute a Homebrew Portable Ruby for ARM.
 

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -5,7 +5,7 @@ redirect_from:
   - /linux
   - /Linux
   - /Linuxbrew
-last_review_date: "1970-01-01"
+last_review_date: "2025-04-02"
 ---
 
 # Homebrew on Linux
@@ -78,13 +78,13 @@ To install build tools, paste at a terminal prompt:
 
 Homebrew can run on 32-bit ARM (e.g. Raspberry Pi and others), but as they lack bottles (binary packages) they are a [Tier 3 supported platform](https://docs.brew.sh/Support-Tiers#tier-3)
 
-You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as we no longer distribute a Homebrew Portable Ruby for ARM.
+You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as we don't distribute a Homebrew Portable Ruby for ARM32.
 
-### 32-bit x86 (incompatible)
+### 32-bit x86 (Unsupported)
 
 Homebrew does not run at all on 32-bit x86 platforms.
 
-### Windows Subsystem for Linux (WSL) 1
+### Windows Subsystem for Linux 1 (Tier 3 Support)
 
 Due to [known issues](https://github.com/microsoft/WSL/issues/8219) with WSL 1, you may experience issues running various executables installed by Homebrew. We recommend you switch to WSL 2 instead.
 

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -51,9 +51,7 @@ If you're using an older distribution of Linux, installing your first package wi
 
 ## Requirements
 
-- **Linux** 3.2 or newer
-- **Glibc** 2.13 or newer
-- **64-bit x86_64** or **64-bit aarch64** (including Apple Silicon) CPU's
+See [Support Tiers](Support-Tiers.md)
 
 To install build tools, paste at a terminal prompt:
 
@@ -76,9 +74,9 @@ To install build tools, paste at a terminal prompt:
   sudo pacman -S base-devel procps-ng curl file git
   ```
 
-### ARM32 (unsupported)
+### ARM32 (Tier 3 Support)
 
-Homebrew can run on 32-bit ARM (e.g. Raspberry Pi and others), but as they lack bottles (binary packages) they are unsupported. Pull requests are welcome to improve the experience on ARM platforms.
+Homebrew can run on 32-bit ARM (e.g. Raspberry Pi and others), but as they lack bottles (binary packages) they are a [Tier 3 supported platform](https://docs.brew.sh/Support-Tiers#tier-3)
 
 You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as we no longer distribute a Homebrew Portable Ruby for ARM.
 

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -38,6 +38,7 @@ For Tier 1 support, Homebrew on Linux must be all of:
 
 - running on Ubuntu or a Homebrew-provided Docker image
 - have a system `glibc` >= 2.35
+- have a Linux kernel >= 3.2
 - if running Ubuntu, running an Ubuntu version in "standard support": <https://ubuntu.com/about/release-cycle>
 - installed in the default prefix (i.e. `/home/linuxbrew/.linuxbrew`)
 - running on a supported architecture (i.e. Intel x86_64)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

After https://github.com/Homebrew/install/pull/963/files merge, Homebrew is working on my Setup in Debian docker image on Apple M1. Since it's fixed, it should be reflected in the docs.

Note that I cannot test on arm32, but the PR mentioned above was only about 64-bit arch, so for 32-bit platforms, the restrictions seem to be still actual