### PR TITLE
cask/uninstall: fix `HOME` references in uninstall stanzas for multi-user installs

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -4,6 +4,7 @@
 require "timeout"
 
 require "utils/user"
+require "utils/uid"
 require "cask/artifact/abstract_artifact"
 require "cask/pkg"
 require "extend/hash/keys"
@@ -74,7 +75,12 @@ module Cask
 
         args = directives[directive_sym]
 
-        send(:"uninstall_#{directive_sym}", *(args.is_a?(Hash) ? [args] : args), **options)
+        ::Utils::UID.drop_euid do
+          env = { HOME: ::Utils::UID.uid_home }.compact
+          with_env(env) do
+            send(:"uninstall_#{directive_sym}", *(args.is_a?(Hash) ? [args] : args), **options)
+          end
+        end
       end
 
       def stanza


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Uninstall stanzas (e.g. `zap`) don't work correctly on multi-user
installations where the user's UID might differ from the EUID.

Let's try to fix that by ensuring that `~` is resolved to the running
user's `HOME` (instead of the `HOME` of the EUID user).
