### PR TITLE
Drop macOS Ventura CI in Homebrew/core

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -10,7 +10,7 @@ class GitHubRunnerMatrix
   # `git tag 15-sequoia f42c4a659e4da887fc714f8f41cc26794a4bb320`
   # to allow people to jump to specific commits based on their macOS version.
   NEWEST_HOMEBREW_CORE_MACOS_RUNNER = :sequoia
-  OLDEST_HOMEBREW_CORE_MACOS_RUNNER = :ventura
+  OLDEST_HOMEBREW_CORE_MACOS_RUNNER = :sonoma
   NEWEST_HOMEBREW_CORE_INTEL_MACOS_RUNNER = :sonoma
 
   RunnerSpec = T.type_alias { T.any(LinuxRunnerSpec, MacOSRunnerSpec) }


### PR DESCRIPTION
As discussed in Slack, we're ready to drop macOS Ventura from Homebrew/core CI. Once mass bottling progresses further, we'll add Tahoe as the newest.