### PR TITLE
bin/brew: don't copy across zeroed env values.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -183,8 +183,8 @@ MANPAGE_VARS=(
 )
 for VAR in "${MANPAGE_VARS[@]}"
 do
-  # Skip if variable value is empty.
-  [[ -z "${!VAR:-}" ]] && continue
+  # Skip if variable value is empty or set to 0.
+  [[ -z "${!VAR:-}" || "${!VAR:-}" = "0" ]] && continue
 
   VAR_NEW="HOMEBREW_${VAR}"
   # Skip if existing HOMEBREW_* variable is set.


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/20049