### PR TITLE
cmd/update: use short option in update.sh

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -211,9 +211,8 @@ merge_or_rebase() {
   if [[ "${DIR}" == "${HOMEBREW_REPOSITORY}" && -n "${HOMEBREW_UPDATE_TO_TAG}" ]]
   then
     UPSTREAM_TAG="$(
-      git tag --list |
-        sort --field-separator=. --key=1,1nr -k 2,2nr -k 3,3nr |
-        grep --max-count=1 '^[0-9]*\.[0-9]*\.[0-9]*$'
+      git tag --list --sort=-version:refname |
+        grep -m 1 '^[0-9]*\.[0-9]*\.[0-9]*$'
     )"
   else
     UPSTREAM_TAG=""


### PR DESCRIPTION
Following [McQuaid's suggestion](https://github.com/Homebrew/brew/pull/20323#issuecomment-3131943340), I chose a practical target: installing Homebrew on Alpine Linux. I understood each step and the current issues faced, then I wrote [an article](https://github.com/chirsz-ever/install-homebrew-on-alpine-linux) describing the installation process.

According to [the current tier policy](https://github.com/Homebrew/brew/blob/563d066821df890742a1d6961c47d6aa9d2d250a/docs/Support-Tiers.md), Alpine Linux should be considered Tier 2. Since Homebrew doesn't appear to be interested in migrating its images to Alpine, I didn't add CI tests running on Alpine Linux.

The current issues of installing and running Homebrew on Alpine Linux are:

- It needs to patch `ldd` for installation.
  - This is unavoidable, Apline Linux is based on musl libc.
- It needs long options of `grep` and `sort` for installation, but busybox do not support them.
  - This would be unneeded after this PR merged.
- It needs `/usr/bin/stat` existing for installation, but Alpine Linux only has `/bin/stat`.
  - This should be resolved after [the /usr-merge work](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.21.0#Preparations_for_/usr-merge).
- `brew shellenv` needs `ps` to support `-p` option, but busybox do not support it.
  - `-p` is POSIX-required, that should be fixed by busybox.
  - This can be bypassed by explicitly providing the second argument, such as `brew shellenv sh`.
- `brew list` needs `ls` to support `-q` option, but busybox do not support it.
  - `-q` is POSIX-required, that should be fixed by busybox.
  - We can use [a stub script](https://github.com/chirsz-ever/install-homebrew-on-alpine-linux/blob/7da949da28330fcfb84cc1daf851e8ddade3a18c/patched-ls.sh) to patch the ls command.
- The uninstallation script need `find` to support `-lname` option, but busybox do not support it.
  - The uninstallation script is not used often. It would be easy to edit it before executing it.

In summary, the changes involved in this PR are all the required changes.