### PR TITLE
bump-cask-pr: fix macOS host handling

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -220,7 +220,7 @@ module Homebrew
             # Handle the cask being invalid for specific os/arch combinations
             old_cask = begin
               Cask::CaskLoader.load(cask.sourcefile_path)
-            rescue Cask::CaskInvalidError
+            rescue Cask::CaskInvalidError, Cask::CaskUnreadableError
               raise unless cask.on_system_blocks_exist?
             end
             next if old_cask.nil?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`bump-cask-pr` was recently updated to add Linux support but the change to the `replace_version_and_checksum` logic has broken the command for casks that have on_system blocks that reference specific macOS versions (e.g., `on_monterey :or_newer` in `logi-options+`).

The previous logic only simulated the arch, so the `current_os` value on macOS was a specific version like `:sequoia`. The current logic uses generic `:macos` values, which work for `on_macos` blocks but don't work for blocks like `on_sequoia`, etc. This leads to an `undefined method 'latest?' for nil` error, as `old_cask.version` is `nil` in this scenario (i.e., none of the on_system blocks apply to `:macos`, so `version` is never set).

This updates the method to use the host OS value in `system_options` if the host is macOS, which is closer to the previous behavior. This also skips `system_options` values where `old_cask` has no version, as this means the cask doesn't apply to that OS/arch.

-----

I'm creating this as a draft for now (it's late over here and I'm off to bed), as I need to test this some more (i.e., across a broader variety of casks, on Linux, etc.).