### PR TITLE
workflows/tests: drop macOS 13 tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -257,9 +257,6 @@ jobs:
             test-flags: --coverage
             runs-on: ubuntu-latest
             container: ghcr.io/homebrew/ubuntu20.04:latest
-          - name: tests (macOS 13 x86_64)
-            test-flags: --coverage
-            runs-on: macos-13
           - name: tests (macOS 15 arm64)
             test-flags: --coverage
             runs-on: macos-15


### PR DESCRIPTION
These are almost 2x as slow as the next slowest tests and we'll be dropping them around September this year at the latest anyway.

There's still some basic coverage from the "default formula" tests which are much quicker to run on macOS 13.