### PR TITLE
Move formula analytics pretty name logic to `MacOSVersion`.

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -365,21 +365,14 @@ module Homebrew
       def format_os_version_dimension(dimension)
         return if dimension.blank?
 
+        require "macos_version"
+
         dimension = dimension.gsub(/^Intel ?/, "")
                              .gsub(/^macOS ?/, "")
                              .gsub(/ \(.+\)$/, "")
         case dimension
-        when "10.11", /^10\.11\.?/ then "OS X El Capitan (10.11)"
-        when "10.12", /^10\.12\.?/ then "macOS Sierra (10.12)"
-        when "10.13", /^10\.13\.?/ then "macOS High Sierra (10.13)"
-        when "10.14", /^10\.14\.?/ then "macOS Mojave (10.14)"
-        when "10.15", /^10\.15\.?/ then "macOS Catalina (10.15)"
-        when "10.16", /^11\.?/ then "macOS Big Sur (11)"
-        when /^12\.?/ then "macOS Monterey (12)"
-        when /^13\.?/ then "macOS Ventura (13)"
-        when /^14\.?/ then "macOS Sonoma (14)"
-        when /^15\.?/ then "macOS Sequoia (15)"
-        when /^26\.?/ then "macOS Tahoe (26)"
+        when (macos_pretty_name = ::MacOSVersion.analytics_pretty_name(dimension))
+          macos_pretty_name
         when /Ubuntu(-Server)? (14|16|18|20|22)\.04/ then "Ubuntu #{Regexp.last_match(2)}.04 LTS"
         when /Ubuntu(-Server)? (\d+\.\d+).\d ?(LTS)?/
           "Ubuntu #{Regexp.last_match(2)} #{Regexp.last_match(3)}".strip

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -33,6 +33,32 @@ class MacOSVersion < Version
     el_capitan:  "10.11",
   }.freeze, T::Hash[Symbol, String])
 
+  # TODO: can be replaced with a call to `#pretty_name` once we remove support
+  # for El Capitan.
+  VERSIONS_TO_ANALYTICS_PRETTY_NAMES = T.let({
+    "26"    => "macOS Tahoe (26)",
+    "15"    => "macOS Sequoia (15)",
+    "14"    => "macOS Sonoma (14)",
+    "13"    => "macOS Ventura (13)",
+    "12"    => "macOS Monterey (12)",
+    "11"    => "macOS Big Sur (11)",
+    "10.16" => "macOS Big Sur (11)",
+    "10.15" => "macOS Catalina (10.15)",
+    "10.14" => "macOS Mojave (10.14)",
+    "10.13" => "macOS High Sierra (10.13)",
+    "10.12" => "macOS Sierra (10.12)",
+    "10.11" => "OS X El Capitan (10.11)",
+  }.freeze, T::Hash[String, String])
+
+  sig { params(version: String).returns(T.nilable(String)) }
+  def self.analytics_pretty_name(version)
+    VERSIONS_TO_ANALYTICS_PRETTY_NAMES.fetch(version) do
+      VERSIONS_TO_ANALYTICS_PRETTY_NAMES.find do |v, _|
+        version.start_with?(v)
+      end&.last
+    end
+  end
+
   sig { params(macos_version: MacOSVersion).returns(Version) }
   def self.kernel_major_version(macos_version)
     version_major = macos_version.major.to_i


### PR DESCRIPTION
This makes sense to centralize these so when we support new macOS versions we can just add them to the `VERSIONS_TO_ANALYTICS_PRETTY_NAMES` hash.

CC @p-linnane as I beat you to this 😇 