### PR TITLE
dev-cmd/contributions: fix zero nil check.

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -124,7 +124,7 @@ module Homebrew
           greater_than_total = T.let(false, T::Boolean)
           contributions = CONTRIBUTION_TYPES.keys.filter_map do |type|
             type_count = grand_totals[username][type]
-            next if type_count.zero?
+            next if type_count.nil? || type_count.zero?
 
             count_prefix = ""
             if (search_types.include?(type) && type_count == MAX_PR_SEARCH) ||


### PR DESCRIPTION
This seems to be able to be `nil` in some cases.