### PR TITLE
SkipConditions: check disabled before deprecated

### DIFF
--- a/Library/Homebrew/livecheck/skip_conditions.rb
+++ b/Library/Homebrew/livecheck/skip_conditions.rb
@@ -198,8 +198,8 @@ module Homebrew
       FORMULA_CHECKS = T.let([
         :package_or_resource_skip,
         :formula_head_only,
-        :formula_deprecated,
         :formula_disabled,
+        :formula_deprecated,
         :formula_versioned,
       ].freeze, T::Array[Symbol])
       private_constant :FORMULA_CHECKS
@@ -207,8 +207,8 @@ module Homebrew
       # Skip conditions for casks.
       CASK_CHECKS = T.let([
         :package_or_resource_skip,
-        :cask_deprecated,
         :cask_disabled,
+        :cask_deprecated,
         :cask_extract_plist,
         :cask_version_latest,
         :cask_url_unversioned,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We have some formulae and casks that contain both `deprecate!` and `disable!` calls, presumably as a way of controlling the deprecation behavior before the disable date is reached. However, once the disable date has been reached, `Livecheck::SkipConditions` continues to skip the package as deprecated instead of disabled. This isn't a functional issue as the package is still skipped but it isn't accurate because it's not being skipped as disabled.

This reorders `FORMULA_CHECKS` and `CASK_CHECKS` to run the disabled check before the deprecated check, so the disable date will take precedence when it's been reached.