### PR TITLE
cli/named_args: don't warn about old tokens overlapping.

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -571,6 +571,7 @@ module Homebrew
         end
         return unless available
         return if Context.current.quiet?
+        return if cask&.old_tokens&.include?(ref)
 
         opoo package_conflicts_message(ref, loaded_type, cask)
       end


### PR DESCRIPTION
This avoids e.g.

```
Warning: Treating angband as a formula.
For the cask, use homebrew/cask/angband-app or specify the `--cask` flag.
To silence this message, use the `--formula` flag.
```

when running `brew install angband`.