### PR TITLE
bundle/dsl: combine cask_args calls

### DIFF
--- a/Library/Homebrew/bundle/cask_installer.rb
+++ b/Library/Homebrew/bundle/cask_installer.rb
@@ -41,7 +41,7 @@ module Homebrew
             case v
             when TrueClass
               "--#{k}"
-            when FalseClass
+            when FalseClass, NilClass
               nil
             else
               "--#{k}=#{v}"

--- a/Library/Homebrew/bundle/dsl.rb
+++ b/Library/Homebrew/bundle/dsl.rb
@@ -42,7 +42,7 @@ module Homebrew
       def cask_args(args)
         raise "cask_args(#{args.inspect}) should be a Hash object" unless args.is_a? Hash
 
-        @cask_arguments = args
+        @cask_arguments.merge!(args)
       end
 
       def brew(name, options = {})

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -60,6 +60,20 @@ RSpec.describe Homebrew::Bundle::Dsl do
     end
   end
 
+  context "with multiple cask_args" do
+    subject(:dsl) do
+      dsl_from_string <<~EOS
+        cask_args appdir: '/global-apps'
+        cask_args require_sha: true
+        cask_args appdir: '~/my-apps'
+      EOS
+    end
+
+    it "merges the arguments" do
+      expect(dsl.cask_arguments).to eql(appdir: "~/my-apps", require_sha: true)
+    end
+  end
+
   context "with invalid input" do
     it "handles completely invalid code" do
       expect { dsl_from_string "abcdef" }.to raise_error(RuntimeError)


### PR DESCRIPTION
Currently, calling `cask_args` a second time will completely override the first one. This PR switches it so it merges the two.

This is a behavioural change so does carry some risk of breaking some existing Brewfiles as a result. However looking at current Brewfiles in the wild, it seems like this behaviour change I'm proposing here might actually be what people thought it did all along: https://github.com/search?q=%22cask_args%20a%22%20%2Fcask_args%20%5B%5Ea%5D%2F&type=code

Given every other bundle DSL appends, I think it makes more intuitive sense for this to also append in a similar fashion.

This can make it nicer to do do things like this:

```rb
cask_args appdir: "/Applications", require_sha: true

# sha group
cask "1password"
cask "firefox"

cask_args require_sha: false # retains appdir

# no-sha group
cask "chromium"
cask "..."
```

or

```rb
# appdir stays set for conditional
cask_args appdir: "/Applications"
cask_args no_quarantine: true if ...
```
```rb
# appdir not set for conditional
if ...
  cask_args no_quarantine: true
else
  cask_args appdir: "/Applications"
end
```

---

To support this change, the behaviour for `nil` has also changed:

```rb
cask_args appdir: nil
```

Previous behaviour would pass `--appdir=` (empty value). The new behaviour will omit passing any flag. This allows you to do things like:

```rb
cask_args appdir: "/Applications"

# group to install to that appdir

cask_args appdir: nil

# group to install to default location
```

Retaining the old empty-value arg is still possible via `cask_args appdir: ""`.

I did not find any Brewfiles out in the wild that used `nil`, which hopefully means we won't be breaking much noticeable.