### PR TITLE
tap: move migration downloads to API::Formula/Cask

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -13,6 +13,7 @@ module Homebrew
 
     HOMEBREW_CACHE_API = T.let((HOMEBREW_CACHE/"api").freeze, Pathname)
     HOMEBREW_CACHE_API_SOURCE = T.let((HOMEBREW_CACHE/"api-source").freeze, Pathname)
+    TAP_MIGRATIONS_STALE_SECONDS = T.let(86400, Integer) # 1 day
 
     sig { params(endpoint: String).returns(T::Hash[String, T.untyped]) }
     def self.fetch(endpoint)

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cachable"
+require "api"
 require "api/download"
 
 module Homebrew
@@ -52,9 +53,26 @@ module Homebrew
         HOMEBREW_CACHE_API/api_filename
       end
 
+      sig {
+        params(download_queue: T.nilable(::Homebrew::DownloadQueue))
+          .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
+      }
+      def self.fetch_api!(download_queue: nil)
+        Homebrew::API.fetch_json_api_file api_filename, download_queue:
+      end
+
+      sig {
+        params(download_queue: T.nilable(::Homebrew::DownloadQueue))
+          .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
+      }
+      def self.fetch_tap_migrations!(download_queue: nil)
+        stale_seconds = Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS
+        Homebrew::API.fetch_json_api_file "cask_tap_migrations.jws.json", stale_seconds:, download_queue:
+      end
+
       sig { returns(T::Boolean) }
       def self.download_and_cache_data!
-        json_casks, updated = Homebrew::API.fetch_json_api_file api_filename
+        json_casks, updated = fetch_api!
 
         cache["renames"] = {}
         cache["casks"] = json_casks.to_h do |json_cask|
@@ -89,6 +107,16 @@ module Homebrew
         end
 
         cache.fetch("renames")
+      end
+
+      sig { returns(T::Hash[String, T.untyped]) }
+      def self.tap_migrations
+        unless cache.key?("tap_migrations")
+          json_migrations, = fetch_tap_migrations!
+          cache["tap_migrations"] = json_migrations
+        end
+
+        cache.fetch("tap_migrations")
       end
 
       sig { params(regenerate: T::Boolean).void }

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cachable"
+require "api"
 require "api/download"
 
 module Homebrew
@@ -52,9 +53,26 @@ module Homebrew
         HOMEBREW_CACHE_API/api_filename
       end
 
+      sig {
+        params(download_queue: T.nilable(Homebrew::DownloadQueue))
+          .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
+      }
+      def self.fetch_api!(download_queue: nil)
+        Homebrew::API.fetch_json_api_file api_filename, download_queue:
+      end
+
+      sig {
+        params(download_queue: T.nilable(Homebrew::DownloadQueue))
+          .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
+      }
+      def self.fetch_tap_migrations!(download_queue: nil)
+        stale_seconds = Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS
+        Homebrew::API.fetch_json_api_file "formula_tap_migrations.jws.json", stale_seconds:, download_queue:
+      end
+
       sig { returns(T::Boolean) }
       def self.download_and_cache_data!
-        json_formulae, updated = Homebrew::API.fetch_json_api_file api_filename
+        json_formulae, updated = fetch_api!
 
         cache["aliases"] = {}
         cache["renames"] = {}
@@ -80,7 +98,7 @@ module Homebrew
           write_names_and_aliases(regenerate: json_updated)
         end
 
-        cache["formulae"]
+        cache.fetch("formulae")
       end
 
       sig { returns(T::Hash[String, String]) }
@@ -90,7 +108,7 @@ module Homebrew
           write_names_and_aliases(regenerate: json_updated)
         end
 
-        cache["aliases"]
+        cache.fetch("aliases")
       end
 
       sig { returns(T::Hash[String, String]) }
@@ -100,29 +118,17 @@ module Homebrew
           write_names_and_aliases(regenerate: json_updated)
         end
 
-        cache["renames"]
+        cache.fetch("renames")
       end
 
       sig { returns(T::Hash[String, T.untyped]) }
       def self.tap_migrations
-        # Not sure that we need to reload here.
         unless cache.key?("tap_migrations")
-          json_updated = download_and_cache_data!
-          write_names_and_aliases(regenerate: json_updated)
+          json_migrations, = fetch_tap_migrations!
+          cache["tap_migrations"] = json_migrations
         end
 
-        cache["tap_migrations"]
-      end
-
-      sig { returns(String) }
-      def self.tap_git_head
-        # Note sure we need to reload here.
-        unless cache.key?("tap_git_head")
-          json_updated = download_and_cache_data!
-          write_names_and_aliases(regenerate: json_updated)
-        end
-
-        cache["tap_git_head"]
+        cache.fetch("tap_migrations")
       end
 
       sig { params(regenerate: T::Boolean).void }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -31,9 +31,6 @@ class Tap
   HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR = "style_exceptions"
   private_constant :HOMEBREW_TAP_STYLE_EXCEPTIONS_DIR
 
-  TAP_MIGRATIONS_STALE_SECONDS = 86400 # 1 day
-  private_constant :TAP_MIGRATIONS_STALE_SECONDS
-
   HOMEBREW_TAP_JSON_FILES = %W[
     #{HOMEBREW_TAP_FORMULA_RENAMES_FILE}
     #{HOMEBREW_TAP_CASK_RENAMES_FILE}
@@ -1312,9 +1309,7 @@ class CoreTap < AbstractCoreTap
       ensure_installed!
       super
     else
-      migrations, = Homebrew::API.fetch_json_api_file "formula_tap_migrations.jws.json",
-                                                      stale_seconds: TAP_MIGRATIONS_STALE_SECONDS
-      migrations
+      Homebrew::API::Formula.tap_migrations
     end
   end
 
@@ -1471,9 +1466,7 @@ class CoreCaskTap < AbstractCoreTap
     @tap_migrations ||= if Homebrew::EnvConfig.no_install_from_api?
       super
     else
-      migrations, = Homebrew::API.fetch_json_api_file "cask_tap_migrations.jws.json",
-                                                      stale_seconds: TAP_MIGRATIONS_STALE_SECONDS
-      migrations
+      Homebrew::API::Cask.tap_migrations
     end
   end
 end


### PR DESCRIPTION
This provides a nicer API that is a bit more consistent.

While we're here, also fix the previously broken
`Formula.tap_migrations` method and remove `Formula.tap_git_head` which was unused and broken.

Extracted from https://github.com/Homebrew/brew/pull/20245