### PR TITLE
tests: default to API mode enabled.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -28,6 +28,8 @@ module Homebrew
                description: "Only runs tests on files that were changed from the master branch."
         switch "--fail-fast",
                description: "Exit early on the first failing test."
+        switch "--no-parallel",
+               description: "Run tests serially."
         flag   "--only=",
                description: "Run only `<test_script>_spec.rb`. Appending `:<line_number>` will start at a " \
                             "specific line."
@@ -49,7 +51,7 @@ module Homebrew
         HOMEBREW_LIBRARY_PATH.cd do
           setup_environment!
 
-          parallel = true
+          parallel = !args.no_parallel?
 
           only = args.only
           files = if only
@@ -239,9 +241,6 @@ module Homebrew
         ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
         ENV["HOMEBREW_SORBET_RUNTIME"] = "1"
         ENV["HOMEBREW_NO_FORCE_BREW_WRAPPER"] = "1"
-
-        # TODO: remove this and fix tests when possible.
-        ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
 
         ENV["USER"] ||= system_command!("id", args: ["-nu"]).stdout.chomp
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -520,6 +520,7 @@ class FormulaInstaller
     oh1 "Installing #{Formatter.identifier(formula.full_name)} #{options}".strip if show_header?
 
     if (tap = formula.tap) && tap.should_report_analytics?
+      require "utils/analytics"
       Utils::Analytics.report_package_event(:formula_install, package_name: formula.name, tap_name: tap.name,
 on_request: installed_on_request?, options:)
     end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/tests.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/tests.rbi
@@ -24,6 +24,9 @@ class Homebrew::DevCmd::Tests::Args < Homebrew::CLI::Args
   def generic?; end
 
   sig { returns(T::Boolean) }
+  def no_parallel?; end
+
+  sig { returns(T::Boolean) }
   def online?; end
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Homebrew::API::Cask do
     end
 
     before do
