### PR TITLE
bump: respect livecheck skipped status

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -382,6 +382,7 @@ module Homebrew
 
         if !args.no_pull_requests? &&
            (new_version.general != "unable to get versions") &&
+           (new_version.general != "skipped") &&
            (new_version != current_version)
           # We use the ARM version for the pull request version. This is
           # consistent with the behavior of bump-cask-pr.
@@ -480,6 +481,7 @@ module Homebrew
         end
         if !args.no_pull_requests? &&
            (new_version.general != "unable to get versions") &&
+           (new_version.general != "skipped") &&
            !versions_equal
           if duplicate_pull_requests
             duplicate_pull_requests_text = duplicate_pull_requests
@@ -497,7 +499,11 @@ module Homebrew
           end
         end
 
-        return unless args.open_pr?
+        if !args.open_pr? ||
+           (new_version.general == "unable to get versions") ||
+           (new_version.general == "skipped")
+          return
+        end
 
         if GitHub.too_many_open_prs?(formula_or_cask.tap)
           odie "You have too many PRs open: close or merge some first!"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew bump` understands that some formulae/casks are skipped by livecheck but it doesn't use this information to avoid doing unnecessary or inappropriate work. This modifies related logic to not fetch PR information or try to open a version bump PR if livecheck is skipped. livecheck is our only source of version information these days, so we can't try to version bump a package if we don't have upstream version information.

This has been leading to an "Invalid usage: `--version` must not be empty" error (e.g., https://github.com/Homebrew/homebrew-cask/issues/224962) and this _should_ fix the issue under these particular circumstances. There's still plenty of room for improvement in how all of this is handled in bump but this is just a quick bug fix.