### PR TITLE
Add appimage support for linux

### DIFF
--- a/Library/Homebrew/cask/artifact.rb
+++ b/Library/Homebrew/cask/artifact.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cask/artifact/app"
+require "cask/artifact/appimage"
 require "cask/artifact/artifact" # generic 'artifact' stanza
 require "cask/artifact/audio_unit_plugin"
 require "cask/artifact/binary"
@@ -54,6 +55,8 @@ module Cask
       ::Cask::Artifact::Vst3Plugin,
     ].freeze
 
-    LINUX_ONLY_ARTIFACTS = T.let([].freeze, T::Array[T.untyped])
+    LINUX_ONLY_ARTIFACTS = [
+      ::Cask::Artifact::AppImage,
+    ].freeze
   end
 end

--- a/Library/Homebrew/cask/artifact/appimage.rb
+++ b/Library/Homebrew/cask/artifact/appimage.rb
@@ -1,0 +1,15 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "cask/artifact/symlinked"
+
+module Cask
+  module Artifact
+    class AppImage < Symlinked
+      sig { params(target: T.any(String, Pathname)).returns(Pathname) }
+      def resolve_target(target)
+        Pathname.new("#{config.appimagedir}/#{target}")
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cask/artifact/appimage.rb
+++ b/Library/Homebrew/cask/artifact/appimage.rb
@@ -6,9 +6,28 @@ require "cask/artifact/symlinked"
 module Cask
   module Artifact
     class AppImage < Symlinked
-      sig { params(target: T.any(String, Pathname)).returns(Pathname) }
-      def resolve_target(target)
+      sig { override.params(target: T.any(String, Pathname), base_dir: T.nilable(Pathname)).returns(Pathname) }
+      def resolve_target(target, base_dir: nil)
         Pathname.new("#{config.appimagedir}/#{target}")
