### PR TITLE
api: force encoding to UTF-8

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -96,7 +96,7 @@ module Homebrew
 
         mtime = insecure_download ? Time.new(1970, 1, 1) : Time.now
         FileUtils.touch(target, mtime:) unless skip_download
-        JSON.parse(target.read, freeze: true)
+        JSON.parse(target.read(encoding: Encoding::UTF_8), freeze: true)
       rescue JSON::ParserError
         target.unlink
         retry_count += 1


### PR DESCRIPTION
For reasons not yet known, our attempt to force UTF-8 encoding by default in brew.sh doesn't always work for Linux users.

This is causing JSON parsing to fail on some Linux systems after 4.5.0 due to Ruby 3.4 now enforcing invalid encoding as errors properly.

Given we know/expect the JSON is UTF-8, let's just explicitly state it here when reading.