### PR TITLE
dev-cmd/cat: add `require "formula"`

### DIFF
--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -30,6 +30,7 @@ module Homebrew
           pager = if Homebrew::EnvConfig.bat?
             ENV["BAT_CONFIG_PATH"] = Homebrew::EnvConfig.bat_config_path
             ENV["BAT_THEME"] = Homebrew::EnvConfig.bat_theme
+            require "formula"
             ensure_formula_installed!(
               "bat",
               reason:           "displaying <formula>/<cask> source",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes

    ❯ HOMEBREW_BAT=1 brew cat xz
    Error: uninitialized constant Kernel::Formula
    Warning: Removed Sorbet lines from backtrace!
    Rerun with `--verbose` to see the original backtrace
    /opt/homebrew/Library/Homebrew/extend/kernel.rb:445:in 'block in <module:Kernel>'
    /opt/homebrew/Library/Homebrew/dev-cmd/cat.rb:33:in 'block in Homebrew::DevCmd::Cat#run'
    /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/3.4.0/fileutils.rb:241:in 'Dir.chdir'
    /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/3.4.0/fileutils.rb:241:in 'FileUtils#cd'
    /opt/homebrew/Library/Homebrew/dev-cmd/cat.rb:29:in 'Homebrew::DevCmd::Cat#run'
    /opt/homebrew/Library/Homebrew/brew.rb:113:in '<main>'
    Please report this issue:
      https://docs.brew.sh/Troubleshooting
