### PR TITLE
os/linux/development_tools: update cop namespace

### DIFF
--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -38,13 +38,13 @@ module OS
       end
 
       # Keep this method around for now to make it easier to add this functionality later.
-      # rubocop:disable Style/UselessMethodDefinition
+      # rubocop:disable Lint/UselessMethodDefinition
       sig { returns(Pathname) }
       def host_gcc_path
         # TODO: override this if/when we to pick the GCC based on e.g. the Ubuntu version.
         super
       end
-      # rubocop:enable Style/UselessMethodDefinition
+      # rubocop:enable Lint/UselessMethodDefinition
 
       sig { returns(T::Boolean) }
       def needs_compiler_formula?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Noticed this when running `brew style` after the the bump to Rubocop 1.75.2:

```
extend/os/linux/development_tools.rb: Style/UselessMethodDefinition has the wrong namespace - replace it with Lint/UselessMethodDefinition
extend/os/linux/development_tools.rb: Style/UselessMethodDefinition has the wrong namespace - replace it with Lint/UselessMethodDefinition
```