### PR TITLE
github_runner_matrix: deploy arm64 Linux runner for formulae without bottles

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -154,7 +154,11 @@ class GitHubRunnerMatrix
       @runners << create_runner(:linux, :x86_64)
 
       if !@dependent_matrix &&
-         @testing_formulae.any? { |tf| tf.formula.bottle_specification.tag?(Utils::Bottles.tag(:arm64_linux)) }
+         @testing_formulae.any? do |tf|
+           bottle_specification = tf.formula.bottle_specification
+
+           bottle_specification.collector.tags.none? || bottle_specification.tag?(Utils::Bottles.tag(:arm64_linux))
+         end
         @runners << create_runner(:linux, :arm64)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These are typically new formulae, and will save us from having to
manually dispatch arm64 Linux builds manually after merging new formula
PRs.
