### PR TITLE
Enable loading formulae from stubs

### DIFF
--- a/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
@@ -112,6 +112,9 @@ class Formula
   def loaded_from_api?(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
+  def loaded_from_stub?(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
   def network_access_allowed?(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }


### PR DESCRIPTION
This PR makes use of the minimal API to set up loading a formula from a `FormulaStub`. This formula is incomplete, meaning it may not return fully accurate information (e.g. `deps`). The `loaded_from_stub?` method can be used to check whether a formula was loaded in this way or not.

Formulae will still be loaded completely by default, and will require an opt-in via the `prefer_stub` switch to `Formulary.factory`

The `Formulary` methods modified here include:

- `factory` and `resolve` now accept the `prefer_stub` switch. This controls whether stubs are used when available. This is off by default, and only works if `HOMEBREW_USE_INTERNAL_API` is set, anyway.
- `from_json_contents` is used to load a formula directly from its JSON contents. This will allow us to pass a hash directly to `Formulary` once we've downloaded the bottle manifest file and extracted the metadata from there. The resulting formula is cached, so the next time `Formulary.factory` is called on that formula name, it will return the version from the API.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #20490 
- <kbd>&nbsp;1&nbsp;</kbd> #20489 👈 
<!-- GitButler Footer Boundary Bottom -->

