### PR TITLE
cask/dsl: set `no_autobump!` if livecheck uses `:extract_plist`

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -161,8 +161,6 @@ module Cask
       @token = T.let(cask.token, String)
       @url = T.let(nil, T.nilable(URL))
       @version = T.let(nil, T.nilable(DSL::Version))
-
-      set_no_autobump!
     end
 
     sig { returns(T::Boolean) }
@@ -176,13 +174,6 @@ module Cask
 
     sig { returns(T::Boolean) }
     def livecheck_defined? = @livecheck_defined
-
-    sig { void }
-    def set_no_autobump!
-      return if @livecheck.strategy != :extract_plist
-
-      no_autobump! because: :extract_plist
-    end
 
     sig { returns(T::Boolean) }
     def on_system_blocks_exist? = @on_system_blocks_exist
@@ -547,6 +538,8 @@ module Cask
 
       @livecheck_defined = true
       @livecheck.instance_eval(&block)
+      no_autobump! because: :extract_plist if @livecheck.strategy == :extract_plist
+      @livecheck
     end
 
     # Whether the cask contains a `livecheck` block. This is a legacy alias


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I did a mistake when adding `:extract_plist` no autobump reason, it tries to check livecheck strategy before livecheck block is evaluated. This PR fixes this problem
```shell
# cask api (before the fix)
$ grep "\"autobump\": false" -r _data/cask | wc -l
2043
# caks api (after the fix)
$ grep "\"autobump\": false" -r _data/cask | wc -l
2130
$ grep ":extract_plist" -r /opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks | wc -l
87 # how many casks use `:extract_plist` strategy
```