### PR TITLE
util/pypi: limit pypi url

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -205,6 +205,8 @@ module PyPI
     return unless package.valid_pypi_package?
 
     _, url = package.pypi_info(new_version: version)
+    return if url&.end_with?("-none-any.whl")
+
     url
   rescue ArgumentError
     nil


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think formula is not allowed to use wheel for PyPI resource, but there can be.
So, I have added some lines only for the formula url, not resources.
- https://github.com/Homebrew/homebrew-core/pull/222594