### PR TITLE
workflows/tests: set HOMEBREW_DOWNLOAD_CONCURRENCY for test-bot tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -368,6 +368,7 @@ jobs:
     env:
       HOMEBREW_TEST_BOT_ANALYTICS: 1
       HOMEBREW_ENFORCE_SBOM: 1
+      HOMEBREW_DOWNLOAD_CONCURRENCY: 4
     steps:
       - name: Install Homebrew and Homebrew's dependencies
         # All other images are built from our Homebrew Dockerfile.


### PR DESCRIPTION
This should give us some basic integration testing for the new download concurrency code before we enabled/test it in homebrew-core's CI.

CC @carlocab fine to merge https://github.com/Homebrew/homebrew-test-bot/pull/1526 when this is merged.