### PR TITLE
Retry only generating cask variations for supported macOS configurations

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -426,6 +426,12 @@ module Cask
             Homebrew::SimulateSystem.with_tag(bottle_tag) do
               refresh
 
+              next if bottle_tag.macos? && depends_on.macos && !depends_on.macos.allows?(bottle_tag.to_macos_version)
+              next if depends_on.arch&.none? do |arch|
+                arch_tag = ::Utils::Bottles::Tag.new(system: bottle_tag.system, arch: arch[:type])
+                arch_tag.standardized_arch == bottle_tag.standardized_arch
+              end
+
               to_h.each do |key, value|
                 next if HASH_KEYS_TO_SKIP.include? key
                 next if value.to_s == hash[key].to_s

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -484,6 +484,108 @@ RSpec.describe Cask::Cask, :cask do
         }
       JSON
     end
+    let(:expected_depends_on_macos_variations_os) do
+      <<~JSON
+        {
+          "tahoe": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "sequoia": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "sonoma": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "ventura": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "monterey": {
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "big_sur": {
+            "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          },
+          "arm64_big_sur": {
+            "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+          },
+          "catalina": {
+            "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+            "depends_on": {
+              "macos": {
+                ">=": [
+                  "10.15"
+                ]
+              }
+            }
+          }
+        }
+      JSON
+    end
+    let(:expected_depends_on_arch_variations_os) do
+      <<~JSON
+        {
+          "ventura": {
+            "sha256": "a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890"
+          },
+          "arm64_ventura": {
+            "sha256": "a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890"
+          },
+          "big_sur": {
+            "sha256": "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2",
+            "depends_on": {
+              "arch": [
+                {
+                  "type": "intel",
+                  "bits": 64
+                }
+              ],
+              "macos": {
+                ">=": [
+                  "10.11"
+                ]
+              }
+            }
+          }
+        }
+      JSON
+    end
 
     before do
       # For consistency, always run on Monterey and ARM
@@ -517,6 +619,22 @@ RSpec.describe Cask::Cask, :cask do
 
       expect(h).to be_a(Hash)
       expect(JSON.pretty_generate(h["variations"])).to eq expected_sha256_variations_os.strip
+    end
+
+    it "returns the correct variations hash for a cask with a different `depends_on macos:` for each arch and os" do
+      c = Cask::CaskLoader.load("with-depends-on-macos-inside-on-arch")
+      h = c.to_hash_with_variations
+
+      expect(h).to be_a(Hash)
+      expect(JSON.pretty_generate(h["variations"])).to eq expected_depends_on_macos_variations_os.strip
+    end
+
+    it "returns the correct variations hash for a cask with a different `depends_on arch:` for some os values" do
+      c = Cask::CaskLoader.load("with-depends-on-arch-inside-on-os")
+      h = c.to_hash_with_variations
+
+      expect(h).to be_a(Hash)
+      expect(JSON.pretty_generate(h["variations"])).to eq expected_depends_on_arch_variations_os.strip
     end
 
     # NOTE: The calls to `Cask.generating_hash!` and `Cask.generated_hash!`

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch-inside-on-os.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch-inside-on-os.rb
@@ -1,0 +1,26 @@
+cask "with-depends-on-arch-inside-on-os" do
+  version "1.2.3"
+
+  on_catalina :or_older do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_big_sur do
+    sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"
+
+    depends_on arch: :x86_64
+  end
+  on_monterey do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_ventura do
+    sha256 "a1b2c3d4e5f67890abcdef1234567890abcdef1234567890abcdef1234567890"
+  end
+  on_sonoma :or_newer do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-macos-failure"
+
+  app "Caffeine.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-inside-on-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-inside-on-arch.rb
@@ -1,0 +1,27 @@
+cask "with-depends-on-macos-inside-on-arch" do
+  version "1.2.3"
+
+  # This is intentionally testing a non-rubocop compliant Cask
+  # rubocop:disable Style/DisableCopsWithinSourceCodeDirective
+  # rubocop:disable Cask/NoOverrides
+  on_arm do
+    depends_on macos: ">= :big_sur"
+  end
+  on_intel do
+    depends_on macos: ">= :catalina"
+  end
+  # rubocop:enable Cask/NoOverrides
+  # rubocop:enable Style/DisableCopsWithinSourceCodeDirective
+
+  on_big_sur :or_older do
+    sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
+  end
+  on_monterey :or_newer do
+    sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"
+  end
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage "https://brew.sh/with-depends-on-macos-failure"
+
+  app "Caffeine.app"
+end


### PR DESCRIPTION
Retry #20080

To be honest, I’m still not entirely sure what went wrong, so I would encourage others to investigate this more. I tried using `brew prof`, but wasn’t able to get particularly useful info (although this is probably me not using it properly).

---

Here is what I found. For some reason, it seems like the `generate-cask-api` job hangs when processing the [`ipartition` cask](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/i/ipartition.rb). As far as I can tell, there doesn’t seem to be anything particularly unique about that cask. It only works on macOS versions up to High Sierra, and while it does have a variation block, the `depends_on` line is outside.

If I manually run `:ipartition.c.to_hash_with_variations`, it seems to work just fine without hanging. Similarly, if I modify `brew generate-cask-api` to skip all casks except `ipartition`, it does not hang. However, when I modify `brew generate-cask-api` to skip all casks that don’t start with the letter `i`, it does hang. If I modify `brew generate-cask-api` to include all casks _except_ `ipartition`, it doesn’t seem to hang.

From this, it seems like there is something special about the `ipartition` cask that causes the generation to hang, but only when processed with others. There is definitely more investigating to be done.

I ended up determining that the line that hands is inside `MacOSRequirement#allows?`, where two `MacOSVersion` objects are compared using `<=`:

https://github.com/Homebrew/brew/blob/d428e832eed4881d84583838e6e16ad9763ad429/Library/Homebrew/requirements/macos_requirement.rb#L83

This comparison is reached many times per-cask, and for some reason, when processing `ipartition`, this line gets slower and slower each time. By the time we are comparing `11` to `10.13` (the latter being the maximum version allowed by the `depends_on`, we’re already pretty slow. By the time we get to comparing `10.14` to `10.13`, I wasn’t able to run the entire comparison before I gave up and exited (which took at least 10 minutes).

If we look at the `MacOSVersion#<=>` method, it caches each comparison to avoid needing to compute the comparisons over and over again:

https://github.com/Homebrew/brew/blob/d428e832eed4881d84583838e6e16ad9763ad429/Library/Homebrew/macos_version.rb#L64-L82

Since the cache key is a `MacOSVersion` object, I thought maybe the issue was that we were recursively comparing `MacOSVersions` which was causing the issue. I also thought maybe we were creating new `MacOSVersion` objects each time, and these weren’t comparing properly.

So, I made two changes to `MacOSVersion` that are included in this PR:
1. Add caching to `::from_symbol` so the same object is returned each time a symbol is requested
2. In `#<=>`, use the stringified version of the other object being compared as the cache key to make the `includes?` check a simple string comparison

Both of these solutions seemed to work on their own to solve this, and I was able to run `brew generate-cask-api` in ~30 seconds on my machine (compared to longer than 10 minutes before, I never waited long enough to know if it actually returned).

---

Clearly, this is weird and I think I’ve gone a little too far down the rabbit hole to really know what the best solution is, so I would appreciate extra eyes from anyone who's willing to do some investigating

I don't really want to merge this as-is because my gut tells me there is either a better way to handle this all together or something else is the root of the problem