### PR TITLE
cask/dsl: set `no_autobump!` automatically in some cases

### DIFF
--- a/Library/Homebrew/autobump_constants.rb
+++ b/Library/Homebrew/autobump_constants.rb
@@ -6,4 +6,5 @@ NO_AUTOBUMP_REASONS_LIST = T.let({
   incompatible_version_format: "incompatible version format",
   bumped_by_upstream:          "bumped by upstream",
   extract_plist:               "livecheck uses `:extract_plist` strategy",
+  latest_version:              "`version` is set to `:latest`",
 }.freeze, T::Hash[Symbol, String])

--- a/Library/Homebrew/autobump_constants.rb
+++ b/Library/Homebrew/autobump_constants.rb
@@ -5,4 +5,5 @@
 NO_AUTOBUMP_REASONS_LIST = T.let({
   incompatible_version_format: "incompatible version format",
   bumped_by_upstream:          "bumped by upstream",
+  extract_plist:               "livecheck uses `:extract_plist` strategy",
 }.freeze, T::Hash[Symbol, String])

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -161,6 +161,8 @@ module Cask
       @token = T.let(cask.token, String)
       @url = T.let(nil, T.nilable(URL))
       @version = T.let(nil, T.nilable(DSL::Version))
+
+      set_no_autobump!
     end
 
     sig { returns(T::Boolean) }
@@ -174,6 +176,12 @@ module Cask
 
     sig { returns(T::Boolean) }
     def livecheck_defined? = @livecheck_defined
+
+    def set_no_autobump!
+      return if @livecheck.strategy != :extract_plist
+
+      no_autobump! because: :extract_plist
+    end
 
     sig { returns(T::Boolean) }
     def on_system_blocks_exist? = @on_system_blocks_exist

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -177,6 +177,7 @@ module Cask
     sig { returns(T::Boolean) }
     def livecheck_defined? = @livecheck_defined
 
+    sig { void }
     def set_no_autobump!
       return if @livecheck.strategy != :extract_plist
 
@@ -358,6 +359,8 @@ module Cask
         if !arg.is_a?(String) && arg != :latest
           raise CaskInvalidError.new(cask, "invalid 'version' value: #{arg.inspect}")
         end
+
+        no_autobump! because: :latest_version if arg == :latest
 
         DSL::Version.new(arg)
       end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Casks with `version :latest` do not require autobump for obvious reasons. Cask that use `:extract_plist` livecheck strategy can slow down CI

Thanks to @bevanjkay and @krehel for pointing that out