### PR TITLE
formulary: tighter path rejection detection.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -619,7 +619,8 @@ module Formulary
       if Homebrew::EnvConfig.forbid_packages_from_paths?
         path_realpath = path.realpath.to_s
         path_string = path.to_s
-        unless path_realpath.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/", "#{HOMEBREW_CACHE}/")
+        if !path_realpath.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/", "#{HOMEBREW_CACHE}/") &&
+           !path_string.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/", "#{HOMEBREW_CACHE}/")
           if path_string.include?("./") || path_string.end_with?(".rb") || path_string.count("/") != 2
             raise <<~WARNING
               Rejecting formula at #{path_string} because it's not in a tap.


### PR DESCRIPTION
We need to handle symlinks in both directions for formulae in the cellar/taps/cache otherwise we can get the nonsensical situation of telling people a formula must me in a tap when it already is (but is symlinked from elsewhere).

Fixes https://github.com/Homebrew/brew/issues/20452