### PR TITLE
cmd/update*: more fixes to allow migration from `master` to `main`.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -320,10 +320,11 @@ module Homebrew
           return if (HOMEBREW_PREFIX/".homebrewdocker").exist?
 
           tap_output_header_printed = T.let(false, T::Boolean)
+          default_branches = %w[main master].freeze
           [CoreTap.instance, CoreCaskTap.instance].each do |tap|
             next unless tap.installed?
 
-            if tap.git_branch == "master" &&
+            if default_branches.include?(tap.git_branch) &&
                (Date.parse(T.must(tap.git_repository.last_commit_date)) <= Date.today.prev_month)
               ohai "#{tap.name} is old and unneeded, untapping to save space..."
               tap.uninstall

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -56,7 +56,7 @@ git_init_if_necessary() {
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     git fetch --force --tags origin
     git remote set-head origin --auto >/dev/null
-    git reset --hard origin/master
+    git reset --hard origin/HEAD
     SKIP_FETCH_BREW_REPOSITORY=1
     set +e
     trap - EXIT
@@ -77,9 +77,9 @@ git_init_if_necessary() {
     fi
     git config remote.origin.url "${HOMEBREW_CORE_GIT_REMOTE}"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    git fetch --force origin refs/heads/master:refs/remotes/origin/master
+    git fetch --force origin
     git remote set-head origin --auto >/dev/null
-    git reset --hard origin/master
+    git reset --hard origin/HEAD
     SKIP_FETCH_CORE_REPOSITORY=1
     set +e
     trap - EXIT
@@ -110,7 +110,7 @@ upstream_branch() {
     upstream_branch="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)"
   fi
   upstream_branch="${upstream_branch#refs/remotes/origin/}"
-  [[ -z "${upstream_branch}" ]] && upstream_branch="master"
+  [[ -z "${upstream_branch}" ]] && upstream_branch="main"
   echo "${upstream_branch}"
 }
 
@@ -242,7 +242,7 @@ merge_or_rebase() {
 Could not 'git stash' in ${DIR}!
 Please stash/commit manually if you need to keep your changes or, if not, run:
   cd ${DIR}
-  git reset --hard origin/master
+  git reset --hard origin/HEAD
 EOS
     fi
     git reset --hard "${QUIET_ARGS[@]}"
@@ -260,10 +260,12 @@ EOS
     then
       git checkout --force "${UPSTREAM_BRANCH}" "${QUIET_ARGS[@]}"
     else
-      if [[ -n "${UPSTREAM_TAG}" && "${UPSTREAM_BRANCH}" != "master" ]] &&
-         [[ "${INITIAL_BRANCH}" != "master" ]]
+      if [[ -n "${UPSTREAM_TAG}" && "${UPSTREAM_BRANCH}" != "master" && "${UPSTREAM_BRANCH}" != "main" ]] &&
+         [[ "${INITIAL_BRANCH}" != "master" && "${INITIAL_BRANCH}" != "main" ]]
       then
-        git branch --force "master" "origin/master" "${QUIET_ARGS[@]}"
+        local detected_upstream_branch
+        detected_upstream_branch="$(upstream_branch)"
+        git branch --force "${detected_upstream_branch}" "origin/${detected_upstream_branch}" "${QUIET_ARGS[@]}"
       fi
 
       git checkout --force -B "${UPSTREAM_BRANCH}" "${REMOTE_REF}" "${QUIET_ARGS[@]}"
@@ -541,7 +543,7 @@ EOS
     echo "HOMEBREW_CORE_GIT_REMOTE set: using ${HOMEBREW_CORE_GIT_REMOTE} as the Homebrew/homebrew-core Git remote."
     git remote set-url origin "${HOMEBREW_CORE_GIT_REMOTE}"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    git fetch --force origin refs/heads/master:refs/remotes/origin/master
+    git fetch --force origin
     SKIP_FETCH_CORE_REPOSITORY=1
   fi
 
@@ -642,9 +644,9 @@ EOS
       UPDATING_MESSAGE_SHOWN=1
     fi
 
-    # The upstream repository's default branch may not be master;
+    # The upstream repository's default branch may not be main or master;
     # check refs/remotes/origin/HEAD to see what the default
-    # origin branch name is, and use that. If not set, fall back to "master".
+    # origin branch name is, and use that. If not set, fall back to "main".
     # the refspec ensures that the default upstream branch gets updated
     (
       UPSTREAM_REPOSITORY_URL="$(git config remote.origin.url)"
@@ -732,9 +734,9 @@ EOS
         then
           local git_errors
           git_errors="$(cat "${tmp_failure_file}")"
+          # Attempt migration from master to main branch.
           if [[ "${git_errors}" == "fatal: couldn't find remote ref refs/heads/master" ]]
           then
-            # Attempt migration from master to main branch.
             if git fetch --tags --force "${QUIET_ARGS[@]}" origin \
                "refs/heads/main:refs/remotes/origin/main" 2>>"${tmp_failure_file}"
             then


### PR DESCRIPTION
We're not migrating Homebrew/brew to `main` yet but this will allow us to ensure we have a `brew update` ready in future when we're ready to do this.

Tested by adjusting default branch on MikeMcQuaid/brew to `main`.

Again @homebrew/maintainers would really appreciate a very thorough review here.

May also take an approach like in https://github.com/Homebrew/actions/pull/702 in Homebrew/brew to be extra conservative here for a wee while.