### PR TITLE
Cask: Initialize yet more instance variables

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -139,7 +139,11 @@ module Cask
 
       def initialize(cask, *dsl_args)
         @cask = cask
+        @dirmethod = nil
         @dsl_args = dsl_args.deep_dup
+        @dsl_key = nil
+        @english_article = nil
+        @english_name = nil
       end
 
       def config

--- a/Library/Homebrew/cask/artifact/relocated.rb
+++ b/Library/Homebrew/cask/artifact/relocated.rb
@@ -41,7 +41,9 @@ module Cask
         super
 
         target = target_hash[:target]
+        @source = nil
         @source_string = source.to_s
+        @target = nil
         @target_string = target.to_s
       end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -69,7 +69,6 @@ module Cask
     ].freeze
 
     DSL_METHODS = Set.new([
-      :appcast,
       :arch,
       :artifacts,
       :auto_updates,
@@ -123,15 +122,21 @@ module Cask
 
     sig { params(cask: Cask).void }
     def initialize(cask)
-      # NOTE: Variables set by `set_unique_stanza` must be initialized to `nil`.
-      @auto_updates = T.let(nil, T.nilable(T::Boolean))
+      # NOTE: `:"@#{stanza}"` variables set by `set_unique_stanza` must be
+      # initialized to `nil`.
       @arch = T.let(nil, T.nilable(String))
+      @arch_set_in_block = T.let(false, T::Boolean)
       @artifacts = T.let(ArtifactSet.new, ArtifactSet)
+      @auto_updates = T.let(nil, T.nilable(T::Boolean))
+      @auto_updates_set_in_block = T.let(false, T::Boolean)
+      @autobump = T.let(true, T::Boolean)
       @called_in_on_system_block = T.let(false, T::Boolean)
       @cask = T.let(cask, Cask)
       @caveats = T.let(DSL::Caveats.new(cask), DSL::Caveats)
       @conflicts_with = T.let(nil, T.nilable(DSL::ConflictsWith))
+      @conflicts_with_set_in_block = T.let(false, T::Boolean)
       @container = T.let(nil, T.nilable(DSL::Container))
+      @container_set_in_block = T.let(false, T::Boolean)
       @depends_on = T.let(DSL::DependsOn.new, DSL::DependsOn)
       @depends_on_set_in_block = T.let(false, T::Boolean)
       @deprecated = T.let(false, T::Boolean)
@@ -140,27 +145,32 @@ module Cask
       @deprecation_replacement_cask = T.let(nil, T.nilable(String))
       @deprecation_replacement_formula = T.let(nil, T.nilable(String))
       @desc = T.let(nil, T.nilable(String))
+      @desc_set_in_block = T.let(false, T::Boolean)
       @disable_date = T.let(nil, T.nilable(Date))
       @disable_reason = T.let(nil, T.nilable(T.any(String, Symbol)))
       @disable_replacement_cask = T.let(nil, T.nilable(String))
       @disable_replacement_formula = T.let(nil, T.nilable(String))
       @disabled = T.let(false, T::Boolean)
       @homepage = T.let(nil, T.nilable(String))
+      @homepage_set_in_block = T.let(false, T::Boolean)
       @language_blocks = T.let({}, T::Hash[T::Array[String], Proc])
       @language_eval = T.let(nil, T.nilable(String))
       @livecheck = T.let(Livecheck.new(cask), Livecheck)
       @livecheck_defined = T.let(false, T::Boolean)
       @name = T.let([], T::Array[String])
-      @autobump = T.let(true, T::Boolean)
       @no_autobump_defined = T.let(false, T::Boolean)
       @on_system_blocks_exist = T.let(false, T::Boolean)
-      @os = T.let(nil, T.nilable(String))
       @on_system_block_min_os = T.let(nil, T.nilable(MacOSVersion))
+      @os = T.let(nil, T.nilable(String))
+      @os_set_in_block = T.let(false, T::Boolean)
       @sha256 = T.let(nil, T.nilable(T.any(Checksum, Symbol)))
+      @sha256_set_in_block = T.let(false, T::Boolean)
       @staged_path = T.let(nil, T.nilable(Pathname))
       @token = T.let(cask.token, String)
       @url = T.let(nil, T.nilable(URL))
+      @url_set_in_block = T.let(false, T::Boolean)
       @version = T.let(nil, T.nilable(DSL::Version))
+      @version_set_in_block = T.let(false, T::Boolean)
     end
 
     sig { returns(T::Boolean) }
@@ -216,7 +226,7 @@ module Cask
           raise CaskInvalidError.new(cask, "'#{stanza}' stanza may only appear once.")
         end
 
-        if instance_variable_defined?(:"@#{stanza}_set_in_block") && @called_in_on_system_block
+        if instance_variable_get(:"@#{stanza}_set_in_block") && @called_in_on_system_block
           raise CaskInvalidError.new(cask, "'#{stanza}' stanza may only be overridden once.")
         end
       end

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -44,7 +44,8 @@ module Homebrew
         titleized_repository = tap.repository.dup
         titleized_user[0] = titleized_user[0].upcase
         titleized_repository[0] = titleized_repository[0].upcase
-        root_url = GitHubPackages.root_url(tap.user, "homebrew-#{tap.repository}") if args.github_packages?
+        # Duplicate assignment to silence `assigned but unused variable` warning
+        root_url = root_url = GitHubPackages.root_url(tap.user, "homebrew-#{tap.repository}") if args.github_packages?
 
         (tap.path/"Formula").mkpath
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I previously added some instance variables in `Cask::DSL` to its `initialize` method (#19806, #19808) but I missed some last time, so we still see warnings like `The class Cask::DSL reached 8 shape variations, instance variables accesses will be slower and memory usage increased. It is recommended to define instance variables in a consistent order, for instance by eagerly defining them all in the #initialize method.`

This initializes more instance variables in `Cask` classes to resolve other situations where this warning may occur. I've been testing this for a while and haven't see any warnings with these changes but there's always a chance that there's still more work to be done.