### PR TITLE
os/linux/keg_relocate: remove `protodesc_cold` exclusion

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -19,9 +19,6 @@ class Keg
 
   def change_rpath!(file, old_prefix, new_prefix)
     return false if !file.elf? || !file.dynamic_elf?
-    # Skip relocation of files with `protodesc_cold` sections because patchelf.rb seems to break them.
-    # https://github.com/Homebrew/homebrew-core/pull/232490#issuecomment-3161362452
-    return false if Hardware::CPU.intel? && file.section_names.include?("protodesc_cold")
 
     updated = {}
     old_rpath = file.rpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This needs to be handled more carefully. It probably works fine for
bottles built *after* this change was added, but it breaks bottles built
before this exclusion was added.

Let's remove it for now to limit the extent of the breakage.
