### PR TITLE
Prohibit non-ASCII characters in URLs, nudge toward punycode

### DIFF
--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -35,6 +35,12 @@ module RuboCop
       def audit_url(type, urls, mirrors, livecheck_url: false)
         @type = type
 
+        # URLs must be ASCII; IDNs must be punycode
+        ascii_pattern = /[^\p{ASCII}]+/
+        audit_urls(urls, ascii_pattern) do |_, url|
+          problem "Please use the ASCII (Punycode encoded host, URL-encoded path and query) version of #{url}."
+        end
+
         # GNU URLs; doesn't apply to mirrors
         gnu_pattern = %r{^(?:https?|ftp)://ftpmirror\.gnu\.org/(.*)}
         audit_urls(urls, gnu_pattern) do |match, url|

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -177,6 +177,14 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "url" => "svn+http://brew.sh/foo/bar",
       "msg" => "Use of the svn+http:// scheme is deprecated, pass `:using => :svn` instead",
       "col" => 2,
+    }, {
+      "url" => "https://🫠.sh/foo/bar",
+      "msg" => "Please use the ASCII (Punycode encoded host, URL-encoded path and query) version of https://🫠.sh/foo/bar.",
+      "col" => 2,
+    }, {
+      "url" => "https://ßreｗ.sh/foo/bar",
+      "msg" => "Please use the ASCII (Punycode encoded host, URL-encoded path and query) version of https://ßreｗ.sh/foo/bar.",
+      "col" => 2,
     }]
   end
 


### PR DESCRIPTION
Inspired by curl's blog post, [Detecting malicious Unicode][1], this likely captures most if not all cases and nudges the user toward supplying IDNs with punycode.

A possible improvement would be telling the user exactly what punycode domain to use instead, but that may require another library as I can't quickly find something built into the Ruby stdlib that handles punycode encoding.

This also needs tests, to follow.


[1]: https://daniel.haxx.se/blog/2025/05/16/detecting-malicious-unicode/

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
