### PR TITLE
utils/ruby: set HOMEBREW_BOOTSNAP_GEM_PATH after Ruby install.

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -127,15 +127,15 @@ If there's no Homebrew Portable Ruby available for your processor:
   if [[ -x "${vendor_ruby_path}" ]]
   then
     HOMEBREW_RUBY_PATH="${vendor_ruby_path}"
-    HOMEBREW_BOOTSNAP_GEM_PATH="$(
-      shopt -s nullglob
-      echo "${vendor_ruby_root}"/lib/ruby/gems/*/gems/bootsnap-*/lib/bootsnap 2>/dev/null
-    )"
     TERMINFO_DIRS="${vendor_ruby_terminfo}"
     if [[ "${vendor_ruby_current_version}" != "${HOMEBREW_PORTABLE_RUBY_VERSION}" ]]
     then
       brew vendor-install ruby || odie "${upgrade_fail}"
     fi
+    HOMEBREW_BOOTSNAP_GEM_PATH="$(
+      shopt -s nullglob
+      echo "${vendor_ruby_root}"/lib/ruby/gems/*/gems/bootsnap-*/lib/bootsnap 2>/dev/null
+    )"
   else
     if system_ruby_supported
     then


### PR DESCRIPTION
This should ensure it's set to the correct path.

Fixes #19715