### PR TITLE
Support Cask renames when installing/dumping

### DIFF
--- a/Library/Homebrew/bundle/cask_dumper.rb
+++ b/Library/Homebrew/bundle/cask_dumper.rb
@@ -8,6 +8,7 @@ module Homebrew
         @casks = nil
         @cask_names = nil
         @cask_hash = nil
+        @cask_oldnames = nil
       end
 
       def self.cask_names
@@ -36,6 +37,25 @@ module Homebrew
           config = ", args: { #{explicit_s(cask.config)} }" if cask.config.present? && cask.config.explicit.present?
           "#{description}cask \"#{cask}\"#{config}"
         end.join("\n")
+      end
+
+      def self.cask_oldnames
+        return @cask_oldnames if @cask_oldnames
+
+        @cask_oldnames = {}
+        casks.each do |c|
+          oldnames = c.old_tokens
+          next if oldnames.blank?
+
+          oldnames.each do |oldname|
+            @cask_oldnames[oldname] = c.full_name
+            if c.full_name.include? "/" # tap cask
+              tap_name = c.full_name.rpartition("/").first
+              @cask_oldnames["#{tap_name}/#{oldname}"] = c.full_name
+            end
+          end
+        end
+        @cask_oldnames
       end
 
       def self.formula_dependencies(cask_list)

--- a/Library/Homebrew/bundle/cask_installer.rb
+++ b/Library/Homebrew/bundle/cask_installer.rb
@@ -87,12 +87,25 @@ module Homebrew
         !cask_upgradable?(cask)
       end
 
+      def self.cask_in_array?(cask, array)
+        return true if array.include?(cask)
+        return true if array.include?(cask.split("/").last)
+
+        require "bundle/cask_dumper"
+        old_names = Homebrew::Bundle::CaskDumper.cask_oldnames
+        old_name = old_names[cask]
+        old_name ||= old_names[cask.split("/").last]
+        return true if old_name && array.include?(old_name)
+
+        false
+      end
+
       def self.cask_installed?(cask)
-        installed_casks.include? cask
+        cask_in_array?(cask, installed_casks)
       end
 
       def self.cask_upgradable?(cask)
-        outdated_casks.include? cask
+        cask_in_array?(cask, outdated_casks)
       end
 
       def self.installed_casks

--- a/Library/Homebrew/test/bundle/cask_dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_dumper_spec.rb
@@ -95,6 +95,27 @@ RSpec.describe Homebrew::Bundle::CaskDumper do
     end
   end
 
+  describe "#cask_oldnames" do
+    before do
+      described_class.reset!
+    end
+
+    it "returns an empty string when no casks are installed" do
+      expect(dumper.cask_oldnames).to eql({})
+    end
+
+    it "returns a hash with installed casks old names" do
+      foo = instance_double(Cask::Cask, to_s: "foo", old_tokens: ["oldfoo"], full_name: "qux/quuz/foo")
+      bar = instance_double(Cask::Cask, to_s: "bar", old_tokens: [], full_name: "bar")
+      allow(Cask::Caskroom).to receive(:casks).and_return([foo, bar])
+      allow(Homebrew::Bundle).to receive(:cask_installed?).and_return(true)
+      expect(dumper.cask_oldnames).to eql({
+        "qux/quuz/oldfoo" => "qux/quuz/foo",
+        "oldfoo"          => "qux/quuz/foo",
+      })
+    end
+  end
+
   describe "#formula_dependencies" do
     context "when the given casks don't have formula dependencies" do
       before do

--- a/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/cleanup_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe Homebrew::Bundle::Commands::Cleanup do
     end
 
     it "computes which casks to uninstall" do
-      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return(%w[123 456])
+      cask_123 = instance_double(Cask::Cask, to_s: "123", old_tokens: [])
+      cask_456 = instance_double(Cask::Cask, to_s: "456", old_tokens: [])
+      allow(Homebrew::Bundle::CaskDumper).to receive(:casks).and_return([cask_123, cask_456])
       expect(described_class.casks_to_uninstall).to eql(%w[456])
     end
 


### PR DESCRIPTION
This adds support for Cask old tokens used for renames of Casks.

We'll now correctly check these at installation time to avoid repeatedly installing renamed Casks and dump them in the Brewfile. We also use this logic to avoid cleaning up renamed Casks.

Fixes #20222