### PR TITLE
cmd/info: fix `brew info <formula>`

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -57,8 +57,7 @@ module Homebrew
         switch "--eval-all",
                depends_on:  "--json",
                description: "Evaluate all available formulae and casks, whether installed or not, to print their " \
-                            "JSON.",
-               env:         :eval_all
+                            "JSON."
         switch "--variations",
                depends_on:  "--json",
                description: "Include the variations hash in each formula's JSON output."


### PR DESCRIPTION
Follow-up to #20204: as with `brew deps`, don't set `--eval-all` from `HOMEBREW_EVAL_ALL` for `brew info`.  
