### PR TITLE
Remove the sentence referencing --force-auto-update from the documentation

### DIFF
--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -31,8 +31,7 @@ but the command isn't limited to any one location.
 * `brew tap <user>/<repo> <URL>` makes a clone of the repository at _URL_.
   Unlike the one-argument version, _URL_ is not assumed to be GitHub, and it
   doesn't have to be HTTP. Any location and any protocol that Git can handle is
-  fine, although non-GitHub taps require running `brew tap --force-auto-update <user>/<repo>`
-  to enable automatic updating.
+  fine.
 
 * `brew tap --repair` migrates tapped formulae from a symlink-based to
   directory-based structure. (This should only need to be run once.)


### PR DESCRIPTION
Because it was removed in `9ac3182`
This is for #19856

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). *No, but this change is 100% documentation*
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
