### PR TITLE
bundle/tap_installer: add force flag for official taps for developers.

### DIFF
--- a/Library/Homebrew/bundle/tap_installer.rb
+++ b/Library/Homebrew/bundle/tap_installer.rb
@@ -18,7 +18,8 @@ module Homebrew
 
         puts "Installing #{name} tap. It is not currently installed." if verbose
         args = []
-        args << "--force" if force
+        official_tap = name.downcase.start_with? "homebrew/"
+        args << "--force" if force || (official_tap && Homebrew::EnvConfig.developer?)
 
         success = if options[:clone_target]
           Bundle.brew("tap", name, options[:clone_target], *args, verbose:)


### PR DESCRIPTION
This avoids a `homebrew/core` in a `Brewfile` failing for Homebrew developers who probably want it.