### PR TITLE
development_tools: make gcc_version public api

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -114,9 +114,9 @@ class DevelopmentTools
 
     # Get the GCC version.
     #
-    # @api internal
+    # @api public
     sig { params(cc: String).returns(Version) }
-    def gcc_version(cc)
+    def gcc_version(cc = host_gcc_path.to_s)
       (@gcc_version ||= T.let({}, T.nilable(T::Hash[String, Version]))).fetch(cc) do
         path = HOMEBREW_PREFIX/"opt/#{CompilerSelector.preferred_gcc}/bin"/cc
         path = locate(cc) unless path.exist?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Useful to have as public API similar to how we use `clang_build_version` on macOS.

Add a default of `host_gcc_path`. `path` is set correctly as `host_gcc_path` is absolute so overrides the brew gcc path

```rb
brew(main):001> DevelopmentTools.gcc_version.to_s
=> "11.4.0"
```