### PR TITLE
system_command: add missing `must_succeed`

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -112,6 +112,7 @@ class SystemCommand
       sudo_as_root: T::Boolean,
       env:          T::Hash[String, String],
       input:        T.any(String, T::Array[String]),
+      must_succeed: T::Boolean,
       print_stdout: T.any(T::Boolean, Symbol),
       print_stderr: T.any(T::Boolean, Symbol),
       debug:        T.nilable(T::Boolean),
@@ -122,9 +123,10 @@ class SystemCommand
       timeout:      T.nilable(T.any(Integer, Float)),
     ).returns(SystemCommand::Result)
   }
-  def self.run!(executable, args: [], sudo: false, sudo_as_root: false, env: {}, input: [], print_stdout: false,
-                print_stderr: true, debug: nil, verbose: nil, secrets: [], chdir: nil, reset_uid: false, timeout: nil)
-    run(executable, args:, sudo:, sudo_as_root:, env:, input:, must_succeed: true, print_stdout:, print_stderr:,
+  def self.run!(executable, args: [], sudo: false, sudo_as_root: false, env: {}, input: [], must_succeed: true,
+                print_stdout: false, print_stderr: true, debug: nil, verbose: nil, secrets: [], chdir: nil,
+                reset_uid: false, timeout: nil)
+    run(executable, args:, sudo:, sudo_as_root:, env:, input:, must_succeed:, print_stdout:, print_stderr:,
         debug:, verbose:, secrets:, chdir:, reset_uid:, timeout:)
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to https://github.com/Homebrew/brew/pull/20613 to add a missing `must_succeed` parameter.
Discovered in https://github.com/Homebrew/homebrew-cask/actions/runs/17564639258/job/49888905675?pr=227110#step:16:18

Resolves https://github.com/Homebrew/homebrew-cask/issues/227138