### PR TITLE
Update and temporarily disable GNU mirror audit

### DIFF
--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -41,11 +41,11 @@ module RuboCop
           problem "Please use the ASCII (Punycode-encoded host, URL-encoded path and query) version of #{url}."
         end
 
-        # GNU URLs; doesn't apply to mirrors
-        gnu_pattern = %r{^(?:https?|ftp)://ftpmirror\.gnu\.org/(.*)}
-        audit_urls(urls, gnu_pattern) do |match, url|
-          problem "#{url} should be: https://ftp.gnu.org/gnu/#{match[1]}"
-        end
+        # TODO: Re-add the following audit after homebrew/core migration.
+        # gnu_pattern = %r{^(?:https?|ftp)://ftp\.gnu\.org/(.*)}
+        # audit_urls(urls, gnu_pattern) do |match, url|
+        #   problem "#{url} should be: https://ftpmirror.gnu.org/gnu/#{match[1]}"
+        # end
 
         # Fossies upstream requests they aren't used as primary URLs
         # https://github.com/Homebrew/homebrew-core/issues/14486#issuecomment-307753234

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -211,10 +211,11 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
         offenses = inspect_source(source)
 
         expected_offenses.zip(offenses.reverse).each do |expected, actual|
-          expect(actual&.message).to eq(expected[:message])
-          expect(actual&.severity).to eq(expected[:severity])
-          expect(actual&.line).to eq(expected[:line])
-          expect(actual&.column).to eq(expected[:column])
+          expect(actual).not_to be_nil
+          expect(actual.message).to eq(expected[:message])
+          expect(actual.severity).to eq(expected[:severity])
+          expect(actual.line).to eq(expected[:line])
+          expect(actual.column).to eq(expected[:column])
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
   subject(:cop) { described_class.new }
 
   let(:offense_list) do
+    # TODO: Re-add the following to the offense list after homebrew/core migration.
+    # {
+    #   "url" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz",
+    #   "msg" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz should be: " \
+    #            "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz",
+    #   "col" => 2,
+    # }
     [{
-      "url" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz",
-      "msg" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz should be: " \
-               "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz",
-      "col" => 2,
-    }, {
       "url" => "https://fossies.org/linux/privat/monit-5.23.0.tar.gz",
       "msg" => "Please don't use \"fossies.org\" in the `url` (using as a mirror is fine)",
       "col" => 2,
@@ -209,10 +211,10 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
         offenses = inspect_source(source)
 
         expected_offenses.zip(offenses.reverse).each do |expected, actual|
-          expect(actual.message).to eq(expected[:message])
-          expect(actual.severity).to eq(expected[:severity])
-          expect(actual.line).to eq(expected[:line])
-          expect(actual.column).to eq(expected[:column])
+          expect(actual&.message).to eq(expected[:message])
+          expect(actual&.severity).to eq(expected[:severity])
+          expect(actual&.line).to eq(expected[:line])
+          expect(actual&.column).to eq(expected[:column])
         end
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Update the audit to prefer ftpmirror.gnu.org over ftp.gnu.org as suggested by GNU [^1]:

> We recommend using this generic ftpmirror.gnu.org address wherever possible in links, documentation, etc., to reduce load on the main GNU server.

The audit is temporarily disabled to allow migrating all homebrew/core formulae first.

Should help to address #20456.

[^1]: https://www.gnu.org/server/mirror.en.html
