### PR TITLE
Load formulae from stubs in argument parser

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -338,21 +338,21 @@ module Homebrew
       end
 
       sig {
-        params(name: String, only: T.nilable(Symbol), method: T.nilable(Symbol), warn: T.nilable(T::Boolean),
+        params(name: String, only: T.nilable(Symbol), method: T.nilable(Symbol), warn: T::Boolean,
                download_queue: T.nilable(Homebrew::DownloadQueue))
           .returns(T.any(Formula, Keg, Cask::Cask, T::Array[Keg]))
       }
-      def load_and_fetch_full_formula_or_cask(name, only: nil, method: nil, warn: nil, download_queue: nil)
+      def load_and_fetch_full_formula_or_cask(name, only: nil, method: nil, warn: false, download_queue: nil)
         formula_or_cask = load_formula_or_cask(name, only:, method:, warn:)
         formula_or_cask.fetch_fully_loaded_formula!(download_queue:) if formula_or_cask.is_a?(Formula)
         formula_or_cask
       end
 
       sig {
-        params(name: String, only: T.nilable(Symbol), method: T.nilable(Symbol), warn: T.nilable(T::Boolean))
+        params(name: String, only: T.nilable(Symbol), method: T.nilable(Symbol), warn: T::Boolean)
           .returns(T.any(Formula, Keg, Cask::Cask, T::Array[Keg]))
       }
-      def load_formula_or_cask(name, only: nil, method: nil, warn: nil)
+      def load_formula_or_cask(name, only: nil, method: nil, warn: false)
         Homebrew.with_no_api_env_if_needed(@without_api) do
           unreadable_error = nil
 

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -97,11 +97,7 @@ module Homebrew
 
           download_queue&.fetch
 
-          formulae_and_casks.map do |formula_or_cask|
-            next formula_or_cask unless formula_or_cask.is_a?(Formula)
-
-            formula_or_cask.fully_loaded_formula
-          end
+          map_to_fully_loaded(formulae_and_casks)
         end.freeze
 
         if uniq
@@ -174,11 +170,7 @@ module Homebrew
 
           download_queue&.fetch
 
-          formulae_and_casks.map do |formula_or_cask|
-            next formula_or_cask unless formula_or_cask.is_a?(Formula)
-
-            formula_or_cask.fully_loaded_formula
-          end
+          map_to_fully_loaded(formulae_and_casks)
         end.freeze
       end
 
@@ -610,6 +602,19 @@ module Homebrew
         return if cask&.old_tokens&.include?(ref)
 
         opoo package_conflicts_message(ref, loaded_type, cask)
+      end
+
+      sig {
+        type_parameters(:U)
+          .params(formulae_and_casks: T::Array[T.all(T.type_parameter(:U), Object)])
+          .returns(T::Array[T.all(T.type_parameter(:U), Object)])
+      }
+      def map_to_fully_loaded(formulae_and_casks)
+        formulae_and_casks.map do |formula_or_cask|
+          next formula_or_cask unless formula_or_cask.is_a?(Formula)
+
+          T.cast(formula_or_cask.fully_loaded_formula, T.all(T.type_parameter(:U), Object))
+        end
       end
     end
   end

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -80,17 +80,28 @@ module Homebrew
         @to_formulae_and_casks ||= T.let(
           {}, T.nilable(T::Hash[T.nilable(Symbol), T::Array[T.any(Formula, Keg, Cask::Cask)]])
         )
-        @to_formulae_and_casks[only] ||= downcased_unique_named.flat_map do |name|
-          options = { warn: }.compact
-          load_formula_or_cask(name, only:, method:, **options)
-        rescue FormulaUnreadableError, FormulaClassUnavailableError,
-               TapFormulaUnreadableError, TapFormulaClassUnavailableError,
-               Cask::CaskUnreadableError
-          # Need to rescue before `*UnavailableError` (superclass of this)
-          # The formula/cask was found, but there's a problem with its implementation
-          raise
-        rescue NoSuchKegError, FormulaUnavailableError, Cask::CaskUnavailableError, FormulaOrCaskUnavailableError
-          ignore_unavailable ? [] : raise
+        @to_formulae_and_casks[only] ||= begin
+          download_queue = Homebrew::DownloadQueue.new if Homebrew::EnvConfig.download_concurrency > 1
+
+          formulae_and_casks = downcased_unique_named.flat_map do |name|
+            load_and_fetch_full_formula_or_cask(name, only:, method:, warn:, download_queue:)
+          rescue FormulaUnreadableError, FormulaClassUnavailableError,
+                 TapFormulaUnreadableError, TapFormulaClassUnavailableError,
+                 Cask::CaskUnreadableError
+            # Need to rescue before `*UnavailableError` (superclass of this)
+            # The formula/cask was found, but there's a problem with its implementation
+            raise
+          rescue NoSuchKegError, FormulaUnavailableError, Cask::CaskUnavailableError, FormulaOrCaskUnavailableError
+            ignore_unavailable ? [] : raise
+          end
+
+          download_queue&.fetch
+
+          formulae_and_casks.map do |formula_or_cask|
+            next formula_or_cask unless formula_or_cask.is_a?(Formula)
+
+            formula_or_cask.fully_loaded_formula
+          end
         end.freeze
 
         if uniq
@@ -152,11 +163,23 @@ module Homebrew
             T::Array[T.any(Formula, Keg, Cask::Cask, T::Array[Keg], FormulaOrCaskUnavailableError)],
           ]),
         )
