### PR TITLE
Remove `T.nilable` keyword arguments from `Formulary`

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -63,7 +63,7 @@ module Homebrew
         with_env(HOMEBREW_INTERNAL_ALLOW_PACKAGES_FROM_PATHS: "1") do
           Formulary.factory(download.symlink_location,
                             formula.active_spec_sym,
-                            alias_path: formula.alias_path,
+                            alias_path: formula.alias_path || T.unsafe(nil),
                             flags:      formula.class.build_flags)
         end
       end

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -390,8 +390,7 @@ module Homebrew
 
             cask = begin
               config = Cask::Config.from_args(@parent) if @cask_options
-              options = { warn: }.compact
-              candidate_cask = Cask::CaskLoader.load(name, config:, **options)
+              candidate_cask = Cask::CaskLoader.load(name, config:, warn:)
 
               if unreadable_error
                 onoe <<~EOS
@@ -473,7 +472,8 @@ module Homebrew
 
       sig { params(name: String).returns(Formula) }
       def resolve_formula(name)
-        Formulary.resolve(name, spec: @override_spec, force_bottle: @force_bottle, flags: @flags, prefer_stub: true)
+        spec = @override_spec || T.unsafe(nil)
+        Formulary.resolve(name, spec:, force_bottle: @force_bottle, flags: @flags, prefer_stub: true)
       end
 
       sig { params(name: String).returns([Pathname, T::Array[Keg]]) }

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -531,11 +531,11 @@ module Formulary
   end
 
   sig {
-    params(name: String, spec: T.nilable(Symbol), force_bottle: T::Boolean, flags: T::Array[String], prefer_stub: T::Boolean).returns(Formula)
+    params(name: String, spec: Symbol, force_bottle: T::Boolean, flags: T::Array[String], prefer_stub: T::Boolean).returns(Formula)
   }
   def self.resolve(
     name,
-    spec: nil,
+    spec: T.unsafe(nil),
     force_bottle: false,
     flags: [],
     prefer_stub: false
@@ -1135,8 +1135,8 @@ module Formulary
     params(
       ref:           T.any(Pathname, String),
       spec:          Symbol,
-      alias_path:    T.any(NilClass, Pathname, String),
-      from:          T.nilable(Symbol),
+      alias_path:    T.any(Pathname, String),
+      from:          Symbol,
       warn:          T::Boolean,
       force_bottle:  T::Boolean,
       flags:         T::Array[String],
@@ -1147,8 +1147,8 @@ module Formulary
   def self.factory(
     ref,
     spec = :stable,
-    alias_path: nil,
-    from: nil,
+    alias_path: T.unsafe(nil),
+    from: T.unsafe(nil),
     warn: false,
     force_bottle: false,
     flags: [],
@@ -1177,13 +1177,13 @@ module Formulary
     params(
       rack:         Pathname,
       # Automatically resolves the formula's spec if not specified.
-      spec:         T.nilable(Symbol),
-      alias_path:   T.any(NilClass, Pathname, String),
+      spec:         Symbol,
+      alias_path:   T.any(Pathname, String),
       force_bottle: T::Boolean,
       flags:        T::Array[String],
     ).returns(Formula)
   }
-  def self.from_rack(rack, spec = nil, alias_path: nil, force_bottle: false, flags: [])
+  def self.from_rack(rack, spec = T.unsafe(nil), alias_path: T.unsafe(nil), force_bottle: false, flags: [])
     kegs = rack.directory? ? rack.subdirs.map { |d| Keg.new(d) } : []
     keg = kegs.find(&:linked?) || kegs.find(&:optlinked?) || kegs.max_by(&:scheme_and_version)
 
@@ -1213,16 +1213,16 @@ module Formulary
     params(
       keg:          Keg,
       # Automatically resolves the formula's spec if not specified.
-      spec:         T.nilable(Symbol),
-      alias_path:   T.any(NilClass, Pathname, String),
+      spec:         Symbol,
+      alias_path:   T.any(Pathname, String),
       force_bottle: T::Boolean,
       flags:        T::Array[String],
     ).returns(Formula)
   }
   def self.from_keg(
     keg,
-    spec = nil,
-    alias_path: nil,
+    spec = T.unsafe(nil),
+    alias_path: T.unsafe(nil),
     force_bottle: false,
     flags: []
   )
@@ -1263,7 +1263,7 @@ module Formulary
       path:          Pathname,
       contents:      String,
       spec:          Symbol,
-      alias_path:    T.nilable(Pathname),
+      alias_path:    Pathname,
       force_bottle:  T::Boolean,
       flags:         T::Array[String],
       ignore_errors: T::Boolean,
@@ -1274,7 +1274,7 @@ module Formulary
     path,
     contents,
     spec = :stable,
-    alias_path: nil,
+    alias_path: T.unsafe(nil),
     force_bottle: false,
     flags: [],
     ignore_errors: false
@@ -1289,7 +1289,7 @@ module Formulary
       name:          String,
       contents:      T::Hash[String, T.untyped],
       spec:          Symbol,
-      alias_path:    T.nilable(Pathname),
+      alias_path:    Pathname,
       force_bottle:  T::Boolean,
       flags:         T::Array[String],
       ignore_errors: T::Boolean,
@@ -1299,7 +1299,7 @@ module Formulary
     name,
     contents,
     spec = :stable,
-    alias_path: nil,
+    alias_path: T.unsafe(nil),
     force_bottle: false,
     flags: [],
     ignore_errors: false


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/20553#discussion_r2296226634

This PR changes the optional keyword argument pattern for some `Formulary` class methods by removing `T.nilable` from the `sig` and using `T.unsafe(nil)` as the default value.

I've done this for the main public API for `Formulary`, but adding it to the rest of the class is tricky and leads to a bunch of runtime errors. If it's important enough, I can continue looking into solutions.

This does introduce a few stray `|| T.unsafe(nil)`, so if we end up preferring the original style that's no problem