### PR TITLE
extend/pathname: accept `String` as `target` in `write_env_script`

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -290,7 +290,7 @@ class Pathname
 
   # Writes an exec script that sets environment variables.
   sig {
-    params(target:      Pathname,
+    params(target:      T.any(Pathname, String),
            args_or_env: T.any(String, T::Array[String], T::Hash[String, String], T::Hash[Symbol, String]),
            env:         T.any(T::Hash[String, String], T::Hash[Symbol, String])).void
   }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There is too much existing usage outside of Homebrew for us to break [1].

[1]: https://github.com/search?q=%22write_env_script%20%5C%22%22%20NOT%20org%3AHomebrew%20NOT%20is%3Afork&type=code

Closes https://github.com/Homebrew/homebrew-core/pull/232573.
