### PR TITLE
Fix CI errors on 20.04

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -460,7 +460,7 @@ fi
 #####
 
 # Docker image deprecation
-if [[ -f "${HOMEBREW_REPOSITORY}/.docker-deprecate" ]]
+if [[ -f "${HOMEBREW_REPOSITORY}/.docker-deprecate" && -z "${HOMEBREW_TESTS}" ]]
 then
   read -r DOCKER_DEPRECATION_MESSAGE <"${HOMEBREW_REPOSITORY}/.docker-deprecate"
   if [[ -n "${GITHUB_ACTIONS}" ]]


### PR DESCRIPTION
We want to keep testing 20.04 because of the glibc + gcc code coverage. The 20.04 image isn't going away until at least 4.7. In the longer term, what we should probably do is adjust the tests so we stub those code paths rather than rely on the host OS being < 22.04 - but I won't have time to change that today.