### PR TITLE
cask/audit: skip audit_rosetta on Intel-only casks & OSes

### DIFF
--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -68,6 +68,13 @@ class MacOSRequirement < Requirement
     @version
   end
 
+  def maximum_version
+    return MacOSVersion.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED) if @comparator == ">=" || !version_specified?
+    return @version.max if @version.respond_to?(:to_ary)
+
+    @version
+  end
+
   def allows?(other)
     return true unless version_specified?
 

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe MacOSRequirement do
   subject(:requirement) { described_class.new }
 
   let(:macos_oldest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_OLDEST_ALLOWED) }
+  let(:macos_newest_allowed) { MacOSVersion.new(HOMEBREW_MACOS_NEWEST_UNSUPPORTED) }
   let(:big_sur_major) { MacOSVersion.new("11.0") }
 
   describe "#satisfied?" do
@@ -35,6 +36,19 @@ RSpec.describe MacOSRequirement do
     expect(min_requirement.minimum_version).to eq big_sur_major
     expect(exact_requirement.minimum_version).to eq big_sur_major
     expect(range_requirement.minimum_version).to eq big_sur_major
+  end
+
+  specify "#maximum_version" do
+    no_requirement = described_class.new
+    max_requirement = described_class.new([:big_sur], comparator: "<=")
+    min_requirement = described_class.new([:big_sur], comparator: ">=")
+    exact_requirement = described_class.new([:big_sur], comparator: "==")
+    range_requirement = described_class.new([[:catalina, :big_sur]], comparator: "==")
+    expect(no_requirement.maximum_version).to eq macos_newest_allowed
+    expect(max_requirement.maximum_version).to eq big_sur_major
+    expect(min_requirement.maximum_version).to eq macos_newest_allowed
+    expect(exact_requirement.maximum_version).to eq big_sur_major
+    expect(range_requirement.maximum_version).to eq big_sur_major
   end
 
   specify "#allows?" do


### PR DESCRIPTION
Addresses audit bug noted in https://github.com/Homebrew/homebrew-cask/pull/212798#issuecomment-2888846354, so that `requires_rosetta` is required only if the Intel-only binary might encounter an ARM-capable macOS version.