### PR TITLE
Remove unused 'which_all' Kernel ext

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -355,19 +355,6 @@ module Kernel
     nil
   end
 
-  def which_all(cmd, path = ENV.fetch("PATH"))
-    PATH.new(path).filter_map do |p|
-      begin
-        pcmd = File.expand_path(cmd, p)
-      rescue ArgumentError
-        # File.expand_path will raise an ArgumentError if the path is malformed.
-        # See https://github.com/Homebrew/legacy-homebrew/issues/32789
-        next
-      end
-      Pathname.new(pcmd) if File.file?(pcmd) && File.executable?(pcmd)
-    end.uniq
-  end
-
   def which_editor(silent: false)
     editor = Homebrew::EnvConfig.editor
     return editor if editor

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -172,10 +172,6 @@ class Requirement
     super(cmd, PATH.new(ORIGINAL_PATHS))
   end
 
-  def which_all(cmd)
-    super(cmd, PATH.new(ORIGINAL_PATHS))
-  end
-
   class << self
     include BuildEnvironment::DSL
 

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -144,32 +144,6 @@ RSpec.describe Kernel do
     end
   end
 
-  describe "#which_all" do
-    let(:cmd_foo) { dir/"foo" }
-    let(:cmd_foo_bar) { dir/"bar/foo" }
-    let(:cmd_bar_baz_foo) { dir/"bar/baz/foo" }
-
-    before do
-      (dir/"bar/baz").mkpath
-
-      FileUtils.touch cmd_foo_bar
-
-      [cmd_foo, cmd_bar_baz_foo].each do |cmd|
-        FileUtils.touch cmd
-        cmd.chmod 0744
-      end
-    end
-
-    it "returns an array of all executables that are found" do
-      path = [
-        "#{dir}/bar/baz",
-        "#{dir}/baz:#{dir}",
-        "~baduserpath",
-      ].join(File::PATH_SEPARATOR)
-      expect(which_all("foo", path)).to eq([cmd_bar_baz_foo, cmd_foo])
-    end
-  end
-
   specify "#which_editor" do
     ENV["HOMEBREW_EDITOR"] = "vemate -w"
     ENV["HOMEBREW_PATH"] = dir


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
