### PR TITLE
cask/dsl/rename: add api support

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -390,6 +390,7 @@ module Cask
         "depends_on"                      => depends_on,
         "conflicts_with"                  => conflicts_with,
         "container"                       => container&.pairs,
+        "rename"                          => rename_list,
         "auto_updates"                    => auto_updates,
         "deprecated"                      => deprecated?,
         "deprecation_date"                => deprecation_date,
@@ -466,6 +467,12 @@ module Cask
 
           { artifact.class.dsl_key => artifact.to_args }
         end
+      end
+    end
+
+    def rename_list(uninstall_only: false)
+      rename.filter_map do |rename|
+        { from: rename.from, to: rename.to }
       end
     end
 

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -384,6 +384,12 @@ module Cask
           auto_updates json_cask[:auto_updates] unless json_cask[:auto_updates].nil?
           conflicts_with(**json_cask[:conflicts_with]) if json_cask[:conflicts_with].present?
 
+          if json_cask[:rename].present?
+            json_cask[:rename].each do |rename_operation|
+              rename rename_operation.fetch(:from), rename_operation.fetch(:to)
+            end
+          end
+
           if json_cask[:depends_on].present?
             dep_hash = json_cask[:depends_on].to_h do |dep_key, dep_value|
               # Arch dependencies are encoded like `{ type: :intel, bits: 64 }`

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Homebrew::API::Cask do
     it "specifies the correct URL and sha256" do
       expect(Homebrew::API::SourceDownload).to receive(:new).with(
         "https://raw.githubusercontent.com/Homebrew/homebrew-cask/abcdef1234567890abcdef1234567890abcdef12/Casks/everything.rb",
-        Checksum.new("bedee3600c8983c63d276ad0aaba2116d9357d433d8c882e45fec0f17393ad66"),
+        Checksum.new("d3c19b564ee5a17f22191599ad795a6cc9c4758d0e1269f2d13207155b378dea"),
         any_args,
       ).and_call_original
       described_class.source_download(cask)

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -255,6 +255,17 @@ RSpec.describe Cask::Cask, :cask do
     end
   end
 
+  describe "#rename_list" do
+    subject(:cask) { Cask::CaskLoader.load("many-renames") }
+
+    it "returns the correct rename list" do
+      expect(cask.rename_list).to eq([
+        { from: "Foobar.app", to: "Foo.app" },
+        { from: "Foo.app", to: "Bar.app" },
+      ])
+    end
+  end
+
   describe "#uninstall_flight_blocks?" do
     matcher :have_uninstall_flight_blocks do
       match do |actual|

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/everything.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/everything.rb
@@ -23,6 +23,9 @@ cask "everything" do
   depends_on cask: "something"
   container type: :naked
 
+  rename "Foobar.app", "Foo.app"
+  rename "Foo.app", "Bar.app"
+
   app "Everything.app"
   installer script: {
     executable:   "~/just/another/path/install.sh",

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/many-renames.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/many-renames.rb
@@ -1,0 +1,28 @@
+cask "many-renames" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/ManyArtifacts.zip"
+  homepage "https://brew.sh/many-artifacts"
+
+  rename "Foobar.app", "Foo.app"
+  rename "Foo.app", "Bar.app"
+
+  app "Bar.app"
+
+  preflight do
+    # do nothing
+  end
+
+  postflight do
+    # do nothing
+  end
+
+  uninstall_preflight do
+    # do nothing
+  end
+
+  uninstall_postflight do
+    # do nothing
+  end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
@@ -94,6 +94,16 @@
   "container": {
     "type": "naked"
   },
+  "rename": [
+    {
+      "from": "Foobar.app",
+      "to": "Foo.app"
+    },
+    {
+      "from": "Foo.app",
+      "to": "Bar.app"
+    }
+  ],
   "auto_updates": true,
   "deprecated": false,
   "deprecation_date": null,
@@ -112,7 +122,7 @@
   ],
   "ruby_source_path": "Casks/everything-with-variations.rb",
   "ruby_source_checksum": {
-    "sha256": "bedee3600c8983c63d276ad0aaba2116d9357d433d8c882e45fec0f17393ad66"
+    "sha256": "d3c19b564ee5a17f22191599ad795a6cc9c4758d0e1269f2d13207155b378dea"
   },
   "variations": {
     "arm64_monterey": {

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -94,6 +94,16 @@
   "container": {
     "type": "naked"
   },
+  "rename": [
+    {
+      "from": "Foobar.app",
+      "to": "Foo.app"
+    },
+    {
+      "from": "Foo.app",
+      "to": "Bar.app"
+    }
+  ],
   "auto_updates": true,
   "deprecated": false,
   "deprecation_date": null,
@@ -112,6 +122,6 @@
   ],
   "ruby_source_path": "Casks/everything.rb",
   "ruby_source_checksum": {
-    "sha256": "bedee3600c8983c63d276ad0aaba2116d9357d433d8c882e45fec0f17393ad66"
+    "sha256": "d3c19b564ee5a17f22191599ad795a6cc9c4758d0e1269f2d13207155b378dea"
   }
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds API support for the new `rename` dsl for Casks.
I was previously unaware that API generation/loading required further work for support.

I have tested the generation and installation by generating the API locally, and installing from the generated JSON file.

Discovered in: https://github.com/Homebrew/homebrew-cask/pull/224086#issuecomment-3196111073