### PR TITLE
SkipConditions: special case unsigned deprecations

### DIFF
--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -120,6 +120,7 @@ module Homebrew
       }
       private_class_method def self.cask_deprecated(cask, livecheck_defined, full_name: false, verbose: false)
         return {} if !cask.deprecated? || livecheck_defined
+        return {} if cask.disable_date && cask.deprecation_reason == :unsigned
 
         Livecheck.status_hash(cask, "deprecated", full_name:, verbose:)
       end

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       basic:                   Cask::Cask.new("test") do
         version "0.0.1,2"
 
-        url "https://brew.sh/test-0.0.1.tgz"
+        url "https://brew.sh/test-#{version.csv.first}.tgz"
         name "Test"
         desc "Test cask"
         homepage "https://brew.sh"
@@ -96,7 +96,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
         version "0.0.1"
         sha256 :no_check
 
-        url "https://brew.sh/test-0.0.1.tgz"
+        url "https://brew.sh/test-#{version}.tgz"
         name "Test Deprecate"
         desc "Deprecated test cask"
         homepage "https://brew.sh"
@@ -107,7 +107,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
         version "0.0.1"
         sha256 :no_check
 
-        url "https://brew.sh/test-0.0.1.tgz"
+        url "https://brew.sh/test-#{version}.tgz"
         name "Test Disable"
         desc "Disabled test cask"
         homepage "https://brew.sh"
@@ -127,7 +127,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       extract_plist:           Cask::Cask.new("test_extract_plist_skip") do
         version "0.0.1"
 
-        url "https://brew.sh/test-0.0.1.tgz"
+        url "https://brew.sh/test-#{version}.tgz"
         name "Test ExtractPlist Skip"
         desc "Skipped test cask"
         homepage "https://brew.sh"
@@ -157,7 +157,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       skip:                    Cask::Cask.new("test_skip") do
         version "0.0.1"
 
-        url "https://brew.sh/test-0.0.1.tgz"
+        url "https://brew.sh/test-#{version}.tgz"
         name "Test Skip"
         desc "Skipped test cask"
         homepage "https://brew.sh"
@@ -169,7 +169,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       skip_with_message:       Cask::Cask.new("test_skip_with_message") do
         version "0.0.1"
 
-        url "https://brew.sh/test-0.0.1.tgz"
+        url "https://brew.sh/test-#{version}.tgz"
         name "Test Skip"
         desc "Skipped test cask"
         homepage "https://brew.sh"

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
 
   let(:casks) do
     {
-      basic:             Cask::Cask.new("test") do
+      basic:                   Cask::Cask.new("test") do
         version "0.0.1,2"
 
         url "https://brew.sh/test-0.0.1.tgz"
@@ -92,7 +92,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           regex(/"stable":"(\d+(?:\.\d+)+)"/i)
         end
       end,
-      deprecated:        Cask::Cask.new("test_deprecated") do
+      deprecated:              Cask::Cask.new("test_deprecated") do
         version "0.0.1"
         sha256 :no_check
 
@@ -103,7 +103,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
 
         deprecate! date: "2020-06-25", because: :discontinued
       end,
-      disabled:          Cask::Cask.new("test_disabled") do
+      disabled:                Cask::Cask.new("test_disabled") do
         version "0.0.1"
         sha256 :no_check
 
@@ -114,7 +114,17 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
 
         disable! date: "2020-06-25", because: :discontinued
       end,
-      extract_plist:     Cask::Cask.new("test_extract_plist_skip") do
+      future_disable_unsigned: Cask::Cask.new("test_future_disable_unsigned") do
+        version "0.0.1"
+
+        url "https://brew.sh/test-#{version}.tgz"
+        name "Test Future Disabled Unsigned"
+        desc "Future Disable Unsigned test cask"
+        homepage "https://brew.sh"
+
+        disable! date: "3000-06-25", because: :unsigned
+      end,
+      extract_plist:           Cask::Cask.new("test_extract_plist_skip") do
         version "0.0.1"
 
         url "https://brew.sh/test-0.0.1.tgz"
@@ -126,7 +136,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           strategy :extract_plist
         end
       end,
-      latest:            Cask::Cask.new("test_latest") do
+      latest:                  Cask::Cask.new("test_latest") do
         version :latest
         sha256 :no_check
 
@@ -135,7 +145,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
         desc "Latest test cask"
         homepage "https://brew.sh"
       end,
-      unversioned:       Cask::Cask.new("test_unversioned") do
+      unversioned:             Cask::Cask.new("test_unversioned") do
         version "1.2.3"
         sha256 :no_check
 
@@ -144,7 +154,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
         desc "Unversioned test cask"
         homepage "https://brew.sh"
       end,
-      skip:              Cask::Cask.new("test_skip") do
+      skip:                    Cask::Cask.new("test_skip") do
         version "0.0.1"
 
         url "https://brew.sh/test-0.0.1.tgz"
@@ -156,7 +166,7 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
           skip
         end
       end,
-      skip_with_message: Cask::Cask.new("test_skip_with_message") do
+      skip_with_message:       Cask::Cask.new("test_skip_with_message") do
         version "0.0.1"
 
         url "https://brew.sh/test-0.0.1.tgz"
@@ -371,6 +381,12 @@ RSpec.describe Homebrew::Livecheck::SkipConditions do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:disabled]))
           .to eq(status_hashes[:cask][:disabled])
+      end
+    end
+
+    context "when a cask without a `livecheck` block is deprecated with a future disable date because `:unsigned`" do
+      it "does not skip" do
+        expect(skip_conditions.skip_information(casks[:future_disable_unsigned])).to eq({})
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We've been adding `disable!` calls with a future date to casks using an unsigned app. That implicitly deprecates the cask until it reaches the disable date, so we've been having to add simple `livecheck` blocks to casks that use a default check to ensure that livecheck continues to check them (e.g., https://github.com/Homebrew/homebrew-cask/pull/222471). It was suggested that it would be simpler to have livecheck not skip casks that have a `disable!` call with a `because: :unsigned` argument and I agree, so this modifies `SkipConditions` to add a special case for this scenario.