### PR TITLE
os/linux/diagnostic: make check_for_symlinked_home doctor-only.

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -29,7 +29,6 @@ module OS
             check_glibc_minimum_version
             check_kernel_minimum_version
             check_supported_architecture
-            check_for_symlinked_home
           ].freeze
         end
 


### PR DESCRIPTION
This avoids printing it every time a `brew install` is run.

Closes https://github.com/orgs/Homebrew/discussions/6350