### PR TITLE
command options: various `--eval-all` fixes

### DIFF
--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -127,7 +127,7 @@ module Homebrew
         conflicts "--all", "--no-vscode"
         conflicts "--vscode", "--no-vscode"
         conflicts "--install", "--upgrade"
-        conflicts "--file=", "--global"
+        conflicts "--file", "--global"
 
         named_args %w[install dump cleanup check exec list sh env edit]
       end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -77,7 +77,6 @@ module Homebrew
                description: "Show the size of installed formulae and casks."
 
         conflicts "--installed", "--eval-all"
-        conflicts "--installed", "--all"
         conflicts "--formula", "--cask"
         conflicts "--fetch-manifest", "--cask"
         conflicts "--fetch-manifest", "--json"

--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -23,7 +23,7 @@ module Homebrew
         flag   "--command=",
                description: "Show options for the specified <command>."
 
-        conflicts "--installed", "--all", "--command"
+        conflicts "--command", "--installed", "--eval-all"
 
         named_args :formula
       end
@@ -47,7 +47,7 @@ module Homebrew
             puts
           end
         elsif args.no_named?
-          raise FormulaUnspecifiedError
+          raise UsageError, "`brew options` needs a formula or `--eval-all` passed or `HOMEBREW_EVAL_ALL=1` set!"
         else
           puts_options args.named.to_formulae
         end

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -37,8 +37,7 @@ module Homebrew
                description: "Search for casks."
         switch "--desc",
                description: "Search for formulae with a description matching <text> and casks with " \
-                            "a name or description matching <text>.",
-               depends_on:  "--eval-all"
+                            "a name or description matching <text>."
         switch "--eval-all",
                description: "Evaluate all available formulae and casks, whether installed or not, to search their " \
                             "descriptions.",

--- a/Library/Homebrew/cmd/services.rb
+++ b/Library/Homebrew/cmd/services.rb
@@ -68,7 +68,7 @@ module Homebrew
                description: "Output as JSON."
 
         conflicts "--all", "--file"
-        conflicts "--max-wait=", "--no-wait"
+        conflicts "--max-wait", "--no-wait"
 
         named_args %w[list info run start stop kill restart cleanup]
       end

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -55,7 +55,7 @@ module Homebrew
                description: "Include only casks."
 
         conflicts "--formula", "--cask"
-        conflicts "--installed", "--all"
+        conflicts "--installed", "--eval-all"
         conflicts "--missing", "--installed"
 
         named_args :formula, min: 1

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -93,11 +93,11 @@ module Homebrew
         switch "--cask", "--casks",
                description: "Treat all named arguments as casks."
 
+        conflicts "--installed", "--eval-all"
         conflicts "--only", "--except"
         conflicts "--only-cops", "--except-cops", "--strict"
         conflicts "--only-cops", "--except-cops", "--only"
         conflicts "--formula", "--cask"
-        conflicts "--installed", "--all"
 
         named_args [:formula, :cask], without_api: true
       end

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -49,8 +49,8 @@ module Homebrew
                description: "Use the specified GitHub organization for forking."
 
         conflicts "--dry-run", "--write"
-        conflicts "--version=", "--version-arm="
-        conflicts "--version=", "--version-intel="
+        conflicts "--version", "--version-arm"
+        conflicts "--version", "--version-intel"
 
         named_args :cask, number: 1, without_api: true
       end

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -57,10 +57,10 @@ module Homebrew
         switch "--bump-synced",
                description: "Bump additional formulae marked as synced with the given formulae."
 
-        conflicts "--cask", "--formula"
-        conflicts "--tap=", "--installed"
-        conflicts "--tap=", "--no-autobump"
-        conflicts "--eval-all", "--installed"
+        conflicts "--formula", "--cask"
+        conflicts "--tap", "--installed"
+        conflicts "--tap", "--no-autobump"
+        conflicts "--installed", "--eval-all"
         conflicts "--installed", "--auto"
         conflicts "--no-pull-requests", "--open-pr"
 

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -41,9 +41,9 @@ module Homebrew
         switch "--autobump",
                description: "Include packages that are autobumped by BrewTestBot. By default these are skipped."
 
-        conflicts "--debug", "--json"
-        conflicts "--tap=", "--eval-all", "--installed"
-        conflicts "--cask", "--formula"
+        conflicts "--tap", "--installed", "--eval-all"
+        conflicts "--json", "--debug"
+        conflicts "--formula", "--cask"
         conflicts "--formula", "--extract-plist"
 
         named_args [:formula, :cask], without_api: true

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Homebrew::CLI::Parser do
         flag      "--flag2=", depends_on: "--flag1="
         flag      "--flag3="
 
-        conflicts "--flag1=", "--flag3="
+        conflicts "--flag1", "--flag3"
       end
     end
 
@@ -204,7 +204,8 @@ RSpec.describe Homebrew::CLI::Parser do
       described_class.new(Cmd) do
         flag      "--flag1="
         flag      "--flag2=", depends_on: "--flag1="
