### PR TITLE
package/scripts/postinstall: add Homebrew to PATH.

### DIFF
--- a/package/scripts/postinstall
+++ b/package/scripts/postinstall
@@ -93,3 +93,12 @@ mkdir -vp "${user_api_cache_dir}"
 mv -v "${homebrew_directory}/cache_api/"* "${user_api_cache_dir}"
 chown -R "${homebrew_pkg_user}:staff" "${user_cache_dir}"
 rm -vrf "${homebrew_directory}/cache_api"
+
+# create paths.d file for /opt/homebrew installs
+# (/usr/local/bin is already in the PATH)
+if [[ -d "/etc/paths.d" && "${homebrew_directory}" == "/opt/homebrew" ]]
+then
+  mkdir -vp /etc/paths.d
+  echo "/opt/homebrew/bin" >/etc/paths.d/homebrew
+  chown root:wheel /etc/paths.d/homebrew
+fi


### PR DESCRIPTION
This is automatic for `/usr/local/bin/brew` but let's do it manually for `/opt/homebrew/bin/brew` too.

See also https://github.com/Homebrew/install/pull/988
Fixes https://github.com/Homebrew/install/issues/986