### PR TITLE
cask/audit: use `gktool` for signing audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -510,8 +510,8 @@ module Cask
           when Artifact::Pkg
             system_command("spctl", args: ["--assess", "--type", "install", path], print_stderr: false)
           when Artifact::App
-            if which("syspolicy_check")
-              system_command("syspolicy_check", args: ["distribution", path], print_stderr: false)
+            if which("gktool")
+              system_command("gktool", args: ["scan", path], print_stderr: false)
             else
               system_command("spctl", args: ["--assess", "--type", "execute", path], print_stderr: false)
             end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

It looks like the changes in https://github.com/Homebrew/brew/pull/20300 may be too strict for how we should apply our codesign check. This PR utilises `gktool` which is the same check used by MacOS to confirm whether an application passes Gatekeeper or not.
