### PR TITLE
Remove deprecated vscode sorbet option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,7 +40,6 @@
       "id": "default",
       "name": "Brew Typecheck",
       "description": "Default configuration",
-      "cwd": "${workspaceFolder}",
       "command": [
         "./bin/brew",
         "typecheck",


### PR DESCRIPTION
I’m getting a message saying this option is deprecated and "was never used”, so may as well remove it to get rid of the message