### PR TITLE
bundle: Rename "brews" to "formulae" for consistency

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -304,7 +304,7 @@ Sorbet/StrictSigil:
     - "Homebrew/utils/ruby_check_version_script.rb" # A standalone script.
     - "Homebrew/{standalone,startup}/*.rb" # These are loaded before sorbet-runtime
     - "Homebrew/test/**/*.rb"
-    - "Homebrew/bundle/{brew_dumper,checker,commands/exec}.rb" # These aren't typed: true yet.
+    - "Homebrew/bundle/{formula_dumper,checker,commands/exec}.rb" # These aren't typed: true yet.
 
 Sorbet/TrueSigil:
   Enabled: true

--- a/Library/Homebrew/bundle/brew_checker.rb
+++ b/Library/Homebrew/bundle/brew_checker.rb
@@ -1,7 +1,7 @@
 # typed: true # rubocop:todo Sorbet/StrictSigil
 # frozen_string_literal: true
 
-require "bundle/brew_installer"
+require "bundle/formula_installer"
 
 module Homebrew
   module Bundle
@@ -11,7 +11,7 @@ module Homebrew
         PACKAGE_TYPE_NAME = "Formula"
 
         def installed_and_up_to_date?(formula, no_upgrade: false)
-          Homebrew::Bundle::BrewInstaller.formula_installed_and_up_to_date?(formula, no_upgrade:)
+          Homebrew::Bundle::FormulaInstaller.formula_installed_and_up_to_date?(formula, no_upgrade:)
         end
       end
     end

--- a/Library/Homebrew/bundle/brew_service_checker.rb
+++ b/Library/Homebrew/bundle/brew_service_checker.rb
@@ -24,8 +24,8 @@ module Homebrew
         end
 
         def entry_to_formula(entry)
-          require "bundle/brew_installer"
-          Homebrew::Bundle::BrewInstaller.new(entry.name, entry.options)
+          require "bundle/formula_installer"
+          Homebrew::Bundle::FormulaInstaller.new(entry.name, entry.options)
         end
 
         def formula_needs_to_start?(formula)
@@ -38,8 +38,8 @@ module Homebrew
         end
 
         def lookup_old_name(service_name)
-          require "bundle/brew_dumper"
-          @old_names ||= Homebrew::Bundle::BrewDumper.formula_oldnames
+          require "bundle/formula_dumper"
+          @old_names ||= Homebrew::Bundle::FormulaDumper.formula_oldnames
           old_name = @old_names[service_name]
           old_name ||= @old_names[service_name.split("/").last]
           old_name

--- a/Library/Homebrew/bundle/checker.rb
+++ b/Library/Homebrew/bundle/checker.rb
@@ -139,14 +139,14 @@ module Homebrew
 
       def self.reset!
         require "bundle/cask_dumper"
-        require "bundle/brew_dumper"
+        require "bundle/formula_dumper"
         require "bundle/mac_app_store_dumper"
         require "bundle/tap_dumper"
         require "bundle/brew_services"
 
         @dsl = nil
         Homebrew::Bundle::CaskDumper.reset!
-        Homebrew::Bundle::BrewDumper.reset!
+        Homebrew::Bundle::FormulaDumper.reset!
         Homebrew::Bundle::MacAppStoreDumper.reset!
         Homebrew::Bundle::TapDumper.reset!
         Homebrew::Bundle::BrewServices.reset!

--- a/Library/Homebrew/bundle/commands/dump.rb
+++ b/Library/Homebrew/bundle/commands/dump.rb
@@ -7,9 +7,10 @@ module Homebrew
   module Bundle
     module Commands
       module Dump
-        def self.run(global:, file:, describe:, force:, no_restart:, taps:, brews:, casks:, mas:, whalebrew:, vscode:)
+        def self.run(global:, file:, describe:, force:, no_restart:, taps:, formulae:, casks:, mas:, whalebrew:,
+                     vscode:)
           Homebrew::Bundle::Dumper.dump_brewfile(
-            global:, file:, describe:, force:, no_restart:, taps:, brews:, casks:, mas:, whalebrew:, vscode:,
+            global:, file:, describe:, force:, no_restart:, taps:, formulae:, casks:, mas:, whalebrew:, vscode:,
           )
         end
       end

