### PR TITLE
Allow REQUESTS_CA_BUNDLE to pass to FILTERED_ENV.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -281,6 +281,7 @@ PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 FILTERED_ENV=()
 ENV_VAR_NAMES=(
   HOME SHELL PATH TERM TERMINFO TERMINFO_DIRS COLUMNS DISPLAY LOGNAME USER CI SSH_AUTH_SOCK SUDO_ASKPASS
+  REQUESTS_CA_BUNDLE
   http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY
 )
 # Filter all but the specific variables.


### PR DESCRIPTION
This allows packages that use Python Requests to access custom root
certificates that are common with corporate networks (e.g. Zscaler).