+      end
+
+      sig {
+        override.params(
+          force:    T::Boolean,
+          adopt:    T::Boolean,
+          command:  T.class_of(SystemCommand),
+          _options: T.anything,
+        ).void
+      }
+      def link(force: false, adopt: false, command: SystemCommand, **_options)
+        super
+        return if source.executable?
+
+        if source.writable?
+          FileUtils.chmod "+x", source
+        else
+          command.run!("chmod", args: ["+x", source], sudo: true)
+        end
       end
     end
   end

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -16,6 +16,7 @@ module Cask
     DEFAULT_DIRS = T.let(
       {
         appdir:               "/Applications",
+        appimagedir:          "~/Applications",
         keyboard_layoutdir:   "/Library/Keyboard Layouts",
         colorpickerdir:       "~/Library/ColorPickers",
         prefpanedir:          "~/Library/PreferencePanes",
@@ -49,6 +50,7 @@ module Cask
       args = T.unsafe(args)
       new(explicit: {
         appdir:               args.appdir,
+        appimagedir:          args.appimagedir,
         keyboard_layoutdir:   args.keyboard_layoutdir,
         colorpickerdir:       args.colorpickerdir,
         prefpanedir:          args.prefpanedir,

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -16,7 +16,6 @@ module Cask
     DEFAULT_DIRS = T.let(
       {
         appdir:               "/Applications",
-        appimagedir:          "~/Applications",
         keyboard_layoutdir:   "/Library/Keyboard Layouts",
         colorpickerdir:       "~/Library/ColorPickers",
         prefpanedir:          "~/Library/PreferencePanes",

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -37,6 +37,7 @@ module Cask
     ORDINARY_ARTIFACT_CLASSES = [
       Artifact::Installer,
       Artifact::App,
+      Artifact::AppImage,
       Artifact::Artifact,
       Artifact::AudioUnitPlugin,
       Artifact::Binary,

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -66,6 +66,10 @@ module Homebrew
             description: "Target location for Applications " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:appdir]}`).",
           }],
+          [:flag, "--appimagedir=", {
+            description: "Target location for AppImages " \
+                         "(default: `#{Cask::Config::DEFAULT_DIRS[:appimagedir]}`).",
+          }],
           [:flag, "--keyboard-layoutdir=", {
             description: "Target location for Keyboard Layouts " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:keyboard_layoutdir]}`).",

--- a/Library/Homebrew/extend/os/cask/installer.rb
+++ b/Library/Homebrew/extend/os/cask/installer.rb
@@ -2,3 +2,4 @@
 # frozen_string_literal: true
 
 require "extend/os/linux/cask/installer" if OS.linux?
+require "extend/os/mac/cask/installer" if OS.mac?

--- a/Library/Homebrew/extend/os/linux/cask/config.rb
+++ b/Library/Homebrew/extend/os/linux/cask/config.rb
@@ -13,6 +13,7 @@ module OS
             vst3_plugindir: "~/.vst3",
             fontdir:        "#{ENV.fetch("HOMEBREW_XDG_DATA_HOME", "~/.local/share")}/fonts",
             appdir:         "~/.config/apps",
+            appimagedir:    "~/Applications",
           }.freeze, T::Hash[Symbol, String])
 
           sig { returns(T::Hash[Symbol, T.any(LazyObject, String)]) }

--- a/Library/Homebrew/extend/os/mac/cask/installer.rb
+++ b/Library/Homebrew/extend/os/mac/cask/installer.rb
@@ -1,0 +1,30 @@
+# typed: strict
+# frozen_string_literal: true
+
+module OS
+  module Mac
+    module Cask
+      module Installer
+        extend T::Helpers
+
+        requires_ancestor { ::Cask::Installer }
+
+        sig { void }
+        def check_stanza_os_requirements
+          return if artifacts.all? { |artifact| supported_artifact?(artifact) }
+
+          raise ::Cask::CaskError, "Linux is required for this software."
+        end
+
+        private
+
+        sig { params(artifact: ::Cask::Artifact::AbstractArtifact).returns(T::Boolean) }
+        def supported_artifact?(artifact)
+          ::Cask::Artifact::LINUX_ONLY_ARTIFACTS.exclude?(artifact.class)
+        end
+      end
+    end
+  end
+end
+
+Cask::Installer.prepend(OS::Mac::Cask::Installer)

--- a/Library/Homebrew/extend/os/mac/cask/installer.rb
+++ b/Library/Homebrew/extend/os/mac/cask/installer.rb
@@ -11,7 +11,7 @@ module OS
 
         sig { void }
         def check_stanza_os_requirements
-          return if artifacts.all? { |artifact| supported_artifact?(artifact) }
+          return if !cask.depends_on.requires_linux? && artifacts.all? { |artifact| supported_artifact?(artifact) }
 
           raise ::Cask::CaskError, "Linux is required for this software."
         end

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
@@ -10,6 +10,9 @@ class Cask::Cask
   def app(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def app_image(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def appdir(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/config.rbi
@@ -11,6 +11,9 @@ module Cask
     def appdir; end
 
     sig { returns(String) }
+    def appimagedir; end
+
+    sig { returns(String) }
     def audio_unit_plugindir; end
 
     sig { returns(String) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/install_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/install_cmd.rbi
@@ -20,6 +20,9 @@ class Homebrew::Cmd::InstallCmd::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(String)) }
   def appdir; end
 
+  sig { returns(T.nilable(String)) }
+  def appimagedir; end
+
   sig { returns(T::Boolean) }
   def as_dependency?; end
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/reinstall.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/reinstall.rbi
@@ -17,6 +17,9 @@ class Homebrew::Cmd::Reinstall::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(String)) }
   def appdir; end
 
+  sig { returns(T.nilable(String)) }
+  def appimagedir; end
+
   sig { returns(T::Boolean) }
   def ask?; end
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/upgrade_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/upgrade_cmd.rbi
@@ -14,6 +14,9 @@ class Homebrew::Cmd::UpgradeCmd::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(String)) }
   def appdir; end
 
+  sig { returns(T.nilable(String)) }
+  def appimagedir; end
+
   sig { returns(T::Boolean) }
   def ask?; end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This adds support for the first linux-only cask stanza: `app_image`.
We should probably add CI for Linux casks, but haven't been able to get that working yet.