### PR TITLE
bump-pr: respect --write-only flag and skip git operations

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -49,7 +49,6 @@ module Homebrew
                description: "Use the specified GitHub organization for forking."
 
         conflicts "--dry-run", "--write"
-        conflicts "--no-audit", "--online"
         conflicts "--version=", "--version-arm="
         conflicts "--version=", "--version-intel="
 
@@ -85,7 +84,9 @@ module Homebrew
           method or 'livecheck' block with 'skip'.)
         EOS
 
-        odie "You have too many PRs open: close or merge some first!" if GitHub.too_many_open_prs?(cask.tap)
+        if !args.write_only? && GitHub.too_many_open_prs?(cask.tap)
+          odie "You have too many PRs open: close or merge some first!"
+        end
 
         new_version = BumpVersionParser.new(
           general: args.version,
@@ -113,7 +114,7 @@ module Homebrew
           raise UsageError, "No `--version`, `--url` or `--sha256` argument specified!"
         end
 
-        check_pull_requests(cask, new_version:)
+        check_pull_requests(cask, new_version:) unless args.write_only?
 
         replacement_pairs ||= []
         branch_name = "bump-#{cask.token}"
@@ -136,7 +137,7 @@ module Homebrew
         end
 
         if new_version.present?
-          # For simplicity, our naming defers to the arm version if we multiple architectures are specified
+          # For simplicity, our naming defers to the arm version if multiple architectures are specified
           branch_version = new_version.arm || new_version.general
           if branch_version.is_a?(Cask::DSL::Version)
             commit_version = shortened_version(branch_version, cask:)
@@ -171,7 +172,7 @@ module Homebrew
           pr_title:    commit_message,
         }
 
-        GitHub.create_bump_pr(pr_info, args:)
+        GitHub.create_bump_pr(pr_info, args:) unless args.write_only?
       end
 
       private

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -121,7 +121,9 @@ module Homebrew
           method or 'livecheck' block with 'skip'.)
         EOS
 
-        odie "You have too many PRs open: close or merge some first!" if GitHub.too_many_open_prs?(tap)
+        if !args.write_only? && GitHub.too_many_open_prs?(tap)
+          odie "You have too many PRs open: close or merge some first!"
+        end
 
         formula_spec = formula.stable
         odie "#{formula}: no stable specification found!" if formula_spec.blank?
@@ -135,7 +137,7 @@ module Homebrew
         remote_branch = tap.git_repository.origin_branch_name
         previous_branch = "-"
 
-        check_pull_requests(formula, tap_remote_repo, state: "open")
+        check_pull_requests(formula, tap_remote_repo, state: "open") unless args.write_only?
 
         all_formulae = []
         if args.bump_synced.present?
@@ -434,7 +436,7 @@ module Homebrew
           # If `brew audit` fails, revert the changes made to any formula.
           commits.each do |revert|
             revert_formula = Formula[revert[:formula_name]]
-            revert_formula.path.atomic_write(revert[:old_contents]) unless args.dry_run?
+            revert_formula.path.atomic_write(revert[:old_contents]) unless args.dry_run? || args.write_only?
             revert_alias_rename = revert[:additional_files]
             if revert_alias_rename && (source = revert_alias_rename.first) && (destination = revert_alias_rename.last)
               FileUtils.mv source, destination
@@ -471,7 +473,7 @@ module Homebrew
           tap_remote_repo:,
           pr_message:,
         }
-        GitHub.create_bump_pr(pr_info, args:)
+        GitHub.create_bump_pr(pr_info, args:) unless args.write_only?
       end
 
       private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The flag used to work well, but at some point started to run more and
more git actions. We use this to update formula and casks in other
homebrew taps, and it works well except for this issue.