### PR TITLE
cmd/deps: add warning when not using runtime dependencies.

### DIFF
--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe Homebrew::Cmd::Deps do
     expect { brew "deps", "baz", "--include-test", "--missing", "--skip-recommended" }
       .to be_a_success
       .and output("bar\nfoo\ntest\n").to_stdout
-      .and not_to_output.to_stderr
+      .and output(/not the actual runtime dependencies/).to_stderr
   end
 end


### PR DESCRIPTION
This should provide clarify as to why the output may differ from a formula's declared dependencies.

Fixes https://github.com/Homebrew/brew/issues/16032