### PR TITLE
formula: append `.log` to formula build log filenames

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3067,7 +3067,9 @@ class Formula
                    cmd_base:   File.basename(cmd).split.first)
     logs.mkpath
 
-    File.open(logfn, "w") do |log|
+    # Append `.log` here instead of in the definition of `logfn` to avoid
+    # log files named `xy.cmake.log.cc.log` from `shims/super/cc`.
+    File.open("#{logfn}.log", "w") do |log|
       log.puts Time.now, "", cmd, args, ""
       log.flush
 

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -532,7 +532,7 @@ def log(basename, argv, tool, args)
   s << "superenv removed:  #{dels.join(" ")}\n" unless dels.empty?
   s << "superenv added:    #{adds.join(" ")}\n" unless adds.empty?
   s << "superenv executed: #{tool} #{args.join(" ")}\n\n"
-  File.open("#{ENV["HOMEBREW_CC_LOG_PATH"]}.cc", "a+") { |f| f.write(s) }
+  File.open("#{ENV["HOMEBREW_CC_LOG_PATH"]}.cc.log", "a+") { |f| f.write(s) }
 end
 
 def remove_superbin_from_path(paths)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Having log files with extensions like `.cc` and `.cmake` is really
unfriendly to editor syntax highlighters and language servers. Let's try
to make sure these are opened as log files by adding a `.log` extension
to them.
