### PR TITLE
Improve some `Pathname` instance variable handling

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -449,7 +449,7 @@ class Pathname
     # This is why monkeypatching is non-ideal (but right solution to get
     # Ruby 3.3 over the line).
     odisabled "rmtree", "FileUtils#rm_r"
-    FileUtils.rm_r(@path, noop:, verbose:, secure:)
+    FileUtils.rm_r(T.must(@path), noop:, verbose:, secure:)
     nil
   end
 end

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -12,11 +12,19 @@ module MachOShim
 
   delegate [:dylib_id] => :macho
 
+  def initialize(*args)
+    @macho = T.let(nil, T.nilable(MachO::MachOFile))
+    @mach_data = T.let(nil, T.nilable(T::Array[T::Hash[Symbol, T.untyped]]))
+
+    super
+  end
+
   def macho
     @macho ||= MachO.open(to_s)
   end
   private :macho
 
+  sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
   def mach_data
     @mach_data ||= begin
       machos = []


### PR DESCRIPTION
Will fix or at least partly address:
```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/os/linux/elf.rb:225: warning: The class Pathname reached 8 shape variations, instance variables accesses will be slower and memory usage increased.
35
It is recommended to define instance variables in a consistent order, for instance by eagerly defining them all in the #initialize method.
```