### PR TITLE
utils/github: fix type error for `pull_request`

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -654,7 +654,7 @@ module GitHub
     end
   end
 
-  sig { params(tap_remote_repo: String, pull_request: String).returns(T::Array[T.untyped]) }
+  sig { params(tap_remote_repo: String, pull_request: T.any(String, Integer)).returns(T::Array[T.untyped]) }
   def self.get_pull_request_changed_files(tap_remote_repo, pull_request)
     files = []
     API.paginate_rest(url_to("repos", tap_remote_repo, "pulls", pull_request, "files")) do |result|


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Autobump is hitting a [type error here](https://github.com/Homebrew/homebrew-core/actions/runs/17699361095/job/50302958620#step:6:5848):

```
Error: Parameter 'pull_request': Expected type String, got type Integer with value 237183
```
