### PR TITLE
uninstall: exclude configurational filess that belong to other formulae

### DIFF
--- a/Library/Homebrew/uninstall.rb
+++ b/Library/Homebrew/uninstall.rb
@@ -67,7 +67,18 @@ module Homebrew
               end
 
               unversioned_name = f.name.gsub(/@.+$/, "")
-              maybe_paths = Dir.glob("#{f.etc}/*#{unversioned_name}*")
+              maybe_paths = Dir.glob("#{f.etc}/#{unversioned_name}*")
+              excluded_names = Homebrew::API::Formula.all_formulae.keys
+              maybe_paths = maybe_paths.reject do |path|
+                # Remove extension only if a file
+                # (f.e. directory with name "openssl@1.1" will be trimmed to "openssl@1")
+                filename = if File.directory?(path)
+                  File.basename(path)
+                 else
+                   File.basename(path, ".*")
+                 end
+                excluded_names.include?(filename)
+              end
               maybe_paths -= paths if paths.present?
               if maybe_paths.present?
                 puts

--- a/Library/Homebrew/uninstall.rb
+++ b/Library/Homebrew/uninstall.rb
@@ -72,12 +72,12 @@ module Homebrew
               maybe_paths = maybe_paths.reject do |path|
                 # Remove extension only if a file
                 # (f.e. directory with name "openssl@1.1" will be trimmed to "openssl@1")
-                filename = if File.directory?(path)
+                basename = if File.directory?(path)
                   File.basename(path)
-                 else
-                   File.basename(path, ".*")
-                 end
-                excluded_names.include?(filename)
+                else
+                  File.basename(path, ".*")
+                end
+                excluded_names.include?(basename)
               end
               maybe_paths -= paths if paths.present?
               if maybe_paths.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Closes Homebrew/homebrew-core#177425

Because the check for the left configurational files in `etc` just matches any files that contain the name of the formula (`.*<formula name>.*`), sometimes it may suggest deleting files that 100% belong to another Homebrew formula.

F.e., because `sl` and `nss` formulae match `openssl`, if a user tries to uninstall them they see this message:
```
$ brew uninstall nss
Uninstalling /opt/homebrew/Cellar/nss/3.111... (216 files, 19.5MB)

Warning: The following may be nss configuration files and have not been removed!
If desired, remove them manually with `rm -rf`:
  /opt/homebrew/etc/openssl@1.1
  /opt/homebrew/etc/openssl@3
```
There's no doubt `/opt/homebrew/etc/openssl@3` belongs to the installed `openssl@3`, and we (probably) do not want to suggest users to remove important files.

This PR should fix it:
```
$ brew uninstall nss
Uninstalling /opt/homebrew/Cellar/nss/3.111... (216 files, 19.5MB)

Warning: The following may be nss configuration files and have not been removed!
If desired, remove them manually with `rm -rf`:
  /opt/homebrew/etc/openssl@1.1
# There is a directory for `openssl@1.1` because I used to have this formula
# but it is uninstalled right now. `/opt/homebrew/etc/openssl@1.1` can be rm-rf-ed safely
```