### PR TITLE
deprecate_disable: beginning to phase out Quick Look plugins

### DIFF
--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -28,6 +28,7 @@ module DeprecateDisable
     no_longer_meets_criteria: "no longer meets the criteria for acceptable casks",
     unmaintained:             "is not maintained upstream",
     fails_gatekeeper_check:   "does not pass the macOS Gatekeeper check",
+    old_quick_look_plugin:    "is using the old Quick Look framework that is no longer supported by macOS",
     unreachable:              "is no longer reliably reachable upstream",
     # odeprecate: remove the unsigned reason in a future release
     unsigned:                 "is unsigned or does not meet signature requirements",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Old-style Quick Look plugins (those with a `.qlgenerator` extension) were [deprecated](https://developer.apple.com/documentation/quicklook/previews-or-thumbnail-images-for-macos-10-14-or-earlier) since Catalina, and Apple decided to [remove support](https://eclecticlight.co/2024/10/31/how-sequoia-has-changed-quicklook-and-its-thumbnails/) for them last year since Sequoia. This means that the [38 casks](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+qlgenerator&type=code) with `qlplugin` artifacts will no longer work on Sequoia and newer systems. Given that Sonoma support will likely be dropped from the CI next year, this means that shortly after macOS 27's release, these casks will no longer work on any Tier 1 configuration.

Most of the casks mentioned are not updated for several years at this point. Newer QL plugins will utilize the [Quick Look Thumbnailing Extension](https://developer.apple.com/documentation/QuickLookThumbnailing) and appear directly as a normal `.app`, for example [QLVideo](https://github.com/Homebrew/homebrew-cask/blob/main/Casks/q/qlvideo.rb).

Therefore, this PR tries to add a reason in preparation for their deprecation.