### PR TITLE
Deprecate `conflicts_with formula:` in Cask DSL.

### DIFF
--- a/Library/Homebrew/cask/dsl/conflicts_with.rb
+++ b/Library/Homebrew/cask/dsl/conflicts_with.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "delegate"
@@ -8,17 +8,23 @@ module Cask
   class DSL
     # Class corresponding to the `conflicts_with` stanza.
     class ConflictsWith < SimpleDelegator
-      VALID_KEYS = [
+      VALID_KEYS = [:cask].freeze
+
+      ODEPRECATED_KEYS = [
         :formula,
-        :cask,
         :macos,
         :arch,
         :x11,
         :java,
       ].freeze
 
+      sig { params(options: T.anything).void }
       def initialize(**options)
-        options.assert_valid_keys(*VALID_KEYS)
+        options.assert_valid_keys(*VALID_KEYS, *ODEPRECATED_KEYS)
+
+        options.keys.intersection(ODEPRECATED_KEYS).each do |key|
+          odeprecated "conflicts_with #{key}:"
+        end
 
         conflicts = options.transform_values { |v| Set.new(Kernel.Array(v)) }
         conflicts.default = Set.new
@@ -26,6 +32,7 @@ module Cask
         super(conflicts)
       end
 
+      sig { params(generator: T.anything).returns(String) }
       def to_json(generator)
         __getobj__.transform_values(&:to_a).to_json(generator)
       end

--- a/Library/Homebrew/cask/dsl/conflicts_with.rbi
+++ b/Library/Homebrew/cask/dsl/conflicts_with.rbi
@@ -1,0 +1,10 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Cask
+  class DSL
+    class ConflictsWith < SimpleDelegator
+      include Kernel
+    end
+  end
+end

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Homebrew::API::Cask do
     it "specifies the correct URL and sha256" do
       expect(Homebrew::API::SourceDownload).to receive(:new).with(
         "https://raw.githubusercontent.com/Homebrew/homebrew-cask/abcdef1234567890abcdef1234567890abcdef12/Casks/everything.rb",
-        Checksum.new("d8d0d6b2e5ff65388eccb82236fd3aa157b4a29bb043a1f72b97f0e9b70e8320"),
+        Checksum.new("bedee3600c8983c63d276ad0aaba2116d9357d433d8c882e45fec0f17393ad66"),
         any_args,
       ).and_call_original
       described_class.source_download(cask)

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/everything.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/everything.rb
@@ -19,7 +19,7 @@ cask "everything" do
   homepage "https://www.everything.app/"
 
   auto_updates true
-  conflicts_with formula: "nothing"
+  conflicts_with cask: "nothing"
   depends_on cask: "something"
   container type: :naked
 

--- a/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
@@ -87,7 +87,7 @@
     }
   },
   "conflicts_with": {
-    "formula": [
+    "cask": [
       "nothing"
     ]
   },
@@ -112,7 +112,7 @@
   ],
   "ruby_source_path": "Casks/everything-with-variations.rb",
   "ruby_source_checksum": {
-    "sha256": "d8d0d6b2e5ff65388eccb82236fd3aa157b4a29bb043a1f72b97f0e9b70e8320"
+    "sha256": "bedee3600c8983c63d276ad0aaba2116d9357d433d8c882e45fec0f17393ad66"
   },
   "variations": {
     "arm64_monterey": {

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -87,7 +87,7 @@
     }
   },
   "conflicts_with": {
-    "formula": [
+    "cask": [
       "nothing"
     ]
   },
@@ -112,6 +112,6 @@
   ],
   "ruby_source_path": "Casks/everything.rb",
   "ruby_source_checksum": {
-    "sha256": "d8d0d6b2e5ff65388eccb82236fd3aa157b4a29bb043a1f72b97f0e9b70e8320"
+    "sha256": "bedee3600c8983c63d276ad0aaba2116d9357d433d8c882e45fec0f17393ad66"
   }
 }

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -337,18 +337,6 @@ Example: [macFUSE](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb511
 conflicts_with cask: "macfuse-dev"
 ```
 
-#### `conflicts_with` *formula*
-
-**Note:** `conflicts_with formula:` is a stub and is not yet functional.
-
-The value should be another formula name.
-
-Example: [MacVim](https://github.com/Homebrew/homebrew-cask/blob/aa461148bbb5119af26b82cccf5003e2b4e50d95/Casks/m/macvim.rb#L16), which conflicts with the `macvim` formula.
-
-```ruby
-conflicts_with formula: "macvim"
-```
-
 ### Stanza: `depends_on`
 
 `depends_on` is used to declare dependencies and requirements for a cask. `depends_on` is not consulted until `install` is attempted.


### PR DESCRIPTION
This is outside of our usual deprecation process but it's a no-op method that does, and has always done, nothing so it doesn't make sense to wait another 2.5 months before deprecating it.

While we're here, make `conflicts_with` `typed: strict` in Sorbet.

Fixes https://github.com/Homebrew/brew/issues/16398