### PR TITLE
test/dev-cmd/tap-new_spec: use `--no-git` to avoid auth prompt

### DIFF
--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Homebrew::DevCmd::TapNew do
     # To ensure that Utils::Git.setup_gpg! doesn't raise an error
     setup_test_formula "gnupg"
 
-    expect { brew "tap-new", "homebrew/foo", "--verbose" }
+    expect { brew "tap-new", "--no-git", "--verbose", "homebrew/foo" }
       .to be_a_success
       .and output(%r{homebrew/foo}).to_stdout
       .and not_to_output.to_stderr


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I keep getting 1Password prompts when running `brew tests`. This is because `brew tap-new` initializes a new git repo and tries to commit it. We only check for the presence of the generated files, so let's avoid the git operation.