### PR TITLE
download_queue: restore `Interrupt` handling

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -156,7 +156,9 @@ module Homebrew
               end
 
               sleep 0.05
-            rescue
+            # We want to catch all exceptions to ensure we can cancel any
+            # running downloads and flush the TTY.
+            rescue Exception # rubocop:disable Lint/RescueException
               remaining_downloads.each do |_, future|
                 # FIXME: Implement cancellation of running downloads.
               end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

178580ac95cf74ce21bb5059951a33e73fe6e1f9 changed `rescue Interrupt` to plain `rescue` but this actually excludes `Interrupt` exceptions, which means that pressing Ctrl-C during a download would leave the terminal in a broken state. To see the problem, one can try e.g. `brew fetch --deps qt` and then press Ctrl-C immediately once the downloads start.
