### PR TITLE
formulary: improve/loosen path rejection logic.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -618,10 +618,11 @@ module Formulary
 
       if Homebrew::EnvConfig.forbid_packages_from_paths?
         path_realpath = path.realpath.to_s
-        unless path_realpath.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/",
-                                         "#{HOMEBREW_CACHE}/")
-          raise <<~WARNING if path_realpath.include?("/") || path_realpath.end_with?(".rb")
-            Rejecting formula at #{path_realpath} because it's not in a tap.
+        path_string = path.to_s
+        if !path_realpath.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/", "#{HOMEBREW_CACHE}/") &&
+           (path_string.include?("/") || path_string.end_with?(".rb"))
+          raise <<~WARNING
+            Rejecting formula at #{!path_realpath} because it's not in a tap.
                    Homebrew requires formulae to be in a tap.
 
             To create a tap, run e.g.
@@ -629,8 +630,6 @@ module Formulary
             To create a formula in a tap run e.g.
               brew create <url> --tap=<user|org>/<repository>
           WARNING
-
-          return
         end
       end
 


### PR DESCRIPTION
- Don't check if the `realpath` includes `/`: it always will. Instead, see if the originally user-passed `ref` includes `/` or ends with `.rb`.
- Always raise an error message, don't silently return.

Fixes https://github.com/Homebrew/brew/issues/20441
Fixes https://github.com/Homebrew/brew/issues/20448
Fixes https://github.com/Homebrew/brew/issues/20452