### PR TITLE
cask/artifact/abstract_uninstall: fix `trash_paths`

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -464,9 +464,9 @@ module Cask
                                  args:         paths,
                                  print_stderr: Homebrew::EnvConfig.developer?
 
-        trashed, _, untrashable = stdout.partition("\n")
-        trashed = trashed.split(":")
-        untrashable = untrashable.split(":")
+        trashed, = stdout.partition("\n")
+        trashed = trashed.split(":") & paths
+        untrashable = paths - trashed
 
         trashed_with_permissions, untrashable = untrashable.partition do |path|
           Utils.gain_permissions(path, ["-R"], SystemCommand) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is currently behaving incorrectly when calling `trash.swift` fails
due to lack of permissions. In this instance, `trash.swift` prints

    error: permissionDenied

to stdout, and this is incorrectly parsed as having successfully trashed
a file named `error` and another named ` permissionDenied`.

Let's fix this by ensuring that:
- any paths in `trashed` are in the `paths` that we wanted to trash in
  the first place
- define `untrashable` by removing the `trashed` paths from `paths`
