### PR TITLE
Fix `formula-analytics` pretty OS name logic

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -370,10 +370,13 @@ module Homebrew
         dimension = dimension.gsub(/^Intel ?/, "")
                              .gsub(/^macOS ?/, "")
                              .gsub(/ \(.+\)$/, "")
+
+        if (macos_pretty_name = ::MacOSVersion.analytics_pretty_name(dimension))
+          return macos_pretty_name
+        end
+
         case dimension
-        when (macos_pretty_name = ::MacOSVersion.analytics_pretty_name(dimension))
-          macos_pretty_name
-        when /Ubuntu(-Server)? (14|16|18|20|22)\.04/ then "Ubuntu #{Regexp.last_match(2)}.04 LTS"
+        when /Ubuntu(-Server)? (14|16|18|20|22|24)\.04/ then "Ubuntu #{Regexp.last_match(2)}.04 LTS"
         when /Ubuntu(-Server)? (\d+\.\d+).\d ?(LTS)?/
           "Ubuntu #{Regexp.last_match(2)} #{Regexp.last_match(3)}".strip
         when %r{Debian GNU/Linux (\d+)\.\d+} then "Debian #{Regexp.last_match(1)} #{Regexp.last_match(2)}"


### PR DESCRIPTION
Follow-up to #20498

macOS version names are no longer shown on the [analytics page](https://formulae.brew.sh/analytics/os-version/365d/)

The macOS version name map can’t happen inside a `case` statement because we’re not matching, we’re checking if the function call returns a non-nil value.

Also, while we’re here, add Ubuntu 24.04 to the list of known LTS releases