### PR TITLE
Remove temporary audit exception for lsr

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -85,9 +85,6 @@ module Homebrew
         end
       end
 
-      # TODO: Remove this exception for `lsr` after support for tangled.sh
-      # Git URLs is available in a brew release.
-      return if name == "lsr"
       return if url_strategy != DownloadStrategyDetector.detect("", using)
 
       problem "Redundant `using:` value in URL"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This removes the temporary `audit_download_strategy` exception for the `lsr` formula. This was necessary to be able to merge support for tangled.sh Git URLs (https://github.com/Homebrew/brew/pull/20599), as it made the `using: :git` argument in the `lsr` formula redundant and caused the "formula audit" check to fail in brew CI.

I've set this as a draft until the aforementioned `DownloadStrategy` change is available in a brew release.