### PR TITLE
docs(cask): clarify that 3rd-party pre-compiled binaries should be casks

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -36,7 +36,7 @@ Linux distribution without requiring `sudo`.
 
 **cask**
 
-: Homebrew package definition that installs macOS native applications
+: Homebrew package definition that installs macOS native applications or pre-compiled binaries
 
 **prefix**
 

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -14,7 +14,7 @@ A *formula* is a package definition written in Ruby. It can be created with `bre
 | term                 | description                                                               | example |
 | -------------------- | ------------------------------------------------------------------------- | ------- |
 | **formula**          | Homebrew package definition that builds from upstream sources             | `/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/f/foo.rb` |
-| **cask**             | Homebrew package definition that installs macOS native applications       | `/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/b/bar.rb` |
+| **cask**             | Homebrew package definition that installs macOS native applications or pre-compiled binaries | `/opt/homebrew/Library/Taps/homebrew/homebrew-cask/Casks/b/bar.rb` |
 | **prefix**           | path in which Homebrew is installed                                       | `/opt/homebrew` |
 | **keg**              | installation destination directory of a given **formula** version         | `/opt/homebrew/Cellar/foo/0.1` |
 | **rack**             | directory containing one or more versioned **kegs**                       | `/opt/homebrew/Cellar/foo` |

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -19,7 +19,7 @@ Linux distribution without requiring `sudo`.
 
 **cask**
 
-: Homebrew package definition that installs macOS native applications
+: Homebrew package definition that installs macOS native applications or pre-compiled binaries
 
 **prefix**
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -14,7 +14,7 @@ Homebrew is the easiest and most flexible way to install the UNIX tools Apple di
 Homebrew package definition that builds from upstream sources
 .TP
 \fBcask\fP
-Homebrew package definition that installs macOS native applications
+Homebrew package definition that installs macOS native applications or pre-compiled binaries
 .TP
 \fBprefix\fP
 path in which Homebrew is installed, e\.g\. \fB/opt/homebrew\fP or \fB/home/linuxbrew/\.linuxbrew\fP


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Goreleaser recently changed their default brew formula generation type
from formula -> cask. This may be confusing for people who vaguely think
that formula == binary, cask == macOS Application.

I'm not sure where to document this in more detail, but my understanding
is that if you `brew install` and it uses a pre-built binary instead of
  building from source:
- If it's from homebrew/core -> formula
- If it's from a third-party tap -> cask

so basically bottles for third-party taps aren't a thing.

Refs: https://github.com/orgs/goreleaser/discussions/5563#discussioncomment-13368387