### PR TITLE
cli/parser: convert switch env values to boolean

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -231,7 +231,8 @@ module Homebrew
         end
 
         env_value = value_for_env(env)
-        set_switch(*names, value: env_value, from: :env) unless env_value.nil?
+        value = env_value&.present?
+        set_switch(*names, value:, from: :env) unless value.nil?
       end
       alias switch_option switch
 

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Homebrew::CLI::Parser do
       described_class.new(Cmd) do
         switch "--more-verbose", description: "Flag for higher verbosity"
         switch "--pry", env: :pry
+        switch "--foo", env: :foo
         switch "--bar", env: :bar
         switch "--hidden", hidden: true
       end
@@ -18,6 +19,7 @@ RSpec.describe Homebrew::CLI::Parser do
     before do
       allow(Homebrew::EnvConfig).to receive(:pry?).and_return(true)
       allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("HOMEBREW_FOO", nil).and_return("")
       allow(ENV).to receive(:fetch).with("HOMEBREW_BAR", nil).and_return("1")
     end
 
@@ -116,6 +118,7 @@ RSpec.describe Homebrew::CLI::Parser do
     it "maps environment var to an option" do
       args = parser.parse([])
       expect(args.pry?).to be true
+      expect(args.foo?).to be false
       expect(args.bar?).to be true
     end
   end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -10,12 +10,15 @@ RSpec.describe Homebrew::CLI::Parser do
       described_class.new(Cmd) do
         switch "--more-verbose", description: "Flag for higher verbosity"
         switch "--pry", env: :pry
+        switch "--bar", env: :bar
         switch "--hidden", hidden: true
       end
     end
 
     before do
       allow(Homebrew::EnvConfig).to receive(:pry?).and_return(true)
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("HOMEBREW_BAR", nil).and_return("1")
     end
 
     context "when using binary options" do
@@ -113,6 +116,7 @@ RSpec.describe Homebrew::CLI::Parser do
     it "maps environment var to an option" do
       args = parser.parse([])
       expect(args.pry?).to be true
+      expect(args.bar?).to be true
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since switch values are boolean, we should be returning the environment variable's presence instead of its string value.

Fixes #20531.
