### PR TITLE
cleanup: don't warn when loading a renamed cask.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -195,7 +195,7 @@ module Homebrew
         return false unless (name = basename.to_s[/\A(.*?)--/, 1])
 
         cask = begin
-          Cask::CaskLoader.load(name)
+          Cask::CaskLoader.load(name, warn: false)
         rescue Cask::CaskError
           nil
         end


### PR DESCRIPTION
Fixes #20248
