### PR TITLE
cmd/update-report: fix formula description display

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -974,7 +974,11 @@ class ReporterHub
       # Skip non-homebrew/core formulae for security.
       return if formula.include?("/")
 
-      Formula[formula].desc&.presence
+      begin
+        Formula[formula].desc&.presence
+      rescue FormulaUnavailableError
+        nil
+      end
     else
       all_formula_json.find { |f| f["name"] == formula }
                       &.fetch("desc", nil)

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -992,7 +992,11 @@ class ReporterHub
       # Skip non-homebrew/cask formulae for security.
       return if cask.include?("/")
 
-      Cask::CaskLoader.load(cask).desc&.presence
+      begin
+        Cask::CaskLoader.load(cask).desc&.presence
+      rescue Cask::CaskError
+        nil
+      end
     else
       all_cask_json.find { |f| f["token"] == cask }
                    &.fetch("desc", nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When on a non-default branch (for e.g., testing), `Formula[formula]` can return an error. In that case let's silently ignore it.
