### PR TITLE
utils/curl: respect `retries: 0` if explicitly provided

### DIFF
--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -401,13 +401,13 @@ RSpec.describe "Utils::Curl" do
       expect(curl_args(*args).join(" ")).to include("--retry 10")
     end
 
-    it "uses `--retry` when `:retries` is a positive Integer" do
+    it "uses `--retry` when `:retries` is a non-negative Integer" do
       expect(curl_args(*args, retries: 5).join(" ")).to include("--retry 5")
+      expect(curl_args(*args, retries: 0).join(" ")).to include("--retry 0")
     end
 
-    it "doesn't use `--retry` when `:retries` is nil or a non-positive Integer" do
+    it "doesn't use `--retry` when `:retries` is nil or a negative Integer" do
       expect(curl_args(*args, retries: nil).join(" ")).not_to include("--retry")
-      expect(curl_args(*args, retries: 0).join(" ")).not_to include("--retry")
       expect(curl_args(*args, retries: -1).join(" ")).not_to include("--retry")
     end
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -136,8 +136,8 @@ module Utils
       args << "--connect-timeout" << connect_timeout.round(3) if connect_timeout.present?
       args << "--max-time" << max_time.round(3) if max_time.present?
 
-      # A non-positive integer (e.g. 0) or `nil` will omit this argument
-      args << "--retry" << retries if retries&.positive?
+      # A negative integer or `nil` will omit this argument
+      args << "--retry" << retries if retries.present? && !retries.negative?
 
       args << "--retry-max-time" << retry_max_time.round if retry_max_time.present?
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR explicitly add `--retry 0` if `retries: 0` is provided. Previously, if `retries: 0` is provided, there will be no `--retry 0` in `curl_args`.

According to `man curl`:

> Setting the number to 0 makes curl do no retries (which is the default).
> 
> ```txt
> --retry <num>
>       If a transient error is returned when curl tries to perform a transfer, it retries this number of times before giving up. Setting the number to 0 makes curl
>       do no retries (which is the default). Transient error means either: a timeout, an FTP 4xx response code or an HTTP 408, 429, 500, 502, 503 or 504 response
>       code.
> 
>       When curl is about to retry a transfer, it first waits one second and then for all forthcoming retries it doubles the waiting time until it reaches 10
>       minutes, which then remains the set fixed delay time between the rest of the retries. By using --retry-delay you disable this exponential backoff algorithm.
>       See also --retry-max-time to limit the total time allowed for retries.
> 
>       curl complies with the Retry-After: response header if one was present to know when to issue the next retry (added in 7.66.0).
> 
>       If --retry is provided several times, the last set value is used.
> 
>       Example:
>       curl --retry 7 https://example.com
> 
>       See also --retry-max-time.
> ```


The default behavior if no options are given is to do no retries. But I tested it locally, and the default is not respected.