### PR TITLE
download_queue: add missing require.

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -5,6 +5,7 @@ require "downloadable"
 require "concurrent/promises"
 require "concurrent/executors"
 require "retryable_download"
+require "resource"
 
 module Homebrew
   class DownloadQueue


### PR DESCRIPTION
We use `Resource` in a few places here so need to require it.