### PR TITLE
Cleanup some `extend/*` types/locations

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1320,6 +1320,7 @@ class Formula
       path = Pathname.new(path)
       path.extend(InstallRenamed)
       path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
+      path
     end
   end
 

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -445,9 +445,11 @@ module Homebrew
 
         puts "#{::Utils.pluralize("Formula", formulae.count, plural: "e")} \
 (#{formulae.count}): #{formulae.join(", ")}\n\n"
-        puts "Download Size: #{disk_usage_readable(sizes[:download])}"
-        puts "Install Size:  #{disk_usage_readable(sizes[:installed])}"
-        puts "Net Install Size: #{disk_usage_readable(sizes[:net])}" if sizes[:net] != 0
+        puts "Download Size: #{disk_usage_readable(sizes.fetch(:download))}"
+        puts "Install Size:  #{disk_usage_readable(sizes.fetch(:installed))}"
+        if (net_install_size = sizes[:net]) && net_install_size != 0
+          puts "Net Install Size: #{disk_usage_readable(net_install_size)}"
+        end
 
         ask_input
       end

--- a/Library/Homebrew/install_renamed.rb
+++ b/Library/Homebrew/install_renamed.rb
@@ -1,9 +1,13 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 # Helper module for installing default files.
 module InstallRenamed
-  def install_p(_, new_basename)
+  sig {
+    params(src: T.any(String, Pathname), new_basename: String,
+           _block: T.nilable(T.proc.params(src: Pathname, dst: Pathname).returns(T.nilable(Pathname)))).void
+  }
+  def install_p(src, new_basename, &_block)
     super do |src, dst|
       if src.directory?
         dst.install(src.children)
@@ -14,22 +18,29 @@ module InstallRenamed
     end
   end
 
-  def cp_path_sub(pattern, replacement)
+  sig {
+    params(pattern: T.any(Pathname, String, Regexp), replacement: T.any(Pathname, String),
+           _block: T.nilable(T.proc.params(src: Pathname, dst: Pathname).returns(Pathname))).void
+  }
+  def cp_path_sub(pattern, replacement, &_block)
     super do |src, dst|
       append_default_if_different(src, dst)
     end
   end
 
+  sig { params(other: T.any(String, Pathname)).returns(Pathname) }
   def +(other)
     super.extend(InstallRenamed)
   end
 
+  sig { params(other: T.any(String, Pathname)).returns(Pathname) }
   def /(other)
     super.extend(InstallRenamed)
   end
 
   private
 
+  sig { params(src: Pathname, dst: Pathname).returns(Pathname) }
   def append_default_if_different(src, dst)
     if dst.file? && !FileUtils.identical?(src, dst)
       Pathname.new("#{dst}.default")

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -19,9 +19,11 @@ module Homebrew
       end
       exit! 1 # never gets here unless exec failed
     end
-    Process.wait(T.must(pid))
+    Process.wait(pid)
     $CHILD_STATUS.success?
   end
+  # TODO: make private_class_method when possible
+  # private_class_method :_system
   # rubocop:enable Naming/PredicateMethod
 
   def self.system(cmd, *args, **options)
@@ -37,9 +39,9 @@ module Homebrew
   # rubocop:disable Style/GlobalVars
   sig { params(the_module: Module, pattern: Regexp).void }
   def self.inject_dump_stats!(the_module, pattern)
-    @injected_dump_stat_modules ||= {}
+    @injected_dump_stat_modules ||= T.let({}, T.nilable(T::Hash[Module, T::Array[String]]))
     @injected_dump_stat_modules[the_module] ||= []
-    injected_methods = @injected_dump_stat_modules[the_module]
+    injected_methods = @injected_dump_stat_modules.fetch(the_module)
     the_module.module_eval do
       instance_methods.grep(pattern).each do |name|
         next if injected_methods.include? name


### PR DESCRIPTION
While working on https://github.com/Homebrew/brew/pull/20331 I noticed some missing Sorbet types/signatures/etc. and that `Pathname#cp_path_sub` could be easily moved to `Utils.cp_path_sub` instead.

Extracted from https://github.com/Homebrew/brew/pull/20331