### PR TITLE
fix: Don't invalidate the cached location if the response is a redirect

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -486,10 +486,10 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         # The cached location is no longer fresh if either:
         # - Last-Modified value is newer than the file's timestamp
         # - Content-Length value is different than the file's size
-        cached_location_valid = if cached_location_valid
+        if cached_location_valid && !is_redirection
           newer_last_modified = last_modified && last_modified > cached_location.mtime
           different_file_size = file_size&.nonzero? && file_size != cached_location.size
-          !(newer_last_modified || different_file_size)
+          cached_location_valid = !(newer_last_modified || different_file_size)
         end
 
         if cached_location_valid


### PR DESCRIPTION
A bug introduced with #19460 is that if a redirection has a file size (for example, if it is a 302 that also has HTML content), Homebrew will invalidate the cached location.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
