### PR TITLE
Optionally use `download_queue` for `brew install`

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -51,12 +51,12 @@ class Dependency
     end
     return false unless formula
 
+    # If the opt prefix doesn't exist: we likely have an incomplete installation.
+    return false unless formula.opt_prefix.exist?
+
     return true if formula.latest_version_installed?
 
     return false if minimum_version.blank?
-
-    # If the opt prefix doesn't exist: we likely have an incomplete installation.
-    return false unless formula.opt_prefix.exist?
 
     installed_keg = formula.any_installed_keg
     return false unless installed_keg

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -30,19 +30,6 @@ class AbstractDownloadStrategy
 
   abstract!
 
-  # Extension for bottle downloads.
-  module Pourable
-    extend T::Helpers
-
-    requires_ancestor { AbstractDownloadStrategy }
-
-    sig { params(block: T.nilable(T.proc.params(arg0: String).returns(T.anything))).returns(T.nilable(T.anything)) }
-    def stage(&block)
-      ohai "Pouring #{basename}"
-      super
-    end
-  end
-
   # The download URL.
   #
   # @api public
@@ -74,7 +61,6 @@ class AbstractDownloadStrategy
     @cache = T.let(meta.fetch(:cache, HOMEBREW_CACHE), Pathname)
     @meta = T.let(meta, T::Hash[Symbol, T.untyped])
     @quiet = T.let(false, T.nilable(T::Boolean))
-    extend Pourable if meta[:bottle]
   end
 
   # Download and cache the resource at {#cached_location}.
@@ -826,7 +812,6 @@ class LocalBottleDownloadStrategy < AbstractFileDownloadStrategy
   sig { params(path: Pathname).void }
   def initialize(path)
     @cached_location = T.let(path, Pathname)
-    extend Pourable
   end
   # rubocop:enable Lint/MissingSuper
 

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -89,6 +89,9 @@ module Homebrew
     sig { override.returns(String) }
     def download_name = downloadable.download_name
 
+    sig { returns(T::Boolean) }
+    def bottle? = downloadable.is_a?(Bottle)
+
     private
 
     sig { returns(Downloadable) }

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -29,10 +29,13 @@ RSpec.describe Homebrew::Cmd::Deps do
     setup_test_formula "recommended_test"
     setup_test_formula "installed"
 
-    # Mock `Formula#any_version_installed?` by creating the tab in a plausible keg directory
-    keg_dir = HOMEBREW_CELLAR/"installed"/"1.0"
+    # Mock `Formula#any_version_installed?` by creating the tab in a plausible keg directory and opt link
+    keg_dir = HOMEBREW_CELLAR/"installed/1.0"
     keg_dir.mkpath
     touch keg_dir/AbstractTab::FILENAME
+    opt_link = HOMEBREW_PREFIX/"opt/installed"
+    opt_link.parent.mkpath
+    FileUtils.ln_sf keg_dir, opt_link
 
     expect { brew "deps", "baz", "--include-test", "--missing", "--skip-recommended" }
       .to be_a_success

--- a/Library/Homebrew/test/download_strategies/abstract_spec.rb
+++ b/Library/Homebrew/test/download_strategies/abstract_spec.rb
@@ -19,18 +19,4 @@ RSpec.describe AbstractDownloadStrategy do
       expect(strategy.source_modified_time).to eq(File.mtime("foo"))
     end
   end
-
-  context "when specs[:bottle]" do
-    let(:specs) { { bottle: true } }
-
-    it "extends Pourable" do
-      expect(strategy).to be_a(AbstractDownloadStrategy::Pourable)
-    end
-  end
-
-  context "without specs[:bottle]" do
-    it "is does not extend Pourable" do
-      expect(strategy).not_to be_a(AbstractDownloadStrategy::Pourable)
-    end
-  end
 end


### PR DESCRIPTION
Allowing using `HOMEBREW_DOWNLOAD_CONCURRENCY` to use the `DownloadQueue` for `brew install` by downloading and extracting bottles in parallel.

This requires some fixes in e.g. `Dependency` and `FormulaInstaller` to be able to front-load all downloads and handle parallelisation of bottle pouring.

Behaviour without `HOMEBREW_DOWNLOAD_CONCURRENCY` set should be unchanged.

Attestations are not handled for now and the UI should be improved before we roll this out to users.

Post-install upgrades are not yet parallelised. 

Performance testing on my M1 Max MacBook Pro (that we do `make -j10` on):
```
Benchmark 1: HOMEBREW_DOWNLOAD_CONCURRENCY=40 brew install ack wget ffmpeg
  Time (mean ± σ):     107.526 s ±  3.498 s    [User: 31.709 s, System: 65.326 s]
  Range (min … max):   105.053 s … 110.000 s    2 runs
 
Benchmark 2: HOMEBREW_DOWNLOAD_CONCURRENCY=20 brew install ack wget ffmpeg
  Time (mean ± σ):     100.833 s ±  3.007 s    [User: 31.519 s, System: 62.292 s]
  Range (min … max):   98.706 s … 102.959 s    2 runs
 
Benchmark 3: HOMEBREW_DOWNLOAD_CONCURRENCY=10 brew install ack wget ffmpeg
  Time (mean ± σ):     103.043 s ±  1.297 s    [User: 31.360 s, System: 63.587 s]
  Range (min … max):   102.126 s … 103.960 s    2 runs
 
Benchmark 4: HOMEBREW_DOWNLOAD_CONCURRENCY=2 brew install ack wget ffmpeg
  Time (mean ± σ):     139.044 s ±  3.662 s    [User: 31.711 s, System: 64.411 s]
  Range (min … max):   136.454 s … 141.633 s    2 runs
 
Benchmark 5: brew install ack wget ffmpeg
  Time (mean ± σ):     162.942 s ±  0.163 s    [User: 32.008 s, System: 57.277 s]
  Range (min … max):   162.827 s … 163.057 s    2 runs
 
Summary
  HOMEBREW_DOWNLOAD_CONCURRENCY=20 brew install ack wget ffmpeg ran
    1.02 ± 0.03 times faster than HOMEBREW_DOWNLOAD_CONCURRENCY=10 brew install ack wget ffmpeg
    1.07 ± 0.05 times faster than HOMEBREW_DOWNLOAD_CONCURRENCY=40 brew install ack wget ffmpeg
    1.38 ± 0.05 times faster than HOMEBREW_DOWNLOAD_CONCURRENCY=2 brew install ack wget ffmpeg
    1.62 ± 0.05 times faster than brew install ack wget ffmpeg
```