### PR TITLE
Refactor DownloadQueue handling

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -630,5 +630,13 @@ module Homebrew
     def devcmdrun?
       Homebrew::Settings.read("devcmdrun") == "true"
     end
+
+    sig { returns(Integer) }
+    def download_concurrency
+      # TODO: document this variable when ready to publicly announce it.
+      concurrency = ENV.fetch("HOMEBREW_DOWNLOAD_CONCURRENCY", 1).to_i
+      concurrency = 1 if concurrency <= 1
+      concurrency
+    end
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3202,6 +3202,15 @@ class Formula
     end
   end
 
+  sig { params(download_queue: Homebrew::DownloadQueue).void }
+  def enqueue_resources_and_patches(download_queue:)
+    resources.each do |resource|
+      download_queue.enqueue(resource)
+      resource.patches.select(&:external?).each { |patch| download_queue.enqueue(patch.resource) }
+    end
+    patchlist.select(&:external?).each { |patch| download_queue.enqueue(patch.resource) }
+  end
+
   sig { void }
   def fetch_patches
     patchlist.select(&:external?).each(&:fetch)

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -5,10 +5,6 @@ module Homebrew
   class RetryableDownload
     include Downloadable
 
-    sig { returns(Downloadable) }
-    attr_reader :downloadable
-    private :downloadable
-
     sig { override.returns(T.any(NilClass, String, URL)) }
     def url = downloadable.url
 
@@ -92,5 +88,10 @@ module Homebrew
 
     sig { override.returns(String) }
     def download_name = downloadable.download_name
+
+    private
+
+    sig { returns(Downloadable) }
+    attr_reader :downloadable
   end
 end

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Homebrew::Cmd::FetchCmd do
     setup_test_formula "testball1"
     setup_test_formula "testball2"
 
-    expect { brew "fetch", "testball1", "testball2", "--concurrency=2" }.to be_a_success
+    expect { brew "fetch", "testball1", "testball2", "HOMEBREW_DOWNLOAD_CONCURRENCY" => "2" }.to be_a_success
 
     expect(HOMEBREW_CACHE/"testball1--0.1.tbz").to be_a_symlink
     expect(HOMEBREW_CACHE/"testball1--0.1.tbz").to exist
@@ -33,7 +33,7 @@ RSpec.describe Homebrew::Cmd::FetchCmd do
     setup_test_formula "testball1"
     setup_test_formula "testball3"
 
-    expect { brew "fetch", "testball1", "testball3", "--concurrency=2" }.to be_a_failure
+    expect { brew "fetch", "testball1", "testball3", "HOMEBREW_DOWNLOAD_CONCURRENCY" => "2" }.to be_a_failure
       .and output(/Error:.*process has already locked/).to_stderr
   end
 end


### PR DESCRIPTION
- Use undocumented (for now) `HOMEBREW_DOWNLOAD_CONCURRENCY` instead of `--concurrency` flag and avoid passing around `concurrency`
- Create and use `Formula#enqueue_resources_and_patches` helper method
- Rename some method calls to be more obvious
- Use `Downloadable` type to simplify type checks
- General refactoring

Extracted from https://github.com/Homebrew/brew/pull/20245