### PR TITLE
services: fix FileUtils usage in Ruby 3.4

### DIFF
--- a/Library/Homebrew/services/cli.rb
+++ b/Library/Homebrew/services/cli.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "services/formula_wrapper"
+require "fileutils"
 
 module Homebrew
   module Services

--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -6,8 +6,6 @@ require_relative "system/systemctl"
 module Homebrew
   module Services
     module System
-      extend FileUtils
-
       # Path to launchctl binary.
       sig { returns(T.nilable(Pathname)) }
       def self.launchctl


### PR DESCRIPTION
Again should only be loaded with `brew services` is run.