### PR TITLE
Enable strict typing in Kernel extensions + utils.rb

### DIFF
--- a/Library/Homebrew/PATH.rb
+++ b/Library/Homebrew/PATH.rb
@@ -15,7 +15,6 @@ class PATH
   Element = T.type_alias { T.nilable(T.any(Pathname, String, PATH)) }
   private_constant :Element
   Elements = T.type_alias { T.any(Element, T::Array[Element]) }
-  private_constant :Elements
   sig { params(paths: Elements).void }
   def initialize(*paths)
     @paths = T.let(parse(paths), T::Array[String])

--- a/Library/Homebrew/bundle.rb
+++ b/Library/Homebrew/bundle.rb
@@ -137,7 +137,7 @@ module Homebrew
       def reset!
         @mas_installed = T.let(nil, T.nilable(T::Boolean))
         @vscode_installed = T.let(nil, T.nilable(T::Boolean))
-        @which_vscode = T.let(nil, T.nilable(String))
+        @which_vscode = T.let(nil, T.nilable(Pathname))
         @whalebrew_installed = T.let(nil, T.nilable(T::Boolean))
         @cask_installed = T.let(nil, T.nilable(T::Boolean))
         @formula_versions_from_env = T.let(nil, T.nilable(T::Hash[String, String]))

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -97,7 +97,7 @@ module Homebrew
           if args.lsp?
             srb_exec << "--lsp"
             if (watchman = which("watchman", ORIGINAL_PATHS))
-              srb_exec << "--watchman-path" << watchman
+              srb_exec << "--watchman-path" << watchman.to_s
             else
               srb_exec << "--disable-watchman"
             end

--- a/Library/Homebrew/extend/ENV/shared.rbi
+++ b/Library/Homebrew/extend/ENV/shared.rbi
@@ -5,7 +5,7 @@ module SharedEnvExtension
   sig {
     type_parameters(:U).params(
       key:   String,
-      value: T.all(T.type_parameter(:U), T.nilable(T.any(String, PATH))),
+      value: T.all(T.type_parameter(:U), T.nilable(T.any(String, Pathname, PATH))),
     ).returns(T.type_parameter(:U))
   }
   def []=(key, value); end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -10,11 +10,8 @@ module OS
           @volumes = T.let(get_mounts, T::Array[String])
         end
 
-        # This is a pre-existing violation that should be refactored
-        # rubocop:todo Sorbet/AllowIncompatibleOverride
-        sig { override(allow_incompatible: true).params(path: T.nilable(Pathname)).returns(Integer) }
-        # rubocop:enable Sorbet/AllowIncompatibleOverride
-        def which(path)
+        sig { params(path: T.nilable(Pathname)).returns(Integer) }
+        def index_of(path)
           vols = get_mounts path
 
           # no volume found
@@ -429,13 +426,13 @@ module OS
 
           # Find the volumes for the TMP folder & HOMEBREW_CELLAR
           real_cellar = HOMEBREW_CELLAR.realpath
-          where_cellar = volumes.which real_cellar
+          where_cellar = volumes.index_of real_cellar
 
           begin
             tmp = Pathname.new(Dir.mktmpdir("doctor", HOMEBREW_TEMP))
             begin
               real_tmp = tmp.realpath.parent
-              where_tmp = volumes.which real_tmp
+              where_tmp = volumes.index_of real_tmp
             ensure
               Dir.delete tmp.to_s
             end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -10,7 +10,10 @@ module OS
           @volumes = T.let(get_mounts, T::Array[String])
         end
 
-        sig { params(path: T.nilable(Pathname)).returns(Integer) }
+        # This is a pre-existing violation that should be refactored
+        # rubocop:todo Sorbet/AllowIncompatibleOverride
+        sig { override(allow_incompatible: true).params(path: T.nilable(Pathname)).returns(Integer) }
+        # rubocop:enable Sorbet/AllowIncompatibleOverride
         def which(path)
           vols = get_mounts path
 

--- a/Library/Homebrew/git_repository.rb
+++ b/Library/Homebrew/git_repository.rb
@@ -27,7 +27,7 @@ class GitRepository
   end
 
   # Sets the URL of the Git origin remote.
-  sig { params(origin: String).returns(T.nilable(T::Boolean)) }
+  sig { params(origin: String).void }
   def origin_url=(origin)
     return if !git_repository? || !Utils::Git.available?
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -40,7 +40,11 @@ module Homebrew
       yield if block_given?
       args.map!(&:to_s)
       begin
-        exec(cmd, argv0, *args, **options)
+        if argv0
+          exec(cmd, argv0, *args, **options)
+        else
+          exec(cmd, *args, **options)
+        end
       rescue
         nil
       end

--- a/Library/Homebrew/utils/service.rb
+++ b/Library/Homebrew/utils/service.rb
@@ -11,6 +11,8 @@ module Utils
         quiet_system(launchctl, "list", formula.plist_name)
       elsif systemctl?
         quiet_system(systemctl, "is-active", "--quiet", formula.service_name)
+      else
+        false
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The various `Kernel.system` wrappers are best typed in lockstep, so this PR spans a couple of files (logically, we should also group them together, and move more core extensions out of Kernel, but I'll save that for a future PR).

Part of https://github.com/Homebrew/brew/issues/17297