### PR TITLE
Replace `ensure_formula_installed!` with `Formula#ensure_installed!`

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -354,9 +354,7 @@ module Homebrew
         end
         return if gnu_tar_formula.blank?
 
-        ensure_formula_installed!(gnu_tar_formula.name, reason: "bottling")
-
-        gnu_tar_formula
+        gnu_tar_formula.ensure_installed!(reason: "bottling")
       end
 
       sig { params(mtime: String, default_tar: T::Boolean).returns([String, T::Array[String]]) }

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -135,10 +135,7 @@ module Homebrew
 
           if args.repology? && !Utils::Curl.curl_supports_tls13?
             begin
-              unless HOMEBREW_BREWED_CURL_PATH.exist?
-                require "formula"
-                ensure_formula_installed!("curl", reason: "Repology queries")
-              end
+              Formula["curl"].ensure_installed!(reason: "Repology queries") unless HOMEBREW_BREWED_CURL_PATH.exist?
             rescue FormulaUnavailableError
               opoo "A newer `curl` is required for Repology queries."
             end

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -31,8 +31,7 @@ module Homebrew
             ENV["BAT_CONFIG_PATH"] = Homebrew::EnvConfig.bat_config_path
             ENV["BAT_THEME"] = Homebrew::EnvConfig.bat_theme
             require "formula"
-            ensure_formula_installed!(
-              "bat",
+            Formula["bat"].ensure_installed!(
               reason:           "displaying <formula>/<cask> source",
               # The user might want to capture the output of `brew cat ...`
               # Redirect stdout to stderr

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -449,7 +449,7 @@ module Kernel
   }
   def ensure_formula_installed!(formula_name, reason: "", latest: false,
                                 output_to_stderr: true, quiet: false)
-    # odeprecated "ensure_formula_installed!", "Formula[\"#{formula_name}\"].ensure_installed!"
+    odeprecated "ensure_formula_installed!", "Formula[\"#{formula_name}\"].ensure_installed!"
 
     if output_to_stderr || quiet
       file = if quiet

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -449,6 +449,8 @@ module Kernel
   }
   def ensure_formula_installed!(formula_name, reason: "", latest: false,
                                 output_to_stderr: true, quiet: false)
+    # odeprecated "ensure_formula_installed!", "Formula[\"#{formula_name}\"].ensure_installed!"
+
     if output_to_stderr || quiet
       file = if quiet
         File::NULL
@@ -496,7 +498,7 @@ module Kernel
     return executable if executable.exist?
 
     require "formula"
-    ensure_formula_installed!(formula_name, reason:, latest:).opt_bin/name
+    Formula[formula_name].ensure_installed!(reason:, latest:).opt_bin/name
   end
 
   sig { returns(T::Array[Pathname]) }

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -322,21 +322,18 @@ module Homebrew
 
     def self.shellcheck
       require "formula"
-      ensure_formula_installed!("shellcheck", latest: true,
-                                              reason: "shell style checks").opt_bin/"shellcheck"
+      Formula["shellcheck"].ensure_installed!(latest: true, reason: "shell style checks").opt_bin/"shellcheck"
     end
 
     def self.shfmt
       require "formula"
-      ensure_formula_installed!("shfmt", latest: true,
-                                         reason: "formatting shell scripts")
+      Formula["shfmt"].ensure_installed!(latest: true, reason: "formatting shell scripts")
       HOMEBREW_LIBRARY/"Homebrew/utils/shfmt.sh"
     end
 
     def self.actionlint
       require "formula"
-      ensure_formula_installed!("actionlint", latest: true,
-                                              reason: "GitHub Actions checks").opt_bin/"actionlint"
+      Formula["actionlint"].ensure_installed!(latest: true, reason: "GitHub Actions checks").opt_bin/"actionlint"
     end
 
     # Collection of style offenses.

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -186,7 +186,10 @@ RSpec.describe Utils::Git do
       unless ENV["HOMEBREW_TEST_GENERIC_OS"]
         it "installs git" do
           expect(described_class).to receive(:available?).and_return(false)
-          allow_any_instance_of(Formula).to receive(:ensure_installed!)
+          allow(CoreTap.instance).to receive(:installed?).and_return(true)
+          formula_double = instance_double(Formula)
+          allow(Formula).to receive(:[]).with("git").and_return(formula_double)
+          allow(formula_double).to receive(:ensure_installed!).and_return(formula_double)
           expect(described_class).to receive(:available?).and_return(true)
 
           described_class.ensure_installed!

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe Utils::Git do
       unless ENV["HOMEBREW_TEST_GENERIC_OS"]
         it "installs git" do
           expect(described_class).to receive(:available?).and_return(false)
-          expect(described_class).to receive(:ensure_formula_installed!).with("git")
+          allow_any_instance_of(Formula).to receive(:ensure_installed!)
           expect(described_class).to receive(:available?).and_return(true)
 
           described_class.ensure_installed!

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -104,7 +104,7 @@ module Utils
           raise "Refusing to install Git on a generic OS." if ENV["HOMEBREW_TEST_GENERIC_OS"]
 
           require "formula"
-          ensure_formula_installed!("git")
+          Formula["git"].ensure_installed!
           clear_available_cache
         rescue
           raise "Git is unavailable"

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -153,7 +153,7 @@ module PyPI
         @version ||= T.let(match[2], T.nilable(String))
       elsif @is_url
         require "formula"
-        ensure_formula_installed!(@python_name)
+        Formula[@python_name].ensure_installed!
 
         # The URL might be a source distribution hosted somewhere;
         # try and use `pip install -q --no-deps --dry-run --report ...` to get its
@@ -262,7 +262,7 @@ module PyPI
       odie "Missing #{missing_msg}" unless install_dependencies
       ohai "Installing #{missing_msg}"
       require "formula"
-      missing_dependencies.each(&:ensure_formula_installed!)
+      missing_dependencies.each { |dep| Formula[dep].ensure_installed! }
     end
 
     python_deps = formula.deps
@@ -337,7 +337,7 @@ module PyPI
     end
 
     require "formula"
-    ensure_formula_installed!(python_name)
+    Formula[python_name].ensure_installed!
 
     # Resolve the dependency tree of all input packages
     show_info = !print_only && !silent


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`ensure_formula_installed!` requires the `Formula` class to be loaded
before being called to work properly.

Let's guarantee that instead by implementing it as an instance method of
the `Formula` class.

See discussion at #20358.
