### PR TITLE
Fix vscode ruby-lsp setup for GitHub codespaces

### DIFF
--- a/.vscode/ruby-lsp-activate.sh
+++ b/.vscode/ruby-lsp-activate.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-HOMEBREW_PREFIX="$(cd "$(dirname "$0")"/../ && pwd)"
+if [[ -n "${BASH_SOURCE[0]}" ]]; then
+    SCRIPT_PATH="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION}" ]]; then
+    SCRIPT_PATH="${(%):-%x}"
+else
+    SCRIPT_PATH="$0"
+fi
+HOMEBREW_PREFIX="$(cd "$(dirname "${SCRIPT_PATH}")"/../ && pwd)"
 
 "${HOMEBREW_PREFIX}/bin/brew" install-bundler-gems --add-groups=style,typecheck,vscode >/dev/null 2>&1
 


### PR DESCRIPTION
To setup the vscode Ruby LSP, the `ruby-lsp-activate.sh` file is sourced from the user's shell, which is `bash` on a GitHub Codespace.

In `bash`, `$0` does not return the name of the file being sourced like it does in `zsh`, so the script doesn’t properly set `HOMEBREW_PREFIX`. This PR changes how the prefix is set based on the shell being used to properly set up the LSP