### PR TITLE
cask/audit: refine codesign audits

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -510,12 +510,17 @@ module Cask
           when Artifact::Pkg
             system_command("spctl", args: ["--assess", "--type", "install", path], print_stderr: false)
           when Artifact::App
-            system_command("spctl", args: ["--assess", "--type", "execute", path], print_stderr: false)
+            if which("syspolicy_check")
+              system_command("syspolicy_check", args: ["distribution", path], print_stderr: false)
+            else
+              system_command("spctl", args: ["--assess", "--type", "execute", path], print_stderr: false)
+            end
           when Artifact::Binary
             # Shell scripts cannot be signed, so we skip them
             next if path.text_executable?
 
-            system_command("codesign",  args: ["--verify", path], print_stderr: false)
+            system_command("codesign",  args:         ["--verify", "-R=notarized", "--check-notarization", path],
+                                        print_stderr: false)
           else
             add_error "Unknown artifact type: #{artifact.class}", location: url.location
           end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR proposes a change to use the newer `syspolicy_check` tool for Application codesign audit.
Also check notarization for binaries.

@Homebrew/cask the main discussion point here is whether we want to require notarization for binaries or not.