### PR TITLE
global brewfile location defaults to user conf dir

### DIFF
--- a/Library/Homebrew/bundle/brewfile.rb
+++ b/Library/Homebrew/bundle/brewfile.rb
@@ -24,12 +24,16 @@ module Homebrew
           else
             raise "'HOMEBREW_BUNDLE_FILE' cannot be specified with '--global'" if env_bundle_file.present?
 
-            if user_config_home && File.exist?("#{user_config_home}/Brewfile")
-              "#{user_config_home}/Brewfile"
+            home_brewfile = Bundle.exchange_uid_if_needed! do
+              "#{Dir.home}/.Brewfile"
+            end
+            user_config_home_brewfile = "#{user_config_home}/Brewfile"
+
+            if user_config_home.present? && Dir.exist?(user_config_home) && \
+               (File.exist?(user_config_home_brewfile) || !File.exist?(home_brewfile))
+              user_config_home_brewfile
             else
-              Bundle.exchange_uid_if_needed! do
-                "#{Dir.home}/.Brewfile"
-              end
+              home_brewfile
             end
           end
         elsif file.present?

--- a/Library/Homebrew/test/bundle/brewfile_spec.rb
+++ b/Library/Homebrew/test/bundle/brewfile_spec.rb
@@ -13,9 +13,12 @@ RSpec.describe Homebrew::Bundle::Brewfile do
     let(:env_bundle_file_global_value) { nil }
     let(:env_bundle_file_value) { nil }
     let(:env_user_config_home_value) { "/Users/username/.homebrew" }
+    let(:env_home_value) { "/Users/username" }
     let(:file_value) { nil }
     let(:has_global) { false }
+    let(:config_dir_exist) { false }
     let(:config_dir_brewfile_exist) { false }
+    let(:home_dir_brewfile_exist) { false }
 
     before do
       allow(ENV).to receive(:fetch).and_return(nil)
@@ -28,6 +31,11 @@ RSpec.describe Homebrew::Bundle::Brewfile do
                                    .and_return(env_user_config_home_value)
       allow(File).to receive(:exist?).with("/Users/username/.homebrew/Brewfile")
                                      .and_return(config_dir_brewfile_exist)
+      allow(File).to receive(:exist?).with("/Users/username/.Brewfile")
+                                     .and_return(home_dir_brewfile_exist)
+      allow(Dir).to receive(:home).and_return(env_home_value)
+      allow(Dir).to receive(:exist?).with("/Users/username/.homebrew")
+                                    .and_return(config_dir_exist)
     end
 
     context "when `file` is specified with a relative path" do
@@ -165,7 +173,28 @@ RSpec.describe Homebrew::Bundle::Brewfile do
 
       context "when HOMEBREW_USER_CONFIG_HOME/Brewfile exists" do
         let(:config_dir_brewfile_exist) { true }
+        let(:config_dir_exist) { true }
+        let(:home_dir_brewfile_exist) { true }
         let(:expected_pathname) { Pathname.new("#{env_user_config_home_value}/Brewfile") }
+
+        it "returns the expected path" do
+          expect(path).to eq(expected_pathname)
+        end
+      end
+
+      context "when empty HOMEBREW_USER_CONFIG_HOME exists, and .Brewfile does not" do
+        let(:config_dir_exist) { true }
+        let(:expected_pathname) { Pathname.new("#{env_user_config_home_value}/Brewfile") }
+
+        it "returns the expected path" do
+          expect(path).to eq(expected_pathname)
+        end
+      end
+
+      context "when empty HOMEBREW_USER_CONFIG_HOME and .Brewfile exist" do
+        let(:config_dir_exist) { true }
+        let(:home_dir_brewfile_exist) { true }
+        let(:expected_pathname) { Pathname.new("#{env_home_value}/.Brewfile") }
 
         it "returns the expected path" do
           expect(path).to eq(expected_pathname)


### PR DESCRIPTION
If dir $HOMEBREW_USER_CONFIG_HOME exists, place global Brewfile there,
unless ~/.Brewfile already exists AND $HOMEBREW_USER_CONFIG_HOME/Brewfile
does not.

This resolves #20628. This intentionally requires the user to have created `~/.config/homebrew`, and assumes that user intent is _not_ to use it for the Brewfile dump if it's not there. The reason being, is that I'm assuming we don't want to create `~/.homebrew/` for the user if it does not exist (when XDG_CONFIG_HOME is unset), and we should ideally treat HOMEBREW_USER_CONFIG_HOME the same no matter how it was populated.

Another alternative would be to semi-deprecate `~/.Brewfile`: use it if it's there, but never create it.

(See also https://github.com/Homebrew/homebrew-bundle/pull/1549, where I created this bug. There was some discussion about this issue there, and the current behavior was settled on as the option that changed existing behavior the least.)

Closes https://github.com/Homebrew/brew/pull/20658