### PR TITLE
os/mac/pkgconfig/15: update `expat` version to 2.7.1

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/15/expat.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/15/expat.pc
@@ -5,7 +5,7 @@ libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
 Name: expat
-Version: 2.6.3
+Version: 2.7.1
 Description: expat XML parser
 URL: https://libexpat.github.io/
 Libs: -L${libdir} -lexpat


### PR DESCRIPTION
Seen in https://github.com/Homebrew/brew/pull/20046

```console
$ grep VERSION /Library/Developer/CommandLineTools/SDKs/MacOSX15.5.sdk/usr/include/expat.h
#define XML_MAJOR_VERSION 2
#define XML_MINOR_VERSION 7
#define XML_MICRO_VERSION 1
```
