### PR TITLE
Enable strict typing in yard extensions

### DIFF
--- a/Library/Homebrew/yard/docstring_parser.rb
+++ b/Library/Homebrew/yard/docstring_parser.rb
@@ -1,5 +1,8 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
+
+require "sorbet-runtime"
+require_relative "../extend/module"
 
 # from https://github.com/lsegal/yard/issues/484#issuecomment-442586899
 module Homebrew
@@ -18,6 +21,7 @@ module Homebrew
         private_constant :SELF_EXPLANATORY_METHODS
       end
 
+      sig { params(content: T.nilable(String)).returns(String) }
       def parse_content(content)
         # Convert plain text to tags.
         content = content&.gsub(/^\s*(TODO|FIXME):\s*/i, "@todo ")

--- a/Library/Homebrew/yard/templates/default/docstring/html/setup.rb
+++ b/Library/Homebrew/yard/templates/default/docstring/html/setup.rb
@@ -1,12 +1,13 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 # This follows the docs at https://github.com/lsegal/yard/blob/main/docs/Templates.md#setuprb
 # rubocop:disable Style/TopLevelMethodDefinition
+sig { void }
 def init
   # `sorbet` is available transitively through the `yard-sorbet` plugin, but we're
   # outside of the standalone sorbet config, so `checked` is enabled by default
-  T.bind(self, T.all(Class, YARD::Templates::Template), checked: false)
+  T.bind(self, T.all(T::Class[T.anything], YARD::Templates::Template), checked: false)
   super
 
   return if sections.empty?
@@ -14,6 +15,7 @@ def init
   sections[:index].place(:internal).before(:private)
 end
 
+sig { returns(T.nilable(String)) }
 def internal
   T.bind(self, YARD::Templates::Template, checked: false)
   erb(:internal) if object.has_tag?(:api) && object.tag(:api).text == "internal"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
☝️ 
Part of https://github.com/Homebrew/brew/issues/17297
Tested via `brew rubydoc`