### PR TITLE
Cask::Auditor: update language_blocks condition

### DIFF
--- a/Library/Homebrew/cask/auditor.rb
+++ b/Library/Homebrew/cask/auditor.rb
@@ -74,7 +74,7 @@ module Cask
     def audit
       errors = Set.new
 
-      if !language && (blocks = language_blocks)
+      if !language && !(blocks = language_blocks).empty?
         sample_languages = if blocks.length > LANGUAGE_BLOCK_LIMIT && !@audit_new_cask
           sample_keys = T.must(blocks.keys.sample(LANGUAGE_BLOCK_LIMIT))
           ohai "Auditing a sample of available languages for #{cask}: " \
@@ -140,7 +140,7 @@ module Cask
       audit.run!
     end
 
-    sig { returns(T.nilable(T::Hash[T::Array[String], T.proc.returns(T.untyped)])) }
+    sig { returns(T::Hash[T::Array[String], T.proc.returns(T.untyped)]) }
     def language_blocks
       cask.instance_variable_get(:@dsl).instance_variable_get(:@language_blocks)
     end

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -149,7 +149,6 @@ module Cask
       @name = T.let([], T::Array[String])
       @on_system_blocks_exist = T.let(false, T::Boolean)
       @os = T.let(nil, T.nilable(String))
-      @token = cask.token
       @on_system_block_min_os = T.let(nil, T.nilable(MacOSVersion))
       @sha256 = T.let(nil, T.nilable(T.any(Checksum, Symbol)))
       @staged_path = T.let(nil, T.nilable(Pathname))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I recently modified `Cask::DSL` to define instance variables in the `#initialize` method and this involved some changes to the `language`, `language_eval`, and `languages` methods. One of those was to initialize `@language_blocks` to an empty hash instead of using a `nil` default. I updated the related condition in the `language_eval` method but I missed that `language_blocks` is used in `Cask::Auditor` and it specifically relies on a false-y value to check if the variable is set. An empty hash isn't false-y, so this is causing issues for `brew audit`.

This updates the condition in `Cask::Auditor` to check for a non-empty hash instead, which resolves the issue. I'll review the other instance variables that use a non-`nil` default to make sure that I haven't introduced any other similar issues.

Besides that, this also removes a duplicate definition of `@token` in `Cask::DSL#initialize` that I introduced. This didn't make a functional difference (as it's redefined using `T.let` afterward), so this is just a bit of tidying up.