### PR TITLE
formulary: do not allow using the cache when forbidding paths

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -619,15 +619,9 @@ module Formulary
       if Homebrew::EnvConfig.forbid_packages_from_paths?
         path_realpath = path.realpath.to_s
         path_string = path.to_s
-        allowed_paths = ["#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/"]
-
-        # Do not allow the cache if we explicitly set HOMEBREW_FORBID_PACKAGES_FROM_PATHS
-        # as the cache can contain arbitrary downloads. Allow it otherwise for convenience.
-        allowed_paths << "#{HOMEBREW_CACHE}/" unless ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"].present?
-
         if (path_realpath.end_with?(".rb") || path_string.end_with?(".rb")) &&
-           !path_realpath.start_with?(*allowed_paths) &&
-           !path_string.start_with?(*allowed_paths)
+           !path_realpath.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/") &&
+           !path_string.start_with?("#{HOMEBREW_CELLAR}/", "#{HOMEBREW_LIBRARY}/Taps/")
           if path_string.include?("./") || path_string.end_with?(".rb") || path_string.count("/") != 2
             raise <<~WARNING
               Homebrew requires formulae to be in a tap, rejecting:

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -155,11 +155,6 @@ RSpec.describe Formulary do
           cache_dir.rmdir if cache_dir.exist?
         end
 
-        it "allows cache paths when paths are implicitly disabled" do
-          allow(Homebrew::EnvConfig).to receive(:forbid_packages_from_paths?).and_return(true)
-          expect(described_class.factory(cache_formula_path)).to be_a(Formula)
-        end
-
         it "disallows cache paths when paths are explicitly disabled" do
           ENV["HOMEBREW_FORBID_PACKAGES_FROM_PATHS"] = "1"
           expect do


### PR DESCRIPTION
While implicitly-set `HOMEBREW_FORBID_PACKAGES_FROM_PATHS` is more to point non-developers away from paths as they're not well supported, explicitly-set `HOMEBREW_FORBID_PACKAGES_FROM_PATHS` is a security feature.

Since the cache can contain arbitrary downloads, we shouldn't allow the cache if `HOMEBREW_FORBID_PACKAGES_FROM_PATHS` is explicitly set.