### PR TITLE
Type remaining Kernel logging extensions

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -148,15 +148,15 @@ class AbstractDownloadStrategy
     cached_location.basename
   end
 
+  sig { override.params(title: T.any(String, Exception), sput: T.anything).void }
+  def ohai(title, *sput)
+    super unless quiet?
+  end
+
   private
 
   sig { params(args: T.anything).void }
   def puts(*args)
-    super unless quiet?
-  end
-
-  sig { params(args: T.anything).void }
-  def ohai(*args)
     super unless quiet?
   end
 

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -44,11 +44,13 @@ module Kernel
     Formatter.headline(title, color: :blue)
   end
 
+  sig { params(title: T.any(String, Exception), sput: T.anything).void }
   def ohai(title, *sput)
     puts ohai_title(title.to_s)
     puts sput
   end
 
+  sig { params(title: T.any(String, Exception), sput: T.anything, always_display: T::Boolean).void }
   def odebug(title, *sput, always_display: false)
     debug = if respond_to?(:debug)
       T.unsafe(self).debug?

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -60,6 +60,7 @@ class FormulaVersions
     # We rescue these so that we can skip bad versions and
     # continue walking the history
     odebug "#{e} in #{name} at revision #{revision}", Utils::Backtrace.clean(e)
+    nil
   rescue FormulaUnavailableError
     nil
   ensure

--- a/Library/Homebrew/messages.rb
+++ b/Library/Homebrew/messages.rb
@@ -4,7 +4,7 @@
 # A {Messages} object collects messages that may need to be displayed together
 # at the end of a multi-step `brew` command run.
 class Messages
-  sig { returns(T::Array[T::Hash[Symbol, Symbol]]) }
+  sig { returns(T::Array[{ package: String, caveats: T.any(String, Caveats) }]) }
   attr_reader :caveats
 
   sig { returns(Integer) }
@@ -15,7 +15,7 @@ class Messages
 
   sig { void }
   def initialize
-    @caveats = T.let([], T::Array[T::Hash[Symbol, Symbol]])
+    @caveats = T.let([], T::Array[{ package: String, caveats: T.any(String, Caveats) }])
     @completions_and_elisp = T.let(Set.new, T::Set[String])
     @package_count = T.let(0, Integer)
     @install_times = T.let([], T::Array[T::Hash[String, Float]])
@@ -53,7 +53,7 @@ class Messages
     return if @package_count == 1 && !force
 
     oh1 "Caveats" if @completions_and_elisp.empty?
-    @caveats.each { |c| ohai c[:package], c[:caveats] }
+    @caveats.each { |c| ohai c.fetch(:package), c.fetch(:caveats) }
   end
 
   sig { void }

--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -24,7 +24,7 @@ module Repology
     if Homebrew::EnvConfig.developer?
       $stderr.puts result&.stderr
     else
-      odebug result&.stderr
+      odebug result&.stderr.to_s
     end
 
     raise


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Adding sigs for `ohai` and `odebug`, consistent with the other o* Kernel extensions. (Note the breaking change of the return types, as illustrated in a comment below.)