### PR TITLE
Reduce Homebrew/brew CI warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          core: true
+          core: false
           cask: false
           test-bot: false
 
@@ -164,7 +164,7 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          core: true
+          core: false
           cask: true
           test-bot: false
 
@@ -213,7 +213,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: update-test (Ubuntu)
+          - name: update-test (Linux)
             runs-on: ubuntu-latest
           - name: update-test (macOS)
             runs-on: macos-15
@@ -237,7 +237,6 @@ jobs:
     name: ${{ matrix.name }}
     needs: syntax
     runs-on: ${{ matrix.runs-on }}
-    container: ${{ matrix.container }}
     strategy:
       matrix:
         include:
@@ -247,17 +246,10 @@ jobs:
           - name: tests (generic OS)
             test-flags: --generic --coverage
             runs-on: ubuntu-latest
-          - name: tests (Ubuntu 24.04)
+          - name: tests (Linux)
             test-flags: --coverage
             runs-on: ubuntu-24.04
-          - name: tests (Ubuntu 22.04)
-            test-flags: --coverage
-            runs-on: ubuntu-22.04
-          - name: tests (Ubuntu 20.04)
-            test-flags: --coverage
-            runs-on: ubuntu-latest
-            container: ghcr.io/homebrew/ubuntu20.04:latest
-          - name: tests (macOS 15 arm64)
+          - name: tests (macOS)
             test-flags: --coverage
             runs-on: macos-15
     steps:
@@ -364,9 +356,10 @@ jobs:
           - name: test default formula (Ubuntu 22.04)
             runs-on: ubuntu-latest
             container: ghcr.io/homebrew/ubuntu22.04:master
-          - name: test default formula (Ubuntu 20.04)
+          # Need to keep this as a target that installs a Homebrew glibc
+          - name: test default formula (Debian Old Stable)
             runs-on: ubuntu-latest
-            container: ghcr.io/homebrew/ubuntu20.04:latest
+            container: debian:oldstable
           - name: test default formula (macOS 13 x86_64)
             runs-on: macos-13
           - name: test default formula (macOS 15 arm64)
@@ -375,18 +368,50 @@ jobs:
       HOMEBREW_TEST_BOT_ANALYTICS: 1
       HOMEBREW_ENFORCE_SBOM: 1
     steps:
+      - name: Install Homebrew and Homebrew's dependencies
+        # All other images are built from our Homebrew Dockerfile.
+        # This is the only one that needs to be set up manually.
+        if: matrix.container == 'debian:oldstable'
+        run: |
+          # Slimmed down version from the Homebrew Dockerfile
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            bzip2 \
+            ca-certificates \
+            curl \
+            file \
+            g++ \
+            git-core \
+            less \
+            locales \
+            make \
+            netbase \
+            patch \
+            procps \
+            sudo \
+            uuid-runtime \
+            tzdata
+
+          # Install Homebrew
+          mkdir -p /home/linuxbrew/.linuxbrew/bin
+          # Don't do shallow clone or it's unshallowed by "Set up Homebrew"
+          git clone https://github.com/Homebrew/brew.git /home/linuxbrew/.linuxbrew/Homebrew
+          cd /home/linuxbrew/.linuxbrew/bin
+          ln -s ../Homebrew/bin/brew brew
+          echo "/home/linuxbrew/.linuxbrew/bin" >>"$GITHUB_PATH"
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          core: true
+          core: false
           cask: false
           test-bot: true
 
       - run: brew test-bot --only-cleanup-before
 
       - name: Setup environment variables
-        if: matrix.container == 'ghcr.io/homebrew/ubuntu20.04:latest'
+        if: matrix.container == 'debian:oldstable'
         run: echo "HOMEBREW_GLIBC_TESTING=1" >> "$GITHUB_ENV"
 
       - run: brew test-bot --only-setup
@@ -403,7 +428,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: test brew bundle and brew services (Ubuntu)
+          - name: test brew bundle and brew services (Linux)
             runs-on: ubuntu-latest
           - name: test brew bundle and brew services (macOS)
             runs-on: macos-15
@@ -412,7 +437,7 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          core: true
+          core: false
           cask: false
           test-bot: false
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -149,7 +149,7 @@ module Cask
 
       oh1 "Installing Cask #{Formatter.identifier(@cask)}"
       # GitHub Actions globally disables Gatekeeper.
-      opoo "macOS's Gatekeeper has been disabled for this Cask" if !quarantine? && !GitHub::Actions.env_set?
+      opoo_outside_github_actions "macOS's Gatekeeper has been disabled for this Cask" unless quarantine?
       stage
 
       @cask.config = @cask.default_config.merge(old_config)

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -125,11 +125,14 @@ module Homebrew
           # rubocop:disable Homebrew/MoveToExtendOS
           unless OS.mac?
             bundle_args << "--tag" << "~needs_macos" << "--tag" << "~cask"
+            bundle_args << "--tag" << "~needs_homebrew_core" if ENV["CI"]
+            bundle_args << "--tag" << "~needs_svn" unless args.online?
+
             files = files.grep_v(%r{^test/(os/mac|cask)(/.*|_spec\.rb)$})
           end
 
           unless OS.linux?
-            bundle_args << "--tag" << "~needs_linux"
+            bundle_args << "--tag" << "~needs_linux" << "--tag" << "~needs_systemd"
             files = files.grep_v(%r{^test/os/linux(/.*|_spec\.rb)$})
           end
           # rubocop:enable Homebrew/MoveToExtendOS
@@ -139,10 +142,8 @@ module Homebrew
           bundle_args << "--tag" << "~needs_intel" unless Hardware::CPU.intel?
 
           bundle_args << "--tag" << "~needs_network" unless args.online?
-          unless ENV["CI"]
-            bundle_args << "--tag" << "~needs_ci" \
-                        << "--tag" << "~needs_svn"
-          end
+
+          bundle_args << "--tag" << "~needs_ci" unless ENV["CI"]
 
           puts "Randomized with seed #{seed}"
 

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -82,6 +82,17 @@ module Kernel
     end
   end
 
+  # Print a warning message only if not running in GitHub Actions.
+  #
+  # @api public
+  sig { params(message: T.any(String, Exception)).void }
+  def opoo_outside_github_actions(message)
+    require "utils/github/actions"
+    return if GitHub::Actions.env_set?
+
+    opoo(message)
+  end
+
   # Print an error message.
   #
   # @api public

--- a/Library/Homebrew/utils/backtrace.rb
+++ b/Library/Homebrew/utils/backtrace.rb
@@ -31,7 +31,8 @@ module Utils
     def self.print_backtrace_message
       return if @print_backtrace_message
 
-      opoo "Removed Sorbet lines from backtrace!"
+      # This is just unactionable noise in GitHub Actions.
+      opoo_outside_github_actions "Removed Sorbet lines from backtrace!"
       puts "Rerun with `--verbose` to see the original backtrace" unless Homebrew::EnvConfig.no_env_hints?
 
       @print_backtrace_message = true


### PR DESCRIPTION
- Remove a bunch of non-actionable/unnecessary noise in GitHub Actions CI.
- Limit number of threads used to generate analytics API data to avoid reproducible failures producing errors and requiring retries.
- Move to Debian Old Stable for testing non-system `glibc`.
- Remove unneeded core taps/updates.
- Improve naming of CI jobs to clarify purpose i.e. we're testing things work on Linux, not Ubuntu specifically.
- Remove dedicated non-online/non-generic Linux `brew tests` jobs from 3 to 1.
