### PR TITLE
Reapply "Make some of the `bundle` commands Sorbet `typed: true`"

### DIFF
--- a/Library/Homebrew/bundle/brew_dumper.rb
+++ b/Library/Homebrew/bundle/brew_dumper.rb
@@ -1,4 +1,4 @@
-# typed: false # rubocop:todo Sorbet/TrueSigil
+# typed: true
 # frozen_string_literal: true
 
 require "json"
@@ -189,7 +189,12 @@ module Homebrew
 
       class Topo < Hash
         include TSort
+
+        def each_key(&block)
+          keys.each(&block)
+        end
         alias tsort_each_node each_key
+
         def tsort_each_child(node, &block)
           fetch(node.downcase).sort.each(&block)
         end
@@ -230,8 +235,8 @@ module Homebrew
 
         odie <<~EOS
           Formulae dependency graph sorting failed (likely due to a circular dependency):
-          #{cycle_first}: #{topo[cycle_first]}
-          #{cycle_last}: #{topo[cycle_last]}
+          #{cycle_first}: #{topo[cycle_first] if topo}
+          #{cycle_last}: #{topo[cycle_last] if topo}
           Please run the following commands and try again:
             brew update
             brew uninstall --ignore-dependencies --force #{cycle_first} #{cycle_last}

--- a/Library/Homebrew/bundle/brew_dumper.rb
+++ b/Library/Homebrew/bundle/brew_dumper.rb
@@ -8,9 +8,7 @@ module Homebrew
   module Bundle
     # TODO: refactor into multiple modules
     module BrewDumper
-      module_function
-
-      def reset!
+      def self.reset!
         require "bundle/brew_services"
 
         Homebrew::Bundle::BrewServices.reset!
@@ -21,14 +19,14 @@ module Homebrew
         @formula_oldnames = nil
       end
 
-      def formulae
+      def self.formulae
         return @formulae if @formulae
 
         formulae_by_full_name
         @formulae
       end
 
-      def formulae_by_full_name(name = nil)
+      def self.formulae_by_full_name(name = nil)
         return @formulae_by_full_name[name] if name.present? && @formulae_by_full_name&.key?(name)
 
         require "formula"
@@ -51,11 +49,11 @@ module Homebrew
         {}
       end
 
-      def formulae_by_name(name)
+      def self.formulae_by_name(name)
         formulae_by_full_name(name) || @formulae_by_name[name]
       end
 
-      def dump(describe: false, no_restart: false)
+      def self.dump(describe: false, no_restart: false)
         require "bundle/brew_services"
 
         requested_formula = formulae.select do |f|
@@ -77,7 +75,7 @@ module Homebrew
         end.join("\n")
       end
 
-      def formula_aliases
+      def self.formula_aliases
         return @formula_aliases if @formula_aliases
 
         @formula_aliases = {}
@@ -96,7 +94,7 @@ module Homebrew
         @formula_aliases
       end
 
-      def formula_oldnames
+      def self.formula_oldnames
         return @formula_oldnames if @formula_oldnames
 
         @formula_oldnames = {}
@@ -115,7 +113,7 @@ module Homebrew
         @formula_oldnames
       end
 
-      def add_formula(formula)
+      private_class_method def self.add_formula(formula)
         hash = formula_to_hash formula
 
         @formulae_by_name[hash[:name]] = hash
@@ -123,9 +121,8 @@ module Homebrew
 
         hash
       end
-      private_class_method :add_formula
 
-      def formula_to_hash(formula)
+      private_class_method def self.formula_to_hash(formula)
         keg = if formula.linked?
           link = true if formula.keg_only?
           formula.linked_keg
@@ -185,7 +182,6 @@ module Homebrew
           official_tap:             formula.tap&.official? || false,
         }
       end
-      private_class_method :formula_to_hash
 
       class Topo < Hash
         include TSort
@@ -200,7 +196,7 @@ module Homebrew
         end
       end
 
-      def sort!(formulae)
+      private_class_method def self.sort!(formulae)
         # Step 1: Sort by formula full name while putting tap formulae behind core formulae.
         #         So we can have a nicer output.
         formulae = formulae.sort do |a, b|
@@ -243,7 +239,6 @@ module Homebrew
             brew install #{cycle_first} #{cycle_last}
         EOS
       end
-      private_class_method :sort!
     end
   end
 end

--- a/Library/Homebrew/bundle/brew_dumper.rbi
+++ b/Library/Homebrew/bundle/brew_dumper.rbi
@@ -1,0 +1,5 @@
+# typed: true
+
+module Homebrew::Bundle::BrewDumper
+  include Kernel
+end

--- a/Library/Homebrew/bundle/brew_dumper.rbi
+++ b/Library/Homebrew/bundle/brew_dumper.rbi
@@ -1,5 +1,0 @@
-# typed: true
-
-module Homebrew::Bundle::BrewDumper
-  include Kernel
-end

--- a/Library/Homebrew/bundle/checker.rb
+++ b/Library/Homebrew/bundle/checker.rb
@@ -1,4 +1,4 @@
-# typed: false # rubocop:todo Sorbet/TrueSigil
+# typed: true
 # frozen_string_literal: true
 
 module Homebrew
@@ -23,7 +23,7 @@ module Homebrew
           else
             "needs to be installed or updated."
           end
-          "#{self.class::PACKAGE_TYPE_NAME} #{name} #{reason}"
+          "#{self.class.const_get(:PACKAGE_TYPE_NAME)} #{name} #{reason}"
         end
 
         def full_check(packages, no_upgrade:)
@@ -33,7 +33,7 @@ module Homebrew
 
         def checkable_entries(all_entries)
           require "bundle/skipper"
-          all_entries.select { |e| e.type == self.class::PACKAGE_TYPE }
+          all_entries.select { |e| e.type == self.class.const_get(:PACKAGE_TYPE) }
                      .reject(&Bundle::Skipper.method(:skip?))
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
  - And `brew typecheck --update` this time to make sure Tapioca doesn't mess with the RBI file!
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This reverts commit 68dbf12220f9a52ddf5ca5eb3aa1b356aa42da3a that was a revert of commit 68596ec720a50f44ae9c30c5806aa7f2d4bcc96f because I put the RBI file in the wrong place and Tapioca got rid of it, causing this week's release to be blocked.
