### PR TITLE
bundle/commands/exec: add missing require.

### DIFF
--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -1,6 +1,7 @@
 # typed: false # rubocop:todo Sorbet/TrueSigil
 # frozen_string_literal: true
 
+require "English"
 require "exceptions"
 require "extend/ENV"
 require "utils"


### PR DESCRIPTION
This should fix the flaky test failures in `exec_spec.rb`.