### PR TITLE
cask/dsl/rename: add new `rename` dsl

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -3,6 +3,7 @@
 
 require "cask/denylist"
 require "cask/download"
+require "cask/installer"
 require "digest"
 require "livecheck/livecheck"
 require "source_location"
@@ -630,6 +631,11 @@ module Cask
         UnpackStrategy.detect(@tmpdir/nested_container, merge_xattrs: true)
                       .extract_nestedly(to: @tmpdir, verbose: false)
       end
+
+      # Process rename operations after extraction
+      # Create a temporary installer to process renames in the audit directory
+      temp_installer = Installer.new(@cask)
+      temp_installer.process_rename_operations(target_dir: @tmpdir)
 
       # Set the flag to indicate that extraction has occurred.
       @artifacts_extracted = T.let(true, T.nilable(TrueClass))

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -19,6 +19,7 @@ require "cask/dsl/container"
 require "cask/dsl/depends_on"
 require "cask/dsl/postflight"
 require "cask/dsl/preflight"
+require "cask/dsl/rename"
 require "cask/dsl/uninstall_postflight"
 require "cask/dsl/uninstall_preflight"
 require "cask/dsl/version"
@@ -81,6 +82,7 @@ module Cask
       :language,
       :name,
       :os,
+      :rename,
       :sha256,
       :staged_path,
       :url,
@@ -162,6 +164,7 @@ module Cask
       @on_system_block_min_os = T.let(nil, T.nilable(MacOSVersion))
       @os = T.let(nil, T.nilable(String))
       @os_set_in_block = T.let(false, T::Boolean)
+      @rename = T.let([], T::Array[DSL::Rename])
       @sha256 = T.let(nil, T.nilable(T.any(Checksum, Symbol)))
       @sha256_set_in_block = T.let(false, T::Boolean)
       @staged_path = T.let(nil, T.nilable(Pathname))
@@ -341,6 +344,28 @@ module Cask
       set_unique_stanza(:container, kwargs.empty?) do
         DSL::Container.new(**kwargs)
       end
+    end
+
+    # Renames files after extraction.
+    #
+    # This is useful when the downloaded file has unpredictable names
+    # that need to be normalized for proper artifact installation.
+    #
+    # ### Example
+    #
+    # ```ruby
+    # rename "RØDECaster App*.pkg", "RØDECaster App.pkg"
+    # ```
+    #
+    # @api public
+    sig {
+      params(from: String,
+             to:   String).returns(T::Array[DSL::Rename])
+    }
+    def rename(from = T.unsafe(nil), to = T.unsafe(nil))
+      return @rename if from.nil?
+
+      @rename << DSL::Rename.new(T.must(from), T.must(to))
     end
 
     # Sets the cask's version.

--- a/Library/Homebrew/cask/dsl/rename.rb
+++ b/Library/Homebrew/cask/dsl/rename.rb
@@ -1,0 +1,52 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Cask
+  class DSL
+    # Class corresponding to the `rename` stanza.
+    class Rename
+      sig { returns(String) }
+      attr_reader :from, :to
+
+      sig { params(from: String, to: String).void }
+      def initialize(from, to)
+        @from = from
+        @to = to
+      end
+
+      sig { params(staged_path: Pathname).void }
+      def perform_rename(staged_path)
+        return unless staged_path.exist?
+
+        # Find files matching the glob pattern
+        matching_files = if @from.include?("*")
+          staged_path.glob(@from)
+        else
+          [staged_path.join(@from)].select(&:exist?)
+        end
+
+        return if matching_files.empty?
+
+        # Rename the first matching file to the target path
+        source_file = matching_files.first
+        return if source_file.nil?
+
+        target_file = staged_path.join(@to)
+
+        # Ensure target directory exists
+        target_file.dirname.mkpath
+
+        # Perform the rename
+        source_file.rename(target_file.to_s) if source_file.exist?
+      end
+
+      sig { returns(T::Hash[Symbol, String]) }
+      def pairs
+        { from:, to: }
+      end
+
+      sig { returns(String) }
+      def to_s = pairs.inspect
+    end
+  end
+end

