### PR TITLE
bump-cask-pr: ensure new_cask has a url

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -273,6 +273,8 @@ module Homebrew
               end
               languages.each do |language|
                 new_cask        = Cask::CaskLoader.load(tmp_contents)
+                next unless new_cask.url
+
                 new_cask.config = if language.blank?
                   tmp_cask.config
                 else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We sometimes see errors like "attempted to use a `Downloadable` without a URL!" in the homebrew/cask autobump workflow log because `bump-cask-pr` can simulate Linux even if a cask doesn't support it, which leads to this error. This is something that should be resolved in the future once I finally wrap up my related work to detect OS/arch requirements but this adds a simple guard to address this in the interim time.