### PR TITLE
test/github_runner_matrix: prevent dropping supported macOS versions from CI

### DIFF
--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
     setup_test_runner_formula("testball-depender-newest", ["testball", { macos: symbol }])
   end
 
+  describe "OLDEST_HOMEBREW_CORE_MACOS_RUNNER" do
+    it "is not newer than HOMEBREW_MACOS_OLDEST_SUPPORTED" do
+      oldest_macos_runner = MacOSVersion.from_symbol(described_class::OLDEST_HOMEBREW_CORE_MACOS_RUNNER)
+      expect(oldest_macos_runner).to be <= HOMEBREW_MACOS_OLDEST_SUPPORTED
+    end
+  end
+
   describe "#active_runner_specs_hash" do
     it "returns an object that responds to `#to_json`" do
       expect(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We should bump `HOMEBREW_MACOS_OLDEST_SUPPORTED` first and make sure
that bump goes out into a release tag before dropping CI in
Homebrew/core. Otherwise, we end up with users getting errors about
missing bottles. See, for example, Homebrew/homebrew-core#240857.

We've made it very hard for users on OS versions newer than
`HOMEBREW_MACOS_OLDEST_SUPPORTED` to *not* use bottles (because only
bottles are supported), but that design assumes we have been building
bottles for them. We should therefore make sure that users we stop
building bottles for are always on a version older than
`HOMEBREW_MACOS_OLDEST_SUPPORTED`.
