### PR TITLE
os/linux/elf: fix file descriptor leak

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -196,7 +196,7 @@ module ELFShim
       end
 
       @interpreter = patcher.interpreter
-      @rpath = patcher.rpath || patcher.runpath
+      @rpath = patcher.runpath || patcher.rpath
       @section_names = patcher.elf.sections.map(&:name).compact_blank
 
       @dt_flags_1 = dynamic_segment&.tag_by_type(:flags_1)&.value


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

On Linux, we occasionally see `EMFILE` ("too many open files") errors especially when installing a large formula like `llvm`. Currently, this can be reliably reproduced in a Homebrew/brew GitHub codespace (where `ulimit -n` seems to be 1024 by default) with `brew install geeqie`, with the following error message:

    Error: Too many open files @ rb_sysopen - /home/linuxbrew/.linuxbrew/Cellar/llvm/20.1.8/bin/tblgen-lsp-server

The reason is that each instance of `PatchELF::Patcher` keeps the ELF file open. We prepend the `ELFShim` module to the `Pathname` class and cache the patcher as an instance variable, which means that the ELF file remains open so long as the `Pathname` instance is still alive even if we don't need to access the ELF metadata anymore. When performing certain checks (e.g., linkage), we also store these `Pathname` instances, so the number of open file descriptors simply keeps increasing.

We can fix that by not caching the patcher and only use it when necessary. We create a patcher instance whenever we need to read or write ELF metadata, and reading of metadata is consolidated into the existing `ELFShim::Metadata` class so that we don't repeatedly create patcher instances.

A fix for a file descriptor leak issue in patchelf.rb has been submitted at https://github.com/david942j/patchelf.rb/pull/48. Together with that, this fixes #19177, #19866, #20223, #20302.
