### PR TITLE
diagnostic: miscellaneous fixes

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -84,7 +84,12 @@ module Homebrew
 
       sig { params(path: String).returns(String) }
       def user_tilde(path)
-        path.gsub(Dir.home, "~")
+        home = Dir.home
+        if path == home
+          "~"
+        else
+          path.gsub(%r{^#{home}/}, "~/")
+        end
       end
 
       sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1076,8 +1076,7 @@ module Homebrew
         cask_environment_variables = (locale_variables + environment_variables).sort.filter_map do |var|
           next unless ENV.key?(var)
 
-          var = %Q(#{var}="#{ENV.fetch(var)}")
-          user_tilde(var)
+          %Q(#{var}="#{Utils::Shell.sh_quote(ENV.fetch(var))}")
         end
         add_info "Cask Environment Variables:", cask_environment_variables
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1068,7 +1068,7 @@ module Homebrew
 
         locale_variables = ENV.keys.grep(/^(?:LC_\S+|LANG|LANGUAGE)\Z/).sort
 
-        cask_environment_variables = (locale_variables + environment_variables).sort.each do |var|
+        cask_environment_variables = (locale_variables + environment_variables).sort.filter_map do |var|
           next unless ENV.key?(var)
 
           var = %Q(#{var}="#{ENV.fetch(var)}")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- diagnostic: fix cask env var output
  With `each`, we don't actually output the processed values. We should therefore be using `filter_map` instead.

- diagnostic: improve tilde expansion logic
  This is a bit pedantic, but the tilde expansion only occurs if the tilde is at the beginning of the string (if we only take the current user into account) [^1].
  [^1]: https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_06_01

- diagnostic: don't expand tildes in cask env vars
  We double quote them so they don't get expanded. Also, use `sh_quote` to quote the variable values properly.
