### PR TITLE
services: try multiple domains when stopping

### DIFF
--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -113,12 +113,17 @@ module Homebrew
         false
       end
 
+      sig { void }
+      def reset_cache!
+        @status_output_success_type = nil
+      end
+
       # Returns `true` if the service is loaded, else false.
       # TODO: this should either be T::Boolean or renamed to `loaded`
       sig { params(cached: T::Boolean).returns(T.nilable(T::Boolean)) }
       def loaded?(cached: false)
         if System.launchctl?
-          @status_output_success_type = nil unless cached
+          reset_cache! unless cached
           _, status_success, = status_output_success_type
           status_success
         elsif System.systemctl?

--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -6,6 +6,8 @@ require_relative "system/systemctl"
 module Homebrew
   module Services
     module System
+      LAUNCHCTL_DOMAIN_ACTION_NOT_SUPPORTED = T.let(125, Integer)
+
       # Path to launchctl binary.
       sig { returns(T.nilable(Pathname)) }
       def self.launchctl
@@ -97,6 +99,13 @@ module Homebrew
         else
           "gui/#{Process.uid}"
         end
+      end
+
+      sig { returns(T::Array[String]) }
+      def self.candidate_domain_targets
+        candidates = [domain_target]
+        candidates += ["user/#{Process.euid}", "gui/#{Process.uid}"] unless root?
+        candidates.uniq
       end
     end
   end

--- a/Library/Homebrew/test/services/cli_spec.rb
+++ b/Library/Homebrew/test/services/cli_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Homebrew::Services::Cli do
         keep_alive?: false,
       )
       allow(service).to receive(:service_name)
+      allow(service).to receive(:reset_cache!)
       allow(Homebrew::Services::FormulaWrapper).to receive(:from).and_return(service)
       allow(services_cli).to receive(:running).and_return(["example_service"])
       expect do


### PR DESCRIPTION
When running on `sudo`, we force `user/` but the service might have started under `gui/`.

There are scenarios where `sudo` over `gui/` can work so when stopping we can try both domains and go with whatever works.