### PR TITLE
rubocops/caveats: only apply dynamic logic check to core.

### DIFF
--- a/Library/Homebrew/rubocops/caveats.rb
+++ b/Library/Homebrew/rubocops/caveats.rb
@@ -48,6 +48,8 @@ module RuboCop
             problem "Don't use ANSI escape codes in the caveats." if regex_match_group(n, /\e/)
           end
 
+          return if formula_tap != "homebrew-core"
+
           # Forbid dynamic logic in caveats (only if/else/unless)
           caveats_method = find_method_def(@body, :caveats)
           return unless caveats_method


### PR DESCRIPTION
This doesn't really matter for non-API taps.

Apologies @Bo98 that you mentioned this in https://github.com/Homebrew/brew/pull/20135 and I applied it but it ended up reverted in a later version (despite me fixing the tests).

Note @ReenigneArcher that this is effectively a revert of https://github.com/Homebrew/brew/pull/20135 for non-core taps. Apologies for the confusion.