### PR TITLE
Load casks from internal API

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -315,6 +315,15 @@ module Homebrew
       end
     end
 
+    sig { returns(Pathname) }
+    def self.cached_formula_json_file_path
+      if Homebrew::EnvConfig.use_internal_api?
+        Homebrew::API::Internal.cached_formula_json_file_path
+      else
+        Homebrew::API::Formula.cached_json_file_path
+      end
+    end
+
     sig { returns(T::Array[String]) }
     def self.cask_tokens
       if Homebrew::EnvConfig.use_internal_api?
@@ -339,6 +348,15 @@ module Homebrew
         Homebrew::API::Internal.cask_tap_migrations
       else
         Homebrew::API::Cask.tap_migrations
+      end
+    end
+
+    sig { returns(Pathname) }
+    def self.cached_cask_json_file_path
+      if Homebrew::EnvConfig.use_internal_api?
+        Homebrew::API::Internal.cached_cask_json_file_path
+      else
+        Homebrew::API::Cask.cached_json_file_path
       end
     end
   end

--- a/Library/Homebrew/api/internal.rb
+++ b/Library/Homebrew/api/internal.rb
@@ -55,6 +55,16 @@ module Homebrew
         stub
       end
 
+      sig { returns(Pathname) }
+      def self.cached_formula_json_file_path
+        HOMEBREW_CACHE_API/formula_endpoint
+      end
+
+      sig { returns(Pathname) }
+      def self.cached_cask_json_file_path
+        HOMEBREW_CACHE_API/cask_endpoint
+      end
+
       sig {
         params(download_queue: T.nilable(Homebrew::DownloadQueue), stale_seconds: T.nilable(Integer))
           .returns([T::Hash[String, T.untyped], T::Boolean])


### PR DESCRIPTION
Now that we have a sharded `/api/internal/cask.PLATFORM.json` file, let's use that when `HOMEBREW_USE_INTERNAL_API` is set.

For now, there are no content differences between the internal and non-internal API files, so this is a very basic change.
