### PR TITLE
rubocops/text: Prefer `lib/"string"` over `lib+"string"`

### DIFF
--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -231,6 +231,19 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
+    it 'reports offenses if eg `lib+"thing"` is present' do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            (lib+"foo").install
+             ^^^^^^^^^ FormulaAudit/Text: Use `lib/"foo"` instead of `lib+"foo"`
+            (bin+"foobar").install
+             ^^^^^^^^^^^^ FormulaAudit/Text: Use `bin/"foobar"` instead of `bin+"foobar"`
+          end
+        end
+      RUBY
+    end
+
     it 'reports an offense if `prefix + "bin"` is present' do
       expect_offense(<<~RUBY)
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- I found a few occurrences of this pattern from https://github.com/orgs/Homebrew/projects/5?pane=issue&itemId=97021840, that is an automated style request for: `core: use / instead of + operator in e.g. (lib+"lv").install "lv.hlp"`, but for more than just `lib`.

/cc @EricFromCanada as you spotted this one!