### PR TITLE
extend/kernel: tighten type sig for `ensure_formula_installed!`

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -354,7 +354,7 @@ module Homebrew
         end
         return if gnu_tar_formula.blank?
 
-        ensure_formula_installed!(gnu_tar_formula, reason: "bottling")
+        ensure_formula_installed!(gnu_tar_formula.name, reason: "bottling")
 
         gnu_tar_formula
       end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -442,10 +442,10 @@ module Kernel
   # Ensure the given formula is installed
   # This is useful for installing a utility formula (e.g. `shellcheck` for `brew style`)
   sig {
-    params(formula_or_name: T.any(String, Formula), reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
+    params(formula_name: String, reason: String, latest: T::Boolean, output_to_stderr: T::Boolean,
            quiet: T::Boolean).returns(Formula)
   }
-  def ensure_formula_installed!(formula_or_name, reason: "", latest: false,
+  def ensure_formula_installed!(formula_name, reason: "", latest: false,
                                 output_to_stderr: true, quiet: false)
     if output_to_stderr || quiet
       file = if quiet
@@ -455,19 +455,14 @@ module Kernel
       end
       # Call this method itself with redirected stdout
       redirect_stdout(file) do
-        return ensure_formula_installed!(formula_or_name, latest:,
+        return ensure_formula_installed!(formula_name, latest:,
                                          reason:, output_to_stderr: false)
       end
     end
 
     require "formula"
 
-    formula = if formula_or_name.is_a?(Formula)
-      formula_or_name
-    else
-      Formula[formula_or_name]
-    end
-
+    formula = Formula[formula_name]
     reason = " for #{reason}" if reason.present?
 
     unless formula.any_version_installed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This does the same as #20356 for `ensure_formula_installed!`. See
discussion at #20352.

Unfortunately, one must still `require "formula"` before using this
method because of the `returns(Formula)`, but tightening the type
signature is generally a good idea anyway.

Closes #20352.
