### PR TITLE
tap: get autobump list from `autobump.txt` file

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -985,19 +985,21 @@ class Tap
   # Array with autobump names
   sig { returns(T::Array[String]) }
   def autobump
-    autobump_packages = if core_cask_tap?
-      Homebrew::API::Cask.all_casks
-    elsif core_tap?
-      Homebrew::API::Formula.all_formulae
-    else
-      {}
-    end
+    # TODO: uncomment when official taps are prepared to use new autobump system
+    #
+    # autobump_packages = if core_cask_tap?
+    #   Homebrew::API::Cask.all_casks
+    # elsif core_tap?
+    #   Homebrew::API::Formula.all_formulae
+    # else
+    #   {}
+    # end
+    #
+    # @autobump ||= autobump_packages.select do |_, p|
+    #   p["autobump"] == true && !p["skip_livecheck"] && !(p["deprecated"] || p["disabled"])
+    # end.keys
 
-    @autobump ||= autobump_packages.select do |_, p|
-      p["autobump"] == true && !p["skip_livecheck"] && !(p["deprecated"] || p["disabled"])
-    end.keys
-
-    if @autobump.empty?
+    if @autobump.blank?
       @autobump = if (autobump_file = path/HOMEBREW_TAP_AUTOBUMP_FILE).file?
         autobump_file.readlines(chomp: true)
       else


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Revert autobump logic (i.e. use `autobump.txt` file to get the list instead of sending requests to the Homebrew API).
Resolves current issues with the homebrew/core and homebrew/cask repositories without the need to revert recent PRs related to autobump (#19920, #19919).