### PR TITLE
unversioned_cask_checker: process rename operations

### DIFF
--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -118,6 +118,7 @@ module Homebrew
         dir = Pathname(dir)
 
         installer.extract_primary_container(to: dir)
+        installer.process_rename_operations(target_dir: dir)
 
         info_plist_paths = [
           *apps,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change runs the `rename` dsl for the `extract_plist` livecheck strategy.
Currently casks using the `extract_plist` strategy will fail because the app path cannot be found.

Unblocks: https://github.com/Homebrew/homebrew-cask/pull/225391