### PR TITLE
deprecate_disable: add `unreachable` reason

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -28,6 +28,7 @@ module DeprecateDisable
     no_longer_meets_criteria: "no longer meets the criteria for acceptable casks",
     unmaintained:             "is not maintained upstream",
     fails_gatekeeper_check:   "does not pass the macOS Gatekeeper check",
+    unreachable:              "is no longer reliably reachable upstream",
     # odeprecate: remove the unsigned reason in a future release
     unsigned:                 "is unsigned or does not meet signature requirements",
   }.freeze, T::Hash[Symbol, String])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We don't currently have a good reason for deprecating/disabling casks where upstream is no long reliably reachable. We have an increasing number of casks we are running as syntax only because we can't reach them in CI. This PR adds such a reason so we can begin deprecating those.