### PR TITLE
Sorting the results of outdated packages

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -219,6 +219,9 @@ module Homebrew
               "#{f.full_specified_name} #{f.pkg_version}"
             end
           end
+          # sorting packages to be upgraded alphabetically
+          formulae_upgrades.sort_by! { |s| s.downcase }
+
           puts formulae_upgrades.join("\n") unless args.ask?
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
It has always bothered me to not be able to instantly find the name of a certain package without resorting to terminal functions if 'brew upgrade' hasn't been run in a while, so it would be more efficient to sort the results before displaying them.