### PR TITLE
bump: use LivecheckVersion for comparison

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -399,7 +399,8 @@ module Homebrew
 
           newer_than_upstream[version_type] =
             (current_version_value = current_version.send(version_type)).is_a?(Version) &&
-            (current_version_value > new_version_value)
+            (Livecheck::LivecheckVersion.create(formula_or_cask, current_version_value) >
+              Livecheck::LivecheckVersion.create(formula_or_cask, new_version_value))
         end
 
         if !args.no_pull_requests? &&


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I recently modified `bump` to show the upstream version even when the formula/cask version is newer (instead of an opaque `Unable to get versions` error) but I noticed an issue while reviewing output from a recent autobump run in homebrew/cask. This change works as expected for versions with only one part (e.g., 1.2.3) but some multipart cask versions (e.g., 1.5,15039) aren't being handled like they should (where we split on commas and compare the version parts separately). As a result, a cask version like 1.5,15039 is incorrectly seen as newer than an upstream version like 1.5.1,15145 because 15039 from the cask version is being compared to 1 in the upstream version.

This addresses the issue by using `LivecheckVersion` objects in the related comparison, so versions will be handled as expected. This was an oversight on my part but it only affects one cask at the moment (`ia-presenter`), so it wasn't a widespread issue.