### PR TITLE
feat: update regex replace for pod2man

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -589,7 +589,7 @@ class Keg
           # pod2man embeds the perl version used into the 5th field of the footer
           parts[4]&.gsub!(/^"perl v.*"$/, "\"\"")
           # man extension remove in man files
-          parts[2]&.gsub!(/([1-9]){,p,pm}/, "\\1")
+          parts[2]&.gsub!(/([1-9])(?:pm|p)?/, "\\1")
 
           "#{parts.join(" ")}\n"
         elsif line.start_with?(".IX")
@@ -599,7 +599,7 @@ class Keg
           next line if parts[1] != "Title"
 
           # man extension remove in man files
-          parts[2]&.gsub!(/\s+([1-9]){,p,pm}/, "\\1")
+          parts[2]&.gsub!(/([1-9])(?:pm|p)?/, "\\1")
 
           "#{parts.join(" ")}\n"
         else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is followup PR for https://github.com/Homebrew/brew/pull/20589

For the replacement, regex expression should be changed to catch correctly. Previous local test was wrong, this is correct.

```diff
diff -u pgFormatter::CGI.3pm pgFormatter::CGI.3pm.new
--- pgFormatter::CGI.3pm        2025-03-17 22:14:30
+++ pgFormatter::CGI.3pm.new    2025-08-28 21:00:12
@@ -69,8 +69,8 @@
 .rr rF
 .\" ========================================================================
 .\"
-.IX Title "pgFormatter::CGI 3pm"
-.TH pgFormatter::CGI 3pm "2025-03-17" "" "User Contributed Perl Documentation"
+.IX Title "pgFormatter::CGI 3"
+.TH pgFormatter::CGI 3 "2025-03-17" "" "User Contributed Perl Documentation"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
```

`3pm` -> `3`