### PR TITLE
Remove redundant `xattr` doctor check on systems without quarantine support

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1009,6 +1009,8 @@ module Homebrew
       end
 
       def check_cask_xattr
+        # If quarantine is not available, a warning is already shown by check_cask_quarantine_support so just return
+        return unless Cask::Quarantine.available?
         return "Unable to find `xattr`." unless File.exist?("/usr/bin/xattr")
 
         result = system_command "/usr/bin/xattr", args: ["-h"]


### PR DESCRIPTION
Follow-up to #20153

If cask quarantine isn't available on a system, don't run the `xattr` availability check in `brew doctor`. There is a separate check that displays a warning if quarantine isn't available, so having both is redundant