+      allow(Homebrew::API).to receive(:fetch_json_api_file).and_return([[], true])
       allow_any_instance_of(Homebrew::API::Download).to receive(:fetch)
       allow_any_instance_of(Homebrew::API::Download).to receive(:symlink_location).and_return(
         TEST_FIXTURE_DIR/"cask/Casks/everything.rb",

--- a/Library/Homebrew/test/bundle/commands/check_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/check_spec.rb
@@ -12,7 +12,7 @@ require "bundle/mac_app_store_installer"
 require "bundle/dsl"
 require "bundle/skipper"
 
-RSpec.describe Homebrew::Bundle::Commands::Check do
+RSpec.describe Homebrew::Bundle::Commands::Check, :no_api do
   let(:do_check) do
     described_class.run(no_upgrade:, verbose:)
   end

--- a/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
@@ -4,7 +4,7 @@ require "bundle"
 require "bundle/commands/cleanup"
 
 RSpec.describe Homebrew::Bundle::Commands::Cleanup do
-  describe "read Brewfile and current installation" do
+  describe "read Brewfile and current installation", :no_api do
     before do
       described_class.reset!
 

--- a/Library/Homebrew/test/bundle/commands/exec_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/exec_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Homebrew::Bundle::Commands::Exec do
     end
   end
 
-  context "when a Brewfile is found" do
+  context "when a Brewfile is found", :no_api do
     let(:brewfile_contents) { "brew 'openssl'" }
 
     before do

--- a/Library/Homebrew/test/bundle/commands/install_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/install_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     end
   end
 
-  context "when a Brewfile is found" do
+  context "when a Brewfile is found", :no_api do
     let(:brewfile_contents) do
       <<~EOS
         tap 'phinze/cask'

--- a/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_api_loader_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Cask::CaskLoader::FromAPILoader, :cask do
     end
 
     context "when using the API" do
-      before do
-        ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
-      end
-
       it "returns a loader for valid token" do
         expect(described_class.try_new(api_token))
           .to be_a(described_class)

--- a/Library/Homebrew/test/cask/cask_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader_spec.rb
@@ -45,10 +45,6 @@ RSpec.describe Cask::CaskLoader, :cask do
       end
 
       context "when using the API" do
-        before do
-          ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
-        end
-
         it "warns when using the short token" do
           expect do
             expect(described_class.for("version-newest")).to be_a Cask::CaskLoader::FromAPILoader

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Cask::Cask, :cask do
       expect(c.token).to eq("caffeine")
     end
 
-    it "returns an instance of the Cask from a URL", :needs_utils_curl, :no_api do
+    it "returns an instance of the Cask from a URL", :needs_utils_curl do
       c = Cask::CaskLoader.load("file://#{tap_path}/Casks/local-caffeine.rb")
       expect(c).to be_a(described_class)
       expect(c.token).to eq("local-caffeine")
     end
 
-    it "raises an error when failing to download a Cask from a URL", :needs_utils_curl, :no_api do
+    it "raises an error when failing to download a Cask from a URL", :needs_utils_curl do
       expect do
         Cask::CaskLoader.load("file://#{tap_path}/Casks/notacask.rb")
       end.to raise_error(Cask::CaskUnavailableError)

--- a/Library/Homebrew/test/cask_dependent_spec.rb
+++ b/Library/Homebrew/test/cask_dependent_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CaskDependent, :needs_macos do
     end
   end
 
-  describe "#recursive_dependencies", :integration_test do
+  describe "#recursive_dependencies", :integration_test, :no_api do
     it "is all the dependencies of the cask" do
       setup_test_formula "foo"
       setup_test_formula "bar"

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Homebrew::Cmd::Deps do
 
   it_behaves_like "parseable arguments"
 
-  it "outputs all of a Formula's dependencies and their dependencies on separate lines", :integration_test do
+  it "outputs all of a Formula's dependencies and their dependencies on separate lines", :integration_test, :no_api do
     # Included in output
     setup_test_formula "bar"
     setup_test_formula "foo"

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Homebrew::Cmd::Desc do
       .and be_a_success
   end
 
-  it "errors when searching without --eval-all", :integration_test do
+  it "errors when searching without --eval-all", :integration_test, :no_api do
     setup_test_formula "testball"
 
     expect { brew "desc", "--search", "testball" }
@@ -23,7 +23,7 @@ RSpec.describe Homebrew::Cmd::Desc do
       .and be_a_failure
   end
 
-  it "successfully searches with --search --eval-all", :integration_test do
+  it "successfully searches with --search --eval-all", :integration_test, :no_api do
     setup_test_formula "testball"
 
     expect { brew "desc", "--search", "--eval-all", "ball" }
@@ -34,7 +34,6 @@ RSpec.describe Homebrew::Cmd::Desc do
   it "successfully searches without --eval-all, with API", :integration_test, :needs_network do
     setup_test_formula "testball"
 
-    expect { brew "desc", "--search", "testball", "HOMEBREW_NO_INSTALL_FROM_API" => nil }
-      .to be_a_success
+    expect { brew "desc", "--search", "testball" }.to be_a_success
   end
 end

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Homebrew::Cmd::Leaves do
     end
   end
 
-  context "when there are installed Formulae", :integration_test do
+  context "when there are installed Formulae", :integration_test, :no_api do
     it "prints all installed Formulae that are not dependencies of another installed Formula" do
       setup_test_formula "foo"
       setup_test_formula "bar"

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -6,7 +6,7 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Migrate do
   it_behaves_like "parseable arguments"
 
-  it "migrates a renamed Formula", :integration_test do
+  it "migrates a renamed Formula", :integration_test, :no_api do
     setup_test_formula "testball1"
     setup_test_formula "testball2"
     install_and_rename_coretap_formula "testball1", "testball2"

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -6,7 +6,7 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::Missing do
   it_behaves_like "parseable arguments"
 
-  it "prints missing dependencies", :integration_test do
+  it "prints missing dependencies", :integration_test, :no_api do
     setup_test_formula "foo"
     setup_test_formula "bar"
 

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -6,7 +6,7 @@ require "cmd/shared_examples/args_parse"
 RSpec.describe Homebrew::Cmd::SearchCmd do
   it_behaves_like "parseable arguments"
 
-  it "finds formula in search", :integration_test do
+  it "finds formula in search", :integration_test, :no_api do
     setup_test_formula "testball"
 
     expect { brew "search", "testball" }

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Homebrew::Cmd::TapInfo do
   end
 
   it "display brief statistics for all installed taps", :integration_test, :needs_network do
-    expect { brew "tap-info", "HOMEBREW_NO_INSTALL_FROM_API" => nil }
+    expect { brew "tap-info" }
       .to output(/\d+ taps?, \d+ private/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Homebrew::Cmd::Untap do
   end
 
   describe "#installed_formulae_for", :integration_test do
-    shared_examples "finds installed formulae in tap" do
+    shared_examples "finds installed formulae in tap", :no_api do
       def load_formula(name:, with_formula_file: false, mock_install: false)
         formula = if with_formula_file
           path = setup_test_formula(name, tap:)
@@ -84,7 +84,7 @@ RSpec.describe Homebrew::Cmd::Untap do
   end
 
   describe "#installed_casks_for", :cask do
-    shared_examples "finds installed casks in tap" do
+    shared_examples "finds installed casks in tap", :no_api do
       def load_cask(token:, with_cask_file: false, mock_install: false)
         cask_loader = Cask::CaskLoader::FromContentLoader.new(<<~RUBY, tap:)
           cask '#{token}' do

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Homebrew::Cmd::Uses do
 
   it_behaves_like "parseable arguments"
 
-  it "prints the Formulae a given Formula is used by", :integration_test do
+  it "prints the Formulae a given Formula is used by", :integration_test, :no_api do
     # Included in output
     setup_test_formula "bar"
     setup_test_formula "optional", <<~RUBY
@@ -46,7 +46,7 @@ RSpec.describe Homebrew::Cmd::Uses do
       .and be_a_success
   end
 
-  it "handles unavailable formula", :integration_test do
+  it "handles unavailable formula", :integration_test, :no_api do
     setup_test_formula "foo"
     setup_test_formula "bar"
     setup_test_formula "optional", <<~RUBY

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CompilerSelector do
     end
   end
 
-  describe "#compiler" do
+  describe "#compiler", :no_api do
     it "defaults to cc" do
       expect(selector.compiler).to eq(cc)
     end

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -117,7 +117,6 @@ RSpec.describe Homebrew::Diagnostic::Checks do
 
   specify "#check_for_unnecessary_core_tap" do
     ENV.delete("HOMEBREW_DEVELOPER")
-    ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
 
     expect_any_instance_of(CoreTap).to receive(:installed?).and_return(true)
 
@@ -126,7 +125,6 @@ RSpec.describe Homebrew::Diagnostic::Checks do
 
   specify "#check_for_unnecessary_cask_tap" do
     ENV.delete("HOMEBREW_DEVELOPER")
-    ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
 
     expect_any_instance_of(CoreCaskTap).to receive(:installed?).and_return(true)
 

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Exception" do
     end
 
     context "without a dependent" do
-      it(:to_s) { expect(error.to_s).to eq('No available formula with the name "foo".') }
+      it(:to_s) { expect(error.to_s).to match(/^No available formula with the name "foo"\./) }
     end
 
     context "with a dependent" do
@@ -80,7 +80,7 @@ RSpec.describe "Exception" do
       end
 
       it(:to_s) do
-        expect(error.to_s).to eq('No available formula with the name "foo" (dependency of foobar).')
+        expect(error.to_s).to match(/^No available formula with the name "foo" \(dependency of foobar\)\./)
       end
     end
   end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1261,7 +1261,7 @@ RSpec.describe Homebrew::FormulaAuditor do
       allow(File).to receive(:open).and_return("")
     end
 
-    specify "it warns when conflicting with non-existing formula" do
+    specify "it warns when conflicting with non-existing formula", :no_api do
       foo = formula("foo") do
         url "https://brew.sh/bar-1.0.tgz"
 
@@ -1275,7 +1275,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         .to match("Can't find conflicting formula \"bar\"")
     end
 
-    specify "it warns when conflicting with itself" do
+    specify "it warns when conflicting with itself", :no_api do
       foo = formula("foo") do
         url "https://brew.sh/bar-1.0.tgz"
 
@@ -1290,7 +1290,7 @@ RSpec.describe Homebrew::FormulaAuditor do
         .to match("Formula should not conflict with itself")
     end
 
-    specify "it warns when another formula does not have a symmetric conflict" do
+    specify "it warns when another formula does not have a symmetric conflict", :no_api do
       stub_formula_loader formula("gcc") { url "gcc-1.0" }
       stub_formula_loader formula("glibc") { url "glibc-1.0" }
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Formulary do
   end
 
   describe "::factory" do
-    context "without the API" do
+    context "without the API", :no_api do
       before do
         formula_path.dirname.mkpath
         formula_path.write formula_content
@@ -129,7 +129,7 @@ RSpec.describe Formulary do
         end.to raise_error(FormulaUnavailableError)
       end
 
-      it "returns a Formula when given a URL", :needs_utils_curl, :no_api do
+      it "returns a Formula when given a URL", :needs_utils_curl do
         formula = described_class.factory("file://#{formula_path}")
         expect(formula).to be_a(Formula)
       end
@@ -398,8 +398,6 @@ RSpec.describe Formulary do
       end
 
       before do
-        ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
-
         # avoid unnecessary network calls
         allow(Homebrew::API::Formula).to receive_messages(all_aliases: {}, all_renames: {})
         allow(CoreTap.instance).to receive(:tap_migrations).and_return({})
@@ -645,16 +643,12 @@ RSpec.describe Formulary do
     end
 
     context "when given a tapped name" do
-      it "returns a `FromTapLoader`" do
+      it "returns a `FromTapLoader`", :no_api do
         expect(described_class.loader_for("homebrew/core/gcc")).to be_a Formulary::FromTapLoader
       end
     end
 
-    context "when not using the API" do
-      before do
-        ENV["HOMEBREW_NO_INSTALL_FROM_API"] = "1"
-      end
-
+    context "when not using the API", :no_api do
       context "when a formula is migrated" do
         let(:token) { "foo" }
 

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -3,17 +3,17 @@
 require "github_runner_matrix"
 require "test/support/fixtures/testball"
 
-RSpec.describe GitHubRunnerMatrix do
+RSpec.describe GitHubRunnerMatrix, :no_api do
   before do
     allow(ENV).to receive(:fetch).with("HOMEBREW_LINUX_RUNNER").and_return("ubuntu-latest")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_LONG_TIMEOUT", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false").and_return("false")
     allow(ENV).to receive(:fetch).with("GITHUB_RUN_ID").and_return("12345")
-    allow(ENV).to receive(:fetch).with("HOMEBREW_NO_INSTALL_FROM_API", nil).and_call_original
     allow(ENV).to receive(:fetch).with("HOMEBREW_EVAL_ALL", nil).and_call_original
     allow(ENV).to receive(:fetch).with("HOMEBREW_SIMULATE_MACOS_ON_LINUX", nil).and_call_original
     allow(ENV).to receive(:fetch).with("HOMEBREW_FORBID_PACKAGES_FROM_PATHS", nil).and_call_original
     allow(ENV).to receive(:fetch).with("HOMEBREW_DEVELOPER", nil).and_call_original
+    allow(ENV).to receive(:fetch).with("HOMEBREW_NO_INSTALL_FROM_API", nil).and_call_original
   end
 
   let(:newest_supported_macos) do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -59,6 +59,7 @@ TEST_DIRECTORIES = [
   CoreTap.instance.path/"Formula",
   HOMEBREW_CACHE,
   HOMEBREW_CACHE_FORMULA,
+  HOMEBREW_CACHE/"api",
   HOMEBREW_CELLAR,
   HOMEBREW_LOCKS,
   HOMEBREW_LOGS,
@@ -248,6 +249,11 @@ RSpec.configure do |config|
     @__stdout = $stdout.clone
     @__stderr = $stderr.clone
     @__stdin = $stdin.clone
+
+    # Link original API cache files to test cache directory.
+    Pathname("#{ENV.fetch("HOMEBREW_CACHE")}/api").glob("*.json").each do |path|
+      FileUtils.ln path, HOMEBREW_CACHE/"api/#{path.basename}"
+    end
 
     begin
       if example.metadata.keys.exclude?(:focus) && !ENV.key?("HOMEBREW_VERBOSE_TESTS")

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -75,14 +75,15 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
     ].compact.join(File::PATH_SEPARATOR)
 
     env.merge!(
-      "PATH"                        => path,
-      "HOMEBREW_PATH"               => path,
-      "HOMEBREW_BREW_FILE"          => HOMEBREW_PREFIX/"bin/brew",
-      "HOMEBREW_INTEGRATION_TEST"   => command_id,
-      "HOMEBREW_TEST_TMPDIR"        => TEST_TMPDIR,
-      "HOMEBREW_DEV_CMD_RUN"        => "true",
-      "HOMEBREW_USE_RUBY_FROM_PATH" => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
-      "GEM_HOME"                    => nil,
+      "PATH"                         => path,
+      "HOMEBREW_PATH"                => path,
+      "HOMEBREW_BREW_FILE"           => HOMEBREW_PREFIX/"bin/brew",
+      "HOMEBREW_INTEGRATION_TEST"    => command_id,
+      "HOMEBREW_TEST_TMPDIR"         => TEST_TMPDIR,
+      "HOMEBREW_DEV_CMD_RUN"         => "true",
+      "HOMEBREW_USE_RUBY_FROM_PATH"  => ENV.fetch("HOMEBREW_USE_RUBY_FROM_PATH", nil),
+      "HOMEBREW_NO_INSTALL_FROM_API" => ENV.fetch("HOMEBREW_NO_INSTALL_FROM_API", nil),
+      "GEM_HOME"                     => nil,
     )
 
     @ruby_args ||= begin
@@ -187,6 +188,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
     end
 
     formula_path = Formulary.find_formula_in_tap(name.downcase, tap).tap do |path|
+      path.dirname.mkpath
       path.write <<~RUBY
         class #{Formulary.class_s(name)} < Formula
         #{content.gsub(/^(?!$)/, "  ")}

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -500,7 +500,6 @@ RSpec.describe Tap do
       end
 
       it "includes the core tap with the api" do
-        ENV.delete("HOMEBREW_NO_INSTALL_FROM_API")
         expect(described_class.to_a).to include(CoreTap.instance)
       end
 
@@ -580,7 +579,7 @@ RSpec.describe Tap do
         let(:cask_tap) { CoreCaskTap.instance }
         let(:core_tap) { CoreTap.instance }
 
-        it "returns expected renames" do
+        it "returns expected renames", :no_api do
           [
             [cask_tap, "gimp", []],
             [core_tap, "schism-tracker", []],
@@ -744,11 +743,11 @@ RSpec.describe Tap do
       expect(core_tap).to be_a_core_tap
     end
 
-    specify "forbidden operations" do
+    specify "forbidden operations", :no_api do
       expect { core_tap.uninstall }.to raise_error(RuntimeError)
     end
 
-    specify "files" do
+    specify "files", :no_api do
       path = HOMEBREW_TAP_DIRECTORY/"homebrew/homebrew-core"
       formula_file = core_tap.formula_dir/"foo.rb"
       core_tap.formula_dir.mkpath


### PR DESCRIPTION
While we're here, also add `brew tests --no-parallel` which I relied on during testing.

Pretty much anywhere we rely on a stubbed formula on disk to work: we need to disable the API.

Fixes https://github.com/Homebrew/brew/issues/16895