### PR TITLE
dev-cmd/tap-new: fix root_url warning.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -126,7 +126,7 @@ module Homebrew
                     echo "::add-mask::${base64_token}"
                     echo "token=${base64_token}" >> "${GITHUB_OUTPUT}"
           <% end -%>
-                - run: brew test-bot --only-formulae<% if root_url %> --root-url='<%= root_url %>'<% end %>
+                - run: brew test-bot --only-formulae#{" --root-url=#{root_url}" if root_url}
                   if: github.event_name == 'pull_request'
           <% if args.github_packages? -%>
                   env:


### PR DESCRIPTION
Ruby couldn't detect the `root_url` usage inside the ERB template. Instead, use interpolation so it can for a fixed warning and more concise syntax.