### PR TITLE
Include aliases and renames in `FormulaStub`

### DIFF
--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -32,11 +32,21 @@ module Homebrew
         stub_array = formula_arrays[name]
         raise "No formula stub found for #{name}" unless stub_array
 
+        aliases = formula_aliases.filter_map do |alias_name, original_name|
+          alias_name if original_name == name
+        end
+
+        oldnames = formula_renames.filter_map do |oldname, newname|
+          oldname if newname == name
+        end
+
         stub = Homebrew::FormulaStub.new(
           name:        name,
           pkg_version: PkgVersion.parse(stub_array[0]),
           rebuild:     stub_array[1],
           sha256:      stub_array[2],
+          aliases:,
+          oldnames:,
         )
 
         cache["formula_stubs"] ||= {}

--- a/Library/Homebrew/formula_stub.rb
+++ b/Library/Homebrew/formula_stub.rb
@@ -10,6 +10,8 @@ module Homebrew
     const :pkg_version, PkgVersion
     const :rebuild, Integer, default: 0
     const :sha256, T.nilable(String)
+    const :aliases, T::Array[String], default: []
+    const :oldnames, T::Array[String], default: []
 
     sig { returns(Version) }
     def version
@@ -25,7 +27,12 @@ module Homebrew
     def ==(other)
       case other
       when FormulaStub
-        name == other.name && pkg_version == other.pkg_version && rebuild == other.rebuild && sha256 == other.sha256
+        name == other.name &&
+          pkg_version == other.pkg_version &&
+          rebuild == other.rebuild &&
+          sha256 == other.sha256 &&
+          aliases == other.aliases &&
+          oldnames == other.oldnames
       else
         false
       end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -504,6 +504,16 @@ module Formulary
       define_method :install do
         raise NotImplementedError, "Cannot build from source from abstract stubbed formula."
       end
+
+      @aliases_array = formula_stub.aliases
+      define_method(:aliases) do
+        self.class.instance_variable_get(:@aliases_array)
+      end
+
+      @oldnames_array = formula_stub.oldnames
+      define_method(:oldnames) do
+        self.class.instance_variable_get(:@oldnames_array)
+      end
     end
 
     mod.const_set(class_name, klass)

--- a/Library/Homebrew/test/api/internal_spec.rb
+++ b/Library/Homebrew/test/api/internal_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe Homebrew::API::Internal do
           pkg_version: PkgVersion.parse(pkg_version),
           rebuild:     rebuild,
           sha256:      sha256,
+          aliases:     formulae_aliases.select { |_, new_name| new_name == name }.keys,
+          oldnames:    formulae_renames.select { |_, new_name| new_name == name }.keys,
         )
         [name, stub]
       end


### PR DESCRIPTION
We have access to alias and rename information in the internal API data, so let’s populate formula stubs with that information so `Formula#oldnames` and `Formula#aliases` always work