### PR TITLE
Fix attestation check timing with concurrent downloads

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -108,6 +108,11 @@ module Homebrew
                 puts (" " * downloadable.download_queue_type.size) + " SHA-256 checksum of downloaded file: #{actual}"
                 Homebrew.failed = true if downloadable.is_a?(Resource::Patch)
                 next 2
+              elsif exception.is_a?(CannotInstallFormulaError)
+                if (cached_download = downloadable.cached_download)&.exist?
+                  cached_download.unlink
+                end
+                raise exception
               else
                 message = future.reason.to_s
                 ofail message
@@ -151,7 +156,7 @@ module Homebrew
               end
 
               sleep 0.05
-            rescue Interrupt
+            rescue
               remaining_downloads.each do |_, future|
                 # FIXME: Implement cancellation of running downloads.
               end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -25,6 +25,7 @@ require "attestation"
 require "sbom"
 require "utils/fork"
 require "utils/output"
+require "utils/attestation"
 
 # Installer for a formula.
 class FormulaInstaller
@@ -1447,7 +1448,7 @@ on_request: installed_on_request?, options:)
     oh1 "Fetching #{Formatter.identifier(formula.full_name)}".strip unless download_queue
 
     downloadable_object = downloadable
-    should_check_attestation = if pour_bottle?(output_warning: true)
+    check_attestation = if pour_bottle?(output_warning: true)
       fetch_bottle_tab
 
       !downloadable_object.cached_download.exist?
@@ -1470,16 +1471,18 @@ on_request: installed_on_request?, options:)
     # to explicitly `brew install gh` without already having a version for bootstrapping.
     # We also skip bottle installs from local bottle paths, as these are done in CI
     # as part of the build lifecycle before attestations are produced.
-    should_check_attestation &&= Homebrew::Attestation.enabled? &&
-                                 formula.tap&.core_tap? &&
-                                 formula.name != "gh"
+    check_attestation &&= Homebrew::Attestation.enabled? &&
+                          (formula.tap&.core_tap? || false) &&
+                          formula.name != "gh"
     if (download_queue = self.download_queue)
       # Check attestation after download completes.
-      callback = proc { check_attestation(downloadable_object, quiet: true) } if should_check_attestation
-      download_queue.enqueue(downloadable_object, callback:)
+      download_queue.enqueue(downloadable_object, check_attestation:)
     else
       downloadable_object.fetch
-      check_attestation(downloadable_object) if should_check_attestation
+      if check_attestation
+        bottle = T.cast(downloadable_object, Bottle)
+        Utils::Attestation.check_attestation(bottle, quiet: @quiet)
+      end
     end
 
     self.class.fetched << formula
@@ -1748,67 +1751,6 @@ on_request: installed_on_request?, options:)
     return if @requirement_messages.empty?
 
     $stderr.puts @requirement_messages
-  end
-
-  sig { params(downloadable_object: Downloadable, quiet: T::Boolean).void }
-  def check_attestation(downloadable_object, quiet: false)
-    ohai "Verifying attestation for #{formula.name}" unless quiet
-    begin
-      Homebrew::Attestation.check_core_attestation T.cast(downloadable_object, Bottle)
-    rescue Homebrew::Attestation::GhIncompatible
-      # A small but significant number of users have developer mode enabled
-      # but *also* haven't upgraded in a long time, meaning that their `gh`
-      # version is too old to perform attestations.
-      raise CannotInstallFormulaError, <<~EOS
-        The bottle for #{formula.name} could not be verified.
-
-        This typically indicates an outdated or incompatible `gh` CLI.
-
-        Please confirm that you're running the latest version of `gh`
-        by performing an upgrade before retrying:
-
-          brew update
-          brew upgrade gh
-      EOS
-    rescue Homebrew::Attestation::GhAuthInvalid
-      # Only raise an error if we explicitly opted-in to verification.
-      raise CannotInstallFormulaError, <<~EOS if Homebrew::EnvConfig.verify_attestations?
-        The bottle for #{formula.name} could not be verified.
-
-        This typically indicates an invalid GitHub API token.
-
-        If you have `$HOMEBREW_GITHUB_API_TOKEN` set, check it is correct
-        or unset it and instead run:
-
-          gh auth login
-      EOS
-
-      # If we didn't explicitly opt-in, then quietly opt-out in the case of invalid credentials.
-      # Based on user reports, a significant number of users are running with stale tokens.
-      ENV["HOMEBREW_NO_VERIFY_ATTESTATIONS"] = "1"
-    rescue Homebrew::Attestation::GhAuthNeeded
-      raise CannotInstallFormulaError, <<~EOS
-        The bottle for #{formula.name} could not be verified.
-
-        This typically indicates a missing GitHub API token, which you
-        can resolve either by setting `$HOMEBREW_GITHUB_API_TOKEN` or
-        by running:
-
-          gh auth login
-      EOS
-    rescue Homebrew::Attestation::MissingAttestationError, Homebrew::Attestation::InvalidAttestationError => e
-      raise CannotInstallFormulaError, <<~EOS
-        The bottle for #{formula.name} has an invalid build provenance attestation.
-
-        This may indicate that the bottle was not produced by the expected
-        tap, or was maliciously inserted into the expected tap's bottle
-        storage.
-
-        Additional context:
-
-        #{e}
-      EOS
-    end
   end
 end
 

