### PR TITLE
Unlink old `*_names.txt` and `*_aliases.txt` files before overwriting

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -196,6 +196,7 @@ module Homebrew
     def self.write_names_file!(names, type, regenerate:)
       names_path = HOMEBREW_CACHE_API/"#{type}_names.txt"
       if !names_path.exist? || regenerate
+        names_path.unlink
         names_path.write(names.join("\n"))
         return true
       end
@@ -210,6 +211,7 @@ module Homebrew
         aliases_text = aliases.map do |alias_name, real_name|
           "#{alias_name}|#{real_name}"
         end
+        aliases_path.unlink
         aliases_path.write(aliases_text.join("\n"))
         return true
       end

--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -196,7 +196,7 @@ module Homebrew
     def self.write_names_file!(names, type, regenerate:)
       names_path = HOMEBREW_CACHE_API/"#{type}_names.txt"
       if !names_path.exist? || regenerate
-        names_path.unlink
+        names_path.unlink if names_path.exist?
         names_path.write(names.join("\n"))
         return true
       end
@@ -211,7 +211,7 @@ module Homebrew
         aliases_text = aliases.map do |alias_name, real_name|
           "#{alias_name}|#{real_name}"
         end
-        aliases_path.unlink
+        aliases_path.unlink if aliases_path.exist?
         aliases_path.write(aliases_text.join("\n"))
         return true
       end


### PR DESCRIPTION
Fixes #20610

If the forked install process attempts to download new API files, it will try to overwrite the various `{formula,cask}_{names,aliases}.txt` files, but this will fail because the the `WriteMkpathExtension` is applied.

To solve this, let’s simply unlink the old files before writing the new contents.