### PR TITLE
extend/pathname: fix signature of `install_metafiles`

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -351,7 +351,7 @@ class Pathname
     EOS
   end
 
-  sig { params(from: Pathname).void }
+  sig { params(from: T.any(String, Pathname)).void }
   def install_metafiles(from = Pathname.pwd)
     require "metafiles"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There is usage of passing a `String` in e.g., https://github.com/Homebrew/homebrew-core/blob/138a870412d2c96c3c0c998ba1e1cdfcb01db3b5/Formula/r/reaver.rb#L33.
