### PR TITLE
dev-cmd/bump-formula-pr: release notes as proper html link

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -404,11 +404,14 @@ module Homebrew
               # maximum length of PR body is 65,536 characters so let's truncate release notes to half of that.
               body = Formatter.truncate(github_release_data["body"], max: 32_768)
 
+              # Ensure the URL is properly HTML encoded to handle any quotes or other special characters
+              html_url = CGI.escapeHTML(github_release_data["html_url"])
+
               formula_pr_message += <<~XML
                 <details>
                   <summary>#{pre}release notes</summary>
                   <pre>#{body}</pre>
-                  <p>View the full release notes at #{github_release_data["html_url"]}.</p>
+                  <p>View the full release notes at <a href="#{html_url}">#{html_url}</a>.</p>
                 </details>
               XML
             end


### PR DESCRIPTION
The release notes link is not rendered as a proper hyperlink, this fixes it.

Few examples of PRs with unclickable links:
* https://github.com/Homebrew/homebrew-core/pull/228256
* https://github.com/Homebrew/homebrew-core/pull/228263
* https://github.com/Homebrew/homebrew-core/pull/228267


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
