### PR TITLE
workflows/tests: fix tap-syntax caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Cache style cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
-          path: ~/.cache/Homebrew/style
+          path: ~/Library/Caches/Homebrew/style
           key: tap-syntax-style-cache-${{ github.sha }}
           restore-keys: tap-syntax-style-cache-
 


### PR DESCRIPTION
This path has been wrong ever since we split this from a Ubuntu runner and moved it to macOS.

This fix could make the job as much as 7-9 minutes faster (but only after this has merged and it's run on `main`).