### PR TITLE
feat: reinstall pkgconf automatically on macOS version mismatch

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -11,6 +11,7 @@ require "cleanup"
 require "description_cache_store"
 require "settings"
 require "linuxbrew-core-migration"
+require "reinstall"
 
 module Homebrew
   module Cmd
@@ -253,6 +254,8 @@ module Homebrew
         elsif !args.auto_update? && !ENV["HOMEBREW_UPDATE_FAILED"] && !ENV["HOMEBREW_MIGRATE_LINUXBREW_FORMULAE"]
           puts "Already up-to-date." unless args.quiet?
         end
+
+        Homebrew::Reinstall.reinstall_pkgconf_if_needed!
 
         Commands.rebuild_commands_completion_list
         link_completions_manpages_and_docs

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -9,6 +9,7 @@ require "cask/utils"
 require "cask/upgrade"
 require "cask/macos"
 require "api"
+require "reinstall"
 
 module Homebrew
   module Cmd
@@ -142,6 +143,8 @@ module Homebrew
         upgrade_outdated_casks!(casks) unless only_upgrade_formulae
 
         Cleanup.periodic_clean!(dry_run: args.dry_run?)
+
+        Homebrew::Reinstall.reinstall_pkgconf_if_needed!(dry_run: args.dry_run?)
 
         Homebrew.messages.display_messages(display_times: args.display_times?)
       end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "extend/os/mac/pkgconf"
+
 module OS
   module Mac
     module Diagnostic
@@ -542,39 +544,10 @@ module OS
 
         sig { returns(T.nilable(String)) }
         def check_pkgconf_macos_sdk_mismatch
-          # We don't provide suitable bottles for these versions.
-          return if OS::Mac.version.prerelease? || OS::Mac.version.outdated_release?
+          mismatch = Homebrew::Pkgconf.macos_sdk_mismatch
+          return unless mismatch
 
-          pkgconf = begin
-            ::Formula["pkgconf"]
-          rescue FormulaUnavailableError
-            nil
-          end
-          return unless pkgconf
-          return unless pkgconf.any_version_installed?
-
-          tab = Tab.for_formula(pkgconf)
-          return unless tab.built_on
-
-          built_on_version = tab.built_on["os_version"]
-                                &.delete_prefix("macOS ")
-                                &.sub(/\.\d+$/, "")
-          return unless built_on_version
-
-          current_version = MacOS.version.to_s
-          return if built_on_version == current_version
-
-          <<~EOS
-            You have pkgconf installed that was built on macOS #{built_on_version}
-                     but you are running macOS #{current_version}.
-
-            This can cause issues with packages that depend on system libraries, such as libffi.
-            To fix this issue, reinstall pkgconf:
-              brew reinstall pkgconf
-
-            For more information, see: https://github.com/Homebrew/brew/issues/16137
-            We'd welcome a PR to automatically mitigate this instead of just warning about it.
-          EOS
+          Homebrew::Pkgconf.mismatch_warning_message(mismatch)
         end
 
         sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/extend/os/mac/pkgconf.rb
+++ b/Library/Homebrew/extend/os/mac/pkgconf.rb
@@ -1,0 +1,48 @@
+# typed: strict
+# frozen_string_literal: true
+
+module Homebrew
+  module Pkgconf
+    module_function
+
+    sig { returns(T.nilable([String, String])) }
+    def macos_sdk_mismatch
+      # We don't provide suitable bottles for these versions.
+      return if OS::Mac.version.prerelease? || OS::Mac.version.outdated_release?
+
+      pkgconf = begin
+        ::Formula["pkgconf"]
+      rescue FormulaUnavailableError
+        nil
+      end
+      return unless pkgconf&.any_version_installed?
+
+      tab = Tab.for_formula(pkgconf)
+      return unless tab.built_on
+
+      built_on_version = tab.built_on["os_version"]
+                            &.delete_prefix("macOS ")
+                            &.sub(/\.\d+$/, "")
+      return unless built_on_version
+
+      current_version = MacOS.version.to_s
+      return if built_on_version == current_version
+
+      [built_on_version, current_version]
+    end
+
+    sig { params(mismatch: [String, String]).returns(String) }
+    def mismatch_warning_message(mismatch)
+      <<~EOS
+        You have pkgconf installed that was built on macOS #{mismatch[0]},
+                 but you are running macOS #{mismatch[1]}.
+
+        This can cause issues with packages that depend on system libraries, such as libffi.
+        To fix this issue, reinstall pkgconf:
+          brew reinstall pkgconf
+
+        For more information, see: https://github.com/Homebrew/brew/issues/16137
+      EOS
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/mac/reinstall.rb
+++ b/Library/Homebrew/extend/os/mac/reinstall.rb
@@ -1,0 +1,41 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "utils/output"
+
+module OS
+  module Mac
+    module Reinstall
+      module ClassMethods
+        extend T::Helpers
+        include ::Utils::Output::Mixin
+
+        requires_ancestor { ::Homebrew::Reinstall }
+
+        sig { params(dry_run: T::Boolean).void }
+        def reinstall_pkgconf_if_needed!(dry_run: false)
+          mismatch = Homebrew::Pkgconf.macos_sdk_mismatch
+          return unless mismatch
+
+          if dry_run
+            opoo "pkgconf would be reinstalled due to macOS version mismatch"
+            return
+          end
+
+          pkgconf = ::Formula["pkgconf"]
+
+          context = T.unsafe(self).build_install_context(pkgconf, flags: [])
+
+          begin
+            T.unsafe(self).reinstall_formula(context)
+            ohai "Reinstalled pkgconf due to macOS version mismatch"
+          rescue
+            ofail Homebrew::Pkgconf.mismatch_warning_message(mismatch)
+          end
+        end
+      end
+    end
+  end
+end
+
+Homebrew::Reinstall.singleton_class.prepend(OS::Mac::Reinstall::ClassMethods)

