### PR TITLE
brew.sh: move sudo reset timestamp.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -1078,6 +1078,22 @@ else
   export HOMEBREW_GITHUB_PACKAGES_AUTH="Bearer QQ=="
 fi
 
+# Avoid picking up any random `sudo` in `PATH`.
+if [[ -x /usr/bin/sudo ]]
+then
+  SUDO=/usr/bin/sudo
+else
+  # Do this after ensuring we're using default Bash builtins.
+  SUDO="$(command -v sudo 2>/dev/null)"
+fi
+
+# Reset sudo timestamp to avoid running unauthorized sudo commands
+if [[ -n "${SUDO}" ]]
+then
+  "${SUDO}" --reset-timestamp 2>/dev/null || true
+fi
+unset SUDO
+
 if [[ -n "${HOMEBREW_BASH_COMMAND}" ]]
 then
   # source rather than executing directly to ensure the entire file is read into

--- a/bin/brew
+++ b/bin/brew
@@ -57,22 +57,6 @@ do
 done
 unset cmd
 
-# Avoid picking up any random `sudo` in `PATH`.
-if [[ -x /usr/bin/sudo ]]
-then
-  SUDO=/usr/bin/sudo
-else
-  # Do this after ensuring we're using default Bash builtins.
-  SUDO="$(command -v sudo 2>/dev/null)"
-fi
-
-# Reset sudo timestamp to avoid running unauthorized sudo commands
-if [[ -n "${SUDO}" ]]
-then
-  "${SUDO}" --reset-timestamp 2>/dev/null || true
-fi
-unset SUDO
-
 # Take the HOMEBREW_PATH if we are running brew within brew, otherwise we would lose the original path.
 if [[ -n "${HOMEBREW_BREW_FILE:-}" && -n "${HOMEBREW_PATH:-}" ]]
 then


### PR DESCRIPTION
Let's move this from `bin/brew` to make things like e.g. `brew --prefix` or `brew shellenv` not reset the sudo timestamp.

This is still in a place that ensures that e.g. no untrusted formula or tap code has been run yet so should have no security implications but provide mild usability improvements.

Fixes https://github.com/Homebrew/brew/issues/20022