### PR TITLE
Cask::DSL: initialize more instance variables

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -119,10 +119,15 @@ module Cask
 
     sig { params(cask: Cask).void }
     def initialize(cask)
+      # NOTE: Variables set by `set_unique_stanza` must be initialized to `nil`.
+      @auto_updates = T.let(nil, T.nilable(T::Boolean))
+      @arch = T.let(nil, T.nilable(String))
       @artifacts = T.let(ArtifactSet.new, ArtifactSet)
       @called_in_on_system_block = T.let(false, T::Boolean)
       @cask = T.let(cask, Cask)
       @caveats = T.let(DSL::Caveats.new(cask), DSL::Caveats)
+      @conflicts_with = T.let(nil, T.nilable(DSL::ConflictsWith))
+      @container = T.let(nil, T.nilable(DSL::Container))
       @depends_on = T.let(DSL::DependsOn.new, DSL::DependsOn)
       @depends_on_set_in_block = T.let(false, T::Boolean)
       @deprecated = T.let(false, T::Boolean)
@@ -130,21 +135,27 @@ module Cask
       @deprecation_reason = T.let(nil, T.nilable(T.any(String, Symbol)))
       @deprecation_replacement_cask = T.let(nil, T.nilable(String))
       @deprecation_replacement_formula = T.let(nil, T.nilable(String))
+      @desc = T.let(nil, T.nilable(String))
       @disable_date = T.let(nil, T.nilable(Date))
       @disable_reason = T.let(nil, T.nilable(T.any(String, Symbol)))
       @disable_replacement_cask = T.let(nil, T.nilable(String))
       @disable_replacement_formula = T.let(nil, T.nilable(String))
       @disabled = T.let(false, T::Boolean)
+      @homepage = T.let(nil, T.nilable(String))
       @language_blocks = T.let({}, T::Hash[T::Array[String], Proc])
       @language_eval = T.let(nil, T.nilable(String))
       @livecheck = T.let(Livecheck.new(cask), Livecheck)
       @livecheck_defined = T.let(false, T::Boolean)
       @name = T.let([], T::Array[String])
       @on_system_blocks_exist = T.let(false, T::Boolean)
+      @os = T.let(nil, T.nilable(String))
       @token = cask.token
       @on_system_block_min_os = T.let(nil, T.nilable(MacOSVersion))
+      @sha256 = T.let(nil, T.nilable(T.any(Checksum, Symbol)))
       @staged_path = T.let(nil, T.nilable(Pathname))
       @token = T.let(cask.token, String)
+      @url = T.let(nil, T.nilable(URL))
+      @version = T.let(nil, T.nilable(DSL::Version))
     end
 
     sig { returns(T::Boolean) }
@@ -196,7 +207,7 @@ module Cask
       return instance_variable_get(:"@#{stanza}") if should_return
 
       unless @cask.allow_reassignment
-        if instance_variable_defined?(:"@#{stanza}") && !@called_in_on_system_block
+        if !instance_variable_get(:"@#{stanza}").nil? && !@called_in_on_system_block
           raise CaskInvalidError.new(cask, "'#{stanza}' stanza may only appear once.")
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I recently updated `Cask::DSL` to define instance variables in `#initialize` (https://github.com/Homebrew/brew/pull/19806) to get us closer to resolving a "shape variation" warning from Ruby. The reason why we continued to receive this warning after the previous changes is because I overlooked the variables that are set using `set_unique_stanza`.

The tricky part about those instance variables is that we need to be able to identify if they've been set. I've handled this by using a `nil` initial value and updating the `instance_variable_defined?` condition to check for a non-`nil` value instead. This works for these variables but it would be a problem if we ever have a DSL method that accepts a `nil` argument.