### PR TITLE
Fix `WriteMkpathExtension` tests

### DIFF
--- a/Library/Homebrew/test/extend/pathname/write_mkpath_extension_spec.rb
+++ b/Library/Homebrew/test/extend/pathname/write_mkpath_extension_spec.rb
@@ -2,16 +2,17 @@
 
 require "extend/pathname/write_mkpath_extension"
 
+# Use a copy of Pathname with the WriteMkpathExtension prepended to avoid affecting the original class for all tests
+class PathnameCopy < Pathname
+  PathnameCopy.prepend WriteMkpathExtension
+end
+
 RSpec.describe WriteMkpathExtension do
   let(:file_content) { "sample contents" }
 
-  before do
-    Pathname.prepend described_class
-  end
-
   it "creates parent directories if they do not exist" do
     mktmpdir do |tmpdir|
-      file = tmpdir/"foo/bar/baz.txt"
+      file = PathnameCopy.new(tmpdir/"foo/bar/baz.txt")
       expect(file.dirname).not_to exist
       file.write(file_content)
       expect(file).to exist
@@ -21,7 +22,7 @@ RSpec.describe WriteMkpathExtension do
 
   it "raises if file exists and not in append mode or with offset" do
     mktmpdir do |tmpdir|
-      file = tmpdir/"file.txt"
+      file = PathnameCopy.new(tmpdir/"file.txt")
       file.write(file_content)
       expect { file.write("new content") }.to raise_error(RuntimeError, /Will not overwrite/)
     end
@@ -29,7 +30,7 @@ RSpec.describe WriteMkpathExtension do
 
   it "allows overwrite if offset is provided" do
     mktmpdir do |tmpdir|
-      file = tmpdir/"file.txt"
+      file = PathnameCopy.new(tmpdir/"file.txt")
       file.write(file_content)
       expect do
         file.write("change", 0)
@@ -40,7 +41,7 @@ RSpec.describe WriteMkpathExtension do
 
   it "allows append mode ('a')" do
     mktmpdir do |tmpdir|
-      file = tmpdir/"file.txt"
+      file = PathnameCopy.new(tmpdir/"file.txt")
       file.write(file_content)
       expect do
         file.write(" appended", mode: "a")
@@ -51,7 +52,7 @@ RSpec.describe WriteMkpathExtension do
 
   it "allows append mode ('a+')" do
     mktmpdir do |tmpdir|
-      file = tmpdir/"file.txt"
+      file = PathnameCopy.new(tmpdir/"file.txt")
       file.write(file_content)
       expect do
         file.write(" again", mode: "a+")


### PR DESCRIPTION
See https://github.com/Homebrew/brew/pull/20566#discussion_r2299781652

To avoid prepending `WriteMkpathExtension` to `Pathname` for all test runs, let’s create a dummy `PathnameCopy < Pathname` class to test the functionality of the extension without globally applying.