### PR TITLE
docs: fix HTML Proofer in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,6 +69,12 @@ jobs:
         working-directory: docs
         run: ../script/generate-api-samples.rb --template
 
+      - name: Cache HTML Proofer
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: tmp/.htmlproofer
+          key: ${{ runner.os }}-htmlproofer
+
       - name: Build the site and check for broken links
         working-directory: docs
         run: bundle exec rake test

--- a/docs/Rakefile
+++ b/docs/Rakefile
@@ -38,10 +38,12 @@ task test: :build do
       %r{https://github.com/},
       %r{https://homebrew.1password.com/},
       "https://legacy.python.org/dev/peps/pep-0453/#recommendations-for-downstream-distributors",
+      "https://metacpan.org/pod/local::lib",
     ],
     cache:               {
       timeframe: {
-        external: "1h",
+        external: "1d",
+        internal: "1h",
       },
     },
   ).run


### PR DESCRIPTION
- Add caching to make this build faster and less flaky.
- Skip the currently flaky URL.
- Cache external links for longer.