### PR TITLE
dev-cmd/bump-formula-pr: handle null body

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -399,7 +399,7 @@ module Homebrew
               nil
             end
 
-            if github_release_data.present?
+            if github_release_data.present? && github_release_data["body"].present?
               pre = "pre" if github_release_data["prerelease"].present?
               # maximum length of PR body is 65,536 characters so let's truncate release notes to half of that.
               body = Formatter.truncate(github_release_data["body"], max: 32_768)


### PR DESCRIPTION
Fixes:

```
Parameter 'string': Expected type String, got type NilClass
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:405
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/formatter.rb:61 (Formatter.truncate)
```