--- a/Library/Homebrew/bundle/commands/list.rb
+++ b/Library/Homebrew/bundle/commands/list.rb
@@ -8,11 +8,11 @@ module Homebrew
   module Bundle
     module Commands
       module List
-        def self.run(global:, file:, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
+        def self.run(global:, file:, formulae:, casks:, taps:, mas:, whalebrew:, vscode:)
           parsed_entries = Brewfile.read(global:, file:).entries
           Homebrew::Bundle::Lister.list(
             parsed_entries,
-            brews:, casks:, taps:, mas:, whalebrew:, vscode:,
+            formulae:, casks:, taps:, mas:, whalebrew:, vscode:,
           )
         end
       end

--- a/Library/Homebrew/bundle/dumper.rb
+++ b/Library/Homebrew/bundle/dumper.rb
@@ -13,9 +13,9 @@ module Homebrew
         true
       end
 
-      def self.build_brewfile(describe:, no_restart:, brews:, taps:, casks:, mas:, whalebrew:, vscode:)
+      def self.build_brewfile(describe:, no_restart:, formulae:, taps:, casks:, mas:, whalebrew:, vscode:)
         require "bundle/tap_dumper"
-        require "bundle/brew_dumper"
+        require "bundle/formula_dumper"
         require "bundle/cask_dumper"
         require "bundle/mac_app_store_dumper"
         require "bundle/whalebrew_dumper"
@@ -23,7 +23,7 @@ module Homebrew
 
         content = []
         content << TapDumper.dump if taps
-        content << BrewDumper.dump(describe:, no_restart:) if brews
+        content << FormulaDumper.dump(describe:, no_restart:) if formulae
         content << CaskDumper.dump(describe:) if casks
         content << MacAppStoreDumper.dump if mas
         content << WhalebrewDumper.dump if whalebrew
@@ -31,11 +31,11 @@ module Homebrew
         "#{content.reject(&:empty?).join("\n")}\n"
       end
 
-      def self.dump_brewfile(global:, file:, describe:, force:, no_restart:, brews:, taps:, casks:, mas:, whalebrew:,
-                             vscode:)
+      def self.dump_brewfile(global:, file:, describe:, force:, no_restart:, formulae:, taps:, casks:, mas:,
+                             whalebrew:, vscode:)
         path = brewfile_path(global:, file:)
         can_write_to_brewfile?(path, force:)
-        content = build_brewfile(describe:, no_restart:, taps:, brews:, casks:, mas:, whalebrew:, vscode:)
+        content = build_brewfile(describe:, no_restart:, taps:, formulae:, casks:, mas:, whalebrew:, vscode:)
         write_file path, content
       end
 

--- a/Library/Homebrew/bundle/formula_dumper.rb
+++ b/Library/Homebrew/bundle/formula_dumper.rb
@@ -7,7 +7,7 @@ require "tsort"
 module Homebrew
   module Bundle
     # TODO: refactor into multiple modules
-    module BrewDumper
+    module FormulaDumper
       def self.reset!
         require "bundle/brew_services"
 

--- a/Library/Homebrew/bundle/formula_installer.rb
+++ b/Library/Homebrew/bundle/formula_installer.rb
@@ -3,7 +3,7 @@
 
 module Homebrew
   module Bundle
-    class BrewInstaller
+    class FormulaInstaller
       def self.reset!
         @installed_formulae = nil
         @outdated_formulae = nil
@@ -179,13 +179,13 @@ module Homebrew
         return true if array.include?(formula)
         return true if array.include?(formula.split("/").last)
 
-        require "bundle/brew_dumper"
-        old_names = Homebrew::Bundle::BrewDumper.formula_oldnames
+        require "bundle/formula_dumper"
+        old_names = Homebrew::Bundle::FormulaDumper.formula_oldnames
         old_name = old_names[formula]
         old_name ||= old_names[formula.split("/").last]
         return true if old_name && array.include?(old_name)
 
-        resolved_full_name = Homebrew::Bundle::BrewDumper.formula_aliases[formula]
+        resolved_full_name = Homebrew::Bundle::FormulaDumper.formula_aliases[formula]
         return false unless resolved_full_name
         return true if array.include?(resolved_full_name)
         return true if array.include?(resolved_full_name.split("/").last)
@@ -219,14 +219,14 @@ module Homebrew
       end
 
       def self.formulae
-        require "bundle/brew_dumper"
-        Homebrew::Bundle::BrewDumper.formulae
+        require "bundle/formula_dumper"
+        Homebrew::Bundle::FormulaDumper.formulae
       end
 
       private
 
       def installed?
-        BrewInstaller.formula_installed?(@name)
+        FormulaInstaller.formula_installed?(@name)
       end
 
       def linked?
@@ -242,7 +242,7 @@ module Homebrew
       end
 
       def upgradable?
-        BrewInstaller.formula_upgradable?(@name)
+        FormulaInstaller.formula_upgradable?(@name)
       end
 
       def conflicts_with
@@ -250,8 +250,8 @@ module Homebrew
           conflicts_with = Set.new
           conflicts_with += @conflicts_with_arg
 
-          require "bundle/brew_dumper"
-          if (formula = Homebrew::Bundle::BrewDumper.formulae_by_full_name(@full_name)) &&
+          require "bundle/formula_dumper"
+          if (formula = Homebrew::Bundle::FormulaDumper.formulae_by_full_name(@full_name)) &&
              (formula_conflicts_with = formula[:conflicts_with])
             conflicts_with += formula_conflicts_with
           end
@@ -262,7 +262,7 @@ module Homebrew
 
       def resolve_conflicts!(verbose:)
         conflicts_with.each do |conflict|
-          next unless BrewInstaller.formula_installed?(conflict)
+          next unless FormulaInstaller.formula_installed?(conflict)
 
           if verbose
             puts <<~EOS
@@ -293,7 +293,7 @@ module Homebrew
           return false
         end
 
-        BrewInstaller.installed_formulae << @name
+        FormulaInstaller.installed_formulae << @name
         @changed = true
         true
       end

--- a/Library/Homebrew/bundle/installer.rb
+++ b/Library/Homebrew/bundle/installer.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundle/dsl"
-require "bundle/brew_installer"
+require "bundle/formula_installer"
 require "bundle/cask_installer"
 require "bundle/mac_app_store_installer"
 require "bundle/whalebrew_installer"
@@ -27,8 +27,8 @@ module Homebrew
           cls = case type
           when :brew
             options = entry.options
-            verb = "Upgrading" if Homebrew::Bundle::BrewInstaller.formula_upgradable?(name)
-            Homebrew::Bundle::BrewInstaller
+            verb = "Upgrading" if Homebrew::Bundle::FormulaInstaller.formula_upgradable?(name)
+            Homebrew::Bundle::FormulaInstaller
           when :cask
             options = entry.options
             verb = "Upgrading" if Homebrew::Bundle::CaskInstaller.cask_upgradable?(name)

--- a/Library/Homebrew/bundle/lister.rb
+++ b/Library/Homebrew/bundle/lister.rb
@@ -4,14 +4,14 @@
 module Homebrew
   module Bundle
     module Lister
-      def self.list(entries, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
+      def self.list(entries, formulae:, casks:, taps:, mas:, whalebrew:, vscode:)
         entries.each do |entry|
-          puts entry.name if show?(entry.type, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
+          puts entry.name if show?(entry.type, formulae:, casks:, taps:, mas:, whalebrew:, vscode:)
         end
       end
 
-      private_class_method def self.show?(type, brews:, casks:, taps:, mas:, whalebrew:, vscode:)
-        return true if brews && type == :brew
+      private_class_method def self.show?(type, formulae:, casks:, taps:, mas:, whalebrew:, vscode:)
+        return true if formulae && type == :brew
         return true if casks && type == :cask
         return true if taps && type == :tap
         return true if mas && type == :mas

--- a/Library/Homebrew/bundle/skipper.rb
+++ b/Library/Homebrew/bundle/skipper.rb
@@ -9,7 +9,7 @@ module Homebrew
       class << self
         sig { params(entry: Dsl::Entry, silent: T::Boolean).returns(T::Boolean) }
         def skip?(entry, silent: false)
-          require "bundle/brew_dumper"
+          require "bundle/formula_dumper"
 
           return true if @failed_taps&.any? do |tap|
             prefix = "#{tap}/"

--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -97,7 +97,7 @@ module Homebrew
                env:         [:bundle_install_cleanup, "--global"]
         switch "--all",
                description: "`list` all dependencies."
-        switch "--formula", "--brews",
+        switch "--formula", "--formulae",
                description: "`list`, `dump` or `cleanup` Homebrew formula dependencies."
         switch "--cask", "--casks",
                description: "`list`, `dump` or `cleanup` Homebrew cask dependencies."
@@ -162,7 +162,7 @@ module Homebrew
         zap = args.zap?
         Homebrew::Bundle.upgrade_formulae = args.upgrade_formulae
 
-        no_type_args = !args.brews? && !args.casks? && !args.taps? && !args.mas? && !args.whalebrew? && !args.vscode?
+        no_type_args = [args.formulae?, args.casks?, args.taps?, args.mas?, args.whalebrew?, args.vscode?].none?
 
         if args.install?
           if [nil, "install", "upgrade"].include?(subcommand)
@@ -209,7 +209,7 @@ module Homebrew
             describe:   args.describe?,
             no_restart: args.no_restart?,
             taps:       args.taps? || no_type_args,
-            brews:      args.brews? || no_type_args,
+            formulae:   args.formulae? || no_type_args,
             casks:      args.casks? || no_type_args,
             mas:        args.mas? || no_type_args,
             whalebrew:  args.whalebrew? || no_type_args,
@@ -222,7 +222,7 @@ module Homebrew
           require "bundle/commands/cleanup"
           Homebrew::Bundle::Commands::Cleanup.run(
             global:, file:, force:, zap:,
-            brews:  args.brews? || no_type_args,
+            formulae:  args.formulae? || no_type_args,
             casks:  args.casks? || no_type_args,
             taps:   args.taps? || no_type_args,
             vscode: args.vscode? || no_type_args
@@ -235,7 +235,7 @@ module Homebrew
           Homebrew::Bundle::Commands::List.run(
             global:,
             file:,
-            brews:     args.brews? || args.all? || no_type_args,
+            formulae:  args.formulae? || args.all? || no_type_args,
             casks:     args.casks? || args.all?,
             taps:      args.taps? || args.all?,
             mas:       args.mas? || args.all?,
@@ -243,9 +243,9 @@ module Homebrew
             vscode:    args.vscode? || args.all?,
           )
         when "add", "remove"
-          # We intentionally omit the `s` from `brews`, `casks`, and `taps` for ease of handling later.
+          # We intentionally omit the s from `brews`, `casks`, and `taps` for ease of handling later.
           type_hash = {
-            brew:      args.brews?,
+            brew:      args.formulae?,
             cask:      args.casks?,
             tap:       args.taps?,
             mas:       args.mas?,

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -415,7 +415,7 @@ module OS
           <<~EOS
             Your Cellar and TEMP directories are on different volumes.
             macOS won't move relative symlinks across volumes unless the target file already
-            exists. Brews known to be affected by this are Git and Narwhal.
+            exists. Formulae known to be affected by this are Git and Narwhal.
 
             You should set the "HOMEBREW_TEMP" environment variable to a suitable
             directory on the same volume as your Cellar.

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/bundle.rbi
@@ -15,9 +15,6 @@ class Homebrew::Cmd::Bundle::Args < Homebrew::CLI::Args
   def all?; end
 
   sig { returns(T::Boolean) }
-  def brews?; end
-
-  sig { returns(T::Boolean) }
   def cask?; end
 
   sig { returns(T::Boolean) }
@@ -43,6 +40,9 @@ class Homebrew::Cmd::Bundle::Args < Homebrew::CLI::Args
 
   sig { returns(T::Boolean) }
   def formula?; end
+
+  sig { returns(T::Boolean) }
+  def formulae?; end
 
   sig { returns(T::Boolean) }
   def global?; end

--- a/Library/Homebrew/test/bundle/brew_dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_dumper_spec.rb
@@ -2,7 +2,7 @@
 
 require "ostruct"
 require "bundle"
-require "bundle/brew_dumper"
+require "bundle/formula_dumper"
 require "tsort"
 require "formula"
 require "tab"
@@ -10,7 +10,7 @@ require "utils/bottles"
 
 # TODO: remove OpenStruct usage
 # rubocop:todo Style/OpenStructUse
-RSpec.describe Homebrew::Bundle::BrewDumper do
+RSpec.describe Homebrew::Bundle::FormulaDumper do
   subject(:dumper) { described_class }
 
   let(:foo) do
@@ -184,7 +184,7 @@ RSpec.describe Homebrew::Bundle::BrewDumper do
 
     it "exits on cyclic exceptions" do
       expect(Formula).to receive(:installed).and_return([foo, bar, baz])
-      expect_any_instance_of(Homebrew::Bundle::BrewDumper::Topo).to receive(:tsort).and_raise(
+      expect_any_instance_of(Homebrew::Bundle::FormulaDumper::Topo).to receive(:tsort).and_raise(
         TSort::Cyclic,
         'topological sort failed: ["foo", "bar"]',
       )

--- a/Library/Homebrew/test/bundle/brew_installer_spec.rb
+++ b/Library/Homebrew/test/bundle/brew_installer_spec.rb
@@ -2,11 +2,11 @@
 
 require "bundle"
 require "formula"
-require "bundle/brew_installer"
-require "bundle/brew_dumper"
+require "bundle/formula_installer"
+require "bundle/formula_dumper"
 require "bundle/brew_services"
 
-RSpec.describe Homebrew::Bundle::BrewInstaller do
+RSpec.describe Homebrew::Bundle::FormulaInstaller do
   let(:formula_name) { "mysql" }
   let(:options) { { args: ["with-option"] } }
   let(:installer) { described_class.new(formula_name, options) }
@@ -182,8 +182,8 @@ RSpec.describe Homebrew::Bundle::BrewInstaller do
 
     context "when the conflicts_with option is provided" do
       before do
-        allow(Homebrew::Bundle::BrewDumper).to receive(:formulae_by_full_name).and_call_original
-        allow(Homebrew::Bundle::BrewDumper).to receive(:formulae_by_full_name).with("mysql").and_return(
+        allow(Homebrew::Bundle::FormulaDumper).to receive(:formulae_by_full_name).and_call_original
+        allow(Homebrew::Bundle::FormulaDumper).to receive(:formulae_by_full_name).with("mysql").and_return(
           name:           "mysql",
           conflicts_with: ["mysql55"],
         )
@@ -311,7 +311,7 @@ RSpec.describe Homebrew::Bundle::BrewInstaller do
   describe ".outdated_formulae" do
     it "calls Homebrew" do
       described_class.reset!
-      expect(Homebrew::Bundle::BrewDumper).to receive(:formulae).and_return(
+      expect(Homebrew::Bundle::FormulaDumper).to receive(:formulae).and_return(
         [
           { name: "a", outdated?: true },
           { name: "b", outdated?: true },
@@ -325,7 +325,7 @@ RSpec.describe Homebrew::Bundle::BrewInstaller do
   describe ".pinned_formulae" do
     it "calls Homebrew" do
       described_class.reset!
-      expect(Homebrew::Bundle::BrewDumper).to receive(:formulae).and_return(
+      expect(Homebrew::Bundle::FormulaDumper).to receive(:formulae).and_return(
         [
           { name: "a", pinned?: true },
           { name: "b", pinned?: true },
@@ -338,11 +338,11 @@ RSpec.describe Homebrew::Bundle::BrewInstaller do
 
   describe ".formula_installed_and_up_to_date?" do
     before do
-      Homebrew::Bundle::BrewDumper.reset!
+      Homebrew::Bundle::FormulaDumper.reset!
       described_class.reset!
       allow(described_class).to receive(:outdated_formulae).and_return(%w[bar])
       allow_any_instance_of(Formula).to receive(:outdated?).and_return(true)
-      allow(Homebrew::Bundle::BrewDumper).to receive(:formulae).and_return [
+      allow(Homebrew::Bundle::FormulaDumper).to receive(:formulae).and_return [
         {
           name:         "foo",
           full_name:    "homebrew/tap/foo",

--- a/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
         { name: "builddependency2", full_name: "builddependency2" },
         { name: "caskdependency", full_name: "homebrew/tap/caskdependency" },
       ].map { |formula| dependencies_arrays_hash.merge(formula) }
-      allow(Homebrew::Bundle::BrewDumper).to receive(:formulae).and_return(formulae_hash)
+      allow(Homebrew::Bundle::FormulaDumper).to receive(:formulae).and_return(formulae_hash)
 
       formulae_hash.each do |hash_formula|
         name = hash_formula[:name]
@@ -106,7 +106,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
 
     it "ignores formulae with .keepme references when computing which formulae to uninstall" do
       name = full_name ="c"
-      allow(Homebrew::Bundle::BrewDumper).to receive(:formulae).and_return([{ name:, full_name: }])
+      allow(Homebrew::Bundle::FormulaDumper).to receive(:formulae).and_return([{ name:, full_name: }])
       f = formula(name) { url "#{name}-1.0" }
       stub_formula_loader f, name
 
@@ -159,7 +159,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
       expect { described_class.run(force: true) }.to output(/Uninstalled 2 casks/).to_stdout
     end
 
-    it "does not uninstall casks if --brews is disabled" do
+    it "does not uninstall casks if --formulae is disabled" do
       expect(Kernel).not_to receive(:system)
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
       expect { described_class.run(force: true, casks: false) }.not_to output.to_stdout
@@ -206,7 +206,7 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     it "does not uninstall formulae if --casks is disabled" do
       expect(Kernel).not_to receive(:system)
       expect(described_class).to receive(:system_output_no_stderr).and_return("")
-      expect { described_class.run(force: true, brews: false) }.not_to output.to_stdout
+      expect { described_class.run(force: true, formulae: false) }.not_to output.to_stdout
     end
   end
 

--- a/Library/Homebrew/test/bundle/commands/dump_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/dump_spec.rb
@@ -3,14 +3,14 @@
 require "bundle"
 require "bundle/commands/dump"
 require "bundle/cask_dumper"
-require "bundle/brew_dumper"
+require "bundle/formula_dumper"
 require "bundle/tap_dumper"
 require "bundle/whalebrew_dumper"
 require "bundle/vscode_extension_dumper"
 
 RSpec.describe Homebrew::Bundle::Commands::Dump do
   subject(:dump) do
-    described_class.run(global:, file: nil, describe: false, force:, no_restart: false, taps: true, brews: true,
+    described_class.run(global:, file: nil, describe: false, force:, no_restart: false, taps: true, formulae: true,
                         casks: true, mas: true, whalebrew: true, vscode: true)
   end
 
@@ -19,7 +19,7 @@ RSpec.describe Homebrew::Bundle::Commands::Dump do
 
   before do
     Homebrew::Bundle::CaskDumper.reset!
-    Homebrew::Bundle::BrewDumper.reset!
+    Homebrew::Bundle::FormulaDumper.reset!
     Homebrew::Bundle::TapDumper.reset!
     Homebrew::Bundle::WhalebrewDumper.reset!
     Homebrew::Bundle::VscodeExtensionDumper.reset!
@@ -39,7 +39,7 @@ RSpec.describe Homebrew::Bundle::Commands::Dump do
 
     it "exits before doing any work" do
       expect(Homebrew::Bundle::TapDumper).not_to receive(:dump)
-      expect(Homebrew::Bundle::BrewDumper).not_to receive(:dump)
+      expect(Homebrew::Bundle::FormulaDumper).not_to receive(:dump)
       expect(Homebrew::Bundle::CaskDumper).not_to receive(:dump)
       expect(Homebrew::Bundle::WhalebrewDumper).not_to receive(:dump)
       expect do

--- a/Library/Homebrew/test/bundle/commands/install_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/install_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     it "does not raise an error" do
       allow(Homebrew::Bundle::TapInstaller).to receive(:preinstall).and_return(false)
       allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive(:preinstall).and_return(false)
-      allow(Homebrew::Bundle::BrewInstaller).to receive_messages(preinstall: true, install: true)
+      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall: true, install: true)
       allow(Homebrew::Bundle::CaskInstaller).to receive_messages(preinstall: true, install: true)
       allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall: true, install: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
@@ -40,7 +40,7 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     it "#dsl returns a valid DSL" do
       allow(Homebrew::Bundle::TapInstaller).to receive(:preinstall).and_return(false)
       allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive(:preinstall).and_return(false)
-      allow(Homebrew::Bundle::BrewInstaller).to receive_messages(preinstall: true, install: true)
+      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall: true, install: true)
       allow(Homebrew::Bundle::CaskInstaller).to receive_messages(preinstall: true, install: true)
       allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall: true, install: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
@@ -49,7 +49,7 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     end
 
     it "does not raise an error when skippable" do
-      expect(Homebrew::Bundle::BrewInstaller).not_to receive(:install)
+      expect(Homebrew::Bundle::FormulaInstaller).not_to receive(:install)
 
       allow(Homebrew::Bundle::Skipper).to receive(:skip?).and_return(true)
       allow_any_instance_of(Pathname).to receive(:read)
@@ -58,7 +58,7 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     end
 
     it "exits on failures" do
-      allow(Homebrew::Bundle::BrewInstaller).to receive_messages(preinstall: true, install: false)
+      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall: true, install: false)
       allow(Homebrew::Bundle::CaskInstaller).to receive_messages(preinstall: true, install: false)
       allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall: true, install: false)
       allow(Homebrew::Bundle::TapInstaller).to receive_messages(preinstall: true, install: false)
@@ -71,7 +71,7 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
     it "skips installs from failed taps" do
       allow(Homebrew::Bundle::CaskInstaller).to receive(:preinstall).and_return(false)
       allow(Homebrew::Bundle::TapInstaller).to receive_messages(preinstall: true, install: false)
-      allow(Homebrew::Bundle::BrewInstaller).to receive_messages(preinstall: true, install: true)
+      allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(preinstall: true, install: true)
       allow(Homebrew::Bundle::MacAppStoreInstaller).to receive_messages(preinstall: true, install: true)
       allow(Homebrew::Bundle::VscodeExtensionInstaller).to receive_messages(preinstall: true, install: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)

--- a/Library/Homebrew/test/bundle/commands/list_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/list_spec.rb
@@ -4,9 +4,11 @@ require "bundle"
 require "bundle/commands/list"
 
 RSpec.describe Homebrew::Bundle::Commands::List do
-  subject(:list) { described_class.run(global: false, file: nil, brews:, casks:, taps:, mas:, whalebrew:, vscode:) }
+  subject(:list) do
+    described_class.run(global: false, file: nil, formulae:, casks:, taps:, mas:, whalebrew:, vscode:)
+  end
 
-  let(:brews) { true }
+  let(:formulae) { true }
   let(:casks) { false }
   let(:taps) { false }
   let(:mas) { false }
@@ -38,7 +40,7 @@ RSpec.describe Homebrew::Bundle::Commands::List do
     describe "limiting when certain options are passed" do
       types_and_deps = {
         taps:      "phinze/cask",
-        brews:     "mysql",
+        formulae:  "mysql",
         casks:     "google-chrome",
         mas:       "1Password",
         whalebrew: "whalebrew/imagemagick",
@@ -56,7 +58,7 @@ RSpec.describe Homebrew::Bundle::Commands::List do
         verb = (options_list.length == 1 && "is") || "are"
 
         context "when #{opts} #{verb} passed" do
-          let(:brews) { args_hash[:brews] }
+          let(:formulae) { args_hash[:formulae] }
           let(:casks) { args_hash[:casks] }
           let(:taps) { args_hash[:taps] }
           let(:mas) { args_hash[:mas] }

--- a/Library/Homebrew/test/bundle/dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/dumper_spec.rb
@@ -2,7 +2,7 @@
 
 require "bundle"
 require "bundle/dumper"
-require "bundle/brew_dumper"
+require "bundle/formula_dumper"
 require "bundle/tap_dumper"
 require "bundle/cask_dumper"
 require "bundle/mac_app_store_dumper"
@@ -22,7 +22,7 @@ RSpec.describe Homebrew::Bundle::Dumper do
         cask_installed?: true, mas_installed?: false, whalebrew_installed?: false,
         vscode_installed?: false
       )
-    Homebrew::Bundle::BrewDumper.reset!
+    Homebrew::Bundle::FormulaDumper.reset!
     Homebrew::Bundle::TapDumper.reset!
     Homebrew::Bundle::CaskDumper.reset!
     Homebrew::Bundle::MacAppStoreDumper.reset!
@@ -49,7 +49,7 @@ RSpec.describe Homebrew::Bundle::Dumper do
 
   it "generates output" do
     expect(dumper.build_brewfile(
-             describe: false, no_restart: false, brews: true, taps: true, casks: true, mas: true,
+             describe: false, no_restart: false, formulae: true, taps: true, casks: true, mas: true,
              whalebrew: true, vscode: true
            )).to eql("cask \"google-chrome\"\ncask \"java\"\ncask \"iterm2-beta\"\n")
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Homebrew Bundle referred to formulae as "brews". But it referred to casks as "casks" and taps as "taps".
- Let's use the same terminology everywhere.
- (I know that `brew "hello"` is the formula syntax in the Brewfile, so I'm not changing that (though would be up for it, in a backwards compatible manner), just making the code more consistent.)
