### PR TITLE
mcp_server: fix EOF handling.

### DIFF
--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -155,6 +155,8 @@ module Homebrew
         input = if ping_switch?
           { jsonrpc: JSON_RPC_VERSION, id: 1, method: "ping" }.to_json
         else
+          break if @stdin.eof?
+
           @stdin.gets
         end
         next if input.nil? || input.strip.empty?

--- a/Library/Homebrew/test/mcp_server_spec.rb
+++ b/Library/Homebrew/test/mcp_server_spec.rb
@@ -228,6 +228,8 @@ RSpec.describe Homebrew::McpServer do
     end
 
     it "exits on Interrupt" do
+      stdin.puts
+      stdin.rewind
       allow(stdin).to receive(:gets).and_raise(Interrupt)
       expect do
         server.run
@@ -237,6 +239,8 @@ RSpec.describe Homebrew::McpServer do
     end
 
     it "exits on error" do
+      stdin.puts
+      stdin.rewind
       allow(stdin).to receive(:gets).and_raise(StandardError, "fail")
       expect do
         server.run


### PR DESCRIPTION
We need to handle when `stdin` is closed but there's no interrupt signal.

Without this, the server will be stuck an in infinite busy loop.