### PR TITLE
download_strategy: fossil now outputs `hash:`

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1542,7 +1542,7 @@ class FossilDownloadStrategy < VCSDownloadStrategy
   sig { override.returns(Time) }
   def source_modified_time
     out = silent_command("fossil", args: ["info", "tip", "-R", cached_location]).stdout
-    Time.parse(T.must(out[/^uuid: +\h+ (.+)$/, 1]))
+    Time.parse(T.must(out[/^(hash|uuid): +\h+ (.+)$/, 1]))
   end
 
   # Return last commit's unique identifier for the repository.
@@ -1551,7 +1551,7 @@ class FossilDownloadStrategy < VCSDownloadStrategy
   sig { override.returns(String) }
   def last_commit
     out = silent_command("fossil", args: ["info", "tip", "-R", cached_location]).stdout
-    T.must(out[/^uuid: +(\h+) .+$/, 1])
+    T.must(out[/^(hash|uuid): +(\h+) .+$/, 1])
   end
 
   sig { override.returns(T::Boolean) }

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1350,7 +1350,7 @@ class CVSDownloadStrategy < VCSDownloadStrategy
     end
 
     command! "cvs",
-             args:    [*quiet_flag, "-d", @url, "checkout", "-d", cached_location.basename, @module],
+             args:    [*quiet_flag, "-d", @url, "checkout", "-d", basename.to_s, @module],
              chdir:   cached_location.dirname,
              timeout: Utils::Timer.remaining(timeout)
   end


### PR DESCRIPTION
URLs using `:fossil` checkouts haven't worked since `fossil` switched from printing [`uuid:` to `hash:`](https://fossil-scm.org/home/info/8ad5e4690854a81a) for `fossil info tip`.

Also, fix this error for CVS checkouts:
```console
$ brew fetch -s -v --HEAD mandoc
==> Cloning anoncvs@mandoc.bsd.lv:/cvs
/usr/bin/env PATH=/usr/bin:/opt/homebrew/opt/cvs/bin:/opt/homebrew/Library/Homebrew/shims/shared:/bin:/usr/sbin:/sbin cvs -d anoncvs@mandoc.bsd.lv:/cvs checkout -d /Users/eric/mandoc--cvs mandoc
Warning: Permanently added 'mandoc.bsd.lv' (ED25519) to the list of known hosts.
cvs [server aborted]: absolute pathname `/Users/eric/mandoc--cvs' illegal for server
Error: Failed to download resource "mandoc"
Failure while executing; `/usr/bin/env PATH=/usr/bin:/opt/homebrew/opt/cvs/bin:/opt/homebrew/Library/Homebrew/shims/shared:/bin:/usr/sbin:/sbin cvs -d anoncvs@mandoc.bsd.lv:/cvs checkout -d /Users/eric/mandoc--cvs mandoc` exited with 1. Here's the output:
Warning: Permanently added 'mandoc.bsd.lv' (ED25519) to the list of known hosts.
cvs [server aborted]: absolute pathname `/Users/eric/mandoc--cvs' illegal for server
```