### PR TITLE
Fix type mismatch in `brew info`

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -266,7 +266,7 @@ module Homebrew
           cask.sourcefile_path.relative_path_from(tap.path)
         end
 
-        github_remote_path(tap.remote, path)
+        github_remote_path(tap.remote, path.to_s)
       end
 
       sig { params(formula: Formula).void }


### PR DESCRIPTION
Follow-up to #20130

Fixes the following issue:

```console
$ brew info hello
==> hello: stable 2.12.2 (bottled)
Program providing model for GNU coding standards and practices
https://www.gnu.org/software/hello/
Not installed
Error: Parameter 'path': Expected type String, got type Pathname with value #<Pathname:Formula/h/hello.rb>
Caller: /opt/homebrew/Library/Homebrew/cmd/info.rb:269
Definition: /opt/homebrew/Library/Homebrew/cmd/info.rb:118 (Homebrew::Cmd::Info#github_remote_path)
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/configuration.rb:296:in 'T::Configuration.call_validation_error_handler_default'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/configuration.rb:303:in 'T::Configuration.call_validation_error_handler'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:322:in 'T::Private::Methods::CallValidation.report_error'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:230:in 'block in T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/signature.rb:213:in 'T::Private::Methods::Signature#each_args_value_type'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:227:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/_methods.rb:277:in 'block in Homebrew::Cmd::Info#_on_method_added'
/opt/homebrew/Library/Homebrew/cmd/info.rb:269:in 'Homebrew::Cmd::Info#github_info'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/_methods.rb:277:in 'block in Homebrew::Cmd::Info#_on_method_added'
/opt/homebrew/Library/Homebrew/cmd/info.rb:337:in 'Homebrew::Cmd::Info#info_formula'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/_methods.rb:277:in 'block in Homebrew::Cmd::Info#_on_method_added'
/opt/homebrew/Library/Homebrew/cmd/info.rb:166:in 'block in Homebrew::Cmd::Info#print_info'
/opt/homebrew/Library/Homebrew/cmd/info.rb:161:in 'Array#each'
/opt/homebrew/Library/Homebrew/cmd/info.rb:161:in 'Enumerable#each_with_index'
/opt/homebrew/Library/Homebrew/cmd/info.rb:161:in 'Homebrew::Cmd::Info#print_info'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/_methods.rb:277:in 'block in Homebrew::Cmd::Info#_on_method_added'
/opt/homebrew/Library/Homebrew/cmd/info.rb:113:in 'Homebrew::Cmd::Info#run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12117/lib/types/private/methods/_methods.rb:277:in 'block in Homebrew::Cmd::Info#_on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:95:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

Since the value of `path` is now a `Pathname`, it needs to be explicitly converted to a `String` to satisfy the signature of `github_remote_path`