### PR TITLE
Allow "all" value for gnome_devel_allowlist

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -831,6 +831,7 @@ module Homebrew
       when %r{download\.gnome\.org/sources}, %r{ftp\.gnome\.org/pub/GNOME/sources}i
         version_prefix = stable.version.major_minor
         return if formula.tap&.audit_exception :gnome_devel_allowlist, formula.name, version_prefix
+        return if formula.tap&.audit_exception :gnome_devel_allowlist, formula.name, "all"
         return if stable_url_version < Version.new("1.0")
         # All minor versions are stable in the new GNOME version scheme (which starts at version 40.0)
         # https://discourse.gnome.org/t/new-gnome-versioning-scheme/4235


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `gnome_devel_allowlist` for formulae requires a specific version as a value (e.g., `"1.57"` to allow 1.57.x versions) and this requires us to update the value when a new odd-numbered minor version appears. For example, the newest `pango` version is 1.57.0 but autobump was unable to update the formula because the `gnome_devel_allowlist` value was `"1.55"`. `pango` doesn't use the "odd-numbered minor versions are development releases" GNOME version scheme but we have to manually update the allowlist because we don't have a version-independent way of opting out of the GNOME version scheme.

This adds support for an alternative `"all"` value in `gnome_devel_allowlist` (similar to `github_prerelease_allowlist`), which essentially opts the formula out of the GNOME version scheme restrictions regardless of the version.