### PR TITLE
Revert "Don't allow installing formulae from paths without HOMEBREW_DEVELOPER"

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -238,10 +238,9 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_FORBID_PACKAGES_FROM_PATHS:       {
-        description:  "If set, Homebrew will refuse to read formulae or casks provided from file paths, " \
-                      "e.g. `brew install ./package.rb`.",
-        boolean:      true,
-        default_text: "true unless `$HOMEBREW_DEVELOPER` is set.",
+        description: "If set, Homebrew will refuse to read formulae or casks provided from file paths, " \
+                     "e.g. `brew install ./package.rb`.",
+        boolean:     true,
       },
       HOMEBREW_FORCE_API_AUTO_UPDATE:            {
         description: "If set, update the Homebrew API formula or cask data even if " \
@@ -553,7 +552,6 @@ module Homebrew
     CUSTOM_IMPLEMENTATIONS = T.let(Set.new([
       :HOMEBREW_MAKE_JOBS,
       :HOMEBREW_CASK_OPTS,
-      :HOMEBREW_FORBID_PACKAGES_FROM_PATHS,
     ]).freeze, T::Set[Symbol])
 
     ENVS.each do |env, hash|
@@ -628,15 +626,6 @@ module Homebrew
     sig { returns(T::Boolean) }
     def cask_opts_require_sha?
       cask_opts.include?("--require-sha")
-    end
-
-    sig { returns(T::Boolean) }
-    def forbid_packages_from_paths?
-      return true if ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"].present?
-
-      # Provide an opt-out for tests and developers.
-      # Our testing framework installs formulae from file paths all over the place.
-      ENV["HOMEBREW_TESTS"].blank? && ENV["HOMEBREW_DEVELOPER"].blank?
     end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -69,34 +69,4 @@ RSpec.describe Homebrew::EnvConfig do
       expect(env_config.make_jobs).to eql("16")
     end
   end
-
-  describe ".forbid_packages_from_paths?" do
-    before do
-      ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = nil
-      ENV["HOMEBREW_DEVELOPER"] = nil
-      ENV["HOMEBREW_TESTS"] = nil
-    end
-
-    it "returns true if HOMEBREW_FORBID_PACKAGES_FROM_PATHS is set" do
-      ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
-      expect(env_config.forbid_packages_from_paths?).to be(true)
-    end
-
-    it "returns true if HOMEBREW_DEVELOPER is not set" do
-      ENV["HOMEBREW_DEVELOPER"] = nil
-      expect(env_config.forbid_packages_from_paths?).to be(true)
-    end
-
-    it "returns false if HOMEBREW_DEVELOPER is set and HOMEBREW_FORBID_PACKAGES_FROM_PATHS is not set" do
-      ENV["HOMEBREW_DEVELOPER"] = "1"
-      ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = nil
-      expect(env_config.forbid_packages_from_paths?).to be(false)
-    end
-
-    it "returns true if both HOMEBREW_DEVELOPER and HOMEBREW_FORBID_PACKAGES_FROM_PATHS are set" do
-      ENV["HOMEBREW_DEVELOPER"] = "1"
-      ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
-      expect(env_config.forbid_packages_from_paths?).to be(true)
-    end
-  end
 end


### PR DESCRIPTION
Reverts Homebrew/brew#20414

This breaks installing formulae from bottle paths.