### PR TITLE
formula_cellar_checks: check unversioned name in `universal_binary_allowlist`

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -371,7 +371,10 @@ module FormulaCellarChecks
     mismatches = mismatches.to_h
 
     universal_binaries_expected = if (formula_tap = formula.tap).present? && formula_tap.core_tap?
-      formula_tap.audit_exception(:universal_binary_allowlist, formula.name)
+      formula_name = formula.name
+      # Apply audit exception to versioned formulae too from the unversioned name.
+      formula_name.gsub!(/@\d+(\.\d+)*$/, "") if formula.versioned_formula?
+      formula_tap.audit_exception(:universal_binary_allowlist, formula_name)
     else
       true
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This will allow us to avoid having to list multiple formula versions in
the universal binary allowlist (e.g. for `llvm`).

Needed for Homebrew/homebrew-core#234488.
