### PR TITLE
brew cmd: read every line of brew.env

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -139,8 +139,10 @@ export_homebrew_env_file() {
 
   env_file="${1}"
   [[ -r "${env_file}" ]] || return 0
-  while read -r line
+  local eof
+  while [[ -z "${eof}" ]]
   do
+    read -r line || eof=1
     # only load HOMEBREW_* lines
     [[ "${line}" = "HOMEBREW_"* ]] || continue
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Ensure we read the last line of brew.env files, even if there is no trailing newline.

Currently, the last line of the file is ignored if not terminated with a newline, which, as a user, is astonishing and confusing.