### PR TITLE
Improve `brew doctor` warnings about `xattr` and cask quarantine

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1009,6 +1009,8 @@ module Homebrew
       end
 
       def check_cask_xattr
+        return "Unable to find `xattr`." unless File.exist?("/usr/bin/xattr")
+
         result = system_command "/usr/bin/xattr", args: ["-h"]
 
         return if result.status.success?
@@ -1031,8 +1033,6 @@ module Homebrew
           end
         elsif result.stderr.include? "pkg_resources.DistributionNotFound"
           "Your Python installation is unable to find `xattr`."
-        elsif result.stderr.include? "No such file or directory"
-          "Unable to find `xattr`."
         else
           "unknown xattr error: #{result.stderr.split("\n").last}"
         end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1031,6 +1031,8 @@ module Homebrew
           end
         elsif result.stderr.include? "pkg_resources.DistributionNotFound"
           "Your Python installation is unable to find `xattr`."
+        elsif result.stderr.include? "No such file or directory"
+          "Unable to find `xattr`."
         else
           "unknown xattr error: #{result.stderr.split("\n").last}"
         end
@@ -1044,6 +1046,8 @@ module Homebrew
           "No Cask quarantine support available: there's no working version of `xattr` on this system."
         when :no_swift
           "No Cask quarantine support available: there's no available version of `swift` on this system."
+        when :linux
+          "No Cask quarantine support available: not available on Linux."
         else
           "No Cask quarantine support available: unknown reason."
         end


### PR DESCRIPTION
Follow-up to #20151 and #20152

On Linux with a cask installed, `brew doctor` displays some unhelpful warnings about `xattr` and cask quarantine. This PR attempts to improve those.

Before:

```console
$ brew doctor 
Warning: No Cask quarantine support available: there's no working version of `xattr` on this system.
/usr/bin/env: ‘/usr/bin/xattr’: No such file or directory

Warning: unknown xattr error: /usr/bin/env: ‘/usr/bin/xattr’: No such file or directory
```

After:

```console
$ brew doctor
Warning: No Cask quarantine support available: not available on Linux.

Warning: Unable to find `xattr`.
```

Note: it might be better to not even run the `check_cask_xattr` if there is no quarantine support anyway, but I wasn’t 100% sure whether `xattr` was used for anything except quarantine.

Also, this PR was not made against the `master` branch because it depends on some of the work in #20152