### PR TITLE
utils/github/actions: fix frozen string handling

### DIFF
--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -98,7 +98,7 @@ module GitHub
 
       sig { returns(String) }
       def to_s
-        metadata = @type.to_s
+        metadata = @type.to_s.dup
         if @file
           metadata << " file=#{Actions.escape(@file.to_s)}"
 


### PR DESCRIPTION
Fixes:

```
/opt/homebrew/Library/Homebrew/utils/github/actions.rb:103: warning: string returned by :error.to_s will be frozen in the future
```