### PR TITLE
workflows/docker: add retry to image push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -306,4 +306,13 @@ jobs:
             image_args+=("ghcr.io/homebrew/ubuntu${VERSION}@sha256:$(<"${RUNNER_TEMP}/digests/${VERSION}-arm64")")
           fi
 
-          docker buildx imagetools create "${tag_args[@]}" "${image_args[@]}"
+          attempts=0
+          until docker buildx imagetools create "${tag_args[@]}" "${image_args[@]}"; do
+            attempts=$((attempts + 1))
+            if [[ $attempts -ge 3 ]]; then
+              echo "[$(date -u)] ERROR: Failed after 3 attempts."
+              exit 1
+            fi
+            echo "Push failed (attempt $attempts). Retrying in $((attempts * 5)) seconds..."
+            sleep $((attempts * 5))
+          done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -310,9 +310,11 @@ jobs:
           until docker buildx imagetools create "${tag_args[@]}" "${image_args[@]}"; do
             attempts=$((attempts + 1))
             if [[ $attempts -ge 3 ]]; then
-              echo "[$(date -u)] ERROR: Failed after 3 attempts."
+              echo "[$(date -u)] ERROR: Failed after 3 attempts." >&2
               exit 1
             fi
-            echo "Push failed (attempt $attempts). Retrying in $((attempts * 5)) seconds..."
-            sleep $((attempts * 5))
+            delay=$((2 ** attempts))
+            if [[ $delay -gt 60 ]]; then delay=60; fi
+            echo "Push failed (attempt $attempts). Retrying in ${delay} seconds..."
+            sleep ${delay}
           done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -314,7 +314,7 @@ jobs:
               exit 1
             fi
             delay=$((2 ** attempts))
-            if [[ $delay -gt 60 ]]; then delay=60; fi
+            if [[ $delay -gt 15 ]]; then delay=15; fi
             echo "Push failed (attempt $attempts). Retrying in ${delay} seconds..."
             sleep ${delay}
           done


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We keep receiving `400 Bad request` when pushing images to Docker Hub. This PR adds a retry with exponential backoff.