### PR TITLE
standalone/init: enable more warnings for developers

### DIFF
--- a/Library/Homebrew/standalone/init.rb
+++ b/Library/Homebrew/standalone/init.rb
@@ -24,6 +24,13 @@ else
   vendored_versions.include?("#{ruby_major}.#{ruby_minor}")
 end.freeze
 
+# TODO(odeprecated): remove `respond_to?` check when required Ruby >= 3.4
+if ENV["HOMEBREW_DEVELOPER"] && Warning.respond_to?(:categories)
+  Warning.categories.each do |category|
+    Warning[category] = true
+  end
+end
+
 # Setup Homebrew::FastBootRequire for faster boot requires.
 # Inspired by https://github.com/Shopify/bootsnap/wiki/Bootlib::Require
 require "rbconfig"


### PR DESCRIPTION
Note: this only does anything on Ruby 3.4 or later as it relies on new API.