### PR TITLE
formula_installer: optlink even with cask installed

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1156,17 +1156,6 @@ on_request: installed_on_request?, options:)
   def link(keg)
     Formula.clear_cache
 
-    unless link_keg
-      begin
-        keg.optlink(verbose: verbose?, overwrite: overwrite?)
-      rescue Keg::LinkError => e
-        ofail "Failed to create #{formula.opt_prefix}"
-        puts "Things that depend on #{formula.full_name} will probably not build."
-        puts e
-      end
-      return
-    end
-
     cask_installed_with_formula_name = begin
       Cask::CaskLoader.load(formula.name, warn: false).installed?
     rescue Cask::CaskUnavailableError, Cask::CaskInvalidError
@@ -1175,6 +1164,17 @@ on_request: installed_on_request?, options:)
 
     if cask_installed_with_formula_name
       ohai "#{formula.name} cask is installed, skipping link."
+      @link_keg = false
+    end
+
+    unless link_keg
+      begin
+        keg.optlink(verbose: verbose?, overwrite: overwrite?)
+      rescue Keg::LinkError => e
+        ofail "Failed to create #{formula.opt_prefix}"
+        puts "Things that depend on #{formula.full_name} will probably not build."
+        puts e
+      end
       return
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes Homebrew/homebrew-core#236514

Run cask check earlier so that we can create an optlink.

Before:
```console
❯ brew install --quiet cmake cmake-app
==> Fetching downloads for: cmake-app
✔︎ Cask cmake-app (4.1.1)
==> Installing Cask cmake-app
==> Moving App 'CMake.app' to '/Applications/CMake.app'
==> Linking ...

==> Fetching downloads for: cmake
✔︎ Bottle Manifest cmake (4.1.1)
✔︎ Bottle cmake (4.1.1)
==> Pouring cmake--4.1.1.arm64_tahoe.bottle.tar.gz
==> cmake cask is installed, skipping link.
🍺  /opt/homebrew/Cellar/cmake/4.1.1: 3,913 files, 58.1MB

❯ brew outdated
cmake (4.1.1) < 4.1.1

❯ realpath $(which cmake)
/Applications/CMake.app/Contents/bin/cmake

❯ $(brew --prefix cmake)/bin/cmake --version
zsh: no such file or directory: /opt/homebrew/opt/cmake/bin/cmake
```

After:
```console
❯ brew install --quiet cmake cmake-app
==> Fetching downloads for: cmake-app
✔︎ Cask cmake-app (4.1.1)
==> Installing Cask cmake-app
==> Moving App 'CMake.app' to '/Applications/CMake.app'
==> Linking ...

==> Fetching downloads for: cmake
✔︎ Bottle Manifest cmake (4.1.1)
✔︎ Bottle cmake (4.1.1)
==> Pouring cmake--4.1.1.arm64_tahoe.bottle.tar.gz
==> cmake cask is installed, skipping link.
🍺  /opt/homebrew/Cellar/cmake/4.1.1: 3,913 files, 58.1MB

❯ brew outdated

❯ realpath $(which cmake)
/Applications/CMake.app/Contents/bin/cmake

❯ $(brew --prefix cmake)/bin/cmake --version
cmake version 4.1.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```