### PR TITLE
AbstractUninstall: coerce which argument to String

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -376,7 +376,7 @@ module Cask
         executable_path = staged_path_join_executable(executable)
 
         if (executable_path.absolute? && !executable_path.exist?) ||
-           (!executable_path.absolute? && (which executable_path).nil?)
+           (!executable_path.absolute? && which(executable_path.to_s).nil?)
           message = "uninstall script #{executable} does not exist"
           raise CaskError, "#{message}." unless force
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Cask::Artifact::AbstractUninstall.uninstall_script` contains a `which` call that uses a `Pathname` argument instead of a `String` and this leads to a type error (`Parameter 'cmd': Expected type String, got type Pathname with value...`, as seen in https://github.com/Homebrew/homebrew-cask/pull/225744). This resolves the error by calling `#to_s` on the `executable_path` argument.