### PR TITLE
create: detect URL from latest release if it isn't archive

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -14,6 +14,9 @@ module Homebrew
     sig { returns(Version) }
     attr_reader :version
 
+    sig { returns(String) }
+    attr_reader :url
+
     sig { returns(T::Boolean) }
     attr_reader :head
 
@@ -79,6 +82,9 @@ module Homebrew
             latest_release = GitHub.get_latest_release(user, repository)
             version = Version.new(latest_release.fetch("tag_name"))
             odebug "github: version from latest_release: #{version}"
+
+            @url = "https://github.com/#{user}/#{repository}/archive/refs/tags/#{version}.tar.gz"
+            odebug "github: url changed to source archive #{@url}"
           rescue GitHub::API::HTTPNotFoundError
             odebug "github: latest_release lookup failed: #{url}"
           end

--- a/Library/Homebrew/test/formula_creator_spec.rb
+++ b/Library/Homebrew/test/formula_creator_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Homebrew::FormulaCreator do
         github_user_repository: ["buildpacks", "pack"],
         latest_release:         { "tag_name" => "v0.37.0" },
         expected_name:          "pack",
+        expected_url:           "https://github.com/buildpacks/pack/archive/refs/tags/v0.37.0.tar.gz",
         expected_version:       "v0.37.0",
       },
       "GitHub URL with name override":   {
@@ -68,6 +69,9 @@ RSpec.describe Homebrew::FormulaCreator do
           expect(formula_creator.version).to eq(expected_version)
         else
           expect(formula_creator.version).to be_null
+        end
+        if (expected_url = test[:expected_url])
+          expect(formula_creator.url).to eq(expected_url)
         end
         expect(formula_creator.head).to eq(test.fetch(:expected_head, false))
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When running `brew create https://github.com/buildpacks/pack` the version is not detected from the URL, so the version from the latest release is used. But the URL still doesn't point to the source code archive. This PR constructs the URL to point to the source archive for the detected release or tag.