-        conflicts "--flag1=", "--flag2="
+
+        conflicts "--flag1", "--flag2"
       end
     end
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -429,7 +429,7 @@ _brew_abv() {
     '(--cask --json)--fetch-manifest[Fetch GitHub Packages manifest for extra information when formula is not installed]' \
     '--github[Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask]' \
     '--help[Show this message]' \
-    '(--eval-all --all)--installed[Print JSON of formulae that are currently installed]' \
+    '(--eval-all)--installed[Print JSON of formulae that are currently installed]' \
     '(--fetch-manifest)--json[Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew]' \
     '--quiet[Make some output more quiet]' \
     '--sizes[Show the size of installed formulae and casks]' \
@@ -471,13 +471,13 @@ _brew_audit() {
     '--audit-debug[Enable debugging and profiling of audit methods]' \
     '--debug[Display any debugging information]' \
     '--display-filename[Prefix every line of output with the file or formula name being audited, to make output easy to grep]' \
-    '--eval-all[Evaluate all available formulae and casks, whether installed or not, to audit them. Enabled by default if `$HOMEBREW_EVAL_ALL` is set]' \
+    '(--installed)--eval-all[Evaluate all available formulae and casks, whether installed or not, to audit them. Enabled by default if `$HOMEBREW_EVAL_ALL` is set]' \
     '(--only)--except[Specify a comma-separated method list to skip running the methods named `audit_`method]' \
     '(--only-cops --strict --only-cops --only)--except-cops[Specify a comma-separated cops list to skip checking for violations of the listed RuboCop cops]' \
     '--fix[Fix style violations automatically using RuboCop'\''s auto-correct feature]' \
     '--git[Run additional, slower style checks that navigate the Git repository]' \
     '--help[Show this message]' \
-    '(--all)--installed[Only check formulae and casks that are currently installed]' \
+    '(--eval-all)--installed[Only check formulae and casks that are currently installed]' \
     '--new[Run various additional style checks to determine if a new formula or cask is eligible for Homebrew. This should be used when creating new formulae or casks and implies `--strict` and `--online`]' \
     '--no-signing[Audit for app signatures, which are required by macOS on ARM]' \
     '--online[Run additional, slower style checks that require a network connection]' \
@@ -1179,7 +1179,7 @@ _brew_info() {
     '(--cask --json)--fetch-manifest[Fetch GitHub Packages manifest for extra information when formula is not installed]' \
     '--github[Open the GitHub source page for formula and cask in a browser. To view the history locally: `brew log -p` formula or cask]' \
     '--help[Show this message]' \
-    '(--eval-all --all)--installed[Print JSON of formulae that are currently installed]' \
+    '(--eval-all)--installed[Print JSON of formulae that are currently installed]' \
     '(--fetch-manifest)--json[Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew]' \
     '--quiet[Make some output more quiet]' \
     '--sizes[Show the size of installed formulae and casks]' \
@@ -1351,7 +1351,7 @@ _brew_lc() {
     '--newer-only[Show the latest version only if it'\''s newer than the current formula or cask version]' \
     '--quiet[Suppress warnings, don'\''t print a progress bar for JSON output]' \
     '--resources[Also check resources for formulae]' \
-    '(--eval-all --installed)--tap[Check formulae and casks within the given tap, specified as user`/`repo]' \
+    '(--installed --eval-all)--tap[Check formulae and casks within the given tap, specified as user`/`repo]' \
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask --extract-plist)--formula[Only check formulae]' \
@@ -1443,7 +1443,7 @@ _brew_livecheck() {
     '--newer-only[Show the latest version only if it'\''s newer than the current formula or cask version]' \
     '--quiet[Suppress warnings, don'\''t print a progress bar for JSON output]' \
     '--resources[Also check resources for formulae]' \
-    '(--eval-all --installed)--tap[Check formulae and casks within the given tap, specified as user`/`repo]' \
+    '(--installed --eval-all)--tap[Check formulae and casks within the given tap, specified as user`/`repo]' \
     '--verbose[Make some output more verbose]' \
     - formula \
     '(--cask --extract-plist)--formula[Only check formulae]' \
@@ -1565,12 +1565,12 @@ _brew_nodenv_sync() {
 # brew options
 _brew_options() {
   _arguments \
-    '(--installed --all)--command[Show options for the specified command]' \
+    '(--installed --eval-all)--command[Show options for the specified command]' \
     '--compact[Show all options on a single line separated by spaces]' \
     '--debug[Display any debugging information]' \
-    '--eval-all[Evaluate all available formulae and casks, whether installed or not, to show their options. Enabled by default if `$HOMEBREW_EVAL_ALL` is set]' \
+    '(--command --installed)--eval-all[Evaluate all available formulae and casks, whether installed or not, to show their options. Enabled by default if `$HOMEBREW_EVAL_ALL` is set]' \
     '--help[Show this message]' \
-    '(--all --command)--installed[Show options for formulae that are currently installed]' \
+    '(--command --eval-all)--installed[Show options for formulae that are currently installed]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \
     - formula \
@@ -2412,13 +2412,13 @@ _brew_uses() {
   _arguments \
     '(--formula)--cask[Include only casks]' \
     '--debug[Display any debugging information]' \
-    '--eval-all[Evaluate all available formulae and casks, whether installed or not, to show their dependents. Enabled by default if `$HOMEBREW_EVAL_ALL` is set]' \
+    '(--installed)--eval-all[Evaluate all available formulae and casks, whether installed or not, to show their dependents. Enabled by default if `$HOMEBREW_EVAL_ALL` is set]' \
     '--help[Show this message]' \
     '--include-build[Include formulae that specify formula as a `:build` dependency]' \
     '--include-implicit[Include formulae that have formula as an implicit dependency for downloading and unpacking source files]' \
     '--include-optional[Include formulae that specify formula as an `:optional` dependency]' \
     '--include-test[Include formulae that specify formula as a `:test` dependency]' \
-    '(--all --missing)--installed[Only list formulae and casks that are currently installed]' \
+    '(--eval-all --missing)--installed[Only list formulae and casks that are currently installed]' \
     '(--installed)--missing[Only list formulae and casks that are not currently installed]' \
     '--quiet[Make some output more quiet]' \
     '--recursive[Resolve more than one level of dependencies]' \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
- remove a depends_on to fix `HOMEBREW_NO_INSTALL_FROM_API= HOMEBREW_EVAL_ALL= brew search --desc searchterm`
- improve usage error for `brew options`
- update references to `--all` and drop non-essential `=` in conflicts lists