### PR TITLE
docs/Homebrew-on-Linux: update instructions for Fedora-based distros

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -61,11 +61,11 @@ To install build tools, paste at a terminal prompt:
   sudo apt-get install build-essential procps curl file git
   ```
 
-- **Fedora, CentOS, or Red Hat**
+- **Fedora, CentOS Stream, or RHEL**
 
   ```sh
-  sudo yum groupinstall 'Development Tools'
-  sudo yum install procps-ng curl file git
+  sudo dnf group install 'Development Tools'
+  sudo dnf install procps-ng curl file
   ```
 
 - **Arch Linux**


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR introduces a number of changes to `Homebrew-on-Linux.md` regarding instructions for Fedora-based distributions:
- **Change CentOS to CentOS Stream**
  - CentOS has been discontinued, and CentOS Stream now serves as the downstream of Fedora and the upstream of RHEL.
- **Change "Red Hat" to RHEL**
  - Red Hat Enterprise Linux is commonly and officially referred to as RHEL, not "Red Hat". The former [Red Hat Linux](https://en.wikipedia.org/wiki/Red_Hat_Linux) has also been discontinued.
- **Change `yum` to `dnf`**
  - `dnf` has been the default package manager on Fedora for over 10 years (since Fedora 22) and on RHEL for over 6 years (since RHEL 8).
  -  More importantly, `yum groupinstall 'Development Tools'` no longer works on Fedora since its adoption of DNF5.
  - This change also aligns with the current [installation script](https://github.com/Homebrew/install/blob/ba0e1ab292bbb88614ac46b599fd184bf74a1979/install.sh#L1113-L1118), which prioritises `dnf` over `yum`.
- **Remove `git` from the second command**
  - `git` is already included in the `Development Tools` group.