### PR TITLE
retryable_download: retry on bottle manifest errors.

### DIFF
--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -68,7 +68,7 @@ module Homebrew
       downloadable.verify_download_integrity(download) if verify_download_integrity
 
       download
-    rescue DownloadError, ChecksumMismatchError
+    rescue DownloadError, ChecksumMismatchError, Resource::BottleManifest::Error
       tries_remaining = @tries - @try
       raise if tries_remaining.zero?
 


### PR DESCRIPTION
This is needed in case these files are e.g. corrupt.