### PR TITLE
os/linux/keg_relocate: skip ELF files with `protodesc_cold` only when bottling

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -4,7 +4,7 @@
 require "compilers"
 
 class Keg
-  def relocate_dynamic_linkage(relocation)
+  def relocate_dynamic_linkage(relocation, skip_protodesc_cold: false)
     # Patching the dynamic linker of glibc breaks it.
     return if name.match? Version.formula_optionally_versioned_regex(:glibc)
 
@@ -12,20 +12,18 @@ class Keg
 
     elf_files.each do |file|
       file.ensure_writable do
-        change_rpath!(file, old_prefix, new_prefix)
+        change_rpath!(file, old_prefix, new_prefix, skip_protodesc_cold:)
       end
     end
   end
 
-  def change_rpath!(file, old_prefix, new_prefix)
+  def change_rpath!(file, old_prefix, new_prefix, skip_protodesc_cold: false)
     return false if !file.elf? || !file.dynamic_elf?
 
-    bottling = old_prefix.to_s.start_with?(HOMEBREW_PREFIX.to_s)
-    bottling &&= !new_prefix.to_s.start_with?(HOMEBREW_PREFIX.to_s)
     # Skip relocation of files with `protodesc_cold` sections because patchelf.rb seems to break them,
     # but only when bottling (as we don't want to break existing bottles that require relocation).
     # https://github.com/Homebrew/homebrew-core/pull/232490#issuecomment-3161362452
-    return false if bottling && file.section_names.include?("protodesc_cold")
+    return false if skip_protodesc_cold && file.section_names.include?("protodesc_cold")
 
     updated = {}
     old_rpath = file.rpath

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -20,7 +20,7 @@ module OS
         end
       end
 
-      def relocate_dynamic_linkage(relocation)
+      def relocate_dynamic_linkage(relocation, skip_protodesc_cold: false)
         mach_o_files.each do |file|
           file.ensure_writable do
             modified = T.let(false, T::Boolean)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -78,7 +78,7 @@ class Keg
     end
   end
 
-  def relocate_dynamic_linkage(_relocation)
+  def relocate_dynamic_linkage(_relocation, skip_protodesc_cold: false)
     []
   end
 
@@ -104,7 +104,7 @@ class Keg
 
   def replace_locations_with_placeholders
     relocation = prepare_relocation_to_placeholders.freeze
-    relocate_dynamic_linkage(relocation)
+    relocate_dynamic_linkage(relocation, skip_protodesc_cold: true)
     replace_text_in_files(relocation)
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We removed this exclusion in #20423 because it broke pouring of existing
bottles, which still need relocation.

Let's skip relocation only when bottling, to avoid breaking existing
bottles that need to be relocated when pouring.
