### PR TITLE
audits: quote and reword problem description text

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -63,7 +63,7 @@ module Homebrew
       url_strategy = DownloadStrategyDetector.detect(url)
 
       if (using == :git || url_strategy == GitDownloadStrategy) && specs[:tag] && !specs[:revision]
-        problem "Git should specify :revision when a :tag is specified."
+        problem "Git should specify `revision:` when a `tag:` is specified."
       end
 
       return unless using
@@ -71,7 +71,7 @@ module Homebrew
       if using == :cvs
         mod = specs[:module]
 
-        problem "Redundant :module value in URL" if mod == name
+        problem "Redundant `module:` value in URL" if mod == name
 
         if url.match?(%r{:[^/]+$})
           mod = url.split(":").last
@@ -79,14 +79,14 @@ module Homebrew
           if mod == name
             problem "Redundant CVS module appended to URL"
           else
-            problem "Specify CVS module as `:module => \"#{mod}\"` instead of appending it to the URL"
+            problem "Specify CVS module as `module: \"#{mod}\"` instead of appending it to the URL"
           end
         end
       end
 
       return if url_strategy != DownloadStrategyDetector.detect("", using)
 
-      problem "Redundant :using value in URL"
+      problem "Redundant `using:` value in URL"
     end
 
     def audit_checksum
@@ -125,7 +125,7 @@ module Homebrew
 
       return if name.casecmp(pypi_package_name).zero?
 
-      problem "resource name should be `#{pypi_package_name}` to match the PyPI package name"
+      problem "`resource` name should be '#{pypi_package_name}' to match the PyPI package name"
     end
 
     def audit_urls
@@ -166,12 +166,12 @@ module Homebrew
             remote_exists = Utils::Git.remote_exists?(url)
             attempts += 1
           end
-          problem "The URL #{url} is not a valid git URL" unless remote_exists
+          problem "The URL #{url} is not a valid Git URL" unless remote_exists
         elsif strategy <= SubversionDownloadStrategy
           next unless DevelopmentTools.subversion_handles_most_https_certificates?
           next unless Utils::Svn.available?
 
-          problem "The URL #{url} is not a valid svn URL" unless Utils::Svn.remote_exists? url
+          problem "The URL #{url} is not a valid SVN URL" unless Utils::Svn.remote_exists? url
         end
       end
     end
@@ -188,7 +188,7 @@ module Homebrew
                     .match(%r{ref: refs/heads/(.*?)\s+HEAD})&.to_a&.second
       return if branch.blank? || branch == specs[:branch]
 
-      problem "Use `branch: \"#{branch}\"` to specify the default branch"
+      problem "Specify the default branch as `branch: \"#{branch}\"`"
     end
 
     def problem(text)

--- a/Library/Homebrew/rubocops/caveats.rb
+++ b/Library/Homebrew/rubocops/caveats.rb
@@ -30,7 +30,7 @@ module RuboCop
         def audit_formula(_formula_nodes)
           caveats_strings.each do |n|
             if regex_match_group(n, /\bsetuid\b/i)
-              problem "Don't recommend `setuid` in the caveats, suggest `sudo` instead."
+              problem "Instead of recommending `setuid` in the caveats, suggest `sudo`."
             end
 
             problem "Don't use ANSI escape codes in the caveats." if regex_match_group(n, /\e/)

--- a/Library/Homebrew/rubocops/checksum.rb
+++ b/Library/Homebrew/rubocops/checksum.rb
@@ -28,17 +28,17 @@ module RuboCop
           return if checksum.nil?
 
           if regex_match_group(checksum, /^$/)
-            problem "sha256 is empty"
+            problem "`sha256` is empty"
             return
           end
 
           if string_content(checksum).size != 64 && regex_match_group(checksum, /^\w*$/)
-            problem "sha256 should be 64 characters"
+            problem "`sha256` should be 64 characters"
           end
 
           return unless regex_match_group(checksum, /[^a-f0-9]+/i)
 
-          add_offense(T.must(@offensive_source_range), message: "sha256 contains invalid characters")
+          add_offense(T.must(@offensive_source_range), message: "`sha256` contains invalid characters")
         end
       end
 
@@ -54,7 +54,7 @@ module RuboCop
             next if checksum.nil?
             next unless regex_match_group(checksum, /[A-F]+/)
 
-            add_offense(@offensive_source_range, message: "sha256 should be lowercase") do |corrector|
+            add_offense(@offensive_source_range, message: "`sha256` should be lowercase") do |corrector|
               correction = T.must(@offensive_node).source.downcase
               corrector.insert_before(T.must(@offensive_node).source_range, correction)
               corrector.remove(T.must(@offensive_node).source_range)

--- a/Library/Homebrew/rubocops/class.rb
+++ b/Library/Homebrew/rubocops/class.rb
@@ -23,7 +23,7 @@ module RuboCop
           parent_class = class_name(parent_class_node)
           return unless DEPRECATED_CLASSES.include?(parent_class)
 
-          problem "#{parent_class} is deprecated, use Formula instead" do |corrector|
+          problem "`#{parent_class}` is deprecated, use `Formula` instead" do |corrector|
             corrector.replace(parent_class_node.source_range, "Formula")
           end
         end
@@ -49,14 +49,14 @@ module RuboCop
             p1, p2 = params
             if (match = string_content(p1).match(%r{(/usr/local/(s?bin))}))
               offending_node(p1)
-              problem "use \#{#{match[2]}} instead of #{match[1]} in #{node}" do |corrector|
+              problem "Use `\#{#{match[2]}}` instead of `#{match[1]}` in `#{node}`" do |corrector|
                 corrector.replace(p1.source_range, p1.source.sub(match[1], "\#{#{match[2]}}"))
               end
             end
 
             if node == :shell_output && node_equals?(p2, 0)
               offending_node(p2)
-              problem "Passing 0 to shell_output() is redundant" do |corrector|
+              problem "Passing 0 to `shell_output` is redundant" do |corrector|
                 corrector.remove(range_with_surrounding_comma(range_with_surrounding_space(range: p2.source_range,
                                                                                            side:  :left)))
               end

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -39,7 +39,7 @@ module RuboCop
 
             if on_method_blocks.length > 1
               @offensive_node = on_method_blocks.second
-              problem "there can only be one `#{on_method}` block in a formula."
+              problem "There can only be one `#{on_method}` block in a formula."
             end
 
             check_on_system_block_content(component_precedence_list, on_method_blocks.first)
@@ -112,7 +112,7 @@ module RuboCop
 
             on_system_blocks.each do |on_method, blocks|
               if blocks.length > 1
-                problem "there can only be one `#{on_method}` block in a resource block."
+                problem "There can only be one `#{on_method}` block in a resource block."
                 next
               end
             end

--- a/Library/Homebrew/rubocops/components_redundancy.rb
+++ b/Library/Homebrew/rubocops/components_redundancy.rb
@@ -32,7 +32,7 @@ module RuboCop
 
               url_args = arg.keys.each.map(&:value)
               if method_called?(body_node, :sha256) && url_args.include?(:tag) && url_args.include?(:revision)
-                problem "Do not use both sha256 and tag/revision."
+                problem "Do not use both `sha256` and `tag:`/`revision:`."
               end
             end
           end

--- a/Library/Homebrew/rubocops/dependency_order.rb
+++ b/Library/Homebrew/rubocops/dependency_order.rb
@@ -108,8 +108,8 @@ module RuboCop
 
             offending_node(node_1)
 
-            problem "dependency \"#{dependency_name(node_1)}\" (line #{l1}) should be put before dependency " \
-                    "\"#{dependency_name(node_2)}\" (line #{l2})" do |corrector|
+            problem "`dependency \"#{dependency_name(node_1)}\"` (line #{l1}) should be put before " \
+                    "`dependency \"#{dependency_name(node_2)}\"` (line #{l2})" do |corrector|
               indentation = " " * (start_column(node_2) - line_start_column(node_2))
               line_breaks = "\n"
               corrector.insert_before(node_2.source_range,

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -165,41 +165,42 @@ module RuboCop
             next unless unless_modifier?(method.parent)
 
             correct = method.source.gsub("out?", "?")
-            problem "Use if #{correct} instead of unless #{method.source}"
+            problem "Use `if #{correct}` instead of `unless #{method.source}`"
           end
 
           find_instance_method_call(body_node, :build, :with?) do |method|
             next unless unless_modifier?(method.parent)
 
             correct = method.source.gsub("?", "out?")
-            problem "Use if #{correct} instead of unless #{method.source}"
+            problem "Use `if #{correct}` instead of `unless #{method.source}`"
           end
 
           find_instance_method_call(body_node, :build, :with?) do |method|
             next unless expression_negated?(method)
 
-            problem "Don't negate 'build.with?': use 'build.without?'"
+            problem "Instead of negating `build.with?`, use `build.without?`"
           end
 
           find_instance_method_call(body_node, :build, :without?) do |method|
             next unless expression_negated?(method)
 
-            problem "Don't negate 'build.without?': use 'build.with?'"
+            problem "Instead of negating `build.without?`, use `build.with?`"
           end
 
           find_instance_method_call(body_node, :build, :without?) do |method|
             arg = parameters(method).first
             next unless (match = regex_match_group(arg, /^-?-?without-(.*)/))
 
-            problem "Don't duplicate 'without': " \
-                    "Use `build.without? \"#{match[1]}\"` to check for \"--without-#{match[1]}\""
+            problem "Instead of duplicating `without`, " \
+                    "use `build.without? \"#{match[1]}\"` to check for \"--without-#{match[1]}\""
           end
 
           find_instance_method_call(body_node, :build, :with?) do |method|
             arg = parameters(method).first
             next unless (match = regex_match_group(arg, /^-?-?with-(.*)/))
 
-            problem "Don't duplicate 'with': Use `build.with? \"#{match[1]}\"` to check for \"--with-#{match[1]}\""
+            problem "Instead of duplicating `with`, " \
+                    "use `build.with? \"#{match[1]}\"` to check for '--with-#{match[1]}'"
           end
 
           find_instance_method_call(body_node, :build, :include?) do
@@ -234,8 +235,8 @@ module RuboCop
           return if formula_tap != "homebrew-core"
 
           find_method_with_args(body_node, :depends_on, "mpich") do
-            problem "Formulae in homebrew/core should use 'depends_on \"open-mpi\"' " \
-                    "instead of '#{T.must(@offensive_node).source}'." do |corrector|
+            problem "Formulae in homebrew/core should use `depends_on \"open-mpi\"` " \
+                    "instead of `#{T.must(@offensive_node).source}`." do |corrector|
               corrector.replace(T.must(@offensive_node).source_range, "depends_on \"open-mpi\"")
             end
           end
@@ -252,15 +253,15 @@ module RuboCop
           return if (body_node = formula_nodes.body_node).nil?
 
           find_method_with_args(body_node, :local_npm_install_args) do
-            problem "Use 'std_npm_args' instead of '#{T.cast(@offensive_node,
-                                                             RuboCop::AST::SendNode).method_name}'." do |corrector|
+            problem "Use `std_npm_args` instead of `#{T.cast(@offensive_node,
+                                                             RuboCop::AST::SendNode).method_name}`." do |corrector|
               corrector.replace(T.must(@offensive_node).source_range, "std_npm_args(prefix: false)")
             end
           end
 
           find_method_with_args(body_node, :std_npm_install_args) do |method|
-            problem "Use 'std_npm_args' instead of '#{T.cast(@offensive_node,
-                                                             RuboCop::AST::SendNode).method_name}'." do |corrector|
+            problem "Use `std_npm_args` instead of `#{T.cast(@offensive_node,
+                                                             RuboCop::AST::SendNode).method_name}`." do |corrector|
               if (param = parameters(method).first.source) == "libexec"
                 corrector.replace(T.must(@offensive_node).source_range, "std_npm_args")
               else
@@ -293,8 +294,8 @@ module RuboCop
           return if formula_tap != "homebrew-core"
 
           find_method_with_args(body_node, :depends_on, "quictls") do
-            problem "Formulae in homebrew/core should use 'depends_on \"openssl@3\"' " \
-                    "instead of '#{T.must(@offensive_node).source}'." do |corrector|
+            problem "Formulae in homebrew/core should use `depends_on \"openssl@3\"` " \
+                    "instead of `#{T.must(@offensive_node).source}`." do |corrector|
               corrector.replace(T.must(@offensive_node).source_range, "depends_on \"openssl@3\"")
             end
           end
@@ -311,7 +312,7 @@ module RuboCop
           return if formula_tap != "homebrew-core"
           return unless depends_on?("pyoxidizer")
 
-          problem "Formulae in homebrew/core should not use '#{T.must(@offensive_node).source}'."
+          problem "Formulae in homebrew/core should not use `#{T.must(@offensive_node).source}`."
         end
       end
 
@@ -505,7 +506,7 @@ module RuboCop
         end
       end
 
-      # This cop makes sure the `MacOS` module is not used in Linux-facing formula code
+      # This cop makes sure the `MacOS` module is not used in Linux-facing formula code.
       class MacOSOnLinux < FormulaCop
         include OnSystemConditionalsHelper
 
@@ -676,7 +677,7 @@ module RuboCop
           # FileUtils is included in Formula
           # encfs modifies a file with this name, so check for some leading characters
           find_instance_method_call(body_node, "FileUtils", nil) do |method_node|
-            problem "Don't need 'FileUtils.' before #{method_node.method_name}"
+            problem "No need for `FileUtils.` before `#{method_node.method_name}`"
           end
 
           # Check for long inreplace block vars
@@ -684,45 +685,41 @@ module RuboCop
             block_arg = node.arguments.children.first
             next if block_arg.source.size <= 1
 
