### PR TITLE
brew.sh: enforce `HOMEBREW_FORCE_BREW_WRAPPER` more strictly

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -245,7 +245,6 @@ module Homebrew
         ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if args.generic?
         ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
         ENV["HOMEBREW_SORBET_RUNTIME"] = "1"
-        ENV["HOMEBREW_NO_FORCE_BREW_WRAPPER"] = "1"
 
         ENV["USER"] ||= system_command!("id", args: ["-nu"]).stdout.chomp
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -87,9 +87,6 @@ module Homebrew
         description: "Use this URL as the Homebrew/brew `git`(1) remote.",
         default:     HOMEBREW_BREW_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_BREW_WRAPPER:                     {
-        description: "If set, use wrapper to call `brew` rather than auto-detecting it.",
-      },
       HOMEBREW_BROWSER:                          {
         description:  "Use this as the browser when opening project homepages.",
         default_text: "`$BROWSER` or the OS's default browser.",
@@ -263,7 +260,7 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_FORCE_BREW_WRAPPER:               {
-        description: "If set, require `$HOMEBREW_BREW_WRAPPER` to be set to the same value as " \
+        description: "If set, require `brew` to be invoked by the value of " \
                      "`$HOMEBREW_FORCE_BREW_WRAPPER` for non-trivial `brew` commands.",
       },
       HOMEBREW_FORCE_VENDOR_RUBY:                {
@@ -391,10 +388,6 @@ module Homebrew
       },
       HOMEBREW_NO_ENV_HINTS:                     {
         description: "If set, do not print any hints about changing Homebrew's behaviour with environment variables.",
-        boolean:     true,
-      },
-      HOMEBREW_NO_FORCE_BREW_WRAPPER:            {
-        description: "If set, disables `$HOMEBREW_FORCE_BREW_WRAPPER` behaviour, even if set.",
         boolean:     true,
       },
       HOMEBREW_NO_GITHUB_API:                    {

--- a/Library/Homebrew/utils/pid_path.rb
+++ b/Library/Homebrew/utils/pid_path.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# typed: strict
+# frozen_string_literal: true
+
+require "fiddle"
+
+libproc = Fiddle.dlopen("/usr/lib/libproc.dylib")
+
+proc_pidpath = Fiddle::Function.new(
+  libproc["proc_pidpath"],
+  [Fiddle::TYPE_INT, Fiddle::TYPE_VOIDP, Fiddle::TYPE_UINT32_T],
+  Fiddle::TYPE_INT,
+)
+
+pid = ARGV[0]&.to_i
+exit 1 unless pid
+
+bufsize = 4 * 1024 # PROC_PIDPATHINFO_MAXSIZE = 4 * MAXPATHLEN
+buf = "\0" * bufsize
+ptr = Fiddle::Pointer.to_ptr(buf)
+
+ret = proc_pidpath.call(pid, ptr, bufsize)
+puts ptr.to_s.strip if ret.positive?

--- a/bin/brew
+++ b/bin/brew
@@ -100,13 +100,6 @@ unset BREW_FILE_DIRECTORY
 # keg_relocate.rb, formula_cellar_checks.rb, and test/global_spec.rb need to change.
 HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
-# Use HOMEBREW_BREW_WRAPPER if set.
-export HOMEBREW_ORIGINAL_BREW_FILE="${HOMEBREW_BREW_FILE}"
-if [[ -n "${HOMEBREW_BREW_WRAPPER:-}" ]]
-then
-  HOMEBREW_BREW_FILE="${HOMEBREW_BREW_WRAPPER}"
-fi
-
 # These variables are exported in this file and are not allowed to be overridden by the user.
 BIN_BREW_EXPORTED_VARS=(
   HOMEBREW_BREW_FILE
@@ -166,6 +159,13 @@ export_homebrew_env_file "${HOMEBREW_USER_CONFIG_HOME}/brew.env"
 if [[ -n "${SYSTEM_ENV_TAKES_PRIORITY-}" ]]
 then
   export_homebrew_env_file "/etc/homebrew/brew.env"
+fi
+
+# Use HOMEBREW_FORCE_BREW_WRAPPER if set.
+export HOMEBREW_ORIGINAL_BREW_FILE="${HOMEBREW_BREW_FILE}"
+if [[ -n "${HOMEBREW_FORCE_BREW_WRAPPER:-}" ]]
+then
+  HOMEBREW_BREW_FILE="${HOMEBREW_FORCE_BREW_WRAPPER}"
 fi
 
 # Copy and export all HOMEBREW_* variables previously mentioned in


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`HOMEBREW_FORCE_BREW_WRAPPER` can be used as a security/compliance
feature, but allowing it to be disabled by setting
`HOMEBREW_NO_FORCE_BREW_WRAPPER` leaves a pretty large hole in it that
allows it to be sidestepped.

Let's fix that by actually checking the path of the process that called
`brew`, and the verify that that path matches the configured value of
`HOMEBREW_NO_FORCE_BREW_WRAPPER`.
