### PR TITLE
test/cask/dsl/container_spec: fix test failure with Ruby 3.4

### DIFF
--- a/Library/Homebrew/test/cask/dsl/container_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/container_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Cask::DSL::Container do
     let(:params) { { nested: "NestedApp.dmg", type: :naked } }
 
     it "returns the stringified attributes" do
-      expect(container.to_s).to eq('{:nested=>"NestedApp.dmg", :type=>:naked}')
+      expect(container.to_s).to eq(params.inspect)
     end
   end
 


### PR DESCRIPTION
After this everything should work.