### PR TITLE
fix: zsh completions for old cask names

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -96,6 +96,9 @@ module Homebrew
         download_and_cache_data! unless cache.key?("casks")
 
         Homebrew::API.write_names_file(all_casks.keys, "cask", regenerate:)
+
+        casks_completion = all_casks.keys + all_renames.keys
+        Homebrew::API.write_names_file(casks_completion.sort.uniq, "cask_completion", regenerate:)
       end
     end
   end

--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -86,7 +86,8 @@ __brew_casks() {
   local comp_cachename=brew_casks
 
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew casks) )
+    local cask_completion_names=$(brew --cache)/api/cask_completion_names.txt
+    list=( $( [[ -f $cask_completion_names ]] && cat "$cask_completion_names" || brew casks ) )
     _store_cache $comp_cachename list
   fi
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -90,7 +90,8 @@ __brew_casks() {
   local comp_cachename=brew_casks
 
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew casks) )
+    local cask_completion_names=$(brew --cache)/api/cask_completion_names.txt
+    list=( $( [[ -f $cask_completion_names ]] && cat "$cask_completion_names" || brew casks ) )
     _store_cache $comp_cachename list
   fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #20056 

Made a new file in the `cache_dir` containing old cask names as well, so as not to disturb the `brew casks` command. Updated the completions logic to take it from the new file if it exists, or else defaults to `brew casks`.
