### PR TITLE
dev-cmd/vendor-gems: fix incorrect Bundler version being used

### DIFF
--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -28,6 +28,7 @@ module Homebrew
         Homebrew.install_bundler!
 
         ENV["BUNDLE_WITH"] = Homebrew.valid_gem_groups.join(":")
+        ENV["BUNDLER_VERSION"] = HOMEBREW_BUNDLER_VERSION
 
         ohai "cd #{HOMEBREW_LIBRARY_PATH}"
         HOMEBREW_LIBRARY_PATH.cd do


### PR DESCRIPTION
Spotted in #19727.