### PR TITLE
cask/dsl: add some Sorbet types.

### DIFF
--- a/Library/Homebrew/cask/dsl/base.rb
+++ b/Library/Homebrew/cask/dsl/base.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/utils"
@@ -10,20 +10,23 @@ module Cask
     class Base
       extend Forwardable
 
+      sig { params(cask: Cask, command: T.class_of(SystemCommand)).void }
       def initialize(cask, command = SystemCommand)
-        @cask = cask
-        @command = command
+        @cask = T.let(cask, Cask)
+        @command = T.let(command, T.class_of(SystemCommand))
       end
 
       def_delegators :@cask, :token, :version, :caskroom_path, :staged_path, :appdir, :language, :arch
 
+      sig { params(executable: String, options: T.untyped).returns(T.nilable(SystemCommand::Result)) }
       def system_command(executable, **options)
         @command.run!(executable, **options)
       end
 
       # No need to define it as it's the default/superclass implementation.
       # rubocop:disable Style/MissingRespondToMissing
-      def method_missing(method, *)
+      sig { params(method: T.nilable(Symbol), args: T.untyped).returns(T.nilable(Object)) }
+      def method_missing(method, *args)
         if method
           underscored_class = T.must(self.class.name).gsub(/([[:lower:]])([[:upper:]][[:lower:]])/, '\1_\2').downcase
           section = underscored_class.split("::").last

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -13,11 +13,12 @@ module Cask
     # to the output by the caller, but that feature is only for the
     # convenience of cask authors.
     class Caveats < Base
+      sig { params(args: T.anything).void }
       def initialize(*args)
         super
-        @built_in_caveats = {}
-        @custom_caveats = []
-        @discontinued = false
+        @built_in_caveats = T.let({}, T::Hash[Symbol, String])
+        @custom_caveats = T.let([], T::Array[String])
+        @discontinued = T.let(false, T::Boolean)
       end
 
       def self.caveat(name, &block)
@@ -40,11 +41,13 @@ module Cask
       end
 
       # Override `puts` to collect caveats.
+      sig { params(args: String).returns(Symbol) }
       def puts(*args)
         @custom_caveats += args
         :built_in_caveat
       end
 
+      sig { params(block: T.proc.returns(T.nilable(T.any(Symbol, String)))).void }
       def eval_caveats(&block)
         result = instance_eval(&block)
         return unless result


### PR DESCRIPTION
Make `cask/dsl/base` `typed: strict` and add some signatures to `cask/dsl/caveats`.