### PR TITLE
fix: prevent Zsh crashes related to autocompletion

### DIFF
--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -238,12 +238,12 @@ module Homebrew
 
             options.delete(opt)
           end
-          args_options << "*::#{type}:#{ZSH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING[type]}"
+          args_options << "*:#{type}:#{ZSH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING[type]}"
         end
 
         if named_args_strings.any?
           args_options << "- subcommand"
-          args_options << "*::subcommand:(#{named_args_strings.join(" ")})"
+          args_options << "*:subcommand:(#{named_args_strings.join(" ")})"
         end
       end
 

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe Homebrew::Completions do
               '--quiet[Make some output more quiet]' \\
               '--verbose[Make some output more verbose]' \\
               - formula \\
-              '*::formula:__brew_formulae'
+              '*:formula:__brew_formulae'
           }
         COMPLETION
       end
@@ -357,10 +357,10 @@ RSpec.describe Homebrew::Completions do
       it "returns appropriate completion for a command with multiple named arg types" do
         completion = described_class.generate_zsh_subcommand_completion("livecheck")
         expect(completion).to match(
-          /'*::formula:__brew_formulae'/,
+          /'*:formula:__brew_formulae'/,
         )
         expect(completion).to match(
-          /'*::cask:__brew_casks'\n}$/,
+          /'*:cask:__brew_casks'\n}$/,
         )
       end
     end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -508,6 +508,7 @@ _brew_bump() {
   case "${cur}" in
     -*)
       __brewcomp "
+      --bump-synced
       --cask
       --debug
       --eval-all

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -399,6 +399,7 @@ __fish_brew_complete_arg 'bottle' -a '(__fish_brew_suggest_formulae_installed)'
 
 
 __fish_brew_complete_cmd 'bump' 'Displays out-of-date packages and the latest version available'
