### PR TITLE
bump: audit formula online before opening a pull request

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -55,6 +55,8 @@ module Homebrew
                description: "Letter or word that the list of package results should alphabetically follow."
         switch "--bump-synced",
                description: "Bump additional formulae marked as synced with the given formulae."
+        switch "--online-audit",
+               description: "Do online audit before opening pull request."
 
         conflicts "--cask", "--formula"
         conflicts "--tap=", "--installed"
@@ -62,6 +64,7 @@ module Homebrew
         conflicts "--eval-all", "--installed"
         conflicts "--installed", "--auto"
         conflicts "--no-pull-requests", "--open-pr"
+        conflicts "--no-pull-requests", "--online-audit"
 
         named_args [:formula, :cask], without_api: true
       end
@@ -532,6 +535,9 @@ module Homebrew
         ]
 
         bump_pr_args << "--no-fork" if args.no_fork?
+        bump_pr_args << "--online" if version_info.type == :formula &&
+                                      args.online_audit? &&
+                                      ENV["HOMEBREW_TEST_BOT_AUTOBUMP"].blank?
 
         if args.bump_synced? && outdated_synced_formulae.present?
           bump_pr_args << "--bump-synced=#{outdated_synced_formulae.join(",")}"

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/bump.rbi
@@ -48,6 +48,9 @@ class Homebrew::DevCmd::Bump::Args < Homebrew::CLI::Args
   def no_pull_requests?; end
 
   sig { returns(T::Boolean) }
+  def online_audit?; end
+
+  sig { returns(T::Boolean) }
   def open_pr?; end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Often BrewTestBot opens pull request for pre-released formula versions. Doing online audit would help to prevent this