### PR TITLE
Include annotations in tapioca updates

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -60,6 +60,7 @@ module Homebrew
         HOMEBREW_LIBRARY_PATH.cd do
           if update
             workers = args.debug? ? ["--workers=1"] : []
+            safe_system "bundle", "exec", "tapioca", "annotations"
             safe_system "bundle", "exec", "tapioca", "dsl", *workers
             # Prefer adding args here: Library/Homebrew/sorbet/tapioca/config.yml
             tapioca_args = args.update_all? ? ["--all"] : []

--- a/Library/Homebrew/sorbet/rbi/annotations/.gitattributes
+++ b/Library/Homebrew/sorbet/rbi/annotations/.gitattributes
@@ -1,0 +1,1 @@
+**/*.rbi linguist-vendored=true

--- a/Library/Homebrew/sorbet/rbi/annotations/minitest.rbi
+++ b/Library/Homebrew/sorbet/rbi/annotations/minitest.rbi
@@ -1,0 +1,119 @@
+# typed: true
+
+# DO NOT EDIT MANUALLY
+# This file was pulled from a central RBI files repository.
+# Please run `bin/tapioca annotations` to update it.
+
+module Minitest::Assertions
+  sig { params(test: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert(test, msg = nil); end
+
+  sig { params(obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_empty(obj, msg = nil); end
+
+  sig { params(exp: T.anything, act: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_equal(exp, act, msg = nil); end
+
+  sig { params(exp: T.anything, act: T.anything, delta: Numeric, msg: T.anything).returns(TrueClass) }
+  def assert_in_delta(exp, act, delta = T.unsafe(nil), msg = nil); end
+
+  sig { params(a: T.anything, b: T.anything, epsilon: Numeric, msg: T.anything).returns(TrueClass) }
+  def assert_in_epsilon(a, b, epsilon = T.unsafe(nil), msg = nil); end
+
+  sig { params(collection: T.anything, obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_includes(collection, obj, msg = nil); end
+
+  sig { params(cls: T.anything, obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_instance_of(cls, obj, msg = nil); end
+
+  sig { params(cls: T.anything, obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_kind_of(cls, obj, msg = nil); end
+
+  sig { params(matcher: T.any(String, Regexp), obj: T.anything, msg: T.anything).returns(MatchData) }
+  def assert_match(matcher, obj, msg = nil); end
+
+  sig { params(obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_nil(obj, msg = nil); end
+
+  sig { params(o1: T.anything, op: T.any(Symbol, String), o2: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_operator(o1, op, o2 = T.unsafe(nil), msg = nil); end
+
+  sig { params(stdout: T.nilable(T.any(String, Regexp)), stderr: T.nilable(T.any(String, Regexp)), block: T.proc.void).returns(T::Boolean) }
+  def assert_output(stdout = nil, stderr = nil, &block); end
+
+  sig { params(path: T.any(String, Pathname), msg: T.anything).returns(TrueClass) }
+  def assert_path_exists(path, msg = nil); end
+
+  sig { params(block: T.proc.void).returns(TrueClass) }
+  def assert_pattern(&block); end
+
+  sig { params(o1: T.anything, op: T.any(String, Symbol), msg: T.anything).returns(TrueClass) }
+  def assert_predicate(o1, op, msg = nil); end
+
+  sig { params(exp: NilClass, block: T.proc.void).returns(StandardError) }
+  sig { type_parameters(:T).params(exp: T.any(T::Class[T.type_parameter(:T)], Regexp, String), block: T.proc.void).returns(T.type_parameter(:T)) }
+  def assert_raises(*exp, &block); end
+
+  sig { params(obj: T.anything, meth: T.any(String, Symbol), msg: T.anything, include_all: T::Boolean).returns(TrueClass) }
+  def assert_respond_to(obj, meth, msg = nil, include_all: false); end
+
+  sig { params(exp: T.anything, act: T.anything, msg: T.anything).returns(TrueClass) }
+  def assert_same(exp, act, msg = nil); end
+
+  sig { params(send_ary: T::Array[T.anything], m: T.anything).returns(T::Boolean) }
+  def assert_send(send_ary, m = nil); end
+
+  sig { params(block: T.proc.void).returns(T::Boolean) }
+  def assert_silent(&block); end
+
+  sig { params(sym: Symbol, msg: T.anything, block: T.proc.void).returns(T.anything) }
+  def assert_throws(sym, msg = nil, &block); end
+
+  sig { params(test: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute(test, msg = nil); end
+
+  sig { params(obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_empty(obj, msg = nil); end
+
+  sig { params(exp: T.anything, act: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_equal(exp, act, msg = nil); end
+
+  sig { params(exp: T.anything, act: T.anything, delta: Numeric, msg: T.anything).returns(TrueClass) }
+  def refute_in_delta(exp, act, delta = T.unsafe(nil), msg = nil); end
+
+  sig { params(a: T.anything, b: T.anything, epsilon: Numeric, msg: T.anything).returns(TrueClass) }
+  def refute_in_epsilon(a, b, epsilon = T.unsafe(nil), msg = nil); end
+
+  sig { params(collection: T.anything, obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_includes(collection, obj, msg = nil); end
+
+  sig { params(cls: T.anything, obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_instance_of(cls, obj, msg = nil); end
+
+  sig { params(cls: T.anything, obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_kind_of(cls, obj, msg = nil); end
+
+  sig { params(matcher: T.any(String, Regexp), obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_match(matcher, obj, msg = nil); end
+
+  sig { params(obj: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_nil(obj, msg = nil); end
+
+  sig { params(block: T.proc.void).returns(TrueClass) }
+  def refute_pattern(&block); end
+
+  sig { params(o1: T.anything, op: T.any(Symbol, String), o2: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_operator(o1, op, o2 = T.unsafe(nil), msg = nil); end
+
+  sig { params(path: T.any(String, Pathname), msg: T.anything).returns(TrueClass) }
+  def refute_path_exists(path, msg = nil); end
+
+  sig { params(o1: T.anything, op: T.any(String, Symbol), msg: T.anything).returns(TrueClass) }
+  def refute_predicate(o1, op, msg = nil); end
+
+  sig { params(obj: T.anything, meth: T.any(String, Symbol), msg: T.anything, include_all: T::Boolean).returns(TrueClass) }
+  def refute_respond_to(obj, meth, msg = nil, include_all: false); end
+
+  sig { params(exp: T.anything, act: T.anything, msg: T.anything).returns(TrueClass) }
+  def refute_same(exp, act, msg = nil); end
+end

--- a/Library/Homebrew/sorbet/rbi/annotations/rainbow.rbi
+++ b/Library/Homebrew/sorbet/rbi/annotations/rainbow.rbi
@@ -1,0 +1,269 @@
+# typed: true
+
+# DO NOT EDIT MANUALLY
+# This file was pulled from a central RBI files repository.
+# Please run `bin/tapioca annotations` to update it.
+
+module Rainbow
+  # @shim: https://github.com/sickill/rainbow/blob/master/lib/rainbow.rb#L10-L12
+  sig { returns(T::Boolean) }
+  attr_accessor :enabled
+
+  class Color
+    sig { returns(Symbol) }
+    attr_reader :ground
+
+    sig { params(ground: Symbol, values: T.any([Integer], [Integer, Integer, Integer])).returns(Color) }
+    def self.build(ground, values); end
+
+    sig { params(hex: String).returns([Integer, Integer, Integer]) }
+    def self.parse_hex_color(hex); end
+
+    class Indexed < Rainbow::Color
+      sig { returns(Integer) }
+      attr_reader :num
+
+      sig { params(ground: Symbol, num: Integer).void }
+      def initialize(ground, num); end
+
+      sig { returns(T::Array[Integer]) }
+      def codes; end
+    end
+
+    class Named < Rainbow::Color::Indexed
+      NAMES = T.let(nil, T::Hash[Symbol, Integer])
+
+      sig { params(ground: Symbol, name: Symbol).void }
+      def initialize(ground, name); end
+
+      sig { returns(T::Array[Symbol]) }
+      def self.color_names; end
+
+      sig { returns(String) }
+      def self.valid_names; end
+    end
+
+    class RGB < Rainbow::Color::Indexed
+      sig { returns(Integer) }
+      attr_reader :r, :g, :b
+
+      sig { params(ground: Symbol, values: Integer).void }
+      def initialize(ground, *values); end
+
+      sig { returns(T::Array[Integer]) }
+      def codes; end
+
+      sig { params(value: Numeric).returns(Integer) }
+      def self.to_ansi_domain(value); end
+    end
+
+    class X11Named < Rainbow::Color::RGB
+      include Rainbow::X11ColorNames
+
+      sig { params(ground: Symbol, name: Symbol).void }
+      def initialize(ground, name); end
+
+      sig { returns(T::Array[Symbol]) }
+      def self.color_names; end
+
+      sig { returns(String) }
+      def self.valid_names; end
+    end
+  end
+
+  sig { returns(Wrapper) }
+  def self.global; end
+
+  sig { returns(T::Boolean) }
+  def self.enabled; end
+
+  sig { params(value: T::Boolean).returns(T::Boolean) }
+  def self.enabled=(value); end
+
+  sig { params(string: String).returns(String) }
+  def self.uncolor(string); end
+
+  class NullPresenter < String
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(NullPresenter) }
+    def color(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(NullPresenter) }
+    def foreground(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(NullPresenter) }
+    def fg(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(NullPresenter) }
+    def background(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(NullPresenter) }
+    def bg(*values); end
+
+    sig { returns(NullPresenter) }
+    def reset; end
+
+    sig { returns(NullPresenter) }
+    def bright; end
+
+    sig { returns(NullPresenter) }
+    def faint; end
+
+    sig { returns(NullPresenter) }
+    def italic; end
+
+    sig { returns(NullPresenter) }
+    def underline; end
+
+    sig { returns(NullPresenter) }
+    def blink; end
+
+    sig { returns(NullPresenter) }
+    def inverse; end
+
+    sig { returns(NullPresenter) }
+    def hide; end
+
+    sig { returns(NullPresenter) }
+    def cross_out; end
+
+    sig { returns(NullPresenter) }
+    def black; end
+
+    sig { returns(NullPresenter) }
+    def red; end
+
+    sig { returns(NullPresenter) }
+    def green; end
+
+    sig { returns(NullPresenter) }
+    def yellow; end
+
+    sig { returns(NullPresenter) }
+    def blue; end
+
+    sig { returns(NullPresenter) }
+    def magenta; end
+
+    sig { returns(NullPresenter) }
+    def cyan; end
+
+    sig { returns(NullPresenter) }
+    def white; end
+
+    sig { returns(NullPresenter) }
+    def bold; end
+
+    sig { returns(NullPresenter) }
+    def dark; end
+
+    sig { returns(NullPresenter) }
+    def strike; end
+  end
+
+  class Presenter < String
+    TERM_EFFECTS = T.let(nil, T::Hash[Symbol, Integer])
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(Presenter) }
+    def color(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(Presenter) }
+    def foreground(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(Presenter) }
+    def fg(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(Presenter) }
+    def background(*values); end
+
+    sig { params(values: T.any([Integer], [Integer, Integer, Integer])).returns(Presenter) }
+    def bg(*values); end
+
+    sig { returns(Presenter) }
+    def reset; end
+
+    sig { returns(Presenter) }
+    def bright; end
+
+    sig { returns(Presenter) }
+    def faint; end
+
+    sig { returns(Presenter) }
+    def italic; end
+
+    sig { returns(Presenter) }
+    def underline; end
+
+    sig { returns(Presenter) }
+    def blink; end
+
+    sig { returns(Presenter) }
+    def inverse; end
+
+    sig { returns(Presenter) }
+    def hide; end
+
+    sig { returns(Presenter) }
+    def cross_out; end
+
+    sig { returns(Presenter) }
+    def black; end
+
+    sig { returns(Presenter) }
+    def red; end
+
+    sig { returns(Presenter) }
+    def green; end
+
+    sig { returns(Presenter) }
+    def yellow; end
+
+    sig { returns(Presenter) }
+    def blue; end
+
+    sig { returns(Presenter) }
+    def magenta; end
+
+    sig { returns(Presenter) }
+    def cyan; end
+
+    sig { returns(Presenter) }
+    def white; end
+
+    sig { returns(Presenter) }
+    def bold; end
+
+    sig { returns(Presenter) }
+    def dark; end
+
+    sig { returns(Presenter) }
+    def strike; end
+  end
+
+  class StringUtils
+    sig { params(string: String, codes: T::Array[Integer]).returns(String) }
+    def self.wrap_with_sgr(string, codes); end
+
+    sig { params(string: String).returns(String) }
+    def self.uncolor(string); end
+  end
+
+  VERSION = T.let(nil, String)
+
+  class Wrapper
+    sig { returns(T::Boolean) }
+    attr_accessor :enabled
+
+    sig { params(enabled: T::Boolean).void }
+    def initialize(enabled = true); end
+
+    sig { params(string: String).returns(T.any(Rainbow::Presenter, Rainbow::NullPresenter)) }
+    def wrap(string); end
+  end
+
+  module X11ColorNames
+    NAMES = T.let(nil, T::Hash[Symbol, [Integer, Integer, Integer]])
+  end
+end
+
+sig { params(string: String).returns(Rainbow::Presenter) }
+def Rainbow(string); end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
tapioca-generated rbis contain no type information by default, but there is an `annotations` command, which pulls in gem type annotations that have been submitted to https://github.com/Shopify/rbi-central. There's not much there now, but I expect the value to grow over time. Thus, it's probably better for us to climb aboard now, than to try to apply it later with a stack of type errors to resolve.