### PR TITLE
keg_relocate: add more /usr/local relocation pairs.

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -97,9 +97,21 @@ class Keg
         old: "/usr/local/Caskroom",
         new: "#{PREFIX_PLACEHOLDER}/Caskroom",
       },
+      etc_name:     {
+        old: "/usr/local/etc/#{name}",
+        new: "#{PREFIX_PLACEHOLDER}/etc/#{name}",
+      },
       var_homebrew: {
         old: "/usr/local/var/homebrew",
         new: "#{PREFIX_PLACEHOLDER}/var/homebrew",
+      },
+      var_name:     {
+        old: "/usr/local/var/#{name}",
+        new: "#{PREFIX_PLACEHOLDER}/var/#{name}",
+      },
+      var_log_name: {
+        old: "/usr/local/var/log/#{name}",
+        new: "#{PREFIX_PLACEHOLDER}/var/log/#{name}",
       },
     }
   end


### PR DESCRIPTION
This should get more of the cases where we install things into HOMEBREW_PREFIX but scoping them to the formula's name to avoid accidental unneccessary relocations preventing `cellar :any` bottles.

Fixes https://github.com/Homebrew/brew/issues/20478