### PR TITLE
dispatch-build-bottle: use `main` branch

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -42,7 +42,7 @@ module Homebrew
       def run
         tap = Tap.fetch(args.tap || CoreTap.instance.name)
         user, repo = tap.full_name.split("/")
-        ref = "master"
+        ref = "main"
         workflow = args.workflow || "dispatch-build-bottle.yml"
 
         runners = []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is really only used in Homebrew/core, so it should be safe to just
change `ref` here to `main`. Without this, `dispatch-build-bottle`
creates PRs that mistakenly target the `master` branch instead of the
`main` branch.
