### PR TITLE
bundle/commands/exec: fix exit code handling.

### DIFF
--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -178,7 +178,9 @@ module Homebrew
             exit_code = 0
             run_services(@dsl.entries) do
               Kernel.system(*args)
-              exit_code = $CHILD_STATUS.exitstatus
+              if (system_exit_code = $CHILD_STATUS&.exitstatus)
+                exit_code = system_exit_code
+              end
             end
             exit!(exit_code)
           else


### PR DESCRIPTION
In some `brew tests` runs (e.g. https://github.com/Homebrew/brew/actions/runs/15163308534/job/42634570735?pr=19991), `$CHILD_STATUS` can be `nil`. Let's handle this and avoid these flaky tests.