### PR TITLE
Make `--debug` output a bit quieter by default

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -622,7 +622,7 @@ module Cask
         NullLoader,
       ].each do |loader_class|
         if (loader = loader_class.try_new(ref, warn:))
-          $stderr.puts "#{$PROGRAM_NAME} (#{loader.class}): loading #{ref}" if debug?
+          $stderr.puts "#{$PROGRAM_NAME} (#{loader.class}): loading #{ref}" if verbose? && debug?
           return loader
         end
       end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1159,7 +1159,7 @@ module Formulary
       NullLoader,
     ].each do |loader_class|
       if (loader = loader_class.try_new(ref, from:, warn:))
-        $stderr.puts "#{$PROGRAM_NAME} (#{loader_class}): loading #{ref}" if debug?
+        $stderr.puts "#{$PROGRAM_NAME} (#{loader_class}): loading #{ref}" if verbose? && debug?
         return loader
       end
     end

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -44,7 +44,7 @@ class SystemCommand
 
   sig { returns(SystemCommand::Result) }
   def run!
-    $stderr.puts redact_secrets(command.shelljoin.gsub('\=', "="), @secrets) if verbose? || debug?
+    $stderr.puts redact_secrets(command.shelljoin.gsub('\=', "="), @secrets) if verbose? && debug?
 
     @output = []
 
@@ -104,7 +104,7 @@ class SystemCommand
     print_stdout: false,
     print_stderr: true,
     debug: nil,
-    verbose: false,
+    verbose: T.unsafe(nil),
     secrets: [],
     chdir: T.unsafe(nil),
     reset_uid: false,

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe SystemCommand do
           .and not_to_output.to_stdout
       end
 
-      context "when `debug?` is true" do
+      context "when `verbose?` and `debug?` are true" do
         include Context
 
         let(:options) do
@@ -203,8 +203,8 @@ RSpec.describe SystemCommand do
           ] }
         end
 
-        it "echoes the command and all output to STDERR when `debug?` is true" do
-          with_context debug: true do
+        it "echoes the command and all output to STDERR" do
+          with_context(verbose: true, debug: true) do
             expect { described_class.run(command, **options) }
               .to output(/\A.*#{Regexp.escape(command)}.*\n1\n2\n3\n4\n5\n6\n\Z/).to_stderr
               .and not_to_output.to_stdout
@@ -323,6 +323,7 @@ RSpec.describe SystemCommand do
           described_class.run! "curl",
                                args:    %w[--user username:hunter2],
                                verbose: true,
+                               debug:   true,
                                secrets: %w[hunter2]
         end.to raise_error(ErrorDuringExecution, redacted_msg).and output(redacted_msg).to_stderr
       end
@@ -333,6 +334,7 @@ RSpec.describe SystemCommand do
           ENV["PASSWORD"] = "hunter2"
           described_class.run! "curl",
                                args:    %w[--user username:hunter2],
+                               debug:   true,
                                verbose: true
         end.to raise_error(ErrorDuringExecution, redacted_msg).and output(redacted_msg).to_stderr
       end


### PR DESCRIPTION
The `Formulary` and `system_command` debug output is incredibly verbose by default and this is pretty annoying when all you want is to get better backtraces when there's an error.

Instead, let's require `--verbose` and `--debug` for the noisiest output message types.