### PR TITLE
cask/artifact/abstract_flight_block: fix warning in Ruby 3.4

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_flight_block.rb
+++ b/Library/Homebrew/cask/artifact/abstract_flight_block.rb
@@ -12,7 +12,7 @@ module Cask
       end
 
       def self.uninstall_dsl_key
-        dsl_key.to_s.prepend("uninstall_").to_sym
+        :"uninstall_#{dsl_key}"
       end
 
       attr_reader :directives


### PR DESCRIPTION
The existing line was overly complex anyway.