### PR TITLE
workflows/pkg-installer: restore Intel testing

### DIFF
--- a/.github/workflows/pkg-installer.yml
+++ b/.github/workflows/pkg-installer.yml
@@ -152,8 +152,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
-            name: macos-14-arm64
+          # Intel
+          - runner: macos-15-intel
+            name: macos-15-x86_64
+          # Apple Silicon
+          - runner: macos-15
+            name: macos-15-arm64
           - runner: macos-26
             name: macos-26-arm64
     steps:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
GitHub has [released](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#what-you-need-to-do) standard macOS 15 Intel runners. This will be the [final](https://github.com/actions/runner-images/issues/13045) macOS Intel runner released for GitHub Actions, and will take us through end of support.