--- a/Library/Homebrew/utils/attestation.rb
+++ b/Library/Homebrew/utils/attestation.rb
@@ -1,0 +1,73 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "attestation"
+require "bottle"
+require "utils/output"
+
+module Utils
+  module Attestation
+    extend Utils::Output::Mixin
+
+    sig { params(bottle: Bottle, quiet: T::Boolean).void }
+    def self.check_attestation(bottle, quiet: false)
+      ohai "Verifying attestation for #{bottle.name}" unless quiet
+      begin
+        Homebrew::Attestation.check_core_attestation bottle
+      rescue Homebrew::Attestation::GhIncompatible
+        # A small but significant number of users have developer mode enabled
+        # but *also* haven't upgraded in a long time, meaning that their `gh`
+        # version is too old to perform attestations.
+        raise CannotInstallFormulaError, <<~EOS
+          The bottle for #{bottle.name} could not be verified.
+
+          This typically indicates an outdated or incompatible `gh` CLI.
+
+          Please confirm that you're running the latest version of `gh`
+          by performing an upgrade before retrying:
+
+            brew update
+            brew upgrade gh
+        EOS
+      rescue Homebrew::Attestation::GhAuthInvalid
+        # Only raise an error if we explicitly opted-in to verification.
+        raise CannotInstallFormulaError, <<~EOS if Homebrew::EnvConfig.verify_attestations?
+          The bottle for #{bottle.name} could not be verified.
+
+          This typically indicates an invalid GitHub API token.
+
+          If you have `$HOMEBREW_GITHUB_API_TOKEN` set, check it is correct
+          or unset it and instead run:
+
+            gh auth login
+        EOS
+
+        # If we didn't explicitly opt-in, then quietly opt-out in the case of invalid credentials.
+        # Based on user reports, a significant number of users are running with stale tokens.
+        ENV["HOMEBREW_NO_VERIFY_ATTESTATIONS"] = "1"
+      rescue Homebrew::Attestation::GhAuthNeeded
+        raise CannotInstallFormulaError, <<~EOS
+          The bottle for #{bottle.name} could not be verified.
+
+          This typically indicates a missing GitHub API token, which you
+          can resolve either by setting `$HOMEBREW_GITHUB_API_TOKEN` or
+          by running:
+
+            gh auth login
+        EOS
+      rescue Homebrew::Attestation::MissingAttestationError, Homebrew::Attestation::InvalidAttestationError => e
+        raise CannotInstallFormulaError, <<~EOS
+          The bottle for #{bottle.name} has an invalid build provenance attestation.
+
+          This may indicate that the bottle was not produced by the expected
+          tap, or was maliciously inserted into the expected tap's bottle
+          storage.
+
+          Additional context:
+
+          #{e}
+        EOS
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When both attestation check and concurrent download are enabled, attestation verification incorrectly starts right after the download is enqueued, rather than after the download completes. This sometimes leads to attestation verification failure. (It does not happen every time because attestation verification is slow compared to downloads, and it has a retry mechanism.)

Fix the issue by allowing `DownloadQueue#enqueue` to accept an optional callback that runs after the download future resolves, and then moving attestation verification into the callback. With that, attestation verification now correctly waits for download completion, whether using concurrent downloads or not.

