### PR TITLE
write_exec_script: add args parameter

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -273,19 +273,24 @@ class Pathname
   end
 
   # Writes an exec script in this folder for each target pathname.
-  sig { params(targets: T.any(T::Array[T.any(String, Pathname)], String, Pathname)).void }
-  def write_exec_script(*targets)
+  sig {
+    params(targets: T.any(T::Array[T.any(String, Pathname)], String, Pathname),
+           args:    T.any(String, T::Array[String])).void
+  }
+  def write_exec_script(*targets, args: T.unsafe(nil))
     targets.flatten!
     if targets.empty?
       opoo "Tried to write exec scripts to #{self} for an empty list of targets"
       return
     end
+    arg_str = "#{Array(args).join(" ")} " if args.present?
+
     mkpath
     targets.each do |target|
       target = Pathname.new(target) # allow pathnames or strings
       join(target.basename).write <<~SH
         #!/bin/bash
-        exec "#{target}" "$@"
+        exec "#{target}" #{arg_str}"$@"
       SH
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Alternative to #20616: add ability to specify `args:` when creating shim scripts with `write_exec_script`. Needs to be a keyword parameter because the method accepts an arbitrary number of strings or pathnames as targets.