### PR TITLE
Fix formula installs without a tab

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1591,7 +1591,7 @@ on_request: installed_on_request?, options:)
 
     keg = Keg.new(formula.prefix)
     skip_linkage = formula.bottle_specification.skip_relocation?
-    keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:) if tab.changed_files
+    keg.replace_placeholders_with_locations(tab.changed_files, skip_linkage:)
 
     cellar = formula.bottle_specification.tag_to_cellar(Utils::Bottles.tag)
     return if [:any, :any_skip_relocation].include?(cellar)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -167,7 +167,7 @@ class Keg
     relocation
   end
 
-  sig { params(files: T::Array[Pathname], skip_linkage: T::Boolean).void }
+  sig { params(files: T.nilable(T::Array[Pathname]), skip_linkage: T::Boolean).void }
   def replace_placeholders_with_locations(files, skip_linkage: false)
     relocation = prepare_relocation_to_locations.freeze
     relocate_dynamic_linkage(relocation) unless skip_linkage


### PR DESCRIPTION
This is a rare case where nil vs an empty array mean different things.

When nil, we fallback to searching all text files, which is a safe default when there is no tab available. An empty array means no files need searching.

You can reproduce the issue here with `brew install "$(brew --cache ruby)"`