### PR TITLE
Use `rubocop_internal` formatter for Ruby LSP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
   ],
   "rubyLsp.customRubyCommand": "source ../../.vscode/ruby-lsp-activate.sh",
   "rubyLsp.bundleGemfile": "Library/Homebrew/Gemfile",
-  "rubyLsp.formatter": "rubocop",
+  "rubyLsp.formatter": "rubocop_internal",
   "[ruby]": {
     "editor.defaultFormatter": "Shopify.ruby-lsp",
     "editor.formatOnSave": true,


### PR DESCRIPTION
Not sure if other folks are having this issue, but the auto format on save feature in VSCode with the Ruby LSP extension stopped working for me. Changing to use `rubocop_internal` instead of `rubocop` seemed to fix it