### PR TITLE
Deprecate/disable/remove code for Homebrew 4.6

### DIFF
--- a/Library/Homebrew/bundle/whalebrew_dumper.rb
+++ b/Library/Homebrew/bundle/whalebrew_dumper.rb
@@ -13,7 +13,7 @@ module Homebrew
       def self.images
         return [] unless Bundle.whalebrew_installed?
 
-        odeprecated "`brew bundle` `whalebrew` support", "using `whalebrew` directly"
+        odisabled "`brew bundle` `whalebrew` support", "using `whalebrew` directly"
         @images ||= T.let(
           `whalebrew list 2>/dev/null`.split("\n")
                                       .reject { |line| line.start_with?("COMMAND ") }

--- a/Library/Homebrew/bundle/whalebrew_installer.rb
+++ b/Library/Homebrew/bundle/whalebrew_installer.rb
@@ -24,7 +24,7 @@ module Homebrew
       end
 
       def self.install!(name, preinstall: true, verbose: false, force: false, **_options)
-        odeprecated "`brew bundle` `whalebrew` support", "using `whalebrew` directly"
+        odisabled "`brew bundle` `whalebrew` support", "using `whalebrew` directly"
         return true unless preinstall
 
         puts "Installing #{name} image. It is not currently installed." if verbose

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -324,7 +324,6 @@ module Cask
       return if cask.deprecated? || cask.disabled?
       return if cask.version&.latest?
       return if (url = cask.url).nil?
-      return if block_url_offline?
       return if cask.livecheck_defined?
       return if livecheck_result == :auto_detected
 
@@ -348,7 +347,6 @@ module Cask
     sig { void }
     def audit_download_url_format
       return if (url = cask.url).nil?
-      return if block_url_offline?
 
       odebug "Auditing URL format"
       return unless bad_sourceforge_url?
@@ -360,7 +358,6 @@ module Cask
     sig { void }
     def audit_download_url_is_osdn
       return if (url = cask.url).nil?
-      return if block_url_offline?
       return unless bad_osdn_url?
 
       add_error "OSDN download urls are disabled.", location: url.location, strict_only: true
@@ -372,7 +369,6 @@ module Cask
     sig { void }
     def audit_unnecessary_verified
       return unless cask.url
-      return if block_url_offline?
       return unless verified_present?
       return unless url_match_homepage?
       return unless verified_matches_url?
@@ -385,7 +381,6 @@ module Cask
     sig { void }
     def audit_missing_verified
       return unless cask.url
-      return if block_url_offline?
       return if file_url?
       return if url_match_homepage?
       return if verified_present?
@@ -398,7 +393,6 @@ module Cask
     sig { void }
     def audit_no_match
       return if (url = cask.url).nil?
-      return if block_url_offline?
       return unless verified_present?
       return if verified_matches_url?
 
@@ -1189,13 +1183,6 @@ module Cask
     sig { returns(T::Boolean) }
     def file_url?
       URI(cask.url.to_s).scheme == "file"
-    end
-
-    sig { returns(T::Boolean) }
-    def block_url_offline?
-      return false if online?
-
-      !!cask.url&.from_block?
     end
 
     sig { returns(Tap) }

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -98,10 +98,9 @@ module Cask
       :disable_reason,
       :disable_replacement_cask,
       :disable_replacement_formula,
-      :discontinued?, # TODO: remove once discontinued? is removed (4.5.0)
       :livecheck,
       :livecheck_defined?,
-      :livecheckable?, # TODO: remove once `#livecheckable?` is removed
+      :livecheckable?, # TODO: remove once `#livecheckable?` was odisabled and is now removed
       :no_autobump!,
       :autobump?,
       :no_autobump_message,
@@ -556,7 +555,7 @@ module Cask
     # for `#livecheck_defined?`.
     sig { returns(T::Boolean) }
     def livecheckable?
-      odeprecated "`livecheckable?`", "`livecheck_defined?`"
+      odisabled "`livecheckable?`", "`livecheck_defined?`"
       @livecheck_defined == true
     end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -58,7 +58,6 @@ module Homebrew
                hidden:      true
         switch "--[no-]signing",
                description: "Audit for app signatures, which are required by macOS on ARM."
-        # should be odeprecated in future
         switch "--token-conflicts",
                description: "Audit for token conflicts.",
                hidden:      true
@@ -105,6 +104,8 @@ module Homebrew
 
       sig { override.void }
       def run
+        odeprecated "brew audit --token-conflicts" if args.token_conflicts?
+
         Formulary.enable_factory_cache!
 
         os_arch_combinations = args.os_arch_combinations

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -439,20 +439,5 @@ class Pathname
                  .encode(Encoding::UTF_8, invalid: :replace)
                  .split("\n")
   end
-
-  # Like regular `rmtree`, except it never ignores errors.
-  #
-  # This was the default behaviour in Ruby 3.1 and earlier.
-  #
-  # @api public
-  def rmtree(noop: nil, verbose: nil, secure: nil)
-    # Ideally we'd odeprecate this but probably can't given gems so let's
-    # create a RuboCop autocorrect instead soon.
-    # This is why monkeypatching is non-ideal (but right solution to get
-    # Ruby 3.3 over the line).
-    odisabled "rmtree", "FileUtils#rm_r"
-    FileUtils.rm_r(T.must(@path), noop:, verbose:, secure:)
-    nil
-  end
 end
 require "extend/os/pathname"

--- a/Library/Homebrew/extend/time.rb
+++ b/Library/Homebrew/extend/time.rb
@@ -7,7 +7,7 @@ class Time
   # Backwards compatibility for formulae that used this ActiveSupport extension
   sig { returns(String) }
   def rfc3339
-    odeprecated "Time#rfc3339", "Time#xmlschema"
+    odisabled "Time#rfc3339", "Time#xmlschema"
     xmlschema
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2796,24 +2796,6 @@ class Formula
     self.class.on_system_blocks_exist? || @on_system_blocks_exist
   end
 
-  sig {
-    params(
-      verify_download_integrity: T::Boolean,
-      timeout:                   T.nilable(T.any(Integer, Float)),
-      quiet:                     T::Boolean,
-    ).returns(Pathname)
-  }
-  def fetch(verify_download_integrity: true, timeout: nil, quiet: false)
-    odisabled "Formula#fetch", "Resource#fetch on Formula#resource"
-    active_spec.fetch(verify_download_integrity:, timeout:, quiet:)
-  end
-
-  sig { params(filename: T.any(Pathname, String)).void }
-  def verify_download_integrity(filename)
-    odisabled "Formula#verify_download_integrity", "Resource#verify_download_integrity on Formula#resource"
-    active_spec.verify_download_integrity(filename)
-  end
-
   sig { params(keep_tmp: T::Boolean).returns(T.untyped) }
   def run_test(keep_tmp: false)
     @prefix_returns_versioned_prefix = T.let(true, T.nilable(T::Boolean))
@@ -2909,22 +2891,15 @@ class Formula
   # @api public
   sig {
     params(
-      paths:            T.any(T::Enumerable[T.any(String, Pathname)], String, Pathname),
-      before:           T.nilable(T.any(Pathname, Regexp, String)),
-      after:            T.nilable(T.any(Pathname, String, Symbol)),
-      old_audit_result: T.nilable(T::Boolean),
-      audit_result:     T::Boolean,
-      global:           T::Boolean,
-      block:            T.nilable(T.proc.params(s: StringInreplaceExtension).void),
+      paths:        T.any(T::Enumerable[T.any(String, Pathname)], String, Pathname),
+      before:       T.nilable(T.any(Pathname, Regexp, String)),
+      after:        T.nilable(T.any(Pathname, String, Symbol)),
+      audit_result: T::Boolean,
+      global:       T::Boolean,
+      block:        T.nilable(T.proc.params(s: StringInreplaceExtension).void),
     ).void
   }
-  def inreplace(paths, before = nil, after = nil, old_audit_result = nil, audit_result: true, global: true, &block)
-    # NOTE: must check for `#nil?` and not `#blank?`, or else `old_audit_result = false` will not call `odeprecated`.
-    unless old_audit_result.nil?
-      odisabled "inreplace(paths, before, after, #{old_audit_result})",
-                "inreplace(paths, before, after, audit_result: #{old_audit_result})"
-      audit_result = old_audit_result
-    end
+  def inreplace(paths, before = nil, after = nil, audit_result: true, global: true, &block)
     Utils::Inreplace.inreplace(paths, before, after, audit_result:, global:, &block)
   rescue Utils::Inreplace::Error => e
     onoe e.to_s
@@ -3558,7 +3533,7 @@ class Formula
     # and `false` otherwise.
     sig { returns(T::Boolean) }
     def livecheckable?
-      odeprecated "`livecheckable?`", "`livecheck_defined?`"
+      odisabled "`livecheckable?`", "`livecheck_defined?`"
       @livecheck_defined == true
     end
 

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -20,13 +20,6 @@ class GitRepository
     pathname.join(".git").exist?
   end
 
-  sig { returns(T::Boolean) }
-  def git_repo?
-    # delete this whole function when removing odisabled
-    odisabled "GitRepository#git_repo?", "GitRepository#git_repository?"
-    git_repository?
-  end
-
   # Gets the URL of the Git origin remote.
   sig { returns(T.nilable(String)) }
   def origin_url

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -182,7 +182,7 @@ class Resource
   # and `false` otherwise.
   sig { returns(T::Boolean) }
   def livecheckable?
-    odeprecated "`livecheckable?`", "`livecheck_defined?`"
+    odisabled "`livecheckable?`", "`livecheck_defined?`"
     @livecheck_defined == true
   end
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -155,14 +155,6 @@ class Tap
   # @api public
   attr_reader :repository
 
-  # @deprecated
-  sig { returns(T::Boolean) }
-  def repo
-    # delete this whole function when removing odisabled
-    odisabled "Tap#repo", "Tap#repository"
-    repository
-  end
-
   # The name of this {Tap}. It combines {#user} and {#repository} with a slash.
   # {#name} is always in lowercase.
   # e.g. `user/repository`
@@ -277,14 +269,6 @@ class Tap
     @remote_repository ||= T.must(match[:remote_repository])
   end
 
-  # @deprecated
-  sig { returns(T.nilable(String)) }
-  def remote_repo
-    # delete this whole function when removing odisabled
-    odisabled "Tap#remote_repo", "Tap#remote_repository"
-    remote_repository
-  end
-
   # The default remote path to this {Tap}.
   sig { returns(String) }
   def default_remote
@@ -297,14 +281,6 @@ class Tap
                                    .delete_prefix(HOMEBREW_TAP_DIRECTORY.to_s)
                                    .tr("^A-Za-z0-9", "_")
                                    .upcase
-  end
-
-  # @deprecated
-  sig { returns(String) }
-  def repo_var_suffix
-    # delete this whole function when removing odisabled
-    odisabled "Tap#repo_var_suffix", "Tap#repository_var_suffix"
-    repository_var_suffix
   end
 
   # Check whether this {Tap} is a Git repository.

--- a/Library/Homebrew/utils/string_inreplace_extension.rb
+++ b/Library/Homebrew/utils/string_inreplace_extension.rb
@@ -37,10 +37,10 @@ class StringInreplaceExtension
     ).returns(T.nilable(String))
   }
   def gsub!(before, after, old_audit_result = nil, audit_result: true)
-    # NOTE: must check for `#nil?` and not `#blank?`, or else `old_audit_result = false` will not call `odeprecated`.
+    # NOTE: must check for `#nil?` and not `#blank?`, or else `old_audit_result = false` will not call `odisabled`.
     unless old_audit_result.nil?
-      odeprecated "gsub!(before, after, #{old_audit_result})",
-                  "gsub!(before, after, audit_result: #{old_audit_result})"
+      odisabled "gsub!(before, after, #{old_audit_result})",
+                "gsub!(before, after, audit_result: #{old_audit_result})"
       audit_result = old_audit_result
     end
     before = before.to_s if before.is_a?(Pathname)


### PR DESCRIPTION
The next minor release will be Homebrew 4.6.0 so let's do the usual deprecation/disable/remove code cycle.