### PR TITLE
create: strip 'v' prefix from version

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -165,7 +165,7 @@ module Homebrew
         <% unless @head %>
           url "#{@url}"
         <% unless @version.detected_from_url? %>
-          version "#{@version}"
+          version "#{@version.to_s.delete_prefix('v')}"
         <% end %>
           sha256 "#{@sha256}"
         <% end %>

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -165,7 +165,7 @@ module Homebrew
         <% unless @head %>
           url "#{@url}"
         <% unless @version.detected_from_url? %>
-          version "#{@version.to_s.delete_prefix('v')}"
+          version "#{@version.to_s.delete_prefix("v")}"
         <% end %>
           sha256 "#{@sha256}"
         <% end %>


### PR DESCRIPTION
To fix subsequent `brew audit` error:

  * line 8, col 3: Version v0.38.1 should not have a leading 'v'

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
