### PR TITLE
Download new API files once per Homebrew instance

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -75,18 +75,18 @@ module Homebrew
       end
 
       sig {
-        params(download_queue: T.nilable(::Homebrew::DownloadQueue), stale_seconds: Integer)
+        params(download_queue: T.nilable(::Homebrew::DownloadQueue), stale_seconds: T.nilable(Integer))
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
+      def self.fetch_api!(download_queue: nil, stale_seconds: nil)
         Homebrew::API.fetch_json_api_file DEFAULT_API_FILENAME, stale_seconds:, download_queue:
       end
 
       sig {
-        params(download_queue: T.nilable(::Homebrew::DownloadQueue), stale_seconds: Integer)
+        params(download_queue: T.nilable(::Homebrew::DownloadQueue), stale_seconds: T.nilable(Integer))
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_tap_migrations!(download_queue: nil, stale_seconds: Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS)
+      def self.fetch_tap_migrations!(download_queue: nil, stale_seconds: nil)
         Homebrew::API.fetch_json_api_file "cask_tap_migrations.jws.json", stale_seconds:, download_queue:
       end
 

--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -74,18 +74,18 @@ module Homebrew
       end
 
       sig {
-        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: Integer)
+        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: T.nilable(Integer))
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
+      def self.fetch_api!(download_queue: nil, stale_seconds: nil)
         Homebrew::API.fetch_json_api_file DEFAULT_API_FILENAME, stale_seconds:, download_queue:
       end
 
       sig {
-        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: Integer)
+        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: T.nilable(Integer))
           .returns([T.any(T::Array[T.untyped], T::Hash[String, T.untyped]), T::Boolean])
       }
-      def self.fetch_tap_migrations!(download_queue: nil, stale_seconds: Homebrew::API::TAP_MIGRATIONS_STALE_SECONDS)
+      def self.fetch_tap_migrations!(download_queue: nil, stale_seconds: nil)
         Homebrew::API.fetch_json_api_file "formula_tap_migrations.jws.json", stale_seconds:, download_queue:
       end
 

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -56,20 +56,20 @@ module Homebrew
       end
 
       sig {
-        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: Integer)
+        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: T.nilable(Integer))
           .returns([T::Hash[String, T.untyped], T::Boolean])
       }
-      def self.fetch_formula_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
-        json_contents, updated = (Homebrew::API.fetch_json_api_file formula_endpoint, stale_seconds:, download_queue:)
+      def self.fetch_formula_api!(download_queue: nil, stale_seconds: nil)
+        json_contents, updated = Homebrew::API.fetch_json_api_file(formula_endpoint, stale_seconds:, download_queue:)
         [T.cast(json_contents, T::Hash[String, T.untyped]), updated]
       end
 
       sig {
-        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: Integer)
+        params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: T.nilable(Integer))
           .returns([T::Hash[String, T.untyped], T::Boolean])
       }
-      def self.fetch_cask_api!(download_queue: nil, stale_seconds: Homebrew::EnvConfig.api_auto_update_secs.to_i)
-        json_contents, updated = (Homebrew::API.fetch_json_api_file cask_endpoint, stale_seconds:, download_queue:)
+      def self.fetch_cask_api!(download_queue: nil, stale_seconds: nil)
+        json_contents, updated = Homebrew::API.fetch_json_api_file(cask_endpoint, stale_seconds:, download_queue:)
         [T.cast(json_contents, T::Hash[String, T.untyped]), updated]
       end
 

--- a/Library/Homebrew/api/json_download.rb
+++ b/Library/Homebrew/api/json_download.rb
@@ -10,13 +10,13 @@ module Homebrew
       def initialize(url, name, version, **meta)
         super
         @target = T.let(meta.fetch(:target), Pathname)
-        @stale_seconds = T.let(meta.fetch(:stale_seconds), Integer)
+        @stale_seconds = T.let(meta[:stale_seconds], T.nilable(Integer))
       end
 
       sig { override.params(timeout: T.nilable(T.any(Integer, Float))).returns(Pathname) }
       def fetch(timeout: nil)
         with_context quiet: quiet? do
-          Homebrew::API.fetch_json_api_file(url, target: cached_location, stale_seconds: meta.fetch(:stale_seconds))
+          Homebrew::API.fetch_json_api_file(url, target: cached_location, stale_seconds: meta[:stale_seconds])
         end
         cached_location
       end
@@ -30,7 +30,7 @@ module Homebrew
     class JSONDownload
       include Downloadable
 
-      sig { params(url: String, target: Pathname, stale_seconds: Integer).void }
+      sig { params(url: String, target: Pathname, stale_seconds: T.nilable(Integer)).void }
       def initialize(url, target:, stale_seconds:)
         super()
         @url = T.let(URL.new(url, using: API::JSONDownloadStrategy, target:, stale_seconds:), URL)


### PR DESCRIPTION
For consistency, we don’t want to download new API files mid-run, even if new data is available on the server. This PR modifies the API fetcher logic to only attempt to fetch the data once per execution.

To clarify why `mtime` and `--time-cond` are insufficient here: these checks simply ensure that enough time has passed in between fetches, and that a new fetch will actually yield a new file. However, when building from source, it's possible that an installation will take long enough that new data is available and enough time has passed that `Homebrew::API` considers the file to be stale. This means that future calls to API data will try to download the data once again, which is what this PR is attempting to prevent.