### PR TITLE
Fix "undefined method 'name' for an instance of FormulaInstaller"

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -327,7 +327,7 @@ module Homebrew
         end
 
         if dry_run
-          if (formulae_name_to_install = formula_installers.map(&:formula))
+          if (formulae_name_to_install = formula_installers.map { |fi| fi.formula.name })
             ohai "Would install #{Utils.pluralize("formula", formulae_name_to_install.count,
                                                   plural: "e", include_count: true)}:"
             puts formulae_name_to_install.join(" ")

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -327,7 +327,7 @@ module Homebrew
         end
 
         if dry_run
-          if (formulae_name_to_install = formula_installers.map(&:name))
+          if (formulae_name_to_install = formula_installers.map(&:formula))
             ohai "Would install #{Utils.pluralize("formula", formulae_name_to_install.count,
                                                   plural: "e", include_count: true)}:"
             puts formulae_name_to_install.join(" ")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #20199.
- Because `name` is not a method on `FormulaInstaller`, instead `formula` shows the name.

Before:

```
$ brew install -n hello
Error: undefined method 'name' for an instance of FormulaInstaller
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/install.rb:330:in 'Array#map'
/opt/homebrew/Library/Homebrew/install.rb:330:in 'Homebrew::Install.install_formulae'
```

After:

```
$ brew install -n hello
==> Would install 1 formula:
hello
```
