### PR TITLE
formula_auditor: remove elasticsearch and kibana refs

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -515,8 +515,6 @@ module Homebrew
     RELICENSED_FORMULAE_VERSIONS = {
       "boundary"           => "0.14",
       "consul"             => "1.17",
-      "elasticsearch"      => "7.11",
-      "kibana"             => "7.11",
       "nomad"              => "1.7",
       "packer"             => "1.10",
       "terraform"          => "1.6",

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -509,14 +509,6 @@ RSpec.describe Version do
         .to be_detected_from("https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1")
     end
 
-    specify "elasticsearch alpha style" do
-      expect(described_class.new("5.0.0-alpha5"))
-        .to be_detected_from(
-          "https://download.elastic.co/elasticsearch/release/org/elasticsearch" \
-          "/distribution/tar/elasticsearch/5.0.0-alpha5/elasticsearch-5.0.0-alpha5.tar.gz",
-        )
-    end
-
     specify "gloox beta style" do
       expect(described_class.new("1.0-beta7"))
         .to be_detected_from("https://camaya.net/download/gloox-1.0-beta7.tar.bz2")


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

both kibana and elasticsearch got removed per https://github.com/Homebrew/homebrew-core/pull/138155 on Aug 2, 2023
