### PR TITLE
`brew (bundle|) sh`: use user's configuration but override prompts.

### DIFF
--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -170,6 +170,18 @@ module Homebrew
               end
             end
             return
+          elsif subcommand == "sh"
+            preferred_path = Utils::Shell.preferred_path(default: "/bin/bash")
+            notice = unless Homebrew::EnvConfig.no_env_hints?
+              <<~EOS
+                Your shell has been configured to use a build environment from your `Brewfile`.
+                This should help you build stuff.
+                Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
+                When done, type `exit`.
+              EOS
+            end
+            ENV["HOMEBREW_FORCE_API_AUTO_UPDATE"] = nil
+            args = [Utils::Shell.shell_with_prompt("brew bundle", preferred_path:, notice:)]
           end
 
           if services

--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -276,17 +276,7 @@ module Homebrew
             _subcommand, *named_args = args.named
             named_args
           when "sh"
-            preferred_path = Utils::Shell.preferred_path(default: "/bin/bash")
-            notice = unless Homebrew::EnvConfig.no_env_hints?
-              <<~EOS
-                Your shell has been configured to use a build environment from your `Brewfile`.
-                This should help you build stuff.
-                Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
-                When done, type `exit`.
-              EOS
-            end
-            ENV["HOMEBREW_FORCE_API_AUTO_UPDATE"] = nil
-            [Utils::Shell.shell_with_prompt("brew bundle", preferred_path:, notice:)]
+            ["sh"]
           when "env"
             ["env"]
           end

--- a/Library/Homebrew/utils/bash/brew-sh-prompt-bashrc.bash
+++ b/Library/Homebrew/utils/bash/brew-sh-prompt-bashrc.bash
@@ -1,0 +1,12 @@
+# Read the user's ~/.bashrc first
+if [[ -f "${HOME}/.bashrc" ]]
+then
+  source "${HOME}/.bashrc"
+fi
+
+# Override the user's Bash prompt with our custom prompt
+export PS1="\\[\\033[1;32m\\]${BREW_PROMPT_TYPE} \\[\\033[1;31m\\]\\w \\[\\033[1;34m\\]$\\[\\033[0m\\] "
+
+# Add the Homebrew PATH in front of the user's PATH
+export PATH="${BREW_PROMPT_PATH}:${PATH}"
+unset BREW_PROMPT_TYPE BREW_PROMPT_PATH

--- a/Library/Homebrew/utils/zsh/brew-sh-prompt-zshrc.zsh
+++ b/Library/Homebrew/utils/zsh/brew-sh-prompt-zshrc.zsh
@@ -1,0 +1,13 @@
+# Read the user's ~/.zshrc first
+if [[ -f "${HOME}/.zshrc" ]]
+then
+  source "${HOME}/.zshrc"
+fi
+
+# Override the user's ZSH prompt with our custom prompt
+export PROMPT="%B%F{green}${BREW_PROMPT_TYPE}%f %F{blue}$%f%b "
+export RPROMPT="[%B%F{red}%~%f%b]"
+
+# Add the Homebrew PATH in front of the user's PATH
+export PATH="${BREW_PROMPT_PATH}:${PATH}"
+unset BREW_PROMPT_TYPE BREW_PROMPT_PATH


### PR DESCRIPTION
This was more painful that I expected but will allow `brew bundle sh` and `brew sh` to use the user's configuration but use our custom prompt for Bash and ZSH.