### PR TITLE
api: fix handling of source downloads

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -47,7 +47,7 @@ module Homebrew
 
         if download_queue
           download_queue.enqueue(download)
-        elsif !download.cache.exist?
+        elsif !download.symlink_location.exist?
           download.fetch
         end
 

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -42,7 +42,7 @@ module Homebrew
 
         if download_queue
           download_queue.enqueue(download)
-        elsif !download.cache.exist?
+        elsif !download.symlink_location.exist?
           download.fetch
         end
 


### PR DESCRIPTION
`cache` is the directory containing the files so downloading one package would prevent any other package from fetching. Fix this by checking the file we use instead.

Fixes #20332