### PR TITLE
Refactor `OnSystem` and `SimulateSystem` bottle tag handling

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -126,8 +126,7 @@ module Homebrew
     def self.merge_variations(json, bottle_tag: nil)
       return json unless json.key?("variations")
 
-      bottle_tag ||= ::Utils::Bottles::Tag.new(system: Homebrew::SimulateSystem.current_os,
-                                               arch:   Homebrew::SimulateSystem.current_arch)
+      bottle_tag ||= Homebrew::SimulateSystem.current_tag
 
       if (variation = json.dig("variations", bottle_tag.to_s).presence) ||
          (variation = json.dig("variations", bottle_tag.to_sym).presence)

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -416,16 +416,14 @@ module Cask
 
       if @dsl.on_system_blocks_exist?
         begin
-          OnSystem::ALL_OS_ARCH_COMBINATIONS.each do |os, arch|
-            bottle_tag = ::Utils::Bottles::Tag.new(system: os, arch:)
-            next unless bottle_tag.valid_combination?
+          OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
             next if bottle_tag.linux? && @dsl.os.nil?
             next if bottle_tag.macos? &&
                     depends_on.macos &&
                     !@dsl.depends_on_set_in_block? &&
                     !depends_on.macos.allows?(bottle_tag.to_macos_version)
 
-            Homebrew::SimulateSystem.with(os:, arch:) do
+            Homebrew::SimulateSystem.with_tag(bottle_tag) do
               refresh
 
               to_h.each do |key, value|

--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -70,10 +70,7 @@ module Homebrew
           canonical_json = JSON.pretty_generate(tap.cask_renames)
           File.write("_data/cask_canonical.json", "#{canonical_json}\n") unless args.dry_run?
 
-          OnSystem::ALL_OS_ARCH_COMBINATIONS.filter_map do |os, arch|
-            bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
-            next unless bottle_tag.valid_combination?
-
+          OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
             variation_casks = all_casks.transform_values do |cask|
               Homebrew::API.merge_variations(cask, bottle_tag:)
             end

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -68,10 +68,7 @@ module Homebrew
           canonical_json = JSON.pretty_generate(tap.formula_renames.merge(tap.alias_table))
           File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
 
-          OnSystem::ALL_OS_ARCH_COMBINATIONS.filter_map do |os, arch|
-            bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
-            next unless bottle_tag.valid_combination?
-
+          OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
             variation_formulae = all_formulae.transform_values do |formula|
               Homebrew::API.merge_variations(formula, bottle_tag:)
             end

--- a/Library/Homebrew/extend/on_system.rb
+++ b/Library/Homebrew/extend/on_system.rb
@@ -9,6 +9,13 @@ module OnSystem
   ALL_OS_OPTIONS = [*MacOSVersion::SYMBOLS.keys, :linux].freeze
   ALL_OS_ARCH_COMBINATIONS = ALL_OS_OPTIONS.product(ARCH_OPTIONS).freeze
 
+  VALID_OS_ARCH_TAGS = ALL_OS_ARCH_COMBINATIONS.filter_map do |os, arch|
+    tag = Utils::Bottles::Tag.new(system: os, arch:)
+    next unless tag.valid_combination?
+
+    tag
+  end.freeze
+
   sig { params(arch: Symbol).returns(T::Boolean) }
   def self.arch_condition_met?(arch)
     raise ArgumentError, "Invalid arch condition: #{arch.inspect}" if ARCH_OPTIONS.exclude?(arch)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2593,11 +2593,8 @@ class Formula
 
     if path.exist? && on_system_blocks_exist?
       formula_contents = path.read
-      OnSystem::ALL_OS_ARCH_COMBINATIONS.each do |os, arch|
-        bottle_tag = Utils::Bottles::Tag.new(system: os, arch:)
-        next unless bottle_tag.valid_combination?
-
-        Homebrew::SimulateSystem.with(os:, arch:) do
+      OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
+        Homebrew::SimulateSystem.with_tag(bottle_tag) do
           variations_namespace = Formulary.class_s("Variations#{bottle_tag.to_sym.capitalize}")
           variations_formula_class = Formulary.load_formula(name, path, formula_contents, variations_namespace,
                                                             flags: self.class.build_flags, ignore_errors: true)

--- a/Library/Homebrew/simulate_system.rb
+++ b/Library/Homebrew/simulate_system.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "macos_version"
+require "utils/bottles"
 
 module Homebrew
   # Helper module for simulating different system configurations.
@@ -31,6 +32,18 @@ module Homebrew
           @os = old_os
           @arch = old_arch
         end
+      end
+
+      sig {
+        type_parameters(:U).params(
+          tag:   Utils::Bottles::Tag,
+          block: T.proc.returns(T.type_parameter(:U)),
+        ).returns(T.type_parameter(:U))
+      }
+      def with_tag(tag, &block)
+        raise ArgumentError, "Invalid tag: #{tag}" unless tag.valid_combination?
+
+        with(os: tag.system, arch: tag.arch, &block)
       end
 
       sig { params(new_os: Symbol).void }
@@ -71,6 +84,14 @@ module Homebrew
       sig { returns(Symbol) }
       def current_os
         os || :generic
+      end
+
+      sig { returns(Utils::Bottles::Tag) }
+      def current_tag
+        Utils::Bottles::Tag.new(
+          system: current_os,
+          arch:   current_arch,
+        )
       end
     end
   end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1046,7 +1046,13 @@ RSpec.describe Formula do
     before do
       # Use a more limited os list to shorten the variations hash
       os_list = [:monterey, :big_sur, :catalina, :mojave, :linux]
-      stub_const("OnSystem::ALL_OS_ARCH_COMBINATIONS", os_list.product(OnSystem::ARCH_OPTIONS))
+      valid_tags = os_list.product(OnSystem::ARCH_OPTIONS).filter_map do |os, arch|
+        tag = Utils::Bottles::Tag.new(system: os, arch:)
+        next unless tag.valid_combination?
+
+        tag
+      end
+      stub_const("OnSystem::VALID_OS_ARCH_TAGS", valid_tags)
 
       # For consistency, always run on Monterey and ARM
       allow(MacOS).to receive(:version).and_return(MacOSVersion.new("12"))


### PR DESCRIPTION
As a follow up to <https://github.com/Homebrew/brew/pull/20038>, I realized that we could probably simplify some of the logic here since the `OnSystem::ALL_OS_ARCH_COMBINATIONS` to valid bottle tag to `SimulateSystem` pattern is pretty common.

This PR just refactors some of the shared logic to make it more user-friendly.
