### PR TITLE
cask/quarantine: fix quarantine support

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -88,9 +88,9 @@ module Cask
 
     sig { returns(T::Boolean) }
     def self.available?
-      @status ||= check_quarantine_support
+      @quarantine_support ||= check_quarantine_support
 
-      @status == :quarantine_available
+      @quarantine_support[0] == :quarantine_available
     end
 
     def self.detect(file)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A recent PR broke quarantine support https://github.com/Homebrew/brew/pull/20415

The [`check_quarantine_support`](https://github.com/Homebrew/brew/commit/4ee43fbde119c2ba1ea623b77fc771810a066c4d#diff-734ad301f6ab0d60ba53ad628f64ec62e4c16a934f1acfe3a56c3ee10acc4a9eR44) method was updated to return `[status, check_output]`, but the corresponding `available?` method was not updated, and was expecting only expect the `status` to be returned.

There may be a more correct fix than my suggestion, feel free to push straight to this PR.