### PR TITLE
formulary: prevent formulae from printing to stdout while being loaded

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -139,11 +139,12 @@ module Formulary
       raise new_exception, "", e.backtrace
     end
   ensure
-    printed_to_stdout = $stdout.string.strip
-    if printed_to_stdout.present?
+    # TODO: Make printing to stdout an error so that we can print a tap name.
+    # See discussion at https://github.com/Homebrew/brew/pull/20226#discussion_r2195886888
+    if (printed_to_stdout = $stdout.string.strip.presence)
       opoo <<~WARNING
         Formula #{name} attempted to print the following while being loaded:
-        #{$stdout.string.strip}
+        #{printed_to_stdout}
       WARNING
     end
     $stdout = old_stdout

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -97,6 +97,11 @@ module Formulary
 
     require "formula"
     require "ignorable"
+    require "stringio"
+
+    # Capture stdout to prevent formulae from printing to stdout unexpectedly.
+    old_stdout = $stdout
+    $stdout = StringIO.new
 
     mod = Module.new
     remove_const(namespace) if const_defined?(namespace)
@@ -133,6 +138,15 @@ module Formulary
       remove_const(namespace)
       raise new_exception, "", e.backtrace
     end
+  ensure
+    printed_to_stdout = $stdout.string.strip
+    if printed_to_stdout.present?
+      opoo <<~WARNING
+        Formula #{name} attempted to print the following while being loaded:
+        #{$stdout.string.strip}
+      WARNING
+    end
+    $stdout = old_stdout
   end
 
   sig { params(identifier: String).returns(String) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Formulae can execute arbitrary Ruby code when being loaded. In
particular, they can print to stdout with methods like `puts`. This can
break the parsing of output of commands like `brew info --json=v2`.

Let's fix that by capturing the output to stdout, and then printing
those messages to stderr instead (using `opoo` to try to discourage
formula authors from doing this).
