### PR TITLE
github: handle user opting out of github API in private_repo check

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -123,7 +123,7 @@ module GitHub
   sig { params(full_name: String).returns(T::Boolean) }
   def self.private_repo?(full_name)
     uri = url_to "repos", full_name
-    API.open_rest(uri) { |json| json["private"].nil? || json["private"] }
+    API.open_rest(uri) { |json| json.fetch("private", true) }
   end
 
   def self.search_query_string(*main_params, **qualifiers)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

Today we get a sorbet error when the user opts out, because `json` is
`{}`, so `json["private"]` is `nil`.

Given this function is used to check whether to send analytics, I assume
we should default to treating the repo as a private repo.

Refs: https://github.com/homebrew/brew/blob/8ef7a9dbd42cec14b745867b8c9ef4077074770e/Library/Homebrew/utils/github/api.rb#L276