### PR TITLE
diagnostic: Use pushd/popd in uncommited modifications nudge

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -703,7 +703,7 @@ module Homebrew
             If this is a surprise to you, then you should stash these modifications.
             Stashing returns Homebrew to a pristine state but can be undone
             should you later need to do so for some reason.
-              git stash -u -C #{path} && git clean -d -f -C #{path}
+              git -C "#{path}" stash -u && git -C "${path}" clean -d -f
           EOS
 
           modified = status.split("\n")

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -703,7 +703,7 @@ module Homebrew
             If this is a surprise to you, then you should stash these modifications.
             Stashing returns Homebrew to a pristine state but can be undone
             should you later need to do so for some reason.
-              pushd #{path} && git stash -u && git clean -d -f && popd
+              git stash -u -C #{path} && git clean -d -f -C #{path}
           EOS
 
           modified = status.split("\n")

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -703,7 +703,7 @@ module Homebrew
             If this is a surprise to you, then you should stash these modifications.
             Stashing returns Homebrew to a pristine state but can be undone
             should you later need to do so for some reason.
-              cd #{path} && git stash -u && git clean -d -f
+              pushd #{path} && git stash -u && git clean -d -f && popd
           EOS
 
           modified = status.split("\n")


### PR DESCRIPTION
While filing https://github.com/Homebrew/brew/issues/20379, I lost where I was because I followed the given instruction. Instead, let's use pushd/popd so the user is returned to their pwd if the git operations succeed.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
