### PR TITLE
Deprecate `Language::Python.setup_install_args`

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -1,11 +1,15 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "utils/output"
+
 module Language
   # Helper functions for Python formulae.
   #
   # @api public
   module Python
+    extend ::Utils::Output::Mixin
+
     sig { params(python: T.any(String, Pathname)).returns(T.nilable(Version)) }
     def self.major_minor_version(python)
       version = `#{python} --version 2>&1`.chomp[/(\d\.\d+)/, 1]
@@ -84,6 +88,7 @@ module Language
 
     sig { params(prefix: Pathname, python: T.any(String, Pathname)).returns(T::Array[String]) }
     def self.setup_install_args(prefix, python = "python3")
+      # odeprecated "Language::Python.setup_install_args", "pip and `std_pip_args`"
       shim = <<~PYTHON
         import setuptools, tokenize
         __file__ = 'setup.py'


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

This method predates Python's standardized `pyproject.toml` build system,
introduced in PEP 517 to allow for more build backends than just
`setuptools`: https://peps.python.org/pep-0517/. Directly executing
`setup.py` has since been deprecated in favor of using PEP 517 compliant
installers, such as `pip`: https://packaging.python.org/en/latest/discussions/setup-py-deprecated/

In homebrew/core, our last remaining use is a [single disabled formula](https://github.com/Homebrew/homebrew-core/blob/main/Formula/p/pytouhou.rb).
For third party taps, simply migrate to `std_pip_args`:

```ruby
# Old
system python3, *Language::Python.setup_install_args(libexec, python3)
# New
system python3, "-m", "pip", "install", *std_pip_args, "."
```
