### PR TITLE
Only generate cask variations for supported macOS configurations

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -426,6 +426,12 @@ module Cask
             Homebrew::SimulateSystem.with_tag(bottle_tag) do
               refresh
 
+              next if bottle_tag.macos? && depends_on.macos && !depends_on.macos.allows?(bottle_tag.to_macos_version)
+              next if depends_on.arch&.none? do |arch|
+                arch_tag = ::Utils::Bottles::Tag.new(system: bottle_tag.system, arch: arch[:type])
+                arch_tag.standardized_arch == bottle_tag.standardized_arch
+              end
+
               to_h.each do |key, value|
                 next if HASH_KEYS_TO_SKIP.include? key
                 next if value.to_s == hash[key].to_s

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -484,6 +484,108 @@ RSpec.describe Cask::Cask, :cask do
         }
       JSON
     end
+    let(:expected_depends_on_macos_variations_os) do
+      <<~JSON
+        {
+          "tahoe": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "sequoia": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "sonoma": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "ventura": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "monterey": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "big_sur": {
+            "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "arm64_big_sur": {
+            "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+          },
+          "catalina": {
+            "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          }
+        }
+      JSON
+    end
+    let(:expected_depends_on_arch_variations_os) do
+      <<~JSON
+        {
+          "ventura": {
+            "sha256": "a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890"
+          },
+          "arm64_ventura": {
+            "sha256": "a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890"
+          },
+          "big_sur": {
+            "sha256": "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2",
+            "depends_on": {
+              "arch": [
+                {
+                  "type": "intel",
+                  "bits": 64
+                }
+              ],
+              "macos": {
+                ">=": [
+                  "10.11"
+                ]
+              }
+            }
+          }
+        }
+      JSON
+    end
 
     before do
       # For consistency, always run on Monterey and ARM
@@ -517,6 +619,22 @@ RSpec.describe Cask::Cask, :cask do
 
       expect(h).to be_a(Hash)
       expect(JSON.pretty_generate(h["variations"])).to eq expected_sha256_variations_os.strip
+    end
+
+    it "returns the correct variations hash for a cask with a different `depends_on macos:` for each arch and os" do
+      c = Cask::CaskLoader.load("with-depends-on-macos-inside-on-arch")
+      h = c.to_hash_with_variations
+
+      expect(h).to be_a(Hash)
+      expect(JSON.pretty_generate(h["variations"])).to eq expected_depends_on_macos_variations_os.strip
+    end
+
+    it "returns the correct variations hash for a cask with a different `depends_on arch:` for some os values" do
+      c = Cask::CaskLoader.load("with-depends-on-arch-inside-on-os")
+      h = c.to_hash_with_variations
+
+      expect(h).to be_a(Hash)
+      expect(JSON.pretty_generate(h["variations"])).to eq expected_depends_on_arch_variations_os.strip
     end
 
     # NOTE: The calls to `Cask.generating_hash!` and `Cask.generated_hash!`

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch-inside-on-os.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch-inside-on-os.rb
@@ -1,0 +1,26 @@
+cask "with-depends-on-arch-inside-on-os" do
+  version "1.2.3"
+
+  on_catalina :or_older do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_big_sur do
+    sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"
+
+    depends_on arch: :x86_64
+  end
+  on_monterey do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_ventura do
+    sha256 "a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890"
+  end
+  on_sonoma :or_newer do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-macos-failure"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-inside-on-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-inside-on-arch.rb
@@ -1,0 +1,27 @@
+cask "with-depends-on-macos-inside-on-arch" do
+  version "1.2.3"
+
+  # This is intentionally testing a non-rubocop compliant Cask
+  # rubocop:disable Style/DisableCopsWithinSourceCodeDirective
+  # rubocop:disable Cask/NoOverrides
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
+  # rubocop:enable Cask/NoOverrides
+  # rubocop:enable Style/DisableCopsWithinSourceCodeDirective
+
+  on_big_sur :or_older do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_monterey :or_newer do
+    sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"
+  end
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-macos-failure"
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
Follow-up to #20075

This PR fixes the issue where `Cask#to_hash_from_variations` includes variations that are not allowable given the `depends_on macos:` or `depends_on arch:` rules. Now, we also check whether the current variation OS is allowable _after_ refreshing the Cask, as we cannot determine whether the given OS is supported otherwise.

CC: @EricFromCanada
