### PR TITLE
shims/super/rustc_wrapper: fix comment

### DIFF
--- a/Library/Homebrew/shims/super/rustc_wrapper
+++ b/Library/Homebrew/shims/super/rustc_wrapper
@@ -9,7 +9,6 @@
 RUSTC="${1}"
 shift
 
-# Prepend HOMEBREW_RUSTFLAGS to the arguments if set.
-# HOMEBREW_RUSTFLAGS is set in extend/ENV/{std,super}.rb
-# shellcheck disable=SC2086,SC2154
-exec "${RUSTC}" "$@" ${HOMEBREW_RUSTFLAGS}
+# Append HOMEBREW_RUSTFLAGS to the arguments if set.
+read -ra RUSTFLAGS <<<"${HOMEBREW_RUSTFLAGS:-}"
+exec "${RUSTC}" "$@" "${RUSTFLAGS[@]}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In #20424, we moved `HOMEBREW_RUSTFLAGS` to the end of the compiler
invocation, but didn't update the comment. Let's fix that.

While we're here, let's fix `shellcheck disable`s.
