### PR TITLE
Fix some stdout issues with concurrence

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -36,7 +36,9 @@ module Homebrew
 
     sig { void }
     def fetch
-      if concurrency == 1
+      return if downloads.empty?
+
+      if concurrency == 1 || downloads.one?
         downloads.each do |downloadable, promise|
           promise.wait!
         rescue ChecksumMismatchError => e

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
     # Ignore dependencies, because we'll try to resolve requirements in build.rb
     # and there will be the git requirement, but we cannot instantiate git
     # formula since we only have testball1 formula.
-    expect { brew "install", "testball1", "--HEAD", "--ignore-dependencies" }
+    expect { brew "install", "testball1", "--HEAD", "--ignore-dependencies", "HOMEBREW_DOWNLOAD_CONCURRENCY" => "1" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/HEAD-d5eb689}o).to_stdout
       .and output(/Cloning into/).to_stderr
       .and be_a_success


### PR DESCRIPTION
If `HOMEBREW_DOWNLOAD_CONCURRENCY` is set, every `brew` command calls `Tty::hide_cursor` and `Tty::show_cursor`, which prints invisible characters to `stdout`. This breaks things like `brew info --json=v2 wget | jq .` and also some of `brew tests`.

This PR modifies the `DownloadQueue#fetch` method to return early if there are no pending downloads, and to handle a single download as if `HOMEBREW_DOWNLOAD_CONCURRENCY` is set to 1. This means that we only enter the region that needs to hide and show the cursor if we actually need.

To avoid this regressing in the future, we should really have at least one integration test that has concurrency enabled, but I held off on that for now since we may get that for free if concurrent downloads ever become the default