### PR TITLE
feat: add _ to powershell completion filename

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2126,7 +2126,7 @@ class Formula
       bash: bash_completion/base_name,
       zsh:  zsh_completion/"_#{base_name}",
       fish: fish_completion/"#{base_name}.fish",
-      pwsh: pwsh_completion/"#{base_name}.ps1",
+      pwsh: pwsh_completion/"_#{base_name}.ps1",
     }
 
     shells.each do |shell|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Based on https://github.com/Homebrew/homebrew-core/pull/224200, the powershell completion filename usually have _ prefix and so here I add it. There is no usage of `:pwsh` in the method `generate_completions_from_executable`, so we can change this without impact.
