### PR TITLE
Make `os` available in `livecheck` blocks

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -80,6 +80,7 @@ module Cask
       :homepage,
       :language,
       :name,
+      :os,
       :sha256,
       :staged_path,
       :url,

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -134,6 +134,10 @@ module Homebrew
           end
           # rubocop:enable Homebrew/MoveToExtendOS
 
+          bundle_args << "--tag" << "~needs_arm" unless Hardware::CPU.arm?
+
+          bundle_args << "--tag" << "~needs_intel" unless Hardware::CPU.intel?
+
           bundle_args << "--tag" << "~needs_network" unless args.online?
           unless ENV["CI"]
             bundle_args << "--tag" << "~needs_ci" \

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -194,9 +194,10 @@ class Livecheck
   end
 
   delegate url_options: :@options
-  delegate version: :@package_or_resource
   delegate arch: :@package_or_resource
-  private :version, :arch
+  delegate os: :@package_or_resource
+  delegate version: :@package_or_resource
+  private :arch, :os, :version
   # Returns a `Hash` of all instance variable values.
   # @return [Hash]
   sig { returns(T::Hash[String, T.untyped]) }

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -182,6 +182,32 @@ RSpec.describe Livecheck do
     end
   end
 
+  describe "#arch" do
+    let(:c_arch) do
+      Cask::Cask.new("c-arch") do
+        arch arm: "arm", intel: "intel"
+
+        version "0.0.1"
+
+        url "https://brew.sh/test-0.0.1.dmg"
+        name "Test"
+        desc "Test cask"
+        homepage "https://brew.sh"
+
+        livecheck do
+          url "https://brew.sh/#{arch}"
+        end
+      end
+    end
+
+    [:needs_arm, :needs_intel].each do |needs_arch|
+      arch_value = needs_arch.to_s.delete_prefix("needs_")
+      it "delegates `arch` in `livecheck` block to `package_or_resource`", needs_arch do
+        expect(c_arch.livecheck.url).to eq("https://brew.sh/#{arch_value}")
+      end
+    end
+  end
+
   describe "#os" do
     let(:c_os) do
       Cask::Cask.new("c-os") do
@@ -205,6 +231,52 @@ RSpec.describe Livecheck do
       it "delegates `os` in `livecheck` block to `package_or_resource`", needs_os do
         expect(c_os.livecheck.url).to eq("https://brew.sh/#{os_value}")
       end
+    end
+  end
+
+  describe "#version" do
+    let(:url_with_version) { "https://brew.sh/0.0.1" }
+
+    let(:f_version) do
+      formula do
+        homepage "https://brew.sh"
+        url "https://brew.sh/test-0.0.1.tgz"
+
+        livecheck do
+          url "https://brew.sh/#{version}"
+        end
+      end
+    end
+
+    let(:c_version) do
+      Cask::Cask.new("c-version") do
+        version "0.0.1"
+
+        url "https://brew.sh/test-0.0.1.dmg"
+        name "Test"
+        desc "Test cask"
+        homepage "https://brew.sh"
+
+        livecheck do
+          url "https://brew.sh/#{version}"
+        end
+      end
+    end
+
+    let(:r_version) do
+      Resource.new do
+        url "https://brew.sh/test-0.0.1.tgz"
+
+        livecheck do
+          url "https://brew.sh/#{version}"
+        end
+      end
+    end
+
+    it "delegates `version` in `livecheck` block to `package_or_resource`" do
+      expect(f_version.livecheck.url).to eq(url_with_version)
+      expect(c_version.livecheck.url).to eq(url_with_version)
+      expect(r_version.livecheck.url).to eq(url_with_version)
     end
   end
 

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -182,6 +182,32 @@ RSpec.describe Livecheck do
     end
   end
 
+  describe "#os" do
+    let(:c_os) do
+      Cask::Cask.new("c-os") do
+        os macos: "macos", linux: "linux"
+
+        version "0.0.1"
+
+        url "https://brew.sh/test-0.0.1.dmg"
+        name "Test"
+        desc "Test cask"
+        homepage "https://brew.sh"
+
+        livecheck do
+          url "https://brew.sh/#{os}"
+        end
+      end
+    end
+
+    [:needs_macos, :needs_linux].each do |needs_os|
+      os_value = needs_os.to_s.delete_prefix("needs_")
+      it "delegates `os` in `livecheck` block to `package_or_resource`", needs_os do
+        expect(c_os.livecheck.url).to eq("https://brew.sh/#{os_value}")
+      end
+    end
+  end
+
   describe "#to_hash" do
     it "returns a Hash of all instance variables" do
       expect(livecheck_f.to_hash).to eq(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Casks now support an `os` DSL method, similar to `arch`. This makes it available in `livecheck` blocks, like we do with `arch`.

Besides that, this also adds tests for the `version` and `arch` delegate methods in the `livecheck` block DSL. This doesn't affect test coverage but it ensures that the methods work as expected in `livecheck` blocks. For what it's worth, it was necessary to use `Cask::Cask.new` in these tests, as the delegate methods don't work when using the existing `Cask::CaskLoader.load` approach (for whatever reason).

Related to https://github.com/Homebrew/homebrew-cask/pull/207471.