### PR TITLE
handle false content_type

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -468,7 +468,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
         # The cached location is no longer fresh if either:
         # - Last-Modified value is newer than the file's timestamp
         # - Content-Length value is different than the file's size
-        if cached_location_valid && (content_type.nil? || !content_type.start_with?("text/"))
+        if cached_location_valid && (!content_type.is_a?(String) || !content_type.start_with?("text/"))
           if last_modified && last_modified > cached_location.mtime
             ohai "Ignoring #{cached_location}",
                  "Cached modified time #{cached_location.mtime.iso8601} is before" \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
   - I tried to run tests locally but they set my laptop on fire.

-----

I use Homebrew with a private internal repository of Formulae. I understand [this is not a supported workflow](https://github.com/Homebrew/brew/issues/15169#issuecomment-1500547374) - however, it has uncovered a bug in Homebrew that I think should be patched regardless.

https://github.com/Homebrew/brew/pull/20200 introduces a bug (first released in [4.5.9](https://github.com/Homebrew/brew/releases/tag/4.5.9), still present on [main](https://github.com/Homebrew/brew/tree/main) as of 726f83c4a85f2540084c964073982f31f17cc248) wherein a ruby stack trace is dumped when installing certain kinds of Formulae using `CurlDownloadStrategy`.

The particular cause is still unclear to me, but the behavior is that `content_type` may be set to `false`, causing [this boolean condition](https://github.com/Homebrew/brew/blob/726f83c4a85f2540084c964073982f31f17cc248/Library/Homebrew/download_strategy.rb#L471) to fail due to:
```
Error: undefined method 'start_with?' for false
/opt/homebrew/Library/Homebrew/download_strategy.rb:471:in 'CurlDownloadStrategy#fetch'
```

This pull request changes a nil-check (`content_type.nil?`) to a broader non-String type check (`!content_type.is_a?(String)`).