### PR TITLE
cmd/update-report: fix an "unsupported key" error

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -816,7 +816,7 @@ class ReporterHub
 
   sig { params(key: Symbol).returns(T::Array[String]) }
   def select_formula_or_cask(key)
-    raise "Unsupported key #{key}" unless [:A, :AC, :D, :DC, :M, :MC].include?(key)
+    raise "Unsupported key #{key}" unless [:A, :AC, :D, :DC, :M, :MC, :R, :RC].include?(key)
 
     T.cast(@hash.fetch(key, []), T::Array[String])
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes the following error:

```console
$ brew update
==> Updating Homebrew...
==> Updated Homebrew from 1a11875c52 to d7feec4910.
Updated 1 tap (homebrew/core).
Error: Unsupported key R
```

Call site is at:

https://github.com/Homebrew/brew/blob/318ef1c43a098f75ded159d010f37ca9aab6bb7c/Library/Homebrew/description_cache_store.rb#L51
