### PR TITLE
dev-cmd/update-maintainers: various fixes.

### DIFF
--- a/Library/Homebrew/dev-cmd/update-maintainers.rb
+++ b/Library/Homebrew/dev-cmd/update-maintainers.rb
@@ -21,12 +21,22 @@ module Homebrew
 
       sig { override.void }
       def run
+        # Needed for Manpages.regenerate_man_pages below
+        Homebrew.install_bundler_gems!(groups: ["man"])
+
         # We assume that only public members wish to be included in the README
         public_members = GitHub.public_member_usernames("Homebrew")
         maintainers = GitHub.members_by_team("Homebrew", "maintainers")
 
+        # Not all PLC members are Homebrew GitHub organisation members any more
+        non_maintainer_plc_members = {
+          colindean: "Colin Dean",
+          mozzadrella: "Vanessa Gennarelli",
+        }.transform_keys(&:to_s)
+        public_members += non_maintainer_plc_members.keys
+
         members = {
-          plc:         GitHub.members_by_team("Homebrew", "plc"),
+          plc:         GitHub.members_by_team("Homebrew", "plc").merge(non_maintainer_plc_members),
           tsc:         GitHub.members_by_team("Homebrew", "tsc"),
           maintainers:,
         }

--- a/Library/Homebrew/dev-cmd/update-maintainers.rb
+++ b/Library/Homebrew/dev-cmd/update-maintainers.rb
@@ -30,7 +30,7 @@ module Homebrew
 
         # Not all PLC members are Homebrew GitHub organisation members any more
         non_maintainer_plc_members = {
-          colindean: "Colin Dean",
+          colindean:   "Colin Dean",
           mozzadrella: "Vanessa Gennarelli",
         }.transform_keys(&:to_s)
         public_members += non_maintainer_plc_members.keys


### PR DESCRIPTION
- install the `man` gem group for `kramdown` so `Manpages.regenerate_man_pages` can run successfully
- hardcode the non-organisation PLC members so that they aren't missing from the GitHub team
- correctly populate the PLC members again