By fixing the timing, we also have one extra substantial benefit: the existing enqueue-then-verify logic makes attestation verification sequential, but with the callback approach, we can now verify attestation in parallel when we have concurrent downloads.

A notable change is that we no longer print the "verifying attestation" message with concurrent downloads, because the message messes up the concurrent download progress display. But, so is the case with the existing logic: see the example below, where the download progress only gets displayed after all attestations have been verified. A suggested future improvement is to make attestation a separate item in the download queue, so that it can have its own progress display. That is left as an exercise for the reader (or possibly future me).

Fixes:

```console
$ brew install llvm
==> Fetching downloads for: llvm
✔︎ Bottle Manifest llvm (21.1.1)
==> Verifying attestation for mpdecimal
==> Verifying attestation for ca-certificates
==> Verifying attestation for openssl@3
==> Verifying attestation for ncurses
==> Verifying attestation for readline
==> Verifying attestation for zlib
==> Verifying attestation for sqlite
==> Verifying attestation for xz
==> Verifying attestation for bzip2
==> Verifying attestation for expat
==> Verifying attestation for libedit
==> Verifying attestation for libffi
==> Verifying attestation for unzip
==> Verifying attestation for berkeley-db@5
==> Verifying attestation for python@3.13
Warning: Failed to verify attestation. Retrying in 1s...
==> Verifying attestation for z3
Warning: Failed to verify attestation. Retrying in 1s...
Warning: Failed to verify attestation. Retrying in 3s...
==> Verifying attestation for lz4
==> Verifying attestation for zstd
==> Verifying attestation for binutils
Warning: Failed to verify attestation. Retrying in 1s...
==> Verifying attestation for elfutils
==> Verifying attestation for llvm
Warning: Failed to verify attestation. Retrying in 1s...
Warning: Failed to verify attestation. Retrying in 3s...
Warning: Failed to verify attestation. Retrying in 9s...
Warning: Failed to verify attestation. Retrying in 27s...
✔︎ Bottle Manifest mpdecimal (4.0.1)
✔︎ Bottle mpdecimal (4.0.1)
✔︎ Bottle Manifest ca-certificates (2025-09-09)
✔︎ Bottle ca-certificates (2025-09-09)
✔︎ Bottle Manifest openssl@3 (3.5.2)
✔︎ Bottle openssl@3 (3.5.2)
✔︎ Bottle Manifest ncurses (6.5)
✔︎ Bottle ncurses (6.5)
✔︎ Bottle Manifest readline (8.3.1)
✔︎ Bottle readline (8.3.1)
✔︎ Bottle Manifest zlib (1.3.1)
✔︎ Bottle zlib (1.3.1)
✔︎ Bottle Manifest sqlite (3.50.4)
✔︎ Bottle sqlite (3.50.4)
✔︎ Bottle Manifest xz (5.8.1)
✔︎ Bottle xz (5.8.1)
✔︎ Bottle Manifest bzip2 (1.0.8)
✔︎ Bottle bzip2 (1.0.8)
✔︎ Bottle Manifest expat (2.7.2)
✔︎ Bottle expat (2.7.2)
✔︎ Bottle Manifest libedit (20250104-3.1)
✔︎ Bottle libedit (20250104-3.1)
✔︎ Bottle Manifest libffi (3.5.2)
✔︎ Bottle libffi (3.5.2)
✔︎ Bottle Manifest unzip (6.0_8)
✔︎ Bottle unzip (6.0_8)
✔︎ Bottle Manifest berkeley-db@5 (5.3.28_1)
✔︎ Bottle berkeley-db@5 (5.3.28_1)
✔︎ Bottle Manifest python@3.13 (3.13.7)
✔︎ Bottle python@3.13 (3.13.7)
✔︎ Bottle Manifest z3 (4.15.3)
✔︎ Bottle z3 (4.15.3)
✔︎ Bottle Manifest lz4 (1.10.0)
✔︎ Bottle lz4 (1.10.0)
✔︎ Bottle Manifest zstd (1.5.7)
✔︎ Bottle zstd (1.5.7)
✔︎ Bottle Manifest binutils (2.45)
✔︎ Bottle binutils (2.45)
✔︎ Bottle Manifest elfutils (0.193)
✔︎ Bottle elfutils (0.193)
✔︎ Bottle llvm (21.1.1)
```
