### PR TITLE
Fix `brew doctor` cask handling on Linux

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -908,6 +908,19 @@ module Homebrew
         EOS
       end
 
+      def check_deprecated_cask_taps
+        tapped_caskroom_taps = ::Tap.select { |t| t.user == "caskroom" || t.name == "phinze/cask" }
+                                    .map(&:name)
+        return if tapped_caskroom_taps.empty?
+
+        <<~EOS
+          You have the following deprecated Cask taps installed:
+            #{tapped_caskroom_taps.join("\n  ")}
+          Please remove them with:
+            brew untap #{tapped_caskroom_taps.join(" ")}
+        EOS
+      end
+
       def check_cask_software_versions
         add_info "Homebrew Version", HOMEBREW_VERSION
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -910,22 +910,6 @@ module Homebrew
 
       def check_cask_software_versions
         add_info "Homebrew Version", HOMEBREW_VERSION
-        add_info "macOS", MacOS.full_version
-        add_info "SIP", begin
-          csrutil = "/usr/bin/csrutil"
-          if File.executable?(csrutil)
-            Open3.capture2(csrutil, "status")
-                 .first
-                 .gsub("This is an unsupported configuration, likely to break in " \
-                       "the future and leave your machine in an unknown state.", "")
-                 .gsub("System Integrity Protection status: ", "")
-                 .delete("\t.")
-                 .capitalize
-                 .strip
-          else
-            "N/A"
-          end
-        end
 
         nil
       end

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -189,6 +189,13 @@ module OS
             are prone to breaking when GCC is updated. You should `brew reinstall` these formulae:
           EOS
         end
+
+        def check_cask_software_versions
+          super
+          add_info "Linux", OS::Linux.os_version
+
+          nil
+        end
       end
     end
   end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -496,6 +496,28 @@ module OS
             #{installation_instructions}
           EOS
         end
+
+        def check_cask_software_versions
+          super
+          add_info "macOS", MacOS.full_version
+          add_info "SIP", begin
+            csrutil = "/usr/bin/csrutil"
+            if File.executable?(csrutil)
+              Open3.capture2(csrutil, "status")
+                   .first
+                   .gsub("This is an unsupported configuration, likely to break in " \
+                         "the future and leave your machine in an unknown state.", "")
+                   .gsub("System Integrity Protection status: ", "")
+                   .delete("\t.")
+                   .capitalize
+                   .strip
+            else
+              "N/A"
+            end
+          end
+
+          nil
+        end
       end
     end
   end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -424,18 +424,6 @@ module OS
           EOS
         end
 
-        def check_deprecated_caskroom_taps
-          tapped_caskroom_taps = ::Tap.select { |t| t.user == "caskroom" || t.name == "phinze/cask" }
-                                      .map(&:name)
-          return if tapped_caskroom_taps.empty?
-
-          <<~EOS
-            You have the following deprecated, cask taps tapped:
-              #{tapped_caskroom_taps.join("\n  ")}
-            Untap them with `brew untap`.
-          EOS
-        end
-
         def check_if_supported_sdk_available
           return unless ::DevelopmentTools.installed?
           return unless MacOS.sdk_root_needed?


### PR DESCRIPTION
Fixes #20148

This PR modifies the `check_cask_software_versions` diagnostic check so that it only reports SIP status on macOS, and displays the appropriate OS version on both macOS and Linux.

While we're here, let's move the check for deprecated cask taps to run on both macOS and Linux since you can now have casks on Linux