### PR TITLE
patches audit: bitbucket patches should use api

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -59,6 +59,15 @@ module RuboCop
             problem "GitHub patches should end with .patch, not .diff: #{patch_url}"
           end
 
+          bitbucket_regex = %r{bitbucket\.org/([^/]+)/([^/]+)/commits/([a-f0-9]+)/raw}i
+          if regex_match_group(patch_url_node, bitbucket_regex)
+            owner, repo, commit = patch_url_node.source.match(bitbucket_regex).captures
+            correct_url = "https://api.bitbucket.org/2.0/repositories/#{owner}/#{repo}/diff/#{commit}"
+            problem "Bitbucket patches should use the api url: #{correct_url}" do |corrector|
+              corrector.replace(patch_url_node.source_range, %Q("#{correct_url}"))
+            end
+          end
+
           # Only .diff passes `--full-index` to `git diff` and there is no documented way
           # to get .patch to behave the same for GitLab.
           if regex_match_group(patch_url_node, %r{.*gitlab.*/commit/[a-fA-F0-9]*\.patch})

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
         "http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-libunac1.txt;att=1;bug=623340",
         "https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch",
         "https://github.com/dlang/dub/commit/2c916b1a7999a050ac4970c3415ff8f91cd487aa.patch",
+        "https://bitbucket.org/multicoreware/x265_git/commits/b354c009a60bcd6d7fc04014e200a1ee9c45c167/raw",
       ]
       patch_urls.each do |patch_url|
         source = <<~EOS
@@ -77,6 +78,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
         elsif patch_url.match?(%r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)})
           expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
             FormulaAudit/Patches: GitHub patches should use the full_index parameter: #{patch_url}?full_index=1
+          EOS
+        elsif patch_url.start_with?("https://bitbucket.org/")
+          commit = "b354c009a60bcd6d7fc04014e200a1ee9c45c167"
+          fixed_url = "https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/#{commit}"
+          expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
+            FormulaAudit/Patches: Bitbucket patches should use the api url: #{fixed_url}
           EOS
         end
         expected_offense.zip([inspect_source(source).last]).each do |expected, actual|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Following https://github.com/Homebrew/homebrew-core/pull/221961

I also added a corrector that I tested manually. I couldn't figure out how to test that part in `patches_spec.rb`.