--- a/Library/Homebrew/extend/os/reinstall.rb
+++ b/Library/Homebrew/extend/os/reinstall.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/mac/reinstall" if OS.mac?

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -120,6 +120,11 @@ module Homebrew
         end
       end
 
+      sig { params(dry_run: T::Boolean).void }
+      def reinstall_pkgconf_if_needed!(dry_run: false)
+        nil
+      end
+
       private
 
       sig { params(keg: Keg).void }
@@ -154,3 +159,5 @@ module Homebrew
     end
   end
 end
+
+require "extend/os/reinstall"

--- a/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed_spec.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed_spec.rb
@@ -1,0 +1,81 @@
+# typed: false
+# frozen_string_literal: true
+
+require "reinstall"
+require "formula_installer"
+
+RSpec.shared_examples "reinstall_pkgconf_if_needed" do
+  context "when running on macOS", :needs_macos do
+    describe ".reinstall_pkgconf_if_needed!" do
+      let(:formula) { instance_double(Formula) }
+      let(:context) { instance_double(Homebrew::Reinstall::InstallationContext) }
+
+      before do
+        allow(OS).to receive(:mac?).and_return(true)
+        allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)
+        allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(context)
+      end
+
+      context "when there is no macOS SDK mismatch" do
+        it "does nothing" do
+          allow(Homebrew::Pkgconf).to receive(:macos_sdk_mismatch).and_return(nil)
+          expect(Homebrew::Reinstall).not_to receive(:reinstall_formula)
+
+          Homebrew::Reinstall.reinstall_pkgconf_if_needed!
+        end
+      end
+
+      context "when dry_run is true" do
+        it "prints a warning and does not reinstall" do
+          allow(Homebrew::Pkgconf).to receive_messages(
+            macos_sdk_mismatch:       %w[13 14],
+            mismatch_warning_message: "warning",
+          )
+          expect(Homebrew::Reinstall).not_to receive(:reinstall_formula)
+          expect(Homebrew::Reinstall).to receive(:opoo).with(/would be reinstalled/)
+
+          Homebrew::Reinstall.reinstall_pkgconf_if_needed!(dry_run: true)
+        end
+      end
+
+      context "when there is a mismatch and reinstall succeeds" do
+        it "reinstalls pkgconf and prints success" do
+          allow(Homebrew::Pkgconf).to receive(:macos_sdk_mismatch).and_return(%w[13 14])
+          expect(Homebrew::Reinstall).to receive(:reinstall_formula).with(context)
+          expect(Homebrew::Reinstall).to receive(:ohai).with(/Reinstalled pkgconf/)
+          allow(Homebrew::Reinstall).to receive(:restore_backup)
+
+          Homebrew::Reinstall.reinstall_pkgconf_if_needed!
+        end
+      end
+
+      context "when reinstall_formula raises an error" do
+        it "rescues and prints the mismatch warning" do
+          allow(Homebrew::Pkgconf).to receive_messages(
+            macos_sdk_mismatch:       %w[13 14],
+            mismatch_warning_message: "warning",
+          )
+          allow(Homebrew::Reinstall).to receive(:reinstall_formula).and_raise(RuntimeError)
+          allow(Homebrew::Reinstall).to receive(:restore_backup)
+          allow(Homebrew::Reinstall).to receive(:backup)
+
+          expect(Homebrew::Reinstall).to receive(:ofail).with("warning")
+
+          Homebrew::Reinstall.reinstall_pkgconf_if_needed!
+        end
+      end
+    end
+  end
+
+  context "when on a non-macOS platform" do
+    before do
+      allow(OS).to receive(:mac?).and_return(false)
+    end
+
+    it "does nothing and does not crash" do
+      expect(Homebrew::Reinstall).not_to receive(:reinstall_formula)
+
+      expect { Homebrew::Reinstall.reinstall_pkgconf_if_needed! }.not_to raise_error
+    end
+  end
+end

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -4,9 +4,12 @@ require "cmd/update-report"
 require "formula_versions"
 require "yaml"
 require "cmd/shared_examples/args_parse"
