### PR TITLE
Generate template API samples for `formulae.brew.sh` docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,3 @@
-# This file is synced from `Homebrew/brew` by the `.github` repository, do not modify it directly.
 name: Documentation CI
 
 on:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,4 @@
+# This file is synced from `Homebrew/brew` by the `.github` repository, do not modify it directly.
 name: Documentation CI
 
 on:
@@ -67,7 +68,7 @@ jobs:
       - name: Generate formulae.brew.sh API samples
         if: github.repository == 'Homebrew/formulae.brew.sh'
         working-directory: docs
-        run: ../script/generate-api-samples.rb
+        run: ../script/generate-api-samples.rb --template
 
       - name: Build the site and check for broken links
         working-directory: docs


### PR DESCRIPTION
See https://github.com/Homebrew/formulae.brew.sh/pull/1918

I didn't realize that the `docs` workflow in formulae.brew.sh synced from here, so this PR just copies over the change I made in https://github.com/Homebrew/formulae.brew.sh/pull/1906.

I also added a comment at the top of the file marking this.

Eventually, the comments should probably be added automatically by the sync action in `.github`, but I'm going to hold off on figuring that out until https://github.com/Homebrew/.github/pull/309 and related work is done to avoid conflicts

CC @MikeMcQuaid
