### PR TITLE
os/linux/ld: add support for using system ld.so

### DIFF
--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -1,26 +1,13 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "os/linux/ld"
 require "utils/output"
 
 module OS
   module Linux
     module Install
       module ClassMethods
-        # This is a list of known paths to the host dynamic linker on Linux if
-        # the host glibc is new enough. The symlink_ld_so method will fail if
-        # the host linker cannot be found in this list.
-        DYNAMIC_LINKERS = %w[
-          /lib64/ld-linux-x86-64.so.2
-          /lib64/ld64.so.2
-          /lib/ld-linux.so.3
-          /lib/ld-linux.so.2
-          /lib/ld-linux-aarch64.so.1
-          /lib/ld-linux-armhf.so.3
-          /system/bin/linker64
-          /system/bin/linker
-        ].freeze
-
         # We link GCC runtime libraries that are not specifically used for Fortran,
         # which are linked by the GCC formula. We only use the versioned shared libraries
         # as the other shared and static libraries are only used at build time where
@@ -67,7 +54,7 @@ module OS
 
           ld_so = HOMEBREW_PREFIX/"opt/glibc/bin/ld.so"
           unless ld_so.readable?
-            ld_so = DYNAMIC_LINKERS.find { |s| File.executable? s }
+            ld_so = OS::Linux::Ld.system_ld_so
             if ld_so.blank?
               ::Kernel.raise "Unable to locate the system's dynamic linker" unless brew_ld_so.readable?
 

--- a/Library/Homebrew/test/os/linux/ld_spec.rb
+++ b/Library/Homebrew/test/os/linux/ld_spec.rb
@@ -4,6 +4,61 @@ require "os/linux/ld"
 require "tmpdir"
 
 RSpec.describe OS::Linux::Ld do
+  let(:diagnostics) do
+    <<~EOS
+      path.prefix="/usr"
+      path.sysconfdir="/usr/local/etc"
+      path.system_dirs[0x0]="/lib64"
+      path.system_dirs[0x1]="/var/lib"
+    EOS
+  end
+
+  describe "::system_ld_so" do
+    let(:ld_so) { "/lib/ld-linux.so.3" }
+
+    before do
+      allow(File).to receive(:executable?).and_return(false)
+      described_class.instance_variable_set(:@system_ld_so, nil)
+    end
+
+    it "returns the path to a known dynamic linker" do
+      allow(File).to receive(:executable?).with(ld_so).and_return(true)
+      expect(described_class.system_ld_so).to eq(Pathname(ld_so))
+    end
+
+    it "returns nil when there is no known dynamic linker" do
+      expect(described_class.system_ld_so).to be_nil
+    end
+  end
+
+  describe "::sysconfdir" do
+    it "returns path.sysconfdir" do
+      allow(described_class).to receive(:ld_so_diagnostics).and_return(diagnostics)
+      expect(described_class.sysconfdir).to eq("/usr/local/etc")
+      expect(described_class.sysconfdir(brewed: false)).to eq("/usr/local/etc")
+    end
+
+    it "returns fallback on blank diagnostics" do
+      allow(described_class).to receive(:ld_so_diagnostics).and_return("")
+      expect(described_class.sysconfdir).to eq("/etc")
+      expect(described_class.sysconfdir(brewed: false)).to eq("/etc")
+    end
+  end
+
+  describe "::system_dirs" do
+    it "returns all path.system_dirs" do
+      allow(described_class).to receive(:ld_so_diagnostics).and_return(diagnostics)
+      expect(described_class.system_dirs).to eq(["/lib64", "/var/lib"])
+      expect(described_class.system_dirs(brewed: false)).to eq(["/lib64", "/var/lib"])
+    end
+
+    it "returns an empty array on blank diagnostics" do
+      allow(described_class).to receive(:ld_so_diagnostics).and_return("")
+      expect(described_class.system_dirs).to eq([])
+      expect(described_class.system_dirs(brewed: false)).to eq([])
+    end
+  end
+
   describe "::library_paths" do
     ld_etc = Pathname("")
     before do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Adding ability to query the system's `ld.so --list-diagnostics` to work even if brew `glibc` is installed 
- #20609

```rb
brew(main):001> OS::Linux::Ld.system_ld_so
=> #<Pathname:/lib/ld-linux-aarch64.so.1>

brew(main):002> OS::Linux::Ld.system_dirs
=> ["/home/linuxbrew/.linuxbrew/Cellar/glibc/2.35_1/lib/"]

brew(main):003> OS::Linux::Ld.system_dirs(brewed: false)
=> ["/lib/aarch64-linux-gnu/", "/usr/lib/aarch64-linux-gnu/", "/lib/", "/usr/lib/"]

brew(main):004> OS::Linux::Ld.library_paths
=> ["/home/linuxbrew/.linuxbrew/opt/glibc/lib", "/home/linuxbrew/.linuxbrew/lib"]

brew(main):005> OS::Linux::Ld.library_paths(brewed: false)
=> ["/usr/local/lib/aarch64-linux-gnu", "/lib/aarch64-linux-gnu", "/usr/lib/aarch64-linux-gnu", "/usr/local/lib"]
```