### PR TITLE
Don't query analytics for third-party formulae/casks in `brew info`

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -36,6 +36,8 @@ module Cask
     def self.info(cask, args:)
       puts get_info(cask)
 
+      return unless cask.tap.core_cask_tap?
+
       require "utils/analytics"
       ::Utils::Analytics.cask_output(cask, args:)
     end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -159,9 +159,9 @@ module Homebrew
 
           case obj
           when Formula
-            Utils::Analytics.formula_output(obj, args:)
+            Utils::Analytics.formula_output(obj, args:) if obj.core_formula?
           when Cask::Cask
-            Utils::Analytics.cask_output(obj, args:)
+            Utils::Analytics.cask_output(obj, args:) if obj.tap.core_cask_tap?
           when FormulaOrCaskUnavailableError
             Utils::Analytics.output(filter: obj.name, args:)
           else
@@ -379,6 +379,8 @@ module Homebrew
         if (caveats_string = caveats.to_s.presence)
           ohai "Caveats", caveats_string
         end
+
+        return unless formula.core_formula?
 
         Utils::Analytics.formula_output(formula, args:)
       end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -329,6 +329,8 @@ module Utils
 
         require "api"
 
+        return unless Homebrew::API::Formula.all_formulae.key? formula.name
+
         json = Homebrew::API::Formula.formula_json formula.name
         return if json.blank? || json["analytics"].blank?
 
@@ -344,6 +346,8 @@ module Utils
         return if Homebrew::EnvConfig.no_analytics? || Homebrew::EnvConfig.no_github_api?
 
         require "api"
+
+        return unless Homebrew::API::Cask.all_casks.key? cask.token
 
         json = Homebrew::API::Cask.cask_json cask.token
         return if json.blank? || json["analytics"].blank?


### PR DESCRIPTION
Fixes https://github.com/orgs/Homebrew/discussions/6335

We don’t have any analytics data for non-core formulae/casks, so let’s not even try to query.

Also, while we’re here, fail more gracefully in case a core formula/cask API file isn’t available for some reason