### PR TITLE
cask/audit: skip signing audit for shell scripts

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -512,6 +512,9 @@ module Cask
           when Artifact::App
             system_command("spctl", args: ["--assess", "--type", "execute", path], print_stderr: false)
           when Artifact::Binary
+            # Shell scripts cannot be signed, so we skip them
+            next if path.text_executable?
+
             system_command("codesign",  args: ["--verify", path], print_stderr: false)
           else
             add_error "Unknown artifact type: #{artifact.class}", location: url.location


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Shell scripts cannot be codesigned, so we need to skip them in the audit.