### PR TITLE
cask/installer: remove confusing `zap` messaging

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -604,7 +604,6 @@ on_request: true)
 
     def zap
       load_installed_caskfile!
-      ohai "Implied `brew uninstall --cask #{@cask}`"
       uninstall_artifacts
       if (zap_stanzas = @cask.artifacts.select { |a| a.is_a?(Artifact::Zap) }).empty?
         opoo "No zap stanza present for Cask '#{@cask}'"

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Cask::Reinstall, :cask do
     output = Regexp.new <<~EOS
       ==> Downloading file:.*caffeine.zip
       Already downloaded: .*--caffeine.zip
-      ==> Implied `brew uninstall --cask local-caffeine`
       ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Dispatching zap stanza


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This messaging is confusing, and doesn't feel helpful.

Currently:

```
╰─ brew uninstall --zap foo
==> Implied `brew uninstall --cask foo`
```

In my mind, I take that to be "Oh, it must have wanted me to `brew uninstall --cask --zap foo`".  `zap` only applies to casks, and running `brew uninstall --cask --zap foo` still emits the same message, so I'm not sure what this is trying to tell the user.