### PR TITLE
software_spec: fix type signatures

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -152,12 +152,12 @@ class SoftwareSpec
     !bottle_specification.collector.tags.empty?
   end
 
-  sig { params(tag: T.nilable(Utils::Bottles::Tag)).returns(T::Boolean) }
+  sig { params(tag: T.nilable(T.any(Utils::Bottles::Tag, Symbol))).returns(T::Boolean) }
   def bottle_tag?(tag = nil)
     bottle_specification.tag?(Utils::Bottles.tag(tag))
   end
 
-  sig { params(tag: T.nilable(Utils::Bottles::Tag)).returns(T::Boolean) }
+  sig { params(tag: T.nilable(T.any(Utils::Bottles::Tag, Symbol))).returns(T::Boolean) }
   def bottled?(tag = nil)
     return false unless bottle_tag?(tag)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes

    Error: Parameter 'tag': Expected type T.nilable(Utils::Bottles::Tag), got type Symbol with value :arm64_sequoia

https://github.com/Homebrew/homebrew-core/actions/runs/16998107196/job/48193586673#step:5:45
