### PR TITLE
formula_cellar_checks: add no_cpuid_allowlist

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -320,6 +320,7 @@ module FormulaCellarChecks
     return unless dot_brew_formula.exist?
 
     return unless dot_brew_formula.read.include? "ENV.runtime_cpu_detection"
+    return if formula.tap&.audit_exception(:no_cpuid_allowlist, formula.name)
 
     # macOS `objdump` is a bit slow, so we prioritise llvm's `llvm-objdump` (~5.7x faster)
     # or binutils' `objdump` (~1.8x faster) if they are installed.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Sometimes the CPUID instruction exists in a dependency, e.g. `aws-checksums` performs CPU detection via `aws-c-common`.

Open to alternative names, e.g. `:missing_cpuid_allowlist`, `:no_cpuid_instruction_allowlist`, ...