### PR TITLE
cmd/bundle: fix no_upgrade type.

### DIFF
--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -155,11 +155,10 @@ module Homebrew
 
         global = args.global?
         file = args.file
-        args.zap?
         no_upgrade = if args.upgrade? || subcommand == "upgrade"
           false
         else
-          args.no_upgrade?
+          args.no_upgrade?.present?
         end
         verbose = args.verbose?
         force = args.force?


### PR DESCRIPTION
If you set `HOMEBREW_BUNDLE_NO_UPGRADE=1`, `brew bundle check` will output:

```
Error: Parameter 'no_upgrade': Expected type T::Boolean, got type String with value "1"
Caller: /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12039/lib/types/private/methods/call_validation.rb:227
Definition: /opt/homebrew/Library/Homebrew/bundle/commands/check.rb:14 (Homebrew::Bundle::Commands::Check.run)
```