### PR TITLE
Phase out using `cgi` library

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -11,8 +11,6 @@ require "cask/migrator"
 require "cask/quarantine"
 require "cask/tab"
 
-require "cgi"
-
 module Cask
   # Installer for a {Cask}.
   class Installer

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -5,7 +5,6 @@ require "json"
 require "time"
 require "unpack_strategy"
 require "lazy_object"
-require "cgi"
 require "lock_file"
 require "system_command"
 
@@ -384,9 +383,12 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     if url.match?(URI::DEFAULT_PARSER.make_regexp)
       uri = URI(url)
 
-      if uri.query
-        query_params = CGI.parse(uri.query)
-        query_params["response-content-disposition"].each do |param|
+      if (uri_query = uri.query.presence)
+        URI.decode_www_form(uri_query).each do |key, param|
+          components[:query] << param if search_query
+
+          next if key != "response-content-disposition"
+
           query_basename = param[/attachment;\s*filename=(["']?)(.+)\1/i, 2]
           return File.basename(query_basename) if query_basename
         end
@@ -396,10 +398,6 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
         components[:path] = uri_path.split("/").filter_map do |part|
           URI::DEFAULT_PARSER.unescape(part).presence
         end
-      end
-
-      if search_query && (uri_query = uri.query.presence)
-        components[:query] = URI.decode_www_form(uri_query).map { _2 }
       end
     else
       components[:path] = [url]

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -346,7 +346,8 @@ class Version
 
   sig { params(spec: T.any(String, Pathname), detected_from_url: T::Boolean).returns(Version) }
   def self.parse(spec, detected_from_url: false)
-    spec = CGI.unescape(spec.to_s) if detected_from_url
+    # This type of full-URL decoding is not technically correct but we only need a rough decode for version parsing.
+    spec = URI.decode_www_form_component(spec.to_s) if detected_from_url
 
     spec = Pathname(spec)
 


### PR DESCRIPTION
Upstream suddenly plan to remove it in Ruby 3.5: https://bugs.ruby-lang.org/issues/21258.

There will be a `cgi/escape` but I think we can just avoid it entirely.