### PR TITLE
formula_assertions: fix typechecking error in `{shell,pipe}_output`

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -26,7 +26,8 @@ module Homebrew
     # @api public
     sig { params(cmd: T.any(Pathname, String), result: Integer).returns(String) }
     def shell_output(cmd, result = 0)
-      ohai cmd
+      ohai cmd.to_s
+      assert_path_exists cmd, "Pathname '#{cmd}' does not exist!" if cmd.is_a?(Pathname)
       output = `#{cmd}`
       assert_equal result, $CHILD_STATUS.exitstatus
       output
@@ -41,7 +42,8 @@ module Homebrew
     # @api public
     sig { params(cmd: T.any(String, Pathname), input: T.nilable(String), result: T.nilable(Integer)).returns(String) }
     def pipe_output(cmd, input = nil, result = nil)
-      ohai cmd
+      ohai cmd.to_s
+      assert_path_exists cmd, "Pathname '#{cmd}' does not exist!" if cmd.is_a?(Pathname)
       output = IO.popen(cmd, "w+") do |pipe|
         pipe.write(input) unless input.nil?
         pipe.close_write


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`cmd` can be a `Pathname` (see the type signature), but `ohai` seems to
expect only `String`s now.

While we're here, let's assert that `cmd` exists whenever it is a
`Pathname`, to avoid passing arguments like `bin/"cmd --version"` (which
is not a valid `Pathname`).

See, for example, Homebrew/homebrew-core#231882.
