### PR TITLE
github_runner_matrix: emulate plaform when sending `compatible?` requests

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -255,8 +255,18 @@ class GitHubRunnerMatrix
       @testing_formulae.select do |formula|
         next false if macos_version && !formula.compatible_with?(macos_version)
 
-        formula.public_send(:"#{platform}_compatible?") &&
-          formula.public_send(:"#{arch}_compatible?")
+        simulate_arch = case arch
+        when :x86_64
+          :intel
+        when :arm64
+          :arm
+        else
+          :dunno
+        end
+        Homebrew::SimulateSystem.with(os: platform, arch: simulate_arch) do
+          formula.public_send(:"#{platform}_compatible?") &&
+            formula.public_send(:"#{arch}_compatible?")
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Closes #19838

There is a problem when CI determines which runners it needs when testing formulae. If a formula has `on_linux do` block with `depends_on arch:` requirement, it'll be added to `formula.requirements` list, even if there's no such restriction on macOS. The opposite problem happens with `on_macos` block. Because CI runs on Linux, it is not able to check `depends_on arch:` there. To solve this problem, we need to simulate the specific platform when sending `#{arch}_compatible?` request.

Unfortunately, I don't know how to check if it works (I didn't find how to test `on_*` block in `github_runner_matrix_spec.rb`), but I hope it will work as expected