### PR TITLE
Formula-Cookbook: Recommend the in-use `write_exec_script` syntax

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1025,7 +1025,7 @@ end
 * To surface one or more binaries buried in `libexec` or a macOS `.app` package, use [`write_exec_script`](https://rubydoc.brew.sh/Pathname#write_exec_script-instance_method) or [`write_jar_script`](https://rubydoc.brew.sh/Pathname#write_jar_script-instance_method):
 
 ```ruby
-bin.write_exec_script (libexec/"bin").children
+bin.write_exec_script Dir[libexec/"bin/*"]
 bin.write_exec_script prefix/"Package.app/Contents/MacOS/package"
 bin.write_jar_script libexec/jar_file, "jarfile", java_version: "11"
 ```


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- The `bin.write_exec_script Dir[libexec/"bin/*"]` is used in core formulae, whereas the previously recommended syntax is not found at all. Let's make reality match the documentation.
- Part of https://github.com/orgs/Homebrew/projects/5?pane=issue&itemId=97021840.
