### PR TITLE
config: Remove use of `/etc/redhat-release`

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -29,10 +29,10 @@ module OS
         else
           "#{description} (#{codename})"
         end
-      elsif (redhat_release = Pathname.new("/etc/redhat-release")).readable?
-        redhat_release.read.chomp
       elsif ::OS_VERSION.present?
         ::OS_VERSION
+      elsif (redhat_release = Pathname.new("/etc/redhat-release")).readable?
+        redhat_release.read.chomp
       else
         "Unknown"
       end

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -31,8 +31,6 @@ module OS
         end
       elsif ::OS_VERSION.present?
         ::OS_VERSION
-      elsif (redhat_release = Pathname.new("/etc/redhat-release")).readable?
-        redhat_release.read.chomp
       else
         "Unknown"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

On the [beta Bluefin LTS](https://docs.projectbluefin.io/lts), `brew config` reports:

```console
OS: CentOS Stream release 10 (Coughlan)
```

This is due to the `/etc/redhat-release` file being prioritized over `::OS_VERSION` (`PRETTY_NAME` from `/etc/os-release`).

On Bluefin LTS, `PRETTY_NAME` is `Bluefin LTS`.

This commit reverses the order so `brew config` has better detection:

```
OS: Bluefin LTS
```

I tested on RHEL 10 and the OS line only changed in that the word "release" was omitted:

```
$ cat /etc/redhat-release
Red Hat Enterprise Linux release 10.0 (Coughlan)
$ grep PRETTY_NAME /etc/os-release
PRETTY_NAME="Red Hat Enterprise Linux 10.0 (Coughlan)"
```

- This is an improvement on my previous PR https://github.com/Homebrew/brew/pull/15788