### PR TITLE
OnSystem: Add UsesOnSystem class

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -718,7 +718,7 @@ module Cask
       cask_min_os = [on_system_block_min_os, cask.depends_on.macos&.minimum_version].compact.max
       odebug "Declared minimum OS version: #{cask_min_os&.to_sym}"
       return if cask_min_os&.to_sym == min_os.to_sym
-      return if cask.on_system_blocks_exist? &&
+      return if cask.uses_on_system.present? &&
                 OnSystem.arch_condition_met?(:arm) &&
                 cask_min_os.present? &&
                 cask_min_os < MacOSVersion.new("11")

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -414,7 +414,7 @@ module Cask
       hash = to_h
       variations = {}
 
-      if @dsl.on_system_blocks_exist?
+      if @dsl.uses_on_system.present?
         begin
           OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
             next if bottle_tag.linux? && @dsl.os.nil?

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -60,9 +60,9 @@ module Cask
           elsif MacOSVersion::SYMBOLS.key?(args.first)
             MacOSRequirement.new([args.first], comparator: "==")
           elsif (md = /^\s*(?<comparator><|>|[=<>]=)\s*:(?<version>\S+)\s*$/.match(first_arg))
-            MacOSRequirement.new([T.must(md[:version]).to_sym], comparator: md[:comparator])
+            MacOSRequirement.new([T.must(md[:version]).to_sym], comparator: T.must(md[:comparator]))
           elsif (md = /^\s*(?<comparator><|>|[=<>]=)\s*(?<version>\S+)\s*$/.match(first_arg))
-            MacOSRequirement.new([md[:version]], comparator: md[:comparator])
+            MacOSRequirement.new([md[:version]], comparator: T.must(md[:comparator]))
           # This is not duplicate of the first case: see `args.first` and a different comparator.
           else # rubocop:disable Lint/DuplicateBranch
             MacOSRequirement.new([args.first], comparator: "==")

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -199,7 +199,7 @@ module Homebrew
         # to on_system blocks referencing macOS versions.
         os_values = []
         arch_values = depends_on_archs.presence || []
-        if cask.on_system_blocks_exist?
+        if cask.uses_on_system.present?
           OnSystem::BASE_OS_OPTIONS.each do |os|
             os_values << if os == :macos
               (current_os_is_macos ? current_os : newest_macos)
@@ -235,7 +235,7 @@ module Homebrew
             old_cask = begin
               Cask::CaskLoader.load(cask.sourcefile_path)
             rescue Cask::CaskInvalidError, Cask::CaskUnreadableError
-              raise unless cask.on_system_blocks_exist?
+              raise unless cask.uses_on_system.present?
             end
             next if old_cask.nil?
 
@@ -262,7 +262,7 @@ module Homebrew
               replacement_pairs << [/"#{old_hash}"/, ":no_check"] if old_hash != :no_check
             elsif old_hash == :no_check && new_hash != :no_check
               replacement_pairs << [":no_check", "\"#{new_hash}\""] if new_hash.is_a?(String)
-            elsif new_hash && !cask.on_system_blocks_exist? && cask.languages.empty?
+            elsif new_hash && cask.uses_on_system.blank? && cask.languages.empty?
               replacement_pairs << [old_hash.to_s, new_hash.to_s]
             elsif old_hash != :no_check
               opoo "Multiple checksum replacements required; ignoring specified `--sha256` argument." if new_hash

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -305,7 +305,7 @@ module Homebrew
         ).returns(VersionBumpInfo)
       }
       def retrieve_versions_by_arch(formula_or_cask:, repositories:, name:)
-        is_cask_with_blocks = formula_or_cask.is_a?(Cask::Cask) && formula_or_cask.on_system_blocks_exist?
+        is_cask_with_blocks = formula_or_cask.is_a?(Cask::Cask) && formula_or_cask.uses_on_system.present?
         type, version_name = if formula_or_cask.is_a?(Formula)
           [:formula, "formula version:"]
         else

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -1,20 +1,26 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "simulate_system"
 
 module OnSystem
-  ARCH_OPTIONS = [:intel, :arm].freeze
-  BASE_OS_OPTIONS = [:macos, :linux].freeze
-  ALL_OS_OPTIONS = [*MacOSVersion::SYMBOLS.keys, :linux].freeze
-  ALL_OS_ARCH_COMBINATIONS = ALL_OS_OPTIONS.product(ARCH_OPTIONS).freeze
+  ARCH_OPTIONS = T.let([:intel, :arm].freeze, T::Array[Symbol])
+  BASE_OS_OPTIONS = T.let([:macos, :linux].freeze, T::Array[Symbol])
+  ALL_OS_OPTIONS = T.let([*MacOSVersion::SYMBOLS.keys, :linux].freeze, T::Array[Symbol])
+  ALL_OS_ARCH_COMBINATIONS = T.let(
+    ALL_OS_OPTIONS.product(ARCH_OPTIONS).freeze,
+    T::Array[[Symbol, Symbol]],
+  )
 
