### PR TITLE
bin/brew: better user config home handling

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -153,9 +153,18 @@ fi
 export_homebrew_env_file "${HOMEBREW_PREFIX}/etc/homebrew/brew.env"
 
 # Finally, load the user configuration
-if [[ -n "${XDG_CONFIG_HOME-}" ]]
+if [[ -d "${HOME}/.homebrew" ]]
+then
+  HOMEBREW_USER_CONFIG_HOME="${HOME}/.homebrew"
+elif [[ -n "${XDG_CONFIG_HOME-}" ]]
 then
   HOMEBREW_USER_CONFIG_HOME="${XDG_CONFIG_HOME}/homebrew"
+elif [[ -d "${HOME}/.config/homebrew" ]]
+then
+  HOMEBREW_USER_CONFIG_HOME="${HOME}/.config/homebrew"
+elif [[ -d "${HOME}/Library/Application Support/homebrew" ]]
+then
+  HOMEBREW_USER_CONFIG_HOME="${HOME}/Library/Application Support/homebrew"
 else
   HOMEBREW_USER_CONFIG_HOME="${HOME}/.homebrew"
 fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Feature: improved HOMEBREW_USER_CONFIG_HOME

`HOMEBREW_USER_CONFIG_HOME` can now be in a few standard locations
1. `~/.homebrew`
2. `$XDG_CONFIG_HOME/homebrew` (if the variable is set)
3. `~/.config/homebrew`
4. `~/Library/Application Support/homebrew`

See issue #20251 for more details.
I've been using this on both macOS and Linux, without `XDG_CONFIG_HOME` explicitly set, and it reads my `~/.config/homebrew/brew.env` whenever I run the `brew` command, which is nice.
If the idea meets with approval, I can add any appropriate tests and documentation.