### PR TITLE
style: run shfmt on real brew

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -298,7 +298,7 @@ module Homebrew
 
     def self.shell_scripts
       [
-        HOMEBREW_ORIGINAL_BREW_FILE,
+        HOMEBREW_ORIGINAL_BREW_FILE.realpath,
         HOMEBREW_REPOSITORY/"completions/bash/brew",
         HOMEBREW_REPOSITORY/"Dockerfile",
         *HOMEBREW_REPOSITORY.glob(".devcontainer/**/*.sh"),


### PR DESCRIPTION
`shfmt` no longer allows using symlinks