### PR TITLE
tap: fix handling of `--repair` with no branches

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -600,7 +600,7 @@ class Tap
     safe_system "git", "-C", path, *args
     git_repository.set_head_origin_auto
 
-    current_upstream_head = git_repository.origin_branch_name if current_upstream_head.nil?
+    current_upstream_head ||= git_repository.origin_branch_name
 
     new_upstream_head = T.must(git_repository.origin_branch_name)
     return if new_upstream_head == current_upstream_head

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -590,14 +590,15 @@ class Tap
     end
     return unless remote
 
-    current_upstream_head = T.must(git_repository.origin_branch_name)
-    return if requested_remote.blank? && git_repository.origin_has_branch?(current_upstream_head)
-
     args = %w[fetch]
     args << "--quiet" if quiet
     args << "origin"
     args << "+refs/heads/*:refs/remotes/origin/*"
     safe_system "git", "-C", path, *args
+
+    current_upstream_head = T.must(git_repository.origin_branch_name)
+    return if requested_remote.blank? && git_repository.origin_has_branch?(current_upstream_head)
+
     git_repository.set_head_origin_auto
 
     new_upstream_head = T.must(git_repository.origin_branch_name)

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -590,16 +590,17 @@ class Tap
     end
     return unless remote
 
+    current_upstream_head = git_repository.origin_branch_name
+    return if current_upstream_head.present? && requested_remote.blank? && git_repository.origin_has_branch?(current_upstream_head)
+
     args = %w[fetch]
     args << "--quiet" if quiet
     args << "origin"
     args << "+refs/heads/*:refs/remotes/origin/*"
     safe_system "git", "-C", path, *args
-
-    current_upstream_head = T.must(git_repository.origin_branch_name)
-    return if requested_remote.blank? && git_repository.origin_has_branch?(current_upstream_head)
-
     git_repository.set_head_origin_auto
+
+    current_upstream_head = git_repository.origin_branch_name if current_upstream_head.nil?
 
     new_upstream_head = T.must(git_repository.origin_branch_name)
     return if new_upstream_head == current_upstream_head

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -591,7 +591,8 @@ class Tap
     return unless remote
 
     current_upstream_head = git_repository.origin_branch_name
-    return if current_upstream_head.present? && requested_remote.blank? && git_repository.origin_has_branch?(current_upstream_head)
+    return if current_upstream_head.present? && requested_remote.blank? &&
+              git_repository.origin_has_branch?(current_upstream_head)
 
     args = %w[fetch]
     args << "--quiet" if quiet

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -601,7 +601,7 @@ class Tap
     safe_system "git", "-C", path, *args
     git_repository.set_head_origin_auto
 
-    current_upstream_head ||= git_repository.origin_branch_name
+    current_upstream_head ||= T.must(git_repository.origin_branch_name)
 
     new_upstream_head = T.must(git_repository.origin_branch_name)
     return if new_upstream_head == current_upstream_head


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I was messing around creating a new tap and tapped a git repo that was empty. I got this error because Homebrew can't figure out the branch (because there are no branches in my empty repo).

```
 ~/ brew tap --repair
Error: Passed `nil` into T.must
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/_types.rb:222:in 'T.must'
/opt/homebrew/Library/Homebrew/tap.rb:594:in 'Tap#fix_remote_configuration'
/opt/homebrew/Library/Homebrew/cmd/tap.rb:57:in 'block in Homebrew::Cmd::TapCmd#run'
/opt/homebrew/Library/Homebrew/cmd/tap.rb:55:in 'Array#each'
/opt/homebrew/Library/Homebrew/cmd/tap.rb:55:in 'Homebrew::Cmd::TapCmd#run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/_methods.rb:277:in 'block in Homebrew::Cmd::TapCmd#_on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:95:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
 ~/ 
````

The problem is that this error persists when I've created a branch and pushed to it, since we don't fetch the repo before checking for a branch. To fix this, I just moved the existing `git fetch` to occur before we get the `origin_branch_name`.

I'm happy to add tests, but I think it would require setting up a different empty git repo in `tap_spec.rb.rb` and using that for assertions. The overhead didn't seem worth it for this edge case, but let me know, and I'll get that cracking.

Also happy to file a issue for this but I thought this was lightweight enough to warrant just a quick PR.



