### PR TITLE
Anonymous OCI registry mirror support 

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -705,7 +705,7 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
     meta[:headers] ||= []
     # GitHub Packages authorization header.
     # HOMEBREW_GITHUB_PACKAGES_AUTH set in brew.sh
-    # If using a private GHCR mirror with no Authentication set than do not add the header. In all other cases add it.
+    # If using a private GHCR mirror with no Authentication set then do not add the header. In all other cases add it.
     if !Homebrew::EnvConfig.artifact_domain.presence ||
        Homebrew::EnvConfig.docker_registry_basic_auth_token.presence ||
        Homebrew::EnvConfig.docker_registry_token.presence

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -705,7 +705,10 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
     meta[:headers] ||= []
     # GitHub Packages authorization header.
     # HOMEBREW_GITHUB_PACKAGES_AUTH set in brew.sh
-    meta[:headers] << "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}"
+    # If using a private GHCR mirror with no Authentication set than do not add the header. In all other cases add it.
+    if not (Homebrew::EnvConfig.artifact_domain.presence && !Homebrew::EnvConfig.docker_registry_basic_auth_token.presence && !Homebrew::EnvConfig.docker_registry_token.presence)
+      meta[:headers] << "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}"
+    end
     super
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -707,10 +707,10 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
     # HOMEBREW_GITHUB_PACKAGES_AUTH set in brew.sh
     # If using a private GHCR mirror with no Authentication set than do not add the header. In all other cases add it.
     if !Homebrew::EnvConfig.artifact_domain.presence ||
-      Homebrew::EnvConfig.docker_registry_basic_auth_token.presence ||
-      Homebrew::EnvConfig.docker_registry_token.presence
-     meta[:headers] << "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}"
-   end
+       Homebrew::EnvConfig.docker_registry_basic_auth_token.presence ||
+       Homebrew::EnvConfig.docker_registry_token.presence
+      meta[:headers] << "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}"
+    end
     super
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -706,9 +706,11 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
     # GitHub Packages authorization header.
     # HOMEBREW_GITHUB_PACKAGES_AUTH set in brew.sh
     # If using a private GHCR mirror with no Authentication set than do not add the header. In all other cases add it.
-    if not (Homebrew::EnvConfig.artifact_domain.presence && !Homebrew::EnvConfig.docker_registry_basic_auth_token.presence && !Homebrew::EnvConfig.docker_registry_token.presence)
-      meta[:headers] << "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}"
-    end
+    if !Homebrew::EnvConfig.artifact_domain.presence ||
+      Homebrew::EnvConfig.docker_registry_basic_auth_token.presence ||
+      Homebrew::EnvConfig.docker_registry_token.presence
+     meta[:headers] << "Authorization: #{HOMEBREW_GITHUB_PACKAGES_AUTH}"
+   end
     super
   end
 


### PR DESCRIPTION
Fixes #16669

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Currently an Authorization header is added to all requests for CurlGithubPackageDownload.  It includes the contents of an `ARTIFACT_TOKEN` auth var or "A" which is used for access to ghcr.io.  This causes an issue though if you host a private mirror of GHCR where auth is optional.  This adds a conditional where for 7 of the 8 cases it adds the header, but for the 1 where you have a `DOMAIN` set and not `TOKEN`s it will skip adding the header.

- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).

I couldn't figure out a great way to test this given the environmental aspects, but I am up for suggestions and can tweak the PR to fit.

- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
