### PR TITLE
Use hash for internal cask API

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-api.rb
@@ -72,14 +72,14 @@ module Homebrew
 
           OnSystem::VALID_OS_ARCH_TAGS.each do |bottle_tag|
             renames = {}
-            variation_casks = all_casks.map do |token, cask|
+            variation_casks = all_casks.to_h do |token, cask|
               cask = Homebrew::API.merge_variations(cask, bottle_tag:)
 
               cask["old_tokens"]&.each do |old_token|
                 renames[old_token] = token
               end
 
-              cask
+              [token, cask]
             end
 
             json_contents = {


### PR DESCRIPTION
Spin-off of #20425

I realized that I forgot to make the cask internal API file use a hash rather than an array for the cask info. Having this as a hash makes parsing it slightly easier, and is closer to how this will eventually look