### PR TITLE
Remove unused --force-auto-update option

### DIFF
--- a/Library/Homebrew/bundle/tap_installer.rb
+++ b/Library/Homebrew/bundle/tap_installer.rb
@@ -19,7 +19,6 @@ module Homebrew
         puts "Installing #{name} tap. It is not currently installed." if verbose
         args = []
         args << "--force" if force
-        args.append("--force-auto-update") if options[:force_auto_update]
 
         success = if options[:clone_target]
           Bundle.brew("tap", name, options[:clone_target], *args, verbose:)

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -33,8 +33,6 @@ module Homebrew
                             "integration.",
                replacement: false,
                disable:     true
-        switch "--[no-]force-auto-update",
-               hidden: true
         switch "--custom-remote",
                description: "Install or change a tap with a custom remote. Useful for mirrors."
         switch "--repair",

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/tap_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/tap_cmd.rbi
@@ -24,8 +24,5 @@ class Homebrew::Cmd::TapCmd::Args < Homebrew::CLI::Args
   def force?; end
 
   sig { returns(T::Boolean) }
-  def force_auto_update?; end
-
-  sig { returns(T::Boolean) }
   def repair?; end
 end

--- a/Library/Homebrew/test/bundle/dsl_spec.rb
+++ b/Library/Homebrew/test/bundle/dsl_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Homebrew::Bundle::Dsl do
         cask_args appdir: '/Applications'
         tap 'homebrew/cask'
         tap 'telemachus/brew', 'https://telemachus@bitbucket.org/telemachus/brew.git'
-        tap 'auto/update', 'https://bitbucket.org/auto/update.git', force_auto_update: true
+        tap 'auto/update', 'https://bitbucket.org/auto/update.git'
         brew 'imagemagick'
         brew 'mysql@5.6', restart_service: true, link: true, conflicts_with: ['mysql']
         brew 'emacs', args: ['with-cocoa', 'with-gnutls'], link: :overwrite
@@ -40,10 +40,7 @@ RSpec.describe Homebrew::Bundle::Dsl do
       expect(dsl.entries[0].name).to eql("homebrew/cask")
       expect(dsl.entries[1].name).to eql("telemachus/brew")
       expect(dsl.entries[1].options).to eql(clone_target: "https://telemachus@bitbucket.org/telemachus/brew.git")
-      expect(dsl.entries[2].options).to eql(
-        clone_target:      "https://bitbucket.org/auto/update.git",
-        force_auto_update: true,
-      )
+      expect(dsl.entries[2].options).to eql(clone_target: "https://bitbucket.org/auto/update.git")
       expect(dsl.entries[3].name).to eql("imagemagick")
       expect(dsl.entries[4].name).to eql("mysql@5.6")
       expect(dsl.entries[4].options).to eql(restart_service: true, link: true, conflicts_with: ["mysql"])

--- a/Library/Homebrew/test/bundle/tap_installer_spec.rb
+++ b/Library/Homebrew/test/bundle/tap_installer_spec.rb
@@ -55,25 +55,5 @@ RSpec.describe Homebrew::Bundle::TapInstaller do
         expect(described_class.install("homebrew/cask", clone_target: "clone_target_path")).to be(false)
       end
     end
-
-    context "with force_auto_update" do
-      it "taps" do
-        expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask",
-                                                          "--force-auto-update",
-                                                          verbose: false)
-                                                    .and_return(true)
-        expect(described_class.preinstall("homebrew/cask", force_auto_update: true)).to be(true)
-        expect(described_class.install("homebrew/cask", force_auto_update: true)).to be(true)
-      end
-
-      it "fails" do
-        expect(Homebrew::Bundle).to receive(:system).with(HOMEBREW_BREW_FILE, "tap", "homebrew/cask",
-                                                          "--force-auto-update",
-                                                          verbose: false)
-                                                    .and_return(false)
-        expect(described_class.preinstall("homebrew/cask", force_auto_update: true)).to be(true)
-        expect(described_class.install("homebrew/cask", force_auto_update: true)).to be(false)
-      end
-    end
   end
 end

--- a/Library/Homebrew/test/cmd/tap_spec.rb
+++ b/Library/Homebrew/test/cmd/tap_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Homebrew::Cmd::TapCmd do
   it "taps a given Tap", :integration_test do
     path = setup_test_tap
 
-    expect { brew "tap", "--force-auto-update", "homebrew/bar", path/".git" }
+    expect { brew "tap", "homebrew/bar", path/".git" }
       .to output(/Tapped/).to_stderr
       .and be_a_success
   end


### PR DESCRIPTION
Remove the `brew tap --force-auto-update` option and the `force_auto_update` configuration file option from Homebrew Bundles.

Fixes #19856

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
