### PR TITLE
Cleanup internal API handling

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -162,6 +162,20 @@ module Homebrew
       false
     end
 
+    sig { params(aliases: T::Hash[String, String], type: String, regenerate: T::Boolean).returns(T::Boolean) }
+    def self.write_aliases_file!(aliases, type, regenerate:)
+      aliases_path = HOMEBREW_CACHE_API/"#{type}_aliases.txt"
+      if !aliases_path.exist? || regenerate
+        aliases_text = aliases.map do |alias_name, real_name|
+          "#{alias_name}|#{real_name}"
+        end
+        aliases_path.write(aliases_text.join("\n"))
+        return true
+      end
+
+      false
+    end
+
     sig {
       params(json_data: T::Hash[String, T.untyped])
         .returns([T::Boolean, T.any(String, T::Array[T.untyped], T::Hash[String, T.untyped])])

--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -14,13 +14,6 @@ module Homebrew
 
       DEFAULT_API_FILENAME = "cask.jws.json"
 
-      sig { returns(String) }
-      def self.api_filename
-        return DEFAULT_API_FILENAME unless ENV.fetch("HOMEBREW_USE_INTERNAL_API", false)
-
-        "cask.#{SimulateSystem.current_tag}.jws.json"
-      end
-
       private_class_method :cache
 
       sig { params(token: String).returns(T::Hash[String, T.untyped]) }
@@ -64,7 +57,7 @@ module Homebrew
 
       sig { returns(Pathname) }
       def self.cached_json_file_path
-        HOMEBREW_CACHE_API/api_filename
+        HOMEBREW_CACHE_API/DEFAULT_API_FILENAME
       end
 
       sig {
@@ -72,7 +65,7 @@ module Homebrew
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
       def self.fetch_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
-        Homebrew::API.fetch_json_api_file api_filename, stale_seconds:, download_queue:
+        Homebrew::API.fetch_json_api_file DEFAULT_API_FILENAME, stale_seconds:, download_queue:
       end
 
       sig {

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -14,13 +14,6 @@ module Homebrew
 
       DEFAULT_API_FILENAME = "formula.jws.json"
 
-      sig { returns(String) }
-      def self.api_filename
-        return DEFAULT_API_FILENAME unless ENV.fetch("HOMEBREW_USE_INTERNAL_API", false)
-
-        "internal/formula.#{SimulateSystem.current_tag}.jws.json"
-      end
-
       private_class_method :cache
 
       sig { params(name: String).returns(T::Hash[String, T.untyped]) }
@@ -63,7 +56,7 @@ module Homebrew
 
       sig { returns(Pathname) }
       def self.cached_json_file_path
-        HOMEBREW_CACHE_API/api_filename
+        HOMEBREW_CACHE_API/DEFAULT_API_FILENAME
       end
 
       sig {
@@ -71,7 +64,7 @@ module Homebrew
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
       def self.fetch_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
-        Homebrew::API.fetch_json_api_file api_filename, stale_seconds:, download_queue:
+        Homebrew::API.fetch_json_api_file DEFAULT_API_FILENAME, stale_seconds:, download_queue:
       end
 
       sig {
@@ -147,13 +140,8 @@ module Homebrew
       def self.write_names_and_aliases(regenerate: false)
         download_and_cache_data! unless cache.key?("formulae")
 
-        return unless Homebrew::API.write_names_file!(all_formulae.keys, "formula", regenerate:)
-
-        (HOMEBREW_CACHE_API/"formula_aliases.txt").open("w") do |file|
-          all_aliases.each do |alias_name, real_name|
-            file.puts "#{alias_name}|#{real_name}"
-          end
-        end
+        Homebrew::API.write_names_file!(all_formulae.keys, "formula", regenerate:)
+        Homebrew::API.write_aliases_file!(all_aliases, "formula", regenerate:)
       end
     end
   end

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -17,8 +17,22 @@ module Homebrew
       private_class_method :cache
 
       sig { params(name: String).returns(T::Hash[String, T.untyped]) }
-      def self.fetch(name)
-        Homebrew::API.fetch "formula/#{name}.json"
+      def self.formula_json(name)
+        fetch_formula_json! name if !cache.key?("formula_json") || !cache.fetch("formula_json").key?(name)
+
+        cache.fetch("formula_json").fetch(name)
+      end
+
+      sig { params(name: String, download_queue: T.nilable(DownloadQueue)).void }
+      def self.fetch_formula_json!(name, download_queue: nil)
+        endpoint = "formula/#{name}.json"
+        json_formula, updated = Homebrew::API.fetch_json_api_file endpoint, download_queue: download_queue
+        return if download_queue
+
+        json_formula = JSON.parse((HOMEBREW_CACHE_API/endpoint).read) unless updated
+
+        cache["formula_json"] ||= {}
+        cache["formula_json"][name] = json_formula
       end
 
       sig { params(formula: ::Formula, download_queue: T.nilable(Homebrew::DownloadQueue)).returns(Homebrew::API::SourceDownload) }

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -329,7 +329,7 @@ module Utils
 
         require "api"
 
-        json = Homebrew::API::Formula.fetch formula.name
+        json = Homebrew::API::Formula.formula_json formula.name
         return if json.blank? || json["analytics"].blank?
 
         output_analytics(json, args:)
@@ -345,7 +345,7 @@ module Utils
 
         require "api"
 
-        json = Homebrew::API::Cask.fetch cask.token
+        json = Homebrew::API::Cask.cask_json cask.token
         return if json.blank? || json["analytics"].blank?
 
         output_analytics(json, args:)


### PR DESCRIPTION
This PR does a few cleanup things:

1. Removes references to `HOMEBREW_USE_INTERNAL_API` in `Homebrew::API::{Formula,Cask}`. This functionality will end up living in `Homebrew::API::Internal` (coming soon)
2. Move the `formula_aliases.txt` file generation to a helper method in `Homebrew::API`. This is only used in one place for now, but eventually will be used in `Homebrew::API::Internal`
3. Enable download queue support for individual formula/cask API fetches
4. Add alias, rename, and tap migration information to the internal API generation

A quick note on the last item: this means that the minimal JSON file now is in this format:

```json
{
  "formulae": {
    "name": ["pkg_version", rebuild, "sha256"],
    ...
  },
  "aliases": {
    "alias_name": "real_name",
    ...
  },
  "renames": {
    "old_name": "real_name",
    ...
  },
  "tap_migrations": {
    "name": "tap",
    ...
  }
}
```

I tried a few different structures to see which was the most space-efficient when compressed, and this seemed to be the best and most readable. I'm happy to share these results if anyone is interested. Also happy to try other suggestions.

Here are the compressed file sizes:

```console
$ eza -l
.rw-r--r-- 175k rylanpolster 10 Aug 23:31 formula.arm64_big_sur.json.gz
.rw-r--r-- 334k rylanpolster 10 Aug 23:31 formula.arm64_linux.json.gz
.rw-r--r-- 206k rylanpolster 10 Aug 23:31 formula.arm64_monterey.json.gz
.rw-r--r-- 376k rylanpolster 10 Aug 23:31 formula.arm64_sequoia.json.gz
.rw-r--r-- 376k rylanpolster 10 Aug 23:31 formula.arm64_sonoma.json.gz
.rw-r--r-- 376k rylanpolster 10 Aug 23:31 formula.arm64_tahoe.json.gz
.rw-r--r-- 376k rylanpolster 10 Aug 23:31 formula.arm64_ventura.json.gz
.rw-r--r-- 176k rylanpolster 10 Aug 23:31 formula.big_sur.json.gz
.rw-r--r-- 161k rylanpolster 10 Aug 23:31 formula.catalina.json.gz
.rw-r--r-- 126k rylanpolster 10 Aug 23:31 formula.el_capitan.json.gz
.rw-r--r-- 137k rylanpolster 10 Aug 23:31 formula.high_sierra.json.gz
.rw-r--r-- 147k rylanpolster 10 Aug 23:31 formula.mojave.json.gz
.rw-r--r-- 206k rylanpolster 10 Aug 23:31 formula.monterey.json.gz
.rw-r--r-- 377k rylanpolster 10 Aug 23:31 formula.sequoia.json.gz
.rw-r--r-- 129k rylanpolster 10 Aug 23:31 formula.sierra.json.gz
.rw-r--r-- 377k rylanpolster 10 Aug 23:31 formula.sonoma.json.gz
.rw-r--r-- 377k rylanpolster 10 Aug 23:31 formula.tahoe.json.gz
.rw-r--r-- 377k rylanpolster 10 Aug 23:31 formula.ventura.json.gz
.rw-r--r-- 377k rylanpolster 10 Aug 23:31 formula.x86_64_linux.json.gz
```