### PR TITLE
Make `Pathname.prepend WriteMkpathExtension` as late as possible.

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -183,6 +183,8 @@ class Build
 
             (formula.logs/"00.options.out").write \
               "#{formula.full_name} #{formula.build.used_options.sort.join(" ")}".strip
+
+            Pathname.prepend WriteMkpathExtension
             formula.install
 
             stdlibs = detect_stdlibs
@@ -246,8 +248,6 @@ begin
   formula = args.named.to_formulae.first
   options = Options.create(args.flags_only)
   build   = Build.new(formula, options, args:)
-
-  Pathname.prepend WriteMkpathExtension
 
   build.install
 # Any exception means the build did not complete.

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -32,8 +32,8 @@ begin
   end
 
   Pathname.prepend WriteMkpathExtension
-
   formula.run_post_install
+
 # Handle all possible exceptions.
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe&.puts e.to_json

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -45,10 +45,9 @@ begin
     formula.extend(Debrew::Formula)
   end
 
-  Pathname.prepend WriteMkpathExtension
-
   ENV.extend(Stdenv)
   ENV.setup_build_environment(formula:, testing_formula: true)
+  Pathname.prepend WriteMkpathExtension
 
   # tests can also return false to indicate failure
   run_test = proc { |_ = nil| raise "test returned false" if formula.run_test(keep_tmp: args.keep_tmp?) == false }


### PR DESCRIPTION
Let's avoid weirdness in other parts of Homebrew by moving this prepend to be as late as possible.

This may well go 💥 in which case: we should fix these cases so essentially only `Formula#install`/`Formula#test`/`Formula#postinstall` relies on this behaviour.