### PR TITLE
patches audit: add tests for patches corrector

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -100,16 +100,16 @@ module RuboCop
 
           if regex_match_group(patch_url_node, %r{^http://trac\.macports\.org})
             problem "Patches from MacPorts Trac should be https://, not http: #{patch_url}" do |corrector|
-              correct = patch_url_node.source.gsub(%r{^http://}, "https://")
-              corrector.replace(patch_url_node.source_range, correct)
+              corrector.replace(patch_url_node.source_range,
+                                patch_url_node.source.sub(%r{\A"http://}, '"https://'))
             end
           end
 
           return unless regex_match_group(patch_url_node, %r{^http://bugs\.debian\.org})
 
           problem "Patches from Debian should be https://, not http: #{patch_url}" do |corrector|
-            correct = patch_url_node.source.gsub(%r{^http://}, "https://")
-            corrector.replace(patch_url_node.source_range, correct)
+            corrector.replace(patch_url_node.source_range,
+                              patch_url_node.source.sub(%r{\A"http://}, '"https://'))
           end
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Two correctors in the rubocop patches.rb were broken, which I found by adding tests. This PR also fix them. I removed redundant tests.