### PR TITLE
Improve Download Queue output

### DIFF
--- a/Library/Homebrew/api/json_download.rb
+++ b/Library/Homebrew/api/json_download.rb
@@ -44,10 +44,7 @@ module Homebrew
       end
 
       sig { override.returns(String) }
-      def name = download_name
-
-      sig { override.returns(String) }
-      def download_type = "JSON API"
+      def download_queue_type = "JSON API"
     end
   end
 end

--- a/Library/Homebrew/api/source_download.rb
+++ b/Library/Homebrew/api/source_download.rb
@@ -37,10 +37,7 @@ module Homebrew
       end
 
       sig { override.returns(String) }
-      def name = download_name
-
-      sig { override.returns(String) }
-      def download_type = "API Source"
+      def download_queue_type = "API Source"
 
       sig { override.returns(Pathname) }
       def cache

--- a/Library/Homebrew/bottle.rb
+++ b/Library/Homebrew/bottle.rb
@@ -186,7 +186,10 @@ class Bottle
   end
 
   sig { override.returns(String) }
-  def download_type = "Bottle"
+  def download_queue_type = "Bottle"
+
+  sig { override.returns(String) }
+  def download_queue_name = "#{name} (#{resource.version})"
 
   private
 

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -24,11 +24,6 @@ module Cask
       @quarantine = quarantine
     end
 
-    sig { override.returns(String) }
-    def name
-      cask.token
-    end
-
     sig { override.returns(T.nilable(::URL)) }
     def url
       return if (cask_url = cask.url).nil?
@@ -95,10 +90,10 @@ module Cask
     end
 
     sig { override.returns(String) }
-    def download_name = cask.token
+    def download_queue_name = "#{cask.token} (#{version})"
 
     sig { override.returns(String) }
-    def download_type = "Cask"
+    def download_queue_type = "Cask"
 
     private
 

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -32,11 +32,11 @@ module Homebrew
     def fetch
       return if downloads.empty?
 
-      if concurrency == 1 || downloads.one?
+      if concurrency == 1
         downloads.each do |downloadable, promise|
           promise.wait!
         rescue ChecksumMismatchError => e
-          opoo "#{downloadable.download_type} reports different checksum: #{e.expected}"
+          opoo "#{downloadable.download_queue_type} reports different checksum: #{e.expected}"
           Homebrew.failed = true if downloadable.is_a?(Resource::Patch)
         rescue => e
           raise e unless bottle_manifest_error?(downloadable, e)
@@ -73,7 +73,7 @@ module Homebrew
             exception = future.reason if future.rejected?
             next 1 if bottle_manifest_error?(downloadable, exception)
 
-            message = "#{downloadable.download_type} #{downloadable.name}"
+            message = "#{downloadable.download_queue_type} #{downloadable.download_queue_name}"
             if tty
               stdout_print_and_flush "#{status} #{message}#{"\n" unless last}"
             elsif status
@@ -82,7 +82,7 @@ module Homebrew
 
             if future.rejected?
               if exception.is_a?(ChecksumMismatchError)
-                opoo "#{downloadable.download_type} reports different checksum: #{exception.expected}"
+                opoo "#{downloadable.download_queue_type} reports different checksum: #{exception.expected}"
                 Homebrew.failed = true if downloadable.is_a?(Resource::Patch)
                 next 2
               else

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -48,14 +48,11 @@ module Downloadable
     super
   end
 
-  sig { abstract.returns(String) }
-  def name; end
-
   sig { returns(String) }
-  def download_type
-    class_name = T.let(self.class, T::Class[Downloadable]).name&.split("::")&.last
-    T.must(class_name).gsub(/([[:lower:]])([[:upper:]])/, '\1 \2').downcase
-  end
+  def download_queue_name = download_name
+
+  sig { abstract.returns(String) }
+  def download_queue_type; end
 
   sig(:final) { returns(T::Boolean) }
   def downloaded?
@@ -135,12 +132,12 @@ module Downloadable
     EOS
   end
 
+  private
+
   sig { overridable.returns(String) }
   def download_name
     @download_name ||= File.basename(determine_url.to_s).freeze
   end
-
-  private
 
   sig { overridable.returns(T::Boolean) }
   def silence_checksum_missing_error?

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -632,7 +632,7 @@ class DownloadError < RuntimeError
 
   def initialize(downloadable, cause)
     super <<~EOS
-      Failed to download resource #{downloadable.download_name.inspect}
+      Failed to download resource #{downloadable.download_queue_name.inspect}
       #{cause.message}
     EOS
     @cause = cause

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -57,19 +57,8 @@ class Resource
     patches.each { |p| p.owner = owner }
   end
 
