### PR TITLE
keg_relocate: check for `uses_from_macos` when replacing Perl prefix

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -201,7 +201,9 @@ module OS
       def prepare_relocation_to_locations
         relocation = generic_prepare_relocation_to_locations
 
-        brewed_perl = runtime_dependencies&.any? { |dep| dep["full_name"] == "perl" && dep["declared_directly"] }
+        brewed_perl = runtime_dependencies&.any? do |dep|
+          dep["full_name"] == "perl" && dep["declared_directly"] && !dep["uses_from_macos"]
+        end
         perl_path = if brewed_perl || name == "perl"
           "#{HOMEBREW_PREFIX}/opt/perl/bin/perl"
         elsif tab.built_on.present?

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -95,7 +95,7 @@ class AbstractTab
     new(attributes)
   end
 
-  def self.formula_to_dep_hash(formula, declared_deps)
+  def self.formula_to_dep_hash(formula, declared_deps, uses_from_macos: false)
     {
       "full_name"         => formula.full_name,
       "version"           => formula.version.to_s,
@@ -103,6 +103,7 @@ class AbstractTab
       "bottle_rebuild"    => formula.bottle&.rebuild,
       "pkg_version"       => formula.pkg_version.to_s,
       "declared_directly" => declared_deps.include?(formula.full_name),
+      "uses_from_macos"   => uses_from_macos,
     }.compact
   end
   private_class_method :formula_to_dep_hash
@@ -304,7 +305,7 @@ class Tab < AbstractTab
 
   def self.runtime_deps_hash(formula, deps)
     deps.map do |dep|
-      formula_to_dep_hash(dep.to_formula, formula.deps.map(&:name))
+      formula_to_dep_hash(dep.to_formula, formula.deps.map(&:name), uses_from_macos: dep.uses_from_macos?)
     end
   end
 

--- a/Library/Homebrew/test/cask/tab_spec.rb
+++ b/Library/Homebrew/test/cask/tab_spec.rb
@@ -137,7 +137,8 @@ RSpec.describe Cask::Tab, :cask do
           { "full_name"=>"local-transmission", "version"=>"2.61", "declared_directly"=>false },
         ],
         formula: [
-          { "full_name"=>"unar", "version"=>"1.2", "revision"=>0, "pkg_version"=>"1.2", "declared_directly"=>true },
+          { "full_name"=>"unar", "version"=>"1.2", "revision"=>0, "pkg_version"=>"1.2", "uses_from_macos" => false,
+            "declared_directly"=>true },
         ],
       }
 

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Tab do
       tab.runtime_dependencies = runtime_deps_hash
       expect(tab.runtime_dependencies).to eql(
         [{ "full_name" => "foo", "version" => "1.0", "revision" => 0, "pkg_version" => "1.0",
-        "declared_directly" => false }],
+        "declared_directly" => false, "uses_from_macos" => false }],
       )
     end
 
@@ -184,6 +184,27 @@ RSpec.describe Tab do
           "revision"          => 0,
           "pkg_version"       => "1.0",
           "declared_directly" => true,
+          "uses_from_macos"   => false,
+        },
+      ]
+      expect(described_class.runtime_deps_hash(formula, runtime_deps)).to eq(expected_output)
+    end
+
+    it "include dependencies from macOS" do
+      foo = formula("foo") { url "foo-1.0" }
+      stub_formula_loader foo
+
+      runtime_deps = [UsesFromMacOSDependency.new("foo", bounds: {})]
+      formula = instance_double(Formula, deps: runtime_deps)
+
+      expected_output = [
+        {
+          "full_name"         => "foo",
+          "version"           => "1.0",
+          "revision"          => 0,
+          "pkg_version"       => "1.0",
+          "declared_directly" => true,
+          "uses_from_macos"   => true,
         },
       ]
       expect(described_class.runtime_deps_hash(formula, runtime_deps)).to eq(expected_output)
@@ -207,6 +228,7 @@ RSpec.describe Tab do
           "revision"          => 0,
           "pkg_version"       => "1.0",
           "declared_directly" => true,
+          "uses_from_macos"   => false,
         },
         {
           "full_name"         => "bar",
@@ -214,6 +236,7 @@ RSpec.describe Tab do
           "revision"          => 0,
           "pkg_version"       => "2.0",
           "declared_directly" => false,
+          "uses_from_macos"   => false,
         },
       ]
       expect(described_class.runtime_deps_hash(formula, formula_recursive_deps)).to eq(expected_output)
@@ -354,9 +377,9 @@ RSpec.describe Tab do
 
       runtime_dependencies = [
         { "full_name" => "bar", "version" => "2.0", "revision" => 0, "pkg_version" => "2.0",
-"declared_directly" => true },
+"declared_directly" => true, "uses_from_macos" => false },
         { "full_name" => "user/repo/from_tap", "version" => "1.0", "revision" => 1, "pkg_version" => "1.0_1",
-"declared_directly" => true },
+"declared_directly" => true, "uses_from_macos" => false },
       ]
       expect(tab.runtime_dependencies).to eq(runtime_dependencies)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Closes #20023