### PR TITLE
Remove redundant `T.bind(self, Pathname)`

### DIFF
--- a/Library/Homebrew/extend/pathname/write_mkpath_extension.rb
+++ b/Library/Homebrew/extend/pathname/write_mkpath_extension.rb
@@ -24,7 +24,6 @@ module WriteMkpathExtension
   def write(content, offset = T.unsafe(nil), external_encoding: T.unsafe(nil), internal_encoding: T.unsafe(nil),
             encoding: T.unsafe(nil), textmode: T.unsafe(nil), binmode: T.unsafe(nil), autoclose: T.unsafe(nil),
             mode: T.unsafe(nil), perm: T.unsafe(nil))
-    T.bind(self, Pathname)
     raise "Will not overwrite #{self}" if exist? && !offset && !mode&.match?(/^a\+?$/)
 
     dirname.mkpath


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/20566

Removes redundant `T.bind(self, Pathname)` since we use `requires_ancestor` above