### PR TITLE
cmd/search: `--desc` depends on `--eval-all`, not the other way around

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -36,9 +36,9 @@ module Homebrew
                description: "Search for casks."
         switch "--desc",
                description: "Search for formulae with a description matching <text> and casks with " \
-                            "a name or description matching <text>."
+                            "a name or description matching <text>.",
+               depends_on:  "--eval-all"
         switch "--eval-all",
-               depends_on:  "--desc",
                description: "Evaluate all available formulae and casks, whether installed or not, to search their " \
                             "descriptions.",
                env:         :eval_all


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- When the user tried `brew search foo` with `--eval-all` or its envvar, it would fail with "Error: Invalid usage: `--eval-all` cannot be passed without `--desc`".
- This was the wrong way around: `--desc` depends on `--eval-all`.
