### PR TITLE
docs/Support-Tiers: tweak wording, add CODEOWNERS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@
 !/completions
 !/docs
 !/manpages
+!/CODEOWNERS
 
 # Unignore our packaging files
 !/package

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# Note that the naming of this file is incorrect for our case: these people do not "own" the provided files but are
+# people with write-access to this repository who wish to approve changes to these files.
+#
+# Their review is required to merge PRs that change these files.
+#
+# To be explicit: we will never accept changes to this file adding people from outside the Homebrew GitHub
+# organisation. If you are not a Homebrew maintainer: you do not personally "own" or "maintain" any files.
+#
+# Note: @Homebrew/plc does not have write-access to this repository, and therefore cannot be listed in this file.
+
+docs/Support-Tiers.md  @Homebrew/tsc @MikeMcQuaid

--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -22,7 +22,7 @@ A Tier 1 supported configuration is one in which:
 For Tier 1 support, Homebrew on macOS must be all of:
 
 - running on official Apple hardware (e.g. not a "Hackintosh" or VM)
-- running the latest patch of a version of macOS supported by Apple on that hardware
+- running the latest patch release of a macOS version supported by Apple on that hardware
 - running a version of macOS with Homebrew CI coverage (i.e. the latest stable or prerelease version, two preceding versions)
 - installed in the default prefix (i.e. `/opt/homebrew` on Apple Silicon, `/usr/local` on Intel x86_64)
 - running on a supported architecture (i.e. Apple Silicon or Intel x86_64)


### PR DESCRIPTION
Let's improve the wording of the Support Tiers document and add it to a (new) CODEOWNERS file to ensure that I or the TSC review changes.

From discussion in https://github.com/Homebrew/brew/pull/20007