### PR TITLE
Cask::DSL: define instance variables in initialize

### DIFF
--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -82,6 +82,12 @@ module Cask
 
         @arch.concat(arches.map { |arch| VALID_ARCHES[arch] })
       end
+
+      sig { returns(T::Boolean) }
+      def empty? = T.let(__getobj__, T::Hash[Symbol, T.untyped]).empty?
+
+      sig { returns(T::Boolean) }
+      def present? = !empty?
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We're now seeing warnings related to the cask DSL surfaced by Ruby 3.4:

```
/opt/homebrew/Library/Homebrew/cask/dsl.rb:456: warning: The class Cask::DSL reached 8 shape variations, instance variables accesses will be slower and memory usage increased.
It is recommended to define instance variables in a consistent order, for instance by eagerly defining them all in the #initialize method.
```

I've been working on upgrading `Cask::DSL` to `typed: strict` and part of that involves defining all of the instance variables in the `initialize` method, so I've extracted this part of that work as a way of helping to resolve the aforementioned warning. This doesn't fully resolve the warning but it addresses what it was originally referencing, at least.

After the changes in this PR, the warning references line 208, which is an `instance_variable_set` call in `set_unique_stanza`. Sorbet also has trouble understanding the `set_unique_stanza` setup (i.e., it's necessary to add `T.cast` annotations wherever it's used), so we may want to reevaluate this approach at some point.

-----

For what it's worth, this includes some type fixes but I've only included what's necessary to pass `brew typecheck` (the rest will be part of a future PR for the aforementioned `Cask::DSL` type work). This also adds explicit `#empty?`/`#present?` methods to `Cask::DSL::DependsOn` to resolve a `brew typecheck` error about there being no `present?` method for `DependsOn`, as Sorbet has trouble understanding these kinds of implicit `SimpleDelegator` interactions.