### PR TITLE
extend/os/mac/reinstall: fix pkgconf reinstall

### DIFF
--- a/Library/Homebrew/extend/os/mac/reinstall.rb
+++ b/Library/Homebrew/extend/os/mac/reinstall.rb
@@ -1,6 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "install"
 require "utils/output"
 
 module OS
@@ -27,6 +28,7 @@ module OS
           context = T.unsafe(self).build_install_context(pkgconf, flags: [])
 
           begin
+            Homebrew::Install.fetch_formulae([context.formula_installer])
             T.unsafe(self).reinstall_formula(context)
             ohai "Reinstalled pkgconf due to macOS version mismatch"
           rescue

--- a/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed_spec.rb
+++ b/Library/Homebrew/test/cmd/shared_examples/reinstall_pkgconf_if_needed_spec.rb
@@ -8,11 +8,15 @@ RSpec.shared_examples "reinstall_pkgconf_if_needed" do
   context "when running on macOS", :needs_macos do
     describe ".reinstall_pkgconf_if_needed!" do
       let(:formula) { instance_double(Formula) }
-      let(:context) { instance_double(Homebrew::Reinstall::InstallationContext) }
+      let(:formula_installer) do
+        instance_double(FormulaInstaller, formula:, prelude_fetch: true, prelude: true, fetch: true)
+      end
+      let(:context) { instance_double(Homebrew::Reinstall::InstallationContext, formula_installer:) }
 
       before do
         allow(OS).to receive(:mac?).and_return(true)
         allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)
+        allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer])
         allow(Homebrew::Reinstall).to receive(:build_install_context).and_return(context)
       end
 

--- a/Library/Homebrew/test/os/mac/reinstall_spec.rb
+++ b/Library/Homebrew/test/os/mac/reinstall_spec.rb
@@ -7,10 +7,14 @@ require "extend/os/mac/pkgconf"
 RSpec.describe Homebrew::Reinstall do
   describe ".reinstall_pkgconf_if_needed!" do
     let(:formula) { instance_double(Formula) }
-    let(:context) { instance_double(described_class::InstallationContext) }
+    let(:formula_installer) do
+      instance_double(FormulaInstaller, formula:, prelude_fetch: true, prelude: true, fetch: true)
+    end
+    let(:context) { instance_double(described_class::InstallationContext, formula_installer:) }
 
     before do
       allow(Formula).to receive(:[]).with("pkgconf").and_return(formula)
+      allow(Homebrew::Install).to receive(:fetch_formulae).with([formula_installer])
       allow(described_class).to receive(:build_install_context).and_return(context)
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Before:

    $ rm `brew --cache`/downloads/*pkgconf*
    $ gsed -Ei 's/macOS [[:digit:]]+/macOS 14/g' `brew --prefix pkgconf`/INSTALL_RECEIPT.json
    $ brew up
    ==> Updating Homebrew...
    Already up-to-date.
    Error: wrong number of arguments (given 2, expected 0)
    Warning: Removed Sorbet lines from backtrace!
    Rerun with `--verbose` to see the original backtrace
    /opt/homebrew/Library/Homebrew/reinstall.rb:67:in 'BasicObject#initialize'
    /opt/homebrew/Library/Homebrew/reinstall.rb:67:in 'Class#new'
    /opt/homebrew/Library/Homebrew/reinstall.rb:67:in 'Homebrew::Reinstall.build_install_context'
    /opt/homebrew/Library/Homebrew/extend/os/mac/reinstall.rb:27:in 'OS::Mac::Reinstall::ClassMethods#reinstall_pkgconf_if_needed!'
    /opt/homebrew/Library/Homebrew/cmd/update-report.rb:258:in 'Homebrew::Cmd::UpdateReport#output_update_report'
    /opt/homebrew/Library/Homebrew/cmd/update-report.rb:34:in 'Homebrew::Cmd::UpdateReport#run'
    /opt/homebrew/Library/Homebrew/brew.rb:101:in '<main>'
    Please report this issue:
      https://docs.brew.sh/Troubleshooting

There are two problems here:
1. We don't require `formula_installer` in `reinstall.rb`, and it isn't required indirectly anywhere else, so `FormulaInstaller` is undefined.
2. We don't fetch the `pkgconf` bottle before trying to reinstall it, so the reinstall fails because the bottle isn't available.

We fix 2. by fetching the formula before attempting to reinstall it. Then, at the same time, by sourcing `install`, we also fix 1.

After:

    $ brew up
    ==> Updating Homebrew...
    Already up-to-date.
    ==> Fetching downloads for: pkgconf
    ✔︎ Bottle Manifest pkgconf (2.5.1)
    ==> Verifying attestation for pkgconf
    ✔︎ Bottle pkgconf (2.5.1)
    ==> Reinstalling pkgconf
    ==> Pouring pkgconf--2.5.1.arm64_tahoe.bottle.tar.gz
    🍺  /opt/homebrew/Cellar/pkgconf/2.5.1: 28 files, 519.8KB
    ==> Reinstalled pkgconf due to macOS version mismatch
