### PR TITLE
Update `executables.txt` in `brew update` when needed

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -641,9 +641,15 @@ EOS
   safe_cd "${HOMEBREW_REPOSITORY}"
 
   # This means a migration is needed but hasn't completed (yet).
-  if [[ "$(git config homebrew.linuxbrewmigrated 2>/dev/null)" == "false" ]]
+  if [[ "$(git config get --type=bool homebrew.linuxbrewmigrated 2>/dev/null)" == "false" ]]
   then
     export HOMEBREW_MIGRATE_LINUXBREW_FORMULAE=1
+  fi
+
+  # This means the user has run `brew which-formula` before and we should fetch executables.txt
+  if [[ "$(git config get --type=bool homebrew.commandnotfound 2>/dev/null)" == "true" ]]
+  then
+    export HOMEBREW_FETCH_EXECUTABLES_TXT=1
   fi
 
   # if an older system had a newer curl installed, change each repo's remote URL from git to https
@@ -957,6 +963,12 @@ EOS
     then
       echo "HOMEBREW_NO_INSTALL_FROM_API set: skipping API JSON downloads."
     fi
+  fi
+
+  # Update executables.txt if the user has ever run `brew which-formula` before.
+  if [[ -n "${HOMEBREW_FETCH_EXECUTABLES_TXT}" ]]
+  then
+    fetch_api_file "internal/executables.txt" "${update_failed_file}"
   fi
 
   if [[ -f "${update_failed_file}" ]]

--- a/Library/Homebrew/cmd/which-formula.rb
+++ b/Library/Homebrew/cmd/which-formula.rb
@@ -60,6 +60,8 @@ module Homebrew
 
         Utils::Curl.curl_download(*args, url, to: DATABASE_FILE)
         FileUtils.touch(DATABASE_FILE, mtime: Time.now)
+
+        Settings.write :commandnotfound, true
       end
 
       sig { params(cmd: String).returns(T::Array[String]) }

--- a/Library/Homebrew/command-not-found/handler.fish
+++ b/Library/Homebrew/command-not-found/handler.fish
@@ -6,7 +6,7 @@ function fish_command_not_found
     set -l txt
 
     if not contains -- "$cmd" "-h" "--help" "--usage" "-?"
-        set txt (brew which-formula --explain $cmd 2> /dev/null)
+        set txt (brew which-formula --skip-update --explain $cmd 2> /dev/null)
     end
 
     if test -z "$txt"

--- a/Library/Homebrew/command-not-found/handler.sh
+++ b/Library/Homebrew/command-not-found/handler.sh
@@ -37,7 +37,7 @@ homebrew_command_not_found_handle() {
   if [[ "${cmd}" != "-h" ]] && [[ "${cmd}" != "--help" ]] && [[ "${cmd}" != "--usage" ]] && [[ "${cmd}" != "-?" ]]
   then
     local txt
-    txt="$(brew which-formula --explain "${cmd}" 2>/dev/null)"
+    txt="$(brew which-formula --skip-update --explain "${cmd}" 2>/dev/null)"
   fi
 
   if [[ -z "${txt}" ]]


### PR DESCRIPTION
Now that `which-formula` lives in this repo, we should fetch `executables.txt` on `brew update` invocations. When a user runs `brew which-formula` for the first time, a setting is saved indicating that `executables.txt` should be downloaded on future `brew update` calls. If a user does not run `brew which-formula`, the file will not be fetched.

To make this easier, I've extracted the API file fetch logic to a helper function in `update.sh`. You can view that change in isolation in [`1f042a3` (#20739)](https://github.com/Homebrew/brew/pull/20739/commits/1f042a3a69b3d02e337dc14837e77f6ba064c7f4).

I've also added `--skip-update` to the shell handlers that call `which-formula` so no new files will be downloaded if a user types the wrong command in their shell.
