### PR TITLE
bundle/adder: create Brewfile if it doesn't exist.

### DIFF
--- a/Library/Homebrew/bundle/adder.rb
+++ b/Library/Homebrew/bundle/adder.rb
@@ -11,6 +11,9 @@ module Homebrew
 
       sig { params(args: String, type: Symbol, global: T::Boolean, file: String).void }
       def add(*args, type:, global:, file:)
+        brewfile_path = Brewfile.path(global:, file:)
+        brewfile_path.write("") unless brewfile_path.exist?
+
         brewfile = Brewfile.read(global:, file:)
         content = brewfile.input
         # TODO: - support `:describe`


### PR DESCRIPTION
This provides a nicer interface into using `brew bundle add` as a first command.