### PR TITLE
Move 'paths' out of Kernel

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1109,6 +1109,13 @@ module Homebrew
       def current_user
         ENV.fetch("USER", "$(whoami)")
       end
+
+      private
+
+      sig { returns(T::Array[Pathname]) }
+      def paths
+        @paths ||= T.let(ORIGINAL_PATHS.uniq.map(&:to_s), T.nilable(T::Array[Pathname]))
+      end
     end
   end
 end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -458,11 +458,6 @@ module Kernel
     Formula[formula_name].ensure_installed!(reason:, latest:).opt_bin/name
   end
 
-  sig { returns(T::Array[Pathname]) }
-  def paths
-    @paths ||= T.let(ORIGINAL_PATHS.uniq.map(&:to_s), T.nilable(T::Array[Pathname]))
-  end
-
   sig { params(size_in_bytes: T.any(Integer, Float)).returns(String) }
   def disk_usage_readable(size_in_bytes)
     if size_in_bytes.abs >= 1_073_741_824


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
There appears to be a single class that makes use of this Kernel extension, let's colocate it there instead.