### PR TITLE
Create `DownloadQueue` helper to check concurrency and initialize

### DIFF
--- a/Library/Homebrew/cask/reinstall.rb
+++ b/Library/Homebrew/cask/reinstall.rb
@@ -27,7 +27,7 @@ module Cask
 
       quarantine = true if quarantine.nil?
 
-      download_queue = Homebrew::DownloadQueue.new(pour: true) if Homebrew::EnvConfig.download_concurrency > 1
+      download_queue = Homebrew::DownloadQueue.new_if_concurrency_enabled(pour: true)
       cask_installers = casks.map do |cask|
         Installer.new(cask, binaries:, verbose:, force:, skip_cask_deps:, require_sha:, reinstall: true,
                       quarantine:, zap:, download_queue:)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -81,7 +81,7 @@ module Homebrew
           {}, T.nilable(T::Hash[T.nilable(Symbol), T::Array[T.any(Formula, Keg, Cask::Cask)]])
         )
         @to_formulae_and_casks[only] ||= begin
-          download_queue = Homebrew::DownloadQueue.new if Homebrew::EnvConfig.download_concurrency > 1
+          download_queue = Homebrew::DownloadQueue.new_if_concurrency_enabled
 
           formulae_and_casks = downcased_unique_named.flat_map do |name|
             load_and_fetch_full_formula_or_cask(name, only:, method:, warn:, download_queue:)
@@ -160,7 +160,7 @@ module Homebrew
           ]),
         )
         @to_formulae_casks_unknowns[method] = begin
-          download_queue = Homebrew::DownloadQueue.new if Homebrew::EnvConfig.download_concurrency > 1
+          download_queue = Homebrew::DownloadQueue.new_if_concurrency_enabled
 
           formulae_and_casks = downcased_unique_named.map do |name|
             load_and_fetch_full_formula_or_cask(name, only:, method:, download_queue:)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -244,7 +244,7 @@ module Homebrew
 
           installed_casks, new_casks = casks.partition(&:installed?)
 
-          download_queue = Homebrew::DownloadQueue.new(pour: true) if Homebrew::EnvConfig.download_concurrency > 1
+          download_queue = Homebrew::DownloadQueue.new_if_concurrency_enabled(pour: true)
           fetch_casks = Homebrew::EnvConfig.no_install_upgrade? ? new_casks : casks
 
           if download_queue

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -12,6 +12,13 @@ module Homebrew
   class DownloadQueue
     include Utils::Output::Mixin
 
+    sig { params(retries: Integer, force: T::Boolean, pour: T::Boolean).returns(T.nilable(DownloadQueue)) }
+    def self.new_if_concurrency_enabled(retries: 1, force: false, pour: false)
+      return if Homebrew::EnvConfig.download_concurrency <= 1
+
+      new(retries:, force:, pour:)
+    end
+
     sig { params(retries: Integer, force: T::Boolean, pour: T::Boolean).void }
     def initialize(retries: 1, force: false, pour: false)
       @concurrency = T.let(EnvConfig.download_concurrency, Integer)


### PR DESCRIPTION
We use the following pattern a lot:

```ruby
download_queue = Homebrew::DownloadQueue.new if Homebrew::EnvConfig.download_concurrency > 1
```

So, this creats a helper to easily create one if concurrency is enabled

```ruby
download_queue = Homebrew::DownloadQueue.new_if_concurrency_enabled
```

Definitely open to a shorter name is anyone has ideas