### PR TITLE
os/linux/ld: do not crash the program if the `ld.so.conf` entry is not readable

### DIFF
--- a/Library/Homebrew/os/linux/ld.rb
+++ b/Library/Homebrew/os/linux/ld.rb
@@ -49,6 +49,8 @@ module OS
       def self.library_paths(conf_path = Pathname(sysconfdir)/"ld.so.conf")
         conf_file = Pathname(conf_path)
         return [] unless conf_file.exist?
+        return [] unless conf_file.file?
+        return [] unless conf_file.readable?
 
         @library_paths_cache ||= T.let({}, T.nilable(T::Hash[String, T::Array[String]]))
         cache_key = conf_file.to_s


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The system `/etc/ld.so.conf` may contain broken entries (e.g., exist but are not readable). If this scenario happens on a cloud machine while the users do not have `sudo` access, they cannot fix that, and `brew` always crashes.

Partial failure log from mine:

```text
Error: An exception occurred within a child process:
  Errno::EACCES: Permission denied @ rb_sysopen - /etc/ld.so.conf.d/nvcr-1788820824.conf
/nfs-hg/prod/containers/panxuehai/dev/.linuxbrew/Homebrew/Library/Homebrew/os/linux/ld.rb:62:in 'File#initialize'
/nfs-hg/prod/containers/panxuehai/dev/.linuxbrew/Homebrew/Library/Homebrew/os/linux/ld.rb:62:in 'IO.open'
/nfs-hg/prod/containers/panxuehai/dev/.linuxbrew/Homebrew/Library/Homebrew/os/linux/ld.rb:62:in 'Pathname#open'
/nfs-hg/prod/containers/panxuehai/dev/.linuxbrew/Homebrew/Library/Homebrew/os/linux/ld.rb:62:in 'OS::Linux::Ld.library_paths'
```

~~This PR ignores the invalid entry by adding a `rescue` clause and prevents `brew` from crashing.~~ This PR adds guard conditions.