### PR TITLE
command-not-found-init: match fish init behavior to *sh

### DIFF
--- a/Library/Homebrew/cmd/command-not-found-init.rb
+++ b/Library/Homebrew/cmd/command-not-found-init.rb
@@ -41,7 +41,7 @@ module Homebrew
         when :bash, :zsh
           puts File.read(File.expand_path("#{File.dirname(__FILE__)}/../command-not-found/handler.sh"))
         when :fish
-          puts File.expand_path("#{File.dirname(__FILE__)}/../command-not-found/handler.fish")
+          puts File.read(File.expand_path("#{File.dirname(__FILE__)}/../command-not-found/handler.fish"))
         else
           raise "Unsupported shell type #{shell}"
         end

--- a/Library/Homebrew/command-not-found/handler.fish
+++ b/Library/Homebrew/command-not-found/handler.fish
@@ -1,3 +1,4 @@
+# See https://docs.brew.sh/Command-Not-Found for current setup instructions
 # License: MIT
 # The license text can be found in Library/Homebrew/command-not-found/LICENSE
 


### PR DESCRIPTION
Addresses #20740.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
