### PR TITLE
bin/brew: expand env file filter to allow manpage-documented envs

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -125,8 +125,8 @@ export_homebrew_env_file() {
   [[ -r "${env_file}" ]] || return 0
   while read -r line
   do
-    # only load HOMEBREW_* lines
-    [[ "${line}" = "HOMEBREW_"* ]] || continue
+    # only load variables defined in env_config.rb
+    [[ "${line}" =~ ^(HOMEBREW_|SUDO_ASKPASS=|(all|no|ftp|https?)_proxy=) ]] || continue
 
     # forbid overriding variables that are set in this file
     local invalid_variable


### PR DESCRIPTION
The proxy and `SUDO_ASKPASS` variables are explicitly documented at https://docs.brew.sh/Manpage#environment so allow them.