### PR TITLE
write_env_script: allow setting args without env

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -297,8 +297,8 @@ class Pathname
            env:         T.any(T::Hash[String, String], T::Hash[Symbol, String])).void
   }
   def write_env_script(target, args_or_env, env = T.unsafe(nil))
-    args = if env.nil?
-      env = args_or_env if args_or_env.is_a?(Hash)
+    args = if env.nil? && args_or_env.is_a?(Hash)
+      env = args_or_env
 
       nil
     elsif args_or_env.is_a?(Array)
@@ -307,6 +307,7 @@ class Pathname
       T.cast(args_or_env, T.nilable(String))
     end
 
+    env ||= {}
     env_export = +""
     env.each { |key, value| env_export << "#{key}=\"#{value}\" " }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`write_env_script` can include arguments in the scripts it generates, but only if a third argument is present. Currently, `vulkan-tools` [works around this](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/v/vulkan-tools.rb#L94-L95) by passing an empty hash. This drops that requirement, which paves the way for more usage of `write_env_script` for simple shim scripts in formulae, e.g. [`ckan`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/c/ckan.rb#L21-L24). 