### PR TITLE
Bitbucket: update generated urls

### DIFF
--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -68,14 +68,14 @@ module Homebrew
           # `/get/` archives are Git tag snapshots, so we need to check that tab
           # instead of the main `/downloads/` page
           if match[:dl_type] == "get"
-            values[:url] = "https://bitbucket.org/#{match[:path]}/downloads/?tab=tags"
+            values[:url] = "https://bitbucket.org/#{match[:path]}/downloads/?tab=tags&iframe=true&spa=0"
 
             # Example tag regexes:
             # * `/<td[^>]*?class="name"[^>]*?>\s*v?(\d+(?:\.\d+)+)\s*?</im`
             # * `/<td[^>]*?class="name"[^>]*?>\s*abc-v?(\d+(?:\.\d+)+)\s*?</im`
             values[:regex] = /<td[^>]*?class="name"[^>]*?>\s*#{regex_prefix}v?(\d+(?:\.\d+)+)\s*?</im
           else
-            values[:url] = "https://bitbucket.org/#{match[:path]}/downloads/"
+            values[:url] = "https://bitbucket.org/#{match[:path]}/downloads/?iframe=true&spa=0"
 
             # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
             suffix = T.must(match[:suffix]).sub(Strategy::TARBALL_EXTENSION_REGEX, ".t")

--- a/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/bitbucket_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Homebrew::Livecheck::Strategy::Bitbucket do
   let(:generated) do
     {
       get:       {
-        url:   "https://bitbucket.org/abc/def/downloads/?tab=tags",
+        url:   "https://bitbucket.org/abc/def/downloads/?tab=tags&iframe=true&spa=0",
         regex: /<td[^>]*?class="name"[^>]*?>\s*v?(\d+(?:\.\d+)+)\s*?</im,
       },
       downloads: {
-        url:   "https://bitbucket.org/abc/def/downloads/",
+        url:   "https://bitbucket.org/abc/def/downloads/?iframe=true&spa=0",
         regex: /href=.*?ghi-v?(\d+(?:\.\d+)+)\.t/i,
       },
     }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `Bitbucket` strategy checks download or tag pages but the content is now fetched separately on page load, so the strategy is failing for all related formulae. This updates the generated strategy URLs to fetch the page content instead, which works as expected.