-        @to_formulae_casks_unknowns[method] = downcased_unique_named.map do |name|
-          load_formula_or_cask(name, only:, method:)
-        rescue FormulaOrCaskUnavailableError => e
-          e
-        end.uniq.freeze
+        @to_formulae_casks_unknowns[method] = begin
+          download_queue = Homebrew::DownloadQueue.new if Homebrew::EnvConfig.download_concurrency > 1
+
+          formulae_and_casks = downcased_unique_named.map do |name|
+            load_and_fetch_full_formula_or_cask(name, only:, method:, download_queue:)
+          rescue FormulaOrCaskUnavailableError => e
+            e
+          end.uniq
+
+          download_queue&.fetch
+
+          formulae_and_casks.map do |formula_or_cask|
+            next formula_or_cask unless formula_or_cask.is_a?(Formula)
+
+            formula_or_cask.fully_loaded_formula
+          end
+        end.freeze
       end
 
       sig { params(uniq: T::Boolean).returns(T::Array[Formula]) }
@@ -315,6 +338,17 @@ module Homebrew
       end
 
       sig {
+        params(name: String, only: T.nilable(Symbol), method: T.nilable(Symbol), warn: T.nilable(T::Boolean),
+               download_queue: T.nilable(Homebrew::DownloadQueue))
+          .returns(T.any(Formula, Keg, Cask::Cask, T::Array[Keg]))
+      }
+      def load_and_fetch_full_formula_or_cask(name, only: nil, method: nil, warn: nil, download_queue: nil)
+        formula_or_cask = load_formula_or_cask(name, only:, method:, warn:)
+        formula_or_cask.fetch_fully_loaded_formula!(download_queue:) if formula_or_cask.is_a?(Formula)
+        formula_or_cask
+      end
+
+      sig {
         params(name: String, only: T.nilable(Symbol), method: T.nilable(Symbol), warn: T.nilable(T::Boolean))
           .returns(T.any(Formula, Keg, Cask::Cask, T::Array[Keg]))
       }
@@ -326,8 +360,8 @@ module Homebrew
             begin
               case method
               when nil, :factory
-                options = { warn:, force_bottle: @force_bottle, flags: @flags }.compact
-                Formulary.factory(name, *@override_spec, **options)
+                Formulary.factory(name, *@override_spec,
+                                  warn:, force_bottle: @force_bottle, flags: @flags, prefer_stub: true)
               when :resolve
                 resolve_formula(name)
               when :latest_kegs
@@ -447,7 +481,7 @@ module Homebrew
 
       sig { params(name: String).returns(Formula) }
       def resolve_formula(name)
-        Formulary.resolve(name, **{ spec: @override_spec, force_bottle: @force_bottle, flags: @flags }.compact)
+        Formulary.resolve(name, spec: @override_spec, force_bottle: @force_bottle, flags: @flags, prefer_stub: true)
       end
 
       sig { params(name: String).returns([Pathname, T::Array[Keg]]) }

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -733,7 +733,7 @@ module Homebrew
           next if arg.match?(HOMEBREW_CASK_TAP_CASK_REGEX)
 
           begin
-            Formulary.factory(arg, spec, flags: argv.select { |a| a.start_with?("--") })
+            Formulary.factory(arg, spec, flags: argv.select { |a| a.start_with?("--") }, prefer_stub: true)
           rescue FormulaUnavailableError, FormulaSpecificationError
             nil
           end

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -36,8 +36,8 @@ class Dependency
     [name, tags].hash
   end
 
-  def to_formula
-    formula = Formulary.factory(name, warn: false)
+  def to_formula(prefer_stub: false)
+    formula = Formulary.factory(name, warn: false, prefer_stub:)
     formula.build = BuildOptions.new(options, formula.options)
     formula
   end
@@ -45,7 +45,7 @@ class Dependency
   sig { params(minimum_version: T.nilable(Version), minimum_revision: T.nilable(Integer)).returns(T::Boolean) }
   def installed?(minimum_version: nil, minimum_revision: nil)
     formula = begin
