### PR TITLE
download_strategy: fix UID handling with credential helpers on fetch

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1106,20 +1106,25 @@ class GitDownloadStrategy < VCSDownloadStrategy
     # Convert any shallow clone to full clone
     if shallow_dir?
       command! "git",
-               args:    ["fetch", "origin", "--unshallow"],
-               chdir:   cached_location,
-               timeout: Utils::Timer.remaining(timeout)
+               args:      ["fetch", "origin", "--unshallow"],
+               chdir:     cached_location,
+               timeout:   Utils::Timer.remaining(timeout),
+               reset_uid: true
     else
       command! "git",
-               args:    ["fetch", "origin"],
-               chdir:   cached_location,
-               timeout: Utils::Timer.remaining(timeout)
+               args:      ["fetch", "origin"],
+               chdir:     cached_location,
+               timeout:   Utils::Timer.remaining(timeout),
+               reset_uid: true
     end
   end
 
   sig { override.params(timeout: T.nilable(Time)).void }
   def clone_repo(timeout: nil)
-    command! "git", args: clone_args, timeout: Utils::Timer.remaining(timeout)
+    command! "git",
+             args:      clone_args,
+             timeout:   Utils::Timer.remaining(timeout),
+             reset_uid: true
 
     command! "git",
              args:    ["config", "homebrew.cacheversion", cache_version],


### PR DESCRIPTION
While fetch operations themselves do not need this, they might write to a credential helper that could.