### PR TITLE
tap: continue to autobump deprecated unsigned casks

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -994,7 +994,8 @@ class Tap
     end
 
     @autobump ||= autobump_packages.select do |_, p|
-      next if p["deprecated"] || p["disabled"]
+      next if p["disabled"]
+      next if p["deprecated"] && p["deprecation_reason"] != "unsigned"
       next if p["skip_livecheck"]
 
       p["autobump"] == true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This will re-add casks that are deprecated as `unsigned` to autobump (as a special case).

The caveat here is that if they become signed, the autobump fails (because the audit will fail) - but we are regularly checking the failures in the CI job.

I'm open to not making this change if others disagree.