### PR TITLE
Add --force switch for contributions command

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -52,6 +52,8 @@ module Homebrew
                description: "Date (ISO 8601 format) to stop searching contributions."
         switch "--csv",
                description: "Print a CSV of contributions across repositories over the time period."
+        switch "--force",
+               description: "Force the installation of missing taps."
         conflicts "--organisation", "--repositories"
         conflicts "--organisation", "--team"
         conflicts "--user", "--team"
@@ -234,7 +236,7 @@ module Homebrew
           repository_path, tap = repository_path_and_tap(repository)
           if repository_path && tap && !repository_path.exist?
             opoo "Repository #{repository} not yet tapped! Tapping it now..."
-            tap.install
+            tap.install(force: args.force?)
           end
 
           repository_full_name = tap&.full_name

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/contributions.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/contributions.rbi
@@ -14,6 +14,9 @@ class Homebrew::DevCmd::Contributions::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def csv?; end
 
+  sig { returns(T::Boolean) }
+  def force?; end
+
   sig { returns(T.nilable(String)) }
   def from; end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Resolves a misleading `brew contributions` error:
```
$ brew contributions
Warning: Repository Homebrew/homebrew-core not yet tapped! Tapping it now...
Error: Tapping homebrew/core is no longer typically necessary.
Add --force if you are sure you need it for contributing to Homebrew.
exit 1
```
However, the command did not support `--force`, which this PR introduces.