### PR TITLE
list: make `brew list` output consistent in TTY and non-TTY modes

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -169,7 +169,7 @@ module Homebrew
         else
           kegs, casks = args.named.to_kegs_to_casks
 
-          if args.verbose? || !$stdout.tty?
+          if args.verbose?
             find_args = %w[-not -type d -not -name .DS_Store -print]
             system_command! "find", args: kegs.map(&:to_s) + find_args, print_stdout: true if kegs.present?
             system_command! "find", args: casks.map(&:caskroom_path) + find_args, print_stdout: true if casks.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
  - Yes - in https://github.com/Homebrew/brew/issues/20067.  
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
  - Behavior of `brew list` based on TTY mode wasn't explicitly tested, so I didn't introduce it either.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/20067