-  VALID_OS_ARCH_TAGS = ALL_OS_ARCH_COMBINATIONS.filter_map do |os, arch|
-    tag = Utils::Bottles::Tag.new(system: os, arch:)
-    next unless tag.valid_combination?
+  VALID_OS_ARCH_TAGS = T.let(
+    ALL_OS_ARCH_COMBINATIONS.filter_map do |os, arch|
+      tag = Utils::Bottles::Tag.new(system: os, arch:)
+      next unless tag.valid_combination?
 
-    tag
-  end.freeze
+      tag
+    end.freeze,
+    T::Array[Utils::Bottles::Tag],
+  )
 
   sig { params(arch: Symbol).returns(T::Boolean) }
   def self.arch_condition_met?(arch)
@@ -55,15 +61,15 @@ module OnSystem
     method_name.to_s.sub(/^on_/, "").to_sym
   end
 
-  sig { params(base: Class).void }
+  sig { params(base: T::Class[T.anything]).void }
   def self.setup_arch_methods(base)
     ARCH_OPTIONS.each do |arch|
       base.define_method(:"on_#{arch}") do |&block|
-        @on_system_blocks_exist = true
+        @on_system_blocks_exist = T.let(true, T.nilable(T::Boolean))
 
         return unless OnSystem.arch_condition_met? OnSystem.condition_from_method_name(T.must(__method__))
 
-        @called_in_on_system_block = true
+        @called_in_on_system_block = T.let(true, T.nilable(T::Boolean))
         result = block.call
         @called_in_on_system_block = false
 
@@ -82,7 +88,7 @@ module OnSystem
     end
   end
 
-  sig { params(base: Class).void }
+  sig { params(base: T::Class[T.anything]).void }
   def self.setup_base_os_methods(base)
     BASE_OS_OPTIONS.each do |base_os|
       base.define_method(:"on_#{base_os}") do |&block|
@@ -128,7 +134,7 @@ module OnSystem
     end
   end
 
-  sig { params(base: Class).void }
+  sig { params(base: T::Class[T.anything]).void }
   def self.setup_macos_methods(base)
     MacOSVersion::SYMBOLS.each_key do |os_name|
       base.define_method(:"on_#{os_name}") do |or_condition = nil, &block|
@@ -137,11 +143,14 @@ module OnSystem
         os_condition = OnSystem.condition_from_method_name T.must(__method__)
         return unless OnSystem.os_condition_met? os_condition, or_condition
 
-        @on_system_block_min_os = if or_condition == :or_older
-          @called_in_on_system_block ? @on_system_block_min_os : MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED)
-        else
-          MacOSVersion.from_symbol(os_condition)
-        end
+        @on_system_block_min_os = T.let(
+          if or_condition == :or_older
+            @called_in_on_system_block ? @on_system_block_min_os : MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED)
+          else
+            MacOSVersion.from_symbol(os_condition)
+          end,
+          T.nilable(MacOSVersion),
+        )
         @called_in_on_system_block = true
         result = block.call
         @called_in_on_system_block = false
@@ -151,13 +160,13 @@ module OnSystem
     end
   end
 
-  sig { params(_base: Class).void }
+  sig { params(_base: T::Class[T.anything]).void }
   def self.included(_base)
     raise "Do not include `OnSystem` directly. Instead, include `OnSystem::MacOSAndLinux` or `OnSystem::MacOSOnly`"
   end
 
   module MacOSAndLinux
-    sig { params(base: Class).void }
+    sig { params(base: T::Class[T.anything]).void }
     def self.included(base)
       OnSystem.setup_arch_methods(base)
       OnSystem.setup_base_os_methods(base)
@@ -166,7 +175,7 @@ module OnSystem
   end
 
   module MacOSOnly
-    sig { params(base: Class).void }
+    sig { params(base: T::Class[T.anything]).void }
     def self.included(base)
       OnSystem.setup_arch_methods(base)
       OnSystem.setup_macos_methods(base)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -270,7 +270,7 @@ class Formula
     @follow_installed_alias = T.let(true, T::Boolean)
     @prefix_returns_versioned_prefix = T.let(false, T.nilable(T::Boolean))
     @oldname_locks = T.let([], T::Array[FormulaLock])
-    @on_system_blocks_exist = T.let(false, T::Boolean)
+    @uses_on_system = T.let(OnSystem::UsesOnSystem.new, OnSystem::UsesOnSystem)
   end
 
   sig { params(spec_sym: Symbol).void }
@@ -2591,7 +2591,7 @@ class Formula
 
     variations = {}
 
