### PR TITLE
cask/audit: fix install of container deps

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -622,15 +622,17 @@ module Cask
         }.compact
 
         Homebrew::Install.perform_preinstall_checks_once
-        valid_formula_installers = Homebrew::Install.fetch_formulae(primary_container.dependencies)
-
-        primary_container.dependencies.each do |dep|
-          next unless valid_formula_installers.include?(dep)
-
-          fi = FormulaInstaller.new(
+        formula_installers = primary_container.dependencies.map do |dep|
+          FormulaInstaller.new(
             dep,
             **install_options,
           )
+        end
+        valid_formula_installers = Homebrew::Install.fetch_formulae(formula_installers)
+
+        formula_installers.each do |fi|
+          next unless valid_formula_installers.include?(fi)
+
           fi.install
           fi.finish
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

After changes to utilise the download queue, the installation of "container dependencies" during `brew audit` were no longer working as expected. The `Homebrew::Install.fetch_formulae` method expects a formula installer to be passed to it, but a Formula was being passed instead.