### PR TITLE
Fix handling of formula install blocks

### DIFF
--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -95,4 +95,14 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
     expect(HOMEBREW_CELLAR/"testball1/0.1/bin/test").to be_a_file
   end
+
+  it "refuses to install forbidden formulae", :integration_test do
+    setup_test_formula "testball1"
+
+    expect { brew "install", "testball1", { "HOMEBREW_FORBIDDEN_FORMULAE" => "testball1" } }
+      .to not_to_output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}o).to_stdout
+      .and output(/testball1 was forbidden/).to_stderr
+      .and be_a_failure
+    expect(HOMEBREW_CELLAR/"testball1").not_to exist
+  end
 end

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe Homebrew::Cmd::Reinstall do
 
     expect(foo_dir).to exist
   end
+
+  it "refuses to reinstall a forbidden formula", :integration_test do
+    install_test_formula "testball"
+    foo_dir = HOMEBREW_CELLAR/"testball/0.1/bin"
+    expect(foo_dir).to exist
+    FileUtils.rm_r(foo_dir)
+
+    expect { brew "reinstall", "testball", { "HOMEBREW_FORBIDDEN_FORMULAE" => "testball" } }
+      .to not_to_output(%r{#{HOMEBREW_CELLAR}/testball/0\.1}o).to_stdout
+      .and output(/testball was forbidden/).to_stderr
+      .and be_a_failure
+
+    expect(foo_dir).not_to exist
+  end
 end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -28,4 +28,15 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     expect(HOMEBREW_CELLAR/"testball/0.1").to be_a_directory
     expect(HOMEBREW_CELLAR/"testball/0.0.1").not_to exist
   end
+
+  it "refuses to upgrades a forbidden formula", :integration_test do
+    setup_test_formula "testball"
+    (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+
+    expect { brew "upgrade", "testball", { "HOMEBREW_FORBIDDEN_FORMULAE" => "testball" } }
+      .to not_to_output(%r{#{HOMEBREW_CELLAR}/testball/0\.1}o).to_stdout
+      .and output(/testball was forbidden/).to_stderr
+      .and be_a_failure
+    expect(HOMEBREW_CELLAR/"testball/0.1").not_to exist
+  end
 end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -92,18 +92,23 @@ module Homebrew
     end
 
     def self.upgrade_formulae(formula_installers, dry_run: false, verbose: false)
+      valid_formula_installers = formula_installers.dup
+
       unless dry_run
-        formula_installers.each do |fi|
+        valid_formula_installers.select! do |fi|
           fi.prelude
           fi.fetch
+          true
         rescue CannotInstallFormulaError => e
           ofail e
+          false
         rescue UnsatisfiedRequirements, DownloadError => e
           ofail "#{fi.formula.full_name}: #{e}"
+          false
         end
       end
 
-      formula_installers.each do |fi|
+      valid_formula_installers.each do |fi|
         upgrade_formula(fi, dry_run:, verbose:)
         Cleanup.install_formula_clean!(fi.formula, dry_run:)
       end


### PR DESCRIPTION
These were unfortunately non-functional after recent changes.

Will issue a new release with this once merged.