### PR TITLE
Revert "Use `rubocop_internal` formatter for Ruby LSP"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
   ],
   "rubyLsp.customRubyCommand": "source ../../.vscode/ruby-lsp-activate.sh",
   "rubyLsp.bundleGemfile": "Library/Homebrew/Gemfile",
-  "rubyLsp.formatter": "rubocop_internal",
+  "rubyLsp.formatter": "rubocop",
   "[ruby]": {
     "editor.defaultFormatter": "Shopify.ruby-lsp",
     "editor.formatOnSave": true,


### PR DESCRIPTION
Reverts Homebrew/brew#20535

This was addressed by https://github.com/rubocop/rubocop/issues/14475 and https://github.com/rubocop/rubocop/pull/14478, and the fix was released in RuboCop 1.80.1