### PR TITLE
utils/pid_path: use libSystem

### DIFF
--- a/Library/Homebrew/utils/pid_path.rb
+++ b/Library/Homebrew/utils/pid_path.rb
@@ -7,7 +7,9 @@ raise "Missing `pid` argument!" unless pid
 
 require "fiddle"
 
-libproc = Fiddle.dlopen("/usr/lib/libproc.dylib")
+# Canonically, this is a part of libproc.dylib. libproc is however just a symlink to libSystem
+# and some security tools seem to not support aliases from the dyld shared cache and incorrectly flag this.
+libproc = Fiddle.dlopen("/usr/lib/libSystem.B.dylib")
 
 libproc_proc_pidpath_function = Fiddle::Function.new(
   libproc["proc_pidpath"],


### PR DESCRIPTION
It seems a certain enterprise security tool flags this file for the `dlopen`. It's unclear why as it is a trusted, signed dylib shipped with macOS.

The symbol we need however also exists in `libSystem`, which we have successfully loaded elsewhere: https://github.com/Homebrew/brew/blob/43433244682cdc54bd7fe770577f102c9234bc3f/Library/Homebrew/linkage_checker.rb#L201

As such, it's a reasonable guess that `libSystem` might work here.

Ultimately, this PR is entirely a speculative fix as I have no way to verify if this fixes the issue or not.