-            problem "\"inreplace <filenames> do |s|\" is preferred over \"|#{block_arg.source}|\"."
+            problem "`inreplace <filenames> do |s|` is preferred over `|#{block_arg.source}|`."
           end
 
           [:rebuild, :version_scheme].each do |method_name|
             find_method_with_args(body_node, method_name, 0) do
-              problem "'#{method_name} 0' should be removed"
+              problem "`#{method_name} 0` should be removed"
             end
           end
 
           find_instance_call(body_node, "ARGV") do |_method_node|
-            problem "Use build instead of ARGV to check options"
+            problem "Use `build.with?` or `build.without?` instead of `ARGV` to check options"
           end
 
           find_instance_method_call(body_node, :man, :+) do |method|
             next unless (match = regex_match_group(parameters(method).first, /^man[1-8]$/))
 
-            problem "\"#{method.source}\" should be \"#{match[0]}\""
+            problem "`#{method.source}` should be `#{match[0]}`"
           end
 
           # Avoid hard-coding compilers
           find_every_method_call_by_name(body_node, :system).each do |method|
-            next if @formula_name == "bazel" # TODO: Remove shim bypass in bazel.
-
             param = parameters(method).first
             if (match = regex_match_group(param, %r{^(/usr/bin/)?(gcc|clang|cc|c[89]9)(\s|$)}))
-              problem "Use \"\#{ENV.cc}\" instead of hard-coding \"#{match[2]}\""
+              problem "Use `\#{ENV.cc}` instead of hard-coding `#{match[2]}`"
             elsif (match = regex_match_group(param, %r{^(/usr/bin/)?((g|clang|c)\+\+)(\s|$)}))
-              problem "Use \"\#{ENV.cxx}\" instead of hard-coding \"#{match[2]}\""
+              problem "Use `\#{ENV.cxx}` instead of hard-coding `#{match[2]}`"
             end
           end
 
           find_instance_method_call(body_node, "ENV", :[]=) do |method|
-            next if @formula_name == "bazel" # TODO: Remove shim bypass in bazel.
-
             param = parameters(method)[1]
             if (match = regex_match_group(param, %r{^(/usr/bin/)?(gcc|clang|cc|c[89]9)(\s|$)}))
-              problem "Use \"\#{ENV.cc}\" instead of hard-coding \"#{match[2]}\""
+              problem "Use `\#{ENV.cc}` instead of hard-coding `#{match[2]}`"
             elsif (match = regex_match_group(param, %r{^(/usr/bin/)?((g|clang|c)\+\+)(\s|$)}))
-              problem "Use \"\#{ENV.cxx}\" instead of hard-coding \"#{match[2]}\""
+              problem "Use `\#{ENV.cxx}` instead of hard-coding `#{match[2]}`"
             end
           end
 
@@ -730,18 +727,18 @@ module RuboCop
           formula_path_strings(body_node, :share) do |p|
             next unless (match = regex_match_group(p, %r{^(/(man))/?}))
 
-            problem "\"\#{share}#{match[1]}\" should be \"\#{#{match[2]}}\""
+            problem "`\#{share}#{match[1]}` should be `\#{#{match[2]}}`"
           end
 
           formula_path_strings(body_node, :prefix) do |p|
             if (match = regex_match_group(p, %r{^(/share/(info|man))$}))
-              problem ['"#', "{prefix}", match[1], '" should be "#{', match[2], '}"'].join
+              problem ["`#", "{prefix}", match[1], '` should be `#{', match[2], "}`"].join
             end
             if (match = regex_match_group(p, %r{^((/share/man/)(man[1-8]))}))
-              problem ['"#', "{prefix}", match[1], '" should be "#{', match[3], '}"'].join
+              problem ["`#", "{prefix}", match[1], '` should be `#{', match[3], "}`"].join
             end
             if (match = regex_match_group(p, %r{^(/(bin|include|libexec|lib|sbin|share|Frameworks))}i))
-              problem ['"#', "{prefix}", match[1], '" should be "#{', match[2].downcase, '}"'].join
+              problem ["`#", "{prefix}", match[1], '` should be `#{', match[2].downcase, "}`"].join
             end
           end
 
@@ -750,13 +747,13 @@ module RuboCop
             next if key.nil? || value.nil?
             next unless (match = regex_match_group(value, /^(lua|perl|python|ruby)(\d*)/))
 
-            problem "#{match[1]} modules should be vendored rather than use deprecated `#{method.source}`"
+            problem "#{match[1]} modules should be vendored rather than using deprecated `#{method.source}`"
           end
 
           find_every_method_call_by_name(body_node, :system).each do |method|
             next unless (match = regex_match_group(parameters(method).first, /^(env|export)(\s+)?/))
 
-            problem "Use ENV instead of invoking '#{match[1]}' to modify the environment"
+            problem "Use `ENV` instead of invoking `#{match[1]}` to modify the environment"
           end
 
           find_every_method_call_by_name(body_node, :depends_on).each do |method|
@@ -768,7 +765,7 @@ module RuboCop
               find_strings(option).each do |dependency|
                 next unless (match = regex_match_group(dependency, /(with(out)?-\w+|c\+\+11)/))
 
-                problem "Dependency #{string_content(dep)} should not use option #{match[0]}"
+                problem "Dependency '#{string_content(dep)}' should not use option `#{match[0]}`"
               end
             end
           end
@@ -776,21 +773,21 @@ module RuboCop
           find_instance_method_call(body_node, :version, :==) do |method|
             next unless parameters_passed?(method, ["HEAD"])
 
-            problem "Use 'build.head?' instead of inspecting 'version'"
+            problem "Use `build.head?` instead of inspecting `version`"
           end
 
           find_instance_method_call(body_node, "ARGV", :include?) do |method|
             next unless parameters_passed?(method, ["--HEAD"])
 
-            problem "Use \"if build.head?\" instead"
+            problem "Use `if build.head?` instead"
           end
 
           find_const(body_node, "MACOS_VERSION") do
-            problem "Use MacOS.version instead of MACOS_VERSION"
+            problem "Use `MacOS.version` instead of `MACOS_VERSION`"
           end
 
           find_const(body_node, "MACOS_FULL_VERSION") do
-            problem "Use MacOS.full_version instead of MACOS_FULL_VERSION"
+            problem "Use `MacOS.full_version` instead of `MACOS_FULL_VERSION`"
           end
 
           conditional_dependencies(body_node) do |node, method, param, dep_node|
