### PR TITLE
Improve readability of disabled command message

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -169,7 +169,7 @@ module Homebrew
                               T::Boolean)
           odisabled(
             "`brew #{@command_name}'. This command needs to be refactored, as it is written in a style that",
-            "inherits from `Homebrew::AbstractCommand' ( see https://docs.brew.sh/External-Commands )",
+            "subclassing of `Homebrew::AbstractCommand' ( see https://docs.brew.sh/External-Commands )",
             disable_for_developers: false,
           )
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Following up on https://github.com/Homebrew/brew/pull/19801#discussion_r2083232560, this slightly improves the readability message of a disabled command from:
```
Error: Calling `brew Homebrew.irb'. This command needs to be refactored, as it is 
written in a style that is disabled! Use inherits from `Homebrew::AbstractCommand' 
( see https://docs.brew.sh/External-Commands ) instead.
```
to
```
Error: Calling `brew Homebrew.irb'. This command needs to be refactored, as it is
written in a style that is disabled! Use subclassing of `Homebrew::AbstractCommand' 
( see https://docs.brew.sh/External-Commands ) instead.
```
(`irb` is not actually disabled, i just reverted it to an earlier state for demonstration purposes.)