### PR TITLE
bump-cask-pr: handle nil cask version, add tests

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -174,7 +174,11 @@ module Homebrew
 
       sig { params(version: Cask::DSL::Version, cask: Cask::Cask).returns(Cask::DSL::Version) }
       def shortened_version(version, cask:)
-        if version.before_comma == cask.version.before_comma
+        unless (cask_version = cask.version)
+          raise Cask::CaskInvalidError.new(cask, "invalid 'version' value: #{cask_version.inspect}")
+        end
+
+        if version.before_comma == cask_version.before_comma
           version
         else
           version.before_comma


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `shortened_version` method in the `bump-cask-pr` command can produce an error if `cask.version` is `nil`. For example, this can happen on Linux when a cask only sets the `version` in macOS on_system blocks. This modifies the method to explicitly raise a `CaskInvalidError` when `cask.version` is `nil`, as we need to know the existing version to be able to determine how to handle the new `version`. [It's possible to fall back to the full version instead but that can allow certain types of duplicate PRs when `cask.version` is or isn't `nil` on a given host.]

This also adds tests for the `shortened_version` method, bringing it to 100% coverage.

-----

For what it's worth, to allow `bump-cask-pr` to bump casks where the version is only set in macOS on_system blocks, we would need to simulate macOS earlier in `bump-cask-pr` (i.e., when defining `cask` in `run`). Some casks loudly fail early as invalid, while others may only end up with invalid values like a `nil` `version`. This is something for a follow-up PR but I'll tinker with this to see if we can implement it now or if we have to wait for more reliable indicators of OS requirements (something else that I'm working on).