### PR TITLE
tap: fix autobump logic for unofficial taps

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -987,8 +987,10 @@ class Tap
   def autobump
     autobump_packages = if core_cask_tap?
       Homebrew::API::Cask.all_casks
-    else
+    elsif core_tap?
       Homebrew::API::Formula.all_formulae
+    else
+      {}
     end
 
     @autobump ||= autobump_packages.select do |_, p|

--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -17,6 +17,7 @@ module Homebrew
         @tap_style_exceptions      = tap.style_exceptions
         @tap_pypi_formula_mappings = tap.pypi_formula_mappings
         @tap_autobump              = tap.autobump
+        @tap_official              = tap.official?
         @problems                  = []
 
         @cask_tokens = tap.cask_tokens.map do |cask_token|
@@ -54,8 +55,8 @@ module Homebrew
       check_formula_list_directory "audit_exceptions", @tap_audit_exceptions
       check_formula_list_directory "style_exceptions", @tap_style_exceptions
       check_formula_list "pypi_formula_mappings", @tap_pypi_formula_mappings
-      check_formula_list ".github/autobump.txt", @tap_autobump
       check_formula_list "formula_renames", @formula_renames.values
+      check_formula_list ".github/autobump.txt", @tap_autobump unless @tap_official
     end
 
     sig { void }


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
`brew audit` on unofficial taps throws error because `autobump_packages` tries to audit all official packages in external tap. Package list should be empty if neither `core_tap?` nor `core_cask_tap?` are true