### PR TITLE
bump-formula-pr: restore pr message

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -443,7 +443,7 @@ module Homebrew
           "#{Array(args.bump_synced).join(" ")} #{new_formula_version}"
         end
 
-        pr_message = "Created by `brew bump-formula-pr`."
+        pr_message = "Created with `brew bump-formula-pr`."
         commits.each do |commit|
           next if commit[:formula_pr_message].empty?
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

@khipp noticed that the `bump-formula-pr` was no longer being applied in `homebrew-core`, after recent changes in #19798
This PR restores the previous wording.
