### PR TITLE
dev-cmd/prof: require fileutils

### DIFF
--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "abstract_command"
+require "fileutils"
 
 module Homebrew
   module DevCmd


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes error when running `brew prof`: `uninitialized constant Homebrew::DevCmd::Prof::FileUtils`.

~~~
$ brew prof --prefix
Error: uninitialized constant Homebrew::DevCmd::Prof::FileUtils
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/usr/local/Homebrew/Library/Homebrew/dev-cmd/prof.rb:26:in 'Homebrew::DevCmd::Prof#run'
/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
~~~

I was also able to reproduce this failure with `brew tests --only=dev-cmd/prof  --online`:

<details>

~~~
$ brew tests --only=dev-cmd/prof  --online
Randomized with seed 44002
1 process for 1 spec, ~ 1 spec per process
FF.

Failures:

  1) Homebrew::DevCmd::Prof integration tests works using ruby-prof (the default)
     Failure/Error:
       expect { brew "prof", "help", "HOMEBREW_BROWSER" => "echo" }
         .to output(/^Example usage:/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     
          expected block to output /^Example usage:/ to stdout, but output "Rerun with `--verbose` to see the original backtrace\n"
     
       ...and:
     
             expected block to not output to stderr, but output "Error: uninitialized constant Homebrew::DevCmd::Prof::FileUtils\nWarning: Removed Sorbet lines from backtrace!\n/usr/local/Homebrew/Library/Homebrew/dev-cmd/prof.rb:26:in 'Homebrew::DevCmd::Prof#run'\n/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in '<top (required)>'\n-e:1:in 'Kernel#load'\n-e:1:in '<main>'\nThis error was expected, as this is not a Tier 1 configuration:\n  https://docs.brew.sh/Support-Tiers\nDo not report any issues to Homebrew/* repositories!\nRead the above document instead before opening any issues or PRs.\n"
     
          ...and:
     
             expected #<Proc:0x0000000126b8a868 /usr/local/Homebrew/Library/Homebrew/test/dev-cmd/prof_spec.rb:15> to be a success
       Diff for (output /^Example usage:/ to stdout):
       @@ -1 +1 @@
       -/^Example usage:/
       +Rerun with `--verbose` to see the original backtrace
       
     # ./test/dev-cmd/prof_spec.rb:15:in 'block (3 levels) in <main>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:50:in 'block (2 levels) in <main>'

  2) Homebrew::DevCmd::Prof integration tests works using stackprof
     Failure/Error:
       expect { brew "prof", "--stackprof", "help", "HOMEBREW_BROWSER" => "echo" }
         .to output(/^Example usage:/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     
          expected block to output /^Example usage:/ to stdout, but output "Rerun with `--verbose` to see the original backtrace\n"
     
       ...and:
     
             expected block to not output to stderr, but output "Error: uninitialized constant Homebrew::DevCmd::Prof::FileUtils\nWarning: Removed Sorbet lines from backtrace!\n/usr/local/Homebrew/Library/Homebrew/dev-cmd/prof.rb:26:in 'Homebrew::DevCmd::Prof#run'\n/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in '<top (required)>'\n-e:1:in 'Kernel#load'\n-e:1:in '<main>'\nThis error was expected, as this is not a Tier 1 configuration:\n  https://docs.brew.sh/Support-Tiers\nDo not report any issues to Homebrew/* repositories!\nRead the above document instead before opening any issues or PRs.\n"
     
          ...and:
     
             expected #<Proc:0x00000001261453d0 /usr/local/Homebrew/Library/Homebrew/test/dev-cmd/prof_spec.rb:22> to be a success
       Diff for (output /^Example usage:/ to stdout):
       @@ -1 +1 @@
       -/^Example usage:/
       +Rerun with `--verbose` to see the original backtrace
       
     # ./test/dev-cmd/prof_spec.rb:22:in 'block (3 levels) in <main>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:50:in 'block (2 levels) in <main>'



Took 33 seconds
Tests Failed
~~~

</details>