### PR TITLE
Deep typecheck arrays in specs

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -9,7 +9,7 @@ module Homebrew
       #   1: long option name (e.g. "--debug")
       #   2: option description (e.g. "Print debugging information")
       #   3: whether the option is hidden
-      OptionsType = T.type_alias { T::Array[[String, T.nilable(String), String, T::Boolean]] }
+      OptionsType = T.type_alias { T::Array[[T.nilable(String), T.nilable(String), String, T::Boolean]] }
 
       sig { returns(T::Array[String]) }
       attr_reader :options_only, :flags_only, :remaining

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -78,7 +78,7 @@ class SystemCommand
   sig {
     params(
       executable:   T.any(String, Pathname),
-      args:         T::Array[T.any(String, Integer, Float, URI::Generic)],
+      args:         T::Array[T.any(String, Pathname, Integer, Float, URI::Generic)],
       sudo:         T::Boolean,
       sudo_as_root: T::Boolean,
       env:          T::Hash[String, String],

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DependencyCollector do
     end
 
     specify "requirement tags" do
-      collector.add xcode: :build
+      collector.add xcode: "build"
       expect(find_requirement(XcodeRequirement)).to be_a_build_requirement
     end
 

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
         old_spec = BottleSpecification.new
         old_spec.root_url("https://failbrew.bintray.com/bottles")
         new_hash = { "root_url" => "https://testbrew.bintray.com/bottles" }
-        expect(homebrew.merge_bottle_spec([:root_url], old_spec, new_hash)).to eq [
+        expect(homebrew.merge_bottle_spec(["root_url"], old_spec, new_hash)).to eq [
           ['root_url: old: "https://failbrew.bintray.com/bottles", new: "https://testbrew.bintray.com/bottles"'],
           [],
         ]
@@ -440,7 +440,7 @@ RSpec.describe Homebrew::DevCmd::Bottle do
         old_spec = BottleSpecification.new
         old_spec.rebuild(1)
         new_hash = { "rebuild" => 2 }
-        expect(homebrew.merge_bottle_spec([:rebuild], old_spec, new_hash)).to eq [
+        expect(homebrew.merge_bottle_spec(["rebuild"], old_spec, new_hash)).to eq [
           ['rebuild: old: "1", new: "2"'],
           [],
         ]

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -919,7 +919,7 @@ RSpec.describe Formula do
     f1 = formula "f1" do
       url "f1-1"
 
-      depends_on xcode: ["1.0", :optional]
+      depends_on xcode: ["1.0", "optional"]
     end
     stub_formula_loader(f1)
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -25,6 +25,19 @@ end
 require_relative "../standalone"
 require_relative "../warnings"
 
+module T::Types
+  class TypedArray < TypedEnumerable
+    def recursively_valid?(obj)
+      obj.is_a?(Array) && obj.all? { |e| type.recursively_valid?(e) } && super
+    end
+
+    # overrides Base
+    def valid?(obj)
+      obj.is_a?(Array) && obj.all? { |e| type.valid?(e) }
+    end
+  end
+end
+
 Warnings.ignore :parser_syntax do
   require "rubocop"
 end

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -86,7 +86,7 @@ module Utils
     sig {
       params(
         path:              T.any(String, Pathname),
-        replacement_pairs: T::Array[[T.any(Regexp, Pathname, String), T.any(Pathname, String)]],
+        replacement_pairs: T::Array[[T.any(NilClass, Regexp, Pathname, String), T.any(Pathname, String)]],
         read_only_run:     T::Boolean,
         silent:            T::Boolean,
       ).returns(String)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Just prototyping, curious what happens if we enable deep typechecking of Arrays (and potentially other containers) in specs. Comment if you think this is or isn't a valuable route to pursue further.