### PR TITLE
Fix HEAD installations with HOMEBREW_FORBID_PACKAGES_FROM_PATHS

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -617,7 +617,8 @@ module Formulary
       return unless path.expand_path.exist?
 
       return if Homebrew::EnvConfig.forbid_packages_from_paths? &&
-                !path.realpath.to_s.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/")
+                !path.realpath.to_s.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/",
+                                                "#{HOMEBREW_CACHE}/")
 
       if (tap = Tap.from_path(path))
         # Only treat symlinks in taps as aliases.

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -141,6 +141,21 @@ RSpec.describe Formulary do
         end.to raise_error(FormulaUnavailableError)
       end
 
+      it "allows cache paths even when paths are disabled" do
+        ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
+        cache_dir = HOMEBREW_CACHE/"test_formula_cache"
+        cache_dir.mkpath
+        cache_formula_path = cache_dir/formula_path.basename
+        FileUtils.cp formula_path, cache_formula_path
+        begin
+          formula = described_class.factory(cache_formula_path)
+          expect(formula).to be_a(Formula)
+        ensure
+          cache_formula_path.unlink if cache_formula_path.exist?
+          cache_dir.rmdir if cache_dir.exist?
+        end
+      end
+
       context "when given a bottle" do
         subject(:formula) { described_class.factory(bottle) }
 


### PR DESCRIPTION
- Allow cache paths in FromPathLoader when HOMEBREW_FORBID_PACKAGES_FROM_PATHS is set
- Fixes issue where HEAD installations fail due to temporary source downloads
- Add test case to verify cache paths are allowed when path restrictions are enabled

The issue occurred because HEAD installations download formula sources to cache directories, but HOMEBREW_FORBID_PACKAGES_FROM_PATHS only allowed paths from HOMEBREW_CELLAR and HOMEBREW_LIBRARY/Taps, causing the installation to fail.

Since #20414, `HOMEBREW_FORBID_PACKAGES_FROM_PATHS` is now enabled by default, which may cause `brew install --HEAD formula` to fail.

Closes: homebrew/brew#issue-number

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
