### PR TITLE
rubocops/caveats: check for dynamic caveats.

### DIFF
--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -42,5 +42,35 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Caveats do
         end
       RUBY
     end
+
+    it "reports an offense if dynamic logic (if/else/unless) is used in caveats" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          homepage "https://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
+          def caveats
+            if true
+            ^^^^^^^ FormulaAudit/Caveats: Don't use dynamic logic (if/else/unless) in caveats.
+              "foo"
+            else
+              "bar"
+            end
+          end
+        end
+      RUBY
+
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          homepage "https://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
+          def caveats
+            unless false
+            ^^^^^^^^^^^^ FormulaAudit/Caveats: Don't use dynamic logic (if/else/unless) in caveats.
+              "foo"
+            end
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
This will avoid issues with the JSON API.

I expect this to fail CI but reveal problematic caveats that must be updated.

Fixes https://github.com/Homebrew/brew/issues/19327