### PR TITLE
cask/audit: correctly filter artifact types in audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -672,10 +672,17 @@ module Cask
         mentions_rosetta = cask.caveats.include?("requires Rosetta 2")
         requires_intel = cask.depends_on.arch&.any? { |arch| arch[:type] == :intel }
 
-        any_requires_rosetta = artifacts.any? do |artifact|
+        artifacts_to_test = artifacts.filter do |artifact|
           next false if !artifact.is_a?(Artifact::App) && !artifact.is_a?(Artifact::Binary)
           next false if artifact.is_a?(Artifact::Binary) && is_container
 
+          true
+        end
+
+        next if artifacts_to_test.blank?
+
+        any_requires_rosetta = artifacts_to_test.any? do |artifact|
+          artifact = T.cast(artifact, T.any(Artifact::App, Artifact::Binary))
           path = tmpdir/artifact.source.relative_path_from(cask.staged_path)
 
           result = case artifact


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In cases where we cannot systematically test for the requirement of Rosetta, we need to skip the tests earlier.

This was resulting in some false audit results being reported for `pkg` as we are currently not testing the contents. It may be possible, but introduces a significant amount of complexity. Ref: https://github.com/Homebrew/homebrew-cask/pull/224320