### PR TITLE
Fix undefined method 'ohai'

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -13,6 +13,7 @@ require "development_tools"
 module SharedEnvExtension
   extend T::Helpers
   include CompilerConstants
+  include Utils::Output::Mixin
 
   requires_ancestor { Sorbet::Private::Static::ENVClass }
 
@@ -258,7 +259,7 @@ module SharedEnvExtension
     flags = []
 
     if fc
-      ohai "Building with an alternative Fortran compiler", "This is unsupported."
+      opoo "Building with an unsupported Fortran compiler"
       self["F77"] ||= fc
     else
       if (gfortran = which("gfortran", (HOMEBREW_PREFIX/"bin").to_s))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Seems to have broken recently. Seen in Homebrew/core and can be reproduced via `brew test -v fypp`
```
Error: fypp: failed
An exception occurred within a child process:
  NoMethodError: undefined method 'ohai' for #<Object:0x00000001017eecd8>
/opt/homebrew/Library/Homebrew/extend/ENV/shared.rb:265:in 'SharedEnvExtension#fortran'
```

Could alternatively add `include ::Utils::Output::Mixin` though I don't think we need `ohai` here.