### PR TITLE
bump*: allow auto bumped casks to be manually bumped

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -76,14 +76,6 @@ module Homebrew
         odie "This cask is not in a tap!" if cask.tap.blank?
         odie "This cask's tap is not a Git repository!" unless cask.tap.git?
 
-        odie <<~EOS unless cask.tap.allow_bump?(cask.token)
-          Whoops, the #{cask.token} cask has its version update
-          pull requests automatically opened by BrewTestBot every ~3 hours!
-          We'd still love your contributions, though, so try another one
-          that is excluded from autobump list (i.e. it has 'no_autobump!'
-          method or 'livecheck' block with 'skip'.)
-        EOS
-
         if !args.write_only? && GitHub.too_many_open_prs?(cask.tap)
           odie "You have too many PRs open: close or merge some first!"
         end

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -209,14 +209,14 @@ module Homebrew
           skip = formula_or_cask.disabled? || formula_or_cask.head_only?
           name = formula_or_cask.name
           text = "Formula is #{formula_or_cask.disabled? ? "disabled" : "HEAD-only"} so not accepting updates.\n"
+          if (tap = formula_or_cask.tap) && !tap.allow_bump?(name)
+            skip = true
+            text = "#{text.split.first} is autobumped so will have bump PRs opened by BrewTestBot every ~3 hours.\n"
+          end
         else
           skip = formula_or_cask.disabled?
           name = formula_or_cask.token
           text = "Cask is disabled so not accepting updates.\n"
-        end
-        if (tap = formula_or_cask.tap) && !tap.allow_bump?(name)
-          skip = true
-          text = "#{text.split.first} is autobumped so will have bump PRs opened by BrewTestBot every ~3 hours.\n"
         end
         return false unless skip
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `no_autobump!` stanza is being removed from all casks in `homebrew-cask`.
Because all casks will no be checked on a roughly 3 hour interval, the original motivation for this blocker is likely not going to be an issue moving forward.

Using `brew bump` and `brew bump-cask-pr` can be a valuable way to open PRs easily when Casks require small changes such as a url update as a part of the version bump.

CC: @Homebrew/cask 