### PR TITLE
Cask::Audit: fix `key not found: :latest` error

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -755,9 +755,9 @@ module Cask
       latest_version = Homebrew::Livecheck.latest_version(
         cask,
         referenced_formula_or_cask: referenced_cask,
-      )&.fetch(:latest)
+      )&.fetch(:latest, nil)
 
-      return :auto_detected if cask.version.to_s == latest_version.to_s
+      return :auto_detected if latest_version && (cask.version.to_s == latest_version.to_s)
 
       add_error "Version '#{cask.version}' differs from '#{latest_version}' retrieved by livecheck."
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Cask::Audit.audit_livecheck_version` can raise a `key not found: :latest` error when a hash from livecheck's `latest_version` method doesn't have a `:latest` value. This error means that livecheck was unable to identify the latest upstream version but it can only be understood if the reader knows how this audit is implemented (and it may also depend on knowing the structure of livecheck's `latest_version` hash). Without that knowledge, the error doesn't make it clear which audit is failing and why.

This addresses the issue by using `nil` as the default value for this `fetch` call and accounting for a `nil` `latest_version` value. This allows the audit to surface the usual "Version '1.2.3' differs from '' retrieved by livecheck" failure, which makes it more clear that livecheck isn't returning a version.