### PR TITLE
bundle: fix up formula name for environment variable.

### DIFF
--- a/Library/Homebrew/bundle.rb
+++ b/Library/Homebrew/bundle.rb
@@ -102,8 +102,8 @@ module Homebrew
         return_value
       end
 
-      sig { returns(T::Hash[String, String]) }
-      def formula_versions_from_env
+      sig { params(formula_name: String).returns(T.nilable(String)) }
+      def formula_versions_from_env(formula_name)
         @formula_versions_from_env ||= begin
           formula_versions = {}
 
@@ -113,15 +113,23 @@ module Homebrew
             match ||= key.match(/^HOMEBREW_BUNDLE_EXEC_FORMULA_VERSION_(.+)$/)
             next if match.blank?
 
-            formula_name = match[1]
-            next if formula_name.blank?
+            env_formula_name = match[1]
+            next if env_formula_name.blank?
 
             ENV.delete(key)
-            formula_versions[formula_name.downcase] = value
+            formula_versions[env_formula_name] = value
           end
 
           formula_versions
         end
+
+        # Fix up formula name for a valid environment variable name.
+        formula_env_name = formula_name.upcase
+                                       .gsub("@", "AT")
+                                       .tr("+", "X")
+                                       .tr("-", "_")
+
+        @formula_versions_from_env[formula_env_name]
       end
 
       sig { void }

--- a/Library/Homebrew/bundle/brew_installer.rb
+++ b/Library/Homebrew/bundle/brew_installer.rb
@@ -62,7 +62,7 @@ module Homebrew
           if result && @version_file.present?
             # Use the version from the environment if it hasn't changed.
             # Strip the revision number because it's not part of the non-Homebrew version.
-            version = if !changed? && (env_version = Bundle.formula_versions_from_env[@name])
+            version = if !changed? && (env_version = Bundle.formula_versions_from_env(@name))
               PkgVersion.parse(env_version).version
             else
               Formula[@full_name].version

--- a/Library/Homebrew/bundle/brew_services.rb
+++ b/Library/Homebrew/bundle/brew_services.rb
@@ -65,7 +65,7 @@ module Homebrew
       end
 
       def self.versioned_service_file(name)
-        env_version = Bundle.formula_versions_from_env[name]
+        env_version = Bundle.formula_versions_from_env(name)
         return if env_version.nil?
 
         formula = Formula[name]

--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -112,7 +112,11 @@ module Homebrew
           end
 
           # Replace the formula versions from the environment variables
-          Bundle.formula_versions_from_env.each do |formula_name, formula_version|
+          ENV.deps.each do |formula|
+            formula_name = formula.name
+            formula_version = Bundle.formula_versions_from_env(formula_name)
+            next unless formula_version
+
             ENV.each do |key, value|
               opt = %r{/opt/#{formula_name}([/:$])}
               next unless value.match(opt)

--- a/Library/Homebrew/test/bundle/brew_services_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_services_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Homebrew::Bundle::BrewServices do
     shared_examples "returns the versioned service file" do
       it "returns the versioned service file" do
         expect(Formula).to receive(:[]).with(foo.name).and_return(foo)
-        expect(Homebrew::Bundle).to receive(:formula_versions_from_env).and_return(foo.name => foo.version)
+        expect(Homebrew::Bundle).to receive(:formula_versions_from_env).with(foo.name).and_return(foo.version)
 
         prefix = foo.rack/"1.0"
         allow(FileTest).to receive(:directory?).and_call_original


### PR DESCRIPTION
We previously were trying to pass through invalid environment variable names so let's fix these up and query those instead.