### PR TITLE
updating json with `cask/migrator`

### DIFF
--- a/Library/Homebrew/cask/migrator.rb
+++ b/Library/Homebrew/cask/migrator.rb
@@ -80,6 +80,7 @@ module Cask
       when ".json"
         json = JSON.parse(path.read)
         json["token"] = new_token
+        json["old_tokens"] = (json["old_tokens"] << old_token).uniq
         path.atomic_write json.to_json
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is not fixing entirely #19951
As seen in the issue, some casks are called through `.rb` file and not `.json` file. The problem is that the `.rb` doesn't contain an `old_tokens` field 