### PR TITLE
Use type-safe blocks

### DIFF
--- a/Library/Homebrew/bundle/commands/cleanup.rb
+++ b/Library/Homebrew/bundle/commands/cleanup.rb
@@ -183,7 +183,7 @@ module Homebrew
           require "bundle/tap_dumper"
 
           @dsl ||= Brewfile.read(global:, file:)
-          kept_formulae = self.kept_formulae(global:, file:).filter_map(&method(:lookup_formula))
+          kept_formulae = self.kept_formulae(global:, file:).filter_map { lookup_formula(_1) }
           kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
           kept_taps += kept_formulae.filter_map(&:tap).map(&:name)
           current_taps = Homebrew::Bundle::TapDumper.tap_names

--- a/Library/Homebrew/bundle/formula_dumper.rb
+++ b/Library/Homebrew/bundle/formula_dumper.rb
@@ -40,7 +40,7 @@ module Homebrew
         @formulae_by_full_name ||= {}
 
         if name.nil?
-          formulae = Formula.installed.map(&method(:add_formula))
+          formulae = Formula.installed.map { add_formula(_1) }
           sort!(formulae)
           return @formulae_by_full_name
         end

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -128,7 +128,7 @@ module Commands
     OFFICIAL_CMD_TAPS.flat_map do |tap_name, cmds|
       tap = Tap.fetch(tap_name)
       tap.install(quiet:) unless tap.installed?
-      cmds.map(&method(:external_ruby_v2_cmd_path)).compact
+      cmds.map { external_ruby_v2_cmd_path(_1) }.compact
     end
   end
 

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -83,7 +83,7 @@ class DescriptionCacheStore < CacheStore
   def delete_from_formula_names!(formula_names)
     return if database.empty?
 
-    formula_names.each(&method(:delete!))
+    formula_names.each { delete!(_1) }
   end
   alias delete_from_cask_tokens! delete_from_formula_names!
 

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -49,7 +49,7 @@ module Homebrew
       ruby_files = T.let([], T::Array[Pathname])
       shell_files = T.let([], T::Array[Pathname])
       actionlint_files = T.let([], T::Array[Pathname])
-      Array(files).map(&method(:Pathname))
+      Array(files).map { Pathname(_1) }
                   .each do |path|
         case path.extname
         when ".rb"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The `&method` style undergoes type erasure, is disallowed at `typed: strict`, and (IMO) isn't idiomatic ruby: https://sorbet.run/#%23%20typed%3A%20strict%0A%0Anumbers%20%3D%20%5B1%2C2%2C3%5D%0A%0AT.reveal_type%28numbers.map%20%7B%20String%28_1%29%20%7D%29%0AT.reveal_type%28numbers.map%28%26method%28%3AString%29%29%29