### PR TITLE
autobump_constants: add `:requires_manual_review` reason

### DIFF
--- a/Library/Homebrew/autobump_constants.rb
+++ b/Library/Homebrew/autobump_constants.rb
@@ -7,4 +7,5 @@ NO_AUTOBUMP_REASONS_LIST = T.let({
   bumped_by_upstream:          "bumped by upstream",
   extract_plist:               "livecheck uses `:extract_plist` strategy",
   latest_version:              "`version` is set to `:latest`",
+  requires_manual_review:      "a manual review of this package is required for inclusion in autobump",
 }.freeze, T::Hash[Symbol, String])


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Temporary `no_autobump!` reason intended to be used for core formulae and casks that are not in `autobump.txt` file