### PR TITLE
cmd/upgrade: fix ofail/opoo call.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -196,10 +196,13 @@ module Homebrew
         end
 
         if pinned.any?
-          Kernel.public_send(
-            formulae.any? ? :ofail : :opoo, # only fail when pinned formulae are named explicitly
-            "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:",
-          )
+          message = "Not upgrading #{pinned.count} pinned #{Utils.pluralize("package", pinned.count)}:"
+          # only fail when pinned formulae are named explicitly
+          if formulae.any?
+            ofail message
+          else
+            opoo message
+          end
           puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
         end
 


### PR DESCRIPTION
This method doesn't exist on `Kernel` any more. While we're here, let's avoid `public_send` and use `if` instead for a bit more safety.

Fixes https://github.com/Homebrew/brew/pull/20525#issuecomment-3214081946
Fixes https://github.com/Homebrew/brew/issues/20541