### PR TITLE
dev-cmd/bump: adjust `system` call.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -536,7 +536,8 @@ module Homebrew
           bump_pr_args << "--bump-synced=#{outdated_synced_formulae.join(",")}"
         end
 
-        safe_system HOMEBREW_BREW_FILE, *bump_pr_args
+        result = system HOMEBREW_BREW_FILE, *bump_pr_args
+        Homebrew.failed = true unless result
       end
 
       sig {


### PR DESCRIPTION
Instead of immediately failing let's set `Homebrew.failed` to `true` to set a non-zero exit code but continue with the rest of formulae/casks.