### PR TITLE
Revert "autobump_constants: add `bumped_by_upstream` reason"

### DIFF
--- a/Library/Homebrew/autobump_constants.rb
+++ b/Library/Homebrew/autobump_constants.rb
@@ -4,5 +4,4 @@
 # TODO: add more reasons here
 NO_AUTOBUMP_REASONS_LIST = T.let({
   incompatible_version_format: "incompatible version format",
-  bumped_by_upstream:          "bumped by upstream",
 }.freeze, T::Hash[Symbol, String])


### PR DESCRIPTION
Reverts Homebrew/brew#19886


The `no_autobump!` dsl changes have currently left `homebrew-cask` and `homebrew-core` in a somewhat broken state.
Casks and Formula are all currently detected as "autobumpable", so they cannot be bumped with `brew bump` or `brew-bump-(cask|formula)-pr`. 

Let's temporarily revert these changes so that we can make sure we have greater maintainer/contributor awareness of the changes, and the autobump CI workflows can be adjusted at the same time.