### PR TITLE
livecheck: support trailing comments in watchlist

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -78,9 +78,15 @@ module Homebrew
             formulae + casks
           elsif File.exist?(watchlist_path)
             begin
+              # This removes blank lines, comment lines, and trailing comments
               names = Pathname.new(watchlist_path).read.lines
-                              .reject { |line| line.start_with?("#") || line.blank? }
-                              .map(&:strip)
+                              .filter_map do |line|
+                                comment_index = line.index("#")
+                                next if comment_index&.zero?
+
+                                line = line[0...comment_index] if comment_index
+                                line&.strip.presence
+                              end
 
               named_args = CLI::NamedArgs.new(*names, parent: args)
               named_args.to_formulae_and_casks(ignore_unavailable: true)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I ran `brew livecheck` today to check the packages in my watchlist and realized that it wasn't checking one package because I had added a trailing comment after the name (and `package # Comment` isn't a valid package name). I thought we had added support for trailing comments when we originally added comment support years back but I must have been mistaken.

This adds support for trailing comments in livecheck watchlist files as part of refactoring the watchlist line parsing logic to only use one pass (instead of multiple `#map` and `#reject` calls). This maintains the existing behavior, where blank lines and lines starting with `#` are skipped, but does so in a more flexible manner. For example, the existing logic wouldn't skip a comment line that has one or more spaces before the `#` character but this new logic will correctly skip it.