### PR TITLE
global: mark `extend FileUtils` for dropping

### DIFF
--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -60,7 +60,11 @@ HOMEBREW_PULL_OR_COMMIT_URL_REGEX =
   %r[https://github\.com/([\w-]+)/([\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})]
 HOMEBREW_BOTTLES_EXTNAME_REGEX = /\.([a-z0-9_]+)\.bottle\.(?:(\d+)\.)?tar\.gz$/
 
+# odeprecated: remove this in next major/minor release
+require "fileutils"
+
 module Homebrew
+  # odeprecated: remove this in next major/minor release
   extend FileUtils
 
   DEFAULT_PREFIX = T.let(ENV.fetch("HOMEBREW_DEFAULT_PREFIX").freeze, String)


### PR DESCRIPTION
This errors in Ruby 3.4 due to a missing `require "fileutils"`.

So I guess we have two options:

* Add the require (safe)
* Drop the extend (as I think it's unneeded)

The latter is tempting as `brew tests` still passes with it dropped. It is however a breaking change for old-style commands that relied on this, so maybe a change best reserved for the next major/minor release where Ruby 3.4 will have minor breaking changes of its own.

This does not affect formulae - they continue to work as is.