### PR TITLE
Improve Download Queue behaviour

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -55,19 +55,18 @@ module Homebrew
       end
 
       sig {
-        params(download_queue: T.nilable(::Homebrew::DownloadQueue))
+        params(download_queue: T.nilable(::Homebrew::DownloadQueue), stale_seconds: Integer)
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_api!(download_queue: nil)
-        Homebrew::API.fetch_json_api_file api_filename, download_queue:
+      def self.fetch_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
+        Homebrew::API.fetch_json_api_file api_filename, stale_seconds:, download_queue:
       end
 
       sig {
-        params(download_queue: T.nilable(::Homebrew::DownloadQueue))
+        params(download_queue: T.nilable(::Homebrew::DownloadQueue), stale_seconds: Integer)
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_tap_migrations!(download_queue: nil)
-        stale_seconds = Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS
+      def self.fetch_tap_migrations!(download_queue: nil, stale_seconds: Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS)
         Homebrew::API.fetch_json_api_file "cask_tap_migrations.jws.json", stale_seconds:, download_queue:
       end
 

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -55,19 +55,18 @@ module Homebrew
       end
 
       sig {
-        params(download_queue: T.nilable(Homebrew::DownloadQueue))
+        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: Integer)
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_api!(download_queue: nil)
-        Homebrew::API.fetch_json_api_file api_filename, download_queue:
+      def self.fetch_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
+        Homebrew::API.fetch_json_api_file api_filename, stale_seconds:, download_queue:
       end
 
       sig {
-        params(download_queue: T.nilable(Homebrew::DownloadQueue))
+        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: Integer)
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_tap_migrations!(download_queue: nil)
-        stale_seconds = Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS
+      def self.fetch_tap_migrations!(download_queue: nil, stale_seconds: Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS)
         Homebrew::API.fetch_json_api_file "formula_tap_migrations.jws.json", stale_seconds:, download_queue:
       end
 

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -88,16 +88,17 @@ begin
     cmd_class = Homebrew::AbstractCommand.command(cmd)
     Homebrew.running_command = cmd
     if cmd_class
-      if Homebrew::EnvConfig.download_concurrency > 1
+      if !Homebrew::EnvConfig.no_install_from_api? && Homebrew::EnvConfig.download_concurrency > 1
         require "download_queue"
         require "api"
         require "api/formula"
         require "api/cask"
         download_queue = Homebrew::DownloadQueue.new
-        Homebrew::API::Formula.fetch_api!(download_queue:)
-        Homebrew::API::Formula.fetch_tap_migrations!(download_queue:)
-        Homebrew::API::Cask.fetch_api!(download_queue:)
-        Homebrew::API::Cask.fetch_tap_migrations!(download_queue:)
+        stale_seconds = 86400 # 1 day
+        Homebrew::API::Formula.fetch_api!(download_queue:, stale_seconds:)
+        Homebrew::API::Formula.fetch_tap_migrations!(download_queue:, stale_seconds:)
+        Homebrew::API::Cask.fetch_api!(download_queue:, stale_seconds:)
+        Homebrew::API::Cask.fetch_tap_migrations!(download_queue:, stale_seconds:)
         begin
           download_queue.fetch
         ensure

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -184,7 +184,7 @@ module Homebrew
 
       sig { returns(Integer) }
       def retries
-        @retries ||= T.let(args.retry? ? FETCH_MAX_TRIES : 0, T.nilable(Integer))
+        @retries ||= T.let(args.retry? ? FETCH_MAX_TRIES : 1, T.nilable(Integer))
       end
 
       sig { returns(DownloadQueue) }

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -9,7 +9,7 @@ require "retryable_download"
 module Homebrew
   class DownloadQueue
     sig { params(retries: Integer, force: T::Boolean, pour: T::Boolean).void }
-    def initialize(retries: 0, force: false, pour: false)
+    def initialize(retries: 1, force: false, pour: false)
       @concurrency = T.let(EnvConfig.download_concurrency, Integer)
       @quiet = T.let(@concurrency > 1, T::Boolean)
       @tries = T.let(retries + 1, Integer)


### PR DESCRIPTION
- ensure that the `brew.rb` downloads of the API files only happens when they are more stale (>1 day) and using the API is not disabled
- default `brew fetch` and `brew install` to a single download retry