### PR TITLE
dev-cmd/contributions: improve CSV output.

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -88,16 +88,21 @@ module Homebrew
           contributions <<
             "#{Utils.pluralize("time", grand_totals[username].values.sum, include_count: true)} (total)"
 
-          puts [
+          contributions_string = [
             "#{username} contributed",
             *contributions.to_sentence,
             "#{time_period(from:, to: args.to)}.",
           ].join(" ")
+          if args.csv?
+            $stderr.puts contributions_string
+          else
+            puts contributions_string
+          end
         end
 
         return unless args.csv?
 
-        puts
+        $stderr.puts
         puts generate_csv(grand_totals)
       end
 


### PR DESCRIPTION
Output messages to stderr when CSV output is enabled.

This allows doing `brew contributions --csv > contributions.csv` to save the output to a file.