### PR TITLE
dependabot: add Terraform for user-management repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,6 @@ multi-ecosystem-groups:
       time: '08:00'
       timezone: Etc/UTC
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  multi-ecosystem-group: all
-  patterns:
-  - "*"
-  allow:
-  - dependency-type: all
-  cooldown:
-    default-days: 1
-    include:
-    - "*"
 - package-ecosystem: bundler
   directories:
   - "/Library/Homebrew"
@@ -35,6 +24,17 @@ updates:
     semver-patch-days: 1
     include:
     - "*"
+- package-ecosystem: devcontainers
+  directory: "/"
+  multi-ecosystem-group: all
+  patterns:
+  - "*"
+  allow:
+  - dependency-type: all
+  cooldown:
+    default-days: 1
+    include:
+    - "*"
 - package-ecosystem: docker
   directory: "/"
   multi-ecosystem-group: all
@@ -42,7 +42,7 @@ updates:
   - "*"
   allow:
   - dependency-type: all
-- package-ecosystem: devcontainers
+- package-ecosystem: github-actions
   directory: "/"
   multi-ecosystem-group: all
   patterns:
@@ -68,4 +68,10 @@ updates:
     semver-patch-days: 1
     include:
     - "*"
-
+- package-ecosystem: terraform
+  directory: "/"
+  multi-ecosystem-group: all
+  patterns:
+  - "*"
+  allow:
+  - dependency-type: all


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Adding Terraform so that we can support updating dependencies in the user-management repo. While here, I also alphabetized the ecosystems for clarity.