### PR TITLE
aliases: fix missing require with Ruby 3.4

### DIFF
--- a/Library/Homebrew/aliases/alias.rb
+++ b/Library/Homebrew/aliases/alias.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "fileutils"
+
 module Homebrew
   module Aliases
     class Alias


### PR DESCRIPTION
This one is only loaded when running `brew (un)alias`