### PR TITLE
cmd/upgrade: fix output regex in test

### DIFF
--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -54,19 +54,11 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
 
     regex = /
       Formulae\s*\(3\):\s*
-      (
-        testball|testball5|testball4
-      )
+      (testball|testball5|testball4)
       \s*,\s*
-      (?!\1)
-      (
-        testball|testball5|testball4
-      )
+      ((?!\1)testball|testball5|testball4)
       \s*,\s*
-      (?!\1|\2)
-      (
-        testball|testball5|testball4
-      )
+      ((?!\1|\2)testball|testball5|testball4)
     /x
     expect do
       brew "upgrade", "--ask"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The "upgrades with asking for user prompts with dependants checks" test for `cmd/upgrade` has been failing on CI. The regex in the test doesn't match expected output because the negative lookaheads aren't working as expected. The intention is to make sure that the names aren't repeated (i.e., second shouldn't match first, third shouldn't match first or second) but the negative lookaheads should be _inside_ the second/third capture groups for this to work as intended.

This updated regex should work as expected. I manually tested it using the output from CI to make sure that it matches when no formula names are repeated (e.g., `Formulae (3): testball, testball4, testball5`) and does not match if formula names are repeated (e.g., `Formulae (3): testball5, testball4, testball5`).