### PR TITLE
rustc_wrapper: pass `HOMEBREW_RUSTFLAGS` last

### DIFF
--- a/Library/Homebrew/shims/super/rustc_wrapper
+++ b/Library/Homebrew/shims/super/rustc_wrapper
@@ -12,4 +12,4 @@ shift
 # Prepend HOMEBREW_RUSTFLAGS to the arguments if set.
 # HOMEBREW_RUSTFLAGS is set in extend/ENV/{std,super}.rb
 # shellcheck disable=SC2086,SC2154
-exec "${RUSTC}" ${HOMEBREW_RUSTFLAGS} "$@"
+exec "${RUSTC}" "$@" ${HOMEBREW_RUSTFLAGS}


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If we pass it first, it can be overridden by other arguments passed on
the command line. We don't want that.

See discussion at Homebrew/homebrew-core#232566.

As mentioned in the link above, I don't have time to continue work on this until tomorrow. Feel free to push fixes here as needed if we need this fix to go in ASAP.