--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -35,6 +35,9 @@ module RuboCop
             :container,
           ],
           [
+            :rename,
+          ],
+          [
             :suite,
             :app,
             :pkg,

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
@@ -169,6 +169,9 @@ class Cask::Cask
   def qlplugin(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def rename(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def screen_saver(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/test/cask/dsl/rename_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/rename_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+RSpec.describe Cask::DSL::Rename do
+  subject(:rename) { described_class.new(from, to) }
+
+  let(:from) { "Source File*.pkg" }
+  let(:to) { "Target File.pkg" }
+
+  describe "#initialize" do
+    it "sets the from and to attributes" do
+      expect(rename.from).to eq("Source File*.pkg")
+      expect(rename.to).to eq("Target File.pkg")
+    end
+  end
+
+  describe "#pairs" do
+    it "returns the attributes as a hash" do
+      expect(rename.pairs).to eq(from: "Source File*.pkg", to: "Target File.pkg")
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the stringified attributes" do
+      expect(rename.to_s).to eq(rename.pairs.inspect)
+    end
+  end
+
+  describe "#perform_rename" do
+    let(:tmpdir) { mktmpdir }
+    let(:staged_path) { Pathname(tmpdir) }
+
+    context "when staged_path does not exist" do
+      let(:staged_path) { Pathname("/nonexistent/path") }
+
+      it "does nothing" do
+        expect { rename.perform_rename(staged_path) }.not_to raise_error
+      end
+    end
+
+    context "when using glob patterns" do
+      let(:from) { "Test App*.pkg" }
+      let(:to) { "Test App.pkg" }
+
+      before do
+        (staged_path / "Test App v1.2.3.pkg").write("test content")
+        (staged_path / "Test App v2.0.0.pkg").write("other content")
+      end
+
+      it "renames the first matching file" do
+        rename.perform_rename(staged_path)
+
+        expect(staged_path / "Test App.pkg").to exist
+        expect((staged_path / "Test App.pkg").read).to eq("test content")
+        expect(staged_path / "Test App v1.2.3.pkg").not_to exist
+        expect(staged_path / "Test App v2.0.0.pkg").to exist
+      end
+    end
+
+    context "when using exact filenames" do
+      let(:from) { "Exact File.dmg" }
+      let(:to) { "New Name.dmg" }
+
+      before do
+        (staged_path / "Exact File.dmg").write("dmg content")
+      end
+
+      it "renames the exact file" do
+        rename.perform_rename(staged_path)
+
+        expect(staged_path / "New Name.dmg").to exist
+        expect((staged_path / "New Name.dmg").read).to eq("dmg content")
+        expect(staged_path / "Exact File.dmg").not_to exist
+      end
+    end
+
+    context "when target is in a subdirectory" do
+      let(:from) { "source.txt" }
+      let(:to) { "subdir/target.txt" }
+
+      before do
+        (staged_path / "source.txt").write("content")
+      end
+
+      it "creates the subdirectory and renames the file" do
+        rename.perform_rename(staged_path)
+
+        expect(staged_path / "subdir" / "target.txt").to exist
+        expect((staged_path / "subdir" / "target.txt").read).to eq("content")
+        expect(staged_path / "source.txt").not_to exist
+      end
+    end
+
+    context "when no files match the pattern" do
+      let(:from) { "nonexistent*.pkg" }
+      let(:to) { "target.pkg" }
+
+      it "does nothing" do
+        rename.perform_rename(staged_path)
+
+        expect(staged_path / "target.pkg").not_to exist
+      end
+    end
+
+    context "when source file doesn't exist after glob" do
+      let(:from) { "missing.txt" }
+      let(:to) { "target.txt" }
+
+      it "does nothing" do
+        expect { rename.perform_rename(staged_path) }.not_to raise_error
+        expect(staged_path / "target.txt").not_to exist
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -598,4 +598,29 @@ RSpec.describe Cask::DSL, :cask, :no_api do
       ]
     end
   end
+
+  describe "rename stanza" do
+    it "allows setting single rename operation" do
+      cask = Cask::Cask.new("rename-cask") do
+        rename "Source*.pkg", "Target.pkg"
+      end
+
+      expect(cask.rename.length).to eq(1)
+      expect(cask.rename.first.from).to eq("Source*.pkg")
+      expect(cask.rename.first.to).to eq("Target.pkg")
+    end
+
+    it "allows setting multiple rename operations" do
+      cask = Cask::Cask.new("multi-rename-cask") do
+        rename "App*.pkg", "App.pkg"
+        rename "Doc*.dmg", "Doc.dmg"
+      end
+
+      expect(cask.rename.length).to eq(2)
+      expect(cask.rename.first.from).to eq("App*.pkg")
+      expect(cask.rename.first.to).to eq("App.pkg")
+      expect(cask.rename.last.from).to eq("Doc*.dmg")
+      expect(cask.rename.last.to).to eq("Doc.dmg")
+    end
+  end
 end

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -66,6 +66,8 @@ Having a common order for stanzas makes casks easier to update and parse. Below 
     depends_on
     container
 
+    rename
+
     suite
     app
     pkg
@@ -176,6 +178,7 @@ Each cask must declare one or more [artifacts](https://rubydoc.brew.sh/Cask/Arti
 | `container type:`                          | no                            | Symbol to override container-type autodetect. May be one of: `:air`, `:bz2`, `:cab`, `:dmg`, `:generic_unar`, `:gzip`, `:otf`, `:pkg`, `:rar`, `:seven_zip`, `:sit`, `:tar`, `:ttf`, `:xar`, `:zip`, `:naked`. (Example: [parse.rb](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/p/parse.rb#L10)) |
 | `auto_updates`                             | no                            | `true`. Asserts that the cask artifacts auto-update. Use if `Check for Updates…` or similar is present in an app menu, but not if it only opens a webpage and does not do the download and installation for you. |
 | [`no_autobump!`](#stanza-no_autobump)      | no                            | Allowed symbol or a string. Excludes cask from autobumping if set. |
+| [`rename`](#stanza-rename)      | yes                            | A pair of strings. |
 
 ## Stanza descriptions
 
@@ -251,6 +254,18 @@ binary "#{appdir}/Atom.app/Contents/Resources/app/atom.sh", target: "atom"
 ```
 
 Behaviour and usage of `target:` is [the same as with `app`](#renaming-the-target). However, for `binary` the select cases don’t apply as rigidly. It’s fine to take extra liberties with `target:` to be consistent with other command-line tools, like [changing case](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/g/godot.rb#L19), [removing an extension](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/f/filebot.rb#L19), or [cleaning up the name](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/f/fig.rb#L21).
+
+### Stanza: `rename`
+
+The `rename` stanza provides a convenience method to rename files to provide more practical access to them.
+This stanza should be used sparingly, and is reserved for scenarios where a the path of a file/directory is impossible to pre-determine.
+
+The example below can be used when the `pkg` path has a value such as timestamp that can't be detected without extracting the archive it is distributed within.
+
+```ruby
+# Upstream provides a `pkg` - "foobar-<timestamp>.pkg"
+rename "foobar-*.pkg", "foobar.pkg"
+```
 
 ### Stanza: `caveats`
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

*A majority of this code is written by claude, so it needs a more detailed read-through, which I will do before marking ready.*
Opening as a draft for any conceptual notes at this stage.

This PR introduces a new dsl `rename`.
There are some instances where we are required to rename files before installation because we cannot detect the path systematically. At present some casks are using `preflight` blocks.

This also allows us to make sure that we can correctly run `audit_rosetta` and `audit_signing` on these casks, as the paths can be found correctly.


Replaces:
```ruby
  preflight do
    staged_path.glob("RØDECaster App*.pkg")&.first&.rename(staged_path/"RØDECaster App.pkg")
  end
```

With:
```ruby
rename "RØDECaster App*.pkg", "RØDECaster App.pkg"
```