### PR TITLE
Add additional `brew contributions` functionality.

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -208,8 +208,7 @@ module Homebrew
         if pull_request
           # This is a tap pull request and approving reviewers should also sign-off.
           tap = T.must(Tap.from_path(git_repo.pathname))
-          review_trailers = GitHub.approved_reviews(tap.user, tap.full_name.split("/").last,
-                                                    pull_request).map do |r|
+          review_trailers = GitHub.repository_approved_reviews(tap.user, tap.full_repository, pull_request).map do |r|
             "Signed-off-by: #{r["name"]} <#{r["email"]}>"
           end
           trailers = trailers.lines.concat(review_trailers).map(&:strip).uniq.join("\n")

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -23,6 +23,7 @@ DEPRECATED_OFFICIAL_TAPS = %w[
   devel-only
   dupes
   emacs
+  formula-analytics
   fuse
   games
   gui

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/contributions.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/contributions.rbi
@@ -17,6 +17,12 @@ class Homebrew::DevCmd::Contributions::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(String)) }
   def from; end
 
+  sig { returns(T.nilable(String)) }
+  def organisation; end
+
+  sig { returns(T.nilable(String)) }
+  def organization; end
+
   sig { returns(T.nilable(T::Array[String])) }
   def repositories; end
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -169,6 +169,12 @@ class Tap
   sig { returns(String) }
   attr_reader :repository
 
+  # The repository name of this {Tap} including the leading `homebrew-`.
+  #
+  # @api public
+  sig { returns(String) }
+  attr_reader :full_repository
+
   # The name of this {Tap}. It combines {#user} and {#repository} with a slash.
   # {#name} is always in lowercase.
   # e.g. `user/repository`
@@ -210,7 +216,8 @@ class Tap
     @user = user
     @repository = repository
     @name = T.let("#{@user}/#{@repository}".downcase, String)
-    @full_name = T.let("#{@user}/homebrew-#{@repository}", String)
+    @full_repository = T.let("homebrew-#{@repository}", String)
+    @full_name = T.let("#{@user}/#{@full_repository}", String)
     @path = T.let(HOMEBREW_TAP_DIRECTORY/@full_name.downcase, Pathname)
     @git_repository = T.let(GitRepository.new(@path), GitRepository)
   end

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -164,8 +164,8 @@ RSpec.describe Utils::Git do
   end
 
   describe "::ensure_installed!" do
-    it "returns nil if git already available" do
-      expect(described_class.ensure_installed!).to be_nil
+    it "doesn't fail if git already available" do
+      expect { described_class.ensure_installed! }.not_to raise_error
     end
 
     context "when git is not already available" do

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -10,6 +10,7 @@ module Utils
   module Git
     extend SystemCommand::Mixin
 
+    sig { returns(T::Boolean) }
     def self.available?
       version.present?
     end
@@ -21,6 +22,7 @@ module Utils
       @version = status.success? ? stdout.chomp[/git version (\d+(?:\.\d+)*)/, 1] : nil
     end
 
+    sig { returns(T.nilable(String)) }
     def self.path
       return unless available?
       return @path if defined?(@path)
@@ -28,24 +30,31 @@ module Utils
       @path = Utils.popen_read(git, "--homebrew=print-path").chomp.presence
     end
 
+    sig { returns(Pathname) }
     def self.git
       return @git if defined?(@git)
 
       @git = HOMEBREW_SHIMS_PATH/"shared/git"
     end
 
+    sig { params(url: String).returns(T::Boolean) }
     def self.remote_exists?(url)
       return true unless available?
 
       quiet_system "git", "ls-remote", url
     end
 
+    sig { void }
     def self.clear_available_cache
       remove_instance_variable(:@version) if defined?(@version)
       remove_instance_variable(:@path) if defined?(@path)
       remove_instance_variable(:@git) if defined?(@git)
     end
 
+    sig {
+      params(repo: T.any(Pathname, String), file: T.any(Pathname, String),
+             before_commit: T.nilable(String)).returns(String)
+    }
     def self.last_revision_commit_of_file(repo, file, before_commit: nil)
       args = if before_commit.nil?
         ["--skip=1"]
@@ -87,12 +96,14 @@ module Utils
       file_at_commit(repo, file, commit_hash)
     end
 
