### PR TITLE
cmd/info: don't print empty caveats.

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -360,7 +360,9 @@ module Homebrew
         end
 
         caveats = Caveats.new(formula)
-        ohai "Caveats", caveats.to_s unless caveats.empty?
+        if (caveats_string = caveats.to_s.presence)
+          ohai "Caveats", caveats_string
+        end
 
         Utils::Analytics.formula_output(formula, args:)
       end


### PR DESCRIPTION
The existing logic was insufficient so let's check the actual string.

Fixes https://github.com/Homebrew/brew/issues/20326