-    if path.exist? && on_system_blocks_exist?
+    if path.exist? && uses_on_system.present?
       formula_contents = path.read
       OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
         Homebrew::SimulateSystem.with_tag(bottle_tag) do
@@ -2789,9 +2789,11 @@ class Formula
     end
   end
 
-  sig { returns(T.nilable(T::Boolean)) }
-  def on_system_blocks_exist?
-    self.class.on_system_blocks_exist? || @on_system_blocks_exist
+  # A `UsesOnSystem` object that contains boolean instance variables indicating
+  # whether the formula uses specific on_system methods.
+  sig { returns(OnSystem::UsesOnSystem) }
+  def uses_on_system
+    self.class.uses_on_system || @uses_on_system
   end
 
   sig {
@@ -3331,7 +3333,7 @@ class Formula
         @skip_clean_paths = T.let(Set.new, T.nilable(T::Set[T.any(String, Symbol)]))
         @link_overwrite_paths = T.let(Set.new, T.nilable(T::Set[String]))
         @loaded_from_api = T.let(false, T.nilable(T::Boolean))
-        @on_system_blocks_exist = T.let(false, T.nilable(T::Boolean))
+        @uses_on_system = T.let(OnSystem::UsesOnSystem.new, T.nilable(OnSystem::UsesOnSystem))
         @network_access_allowed = T.let(SUPPORTED_NETWORK_ACCESS_PHASES.to_h do |phase|
           [phase, DEFAULT_NETWORK_ACCESS_ALLOWED]
         end, T.nilable(T::Hash[Symbol, T::Boolean]))
@@ -3345,6 +3347,7 @@ class Formula
       @conflicts.freeze
       @skip_clean_paths.freeze
       @link_overwrite_paths.freeze
+      @uses_on_system.freeze
       super
     end
 
@@ -3355,10 +3358,10 @@ class Formula
     sig { returns(T::Boolean) }
     def loaded_from_api? = !!@loaded_from_api
 
-    # Whether this formula contains OS/arch-specific blocks
-    # (e.g. `on_macos`, `on_arm`, `on_monterey :or_older`, `on_system :linux, macos: :big_sur_or_newer`).
-    sig { returns(T::Boolean) }
-    def on_system_blocks_exist? = !!@on_system_blocks_exist
+    # A `UsesOnSystem` object that contains boolean instance variables
+    # indicating whether the formula uses specific on_system methods.
+    sig { returns(T.nilable(OnSystem::UsesOnSystem)) }
+    attr_reader :uses_on_system
 
     # The reason for why this software is not linked (by default) to {::HOMEBREW_PREFIX}.
     sig { returns(T.nilable(KegOnlyReason)) }

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -66,7 +66,7 @@ module Readall
       readall_formula = readall_formula_class.new(formula_name, file, :stable, tap:)
       readall_formula.to_hash
       # TODO: Remove check for MACOS_MODULE_REGEX once the `MacOS` module is undefined on Linux
-      cache[:valid_formulae][file] = if readall_formula.on_system_blocks_exist? ||
+      cache[:valid_formulae][file] = if readall_formula.uses_on_system.present? ||
                                         formula_contents.match?(MACOS_MODULE_REGEX)
         [bottle_tag, *cache[:valid_formulae][file]]
       else

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -90,7 +90,7 @@ module Readall
 
   sig {
     params(
-      tap: Tap, aliases: T::Boolean, no_simulate: T::Boolean, os_arch_combinations: T::Array[T::Array[String]],
+      tap: Tap, aliases: T::Boolean, no_simulate: T::Boolean, os_arch_combinations: T::Array[[Symbol, Symbol]],
     ).returns(T::Boolean)
   }
   def self.valid_tap?(tap, aliases: false, no_simulate: false,

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -88,6 +88,16 @@ class MacOSRequirement < Requirement
     end
   end
 
+  # Finds the highest supported {MacOSVersion} that meets the requirement, if
+  # any.
+  sig { returns(T.nilable(MacOSVersion)) }
+  def highest_allowed
+    MacOSVersion::SYMBOLS.each_key do |sym|
+      candidate_version = MacOSVersion.from_symbol(sym)
+      return candidate_version if allows?(candidate_version)
+    end
+  end
+
   def message(type: :formula)
     return "macOS is required for this software." unless version_specified?
 

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
@@ -153,9 +153,6 @@ class Cask::Cask
   sig { params(args: T.untyped, block: T.untyped).returns(T.nilable(MacOSVersion)) }
   def on_system_block_min_os(*args, &block); end
 
-  sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
-  def on_system_blocks_exist?(*args, &block); end
-
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def os(*args, &block); end
 
@@ -203,6 +200,9 @@ class Cask::Cask
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.nilable(::Cask::URL)) }
   def url(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def uses_on_system(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def version(*args, &block); end

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -855,6 +855,12 @@ RSpec.describe Cask::DSL, :cask do
       it "sets @uses_on_system.macos to true" do
         expect(cask.uses_on_system.macos?).to be true
       end
+
+      it "sets @uses_on_system.macos_requirements using macos argument" do
+        expect(cask.uses_on_system.macos_requirements).to eq(Set[
+          MacOSRequirement.new([:sequoia], comparator: ">="),
+        ])
+      end
     end
 
     context "when cask uses on_system_conditional" do
@@ -889,6 +895,14 @@ RSpec.describe Cask::DSL, :cask do
 
       it "sets @uses_on_system.macos to true" do
         expect(cask.uses_on_system.macos?).to be true
+      end
+
+      it "sets @uses_on_system.macos_requirements using on_* macos version conditions" do
+        expect(cask.uses_on_system.macos_requirements).to eq(Set[
+          MacOSRequirement.new([:big_sur], comparator: "<="),
+          MacOSRequirement.new([:monterey], comparator: "=="),
+          MacOSRequirement.new([:ventura], comparator: ">="),
+        ])
       end
     end
   end

--- a/Library/Homebrew/test/extend/on_system_spec.rb
+++ b/Library/Homebrew/test/extend/on_system_spec.rb
@@ -52,6 +52,24 @@ RSpec.describe OnSystem do
     end
   end
 
+  describe "::comparator_from_or_condition" do
+    it 'returns ">=" for `:or_newer` symbol' do
+      expect(described_class.comparator_from_or_condition(:or_newer)).to eq(">=")
+    end
+
+    it 'returns "<=" for `:or_older` symbol' do
+      expect(described_class.comparator_from_or_condition(:or_older)).to eq("<=")
+    end
+
+    it 'returns "==" for an unsupported symbol' do
+      expect(described_class.comparator_from_or_condition(:nonexistent)).to eq("==")
+    end
+
+    it 'returns "==" for `nil`' do
+      expect(described_class.comparator_from_or_condition(nil)).to eq("==")
+    end
+  end
+
   describe "::arch_condition_met?" do
     it "returns true if current arch equals provided arch" do
       Homebrew::SimulateSystem.with(arch: :arm) do

--- a/Library/Homebrew/test/extend/on_system_spec.rb
+++ b/Library/Homebrew/test/extend/on_system_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "extend/on_system"
+
+RSpec.describe OnSystem do
+  shared_examples "a class with on_arch methods" do
+    it "adds on_arch methods to class for `ARCH_OPTIONS`" do
+      OnSystem::ARCH_OPTIONS.each do |arch|
+        expect(subject.method_defined?(:"on_#{arch}")).to be true
+      end
+    end
+  end
+
+  shared_examples "a class with on_base_os methods" do
+    it "adds on_os methods to class for `BASE_OS_OPTIONS`" do
+      OnSystem::BASE_OS_OPTIONS.each do |os|
+        expect(subject.method_defined?(:"on_#{os}")).to be true
+      end
+    end
+  end
+
+  shared_examples "a class with on_macos methods" do
+    it "adds on_os methods to class for `MacOSVersion::SYMBOLS` keys" do
+      MacOSVersion::SYMBOLS.each_key do |os|
+        expect(subject.method_defined?(:"on_#{os}")).to be true
+      end
+    end
+  end
+
+  describe "::arch_condition_met?" do
+    it "returns true if current arch equals provided arch" do
+      Homebrew::SimulateSystem.with(arch: :arm) do
+        expect(described_class.arch_condition_met?(:arm)).to be true
+      end
+    end
+
+    it "returns false if current arch does not equal provided arch" do
+      Homebrew::SimulateSystem.with(arch: :arm) do
+        expect(described_class.arch_condition_met?(:intel)).to be false
+      end
+    end
+
+    it "raises error if provided arch is not valid" do
+      expect { described_class.arch_condition_met?(:nonexistent_arch) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe "::os_condition_met?" do
+    let(:newest_macos) { MacOSVersion::SYMBOLS.keys.first }
+
+    it "returns result of `SimulateSystem.simulating_or_running_on_<os_name>` for supported OS" do
+      Homebrew::SimulateSystem.with(os: newest_macos) do
+        # This needs to use a value from `BASE_OS_OPTIONS`
+        expect(described_class.os_condition_met?(:macos)).to be true
+      end
+    end
+
+    it "returns false if `os_name` is a macOS version but OS is Linux" do
+      Homebrew::SimulateSystem.with(os: :linux) do
+        expect(described_class.os_condition_met?(newest_macos)).to be false
+      end
+    end
+
+    it "returns false if current OS is `:macos` and `os_name` is a macOS version" do
+      # A generic macOS version is treated as less than any other version.
+      Homebrew::SimulateSystem.with(os: :macos) do
+        expect(described_class.os_condition_met?(newest_macos)).to be false
+      end
+    end
+
+    it "returns true if current OS equals the `os_name` macOS version" do
+      Homebrew::SimulateSystem.with(os: newest_macos) do
+        expect(described_class.os_condition_met?(newest_macos)).to be true
+      end
+    end
+
+    it "returns true if current OS meets the `or_condition` for `os_name` macOS version" do
+      current_os = :ventura
+      Homebrew::SimulateSystem.with(os: current_os) do
+        expect(described_class.os_condition_met?(current_os, :or_newer)).to be true
+        expect(described_class.os_condition_met?(:big_sur, :or_newer)).to be true
+        expect(described_class.os_condition_met?(current_os, :or_older)).to be true
+        expect(described_class.os_condition_met?(newest_macos, :or_older)).to be true
+      end
+    end
+
+    it "returns false if current OS does not meet the `or_condition` for `os_name` macOS version" do
+      Homebrew::SimulateSystem.with(os: :ventura) do
+        expect(described_class.os_condition_met?(newest_macos, :or_newer)).to be false
+        expect(described_class.os_condition_met?(:big_sur, :or_older)).to be false
+      end
+    end
+
+    it "raises an error if `os_name` is not valid" do
+      expect { described_class.os_condition_met?(:nonexistent_os) }
+        .to raise_error(ArgumentError, /Invalid OS condition:/)
+    end
+
+    it "raises an error if `os_name` is a macOS version but `or_condition` is not valid" do
+      expect do
+        described_class.os_condition_met?(newest_macos, :nonexistent_condition)
+      end.to raise_error(ArgumentError, /Invalid OS `or_\*` condition:/)
+    end
+  end
+
+  describe "::condition_from_method_name" do
+    it "returns a symbol with any `on_` prefix removed" do
+      expect(described_class.condition_from_method_name(:on_arm)).to eq(:arm)
+    end
+
+    it "returns provided symbol if there is no `on_` prefix" do
+      expect(described_class.condition_from_method_name(:arm)).to eq(:arm)
+    end
+  end
+
+  describe "::setup_arch_methods" do
+    subject do
+      klass = Class.new
+      described_class.setup_arch_methods(klass)
+      klass
+    end
+
+    it_behaves_like "a class with on_arch methods"
+  end
+
+  describe "::setup_base_os_methods" do
+    subject do
+      klass = Class.new
+      described_class.setup_base_os_methods(klass)
+      klass
+    end
+
+    it_behaves_like "a class with on_base_os methods"
+  end
+
+  describe "::setup_macos_methods" do
+    subject do
+      klass = Class.new
+      described_class.setup_macos_methods(klass)
+      klass
+    end
+
+    it_behaves_like "a class with on_macos methods"
+  end
+
+  describe "::included" do
+    it "raises an error" do
+      expect { Class.new { include OnSystem } }
+        .to raise_error(/Do not include `OnSystem` directly/)
+    end
+  end
+
+  describe "::MacOSAndLinux" do
+    subject { Class.new { include OnSystem::MacOSAndLinux } }
+
+    it "can be included" do
+      expect { Class.new { include OnSystem::MacOSAndLinux } }.not_to raise_error
+    end
+
+    it_behaves_like "a class with on_arch methods"
+    it_behaves_like "a class with on_base_os methods"
+    it_behaves_like "a class with on_macos methods"
+  end
+
+  describe "::MacOSOnly" do
+    subject { Class.new { include OnSystem::MacOSAndLinux } }
+
+    it "can be included" do
+      expect { Class.new { include OnSystem::MacOSOnly } }.not_to raise_error
+    end
+
+    it_behaves_like "a class with on_arch methods"
+    it_behaves_like "a class with on_macos methods"
+  end
+end

--- a/Library/Homebrew/test/extend/on_system_spec.rb
+++ b/Library/Homebrew/test/extend/on_system_spec.rb
@@ -27,6 +27,31 @@ RSpec.describe OnSystem do
     end
   end
 
+  describe "UsesOnSystem" do
+    uses_on_system_empty = described_class::UsesOnSystem.new
+    uses_on_system_present = described_class::UsesOnSystem.new(arm: true)
+
+    describe "#empty?" do
+      it "returns true if all properties are default values" do
+        expect(uses_on_system_empty.empty?).to be true
+      end
+
+      it "returns false if any properties have a non-default value" do
+        expect(uses_on_system_present.empty?).to be false
+      end
+    end
+
+    describe "#present?" do
+      it "returns true if object is not empty" do
+        expect(uses_on_system_present.present?).to be true
+      end
+
+      it "returns false if object is empty" do
+        expect(uses_on_system_empty.present?).to be false
+      end
+    end
+  end
+
   describe "::arch_condition_met?" do
     it "returns true if current arch equals provided arch" do
       Homebrew::SimulateSystem.with(arch: :arm) do

--- a/Library/Homebrew/test/extend/on_system_spec.rb
+++ b/Library/Homebrew/test/extend/on_system_spec.rb
@@ -105,6 +105,11 @@ RSpec.describe OnSystem do
       end
     end
 
+    it "returns false if `os_name` is a macOS version but current OS is `:generic`" do
+      allow(Homebrew::SimulateSystem).to receive(:current_os).and_return(:generic)
+      expect(described_class.os_condition_met?(newest_macos)).to be false
+    end
+
     it "returns false if current OS is `:macos` and `os_name` is a macOS version" do
       # A generic macOS version is treated as less than any other version.
       Homebrew::SimulateSystem.with(os: :macos) do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -2073,6 +2073,12 @@ RSpec.describe Formula do
       it "sets @uses_on_system.macos to true" do
         expect(f_on_system.uses_on_system.macos?).to be true
       end
+
+      it "sets @uses_on_system.macos_requirements using macos argument" do
+        expect(f_on_system.uses_on_system.macos_requirements).to eq(Set[
+          MacOSRequirement.new([:sequoia], comparator: ">="),
+        ])
+      end
     end
 
     context "when formula uses on_system_conditional" do
@@ -2130,6 +2136,14 @@ RSpec.describe Formula do
 
       it "sets @uses_on_system.macos to true" do
         expect(f_on_macos_versions.uses_on_system.macos?).to be true
+      end
+
+      it "sets @uses_on_system.macos_requirements using on_* macos version conditions" do
+        expect(f_on_macos_versions.uses_on_system.macos_requirements).to eq(Set[
+          MacOSRequirement.new([:big_sur], comparator: "<="),
+          MacOSRequirement.new([:monterey], comparator: "=="),
+          MacOSRequirement.new([:ventura], comparator: ">="),
+        ])
       end
     end
   end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1951,6 +1951,189 @@ RSpec.describe Formula do
     end
   end
 
+  describe "#uses_on_system" do
+    # These formula definitions use a different way of creating the formula,
+    # as the `Class.new` approach doesn't seem to work as expected for
+    # `uses_on_system`.
+    context "when formula uses on_arm" do
+      let(:f_on_arm) do
+        formula("on-arm") do
+          on_arm do
+            url "https://brew.sh/foo-1.0-arm.tar.gz"
+          end
+
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      end
+
+      it "sets @uses_on_system.arm to true" do
+        expect(f_on_arm.uses_on_system.arm?).to be true
+      end
+    end
+
+    context "when formula uses on_intel" do
+      let(:f_on_intel) do
+        formula("on-intel") do
+          on_intel do
+            url "https://brew.sh/foo-1.0-arm.tar.gz"
+          end
+
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      end
+
+      it "sets @uses_on_system.intel to true" do
+        expect(f_on_intel.uses_on_system.intel?).to be true
+      end
+    end
+
+    context "when formula uses on_arch_conditional" do
+      let(:f_on_arch_conditional) do
+        formula("on-arch-conditional") do
+          folder = on_arch_conditional arm: "arm/", intel: "intel/"
+
+          url "https://brew.sh/#{folder}foo-1.0.tar.gz"
+        end
+      end
+      let(:f_on_arch_conditional_no_args) do
+        formula("on-arch-conditional-no-args") do
+          folder = on_arch_conditional
+
+          url "https://brew.sh/#{folder}foo-1.0.tar.gz"
+        end
+      end
+
+      context "when arm argument is provided" do
+        it "sets @uses_on_system.arm to true" do
+          expect(f_on_arch_conditional.uses_on_system.arm?).to be true
+        end
+      end
+
+      context "when intel argument is provided" do
+        it "sets @uses_on_system.intel to true" do
+          expect(f_on_arch_conditional.uses_on_system.intel?).to be true
+        end
+      end
+
+      context "when no arguments are provided" do
+        it "doesn't set @uses_on_system.arm or .intel to true" do
+          expect(f_on_arch_conditional_no_args.uses_on_system.arm?).to be false
+          expect(f_on_arch_conditional_no_args.uses_on_system.intel?).to be false
+        end
+      end
+    end
+
+    context "when formula uses on_linux" do
+      let(:f_on_linux) do
+        formula("on-linux") do
+          on_linux do
+            url "https://brew.sh/foo-1.0-linux.tar.gz"
+          end
+
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      end
+
+      it "sets @uses_on_system.linux to true" do
+        expect(f_on_linux.uses_on_system.linux?).to be true
+      end
+    end
+
+    context "when formula uses on_macos" do
+      let(:f_on_macos) do
+        formula("on-macos") do
+          on_macos do
+            url "https://brew.sh/foo-1.0-macos.tar.gz"
+          end
+
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      end
+
+      it "sets @uses_on_system.macos to true" do
+        expect(f_on_macos.uses_on_system.macos?).to be true
+      end
+    end
+
+    context "when formula uses on_system" do
+      let(:f_on_system) do
+        formula("on-system") do
+          on_system :linux, macos: :sequoia_or_newer do
+            url "https://brew.sh/foo-1.0-new.tar.gz"
+          end
+
+          url "https://brew.sh/foo-1.0.tar.gz"
+        end
+      end
+
+      it "sets @uses_on_system.linux to true" do
+        expect(f_on_system.uses_on_system.linux?).to be true
+      end
+
+      it "sets @uses_on_system.macos to true" do
+        expect(f_on_system.uses_on_system.macos?).to be true
+      end
+    end
+
+    context "when formula uses on_system_conditional" do
+      let(:f_on_system_conditional) do
+        formula("on-system-conditional") do
+          folder = on_system_conditional linux: "linux/", macos: "macos/"
+
+          url "https://brew.sh/#{folder}foo-1.0.tar.gz"
+        end
+      end
+      let(:f_on_system_conditional_no_args) do
+        formula("on-system-conditional-no-args") do
+          folder = on_system_conditional
+
+          url "https://brew.sh/#{folder}foo-1.0.tar.gz"
+        end
+      end
+
+      context "when linux argument is provided" do
+        it "sets @uses_on_system.linux to true" do
+          expect(f_on_system_conditional.uses_on_system.linux?).to be true
+        end
+      end
+
+      context "when macos argument is provided" do
+        it "sets @uses_on_system.macos to true" do
+          expect(f_on_system_conditional.uses_on_system.macos?).to be true
+        end
+      end
+
+      context "when no arguments are provided" do
+        it "doesn't set @uses_on_system.linux or .macos to true" do
+          expect(f_on_system_conditional_no_args.uses_on_system.linux?).to be false
+          expect(f_on_system_conditional_no_args.uses_on_system.macos?).to be false
+        end
+      end
+    end
+
+    context "when formula uses on_* macos version methods" do
+      let(:f_on_macos_versions) do
+        formula("on-macos-versions") do
+          url "https://brew.sh/foo-1.0.tar.gz"
+
+          on_big_sur :or_older do
+            depends_on "abc"
+          end
+          on_monterey do
+            depends_on "def"
+          end
+          on_ventura :or_newer do
+            depends_on "ghi"
+          end
+        end
+      end
+
+      it "sets @uses_on_system.macos to true" do
+        expect(f_on_macos_versions.uses_on_system.macos?).to be true
+      end
+    end
+  end
+
   describe "#network_access_allowed?" do
     it "throws an error when passed an invalid symbol" do
       f = Testball.new

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe MacOSRequirement do
 
   let(:macos_oldest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED) }
   let(:macos_newest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED) }
+  let(:macos_newest_supported) { MacOSVersion.new(MacOSVersion::SYMBOLS.values.first) }
   let(:big_sur_major) { MacOSVersion.new("11.0") }
 
   describe "#satisfied?" do
@@ -62,5 +63,20 @@ RSpec.describe MacOSRequirement do
     expect(min_requirement.allows?(big_sur_major)).to be true
     expect(exact_requirement.allows?(big_sur_major)).to be true
     expect(range_requirement.allows?(big_sur_major)).to be true
+  end
+
+  specify "#highest_allowed" do
+    macos_version_sonoma = MacOSVersion.new("14")
+
+    no_requirement = described_class.new
+    max_requirement = described_class.new([:sonoma], comparator: "<=")
+    min_requirement = described_class.new([:sonoma], comparator: ">=")
+    exact_requirement = described_class.new([:sonoma], comparator: "==")
+    range_requirement = described_class.new([[:sonoma, :monterey]], comparator: "==")
+    expect(no_requirement.highest_allowed).to eq macos_newest_supported
+    expect(max_requirement.highest_allowed).to eq macos_version_sonoma
+    expect(min_requirement.highest_allowed).to eq macos_newest_supported
+    expect(exact_requirement.highest_allowed).to eq macos_version_sonoma
+    expect(range_requirement.highest_allowed).to eq macos_version_sonoma
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/arch-intel-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/arch-intel-only.rb
@@ -1,0 +1,11 @@
+cask "arch-intel-only" do
+  arch intel: "-intel"
+
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine#{arch}.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-os.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-os.rb
@@ -1,0 +1,12 @@
+cask "invalid-two-os" do
+  os linux: "linux", macos: "darwin"
+  os linux: "linux2", macos: "darwin2"
+
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/os-linux-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/os-linux-only.rb
@@ -1,0 +1,11 @@
+cask "os-linux-only" do
+  os linux: "-linux"
+
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine#{os}.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/os-macos-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/os-macos-only.rb
@@ -1,0 +1,11 @@
+cask "os-macos-only" do
+  os macos: "-darwin"
+
+  version "1.2.3"
+  sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine#{os}.zip"
+  homepage "https://brew.sh/"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-arch-blocks.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-arch-blocks.rb
@@ -1,0 +1,15 @@
+cask "with-on-arch-blocks" do
+  on_arm do
+    version "1.2.4"
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_intel do
+    version "1.2.3"
+    sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+  end
+
+  url "https://brew.sh/TestCask-#{version}.dmg"
+  homepage "https://brew.sh/"
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-arch-conditional-no-args.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-arch-conditional-no-args.rb
@@ -1,0 +1,8 @@
+cask "with-on-arch-conditional-no-args" do
+  folder = on_arch_conditional
+
+  url "https://brew.sh/#{folder}TestCask-#{version}.dmg"
+  homepage "https://brew.sh/"
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-arch-conditional.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-arch-conditional.rb
@@ -1,0 +1,8 @@
+cask "with-on-arch-conditional" do
+  folder = on_arch_conditional arm: "arm-dir/", intel: "intel-dir/"
+
+  url "https://brew.sh/#{folder}TestCask-#{version}.dmg"
+  homepage "https://brew.sh/"
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-macos-version-blocks.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-macos-version-blocks.rb
@@ -1,0 +1,19 @@
+cask "with-on-macos-version-blocks" do
+  on_big_sur :or_older do
+    version "1.2.3"
+    sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+  end
+  on_monterey do
+    version "1.2.4"
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_ventura :or_newer do
+    version "1.2.5"
+    sha256 "306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb"
+  end
+
+  url "https://brew.sh/TestCask-#{version}.dmg"
+  homepage "https://brew.sh/"
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-os-blocks.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-os-blocks.rb
@@ -1,0 +1,15 @@
+cask "with-on-os-blocks" do
+  on_linux do
+    version "1.2.3"
+    sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+  end
+  on_macos do
+    version "1.2.4"
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+
+  url "https://brew.sh/TestCask-#{version}.zip"
+  homepage "https://brew.sh/"
+
+  binary "testcask"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-system-blocks.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-system-blocks.rb
@@ -1,0 +1,11 @@
+cask "with-on-system-blocks" do
+  on_system :linux, macos: :sequoia_or_newer do
+    version "1.2.4"
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+
+  url "https://brew.sh/TestCask-#{version}.dmg"
+  homepage "https://brew.sh/"
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-system-conditional-no-args.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-system-conditional-no-args.rb
@@ -1,0 +1,8 @@
+cask "with-on-system-conditional-no-args" do
+  folder = on_system_conditional
+
+  url "https://brew.sh/#{folder}TestCask-#{version}.dmg"
+  homepage "https://brew.sh/"
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-system-conditional.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-on-system-conditional.rb
@@ -1,0 +1,8 @@
+cask "with-on-system-conditional" do
+  folder = on_system_conditional linux: "linux-dir/", macos: "macos-dir/"
+
+  url "https://brew.sh/#{folder}TestCask-#{version}.dmg"
+  homepage "https://brew.sh/"
+
+  app "TestCask.app"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a `UsesOnSystem` class to `OnSystem`, containing boolean instance variables to indicate which types of on_system methods are used in a formula or cask. This is intended as a replacement for `@on_system_blocks_exist`, which doesn't allow us to determine what kinds of on_system calls were used. This provides more granularity but we can still use `@uses_on_system.present?` to determine whether any on_system calls were used (and this doubles as a `nil` check in `Formula`, as the `self.class` instance variable has to use a nilable type).

The `UsesOnSystem` instance variables cover the current `ARCH_OPTIONS` and `BASE_OS_OPTIONS`. `UsesOnSystem` also provides a `macos_requirements` set, which is used to keep track of macOS requirements that are specified in `on_system` and `on_<macos_version>` method calls (e.g., `on_system :linux, macos: :ventura_or_newer`, `on_monterey :or_older`, `on_ventura`, `on_sonoma :or_newer`). This can be used to identify macOS dependency variations in a way that doesn't require simulating different OSs when loading the package.

As a practical example, if you wanted to determine whether a cask uses Linux on_system calls, you can call `cask.uses_on_system.linux?`. The `linux` boolean will be `true` if the cask has an `on_linux` block, an `on_system` block (which requires Linux), or uses `os linux: ...`. This is something that would be challenging to determine from outside of `OnSystem` but it's relatively easy to collect the information in `OnSystem` methods and make it available like this.

-----

Edit: I resolved the `Method uses_on_system does not exist on Cask::Cask` error by running `brew typecheck --update` and committing the RBI change (it suddenly occurred to me while I was doing something completely unrelated 😆).