### PR TITLE
caveats: suggest setting `CMAKE_PREFIX_PATH` when appropriate

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -95,11 +95,11 @@ class Caveats
 
       s << "  #{Utils::Shell.export_value("CPPFLAGS", "-I#{formula.opt_include}")}\n" if formula.include.directory?
 
-      if which("pkg-config", ORIGINAL_PATHS) &&
+      if which("pkgconf", ORIGINAL_PATHS) &&
          ((formula.lib/"pkgconfig").directory? || (formula.share/"pkgconfig").directory?)
         s << <<~EOS
 
-          For pkg-config to find #{formula.name} you may need to set:
+          For pkgconf to find #{formula.name} you may need to set:
         EOS
 
         if (formula.lib/"pkgconfig").directory?
@@ -109,6 +109,15 @@ class Caveats
         if (formula.share/"pkgconfig").directory?
           s << "  #{Utils::Shell.export_value("PKG_CONFIG_PATH", "#{formula.opt_share}/pkgconfig")}\n"
         end
+      end
+
+      if which("cmake", ORIGINAL_PATHS) &&
+         ((formula.lib/"cmake").directory? || (formula.share/"cmake").directory?)
+        s << <<~EOS
+
+          For cmake to find #{formula.name} you may need to set:
+            #{Utils::Shell.export_value("CMAKE_PREFIX_PATH", formula.opt_prefix.to_s)}
+        EOS
       end
     end
     s << "\n" unless s.end_with?("\n")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Inspired by Homebrew/homebrew-core#235513.

It doesn't quite fix that issue, because `libomp` does not ship CMake
config files, but this would probably still be useful for keg-only
formulae that do ship CMake config files.

While we're here, let's replace the `pkg-config` references with the
now-canonical name `pkgconf`.
