### PR TITLE
Fix sharded API structure to match existing API

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -71,7 +71,7 @@ module Homebrew
           File.write("_data/cask_canonical.json", "#{canonical_json}\n") unless args.dry_run?
 
           OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
-            variation_casks = all_casks.transform_values do |cask|
+            variation_casks = all_casks.map do |_, cask|
               Homebrew::API.merge_variations(cask, bottle_tag:)
             end
 

--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -69,7 +69,7 @@ module Homebrew
           File.write("_data/formula_canonical.json", "#{canonical_json}\n") unless args.dry_run?
 
           OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
-            variation_formulae = all_formulae.transform_values do |formula|
+            variation_formulae = all_formulae.map do |_, formula|
               Homebrew::API.merge_variations(formula, bottle_tag:)
             end
 


### PR DESCRIPTION
Follow-up to <https://github.com/Homebrew/brew/pull/20038>

I realized that the original API an array at the top-level, but the new version was a hash. This PR fixes this so the new version has the same structure.
