### PR TITLE
utils/wrapper.sh: fix `source` calls

### DIFF
--- a/Library/Homebrew/utils/wrapper.sh
+++ b/Library/Homebrew/utils/wrapper.sh
@@ -61,13 +61,13 @@ check-brew-wrapper() {
 
     if ((HOMEBREW_BREW_CALLER_CHECK_EXIT_CODE != 0))
     then
+      source "${HOMEBREW_LIBRARY}/Homebrew/utils/helpers.sh"
       # Error message already printed above when populating `HOMEBREW_BREW_CALLER`.
       odie "failed to check the path to the parent process!"
     fi
 
     if [[ "${HOMEBREW_BREW_CALLER:-}" != "${HOMEBREW_FORCE_BREW_WRAPPER}" ]]
     then
-      source "${HOMEBREW_LIBRARY}/Homebrew/utils/wrapper.sh"
       odie-with-wrapper-message "but \`brew\` was invoked by ${HOMEBREW_BREW_CALLER}."
     fi
   fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We need to `source utils/helpers.sh` before calling `odie`. We also
don't need to `source utils/wrapper.sh` again here, because we are
already in `utils/wrapper.sh`.
