### PR TITLE
download_queue: display hash of rejected download

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -82,7 +82,9 @@ module Homebrew
 
             if future.rejected?
               if exception.is_a?(ChecksumMismatchError)
+                actual = Digest::SHA256.file(downloadable.cached_download).hexdigest
                 opoo "#{downloadable.download_queue_type} reports different checksum: #{exception.expected}"
+                puts (" " * downloadable.download_queue_type.size) + " SHA-256 checksum of downloaded file: #{actual}"
                 Homebrew.failed = true if downloadable.is_a?(Resource::Patch)
                 next 2
               else

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -735,7 +735,7 @@ class ChecksumMismatchError < RuntimeError
     @expected = expected
 
     super <<~EOS
-      SHA256 mismatch
+      SHA-256 mismatch
       Expected: #{Formatter.success(expected.to_s)}
         Actual: #{Formatter.error(actual.to_s)}
           File: #{path}

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -70,7 +70,7 @@ module Homebrew
 
       unless quiet
         puts "Downloaded to: #{download}" unless already_downloaded
-        puts "SHA256: #{download.sha256}"
+        puts "SHA-256: #{download.sha256}"
       end
 
       json_download = downloadable.is_a?(API::JSONDownload)

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe "Exception" do
     let(:expected_checksum) { instance_double(Checksum, to_s: "deadbeef") }
     let(:actual_checksum) { instance_double(Checksum, to_s: "deadcafe") }
 
-    it(:to_s) { expect(error.to_s).to match(/SHA256 mismatch/) }
+    it(:to_s) { expect(error.to_s).to match(/SHA-256 mismatch/) }
   end
 
   describe ResourceMissingError do


### PR DESCRIPTION
When not using concurrent downloads, the hash of the download is always displayed:
```
$ HOMEBREW_DOWNLOAD_CONCURRENCY= brew fetch -s hello
==> Downloading https://ftp.gnu.org/gnu/hello/hello-2.12.2.tar.gz
############################################################################################################################################################## 100.0%
Downloaded to: /Users/eric/Library/Caches/Homebrew/downloads/4de8a1c9a03acef91d6f2651328042790d8e4929f1d6bab9e097edb88d5846f3--hello-2.12.2.tar.gz
SHA-256: 5a9a996dc292cc24dcf411cee87e92f6aae5b8d13bd9c6819b4c7a9dce0818ab
==> Retrying download in 2s... (1 try left)
==> Downloading https://ftp.gnu.org/gnu/hello/hello-2.12.2.tar.gz
############################################################################################################################################################## 100.0%
Downloaded to: /Users/eric/Library/Caches/Homebrew/downloads/4de8a1c9a03acef91d6f2651328042790d8e4929f1d6bab9e097edb88d5846f3--hello-2.12.2.tar.gz
SHA-256: 5a9a996dc292cc24dcf411cee87e92f6aae5b8d13bd9c6819b4c7a9dce0818ab
Warning: Formula reports different checksum: 2cfd594bc398a53903002973504298115f713422d74b6ff688e5c4bff86d2449
```

This change shows the hash of rejected downloads when using concurrent downloads, which can be helpful when updating formulae/casks. 
```
$ HOMEBREW_DOWNLOAD_CONCURRENCY=2 brew fetch -s hello
✘ Formula hello (2.12.2)
Warning: Formula reports different checksum: e81841d7339d3d83c7fbc3ba2f0ba20d9719b2b6e4db7acd47b5ed3c1ca9448c
        SHA-256 checksum of downloaded file: 5a9a996dc292cc24dcf411cee87e92f6aae5b8d13bd9c6819b4c7a9dce0818ab

$ HOMEBREW_DOWNLOAD_CONCURRENCY=2 brew fetch -s himalaya
✔︎ Formula himalaya (1.1.0)
✘ Patch ea70e7c123fd8b30e5b36ab62bfcfafa63779797.patch?full_index=1
Warning: Patch reports different checksum: 44e8c4158192c2971787761f285be397ddc384a4230890bf1c8494c786b45373
      SHA-256 checksum of downloaded file: 44e8c415819272971787761f285be397ddc384a4230890bf1c8494c786b45373

$ HOMEBREW_DOWNLOAD_CONCURRENCY=2 brew fetch -s help2man
✔︎ Formula help2man (1.49.3)
✘ Resource help2man--Locale::gettext
Warning: Resource reports different checksum: 909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c1c
         SHA-256 checksum of downloaded file: 909d47954697e7c04218f972915b787bd1244d75e3bd01620bc167d5bbc49c15
```

Up for debate:
- whether to always show hashes for downloads, whether accepted or rejected. The [docs](https://docs.brew.sh/Tips-and-Tricks#pre-download-a-file-for-a-formula) and [manpage entry for `fetch`](https://docs.brew.sh/Manpage#fetch-options-formulacask-) currently say SHA-256 checksums are always printed.
- whether to also show the path of downloaded files. The [docs currently suggest](https://docs.brew.sh/Common-Issues#cask---source-is-not-there) using `fetch` to show the downloaded path (although that could be altered to mention `brew --cache` instead).
- my suggestion of "SHA256" → "SHA-256".