### PR TITLE
download_queue: fix patch handling.

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -137,12 +137,13 @@ class Resource
         verify_download_integrity: T::Boolean,
         timeout:                   T.nilable(T.any(Integer, Float)),
         quiet:                     T::Boolean,
+        skip_patches:              T::Boolean,
       ).returns(Pathname)
   }
-  def fetch(verify_download_integrity: true, timeout: nil, quiet: false)
-    fetch_patches
+  def fetch(verify_download_integrity: true, timeout: nil, quiet: false, skip_patches: false)
+    fetch_patches unless skip_patches
 
-    super
+    super(verify_download_integrity:, timeout:, quiet:)
   end
 
   # {Livecheck} can be used to check for newer versions of the software.
@@ -345,6 +346,9 @@ class Resource
     sig { override.returns(String) }
     def download_type = "Bottle Manifest"
 
+    sig { override.returns(String) }
+    def name = bottle.name
+
     private
 
     def manifest_annotations
@@ -400,6 +404,15 @@ class Resource
 
     sig { override.returns(String) }
     def download_type = "Patch"
+
+    sig { override.returns(String) }
+    def name
+      if (url = self.url)
+        url.to_s.split("/").last
+      else
+        super
+      end
+    end
   end
 end
 

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -60,7 +60,11 @@ module Homebrew
 
       already_downloaded = downloadable.downloaded?
 
-      download = downloadable.fetch(verify_download_integrity: false, timeout:, quiet:)
+      download = if downloadable.is_a?(Resource) && (resource = T.cast(downloadable, Resource))
+        resource.fetch(verify_download_integrity: false, timeout:, quiet:, skip_patches: true)
+      else
+        downloadable.fetch(verify_download_integrity: false, timeout:, quiet:)
+      end
 
       return download unless download.file?
 


### PR DESCRIPTION
These were being downloaded twice simultaneously which causes a locking race condition.

While we're here, also improve the output of bottle manifests and patches in the download queue.

@carlocab should fix https://github.com/Homebrew/homebrew-core/pull/231723#issuecomment-3140138146