-  # Removes /s from resource names; this allows Go package names
-  # to be used as resource names without confusing software that
-  # interacts with {download_name}, e.g. `github.com/foo/bar`.
-  def escaped_name
-    name.tr("/", "-")
-  end
-
-  def download_name
-    return owner.name if name.nil?
-    return escaped_name if owner.nil?
-
-    "#{owner.name}--#{escaped_name}"
-  end
+  sig { override.returns(String) }
+  def download_queue_type = "Resource"
 
   # Verifies download and unpacks it.
   # The block may call `|resource, staging| staging.retain!` to retain the staging
@@ -236,9 +225,6 @@ class Resource
     @url&.specs || {}.freeze
   end
 
-  sig { override.returns(String) }
-  def download_type = "Resource"
-
   protected
 
   def stage_resource(prefix, debug_symbols: false, &block)
@@ -246,6 +232,19 @@ class Resource
   end
 
   private
+
+  sig { override.returns(String) }
+  def download_name
+    return owner.name if name.nil?
+
+    # Removes /s from resource names; this allows Go package names
+    # to be used as resource names without confusing software that
+    # interacts with {download_name}, e.g. `github.com/foo/bar`.
+    escaped_name = name.tr("/", "-")
+    return escaped_name if owner.nil?
+
+    "#{owner.name}--#{escaped_name}"
+  end
 
   def determine_url_mirrors
     extra_urls = []
@@ -288,14 +287,10 @@ class Resource
   # A resource for a formula.
   class Formula < Resource
     sig { override.returns(String) }
-    def name
-      T.must(owner).name
-    end
+    def download_queue_type = "Formula"
 
     sig { override.returns(String) }
-    def download_name
-      name
-    end
+    def download_queue_name = "#{T.must(owner).name} (#{version})"
   end
 
   # A resource containing a Go package.
@@ -344,10 +339,10 @@ class Resource
     end
 
     sig { override.returns(String) }
-    def download_type = "Bottle Manifest"
+    def download_queue_type = "Bottle Manifest"
 
     sig { override.returns(String) }
-    def name = bottle.name
+    def download_queue_name = "#{bottle.name} (#{bottle.resource.version})"
 
     private
 
@@ -403,15 +398,15 @@ class Resource
     end
 
     sig { override.returns(String) }
-    def download_type = "Patch"
+    def download_queue_type = "Patch"
 
     sig { override.returns(String) }
-    def name
-      if (url = self.url)
-        url.to_s.split("/").last
-      else
-        super
+    def download_queue_name
+      if (last_url_component = url.to_s.split("/").last)
+        return last_url_component
       end
+
+      super
     end
   end
 end

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -28,10 +28,10 @@ module Homebrew
     end
 
     sig { override.returns(String) }
-    def name = downloadable.name
+    def download_queue_name = downloadable.download_queue_name
 
     sig { override.returns(String) }
-    def download_type = downloadable.download_type
+    def download_queue_type = downloadable.download_queue_type
 
     sig { override.returns(Pathname) }
     def cached_download = downloadable.cached_download
@@ -102,9 +102,6 @@ module Homebrew
 
     sig { override.params(filename: Pathname).void }
     def verify_download_integrity(filename) = downloadable.verify_download_integrity(filename)
-
-    sig { override.returns(String) }
-    def download_name = downloadable.download_name
 
     private
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -28,9 +28,9 @@ class SoftwareSpec
   attr_reader :name, :full_name, :owner, :build, :resources, :patches, :options, :deprecated_flags,
               :deprecated_options, :dependency_collector, :bottle_specification, :compiler_failures
 
-  def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time, :download_name,
+  def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time,
                  :cached_download, :clear_cache, :checksum, :mirrors, :specs, :using, :version, :mirror,
-                 :downloader
+                 :downloader, :download_queue_name, :download_queue_type
 
   def_delegators :@resource, :sha256
 
@@ -80,9 +80,6 @@ class SoftwareSpec
     @compiler_failures.freeze
     super
   end
-
-  sig { override.returns(String) }
-  def download_type = "Formula"
 
   def owner=(owner)
     @name = owner.name


### PR DESCRIPTION
Update the naming, presence and values for various download queue methods to improve the output for users while making the internal code a little easier to follow.

While we're here, also ensure that a single formula download still displays the download queue output and indirectly fix an issue with bottle manifests being named incorrectly (https://github.com/Homebrew/brew/pull/20353#issuecomment-3148363345)