### PR TITLE
formula-analytics: reduce noise from Linux builds

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -384,6 +384,10 @@ module Homebrew
         when /Fedora Linux (\d+)[.\d]*/ then "Fedora Linux #{Regexp.last_match(1)}"
         when /KDE neon .*?([\d.]+)/ then "KDE neon #{Regexp.last_match(1)}"
         when /Amazon Linux (\d+)\.[.\d]*/ then "Amazon Linux #{Regexp.last_match(1)}"
+        when /Fedora Linux Rawhide[.\dn]*/ then "Fedora Linux Rawhide"
+        when /Red Hat Enterprise Linux CoreOS (\d+\.\d+)[-.\d]*/
+          "Red Hat Enterprise Linux CoreOS #{Regexp.last_match(1)}"
+        when /([A-Za-z ]+)\s+(\d+)\.\d{8}[.\d]*/ then "#{Regexp.last_match(1)} #{Regexp.last_match(2)}"
         else dimension
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Frequent Linux builds add a number of low count unique OS variations to analytics, so compress into a major version for displaying.

Specifically -

- Fedora Linux Rawhide is a daily build and isn't versioned at all beyond a build `yyyymmdd.n.0` string.
- Red Hat Enterprise Linux CoreOS has a build of `coreos_version.rhel_version.yyyymmddHHMM-0`, this keeps `coreos_version.rhel_version`
- The last regex captures a multitude of daily built OS versions that look to follow Fedora  (including Fedora CoreOS) with build pattern of `version.major.yyyymmdd.x[.y]?` and keeps the name and major version.

Across the 365d analytics, this should reduce about ~360 Linux variants that match these patterns down to about 30.

