### PR TITLE
extend/kernel: allow exec_editor to open multiple files at once

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -389,10 +389,10 @@ module Kernel
     editor
   end
 
-  sig { params(filename: T.any(String, Pathname)).void }
-  def exec_editor(filename)
-    puts "Editing #{filename}"
-    with_homebrew_path { safe_system(*which_editor.shellsplit, filename) }
+  sig { params(filenames: T.any(String, Pathname)).void }
+  def exec_editor(*filenames)
+    puts "Editing #{filenames.join "\n"}"
+    with_homebrew_path { safe_system(*which_editor.shellsplit, *filenames) }
   end
 
   sig { params(args: T.any(String, Pathname)).void }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew edit` no longer accepts multiple formula names to open:

```
$ brew edit vim mc
Error: wrong number of arguments (given 2, expected 1)
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12357/lib/types/private/methods/signature.rb:204:in 'T::Private::Methods::Signature#each_args_value_type'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12357/lib/types/private/methods/call_validation.rb:227:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12357/lib/types/private/methods/_methods.rb:277:in 'block in Kernel#_on_method_added'
/opt/homebrew/Library/Homebrew/dev-cmd/edit.rb:63:in 'Homebrew::DevCmd::Edit#run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12357/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12357/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12357/lib/types/private/methods/_methods.rb:277:in 'block in Homebrew::DevCmd::Edit#_on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:113:in '<main>'
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

Seems to be caused by an unintended change in https://github.com/Homebrew/brew/pull/20344.
This PR restores the ability of `exec_editor` to open multiple files at once.