### PR TITLE
aliases/aliases: fix naming of symlinks

### DIFF
--- a/Library/Homebrew/test/.brew-aliases/foo
+++ b/Library/Homebrew/test/.brew-aliases/foo
@@ -1,6 +1,0 @@
-#! /bin/bash
-# alias: brew foo
-#:  * `foo` [args...]
-#:    `brew foo` is an alias for `brew bar`
-brew bar $*
-

--- a/Library/Homebrew/test/.brew-aliases/foo_test
+++ b/Library/Homebrew/test/.brew-aliases/foo_test
@@ -1,0 +1,6 @@
+#! /bin/bash
+# alias: brew foo-test
+#:  * `foo-test` [args...]
+#:    `brew foo-test` is an alias for `brew bar`
+brew bar $*
+

--- a/Library/Homebrew/test/cmd/alias_spec.rb
+++ b/Library/Homebrew/test/cmd/alias_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Homebrew::Cmd::Alias do
   it_behaves_like "parseable arguments"
 
   it "sets an alias", :integration_test do
-    expect { brew "alias", "foo=bar" }
+    expect { brew "alias", "foo-test=bar" }
       .to not_to_output.to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
     expect { brew "alias" }
-      .to output(/brew alias foo='bar'/).to_stdout
+      .to output(/brew alias foo-test='bar'/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end


### PR DESCRIPTION
This fixes a bug in `aliases/aliases.rb` in which it assumed that the filename of a `brew alias` symlink in `${HOMEBREW_PREFIX}/bin` was the name of the alias. The contents of `aliases/alias.rb` indicates otherwise: when an alias is first created, the script filename and its symlink have any non-alpahnumeric characters replaced with an underscore—presumably to avoid creating a file with a name starting with a hyphen—so e.g. `brew alias test-command --edit` creates `~/.brew-aliases/test_command`. 

No longer occurs:
- `brew alias` output shows `brew alias test_command` instead of `brew alias test-command`
- running `brew alias` creates a new `brew-test_command` symlink in `${HOMEBREW_PREFIX}/bin` beside the existing `brew-test-command` symlink, which also gets left behind if `brew unalias test-command` is run