@@ -799,30 +796,30 @@ module RuboCop
               if (method == :include? && regex_match_group(param, /^with-#{dep}$/)) ||
                  (method == :with? && regex_match_group(param, /^#{dep}$/))
                 offending_node(dep_node.parent)
-                problem "Replace #{node.source} with #{dep_node.parent.source} => :optional"
+                problem "Replace `#{node.source}` with `#{dep_node.parent.source} => :optional`"
               end
             elsif node.unless?
               if (method == :include? && regex_match_group(param, /^without-#{dep}$/)) ||
                  (method == :without? && regex_match_group(param, /^#{dep}$/))
                 offending_node(dep_node.parent)
-                problem "Replace #{node.source} with #{dep_node.parent.source} => :recommended"
+                problem "Replace `#{node.source}` with `#{dep_node.parent.source} => :recommended`"
               end
             end
           end
 
           find_method_with_args(body_node, :fails_with, :llvm) do
-            problem "'fails_with :llvm' is now a no-op so should be removed"
+            problem "`fails_with :llvm` is now a no-op and should be removed"
           end
 
           find_method_with_args(body_node, :needs, :openmp) do
-            problem "'needs :openmp' should be replaced with 'depends_on \"gcc\"'"
+            problem "`needs :openmp` should be replaced with `depends_on \"gcc\"`"
           end
 
           find_method_with_args(body_node, :system, /^(otool|install_name_tool|lipo)/) do
             problem "Use ruby-macho instead of calling #{T.must(@offensive_node).source}"
           end
 
-          problem "Use new-style test definitions (test do)" if find_method_def(body_node, :test)
+          problem "Use new-style test definitions (`test do`)" if find_method_def(body_node, :test)
 
           find_method_with_args(body_node, :skip_clean, :all) do
             problem "`skip_clean :all` is deprecated; brew no longer strips symbols. " \
@@ -830,7 +827,7 @@ module RuboCop
           end
 
           if find_method_def(processed_source.ast)
-            problem "Define method #{method_name(@offensive_node)} in the class body, not at the top-level"
+            problem "Define method `#{method_name(@offensive_node)}` in the class body, not at the top-level"
           end
 
           find_instance_method_call(body_node, :build, :universal?) do
@@ -849,7 +846,7 @@ module RuboCop
             next if tap_style_exception? :runtime_cpu_detection_allowlist
 
             problem "Formulae should be verified as having support for runtime hardware detection before " \
-                    "using ENV.runtime_cpu_detection."
+                    "using `ENV.runtime_cpu_detection`."
           end
 
           find_every_method_call_by_name(body_node, :depends_on).each do |method|
@@ -864,7 +861,7 @@ module RuboCop
             param = parameters(method).first
             next unless node_equals?(param, "CI")
 
-            problem 'Don\'t use ENV["CI"] for Homebrew CI checks.'
+            problem 'Don\'t use `ENV["CI"]` for Homebrew CI checks.'
           end
 
           find_instance_method_call(body_node, "Dir", :[]) do |method|
@@ -874,7 +871,7 @@ module RuboCop
             next unless path.str_type?
             next unless (match = regex_match_group(path, /^[^*{},]+$/))
 
-            problem "Dir([\"#{string_content(path)}\"]) is unnecessary; just use \"#{match[0]}\""
+            problem "`Dir([\"#{string_content(path)}\"])` is unnecessary; just use `#{match[0]}`"
           end
 
           fileutils_methods = Regexp.new(
@@ -946,7 +943,7 @@ module RuboCop
         end
       end
 
-      # This cop ensures that new formulae depending on removed Requirements are not used
+      # This cop ensures that new formulae depending on removed Requirements are not used.
       class Requirements < FormulaCop
         sig { override.params(_formula_nodes: FormulaNodes).void }
         def audit_formula(_formula_nodes)
@@ -969,16 +966,16 @@ module RuboCop
           return if formula_tap != "homebrew-core"
 
           find_method_with_args(body_node, :depends_on, "rustup") do
-            problem "Formulae in homebrew/core should use 'depends_on \"rust\"' " \
-                    "instead of '#{T.must(@offensive_node).source}'." do |corrector|
+            problem "Formulae in homebrew/core should use `depends_on \"rust\"` " \
+                    "instead of `#{T.must(@offensive_node).source}`." do |corrector|
               corrector.replace(T.must(@offensive_node).source_range, "depends_on \"rust\"")
             end
           end
 
           [:build, [:build, :test], [:test, :build]].each do |type|
             find_method_with_args(body_node, :depends_on, "rustup" => type) do
-              problem "Formulae in homebrew/core should use 'depends_on \"rust\" => #{type}' " \
-                      "instead of '#{T.must(@offensive_node).source}'." do |corrector|
+              problem "Formulae in homebrew/core should use `depends_on \"rust\" => #{type}` " \
+                      "instead of `#{T.must(@offensive_node).source}`." do |corrector|
                 corrector.replace(T.must(@offensive_node).source_range, "depends_on \"rust\" => #{type}")
               end
             end

--- a/Library/Homebrew/rubocops/options.rb
+++ b/Library/Homebrew/rubocops/options.rb
@@ -30,7 +30,7 @@ module RuboCop
             if !/with(out)?-/.match?(option) &&
                option != "cxx11" &&
                option != "universal"
-              problem "Options should begin with with/without. " \
+              problem "Options should begin with `with` or `without`. " \
                       "Migrate '--#{option}' with `deprecated_option`."
             end
 

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -30,14 +30,14 @@ module RuboCop
 
           if inline_patches.empty? && patch_end?
             offending_patch_end_node(node)
-            add_offense(@offense_source_range, message: "patch is missing 'DATA'")
+            add_offense(@offense_source_range, message: "Patch is missing `patch :DATA`")
           end
 
           patches_node = find_method_def(body_node, :patches)
           return if patches_node.nil?
 
           legacy_patches = find_strings(patches_node)
-          problem "Use the patch DSL instead of defining a 'patches' method"
+          problem "Use the `patch` DSL instead of defining a `patches` method"
           legacy_patches.each { |p| patch_problems(p) }
         end
 
@@ -63,7 +63,7 @@ module RuboCop
           if regex_match_group(patch_url_node, bitbucket_regex)
             owner, repo, commit = patch_url_node.source.match(bitbucket_regex).captures
             correct_url = "https://api.bitbucket.org/2.0/repositories/#{owner}/#{repo}/diff/#{commit}"
-            problem "Bitbucket patches should use the api url: #{correct_url}" do |corrector|
+            problem "Bitbucket patches should use the API URL: #{correct_url}" do |corrector|
               corrector.replace(patch_url_node.source_range, %Q("#{correct_url}"))
             end
           end
@@ -118,7 +118,7 @@ module RuboCop
           return if !patch_data?(patch) || patch_end?
 
           offending_node(patch)
-          problem "patch is missing '__END__'"
+          problem "Patch is missing `__END__`"
         end
 
         def_node_search :patch_data?, <<~AST

--- a/Library/Homebrew/rubocops/shared/desc_helper.rb
+++ b/Library/Homebrew/rubocops/shared/desc_helper.rb
@@ -21,7 +21,7 @@ module RuboCop
       def audit_desc(type, name, desc_call)
         # Check if a desc is present.
         if desc_call.nil?
-          problem "#{type.to_s.capitalize} should have a desc (Description)."
+          problem "#{type.to_s.capitalize} should have a `desc` (description)."
           return
         end
 
@@ -32,7 +32,7 @@ module RuboCop
         # Check if the desc is empty.
         desc_length = string_content(desc).length
         if desc_length.zero?
-          problem "The desc (description) should not be an empty string."
+          problem "The `desc` (description) should not be an empty string."
           return
         end
 

--- a/Library/Homebrew/rubocops/shared/homepage_helper.rb
+++ b/Library/Homebrew/rubocops/shared/homepage_helper.rb
@@ -19,10 +19,10 @@ module RuboCop
       def audit_homepage(type, content, homepage_node, homepage_parameter_node)
         @offensive_node = T.let(homepage_node, T.nilable(RuboCop::AST::Node))
 
-        problem "#{type.to_s.capitalize} should have a homepage." if content.empty?
+        problem "#{type.to_s.capitalize} should have a `homepage`." if content.empty?
 
         @offensive_node = homepage_parameter_node
-        problem "The homepage should start with http or https." unless content.match?(%r{^https?://})
+        problem "The `homepage` should start with http or https." unless content.match?(%r{^https?://})
 
         case content
           # Freedesktop is complicated to handle - It has SSL/TLS, but only on certain subdomains.
@@ -31,10 +31,9 @@ module RuboCop
           # "Software" is redirected to https://wiki.freedesktop.org/www/Software/project_name
         when %r{^http://((?:www|nice|libopenraw|liboil|telepathy|xorg)\.)?freedesktop\.org/(?:wiki/)?}
           if content.include?("Software")
-            problem "Freedesktop homepages should be styled " \
-                    "`https://wiki.freedesktop.org/www/Software/project_name`"
+            problem "Freedesktop homepages should be styled: https://wiki.freedesktop.org/www/Software/project_name"
           else
-            problem "Freedesktop homepages should be styled `https://wiki.freedesktop.org/project_name`"
+            problem "Freedesktop homepages should be styled: https://wiki.freedesktop.org/project_name"
           end
 
           # Google Code homepages should end in a slash
@@ -45,13 +44,13 @@ module RuboCop
 
         when %r{^http://([^/]*)\.(sf|sourceforge)\.net(/|$)}
           fixed = "https://#{Regexp.last_match(1)}.sourceforge.io/"
-          problem "Sourceforge homepages should be `#{fixed}`" do |corrector|
+          problem "SourceForge homepages should be: #{fixed}" do |corrector|
             corrector.replace(homepage_parameter_node.source_range, "\"#{fixed}\"")
           end
 
         when /readthedocs\.org/
           fixed = content.sub("readthedocs.org", "readthedocs.io")
-          problem "Readthedocs homepages should be `#{fixed}`" do |corrector|
+          problem "Readthedocs homepages should be: #{fixed}" do |corrector|
             corrector.replace(homepage_parameter_node.source_range, "\"#{fixed}\"")
           end
 

--- a/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
+++ b/Library/Homebrew/rubocops/shared/on_system_conditionals_helper.rb
@@ -69,8 +69,8 @@ module RuboCop
             end
 
             offending_node(on_system_node)
-            problem "Don't use `#{on_system_node.source}` in `#{parent_string}`, " \
-                    "use `#{if_statement_string}#{if_conditional}` instead." do |corrector|
+            problem "Instead of using `#{on_system_node.source}` in `#{parent_string}`, " \
+                    "use `#{if_statement_string}#{if_conditional}`." do |corrector|
               block_node = offending_node.parent
               next if block_node.type != :block
 
@@ -108,7 +108,7 @@ module RuboCop
             next if node_is_allowed?(method_node, allowed_methods:, allowed_blocks:)
 
             offending_node(method_node)
-            problem "Don't use `#{method_node.source}`, use `on_arm` and `on_intel` blocks instead."
+            problem "Instead of `#{method_node.source}`, use `on_arm` and `on_intel` blocks."
           end
         end
       end
@@ -171,7 +171,7 @@ module RuboCop
             next if node_is_allowed?(method_node, allowed_methods:, allowed_blocks:)
 
             offending_node(method_node)
-            problem "Don't use `#{method_node.source}`, use `on_{macos_version}` blocks instead."
+            problem "Instead of `#{method_node.source}`, use `on_{macos_version}` blocks."
           end
         end
       end
@@ -209,8 +209,7 @@ module RuboCop
       def if_statement_problem(if_node, if_statement_string, on_system_method_string,
                                else_method: nil, else_node: nil, autocorrect: true)
         offending_node(if_node)
-        problem "Don't use `#{if_statement_string}`, " \
-                "use `#{on_system_method_string} do` instead." do |corrector|
+        problem "Instead of `#{if_statement_string}`, use `#{on_system_method_string} do`." do |corrector|
           next unless autocorrect
           # TODO: could fix corrector to handle this but punting for now.
           next if if_node.unless?

--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -38,37 +38,37 @@ module RuboCop
         # URLs must be ASCII; IDNs must be punycode
         ascii_pattern = /[^\p{ASCII}]+/
         audit_urls(urls, ascii_pattern) do |_, url|
-          problem "Please use the ASCII (Punycode encoded host, URL-encoded path and query) version of #{url}."
+          problem "Please use the ASCII (Punycode-encoded host, URL-encoded path and query) version of #{url}."
         end
 
         # GNU URLs; doesn't apply to mirrors
         gnu_pattern = %r{^(?:https?|ftp)://ftpmirror\.gnu\.org/(.*)}
         audit_urls(urls, gnu_pattern) do |match, url|
-          problem "Please use \"https://ftp.gnu.org/gnu/#{match[1]}\" instead of #{url}."
+          problem "#{url} should be: https://ftp.gnu.org/gnu/#{match[1]}"
         end
 
         # Fossies upstream requests they aren't used as primary URLs
         # https://github.com/Homebrew/homebrew-core/issues/14486#issuecomment-307753234
         fossies_pattern = %r{^https?://fossies\.org/}
         audit_urls(urls, fossies_pattern) do
-          problem "Please don't use fossies.org in the url (using as a mirror is fine)"
+          problem "Please don't use \"fossies.org\" in the `url` (using as a mirror is fine)"
         end
 
         apache_pattern = %r{^https?://(?:[^/]*\.)?apache\.org/(?:dyn/closer\.cgi\?path=/?|dist/)(.*)}i
         audit_urls(urls, apache_pattern) do |match, url|
           next if url == livecheck_url
 
-          problem "#{url} should be `https://www.apache.org/dyn/closer.lua?path=#{match[1]}`"
+          problem "#{url} should be: https://www.apache.org/dyn/closer.lua?path=#{match[1]}"
         end
 
         version_control_pattern = %r{^(cvs|bzr|hg|fossil)://}
         audit_urls(urls, version_control_pattern) do |match, _|
-          problem "Use of the #{match[1]}:// scheme is deprecated, pass `:using => :#{match[1]}` instead"
+          problem "Use of the \"#{match[1]}://\" scheme is deprecated, pass `using: :#{match[1]}` instead"
         end
 
         svn_pattern = %r{^svn\+http://}
         audit_urls(urls, svn_pattern) do |_, _|
-          problem "Use of the svn+http:// scheme is deprecated, pass `:using => :svn` instead"
+          problem "Use of the \"svn+http://\" scheme is deprecated, pass `using: :svn` instead"
         end
 
         audit_urls(mirrors, /.*/) do |_, mirror|
@@ -117,22 +117,22 @@ module RuboCop
 
         apache_mirror_pattern = %r{^https?://(?:[^/]*\.)?apache\.org/dyn/closer\.(?:cgi|lua)\?path=/?(.*)}i
         audit_urls(mirrors, apache_mirror_pattern) do |match, mirror|
-          problem "Please use `https://archive.apache.org/dist/#{match[1]}` as a mirror instead of #{mirror}."
+          problem "#{mirror} should be: https://archive.apache.org/dist/#{match[1]}"
         end
 
         cpan_pattern = %r{^http://search\.mcpan\.org/CPAN/(.*)}i
         audit_urls(urls, cpan_pattern) do |match, url|
-          problem "#{url} should be `https://cpan.metacpan.org/#{match[1]}`"
+          problem "#{url} should be: https://cpan.metacpan.org/#{match[1]}"
         end
 
         gnome_pattern = %r{^(http|ftp)://ftp\.gnome\.org/pub/gnome/(.*)}i
         audit_urls(urls, gnome_pattern) do |match, url|
-          problem "#{url} should be `https://download.gnome.org/#{match[2]}`"
+          problem "#{url} should be: https://download.gnome.org/#{match[2]}"
         end
 
         debian_pattern = %r{^git://anonscm\.debian\.org/users/(.*)}i
         audit_urls(urls, debian_pattern) do |match, url|
-          problem "#{url} should be `https://anonscm.debian.org/git/users/#{match[1]}`"
+          problem "#{url} should be: https://anonscm.debian.org/git/users/#{match[1]}"
         end
 
         # Prefer HTTP/S when possible over FTP protocol due to possible firewalls.
@@ -143,7 +143,7 @@ module RuboCop
 
         cpan_ftp_pattern = %r{^ftp://ftp\.cpan\.org/pub/CPAN(.*)}i
         audit_urls(urls, cpan_ftp_pattern) do |match_obj, url|
-          problem "#{url} should be `http://search.cpan.org/CPAN#{match_obj[1]}`"
+          problem "#{url} should be: http://search.cpan.org/CPAN#{match_obj[1]}"
         end
 
         # SourceForge url patterns
@@ -155,26 +155,26 @@ module RuboCop
           next if url.include? "/p/"
 
           if url =~ /(\?|&)use_mirror=/
-            problem "Don't use #{Regexp.last_match(1)}use_mirror in SourceForge urls (url is #{url})."
+            problem "Don't use \"#{Regexp.last_match(1)}use_mirror\" in SourceForge URLs (`url` is #{url})."
           end
 
-          problem "Don't use /download in SourceForge urls (url is #{url})." if url.end_with?("/download")
+          problem "Don't use \"/download\" in SourceForge URLs (`url` is #{url})." if url.end_with?("/download")
 
           if url.match?(%r{^https?://(sourceforge|sf)\.}) && url != livecheck_url
-            problem "Use https://downloads.sourceforge.net to get geolocation (url is #{url})."
+            problem "Use \"https://downloads.sourceforge.net\" to get geolocation (`url` is #{url})."
           end
 
           if url.match?(%r{^https?://prdownloads\.})
-            problem "Don't use prdownloads in SourceForge urls (url is #{url})."
+            problem "Don't use \"prdownloads\" in SourceForge URLs (`url` is #{url})."
           end
 
           if url.match?(%r{^http://\w+\.dl\.})
-            problem "Don't use specific dl mirrors in SourceForge urls (url is #{url})."
+            problem "Don't use specific \"dl\" mirrors in SourceForge URLs (`url` is #{url})."
           end
 
           # sf.net does HTTPS -> HTTP redirects.
           if url.match?(%r{^https?://downloads?\.sf\.net})
-            problem "Use https://downloads.sourceforge.net instead of downloads.sf.net (url is #{url})"
+            problem "Use \"https://downloads.sourceforge.net\" instead of \"downloads.sf.net\" (`url` is #{url})"
           end
         end
 
@@ -236,14 +236,14 @@ module RuboCop
         audit_urls(urls, archive_gh_pattern) do |_, url|
           next if url.end_with?(".git")
 
-          problem "Use /archive/ URLs for GitHub tarballs (url is #{url})."
+          problem "Use /archive/ URLs for GitHub tarballs (`url` is #{url})."
         end
 
         archive_refs_gh_pattern = %r{https://.*github.+/archive/(?![a-fA-F0-9]{40})(?!refs/(tags|heads)/)(.*)\.tar\.gz$}
         audit_urls(urls, archive_refs_gh_pattern) do |match, url|
           next if url.end_with?(".git")
 
-          problem "Use refs/tags/#{match[2]} or refs/heads/#{match[2]} for GitHub references (url is #{url})."
+          problem %Q(Use "refs/tags/#{match[2]}" or "refs/heads/#{match[2]}" for GitHub references (`url` is #{url}).)
         end
 
         # Don't use GitHub .zip files
@@ -253,7 +253,7 @@ module RuboCop
           next if url.include?("releases/download")
           next if url.include?("desktop.githubusercontent.com/releases/")
 
-          problem "Use GitHub tarballs rather than zipballs (url is #{url})."
+          problem "Use GitHub tarballs rather than zipballs (`url` is #{url})."
         end
 
         # Don't use GitHub codeload URLs
@@ -270,7 +270,7 @@ module RuboCop
         # Check for Maven Central URLs, prefer HTTPS redirector over specific host
         maven_pattern = %r{https?://(?:central|repo\d+)\.maven\.org/maven2/(.+)$}
         audit_urls(urls, maven_pattern) do |match, url|
-          problem "#{url} should be `https://search.maven.org/remotecontent?filepath=#{match[1]}`"
+          problem "#{url} should be: https://search.maven.org/remotecontent?filepath=#{match[1]}"
         end
       end
     end

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -45,19 +45,19 @@ module RuboCop
 
           # processed_source.ast is passed instead of body_node because `require` would be outside body_node
           find_method_with_args(processed_source.ast, :require, "language/go") do
-            problem "require \"language/go\" is no longer necessary or correct"
+            problem '`require "language/go"` is no longer necessary or correct'
           end
 
           find_instance_method_call(body_node, "Formula", :factory) do
-            problem "\"Formula.factory(name)\" is deprecated in favor of \"Formula[name]\""
+            problem "`Formula.factory(name)` is deprecated in favour of `Formula[name]`"
           end
 
           find_method_with_args(body_node, :revision, 0) do
-            problem "\"revision 0\" is unnecessary"
+            problem "`revision 0` is unnecessary"
           end
 
           find_method_with_args(body_node, :system, "xcodebuild") do
-            problem %q(use "xcodebuild *args" instead of "system 'xcodebuild', *args")
+            problem "Use `xcodebuild *args` instead of `system 'xcodebuild', *args`"
           end
 
           if !depends_on?(:xcode) && method_called_ever?(body_node, :xcodebuild)
@@ -72,7 +72,7 @@ module RuboCop
             find_method_with_args(method_node, :system, "cargo", "build") do |m|
               next if parameters_passed?(m, [/--lib/])
 
-              problem "use \"cargo\", \"install\", *std_cargo_args"
+              problem 'Use `"cargo", "install", *std_cargo_args`'
             end
           end
 
@@ -80,7 +80,7 @@ module RuboCop
             next if parameters_passed?(d, [/vendor-only/])
             next if @formula_name == "goose" # needed in 2.3.0
 
-            problem "use \"dep\", \"ensure\", \"-vendor-only\""
+            problem 'Use `"dep", "ensure", "-vendor-only"`'
           end
 
           find_every_method_call_by_name(body_node, :system).each do |m|

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -54,13 +54,13 @@ module RuboCop
           # Check pypi URLs
           pypi_pattern = %r{^https?://pypi\.python\.org/}
           audit_urls(urls, pypi_pattern) do |_, url|
-            problem "use the `Source` url found on PyPI downloads page (`#{get_pypi_url(url)}`)"
+            problem "Use the \"Source\" URL found on the PyPI downloads page (#{get_pypi_url(url)})"
           end
 
           # Require long files.pythonhosted.org URLs
           pythonhosted_pattern = %r{^https?://files\.pythonhosted\.org/packages/source/}
           audit_urls(urls, pythonhosted_pattern) do |_, url|
-            problem "use the `Source` url found on PyPI downloads page (`#{get_pypi_url(url)}`)"
+            problem "Use the \"Source\" URL found on the PyPI downloads page (#{get_pypi_url(url)})"
           end
         end
 
@@ -84,7 +84,7 @@ module RuboCop
             next if url_has_revision?(parameters(url).last)
 
             offending_node(url)
-            problem "Formulae in homebrew/core should specify a revision for git URLs"
+            problem "Formulae in homebrew/core should specify a revision for Git URLs"
           end
         end
 
@@ -107,7 +107,7 @@ module RuboCop
             next if url_has_tag?(parameters(url).last)
 
             offending_node(url)
-            problem "Formulae in homebrew/core should specify a tag for git URLs"
+            problem "Formulae in homebrew/core should specify a tag for Git URLs"
           end
         end
 

--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -66,7 +66,7 @@ module RuboCop
             return if PROVIDED_BY_MACOS_FORMULAE.include? @formula_name
 
             problem "Formulae that are `keg_only :provided_by_macos` should be " \
-                    "added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repo)"
+                    "added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repository)"
           end
         end
       end
@@ -116,7 +116,7 @@ module RuboCop
             next if ALLOWED_USES_FROM_MACOS_DEPS.include? dep_name
             next if ProvidedByMacos::PROVIDED_BY_MACOS_FORMULAE.include? dep_name
 
-            problem "`uses_from_macos` should only be used for macOS dependencies, not #{dep_name}."
+            problem "`uses_from_macos` should only be used for macOS dependencies, not '#{dep_name}'."
           end
         end
       end

--- a/Library/Homebrew/rubocops/version.rb
+++ b/Library/Homebrew/rubocops/version.rb
@@ -15,13 +15,13 @@ module RuboCop
 
           version = string_content(parameters(version_node).first)
 
-          problem "version is set to an empty string" if version.empty?
+          problem "Version is set to an empty string" if version.empty?
 
-          problem "version #{version} should not have a leading 'v'" if version.start_with?("v")
+          problem "Version #{version} should not have a leading 'v'" if version.start_with?("v")
 
           return unless version.match?(/_\d+$/)
 
-          problem "version #{version} should not end with an underline and a number"
+          problem "Version #{version} should not end with an underline and a number"
         end
       end
     end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -519,7 +519,7 @@ RSpec.describe Homebrew::FormulaAuditor do
 
       fa.audit_specs
       expect(fa.problems.first[:message])
-        .to match("resource name should be `FooSomething` to match the PyPI package name")
+        .to match("`resource` name should be 'FooSomething' to match the PyPI package name")
     end
 
     it "reports a problem if the resource name does not match the python wheel name" do
@@ -538,7 +538,7 @@ RSpec.describe Homebrew::FormulaAuditor do
 
       fa.audit_specs
       expect(fa.problems.first[:message])
-        .to match("resource name should be `FooSomething` to match the PyPI package name")
+        .to match("`resource` name should be 'FooSomething' to match the PyPI package name")
     end
   end
 
@@ -788,7 +788,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       RUBY
 
       fa.audit_specs
-      expect(fa.problems.first[:message]).to match "Versioned formulae should not have a `HEAD` spec"
+      expect(fa.problems.first[:message]).to match "Versioned formulae should not have a `head` spec"
     end
 
     it "allows versioned formulae on the allowlist to have a `HEAD` spec" do
@@ -911,7 +911,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       context "when uncommitted should not decrease" do
         before { formula_gsub "foo-1.0.tar.gz", "foo-0.9.tar.gz" }
 
-        it { is_expected.to match("stable version should not decrease (from 1.0 to 0.9)") }
+        it { is_expected.to match("Stable: version should not decrease (from 1.0 to 0.9)") }
       end
 
       context "when committed can decrease" do
@@ -991,31 +991,31 @@ RSpec.describe Homebrew::FormulaAuditor do
       describe "with the same version, should not decrease" do
         before { formula_gsub_origin_commit "revision 2", "revision 1" }
 
-        it { is_expected.to match("revision should not decrease (from 2 to 1)") }
+        it { is_expected.to match("`revision` should not decrease (from 2 to 1)") }
       end
 
       describe "should not be removed with the same version" do
         before { formula_gsub_origin_commit "revision 2" }
 
-        it { is_expected.to match("revision should not decrease (from 2 to 0)") }
+        it { is_expected.to match("`revision` should not decrease (from 2 to 0)") }
       end
 
       describe "should not decrease with the same, uncommitted version" do
         before { formula_gsub "revision 2", "revision 1" }
 
-        it { is_expected.to match("revision should not decrease (from 2 to 1)") }
+        it { is_expected.to match("`revision` should not decrease (from 2 to 1)") }
       end
 
       describe "should be removed with a newer version" do
         before { formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz" }
 
-        it { is_expected.to match("'revision 2' should be removed") }
+        it { is_expected.to match("`revision 2` should be removed") }
       end
 
       describe "should be removed with a newer local version" do
         before { formula_gsub "foo-1.0.tar.gz", "foo-1.1.tar.gz" }
 
-        it { is_expected.to match("'revision 2' should be removed") }
+        it { is_expected.to match("`revision 2` should be removed") }
       end
 
       describe "should not warn on an newer version revision removal" do
@@ -1044,7 +1044,7 @@ RSpec.describe Homebrew::FormulaAuditor do
           formula_gsub "revision 2", "revision 4"
         end
 
-        it { is_expected.to match("revisions should only increment by 1") }
+        it { is_expected.to match("`revision` should only increment by 1") }
       end
 
       describe "should not warn on past increment by more than 1" do
@@ -1094,7 +1094,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       describe "should not decrease with the same version" do
         before { formula_gsub_origin_commit "version_scheme 1" }
 
-        it { is_expected.to match("version_scheme should not decrease (from 1 to 0)") }
+        it { is_expected.to match("`version_scheme` should not decrease (from 1 to 0)") }
       end
 
       describe "should not decrease with a new version" do
@@ -1104,7 +1104,7 @@ RSpec.describe Homebrew::FormulaAuditor do
           formula_gsub_origin_commit "version_scheme 1", ""
         end
 
-        it { is_expected.to match("version_scheme should not decrease (from 1 to 0)") }
+        it { is_expected.to match("`version_scheme` should not decrease (from 1 to 0)") }
       end
 
       describe "should only increment by 1" do
@@ -1115,7 +1115,7 @@ RSpec.describe Homebrew::FormulaAuditor do
           formula_gsub_origin_commit "# no version_scheme", "version_scheme 3"
         end
 
-        it { is_expected.to match("version_schemes should only increment by 1") }
+        it { is_expected.to match("`version_scheme` should only increment by 1") }
       end
     end
   end

--- a/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/on_system_conditionals_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
         cask 'foo' do
           postflight do
             on_intel do
-            ^^^^^^^^ Don't use `on_intel` in `postflight do`, use `if Hardware::CPU.intel?` instead.
+            ^^^^^^^^ Instead of using `on_intel` in `postflight do`, use `if Hardware::CPU.intel?`.
               foobar
             end
           end
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
         cask 'foo' do
           postflight do
             on_monterey do
-            ^^^^^^^^^^^ Don't use `on_monterey` in `postflight do`, use `if MacOS.version == :monterey` instead.
+            ^^^^^^^^^^^ Instead of using `on_monterey` in `postflight do`, use `if MacOS.version == :monterey`.
               foobar
             end
           end
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
         cask 'foo' do
           postflight do
             on_monterey :or_older do
-            ^^^^^^^^^^^^^^^^^^^^^ Don't use `on_monterey :or_older` in `postflight do`, use `if MacOS.version <= :monterey` instead.
+            ^^^^^^^^^^^^^^^^^^^^^ Instead of using `on_monterey :or_older` in `postflight do`, use `if MacOS.version <= :monterey`.
               foobar
             end
           end
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       expect_offense <<~CASK
         cask 'foo' do
           if Hardware::CPU.arm? && other_condition
-             ^^^^^^^^^^^^^^^^^^ Don't use `Hardware::CPU.arm?`, use `on_arm` and `on_intel` blocks instead.
+             ^^^^^^^^^^^^^^^^^^ Instead of `Hardware::CPU.arm?`, use `on_arm` and `on_intel` blocks.
             sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
           else
             sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       expect_offense <<~CASK
         cask 'foo' do
           if Hardware::CPU.intel? && other_condition
-             ^^^^^^^^^^^^^^^^^^^^ Don't use `Hardware::CPU.intel?`, use `on_arm` and `on_intel` blocks instead.
+             ^^^^^^^^^^^^^^^^^^^^ Instead of `Hardware::CPU.intel?`, use `on_arm` and `on_intel` blocks.
             sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
           else
             sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
@@ -200,7 +200,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
           sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
 
           url "https://example.com/foo-#{version}-#{Hardware::CPU.arch}.zip"
-                                                    ^^^^^^^^^^^^^^^^^^ Don't use `Hardware::CPU.arch`, use `on_arm` and `on_intel` blocks instead.
+                                                    ^^^^^^^^^^^^^^^^^^ Instead of `Hardware::CPU.arch`, use `on_arm` and `on_intel` blocks.
         end
       CASK
     end
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       expect_offense <<~CASK
         cask 'foo' do
           if MacOS.version == :catalina
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use `if MacOS.version == :catalina`, use `on_catalina do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Instead of `if MacOS.version == :catalina`, use `on_catalina do`.
             version "1.0.0"
           else
             version "2.0.0"
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       expect_offense <<~CASK
         cask 'foo' do
           if MacOS.version <= :catalina
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use `if MacOS.version <= :catalina`, use `on_catalina :or_older do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Instead of `if MacOS.version <= :catalina`, use `on_catalina :or_older do`.
             version "1.0.0"
           else
             version "2.0.0"
@@ -237,7 +237,7 @@ RSpec.describe RuboCop::Cop::Cask::OnSystemConditionals, :config do
       expect_offense <<~CASK
         cask 'foo' do
           if MacOS.version >= :catalina
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't use `if MacOS.version >= :catalina`, use `on_catalina :or_newer do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Instead of `if MacOS.version >= :catalina`, use `on_catalina :or_newer do`.
             version "1.0.0"
           else
             version "2.0.0"

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Caveats do
           url "https://brew.sh/foo-1.0.tgz"
            def caveats
             "setuid"
-            ^^^^^^^^ FormulaAudit/Caveats: Don't recommend `setuid` in the caveats, suggest `sudo` instead.
+            ^^^^^^^^ FormulaAudit/Caveats: Instead of recommending `setuid` in the caveats, suggest `sudo`.
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_case_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ChecksumCase do
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0A645b426c0a7cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9a"
-                             ^ FormulaAudit/ChecksumCase: sha256 should be lowercase
+                             ^ FormulaAudit/ChecksumCase: `sha256` should be lowercase
 
             resource "foo-package" do
               url "https://github.com/foo-lang/foo-package/archive/0.18.0.tar.gz"
               sha256 "5cf6e1Ae0a645b426b047aa4cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea9"
-                            ^ FormulaAudit/ChecksumCase: sha256 should be lowercase
+                            ^ FormulaAudit/ChecksumCase: `sha256` should be lowercase
             end
           end
         end
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ChecksumCase do
           resource "foo-outside" do
             url "https://github.com/foo-lang/foo-outside/archive/0.18.0.tar.gz"
             sha256 "A4cc7cd3f7d1605ffa1ac5755cf6e1ae0a645b426b047a6a39a8b2268ddc7ea9"
-                    ^ FormulaAudit/ChecksumCase: sha256 should be lowercase
+                    ^ FormulaAudit/ChecksumCase: `sha256` should be lowercase
           end
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"

--- a/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum/checksum_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Checksum do
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 ""
-                   ^^ FormulaAudit/Checksum: sha256 is empty
+                   ^^ FormulaAudit/Checksum: `sha256` is empty
 
             resource "foo-package" do
               url "https://github.com/foo-lang/foo-package/archive/0.18.0.tar.gz"
               sha256 ""
-                     ^^ FormulaAudit/Checksum: sha256 is empty
+                     ^^ FormulaAudit/Checksum: `sha256` is empty
             end
           end
         end
@@ -32,12 +32,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Checksum do
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0a645b426c0474cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9ad"
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: sha256 should be 64 characters
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: `sha256` should be 64 characters
 
             resource "foo-package" do
               url "https://github.com/foo-lang/foo-package/archive/0.18.0.tar.gz"
               sha256 "5cf6e1ae0a645b426c047aaa4cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9"
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: sha256 should be 64 characters
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: `sha256` should be 64 characters
             end
           end
         end
@@ -51,12 +51,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Checksum do
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0a645b426c0k7cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9a"
-                                       ^ FormulaAudit/Checksum: sha256 contains invalid characters
+                                       ^ FormulaAudit/Checksum: `sha256` contains invalid characters
 
             resource "foo-package" do
               url "https://github.com/foo-lang/foo-package/archive/0.18.0.tar.gz"
               sha256 "5cf6e1ae0a645b426x047aa4cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea9"
-                                       ^ FormulaAudit/Checksum: sha256 contains invalid characters
+                                       ^ FormulaAudit/Checksum: `sha256` contains invalid characters
             end
           end
         end
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Checksum do
 
           bottle do
             sha256 catalina: "5cf6e1ae0a645b426c0474cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9ad"
-                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: sha256 should be 64 characters
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: `sha256` should be 64 characters
           end
         end
       RUBY
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Checksum do
 
           bottle do
             sha256 cellar: :any, catalina: "5cf6e1ae0a645b426c0474cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9ad"
-                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: sha256 should be 64 characters
+                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Checksum: `sha256` should be 64 characters
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/class/class_name_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/class_name_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ClassName do
   it "reports and corrects an offense when using ScriptFileFormula" do
     expect_offense(<<~RUBY)
       class Foo < ScriptFileFormula
-                  ^^^^^^^^^^^^^^^^^ FormulaAudit/ClassName: ScriptFileFormula is deprecated, use Formula instead
+                  ^^^^^^^^^^^^^^^^^ FormulaAudit/ClassName: `ScriptFileFormula` is deprecated, use `Formula` instead
         url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ClassName do
   it "reports and corrects an offense when using GithubGistFormula" do
     expect_offense(<<~RUBY)
       class Foo < GithubGistFormula
-                  ^^^^^^^^^^^^^^^^^ FormulaAudit/ClassName: GithubGistFormula is deprecated, use Formula instead
+                  ^^^^^^^^^^^^^^^^^ FormulaAudit/ClassName: `GithubGistFormula` is deprecated, use `Formula` instead
         url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ClassName do
   it "reports and corrects an offense when using AmazonWebServicesFormula" do
     expect_offense(<<~RUBY)
       class Foo < AmazonWebServicesFormula
-                  ^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ClassName: AmazonWebServicesFormula is deprecated, use Formula instead
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ClassName: `AmazonWebServicesFormula` is deprecated, use `Formula` instead
         url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY

--- a/Library/Homebrew/test/rubocops/class/test_spec.rb
+++ b/Library/Homebrew/test/rubocops/class/test_spec.rb
@@ -6,46 +6,46 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Test do
   subject(:cop) { described_class.new }
 
   it "reports and corrects an offense when /usr/local/bin is found in test calls" do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~'RUBY')
       class Foo < Formula
         url 'https://brew.sh/foo-1.0.tgz'
 
         test do
           system "/usr/local/bin/test"
-                 ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Test: use \#{bin} instead of /usr/local/bin in system
+                 ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Test: Use `#{bin}` instead of `/usr/local/bin` in `system`
         end
       end
     RUBY
 
-    expect_correction(<<~RUBY)
+    expect_correction(<<~'RUBY')
       class Foo < Formula
         url 'https://brew.sh/foo-1.0.tgz'
 
         test do
-          system "\#{bin}/test"
+          system "#{bin}/test"
         end
       end
     RUBY
   end
 
   it "reports and corrects an offense when passing 0 as the second parameter to shell_output" do
-    expect_offense(<<~RUBY)
+    expect_offense(<<~'RUBY')
       class Foo < Formula
         url 'https://brew.sh/foo-1.0.tgz'
 
         test do
-          shell_output("\#{bin}/test", 0)
-                                      ^ FormulaAudit/Test: Passing 0 to shell_output() is redundant
+          shell_output("#{bin}/test", 0)
+                                      ^ FormulaAudit/Test: Passing 0 to `shell_output` is redundant
         end
       end
     RUBY
 
-    expect_correction(<<~RUBY)
+    expect_correction(<<~'RUBY')
       class Foo < Formula
         url 'https://brew.sh/foo-1.0.tgz'
 
         test do
-          shell_output("\#{bin}/test")
+          shell_output("#{bin}/test")
         end
       end
     RUBY

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           end
 
           on_macos do
-          ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_macos` block in a formula.
+          ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_macos` block in a formula.
             depends_on "foo"
           end
         end
@@ -527,7 +527,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           end
 
           on_linux do
-          ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_linux` block in a formula.
+          ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_linux` block in a formula.
             depends_on "foo"
           end
         end
@@ -543,7 +543,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           end
 
           on_intel do
-          ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_intel` block in a formula.
+          ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_intel` block in a formula.
             depends_on "foo"
           end
         end
@@ -559,7 +559,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           end
 
           on_arm do
-          ^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_arm` block in a formula.
+          ^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_arm` block in a formula.
             depends_on "foo"
           end
         end
@@ -575,7 +575,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           end
 
           on_monterey do
-          ^^^^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_monterey` block in a formula.
+          ^^^^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_monterey` block in a formula.
             depends_on "foo"
           end
         end
@@ -591,7 +591,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           end
 
           on_monterey :or_older do
-          ^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_monterey` block in a formula.
+          ^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_monterey` block in a formula.
             depends_on "foo"
           end
         end
@@ -881,7 +881,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_macos` block in a resource block.
+            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_macos` block in a resource block.
               on_macos do
                 url "https://brew.sh/resource1.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -902,7 +902,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_linux` block in a resource block.
+            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_linux` block in a resource block.
               on_linux do
                 url "https://brew.sh/resource1.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -923,7 +923,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_intel` block in a resource block.
+            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_intel` block in a resource block.
               on_intel do
                 url "https://brew.sh/resource1.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -944,7 +944,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_arm` block in a resource block.
+            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_arm` block in a resource block.
               on_arm do
                 url "https://brew.sh/resource1.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -965,7 +965,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: there can only be one `on_monterey` block in a resource block.
+            ^^^^^^^^^^^ FormulaAudit/ComponentsOrder: There can only be one `on_monterey` block in a resource block.
               on_monterey do
                 url "https://brew.sh/resource1.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           url "https://brew.sh/foo-1.0.tgz"
           uses_from_macos "apple" if build.with? "foo"
           uses_from_macos "foo" => :optional
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 5) should be put before dependency "apple" (line 4)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 5) should be put before `dependency "apple"` (line 4)
         end
       RUBY
 
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           url "https://brew.sh/foo-1.0.tgz"
           uses_from_macos "foo"
           uses_from_macos "bar"
-          ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 5) should be put before dependency "foo" (line 4)
+          ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 5) should be put before `dependency "foo"` (line 4)
         end
       RUBY
 
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           url "https://brew.sh/foo-1.0.tgz"
           uses_from_macos FooRequirement
           uses_from_macos "bar"
-          ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 5) should be put before dependency "FooRequirement" (line 4)
+          ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 5) should be put before `dependency "FooRequirement"` (line 4)
         end
       RUBY
 
@@ -77,13 +77,13 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           head do
             uses_from_macos "apple" if build.with? "foo"
             uses_from_macos "bar"
-            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 6) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 6) should be put before `dependency "apple"` (line 5)
             uses_from_macos "foo" => :optional
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 7) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 7) should be put before `dependency "apple"` (line 5)
           end
           uses_from_macos "apple" if build.with? "foo"
           uses_from_macos "foo" => :optional
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 10) should be put before dependency "apple" (line 9)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 10) should be put before `dependency "apple"` (line 9)
         end
       RUBY
 
@@ -122,9 +122,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           on_arm do
             uses_from_macos "apple" if build.with? "foo"
             uses_from_macos "bar"
-            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 6) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 6) should be put before `dependency "apple"` (line 5)
             uses_from_macos "foo" => :optional
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 7) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 7) should be put before `dependency "apple"` (line 5)
           end
         end
       RUBY
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           url "https://brew.sh/foo-1.0.tgz"
           depends_on "apple" if build.with? "foo"
           depends_on "foo" => :optional
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 5) should be put before dependency "apple" (line 4)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 5) should be put before `dependency "apple"` (line 4)
         end
       RUBY
 
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           url "https://brew.sh/foo-1.0.tgz"
           depends_on "foo"
           depends_on "bar"
-          ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 5) should be put before dependency "foo" (line 4)
+          ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 5) should be put before `dependency "foo"` (line 4)
         end
       RUBY
 
@@ -193,7 +193,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           url "https://brew.sh/foo-1.0.tgz"
           depends_on FooRequirement
           depends_on "bar"
-          ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 5) should be put before dependency "FooRequirement" (line 4)
+          ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 5) should be put before `dependency "FooRequirement"` (line 4)
         end
       RUBY
 
@@ -215,13 +215,13 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           head do
             depends_on "apple" if build.with? "foo"
             depends_on "bar"
-            ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 6) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 6) should be put before `dependency "apple"` (line 5)
             depends_on "foo" => :optional
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 7) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 7) should be put before `dependency "apple"` (line 5)
           end
           depends_on "apple" if build.with? "foo"
           depends_on "foo" => :optional
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 10) should be put before dependency "apple" (line 9)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 10) should be put before `dependency "apple"` (line 9)
         end
       RUBY
 
@@ -260,9 +260,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit::DependencyOrder do
           on_linux do
             depends_on "apple" if build.with? "foo"
             depends_on "bar"
-            ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "bar" (line 6) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "bar"` (line 6) should be put before `dependency "apple"` (line 5)
             depends_on "foo" => :optional
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: dependency "foo" (line 7) should be put before dependency "apple" (line 5)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/DependencyOrder: `dependency "foo"` (line 7) should be put before `dependency "apple"` (line 5)
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/desc_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Desc do
     it "reports an offense when there is no `desc`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-        ^^^^^^^^^^^^^^^^^^^ FormulaAudit/Desc: Formula should have a desc (Description).
+        ^^^^^^^^^^^^^^^^^^^ FormulaAudit/Desc: Formula should have a `desc` (description).
           url 'https://brew.sh/foo-1.0.tgz'
         end
       RUBY
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Desc do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           desc ''
-          ^^^^^^^ FormulaAudit/Desc: The desc (description) should not be an empty string.
+          ^^^^^^^ FormulaAudit/Desc: The `desc` (description) should not be an empty string.
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "ftp://brew.sh/foo"
-                   ^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: The homepage should start with http or https.
+                   ^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: The `homepage` should start with http or https.
           url "https://brew.sh/foo-1.0.tgz"
         end
       RUBY
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "http://www.freedesktop.org/wiki/bar"
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Freedesktop homepages should be styled `https://wiki.freedesktop.org/project_name`
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Freedesktop homepages should be styled: https://wiki.freedesktop.org/project_name
           url "https://brew.sh/foo-1.0.tgz"
         end
       RUBY
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "http://www.freedesktop.org/wiki/Software/baz"
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Freedesktop homepages should be styled `https://wiki.freedesktop.org/www/Software/project_name`
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Freedesktop homepages should be styled: https://wiki.freedesktop.org/www/Software/project_name
           url "https://brew.sh/foo-1.0.tgz"
         end
       RUBY
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
       RUBY
     end
 
-    describe "for Sourceforge" do
+    describe "for SourceForge" do
       correct_formula = <<~RUBY
         class Foo < Formula
           homepage "https://foo.sourceforge.io/"
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
         expect_offense(<<~RUBY)
           class Foo < Formula
             homepage "http://foo.sourceforge.net/"
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Sourceforge homepages should be `https://foo.sourceforge.io/`
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: SourceForge homepages should be: https://foo.sourceforge.io/
             url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
         expect_offense(<<~RUBY)
           class Foo < Formula
             homepage "http://foo.sourceforge.net"
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Sourceforge homepages should be `https://foo.sourceforge.io/`
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: SourceForge homepages should be: https://foo.sourceforge.io/
             url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
         expect_offense(<<~RUBY)
           class Foo < Formula
             homepage "http://foo.sf.net/"
-                     ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Sourceforge homepages should be `https://foo.sourceforge.io/`
+                     ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: SourceForge homepages should be: https://foo.sourceforge.io/
             url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
@@ -128,7 +128,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Homepage do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://foo.readthedocs.org"
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Readthedocs homepages should be `https://foo.readthedocs.io`
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Homepage: Readthedocs homepages should be: https://foo.readthedocs.io
           url "https://brew.sh/foo-1.0.tgz"
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines/quictls_check_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::QuicTLSCheck do
           url 'https://brew.sh/foo-1.0.tgz'
 
           depends_on "quictls"
-          ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/QuicTLSCheck: Formulae in homebrew/core should use 'depends_on "openssl@3"' instead of 'depends_on "quictls"'.
+          ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/QuicTLSCheck: Formulae in homebrew/core should use `depends_on "openssl@3"` instead of `depends_on "quictls"`.
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Options do
           url 'https://brew.sh/foo-1.0.tgz'
           option :cxx11
           option "examples", "with-examples"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Options: Options should begin with with/without. Migrate '--examples' with `deprecated_option`.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Options: Options should begin with `with` or `without`. Migrate '--examples' with `deprecated_option`.
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
           homepage "ftp://brew.sh/foo"
           url "https://brew.sh/foo-1.0.tgz"
           def patches
-          ^^^^^^^^^^^ FormulaAudit/Patches: Use the patch DSL instead of defining a 'patches' method
+          ^^^^^^^^^^^ FormulaAudit/Patches: Use the `patch` DSL instead of defining a `patches` method
             DATA
           end
         end
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
           commit = "b354c009a60bcd6d7fc04014e200a1ee9c45c167"
           fixed_url = "https://api.bitbucket.org/2.0/repositories/multicoreware/x265_git/diff/#{commit}"
           expect_offense_hash(message: <<~EOS.chomp, severity: :convention, line: 5, column: 4, source:)
-            FormulaAudit/Patches: Bitbucket patches should use the api url: #{fixed_url}
+            FormulaAudit/Patches: Bitbucket patches should use the API URL: #{fixed_url}
           EOS
         end
         expected_offense.zip([inspect_source(source).last]).each do |expected, actual|
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
 
       expected_offenses = [
         {
-          message:  "FormulaAudit/Patches: Use the patch DSL instead of defining a 'patches' method",
+          message:  "FormulaAudit/Patches: Use the `patch` DSL instead of defining a `patches` method",
           severity: :convention,
           line:     4,
           column:   2,
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           patch :DATA
-          ^^^^^^^^^^^ FormulaAudit/Patches: patch is missing '__END__'
+          ^^^^^^^^^^^ FormulaAudit/Patches: Patch is missing `__END__`
         end
       RUBY
     end
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Patches do
           url 'https://brew.sh/foo-1.0.tgz'
         end
         __END__
-        ^^^^^^^ FormulaAudit/Patches: patch is missing 'DATA'
+        ^^^^^^^ FormulaAudit/Patches: Patch is missing `patch :DATA`
         patch content here
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ProvidedByMacos do
         homepage "https://brew.sh"
 
         keg_only :provided_by_macos
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ProvidedByMacos: Formulae that are `keg_only :provided_by_macos` should be added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repo)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ProvidedByMacos: Formulae that are `keg_only :provided_by_macos` should be added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repository)
       end
     RUBY
   end

--- a/Library/Homebrew/test/rubocops/shell_commands_spec.rb
+++ b/Library/Homebrew/test/rubocops/shell_commands_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe RuboCop::Cop::Homebrew::ShellCommands do
     end
 
     it "reports and corrects an offense when `system` arguments involving interpolation should be separated" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         class Foo < Formula
           def install
-            system "\#{bin}/foo bar"
-                   ^^^^^^^^^^^^^^^^ Homebrew/ShellCommands: Separate `system` commands into `"\#{bin}/foo", "bar"`
+            system "#{bin}/foo bar"
+                   ^^^^^^^^^^^^^^^^ Homebrew/ShellCommands: Separate `system` commands into `"#{bin}/foo", "bar"`
           end
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         class Foo < Formula
           def install
-            system "\#{bin}/foo", "bar"
+            system "#{bin}/foo", "bar"
           end
         end
       RUBY
@@ -151,19 +151,19 @@ RSpec.describe RuboCop::Cop::Homebrew::ShellCommands do
     end
 
     it "reports and corrects an offense when `Utils.popen_read` arguments with interpolation are unseparated" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         class Foo < Formula
           def install
-            Utils.popen_read("\#{bin}/foo bar")
-                             ^^^^^^^^^^^^^^^^ Homebrew/ShellCommands: Separate `Utils.popen_read` commands into `"\#{bin}/foo", "bar"`
+            Utils.popen_read("#{bin}/foo bar")
+                             ^^^^^^^^^^^^^^^^ Homebrew/ShellCommands: Separate `Utils.popen_read` commands into `"#{bin}/foo", "bar"`
           end
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         class Foo < Formula
           def install
-            Utils.popen_read("\#{bin}/foo", "bar")
+            Utils.popen_read("#{bin}/foo", "bar")
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/miscellaneous_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           FileUtils.mv "hello"
-          ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Don't need 'FileUtils.' before mv
+          ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: No need for `FileUtils.` before `mv`
         end
       RUBY
     end
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           inreplace "foo" do |longvar|
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: "inreplace <filenames> do |s|" is preferred over "|longvar|".
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: `inreplace <filenames> do |s|` is preferred over `|longvar|`.
             somerandomCall(longvar)
           end
         end
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           bottle do
             rebuild 0
-            ^^^^^^^^^ FormulaAudit/Miscellaneous: 'rebuild 0' should be removed
+            ^^^^^^^^^ FormulaAudit/Miscellaneous: `rebuild 0` should be removed
             sha256 "fe0679b932dd43a87fd415b609a7fbac7a069d117642ae8ebaac46ae1fb9f0b3" => :sierra
           end
         end
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
             sha256 "fe0679b932dd43a87fd415b609a7fbac7a069d117642ae8ebaac46ae1fb9f0b3" => :sierra
           end
           fails_with :llvm do
-          ^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: 'fails_with :llvm' is now a no-op so should be removed
+          ^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: `fails_with :llvm` is now a no-op and should be removed
             build 2335
             cause "foo"
           end
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
 
           def test
-          ^^^^^^^^ FormulaAudit/Miscellaneous: Use new-style test definitions (test do)
+          ^^^^^^^^ FormulaAudit/Miscellaneous: Use new-style test definitions (`test do`)
             assert_equals "1", "1"
           end
         end
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           rm_rf Dir["src/{llvm,test,librustdoc,etc/snapshot.pyc}"]
           rm_rf Dir["src/snapshot.pyc"]
-                    ^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Dir(["src/snapshot.pyc"]) is unnecessary; just use "src/snapshot.pyc"
+                    ^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: `Dir(["src/snapshot.pyc"])` is unnecessary; just use `src/snapshot.pyc`
         end
       RUBY
     end
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
     it "reports an offense when top-level functions are defined outside of a class body" do
       expect_offense(<<~RUBY)
         def test
-        ^^^^^^^^ FormulaAudit/Miscellaneous: Define method test in the class body, not at the top-level
+        ^^^^^^^^ FormulaAudit/Miscellaneous: Define method `test` in the class body, not at the top-level
            nil
         end
         class Foo < Formula
@@ -201,7 +201,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             man1.install man+"man8" => "faad.1"
-                             ^^^^^^ FormulaAudit/Miscellaneous: "man+"man8"" should be "man8"
+                             ^^^^^^ FormulaAudit/Miscellaneous: `man+"man8"` should be `man8`
           end
         end
       RUBY
@@ -214,7 +214,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "/usr/bin/gcc", "foo"
-                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use "#{ENV.cc}" instead of hard-coding "gcc"
+                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use `#{ENV.cc}` instead of hard-coding `gcc`
           end
         end
       RUBY
@@ -227,7 +227,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "/usr/bin/g++", "-o", "foo", "foo.cc"
-                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use "#{ENV.cxx}" instead of hard-coding "g++"
+                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use `#{ENV.cxx}` instead of hard-coding `g++`
           end
         end
       RUBY
@@ -240,20 +240,20 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             ENV["COMPILER_PATH"] = "/usr/bin/c++"
-                                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use "#{ENV.cxx}" instead of hard-coding "c++"
+                                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use `#{ENV.cxx}` instead of hard-coding `c++`
           end
         end
       RUBY
     end
 
     it "reports an offense when a hard-coded `gcc` is set as COMPILER_PATH" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             ENV["COMPILER_PATH"] = "/usr/bin/gcc"
-                                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use "\#{ENV.cc}" instead of hard-coding "gcc"
+                                   ^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use `#{ENV.cc}` instead of hard-coding `gcc`
           end
         end
       RUBY
@@ -266,7 +266,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             mv "#{share}/man", share
-                        ^^^^ FormulaAudit/Miscellaneous: "#{share}/man" should be "#{man}"
+                        ^^^^ FormulaAudit/Miscellaneous: `#{share}/man` should be `#{man}`
           end
         end
       RUBY
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             mv "#{prefix}/libexec", share
-                         ^^^^^^^^ FormulaAudit/Miscellaneous: "#{prefix}/libexec" should be "#{libexec}"
+                         ^^^^^^^^ FormulaAudit/Miscellaneous: `#{prefix}/libexec` should be `#{libexec}`
           end
         end
       RUBY
@@ -292,7 +292,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "./configure", "--INFODIR=#{prefix}/share/info"
-                                                      ^^^^^^^^^^^ FormulaAudit/Miscellaneous: "#{prefix}/share/info" should be "#{info}"
+                                                      ^^^^^^^^^^^ FormulaAudit/Miscellaneous: `#{prefix}/share/info` should be `#{info}`
           end
         end
       RUBY
@@ -305,7 +305,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "./configure", "--MANDIR=#{prefix}/share/man/man8"
-                                                     ^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: "#{prefix}/share/man/man8" should be "#{man8}"
+                                                     ^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: `#{prefix}/share/man/man8` should be `#{man8}`
           end
         end
       RUBY
@@ -317,7 +317,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on "lpeg" => :lua51
-                               ^^^^^^ FormulaAudit/Miscellaneous: lua modules should be vendored rather than use deprecated `depends_on "lpeg" => :lua51`
+                               ^^^^^^ FormulaAudit/Miscellaneous: lua modules should be vendored rather than using deprecated `depends_on "lpeg" => :lua51`
         end
       RUBY
     end
@@ -328,7 +328,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           system "export", "var=value"
-                 ^^^^^^^^ FormulaAudit/Miscellaneous: Use ENV instead of invoking 'export' to modify the environment
+                 ^^^^^^^^ FormulaAudit/Miscellaneous: Use `ENV` instead of invoking `export` to modify the environment
         end
       RUBY
     end
@@ -339,7 +339,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on "foo" => "with-bar"
-                              ^^^^^^^^^^ FormulaAudit/Miscellaneous: Dependency foo should not use option with-bar
+                              ^^^^^^^^^^ FormulaAudit/Miscellaneous: Dependency 'foo' should not use option `with-bar`
         end
       RUBY
     end
@@ -351,9 +351,9 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on "httpd" => [:build, :test]
           depends_on "foo" => [:optional, "with-bar"]
-                                          ^^^^^^^^^^ FormulaAudit/Miscellaneous: Dependency foo should not use option with-bar
+                                          ^^^^^^^^^^ FormulaAudit/Miscellaneous: Dependency 'foo' should not use option `with-bar`
           depends_on "icu4c" => [:optional, "c++11"]
-                                            ^^^^^^^ FormulaAudit/Miscellaneous: Dependency icu4c should not use option c++11
+                                            ^^^^^^^ FormulaAudit/Miscellaneous: Dependency 'icu4c' should not use option `c++11`
         end
       RUBY
     end
@@ -364,7 +364,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           if version == "HEAD"
-             ^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use 'build.head?' instead of inspecting 'version'
+             ^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use `build.head?` instead of inspecting `version`
             foo()
           end
         end
@@ -378,8 +378,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           test do
             head = ARGV.include? "--HEAD"
-                   ^^^^ FormulaAudit/Miscellaneous: Use build instead of ARGV to check options
-                   ^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use "if build.head?" instead
+                   ^^^^ FormulaAudit/Miscellaneous: Use `build.with?` or `build.without?` instead of `ARGV` to check options
+                   ^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use `if build.head?` instead
           end
         end
       RUBY
@@ -391,7 +391,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           needs :openmp
-          ^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: 'needs :openmp' should be replaced with 'depends_on "gcc"'
+          ^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: `needs :openmp` should be replaced with `depends_on "gcc"`
         end
       RUBY
     end
@@ -403,7 +403,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           test do
             version = MACOS_VERSION
-                      ^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use MacOS.version instead of MACOS_VERSION
+                      ^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Use `MacOS.version` instead of `MACOS_VERSION`
           end
         end
       RUBY
@@ -415,7 +415,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on "foo" if build.with? "foo"
-          ^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Replace depends_on "foo" if build.with? "foo" with depends_on "foo" => :optional
+          ^^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Replace `depends_on "foo" if build.with? "foo"` with `depends_on "foo" => :optional`
         end
       RUBY
     end
@@ -426,7 +426,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on :foo unless build.without? "foo"
-          ^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Replace depends_on :foo unless build.without? "foo" with depends_on :foo => :recommended
+          ^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Replace `depends_on :foo unless build.without? "foo"` with `depends_on :foo => :recommended`
         end
       RUBY
     end
@@ -437,7 +437,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on :foo unless build.include? "without-foo"
-          ^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Replace depends_on :foo unless build.include? "without-foo" with depends_on :foo => :recommended
+          ^^^^^^^^^^^^^^^ FormulaAudit/Miscellaneous: Replace `depends_on :foo unless build.include? "without-foo"` with `depends_on :foo => :recommended`
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/mpi_check_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::MpiCheck do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on "mpich"
-          ^^^^^^^^^^^^^^^^^^ FormulaAudit/MpiCheck: Formulae in homebrew/core should use 'depends_on "open-mpi"' instead of 'depends_on "mpich"'.
+          ^^^^^^^^^^^^^^^^^^ FormulaAudit/MpiCheck: Formulae in homebrew/core should use `depends_on "open-mpi"` instead of `depends_on "mpich"`.
         end
       RUBY
 

--- a/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/on_system_conditionals_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if OS.linux?
-          ^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if OS.linux?`, use `on_linux do` instead.
+          ^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if OS.linux?`, use `on_linux do`.
             url 'https://brew.sh/linux-1.0.tgz'
           else
             url 'https://brew.sh/linux-1.0.tgz'
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if OS.mac?
-          ^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if OS.mac?`, use `on_macos do` instead.
+          ^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if OS.mac?`, use `on_macos do`.
             url 'https://brew.sh/mac-1.0.tgz'
           else
             url 'https://brew.sh/linux-1.0.tgz'
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_macos do
-            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_macos` in `def install`, use `if OS.mac?` instead.
+            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_macos` in `def install`, use `if OS.mac?`.
               true
             end
           end
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_linux do
-            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_linux` in `def install`, use `if OS.linux?` instead.
+            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_linux` in `def install`, use `if OS.linux?`.
               true
             end
           end
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           test do
             on_macos do
-            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_macos` in `test do`, use `if OS.mac?` instead.
+            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_macos` in `test do`, use `if OS.mac?`.
               true
             end
           end
@@ -152,7 +152,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if Hardware::CPU.arm?
-          ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if Hardware::CPU.arm?`, use `on_arm do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if Hardware::CPU.arm?`, use `on_arm do`.
             url 'https://brew.sh/linux-1.0.tgz'
           else
             url 'https://brew.sh/linux-1.0.tgz'
@@ -178,7 +178,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if Hardware::CPU.intel?
-          ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if Hardware::CPU.intel?`, use `on_intel do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if Hardware::CPU.intel?`, use `on_intel do`.
             url 'https://brew.sh/mac-1.0.tgz'
           else
             url 'https://brew.sh/linux-1.0.tgz'
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_intel do
-            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_intel` in `def install`, use `if Hardware::CPU.intel?` instead.
+            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_intel` in `def install`, use `if Hardware::CPU.intel?`.
               true
             end
           end
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_arm do
-            ^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_arm` in `def install`, use `if Hardware::CPU.arm?` instead.
+            ^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_arm` in `def install`, use `if Hardware::CPU.arm?`.
               true
             end
           end
@@ -265,7 +265,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           test do
             on_intel do
-            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_intel` in `test do`, use `if Hardware::CPU.intel?` instead.
+            ^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_intel` in `test do`, use `if Hardware::CPU.intel?`.
               true
             end
           end
@@ -293,7 +293,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if MacOS.version == :monterey
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if MacOS.version == :monterey`, use `on_monterey do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if MacOS.version == :monterey`, use `on_monterey do`.
             url 'https://brew.sh/linux-1.0.tgz'
           end
         end
@@ -314,7 +314,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if MacOS.version <= :monterey
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if MacOS.version <= :monterey`, use `on_system :linux, macos: :monterey_or_older do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if MacOS.version <= :monterey`, use `on_system :linux, macos: :monterey_or_older do`.
             url 'https://brew.sh/mac-1.0.tgz'
           end
         end
@@ -335,7 +335,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if MacOS.version < :monterey
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if MacOS.version < :monterey`, use `on_system do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if MacOS.version < :monterey`, use `on_system do`.
             url 'https://brew.sh/mac-1.0.tgz'
           end
         end
@@ -347,7 +347,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if MacOS.version >= :monterey
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if MacOS.version >= :monterey`, use `on_monterey :or_newer do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if MacOS.version >= :monterey`, use `on_monterey :or_newer do`.
             url 'https://brew.sh/mac-1.0.tgz'
           else
             url 'https://brew.sh/linux-1.0.tgz'
@@ -361,7 +361,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
         class Foo < Formula
           desc "foo"
           if MacOS.version > :monterey
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `if MacOS.version > :monterey`, use `on_monterey do` instead.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of `if MacOS.version > :monterey`, use `on_monterey do`.
             url 'https://brew.sh/mac-1.0.tgz'
           end
         end
@@ -376,7 +376,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_monterey do
-            ^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_monterey` in `def install`, use `if MacOS.version == :monterey` instead.
+            ^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_monterey` in `def install`, use `if MacOS.version == :monterey`.
               true
             end
           end
@@ -405,7 +405,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_monterey :or_older do
-            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_monterey :or_older` in `def install`, use `if MacOS.version <= :monterey` instead.
+            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_monterey :or_older` in `def install`, use `if MacOS.version <= :monterey`.
               true
             end
           end
@@ -434,7 +434,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_monterey :or_newer do
-            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_monterey :or_newer` in `def install`, use `if MacOS.version >= :monterey` instead.
+            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_monterey :or_newer` in `def install`, use `if MacOS.version >= :monterey`.
               true
             end
           end
@@ -463,7 +463,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           def install
             on_system :linux, macos: :monterey_or_newer do
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_system :linux, macos: :monterey_or_newer` in `def install`, use `if OS.linux? || MacOS.version >= :monterey` instead.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_system :linux, macos: :monterey_or_newer` in `def install`, use `if OS.linux? || MacOS.version >= :monterey`.
               true
             end
           end
@@ -492,7 +492,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           test do
             on_monterey do
-            ^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_monterey` in `test do`, use `if MacOS.version == :monterey` instead.
+            ^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_monterey` in `test do`, use `if MacOS.version == :monterey`.
               true
             end
           end
@@ -521,7 +521,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OnSystemConditionals do
 
           test do
             on_system :linux, macos: :monterey do
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Don't use `on_system :linux, macos: :monterey` in `test do`, use `if OS.linux? || MacOS.version == :monterey` instead.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OnSystemConditionals: Instead of using `on_system :linux, macos: :monterey` in `test do`, use `if OS.linux? || MacOS.version == :monterey`.
               true
             end
           end

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
           url 'https://brew.sh/foo-1.0.tgz'
           def post_install
             return unless build.without? "bar"
-                          ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Use if build.with? "bar" instead of unless build.without? "bar"
+                          ^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Use `if build.with? "bar"` instead of `unless build.without? "bar"`
           end
         end
       RUBY
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
           url 'https://brew.sh/foo-1.0.tgz'
           def post_install
             return unless build.with? "bar"
-                          ^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Use if build.without? "bar" instead of unless build.with? "bar"
+                          ^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Use `if build.without? "bar"` instead of `unless build.with? "bar"`
           end
         end
       RUBY
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
           url 'https://brew.sh/foo-1.0.tgz'
           def post_install
             return if !build.with? "bar"
-                      ^^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Don't negate 'build.with?': use 'build.without?'
+                      ^^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Instead of negating `build.with?`, use `build.without?`
           end
         end
       RUBY
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
           url 'https://brew.sh/foo-1.0.tgz'
           def post_install
             return if !build.without? "bar"
-                      ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Don't negate 'build.without?': use 'build.with?'
+                      ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Instead of negating `build.without?`, use `build.with?`
           end
         end
       RUBY
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
           url 'https://brew.sh/foo-1.0.tgz'
           def post_install
             return if build.without? "--without-bar"
-                                     ^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Don't duplicate 'without': Use `build.without? "bar"` to check for "--without-bar"
+                                     ^^^^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Instead of duplicating `without`, use `build.without? "bar"` to check for "--without-bar"
           end
         end
       RUBY
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
           url 'https://brew.sh/foo-1.0.tgz'
           def post_install
             return if build.with? "--with-bar"
-                                  ^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Don't duplicate 'with': Use `build.with? "bar"` to check for "--with-bar"
+                                  ^^^^^^^^^^^^ FormulaAudit/OptionDeclarations: Instead of duplicating `with`, use `build.with? "bar"` to check for '--with-bar'
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/shell_variables_spec.rb
@@ -64,19 +64,19 @@ RSpec.describe RuboCop::Cop::FormulaAudit::ShellVariables do
     end
 
     it "reports and corrects unexpanded shell variables while preserving string interpolation" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         class Foo < Formula
           def install
-            Utils.popen "SHELL=bash \#{bin}/foo"
-                        ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ShellVariables: Use `Utils.popen({ "SHELL" => "bash" }, "\#{bin}/foo")` instead of `Utils.popen "SHELL=bash \#{bin}/foo"`
+            Utils.popen "SHELL=bash #{bin}/foo"
+                        ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/ShellVariables: Use `Utils.popen({ "SHELL" => "bash" }, "#{bin}/foo")` instead of `Utils.popen "SHELL=bash #{bin}/foo"`
           end
         end
       RUBY
 
-      expect_correction(<<~RUBY)
+      expect_correction(<<~'RUBY')
         class Foo < Formula
           def install
-            Utils.popen({ "SHELL" => "bash" }, "\#{bin}/foo")
+            Utils.popen({ "SHELL" => "bash" }, "#{bin}/foo")
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/std_npm_args_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::StdNpmArgs do
         class Foo < Formula
           def install
             system "npm", "install", *Language::Node.local_npm_install_args, "--production"
-                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use 'std_npm_args' instead of 'local_npm_install_args'.
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use `std_npm_args` instead of `local_npm_install_args`.
           end
         end
       RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::StdNpmArgs do
         class Foo < Formula
           def install
             system "npm", "install", *Language::Node.std_npm_install_args(libexec), "--production"
-                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use 'std_npm_args' instead of 'std_npm_install_args'.
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use `std_npm_args` instead of `std_npm_install_args`.
           end
         end
       RUBY
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::StdNpmArgs do
         class Foo < Formula
           def install
             system "npm", "install", *Language::Node.std_npm_install_args(buildpath), "--production"
-                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use 'std_npm_args' instead of 'std_npm_install_args'.
+                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/StdNpmArgs: Use `std_npm_args` instead of `std_npm_install_args`.
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/text/strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/strict_spec.rb
@@ -29,29 +29,29 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
     end
 
     it %Q(reports an offense if "\#{share}/<formula name>" is present) do
-      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+      expect_offense(<<~'RUBY', "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
-            ohai "\#{share}/foo"
-                 ^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `\#{pkgshare}` instead of `\#{share}/foo`
+            ohai "#{share}/foo"
+                 ^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `#{pkgshare}` instead of `#{share}/foo`
           end
         end
       RUBY
 
-      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+      expect_offense(<<~'RUBY', "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
-            ohai "\#{share}/foo/bar"
-                 ^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `\#{pkgshare}` instead of `\#{share}/foo`
+            ohai "#{share}/foo/bar"
+                 ^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `#{pkgshare}` instead of `#{share}/foo`
           end
         end
       RUBY
 
-      expect_offense(<<~RUBY, "/homebrew-core/Formula/foolibc++.rb")
+      expect_offense(<<~'RUBY', "/homebrew-core/Formula/foolibc++.rb")
         class Foolibcxx < Formula
           def install
-            ohai "\#{share}/foolibc++"
-                 ^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `\#{pkgshare}` instead of `\#{share}/foolibc++`
+            ohai "#{share}/foolibc++"
+                 ^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `#{pkgshare}` instead of `#{share}/foolibc++`
           end
         end
       RUBY
@@ -87,10 +87,10 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
     end
 
     it %Q(reports no offenses if "\#{share}/<directory name>" doesn't match formula name) do
-      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+      expect_no_offenses(<<~'RUBY', "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
-            ohai "\#{share}/foo-bar"
+            ohai "#{share}/foo-bar"
           end
         end
       RUBY
@@ -123,10 +123,10 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
     end
 
     it %Q(reports no offenses if formula name appears after "\#{share}/<directory name>") do
-      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+      expect_no_offenses(<<~'RUBY', "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
-            ohai "\#{share}/bar/foo"
+            ohai "#{share}/bar/foo"
           end
         end
       RUBY
@@ -134,13 +134,13 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
 
     context "for interpolated bin paths" do
       it 'reports an offense & autocorrects if "\#{bin}/<formula_name>" or other dashed binaries too are present' do
-        expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        expect_offense(<<~'RUBY', "/homebrew-core/Formula/foo.rb")
           class Foo < Formula
             test do
-              system "\#{bin}/foo", "-v"
-                     ^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"\#{bin}/foo"`
-              system "\#{bin}/foo-bar", "-v"
-                     ^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo-bar"` instead of `"\#{bin}/foo-bar"`
+              system "#{bin}/foo", "-v"
+                     ^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo"` instead of `"#{bin}/foo"`
+              system "#{bin}/foo-bar", "-v"
+                     ^^^^^^^^^^^^^^^^ FormulaAuditStrict/Text: Use `bin/"foo-bar"` instead of `"#{bin}/foo-bar"`
             end
           end
         RUBY
@@ -156,12 +156,12 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
       end
 
       it 'does not report an offense if \#{bin}/foo and then a space and more text' do
-        expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        expect_no_offenses(<<~'RUBY', "/homebrew-core/Formula/foo.rb")
           class Foo < Formula
             test do
-              shell_output("\#{bin}/foo --version")
-              assert_match "help", shell_output("\#{bin}/foo-something --help 2>&1")
-              assert_match "OK", shell_output("\#{bin}/foo-something_else --check 2>&1")
+              shell_output("#{bin}/foo --version")
+              assert_match "help", shell_output("#{bin}/foo-something --help 2>&1")
+              assert_match "OK", shell_output("#{bin}/foo-something_else --check 2>&1")
             end
           end
         RUBY
@@ -169,11 +169,11 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::Text do
     end
 
     it 'does not report an offense if "\#{bin}/foo" is in a word array' do
-      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+      expect_no_offenses(<<~'RUBY', "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           test do
             cmd = %W[
-              \#{bin}/foo
+              #{bin}/foo
               version
             ]
             assert_match version.to_s, shell_output(cmd)

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
           url "https://brew.sh/foo-1.0.tgz"
           homepage "https://brew.sh"
           revision 0
-          ^^^^^^^^^^ FormulaAudit/Text: "revision 0" is unnecessary
+          ^^^^^^^^^^ FormulaAudit/Text: `revision 0` is unnecessary
         end
       RUBY
     end
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
 
           def install
             system "xcodebuild", "foo", "bar"
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: use "xcodebuild *args" instead of "system 'xcodebuild', *args"
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: Use `xcodebuild *args` instead of `system 'xcodebuild', *args`
           end
         end
       RUBY
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
 
           def install
             system "xcodebuild", "foo", "bar"
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: use "xcodebuild *args" instead of "system 'xcodebuild', *args"
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: Use `xcodebuild *args` instead of `system 'xcodebuild', *args`
           end
 
           def plist
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
     it 'reports an offense if `require "language/go"` is present' do
       expect_offense(<<~RUBY)
         require "language/go"
-        ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: require "language/go" is no longer necessary or correct
+        ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: `require "language/go"` is no longer necessary or correct
 
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
 
           def install
             Formula.factory(name)
-            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: "Formula.factory(name)" is deprecated in favor of "Formula[name]"
+            ^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: `Formula.factory(name)` is deprecated in favour of `Formula[name]`
           end
         end
       RUBY
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
 
           def install
             system "dep", "ensure"
-            ^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: use "dep", "ensure", "-vendor-only"
+            ^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: Use `"dep", "ensure", "-vendor-only"`
           end
         end
       RUBY
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
 
           def install
             system "cargo", "build"
-            ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: use "cargo", "install", *std_cargo_args
+            ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/Text: Use `"cargo", "install", *std_cargo_args`
           end
         end
       RUBY
@@ -221,10 +221,10 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
     end
 
     it "reports an offense if paths are concatenated in string interpolation" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~'RUBY')
         class Foo < Formula
           def install
-            ohai "foo \#{bar + "baz"}"
+            ohai "foo #{bar + "baz"}"
                       ^^^^^^^^^^^^^^ FormulaAudit/Text: Do not concatenate paths in string interpolation
           end
         end

--- a/Library/Homebrew/test/rubocops/urls/git_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::GitUrls do
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/GitUrls: Formulae in homebrew/core should specify a revision for git URLs
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/GitUrls: Formulae in homebrew/core should specify a revision for Git URLs
               tag: "v1.0.0"
         end
       RUBY
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::GitUrls do
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/GitUrls: Formulae in homebrew/core should specify a revision for git URLs
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/GitUrls: Formulae in homebrew/core should specify a revision for Git URLs
               shallow: false,
               tag:     "v1.0.0"
         end

--- a/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/git_strict_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::GitUrls do
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/GitUrls: Formulae in homebrew/core should specify a tag for git URLs
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/GitUrls: Formulae in homebrew/core should specify a tag for Git URLs
               revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         end
       RUBY
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::FormulaAuditStrict::GitUrls do
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/GitUrls: Formulae in homebrew/core should specify a tag for git URLs
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAuditStrict/GitUrls: Formulae in homebrew/core should specify a tag for Git URLs
               revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
               shallow:  false
         end

--- a/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/pypi_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::PyPiUrls do
         class Foo < Formula
           desc "foo"
           url "https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/PyPiUrls: use the `Source` url found on PyPI downloads page (`https://pypi.org/project/foo/#files`)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/PyPiUrls: Use the "Source" URL found on the PyPI downloads page (https://pypi.org/project/foo/#files)
         end
       RUBY
     end
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::PyPiUrls do
         class Foo < Formula
           desc "foo"
           url "https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/PyPiUrls: use the `Source` url found on PyPI downloads page (`https://pypi.org/project/foo/#files`)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/PyPiUrls: Use the "Source" URL found on the PyPI downloads page (https://pypi.org/project/foo/#files)
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
   let(:offense_list) do
     [{
       "url" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz",
-      "msg" => 'Please use "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz" instead of https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz.',
+      "msg" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz should be: " \
+               "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz",
       "col" => 2,
     }, {
       "url" => "https://fossies.org/linux/privat/monit-5.23.0.tar.gz",
-      "msg" => "Please don't use fossies.org in the url (using as a mirror is fine)",
+      "msg" => "Please don't use \"fossies.org\" in the `url` (using as a mirror is fine)",
       "col" => 2,
     }, {
       "url" => "http://tools.ietf.org/tools/rfcmarkup/rfcmarkup-1.119.tgz",
@@ -20,23 +21,23 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "col" => 2,
     }, {
       "url" => "https://apache.org/dyn/closer.cgi?path=/apr/apr-1.7.0.tar.bz2",
-      "msg" => "https://apache.org/dyn/closer.cgi?path=/apr/apr-1.7.0.tar.bz2 should be " \
-               "`https://www.apache.org/dyn/closer.lua?path=apr/apr-1.7.0.tar.bz2`",
+      "msg" => "https://apache.org/dyn/closer.cgi?path=/apr/apr-1.7.0.tar.bz2 should be: " \
+               "https://www.apache.org/dyn/closer.lua?path=apr/apr-1.7.0.tar.bz2",
       "col" => 2,
     }, {
       "url" => "http://search.mcpan.org/CPAN/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz",
-      "msg" => "http://search.mcpan.org/CPAN/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz should be " \
-               "`https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz`",
+      "msg" => "http://search.mcpan.org/CPAN/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz should be: " \
+               "https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz",
       "col" => 2,
     }, {
       "url" => "http://ftp.gnome.org/pub/GNOME/binaries/mac/banshee/banshee-2.macosx.intel.dmg",
-      "msg" => "http://ftp.gnome.org/pub/GNOME/binaries/mac/banshee/banshee-2.macosx.intel.dmg should be " \
-               "`https://download.gnome.org/binaries/mac/banshee/banshee-2.macosx.intel.dmg`",
+      "msg" => "http://ftp.gnome.org/pub/GNOME/binaries/mac/banshee/banshee-2.macosx.intel.dmg should be: " \
+               "https://download.gnome.org/binaries/mac/banshee/banshee-2.macosx.intel.dmg",
       "col" => 2,
     }, {
       "url" => "git://anonscm.debian.org/users/foo/foostrap.git",
-      "msg" => "git://anonscm.debian.org/users/foo/foostrap.git should be " \
-               "`https://anonscm.debian.org/git/users/foo/foostrap.git`",
+      "msg" => "git://anonscm.debian.org/users/foo/foostrap.git should be: " \
+               "https://anonscm.debian.org/git/users/foo/foostrap.git",
       "col" => 2,
     }, {
       "url" => "ftp://ftp.mirrorservice.org/foo-1.tar.gz",
@@ -44,31 +45,31 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "col" => 2,
     }, {
       "url" => "ftp://ftp.cpan.org/pub/CPAN/foo-1.tar.gz",
-      "msg" => "ftp://ftp.cpan.org/pub/CPAN/foo-1.tar.gz should be `http://search.cpan.org/CPAN/foo-1.tar.gz`",
+      "msg" => "ftp://ftp.cpan.org/pub/CPAN/foo-1.tar.gz should be: http://search.cpan.org/CPAN/foo-1.tar.gz",
       "col" => 2,
     }, {
       "url" => "http://sourceforge.net/projects/something/files/Something-1.2.3.dmg",
-      "msg" => "Use https://downloads.sourceforge.net to get geolocation (url is " \
+      "msg" => "Use \"https://downloads.sourceforge.net\" to get geolocation (`url` is " \
                "http://sourceforge.net/projects/something/files/Something-1.2.3.dmg).",
       "col" => 2,
     }, {
       "url" => "https://downloads.sourceforge.net/project/foo/download",
-      "msg" => "Don't use /download in SourceForge urls (url is " \
+      "msg" => "Don't use \"/download\" in SourceForge URLs (`url` is " \
                "https://downloads.sourceforge.net/project/foo/download).",
       "col" => 2,
     }, {
       "url" => "https://sourceforge.net/project/foo",
-      "msg" => "Use https://downloads.sourceforge.net to get geolocation " \
-               "(url is https://sourceforge.net/project/foo).",
+      "msg" => "Use \"https://downloads.sourceforge.net\" to get geolocation (`url` is " \
+               "https://sourceforge.net/project/foo).",
       "col" => 2,
     }, {
       "url" => "http://prdownloads.sourceforge.net/foo/foo-1.tar.gz",
-      "msg" => "Don't use prdownloads in SourceForge urls " \
-               "(url is http://prdownloads.sourceforge.net/foo/foo-1.tar.gz).",
+      "msg" => "Don't use \"prdownloads\" in SourceForge URLs (`url` is " \
+               "http://prdownloads.sourceforge.net/foo/foo-1.tar.gz).",
       "col" => 2,
     }, {
       "url" => "http://foo.dl.sourceforge.net/sourceforge/foozip/foozip_1.0.tar.bz2",
-      "msg" => "Don't use specific dl mirrors in SourceForge urls (url is " \
+      "msg" => "Don't use specific \"dl\" mirrors in SourceForge URLs (`url` is " \
                "http://foo.dl.sourceforge.net/sourceforge/foozip/foozip_1.0.tar.bz2).",
       "col" => 2,
     }, {
@@ -129,7 +130,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "col" => 2,
     }, {
       "url" => "https://github.com/foo/bar/tarball/v1.2.3",
-      "msg" => "Use /archive/ URLs for GitHub tarballs (url is https://github.com/foo/bar/tarball/v1.2.3).",
+      "msg" => "Use /archive/ URLs for GitHub tarballs (`url` is https://github.com/foo/bar/tarball/v1.2.3).",
       "col" => 2,
     }, {
       "url" => "https://codeload.github.com/foo/bar/tar.gz/v0.1.1",
@@ -142,8 +143,8 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "col" => 2,
     }, {
       "url" => "https://central.maven.org/maven2/com/bar/foo/1.1/foo-1.1.jar",
-      "msg" => "https://central.maven.org/maven2/com/bar/foo/1.1/foo-1.1.jar should be " \
-               "`https://search.maven.org/remotecontent?filepath=com/bar/foo/1.1/foo-1.1.jar`",
+      "msg" => "https://central.maven.org/maven2/com/bar/foo/1.1/foo-1.1.jar should be: " \
+               "https://search.maven.org/remotecontent?filepath=com/bar/foo/1.1/foo-1.1.jar",
       "col" => 2,
     }, {
       "url"         => "https://brew.sh/example-darwin.x86_64.tar.gz",
@@ -159,31 +160,31 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
       "formula_tap" => "homebrew-core",
     }, {
       "url" => "cvs://brew.sh/foo/bar",
-      "msg" => "Use of the cvs:// scheme is deprecated, pass `:using => :cvs` instead",
+      "msg" => "Use of the \"cvs://\" scheme is deprecated, pass `using: :cvs` instead",
       "col" => 2,
     }, {
       "url" => "bzr://brew.sh/foo/bar",
-      "msg" => "Use of the bzr:// scheme is deprecated, pass `:using => :bzr` instead",
+      "msg" => "Use of the \"bzr://\" scheme is deprecated, pass `using: :bzr` instead",
       "col" => 2,
     }, {
       "url" => "hg://brew.sh/foo/bar",
-      "msg" => "Use of the hg:// scheme is deprecated, pass `:using => :hg` instead",
+      "msg" => "Use of the \"hg://\" scheme is deprecated, pass `using: :hg` instead",
       "col" => 2,
     }, {
       "url" => "fossil://brew.sh/foo/bar",
-      "msg" => "Use of the fossil:// scheme is deprecated, pass `:using => :fossil` instead",
+      "msg" => "Use of the \"fossil://\" scheme is deprecated, pass `using: :fossil` instead",
       "col" => 2,
     }, {
       "url" => "svn+http://brew.sh/foo/bar",
-      "msg" => "Use of the svn+http:// scheme is deprecated, pass `:using => :svn` instead",
+      "msg" => "Use of the \"svn+http://\" scheme is deprecated, pass `using: :svn` instead",
       "col" => 2,
     }, {
       "url" => "https://🫠.sh/foo/bar",
-      "msg" => "Please use the ASCII (Punycode encoded host, URL-encoded path and query) version of https://🫠.sh/foo/bar.",
+      "msg" => "Please use the ASCII (Punycode-encoded host, URL-encoded path and query) version of https://🫠.sh/foo/bar.",
       "col" => 2,
     }, {
       "url" => "https://ßreｗ.sh/foo/bar",
-      "msg" => "Please use the ASCII (Punycode encoded host, URL-encoded path and query) version of https://ßreｗ.sh/foo/bar.",
+      "msg" => "Please use the ASCII (Punycode-encoded host, URL-encoded path and query) version of https://ßreｗ.sh/foo/bar.",
       "col" => 2,
     }]
   end

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
           homepage "https://brew.sh"
 
           uses_from_macos "postgresql"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not postgresql.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not 'postgresql'.
         end
       RUBY
     end
@@ -25,10 +25,10 @@ RSpec.describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
           homepage "https://brew.sh"
 
           uses_from_macos "boost"
-          ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not boost.
+          ^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not 'boost'.
           uses_from_macos "bzip2"
           uses_from_macos "postgresql"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not postgresql.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FormulaAudit/UsesFromMacos: `uses_from_macos` should only be used for macOS dependencies, not 'postgresql'.
           uses_from_macos "zlib"
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Version do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           version ""
-          ^^^^^^^^^^ FormulaAudit/Version: version is set to an empty string
+          ^^^^^^^^^^ FormulaAudit/Version: Version is set to an empty string
         end
       RUBY
     end
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Version do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           version "v1.0"
-          ^^^^^^^^^^^^^^ FormulaAudit/Version: version v1.0 should not have a leading 'v'
+          ^^^^^^^^^^^^^^ FormulaAudit/Version: Version v1.0 should not have a leading 'v'
         end
       RUBY
     end
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Version do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           version "1_0"
-          ^^^^^^^^^^^^^ FormulaAudit/Version: version 1_0 should not end with an underline and a number
+          ^^^^^^^^^^^^^ FormulaAudit/Version: Version 1_0 should not end with an underline and a number
         end
       RUBY
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
A review and cleanup of RuboCop problem descriptions and their associated tests. Also removed the now-unneeded `bazel` formula workarounds in lines.rb and use single-quoted heredocs to reduce the need for `\#{...}` escaping.