-      to_formula
+      to_formula(prefer_stub: true)
     rescue FormulaUnavailableError
       nil
     end
@@ -86,7 +86,7 @@ class Dependency
   end
 
   def missing_options(inherited_options)
-    formula = to_formula
+    formula = to_formula(prefer_stub: true)
     required = options
     required |= inherited_options
     required &= formula.options.to_a

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe Utils::Autoremove do
     include_context "with formulae for dependency testing"
 
     before do
-      allow(Formulary).to receive(:factory).with("three", { warn: false }).and_return(formula_is_build_dep)
+      allow(Formulary).to receive(:factory).with("three", { prefer_stub: false, warn: false })
+                                           .and_return(formula_is_build_dep)
     end
 
     context "when formulae are bottles" do


### PR DESCRIPTION
This PR modifies the named argument handling to load formulae using the internal API when names are passed via command line arguments.

The general idea is that anytime someone runs `brew COMMAND FORMULA`, they probably need the fully loaded formula (except for cases where they actually want a keg or resolved formula). So, when converting named args to formulae, download the JSON data then and use it to return fully-loaded formulae. This means that, for most commands, there should be no need to worry about whether the `Formula` objects are from stubs or not.

For now, there is no bottle information in the manifest files, so use the individual formula JSON files from `formulae.brew.sh`. Eventually that will be changed to try the bottle first, and use `formulae.brew.sh` as a fallback.

This is a draft because I want to give it another look before merging to ensure it doesn’t cause any issues for non-internal-API users.

---

With this PR checked out, try doing the following:

```console
$ rm -rf "$(brew --cache)/api"

$ HOMEBREW_USE_INTERNAL_API=1 brew info wget curl
✔︎ JSON API formula.arm64_sequoia.jws.json
✔︎ JSON API cask.arm64_sequoia.jws.json
✔︎ JSON API wget.json
✔︎ JSON API curl.json
==> wget: stable 1.25.0 (bottled), HEAD
Internet file retriever
https://www.gnu.org/software/wget/
Installed
/opt/homebrew/Cellar/wget/1.25.0 (92 files, 4.5MB) *
  Poured from bottle using the formulae.brew.sh API on 2024-11-12 at 12:09:40
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/w/wget.rb
License: GPL-3.0-or-later
==> Dependencies
Build: pkgconf ✔
Required: libidn2 ✔, openssl@3 ✔, gettext ✔, libunistring ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 37,604 (30 days), 136,700 (90 days), 901,905 (365 days)
install-on-request: 37,372 (30 days), 135,952 (90 days), 898,236 (365 days)
build-error: 21 (30 days)

==> curl: stable 8.15.0 (bottled), HEAD [keg-only]
Get a file from an HTTP, HTTPS or FTP server
https://curl.se
Installed
/opt/homebrew/Cellar/curl/8.15.0 (539 files, 4.3MB)
  Poured from bottle using the formulae.brew.sh API on 2025-07-17 at 12:13:13
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/curl.rb
License: curl
==> Dependencies
Build: pkgconf ✔
Required: brotli ✔, libnghttp2 ✔, libnghttp3 ✘, libngtcp2 ✘, libssh2 ✔, openssl@3 ✔, rtmpdump ✔, zstd ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
curl is keg-only, which means it was not symlinked into /opt/homebrew,
because macOS already provides this software and installing another version in
parallel can cause all kinds of trouble.

If you need to have curl first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/curl/bin:$PATH"' >> ~/.zshrc

For compilers to find curl you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/curl/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/curl/include"

For pkg-config to find curl you may need to set:
  export PKG_CONFIG_PATH="/opt/homebrew/opt/curl/lib/pkgconfig"
==> Analytics
install: 65,361 (30 days), 236,109 (90 days), 999,184 (365 days)
install-on-request: 31,979 (30 days), 122,902 (90 days), 597,067 (365 days)
build-error: 41 (30 days)
```

The full `brew info` is displayed, with the additional download queue messages indicating that `formula.BOTTLE_TAG.jws.json` was downloaded, as well as the JSON API files for `curl` and `wget`.

To verify that this used only the internal API and not the larger `formula.jws.json` file, run:

```console
$ tree "$(brew --cache)/api"
/Users/rylanpolster/Library/Caches/Homebrew/api
├── cask_names.txt
├── formula
│   ├── curl.json
│   └── wget.json
├── formula_aliases.txt
├── formula_names.txt
└── internal
    ├── cask.arm64_sequoia.jws.json
    └── formula.arm64_sequoia.jws.json

3 directories, 7 files
```

---

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #20490 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #20489 
<!-- GitButler Footer Boundary Bottom -->

