### PR TITLE
dev-cmd/create: Handle nil stdin

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -240,8 +240,7 @@ module Homebrew
 
       sig { returns(T.nilable(String)) }
       def __gets
-        gots = $stdin.gets.chomp
-        gots.empty? ? nil : gots
+        $stdin.gets&.presence&.chomp
       end
     end
   end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Using `brew create` without providing a standard input results in an internal error being returned, since `nil` isn't handled - as reported in #19043.

## Command:

```shell
brew create --python https://files.pythonhosted.org/packages/e7/19/fad6f32d430ac1dc44d6cb49cd4245fdb51b840c338e092489463ba50635/baymesh-0.3.3.tar.gz --tap gtaylor/baymesh --verbose < /dev/null
```

## Before

```
Formula name [baymesh]: Error: undefined method `chomp' for nil
/opt/homebrew/Library/Homebrew/dev-cmd/create.rb:243:in `__gets'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/dev-cmd/create.rb:196:in `create_formula'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/dev-cmd/create.rb:76:in `run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11998/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:95:in `<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

## After

```
Formula name [baymesh]: Error: No available tap gtaylor/baymesh.
Run brew tap-new gtaylor/baymesh to create a new gtaylor/baymesh tap!
```