### PR TITLE
rubocops/components_order: skip fails_with inside on_system

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -125,7 +125,8 @@ module RuboCop
         end
 
         def check_on_system_block_content(component_precedence_list, on_system_block)
-          if on_system_block.body.block_type? && !on_system_methods.include?(on_system_block.body.method_name)
+          if on_system_block.body.block_type? && !on_system_methods.include?(on_system_block.body.method_name) &&
+             on_system_block.body.method_name != :fails_with
             offending_node(on_system_block)
             problem "Nest `#{on_system_block.method_name}` blocks inside `#{on_system_block.body.method_name}` " \
                     "blocks when there is only one inner block." do |corrector|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Seen in https://github.com/Homebrew/homebrew-core/pull/241981/files#r2347675278

Prior to change, when trying:
```ruby
on_intel do
  fails_with :gcc do
    version "11"
    cause "reason"
  end
end
```

`brew audit` outputs:
```
Nest `on_intel` blocks inside `fails_with` blocks when there is only one inner block.
```

Changing to:
```ruby
fails_with :gcc do
  on_intel do
    version "11"
    cause "reason"
  end
end
```

`brew audit` outputs:
```
undefined method 'on_intel' for an instance of CompilerFailure
```

---

With PR change, the former now works.