+require "cmd/shared_examples/reinstall_pkgconf_if_needed_spec"
 
 RSpec.describe Homebrew::Cmd::UpdateReport do
   it_behaves_like "parseable arguments"
+
+  it_behaves_like "reinstall_pkgconf_if_needed"
 
   describe Reporter do
     let(:tap) { CoreTap.instance }

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -2,6 +2,7 @@
 
 require "cmd/shared_examples/args_parse"
 require "cmd/upgrade"
+require "cmd/shared_examples/reinstall_pkgconf_if_needed_spec"
 
 RSpec.describe Homebrew::Cmd::UpgradeCmd do
   include FileUtils
@@ -52,4 +53,6 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
       .and be_a_failure
     expect(HOMEBREW_CELLAR/"testball/0.1").not_to exist
   end
+
+  it_behaves_like "reinstall_pkgconf_if_needed"
 end

--- a/Library/Homebrew/test/os/mac/reinstall_spec.rb
+++ b/Library/Homebrew/test/os/mac/reinstall_spec.rb
@@ -1,0 +1,63 @@
+# typed: false
+# frozen_string_literal: true
+
+require "reinstall"
+require "extend/os/mac/pkgconf"
+
+RSpec.describe Homebrew::Reinstall do
+  describe ".reinstall_pkgconf_if_needed!" do
+    let(:formula) { instance_double(Formula) }
+    let(:context) { instance_double(described_class::InstallationContext) }
+
+    before do
+      allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)
+      allow(described_class).to receive(:build_install_context).and_return(context)
+    end
+
+    context "when there is no macOS SDK mismatch" do
+      it "does nothing" do
+        allow(Homebrew::Pkgconf).to receive(:macos_sdk_mismatch).and_return(nil)
+        expect(described_class).not_to receive(:reinstall_formula)
+
+        described_class.reinstall_pkgconf_if_needed!
+      end
+    end
+
+    context "when dry_run is true" do
+      it "prints a warning and does not reinstall" do
+        allow(Homebrew::Pkgconf).to receive_messages(
+          macos_sdk_mismatch:       :mismatch,
+          mismatch_warning_message: "warning",
+        )
+        expect(described_class).not_to receive(:reinstall_formula)
+        expect(described_class).to receive(:opoo).with(/would be reinstalled/)
+
+        described_class.reinstall_pkgconf_if_needed!(dry_run: true)
+      end
+    end
+
+    context "when there is a mismatch and reinstall succeeds" do
+      it "reinstalls pkgconf and prints success" do
+        allow(Homebrew::Pkgconf).to receive(:macos_sdk_mismatch).and_return(:mismatch)
+        expect(described_class).to receive(:reinstall_formula).with(context)
+        expect(described_class).to receive(:ohai).with(/Reinstalled pkgconf/)
+
+        described_class.reinstall_pkgconf_if_needed!
+      end
+    end
+
+    context "when reinstall_formula raises an error" do
+      it "rescues and prints the mismatch warning" do
+        allow(Homebrew::Pkgconf).to receive_messages(
+          macos_sdk_mismatch:       :mismatch,
+          mismatch_warning_message: "warning",
+        )
+        allow(described_class).to receive(:reinstall_formula).and_raise(RuntimeError)
+
+        expect(described_class).to receive(:ofail).with("warning")
+
+        described_class.reinstall_pkgconf_if_needed!
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [ x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ x ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ x ] Have you successfully run `brew style` with your changes locally?
- [ x ] Have you successfully run `brew typecheck` with your changes locally?
- [ x ] Have you successfully run `brew tests` with your changes locally?
  
-----  
  
This PR follows up on #20418 by implementing the automatic mitigation requested in the source code comment. It ~~changes the `pkgconf` macOS SDK mismatch diagnostic from a passive warning to~~ adds an active repair attempt.  
  
~~The diagnostic check~~ `update-report` and `upgrade` now perform the following steps:  
1.  Detects if `pkgconf` was built on a different version of macOS.  
2.  If a mismatch is found, it informs the user and automatically attempts to run `brew reinstall pkgconf`.  
3.  If the automatic reinstall fails, it reports the error and provides the manual command as a fallback.  
  
This provides a better user experience by solving the issue directly for the underlying problem noted in issue #16137.  