+__fish_brew_complete_arg 'bump' -l bump-synced -d 'Bump additional formulae marked as synced with the given formulae'
 __fish_brew_complete_arg 'bump' -l cask -d 'Check only casks'
 __fish_brew_complete_arg 'bump' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'bump' -l eval-all -d 'Evaluate all formulae and casks'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -288,10 +288,10 @@ _brew___cache() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Only show cache files for formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--build-from-source --force-bottle --bottle-tag --HEAD --formula)--cask[Only show cache files for casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew --caskroom
@@ -302,7 +302,7 @@ _brew___caskroom() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - cask \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew --cellar
@@ -313,7 +313,7 @@ _brew___cellar() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew --config
@@ -335,7 +335,7 @@ _brew___env() {
     '--shell[Generate a list of environment variables for the specified shell, or `--shell=auto` to detect the current shell]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew --prefix
@@ -348,7 +348,7 @@ _brew___prefix() {
     '(--installed)--unbrewed[List files in Homebrew'\''s prefix not installed by Homebrew]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew --repo
@@ -359,7 +359,7 @@ _brew___repo() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew --repository
@@ -370,7 +370,7 @@ _brew___repository() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew --version
@@ -433,10 +433,10 @@ _brew_abv() {
     '--verbose[Show more verbose analytics data for formula]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula --fetch-manifest)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew alias
@@ -457,7 +457,7 @@ _brew_analytics() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - subcommand \
-    '*::subcommand:(state on off regenerate-uuid)'
+    '*:subcommand:(state on off regenerate-uuid)'
 }
 
 # brew audit
@@ -489,10 +489,10 @@ _brew_audit() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew autoremove
@@ -526,14 +526,15 @@ _brew_bottle() {
     '--verbose[Make some output more verbose]' \
     '--write[Write changes to the formula file. A new commit will be generated unless `--no-commit` is passed]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - file \
-    '*::file:__brew_formulae_or_ruby_files'
+    '*:file:__brew_formulae_or_ruby_files'
 }
 
 # brew bump
 _brew_bump() {
   _arguments \
+    '--bump-synced[Bump additional formulae marked as synced with the given formulae]' \
     '--debug[Display any debugging information]' \
     '(--installed)--eval-all[Evaluate all formulae and casks]' \
     '--full-name[Print formulae/casks with fully-qualified names]' \
@@ -550,10 +551,10 @@ _brew_bump() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Check only formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Check only casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew bump-cask-pr
@@ -578,7 +579,7 @@ _brew_bump_cask_pr() {
     '(--version)--version-intel[Specify the new cask version for the Intel architecture]' \
     '--write-only[Make the expected file modifications without taking any Git actions]' \
     - cask \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew bump-formula-pr
@@ -610,7 +611,7 @@ _brew_bump_formula_pr() {
     '--version[Use the specified version to override the value parsed from the URL or tag. Note that `--version=0` can be used to delete an existing version override from a formula if it has become redundant]' \
     '(--dry-run)--write-only[Make the expected file modifications without taking any Git actions]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew bump-revision
@@ -625,7 +626,7 @@ _brew_bump_revision() {
     '--verbose[Make some output more verbose]' \
     '(--dry-run)--write-only[Make the expected file modifications without taking any Git actions]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew bump-unversioned-casks
@@ -639,9 +640,9 @@ _brew_bump_unversioned_casks() {
     '--state-file[File for caching state]' \
     '--verbose[Make some output more verbose]' \
     - cask \
-    '*::cask:__brew_casks' \
+    '*:cask:__brew_casks' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew bundle
@@ -672,7 +673,7 @@ _brew_bundle() {
     '--whalebrew[`list` or `dump` Whalebrew dependencies]' \
     '--zap[`cleanup` casks using the `zap` command instead of `uninstall`]' \
     - subcommand \
-    '*::subcommand:(install dump cleanup check exec list sh env edit)'
+    '*:subcommand:(install dump cleanup check exec list sh env edit)'
 }
 
 # brew casks
@@ -693,10 +694,10 @@ _brew_cat() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew cleanup
@@ -711,9 +712,9 @@ _brew_cleanup() {
     '--scrub[Scrub the cache, including downloads for even the latest versions. Note that downloads for any installed formulae or casks will still not be deleted. If you want to delete those too: `rm -rf "$(brew --cache)"`]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew command
@@ -724,7 +725,7 @@ _brew_command() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - command \
-    '*::command:__brew_commands'
+    '*:command:__brew_commands'
 }
 
 # brew commands
@@ -745,7 +746,7 @@ _brew_completions() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - subcommand \
-    '*::subcommand:(state link unlink)'
+    '*:subcommand:(state link unlink)'
 }
 
 # brew config
@@ -808,7 +809,7 @@ _brew_debugger() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - command \
-    '*::command:__brew_commands'
+    '*:command:__brew_commands'
 }
 
 # brew deps
@@ -841,10 +842,10 @@ _brew_deps() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew desc
@@ -860,10 +861,10 @@ _brew_desc() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew determine-test-runners
@@ -886,7 +887,7 @@ _brew_developer() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - subcommand \
-    '*::subcommand:(state on off)'
+    '*:subcommand:(state on off)'
 }
 
 # brew dispatch-build-bottle
@@ -907,7 +908,7 @@ _brew_dispatch_build_bottle() {
     '--verbose[Make some output more verbose]' \
     '--workflow[Dispatch specified workflow (default: `dispatch-build-bottle.yml`)]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew docs
@@ -929,7 +930,7 @@ _brew_doctor() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - diagnostic_check \
-    '*::diagnostic_check:__brew_diagnostic_checks'
+    '*:diagnostic_check:__brew_diagnostic_checks'
 }
 
 # brew dr
@@ -942,7 +943,7 @@ _brew_dr() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - diagnostic_check \
-    '*::diagnostic_check:__brew_diagnostic_checks'
+    '*:diagnostic_check:__brew_diagnostic_checks'
 }
 
 # brew edit
@@ -955,12 +956,12 @@ _brew_edit() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks' \
+    '*:cask:__brew_casks' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew environment
@@ -973,7 +974,7 @@ _brew_environment() {
     '--shell[Generate a list of environment variables for the specified shell, or `--shell=auto` to detect the current shell]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew extract
@@ -987,9 +988,9 @@ _brew_extract() {
     '--verbose[Make some output more verbose]' \
     '--version[Extract the specified version of formula instead of the most recent]' \
     - formula \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew fetch
@@ -1013,10 +1014,10 @@ _brew_fetch() {
     '--verbose[Do a verbose VCS checkout, if the URL represents a VCS. This is useful for seeing if an existing VCS cache has been updated]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--HEAD --deps -s --build-bottle --force-bottle --bottle-tag --formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew formula
@@ -1027,7 +1028,7 @@ _brew_formula() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew formula-analytics
@@ -1096,7 +1097,7 @@ _brew_generate_cask_ci_matrix() {
     '--verbose[Make some output more verbose]' \
     - cask \
     '(--url)--cask[Treat all named arguments as cask tokens]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew generate-formula-api
@@ -1129,7 +1130,7 @@ _brew_gist_logs() {
     '--verbose[Make some output more verbose]' \
     '--with-hostname[Include the hostname in the Gist]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew home
@@ -1141,10 +1142,10 @@ _brew_home() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew homepage
@@ -1156,10 +1157,10 @@ _brew_homepage() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew info
@@ -1180,10 +1181,10 @@ _brew_info() {
     '--verbose[Show more verbose analytics data for formula]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula --fetch-manifest)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew instal
@@ -1241,10 +1242,10 @@ _brew_instal() {
     '(--formula)--zap[For use with `brew reinstall --cask`. Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
     - formula \
     '(--casks --binaries --require-sha --quarantine --adopt --skip-cask-deps --zap --appdir --keyboard-layoutdir --colorpickerdir --prefpanedir --qlplugindir --mdimporterdir --dictionarydir --fontdir --servicedir --input-methoddir --internet-plugindir --audio-unit-plugindir --vst-plugindir --vst3-plugindir --screen-saverdir --language)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formulae --env --ignore-dependencies --only-dependencies --cc --build-from-source --force-bottle --include-test --HEAD --fetch-HEAD --keep-tmp --debug-symbols --build-bottle --skip-post-install --skip-link --as-dependency --bottle-arch --interactive --git --overwrite --ask)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew install
@@ -1302,10 +1303,10 @@ _brew_install() {
     '(--formula)--zap[For use with `brew reinstall --cask`. Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
     - formula \
     '(--casks --binaries --require-sha --quarantine --adopt --skip-cask-deps --zap --appdir --keyboard-layoutdir --colorpickerdir --prefpanedir --qlplugindir --mdimporterdir --dictionarydir --fontdir --servicedir --input-methoddir --internet-plugindir --audio-unit-plugindir --vst-plugindir --vst3-plugindir --screen-saverdir --language)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formulae --env --ignore-dependencies --only-dependencies --cc --build-from-source --force-bottle --include-test --HEAD --fetch-HEAD --keep-tmp --debug-symbols --build-bottle --skip-post-install --skip-link --as-dependency --bottle-arch --interactive --git --overwrite --ask)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew install-bundler-gems
@@ -1348,10 +1349,10 @@ _brew_lc() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask --extract-plist)--formula[Only check formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Only check casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew leaves
@@ -1377,7 +1378,7 @@ _brew_link() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew linkage
@@ -1392,7 +1393,7 @@ _brew_linkage() {
     '--test[Show only missing libraries and exit with a non-zero status if any missing libraries are found]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew list
@@ -1416,10 +1417,10 @@ _brew_list() {
     '(--versions --pinned --full-name)-t[Sort formulae and/or casks by time modified, listing most recently modified first. Has no effect when a formula or cask name is passed as an argument]' \
     - installed_formula \
     '(--cask)--formula[List only formulae, or treat all named arguments as formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula --pinned --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source)--cask[List only casks, or treat all named arguments as casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew livecheck
@@ -1440,10 +1441,10 @@ _brew_livecheck() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask --extract-plist)--formula[Only check formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Only check casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew ln
@@ -1458,7 +1459,7 @@ _brew_ln() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew log
@@ -1475,10 +1476,10 @@ _brew_log() {
     '(--max-count)-1[Print only one commit]' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew ls
@@ -1502,10 +1503,10 @@ _brew_ls() {
     '(--versions --pinned --full-name)-t[Sort formulae and/or casks by time modified, listing most recently modified first. Has no effect when a formula or cask name is passed as an argument]' \
     - installed_formula \
     '(--cask)--formula[List only formulae, or treat all named arguments as formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula --pinned --multiple --installed-on-request --installed-as-dependency --poured-from-bottle --built-from-source)--cask[List only casks, or treat all named arguments as casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew migrate
@@ -1519,10 +1520,10 @@ _brew_migrate() {
     '--verbose[Make some output more verbose]' \
     - installed_formula \
     '(--cask)--formula[Only migrate formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula)--cask[Only migrate casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew missing
@@ -1534,7 +1535,7 @@ _brew_missing() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew nodenv-sync
@@ -1558,7 +1559,7 @@ _brew_options() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew outdated
@@ -1575,10 +1576,10 @@ _brew_outdated() {
     '(--quiet --json)--verbose[Include detailed version information]' \
     - formula \
     '(--cask)--formula[List only outdated formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[List only outdated casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew pin
@@ -1589,7 +1590,7 @@ _brew_pin() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew post_install
@@ -1600,7 +1601,7 @@ _brew_post_install() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew postinstall
@@ -1611,7 +1612,7 @@ _brew_postinstall() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew pr-automerge
@@ -1701,7 +1702,7 @@ _brew_prof() {
     '--verbose[Make some output more verbose]' \
     '--vernier[Use `vernier` instead of `ruby-prof` (the default)]' \
     - command \
-    '*::command:__brew_commands'
+    '*:command:__brew_commands'
 }
 
 # brew pyenv-sync
@@ -1736,7 +1737,7 @@ _brew_readall() {
     '--syntax[Syntax-check all of Homebrew'\''s Ruby files (if no tap is passed)]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew reinstall
@@ -1781,10 +1782,10 @@ _brew_reinstall() {
     '(--formula)--zap[For use with `brew reinstall --cask`. Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
     - formula \
     '(--casks --binaries --require-sha --quarantine --adopt --skip-cask-deps --zap --appdir --keyboard-layoutdir --colorpickerdir --prefpanedir --qlplugindir --mdimporterdir --dictionarydir --fontdir --servicedir --input-methoddir --internet-plugindir --audio-unit-plugindir --vst-plugindir --vst3-plugindir --screen-saverdir --language)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formulae --build-from-source --interactive --force-bottle --keep-tmp --debug-symbols --git --ask)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew release
@@ -1810,10 +1811,10 @@ _brew_remove() {
     '(--formula)--zap[Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
     - installed_formula \
     '(--cask --zap)--formula[Treat all named arguments as formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew rm
@@ -1828,10 +1829,10 @@ _brew_rm() {
     '(--formula)--zap[Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
     - installed_formula \
     '(--cask --zap)--formula[Treat all named arguments as formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew rubocop
@@ -1853,7 +1854,7 @@ _brew_ruby() {
     '-e[Execute the given text string as a script]' \
     '-r[Load a library using `require`]' \
     - file \
-    '*::file:__brew_formulae_or_ruby_files'
+    '*:file:__brew_formulae_or_ruby_files'
 }
 
 # brew rubydoc
@@ -1906,7 +1907,7 @@ _brew_services() {
     '--sudo-service-user[When run as root on macOS, run the service(s) as this user]' \
     '--verbose[Make some output more verbose]' \
     - subcommand \
-    '*::subcommand:(list info run start stop kill restart cleanup)'
+    '*:subcommand:(list info run start stop kill restart cleanup)'
 }
 
 # brew setup-ruby
@@ -1917,7 +1918,7 @@ _brew_setup_ruby() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - command \
-    '*::command:__brew_commands'
+    '*:command:__brew_commands'
 }
 
 # brew sh
@@ -1930,7 +1931,7 @@ _brew_sh() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - file \
-    '*::file:__brew_formulae_or_ruby_files'
+    '*:file:__brew_formulae_or_ruby_files'
 }
 
 # brew shellenv
@@ -1954,15 +1955,15 @@ _brew_style() {
     '--reset-cache[Reset the RuboCop cache]' \
     '--verbose[Make some output more verbose]' \
     - file \
-    '*::file:__brew_formulae_or_ruby_files' \
+    '*:file:__brew_formulae_or_ruby_files' \
     - tap \
-    '*::tap:__brew_any_tap' \
+    '*:tap:__brew_any_tap' \
     - formula \
     '(--cask)--formula[Treat all named arguments as formulae]' \
-    '*::formula:__brew_formulae' \
+    '*:formula:__brew_formulae' \
     - cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::cask:__brew_casks'
+    '*:cask:__brew_casks'
 }
 
 # brew tab
@@ -1976,10 +1977,10 @@ _brew_tab() {
     '--verbose[Make some output more verbose]' \
     - installed_formula \
     '(--cask)--formula[Only mark formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula)--cask[Only mark casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew tap
@@ -1994,7 +1995,7 @@ _brew_tap() {
     '--repair[Add missing symlinks to tap manpages and shell completions. Correct git remote refs for any taps where upstream HEAD branch has been renamed]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew tap-info
@@ -2007,7 +2008,7 @@ _brew_tap_info() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew tap-new
@@ -2022,7 +2023,7 @@ _brew_tap_new() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew tc
@@ -2041,7 +2042,7 @@ _brew_tc() {
     '(--lsp)--update-all[Update all RBI files rather than just updated gems]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew test
@@ -2056,7 +2057,7 @@ _brew_test() {
     '--retry[Retry if a testing fails]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew tests
@@ -2092,7 +2093,7 @@ _brew_typecheck() {
     '(--lsp)--update-all[Update all RBI files rather than just updated gems]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew unalias
@@ -2117,7 +2118,7 @@ _brew_unbottled() {
     '(--dependents --lost)--total[Print the number of unbottled and total formulae]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew uninstal
@@ -2132,10 +2133,10 @@ _brew_uninstal() {
     '(--formula)--zap[Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
     - installed_formula \
     '(--cask --zap)--formula[Treat all named arguments as formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew uninstall
@@ -2150,10 +2151,10 @@ _brew_uninstall() {
     '(--formula)--zap[Remove all files associated with a cask. *May remove files which are shared between applications.*]' \
     - installed_formula \
     '(--cask --zap)--formula[Treat all named arguments as formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formula)--cask[Treat all named arguments as casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew unlink
@@ -2165,7 +2166,7 @@ _brew_unlink() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew unpack
@@ -2180,7 +2181,7 @@ _brew_unpack() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew unpin
@@ -2191,7 +2192,7 @@ _brew_unpin() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - installed_formula \
-    '*::installed_formula:__brew_installed_formulae'
+    '*:installed_formula:__brew_installed_formulae'
 }
 
 # brew untap
@@ -2203,7 +2204,7 @@ _brew_untap() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - tap \
-    '*::tap:__brew_any_tap'
+    '*:tap:__brew_any_tap'
 }
 
 # brew up
@@ -2274,7 +2275,7 @@ _brew_update_python_resources() {
     '--verbose[Make some output more verbose]' \
     '--version[Use the specified version when finding resources for formula. If no version is specified, the current version for formula will be used]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew update-report
@@ -2364,10 +2365,10 @@ _brew_upgrade() {
     '(--formula)--vst3-plugindir[Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)]' \
     - installed_formula \
     '(--casks --skip-cask-deps --greedy --greedy-latest --greedy-auto-updates --binaries --require-sha --quarantine --appdir --keyboard-layoutdir --colorpickerdir --prefpanedir --qlplugindir --mdimporterdir --dictionarydir --fontdir --servicedir --input-methoddir --internet-plugindir --audio-unit-plugindir --vst-plugindir --vst3-plugindir --screen-saverdir --language)--formula[Treat all named arguments as formulae. If no named arguments are specified, upgrade only outdated formulae]' \
-    '*::installed_formula:__brew_installed_formulae' \
+    '*:installed_formula:__brew_installed_formulae' \
     - installed_cask \
     '(--formulae --build-from-source --interactive --force-bottle --fetch-HEAD --keep-tmp --debug-symbols --overwrite --ask)--cask[Treat all named arguments as casks. If no named arguments are specified, upgrade only outdated casks]' \
-    '*::installed_cask:__brew_installed_casks'
+    '*:installed_cask:__brew_installed_casks'
 }
 
 # brew uses
@@ -2389,7 +2390,7 @@ _brew_uses() {
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask)--formula[Include only formulae]' \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # brew vendor-gems
@@ -2426,7 +2427,7 @@ _brew_verify() {
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - formula \
-    '*::formula:__brew_formulae'
+    '*:formula:__brew_formulae'
 }
 
 # The main completion function

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2136,6 +2136,10 @@ displays whether a pull request has been opened with the URL.
 
 : Letter or word that the list of package results should alphabetically follow.
 
+`--bump-synced`
+
+: Bump additional formulae marked as synced with the given formulae.
+
 ### `bump-cask-pr` \[*`options`*\] *`cask`*
 
 Create a pull request to update *`cask`* with a new version.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1342,6 +1342,9 @@ Open a pull request for the new version if none have been opened yet\.
 .TP
 \fB\-\-start\-with\fP
 Letter or word that the list of package results should alphabetically follow\.
+.TP
+\fB\-\-bump\-synced\fP
+Bump additional formulae marked as synced with the given formulae\.
 .SS "\fBbump\-cask\-pr\fP \fR[\fIoptions\fP] \fIcask\fP"
 Create a pull request to update \fIcask\fP with a new version\.
 .P


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
There is a problem where `_arguments` can take up all memory when trying to autocomplete an argument with `*::` syntax. It works well for lightweight functions with subcommand logic but may crash the current shell session if a function returns a lot of values (f.e. `brew formulae`).

Right now, you can crash zsh with any command that uses `__brew_formulae` **and** `__brew_casks` for autocompletion. Steps to reproduce: type `brew install --build-from-source --dry-run ^ aaaa` or something similar in the prompt, go back to `^`, remove the caret, and press tab.

It can be fixed if `*::` are replaced with `*:`. We do not use complex autocomplete logic for named arguments, and it should work a bit faster and more reliably for large lists of packages.

Thanks to @rgoldberg for reporting the issue ([Homebrew/discussions/6097](https://github.com/orgs/Homebrew/discussions/6097))