### PR TITLE
Fix forbidding special license refs

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1618,6 +1618,9 @@ on_request: installed_on_request?, options:)
 
     invalid_licenses = []
     forbidden_licenses = forbidden_licenses.split.each_with_object({}) do |license, hash|
+      license_sym = license.to_sym
+      license = license_sym if SPDX::ALLOWED_LICENSE_SYMBOLS.include?(license_sym)
+
       unless SPDX.valid_license?(license)
         invalid_licenses << license
         next

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -229,13 +229,13 @@ module SPDX
   end
 
   sig {
-    params(license_expression: T.any(String, Symbol, T::Hash[Symbol, T.untyped]),
-           forbidden_licenses: T::Hash[Symbol, T.untyped]).returns(T::Boolean)
+    params(license_expression: T.any(String, Symbol, T::Hash[T.any(Symbol, String), T.untyped]),
+           forbidden_licenses: T::Hash[T.any(Symbol, String), T.untyped]).returns(T::Boolean)
   }
   def licenses_forbid_installation?(license_expression, forbidden_licenses)
     case license_expression
     when String, Symbol
-      forbidden_licenses_include? license_expression.to_s, forbidden_licenses
+      forbidden_licenses_include? license_expression, forbidden_licenses
     when Hash
       key = license_expression.keys.first
       return false if key.nil?


### PR DESCRIPTION
`HOMEBREW_FORBIDDEN_LICENSES=public_domain` is [documented](https://docs.brew.sh/License-Guidelines#specifying-forbidden-licenses) as supported but doesn't actually work. Unclear if it ever did but we can fix it trivially anyway.

Also fix some incorrect types in spdx.rb that we only don't notice because we use `T.untyped` too much.