### PR TITLE
docs/Homebrew-on-Linux: update dnf5 syntax, centos/rhel section

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -61,7 +61,14 @@ To install build tools, paste at a terminal prompt:
   sudo apt-get install build-essential procps curl file git
   ```
 
-- **Fedora, CentOS Stream, or RHEL**
+- **Fedora**
+
+  ```sh
+  sudo dnf group install development-tools
+  sudo dnf install procps-ng curl file
+  ```
+
+- **CentOS Stream or RHEL**
 
   ```sh
   sudo dnf group install 'Development Tools'


### PR DESCRIPTION
Tested on Fedora 42 and RHEL 10 (latest for both).

Note: Fedora 42 uses dnf5 while CentOS Stream/RHEL 10 use dnf4

See:
- https://github.com/Homebrew/install/pull/894
- https://github.com/Homebrew/install/blob/0fd28f83c8a60d8a8fc1d15a1f023d01aa4b7de5/install.sh#L1133

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
