### PR TITLE
style: fix skipping actionlint checks on Homebrew/brew.

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -88,6 +88,7 @@ module Homebrew
       shfmt_result = files.present? && shell_files.empty?
       shfmt_result ||= run_shfmt(shell_files, fix:)
 
+      actionlint_files = github_workflow_files if files.blank? && actionlint_files.blank?
       has_actionlint_workflow = actionlint_files.any? do |path|
         path.to_s.end_with?("/.github/workflows/actionlint.yml")
       end


### PR DESCRIPTION
If we're running `brew style` on Homebrew/brew: let's ensure that we
don't run the `actionlint` checks as they are handled by the dedicated
`actionlint.yml` workflow.
