### PR TITLE
docs: fix Formula Cookbook build command

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -95,7 +95,7 @@ Check out the [License Guidelines](License-Guidelines.md) for examples of comple
 ### Check the build system
 
 ```sh
-HOMEBREW_NO_INSTALL_FROM_API=1 brew install --interactive foo
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --interactive foo
 ```
 
 You’re now at a new prompt with the tarball extracted to a temporary sandbox.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I am following the Formula Cookbook at https://docs.brew.sh/Formula-Cookbook#check-the-build-system but the "Check the build system" step did not run:

```
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --interactive spacetimedb
Error: spacetimedb: no bottle available!
If you're feeling brave, you can try to install from source with:
  brew install --build-from-source spacetimedb

This is a Tier 3 configuration:
  https://docs.brew.sh/Support-Tiers#tier-3
Do not report any issues to Homebrew/* repositories!
Read the above document instead before opening any issues or PRs.
```

It believe it is simply missing the `--build-from-source` flag, unless that should be implicit with `--interactive`?
