### PR TITLE
language/*: fix `*_SHEBANG_REGEX` anchors

### DIFF
--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -96,7 +96,7 @@ module Language
       module_function
 
       # A regex to match potential shebang permutations.
-      NODE_SHEBANG_REGEX = %r{^#! ?(?:/usr/bin/(?:env )?)?node( |$)}
+      NODE_SHEBANG_REGEX = %r{\A#! ?(?:/usr/bin/(?:env )?)?node( |$)}
 
       # The length of the longest shebang matching `SHEBANG_REGEX`.
       NODE_SHEBANG_MAX_LENGTH = T.let("#! /usr/bin/env node ".length, Integer)

--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -15,7 +15,7 @@ module Language
       module_function
 
       # A regex to match potential shebang permutations.
-      PERL_SHEBANG_REGEX = %r{^#! ?(?:/usr/bin/(?:env )?)?perl( |$)}
+      PERL_SHEBANG_REGEX = %r{\A#! ?(?:/usr/bin/(?:env )?)?perl( |$)}
 
       # The length of the longest shebang matching `SHEBANG_REGEX`.
       PERL_SHEBANG_MAX_LENGTH = T.let("#! /usr/bin/env perl ".length, Integer)

--- a/Library/Homebrew/language/php.rb
+++ b/Library/Homebrew/language/php.rb
@@ -15,7 +15,7 @@ module Language
       module_function
 
       # A regex to match potential shebang permutations.
-      PHP_SHEBANG_REGEX = %r{^#! ?(?:/usr/bin/(?:env )?)?php( |$)}
+      PHP_SHEBANG_REGEX = %r{\A#! ?(?:/usr/bin/(?:env )?)?php( |$)}
 
       # The length of the longest shebang matching `SHEBANG_REGEX`.
       PHP_SHEBANG_MAX_LENGTH = T.let("#! /usr/bin/env php ".length, Integer)

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -112,7 +112,7 @@ module Language
       module_function
 
       # A regex to match potential shebang permutations.
-      PYTHON_SHEBANG_REGEX = %r{^#! ?(?:/usr/bin/(?:env )?)?python(?:[23](?:\.\d{1,2})?)?( |$)}
+      PYTHON_SHEBANG_REGEX = %r{\A#! ?(?:/usr/bin/(?:env )?)?python(?:[23](?:\.\d{1,2})?)?( |$)}
 
       # The length of the longest shebang matching `SHEBANG_REGEX`.
       PYTHON_SHEBANG_MAX_LENGTH = T.let("#! /usr/bin/env pythonx.yyy ".length, Integer)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We should use `\A` to pick up shebangs at the start of files instead of
just anywhere in a given script.

See Homebrew/homebrew-core#227654 for an example where this can cause
problems.
