### PR TITLE
lazy_object: fix `__getobj__` signature

### DIFF
--- a/Library/Homebrew/lazy_object.rb
+++ b/Library/Homebrew/lazy_object.rb
@@ -9,17 +9,15 @@ class LazyObject < Delegator
     super(callable)
   end
 
-  def __getobj__
+  def __getobj__(&)
     return @__getobj__ if defined?(@__getobj__)
 
     @__getobj__ = @__callable__.call
   end
-  private :__getobj__
 
   def __setobj__(callable)
     @__callable__ = callable
   end
-  private :__setobj__
 
   # Forward to the inner object to make lazy objects type-checkable.
   #


### PR DESCRIPTION
`__getobj__` actually takes in a block. You call it when there isn't an object to delegate to but that never really is the case for our use case so we don't need to yield here.

Fixes:

```
/opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.3/lib/ruby/3.4.0/delegate.rb:101: warning: the block passed to 'LazyObject#__getobj__' defined at /opt/homebrew/Library/Homebrew/lazy_object.rb:12 may be ignored
```

Also remove the `private` specifier as it's incorrect given the superclass method is public. Fixes another error seen in `brew irb`:


```
An error occurred when inspecting the object: #<NoMethodError: private method '__getobj__' called for an instance of LazyObject>
```