### PR TITLE
Re-enable GNU mirror audit

### DIFF
--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -41,11 +41,11 @@ module RuboCop
           problem "Please use the ASCII (Punycode-encoded host, URL-encoded path and query) version of #{url}."
         end
 
-        # TODO: Re-add the following audit after homebrew/core migration.
-        # gnu_pattern = %r{^(?:https?|ftp)://ftp\.gnu\.org/(.*)}
-        # audit_urls(urls, gnu_pattern) do |match, url|
-        #   problem "#{url} should be: https://ftpmirror.gnu.org/gnu/#{match[1]}"
-        # end
+        # Prefer ftpmirror.gnu.org as suggested by https://www.gnu.org/prep/ftp.en.html
+        gnu_pattern = %r{^(?:https?|ftp)://ftp\.gnu\.org/(.*)}
+        audit_urls(urls, gnu_pattern) do |match, url|
+          problem "#{url} should be: https://ftpmirror.gnu.org/gnu/#{match[1]}"
+        end
 
         # Fossies upstream requests they aren't used as primary URLs
         # https://github.com/Homebrew/homebrew-core/issues/14486#issuecomment-307753234

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -6,14 +6,12 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
   subject(:cop) { described_class.new }
 
   let(:offense_list) do
-    # TODO: Re-add the following to the offense list after homebrew/core migration.
-    # {
-    #   "url" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz",
-    #   "msg" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz should be: " \
-    #            "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz",
-    #   "col" => 2,
-    # }
     [{
+      "url" => "https://ftp.gnu.org/lightning/lightning-2.1.0.tar.gz",
+      "msg" => "https://ftp.gnu.org/lightning/lightning-2.1.0.tar.gz should be: " \
+               "https://ftpmirror.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz",
+      "col" => 2,
+    }, {
       "url" => "https://fossies.org/linux/privat/monit-5.23.0.tar.gz",
       "msg" => "Please don't use \"fossies.org\" in the `url` (using as a mirror is fine)",
       "col" => 2,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to Homebrew/brew#20461 and Homebrew/homebrew-core#233493.