+    sig { params(repo: T.any(Pathname, String), file: T.any(Pathname, String), commit: String).returns(String) }
     def self.file_at_commit(repo, file, commit)
       relative_file = Pathname(file)
       relative_file = relative_file.relative_path_from(repo) if relative_file.absolute?
       Utils.popen_read(git, "-C", repo, "show", "#{commit}:#{relative_file}")
     end
 
+    sig { void }
     def self.ensure_installed!
       return if available?
 
@@ -135,6 +146,7 @@ module Utils
       ENV["GIT_COMMITTER_EMAIL"] = Homebrew::EnvConfig.git_committer_email
     end
 
+    sig { void }
     def self.setup_gpg!
       gnupg_bin = HOMEBREW_PREFIX/"opt/gnupg/bin"
       return unless gnupg_bin.directory?
@@ -145,21 +157,37 @@ module Utils
     # Special case of `git cherry-pick` that permits non-verbose output and
     # optional resolution on merge conflict.
     def self.cherry_pick!(repo, *args, resolve: false, verbose: false)
-      cmd = [git, "-C", repo, "cherry-pick"] + args
+      cmd = [git.to_s, "-C", repo, "cherry-pick"] + args
       output = Utils.popen_read(*cmd, err: :out)
       if $CHILD_STATUS.success?
         puts output if verbose
         output
       else
-        system git, "-C", repo, "cherry-pick", "--abort" unless resolve
+        system git.to_s, "-C", repo, "cherry-pick", "--abort" unless resolve
         raise ErrorDuringExecution.new(cmd, status: $CHILD_STATUS, output: [[:stdout, output]])
       end
     end
 
+    sig { returns(T::Boolean) }
     def self.supports_partial_clone_sparse_checkout?
       # There is some support for partial clones prior to 2.20, but we avoid using it
       # due to performance issues
       Version.new(version) >= Version.new("2.20.0")
+    end
+
+    sig {
+      params(repository_path: T.nilable(Pathname), person: String, from: T.nilable(String),
+             to: T.nilable(String)).returns(Integer)
+    }
+    def self.count_coauthors(repository_path, person, from:, to:)
+      return 0 if repository_path.blank?
+
+      cmd = [git.to_s, "-C", repository_path.to_s, "log", "--oneline"]
+      cmd << "--format='%(trailers:key=Co-authored-by:)''"
+      cmd << "--before=#{to}" if to
+      cmd << "--after=#{from}" if from
+
+      Utils.safe_popen_read(*cmd).lines.count { |l| l.include?(person) }
     end
   end
 end

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -68,17 +68,21 @@ module GitHub
     class RateLimitExceededError < Error
       sig { params(reset: Integer, github_message: String).void }
       def initialize(reset, github_message)
+        @reset = T.let(reset, Integer)
         new_pat_message = ", or:\n#{GitHub.pat_blurb}" if API.credentials.blank?
         message = <<~EOS
           GitHub API Error: #{github_message}
-          Try again in #{pretty_ratelimit_reset(reset)}#{new_pat_message}
+          Try again in #{pretty_ratelimit_reset}#{new_pat_message}
         EOS
         super(message, github_message)
       end
 
-      sig { params(reset: Integer).returns(String) }
-      def pretty_ratelimit_reset(reset)
-        pretty_duration(Time.at(reset) - Time.now)
+      sig { returns(Integer) }
+      attr_reader :reset
+
+      sig { returns(String) }
+      def pretty_ratelimit_reset
+        pretty_duration(Time.at(@reset) - Time.now)
       end
     end
 


### PR DESCRIPTION
- Add an `--organisation` flag to search a specific organisation.
- Wait for the GitHub API rate limit to reset before automatically retrying.
- Use (much) fewer API calls by using organisation-wide API PR searches rather than per-repository. This makes the rate limit easier to avoid and also makes things much faster (with the trade-off of showing a max PR count per-user rather than per-repository).
- Improve output to clarify when the max PR/commit count is reached.
- Move more logic and add more Sorbet signatures to the `GitHub` and `Utils::Git` modules.
- Rename a few GitHub API methods.
- Remove a lot of (now unused) `GitHub` module methods.
- Add, use a `Tap#full_repository` method.
- Add `formula-analytics` as a deprecated tap.