### PR TITLE
Allow head-only formulae in third party taps

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -749,7 +749,7 @@ module Homebrew
     end
 
     def audit_specs
-      problem "HEAD-only (no stable download)" if head_only?(formula)
+      problem "HEAD-only (no stable download)" if head_only?(formula) && @core_tap
 
       %w[Stable HEAD].each do |name|
         spec_name = name.downcase.to_sym


### PR DESCRIPTION
Third party taps should be allowed to have head-only formulae, so let's only check for this in homebrew/core.