### PR TITLE
`brew upgrade --help` missing HOMEBREW_UPGRADE_GREEDY

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -91,6 +91,7 @@ module Homebrew
           }],
           [:switch, "-g", "--greedy", {
             description: "Also include casks with `auto_updates true` or `version :latest`.",
+            env:         :upgrade_greedy,
           }],
           [:switch, "--greedy-latest", {
             description: "Also include casks with `version :latest`.",


### PR DESCRIPTION
`brew upgrade --help` currently doesn't mention the existence of HOMEBREW_UPGRADE_GREEDY like e.g. `brew outdated --help` does.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
