### PR TITLE
formula_auditor: remove redis version limit

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -519,7 +519,6 @@ module Homebrew
       "kibana"             => "7.11",
       "nomad"              => "1.7",
       "packer"             => "1.10",
-      "redis"              => "7.4",
       "terraform"          => "1.6",
       "vagrant"            => "2.4",
       "vagrant-completion" => "2.4",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Redis version 8 has added AGPLv3 as a licensing option.
Reference: https://redis.io/blog/agplv3/