### PR TITLE
extend/kernel: fix circular dependency on `Formula` class

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -234,7 +234,9 @@ module Kernel
     odeprecated(method, replacement, disable: true, disable_on:, disable_for_developers:, caller:)
   end
 
-  sig { params(formula: T.any(String, Formula)).returns(String) }
+  # Signature should be the following, but we don't want to `require "formula"` to use it:
+  # sig { params(formula: T.any(String, Formula)).returns(String) }
+  sig { params(formula: T.untyped).returns(String) }
   def pretty_installed(formula)
     if !$stdout.tty?
       formula.to_s
@@ -245,7 +247,9 @@ module Kernel
     end
   end
 
-  sig { params(formula: T.any(String, Formula)).returns(String) }
+  # Signature should be the following, but we don't want to `require "formula"` to use it:
+  # sig { params(formula: T.any(String, Formula)).returns(String) }
+  sig { params(formula: T.untyped).returns(String) }
   def pretty_outdated(formula)
     if !$stdout.tty?
       formula.to_s
@@ -256,7 +260,9 @@ module Kernel
     end
   end
 
-  sig { params(formula: T.any(String, Formula)).returns(String) }
+  # Signature should be the following, but we don't want to `require "formula"` to use it:
+  # sig { params(formula: T.any(String, Formula)).returns(String) }
+  sig { params(formula: T.untyped).returns(String) }
   def pretty_uninstalled(formula)
     if !$stdout.tty?
       formula.to_s
@@ -285,7 +291,9 @@ module Kernel
     res.freeze
   end
 
-  sig { params(formula: T.nilable(Formula)).void }
+  # Signature should be the following, but we don't want to `require "formula"` to use it:
+  # sig { params(formula: T.nilable(Formula)).void }
+  sig { params(formula: T.untyped).void }
   def interactive_shell(formula = nil)
     unless formula.nil?
       ENV["HOMEBREW_DEBUG_PREFIX"] = formula.prefix.to_s
@@ -441,9 +449,14 @@ module Kernel
 
   # Ensure the given formula is installed
   # This is useful for installing a utility formula (e.g. `shellcheck` for `brew style`)
+  # Signature should be the following, but we don't want to `require "formula"` to use it:
+  # sig {
+  #   params(formula_or_name: T.any(String, Formula), reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
+  #          quiet: T::Boolean).returns(Formula)
+  # }
   sig {
-    params(formula_or_name: T.any(String, Formula), reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
-           quiet: T::Boolean).returns(Formula)
+    params(formula_or_name: T.untyped, reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
+           quiet: T::Boolean).returns(T.untyped)
   }
   def ensure_formula_installed!(formula_or_name, reason: "", latest: false,
                                 output_to_stderr: true, quiet: false)

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -1,6 +1,11 @@
 # typed: true # rubocop:todo Sorbet/StrictSigil
 # frozen_string_literal: true
 
+# Needed to handle circular require dependency.
+# rubocop:disable Lint/EmptyClass
+class Formula; end
+# rubocop:enable Lint/EmptyClass
+
 # Contains shorthand Homebrew utility methods like `ohai`, `opoo`, `odisabled`.
 # TODO: move these out of `Kernel` into `Homebrew::GlobalMethods` and add
 # necessary Sorbet and global Kernel inclusions.
@@ -234,9 +239,7 @@ module Kernel
     odeprecated(method, replacement, disable: true, disable_on:, disable_for_developers:, caller:)
   end
 
-  # Signature should be the following, but we don't want to `require "formula"` to use it:
-  # sig { params(formula: T.any(String, Formula)).returns(String) }
-  sig { params(formula: T.untyped).returns(String) }
+  sig { params(formula: T.any(String, Formula)).returns(String) }
   def pretty_installed(formula)
     if !$stdout.tty?
       formula.to_s
@@ -247,9 +250,7 @@ module Kernel
     end
   end
 
-  # Signature should be the following, but we don't want to `require "formula"` to use it:
-  # sig { params(formula: T.any(String, Formula)).returns(String) }
-  sig { params(formula: T.untyped).returns(String) }
+  sig { params(formula: T.any(String, Formula)).returns(String) }
   def pretty_outdated(formula)
     if !$stdout.tty?
       formula.to_s
@@ -260,9 +261,7 @@ module Kernel
     end
   end
 
-  # Signature should be the following, but we don't want to `require "formula"` to use it:
-  # sig { params(formula: T.any(String, Formula)).returns(String) }
-  sig { params(formula: T.untyped).returns(String) }
+  sig { params(formula: T.any(String, Formula)).returns(String) }
   def pretty_uninstalled(formula)
     if !$stdout.tty?
       formula.to_s
@@ -291,9 +290,7 @@ module Kernel
     res.freeze
   end
 
-  # Signature should be the following, but we don't want to `require "formula"` to use it:
-  # sig { params(formula: T.nilable(Formula)).void }
-  sig { params(formula: T.untyped).void }
+  sig { params(formula: T.nilable(Formula)).void }
   def interactive_shell(formula = nil)
     unless formula.nil?
       ENV["HOMEBREW_DEBUG_PREFIX"] = formula.prefix.to_s
@@ -449,14 +446,9 @@ module Kernel
 
   # Ensure the given formula is installed
   # This is useful for installing a utility formula (e.g. `shellcheck` for `brew style`)
-  # Signature should be the following, but we don't want to `require "formula"` to use it:
-  # sig {
-  #   params(formula_or_name: T.any(String, Formula), reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
-  #          quiet: T::Boolean).returns(Formula)
-  # }
   sig {
-    params(formula_or_name: T.untyped, reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
-           quiet: T::Boolean).returns(T.untyped)
+    params(formula_or_name: T.any(String, Formula), reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
+           quiet: T::Boolean).returns(Formula)
   }
   def ensure_formula_installed!(formula_or_name, reason: "", latest: false,
                                 output_to_stderr: true, quiet: false)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`Formula` has not yet been defined, and we do not want to `require "formula"`
here in order to do so.

Fixes

    ❯ HOMEBREW_BAT=1 brew cat xz
    Error: uninitialized constant Kernel::Formula
    Warning: Removed Sorbet lines from backtrace!
    Rerun with `--verbose` to see the original backtrace
    /opt/homebrew/Library/Homebrew/extend/kernel.rb:445:in 'block in <module:Kernel>'
    /opt/homebrew/Library/Homebrew/dev-cmd/cat.rb:33:in 'block in Homebrew::DevCmd::Cat#run'
    /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/3.4.0/fileutils.rb:241:in 'Dir.chdir'
    /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/3.4.0/fileutils.rb:241:in 'FileUtils#cd'
    /opt/homebrew/Library/Homebrew/dev-cmd/cat.rb:29:in 'Homebrew::DevCmd::Cat#run'
    /opt/homebrew/Library/Homebrew/brew.rb:113:in '<main>'
    Please report this issue:
      https://docs.brew.sh/Troubleshooting

