### PR TITLE
Update eol_data for API changes

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -612,11 +612,10 @@ module Homebrew
       metadata = SharedAudits.eol_data(name, formula.version.major.to_s)
       metadata ||= SharedAudits.eol_data(name, formula.version.major_minor.to_s)
 
-      return if metadata.blank? || (eol = metadata["eol"]).blank?
+      return if metadata.blank? || (metadata.dig("result", "isEol") != true)
 
-      is_eol = eol == true
-      is_eol ||= eol.is_a?(String) && (eol_date = Date.parse(eol)) <= Date.today
-      return unless is_eol
+      eol_from = metadata.dig("result", "eolFrom")
+      eol_date = Date.parse(eol_from) if eol_from.present?
 
       message = "Product is EOL"
       message += " since #{eol_date}" if eol_date.present?

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe SharedAudits do
   describe "::eol_data" do
     it "returns a parsed JSON object if the product is found" do
       mock_curl_output stdout: eol_json_text
-      expect(described_class.eol_data("product", "cycle").dig("result", "isEol")).to be(true)
-      expect(described_class.eol_data("product", "cycle").dig("result", "eolFrom")).to eq("2025-01-01")
+      expect(described_class.eol_data("product", "cycle")&.dig("result", "isEol")).to be(true)
+      expect(described_class.eol_data("product", "cycle")&.dig("result", "eolFrom")).to eq("2025-01-01")
     end
 
     it "returns nil if the product is not found" do

--- a/Library/Homebrew/test/utils/shared_audits_spec.rb
+++ b/Library/Homebrew/test/utils/shared_audits_spec.rb
@@ -8,25 +8,21 @@ RSpec.describe SharedAudits do
     <<~JSON
       {
         "schema_version" : "1.0.0",
-        "generated_at": "2025-05-03T15:47:58+00:00",
+        "generated_at": "2025-01-02T01:23:45+00:00",
         "result": {
-          "name": "22",
+          "name": "1.2",
           "codename": null,
-          "label": "22 (LTS)",
-          "releaseDate": "2024-04-24",
-          "isLts": true,
-          "ltsFrom": "2024-10-29",
-          "isEoas": false,
-          "eoasFrom": "2025-10-21",
-          "isEol": false,
-          "eolFrom": "2027-04-30",
-          "isEoes": null,
-          "eoesFrom": null,
-          "isMaintained": true,
+          "label": "1.2",
+          "releaseDate": "2024-01-01",
+          "isLts": false,
+          "ltsFrom": null,
+          "isEol": true,
+          "eolFrom": "2025-01-01",
+          "isMaintained": false,
           "latest": {
-            "name": "22.15.0",
-            "date": "2025-04-23",
-            "link": "https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#22.15.0"
+            "name": "1.0.0",
+            "date": "2024-01-01",
+            "link": "https://example.com/1.0.0"
           }
         }
       }
@@ -40,10 +36,10 @@ RSpec.describe SharedAudits do
   end
 
   describe "::eol_data" do
-    it "returns the `isEol` and `eolFrom` values if the product is found" do
+    it "returns a parsed JSON object if the product is found" do
       mock_curl_output stdout: eol_json_text
-      expect(described_class.eol_data("product", "cycle").dig("result", "isEol")).to be(false)
-      expect(described_class.eol_data("product", "cycle").dig("result", "eolFrom")).to eq("2027-04-30")
+      expect(described_class.eol_data("product", "cycle").dig("result", "isEol")).to be(true)
+      expect(described_class.eol_data("product", "cycle").dig("result", "eolFrom")).to eq("2025-01-01")
     end
 
     it "returns nil if the product is not found" do

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -12,10 +12,15 @@ module SharedAudits
   def self.eol_data(product, cycle)
     @eol_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
     @eol_data["#{product}/#{cycle}"] ||= begin
-      result = Utils::Curl.curl_output("--location", "https://endoflife.date/api/#{product}/#{cycle}.json")
-      json = JSON.parse(result.stdout) if result.status.success?
-      json = nil if json&.dig("message")&.include?("Product not found")
-      json
+      result = Utils::Curl.curl_output("--location", "https://endoflife.date/api/v1/products/#{product}/releases/#{cycle}")
+
+      if result.status.success?
+        begin
+          JSON.parse(result.stdout)
+        rescue JSON::ParserError
+          nil
+        end
+      end
     end
   end
 

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -11,16 +11,19 @@ module SharedAudits
   sig { params(product: String, cycle: String).returns(T.nilable(T::Hash[String, T.untyped])) }
   def self.eol_data(product, cycle)
     @eol_data ||= T.let({}, T.nilable(T::Hash[String, T.untyped]))
-    @eol_data["#{product}/#{cycle}"] ||= begin
-      result = Utils::Curl.curl_output("--location", "https://endoflife.date/api/v1/products/#{product}/releases/#{cycle}")
+    key = "#{product}/#{cycle}"
+    return @eol_data[key] if @eol_data.key?(key)
 
-      if result.status.success?
-        begin
-          JSON.parse(result.stdout)
-        rescue JSON::ParserError
-          nil
-        end
-      end
+    result = Utils::Curl.curl_output(
+      "--location",
+      "https://endoflife.date/api/v1/products/#{product}/releases/#{cycle}",
+    )
+    return unless result.status.success?
+
+    @eol_data[key] = begin
+      JSON.parse(result.stdout)
+    rescue JSON::ParserError
+      nil
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The endoflife.date API has been updated, so this modifies the URL in `SharedAudits.eol_data` to use the up to date URL and modifies the related logic in `FormulaAuditor.audit_eol` to work with the new response format. Specifically, there is now an `isEol` boolean value and the EOL date is found in `eolFrom`.

One wrinkle of the new setup is that 404 responses now return HTML content even if the request includes an `Accept: application/json` header. This handles these types of responses by catching `JSON::ParserError` but ideally we would parse the response headers and use `Utils::Curl.http_status_ok?` to check for a good response status before trying to parse the response body as JSON. [Edit: I worked on this but hit a wall because the tests return an `undefined method 'parse_curl_response' for module Utils::Curl` error if `Utils::Curl.parse_curl_output` is used in `eol_data`.]

I'll be gone for the next few hours but feel free to make any necessary changes to this to move it forward in the interim time. Otherwise, I'll come back to this later today.