### PR TITLE
cask/audit: always run min_os audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -768,7 +768,6 @@ module Cask
     sig { void }
     def audit_min_os
       return unless online?
-      return unless strict?
 
       odebug "Auditing minimum macOS version"
 
@@ -811,8 +810,7 @@ module Cask
       end
       source = T.must(bundle_min_os.to_s <=> sparkle_min_os.to_s).positive? ? "Artifact" : "Upstream"
       add_error "#{source} defined #{app_min_os.to_sym.inspect} as the minimum macOS version " \
-                "but the cask declared #{min_os_definition}",
-                strict_only: true
+                "but the cask declared #{min_os_definition}"
     end
 
     sig { returns(T.nilable(MacOSVersion)) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change remove the `--strict` guard for the audit that checks Cask application bundles for the minimum macOS version.

CC: @krehel 