### PR TITLE
Skip rpath relocation of ELF files with `protodesc_cold` sections

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -19,6 +19,9 @@ class Keg
 
   def change_rpath!(file, old_prefix, new_prefix)
     return false if !file.elf? || !file.dynamic_elf?
+    # Skip relocation of files with `protodesc_cold` sections because patchelf.rb seems to break them.
+    # https://github.com/Homebrew/homebrew-core/pull/232490#issuecomment-3161362452
+    return false if Hardware::CPU.intel? && file.section_names.include?("protodesc_cold")
 
     updated = {}
     old_rpath = file.rpath

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -143,9 +143,17 @@ module ELFShim
     save_using_patchelf_rb interpreter, rpath
   end
 
+  def elf_parser
+    @elf_parser ||= patchelf_patcher.elf
+  end
+
   sig { returns(T::Boolean) }
   def dynamic_elf?
-    @dynamic_elf ||= patchelf_patcher.elf.segment_by_type(:DYNAMIC).present?
+    @dynamic_elf ||= elf_parser.segment_by_type(:DYNAMIC).present?
+  end
+
+  def section_names
+    @section_names ||= elf_parser.sections.map(&:name).compact_blank
   end
 
   # Helper class for reading metadata from an ELF file.
@@ -194,7 +202,7 @@ module ELFShim
       end
 
       # Check if DF_1_NODEFLIB is set
-      dt_flags_1 = path.patchelf_patcher.elf.segment_by_type(:dynamic)&.tag_by_type(:flags_1)
+      dt_flags_1 = path.elf_parser.segment_by_type(:dynamic)&.tag_by_type(:flags_1)
       nodeflib_flag = if dt_flags_1.nil?
         false
       else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We have multiple formulae (e.g. `ola`, `openvino`, `opencv`, `or-tools`,
`pytorch`) that seem to be broken by `patchelf.rb` on x86_64 Linux.[^1] The
common thread seems to be the presence of a `protodesc_cold` section in
the ELF header.

Let's avoid breaking these bottles by skipping relocation when a binary
file has a `protodesc_cold` section. It will probably hurt
relocatability of these bottles, but that's better shipping broken
binaries.

[^1]: https://github.com/Homebrew/homebrew-core/pull/210860#issue-2918569212
