### PR TITLE
env_config: add `auto` option for `download_concurrency`

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -634,9 +634,16 @@ module Homebrew
     sig { returns(Integer) }
     def download_concurrency
       # TODO: document this variable when ready to publicly announce it.
-      concurrency = ENV.fetch("HOMEBREW_DOWNLOAD_CONCURRENCY", 1).to_i
-      concurrency = 1 if concurrency <= 1
-      concurrency
+      concurrency = ENV.fetch("HOMEBREW_DOWNLOAD_CONCURRENCY", 1)
+      concurrency = if concurrency == "auto"
+        require "os"
+        require "hardware"
+        Hardware::CPU.cores * 2
+      else
+        concurrency.to_i
+      end
+
+      [concurrency, 1].max
     end
   end
 end

--- a/Library/Homebrew/env_config.rbi
+++ b/Library/Homebrew/env_config.rbi
@@ -1,0 +1,8 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  module EnvConfig
+    include Kernel
+  end
+end


### PR DESCRIPTION
This will allow the user to set `HOMEBREW_DOWNLOAD_CONCURRENCY` to `auto` to have Homebrew use the number of cores on the machine * 2.