### PR TITLE
formula_cellar_checks: avoid changing name

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -373,7 +373,7 @@ module FormulaCellarChecks
     universal_binaries_expected = if (formula_tap = formula.tap).present? && formula_tap.core_tap?
       formula_name = formula.name
       # Apply audit exception to versioned formulae too from the unversioned name.
-      formula_name.gsub!(/@\d+(\.\d+)*$/, "") if formula.versioned_formula?
+      formula_name = formula_name.gsub(/@\d+(\.\d+)*$/, "") if formula.versioned_formula?
       formula_tap.audit_exception(:universal_binary_allowlist, formula_name)
     else
       true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #20568

Looks like `gsub!` was modifying `formula.name` when install run on local bottle (e.g. CI)

Prior code with `HOMEBREW_DEVELOPER=1 brew install --only-dependencies ./zig@0.14--0.14.1.arm64_sequoia.bottle.tar.gz --debug`:
```
==> Codesigning /opt/homebrew/Cellar/llvm@19/19.1.7/lib/unwind/libunwind.1.0.dylib
Error: No such file or directory @ rb_file_s_lstat - /opt/homebrew/Cellar/llvm/19.1.7
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/extend/pathname/disk_usage_extension.rb:73:in 'File.lstat'
/opt/homebrew/Library/Homebrew/extend/pathname/disk_usage_extension.rb:73:in 'Pathname#lstat'
/opt/homebrew/Library/Homebrew/extend/pathname/disk_usage_extension.rb:73:in 'DiskUsageExtension#compute_disk_usage'
/opt/homebrew/Library/Homebrew/extend/pathname/disk_usage_extension.rb:30:in 'DiskUsageExtension#abv'
/opt/homebrew/Library/Homebrew/formula_installer.rb:1054:in 'FormulaInstaller#summary'
/opt/homebrew/Library/Homebrew/formula_installer.rb:1043:in 'FormulaInstaller#finish'
/opt/homebrew/Library/Homebrew/formula_installer.rb:926:in 'FormulaInstaller#install_dependency'
/opt/homebrew/Library/Homebrew/formula_installer.rb:836:in 'block in FormulaInstaller#install_dependencies'
/opt/homebrew/Library/Homebrew/formula_installer.rb:836:in 'Array#each'
/opt/homebrew/Library/Homebrew/formula_installer.rb:836:in 'FormulaInstaller#install_dependencies'
/opt/homebrew/Library/Homebrew/formula_installer.rb:559:in 'FormulaInstaller#install'
/opt/homebrew/Library/Homebrew/install.rb:490:in 'Homebrew::Install.install_formula'
/opt/homebrew/Library/Homebrew/install.rb:423:in 'block in Homebrew::Install.install_formulae'
/opt/homebrew/Library/Homebrew/install.rb:420:in 'Array#each'
/opt/homebrew/Library/Homebrew/install.rb:420:in 'Homebrew::Install.install_formulae'
/opt/homebrew/Library/Homebrew/cmd/install.rb:383:in 'Homebrew::Cmd::InstallCmd#run'
/opt/homebrew/Library/Homebrew/brew.rb:101:in '<main>'
```

With change:
```
==> Codesigning /opt/homebrew/Cellar/llvm@19/19.1.7/lib/unwind/libunwind.1.0.dylib
🍺  /opt/homebrew/Cellar/llvm@19/19.1.7: 7,514 files, 1.7GB
==> Installing zig@0.14 dependency: lld@19
==> Pouring lld@19--19.1.7.arm64_sequoia.bottle.tar.gz
```