### PR TITLE
extend/pathname: fix type error.

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -430,7 +430,7 @@ class Pathname
   private
 
   sig {
-    params(src: T.any(String, Pathname), new_basename: String,
+    params(src: T.any(String, Pathname), new_basename: T.any(String, Pathname),
            _block: T.nilable(T.proc.params(src: Pathname, dst: Pathname).returns(T.nilable(Pathname)))).void
   }
   def install_p(src, new_basename, &_block)


### PR DESCRIPTION
`install_p` is sometimes called with a `Pathname` for `new_basename`.