### PR TITLE
official_taps: deprecate homebrew-linux-fonts.

### DIFF
--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -27,6 +27,7 @@ DEPRECATED_OFFICIAL_TAPS = %w[
   games
   gui
   head-only
+  linux-fonts
   livecheck
   nginx
   php


### PR DESCRIPTION
This has been archived and migrated to Homebrew/homebrew-cask.