### PR TITLE
Revert "Use installed keg formula files when referencing installed formulae/dependencies"

### DIFF
--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -32,7 +32,7 @@ class CaskDependent
 
   sig { returns(T::Array[Dependency]) }
   def runtime_dependencies
-    deps.flat_map { |dep| [dep, *dep.to_installed_formula.runtime_dependencies] }.uniq
+    deps.flat_map { |dep| [dep, *dep.to_formula.runtime_dependencies] }.uniq
   end
 
   sig { returns(T::Array[Dependency]) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -722,7 +722,7 @@ module Homebrew
       # Remove formulae listed in HOMEBREW_NO_CLEANUP_FORMULAE and their dependencies.
       if Homebrew::EnvConfig.no_cleanup_formulae.present?
         formulae -= formulae.select { skip_clean_formula?(_1) }
-                            .flat_map { |f| [f, *f.installed_runtime_formula_dependencies] }
+                            .flat_map { |f| [f, *f.runtime_formula_dependencies] }
       end
       casks = Cask::Caskroom.casks
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -229,6 +229,7 @@ module Homebrew
               dep_names = CaskDependent.new(cask)
                                        .runtime_dependencies
                                        .reject(&:installed?)
+                                       .map(&:to_formula)
                                        .map(&:name)
               next if dep_names.blank?
 

--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -24,9 +24,9 @@ module Homebrew
 
       sig { override.void }
       def run
-        leaves_list = Formula.installed - Formula.installed.flat_map(&:installed_runtime_formula_dependencies)
+        leaves_list = Formula.installed - Formula.installed.flat_map(&:runtime_formula_dependencies)
         casks_runtime_dependencies = Cask::Caskroom.casks.flat_map do |cask|
-          CaskDependent.new(cask).runtime_dependencies.map(&:to_installed_formula)
+          CaskDependent.new(cask).runtime_dependencies.map(&:to_formula)
         end
         leaves_list -= casks_runtime_dependencies
         leaves_list.select! { installed_on_request?(_1) } if args.installed_on_request?

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -101,7 +101,7 @@ module Homebrew
                 # There is a newer HEAD but the version number has not changed.
                 "latest HEAD"
               else
-                f.latest_formula.pkg_version.to_s
+                f.pkg_version.to_s
               end
 
               outdated_versions = outdated_kegs.group_by { |keg| Formulary.from_keg(keg).full_name }

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -141,7 +141,7 @@ module Homebrew
             end
             Migrator.migrate_if_needed(formula, force: args.force?)
             Homebrew::Reinstall.build_install_context(
-              formula.latest_formula,
+              formula,
               flags:                      args.flags_only,
               force_bottle:               args.force_bottle?,
               build_from_source_formulae: args.build_from_source_formulae,

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -36,14 +36,8 @@ class Dependency
     [name, tags].hash
   end
 
-  def to_installed_formula
-    formula = Formulary.resolve(name)
-    formula.build = BuildOptions.new(options, formula.options)
-    formula
-  end
-
-  def to_formula
-    formula = Formulary.factory(name, warn: false)
+  def to_formula(prefer_stub: false)
+    formula = Formulary.factory(name, warn: false, prefer_stub:)
     formula.build = BuildOptions.new(options, formula.options)
     formula
   end
@@ -51,7 +45,7 @@ class Dependency
   sig { params(minimum_version: T.nilable(Version), minimum_revision: T.nilable(Integer)).returns(T::Boolean) }
   def installed?(minimum_version: nil, minimum_revision: nil)
     formula = begin
-      to_installed_formula
+      to_formula(prefer_stub: true)
     rescue FormulaUnavailableError
       nil
     end
@@ -92,7 +86,7 @@ class Dependency
   end
 
   def missing_options(inherited_options)
-    formula = to_installed_formula
+    formula = to_formula(prefer_stub: true)
     required = options
     required |= inherited_options
     required &= formula.options.to_a

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -21,7 +21,7 @@ module Homebrew
 
     sig {
       params(formulae: T::Array[Formula], hide: T::Array[String], _block: T.nilable(
-        T.proc.params(formula_name: String, missing_dependencies: T::Array[Dependency]).void,
+        T.proc.params(formula_name: String, missing_dependencies: T::Array[Formula]).void,
       )).returns(T::Hash[String, T::Array[String]])
     }
     def self.missing_deps(formulae, hide = [], &_block)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -936,15 +936,9 @@ module Formulary
     def self.try_new(ref, from: nil, warn: false)
       ref = ref.to_s
 
-      keg_directory = HOMEBREW_PREFIX/"opt/#{ref}"
-      return unless keg_directory.directory?
+      return unless (keg_formula = HOMEBREW_PREFIX/"opt/#{ref}/.brew/#{ref}.rb").file?
 
-      # The formula file in `.brew` will use the canonical name, whereas `ref` can be an alias.
-      # Use `Keg#name` to get the canonical name.
-      keg = Keg.new(keg_directory)
-      return unless (keg_formula = HOMEBREW_PREFIX/"opt/#{ref}/.brew/#{keg.name}.rb").file?
-
-      new(keg.name, keg_formula, tap: keg.tab.tap)
+      new(ref, keg_formula)
     end
   end
 
@@ -1060,12 +1054,7 @@ module Formulary
 
     sig { overridable.params(flags: T::Array[String]).void }
     def load_from_api(flags:)
-      json_formula = if Homebrew::EnvConfig.use_internal_api?
-        Homebrew::API::Formula.formula_json(name)
-      else
-        Homebrew::API::Formula.all_formulae[name]
-      end
-
+      json_formula = Homebrew::API::Formula.all_formulae[name]
       raise FormulaUnavailableError, name if json_formula.nil?
 
       Formulary.load_formula_from_json!(name, json_formula, flags:)
@@ -1234,16 +1223,7 @@ module Formulary
       flags:,
     }.compact
 
-    loader = FromKegLoader.try_new(keg.name, warn: false)
-    f = if loader.present?
-      begin
-        loader.get_formula(spec, alias_path:, force_bottle:, flags:, ignore_errors: true)
-      rescue FormulaUnreadableError
-        nil
-      end
-    end
-
-    f ||= if tap.nil?
+    f = if tap.nil?
       factory(formula_name, spec, **options)
     else
       begin

--- a/Library/Homebrew/installed_dependents.rb
+++ b/Library/Homebrew/installed_dependents.rb
@@ -44,10 +44,10 @@ module InstalledDependents
     dependents_to_check.each do |dependent|
       required = case dependent
       when Formula
-        dependent.missing_dependencies(hide: keg_names).map(&:to_installed_formula)
+        dependent.missing_dependencies(hide: keg_names)
       when Cask::Cask
         # When checking for cask dependents, we don't care about missing or non-runtime dependencies
-        CaskDependent.new(dependent).runtime_dependencies.map(&:to_installed_formula)
+        CaskDependent.new(dependent).runtime_dependencies.map(&:to_formula)
       end
 
       required_kegs = required.filter_map do |f|

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -20,8 +20,9 @@ RSpec.describe Homebrew::Cmd::Leaves do
 
   context "when there are only installed Formulae without dependencies", :integration_test do
     it "prints all installed Formulae" do
-      setup_test_formula "foo", tab_attributes: { installed_on_request: true }
+      setup_test_formula "foo"
       setup_test_formula "bar"
+      (HOMEBREW_CELLAR/"foo/0.1/somedir").mkpath
 
       expect { brew "leaves" }
         .to output("foo\n").to_stdout

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -875,8 +875,6 @@ RSpec.describe Formula do
 
       expect(f3.runtime_dependencies.map(&:name)).to eq(["baz/qux/f2"])
 
-      described_class.clear_cache
-
       f1_path = Tap.fetch("foo", "bar").path/"Formula/f1.rb"
       stub_formula_loader(formula("f1", path: f1_path) { url("f1-1.0") }, "foo/bar/f1")
 
@@ -962,7 +960,6 @@ RSpec.describe Formula do
         sha256 cellar: :any, Utils::Bottles.tag.to_sym => TEST_SHA256
       end
     end
-    stub_formula_loader(f1)
 
     h = f1.to_hash
 
@@ -1273,8 +1270,6 @@ RSpec.describe Formula do
     let(:alias_path) { CoreTap.instance.alias_dir/alias_name }
 
     before do
-      stub_formula_loader(f)
-      stub_formula_loader(new_formula)
       allow(described_class).to receive(:installed).and_return([f])
 
       f.build = tab
@@ -1366,12 +1361,6 @@ RSpec.describe Formula do
 
     let(:alias_name) { "bar" }
     let(:alias_path) { f.tap.alias_dir/alias_name }
-
-    before do
-      stub_formula_loader(f)
-      stub_formula_loader(old_formula)
-      stub_formula_loader(new_formula)
-    end
 
     def setup_tab_for_prefix(prefix, options = {})
       prefix.mkpath

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -21,9 +21,6 @@ RSpec.describe Migrator do
 
   before do |example|
     allow(new_formula).to receive(:oldnames).and_return(["oldname"])
-    allow(Formulary).to receive(:factory).with("homebrew/core/oldname", any_args).and_return(old_formula)
-    allow(Formulary).to receive(:factory).with("oldname", any_args).and_return(old_formula)
-    allow(Formulary).to receive(:factory).with("newname", any_args).and_return(new_formula)
 
     # do not create directories for error tests
     next if example.metadata[:description].start_with?("raises an error")

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -15,7 +15,7 @@ module Test
       def stub_formula_loader(formula, ref = formula.full_name, call_original: false)
         allow(Formulary).to receive(:loader_for).and_call_original if call_original
 
-        loader = instance_double(Formulary::FormulaLoader, get_formula: formula, name: formula.name)
+        loader = instance_double(Formulary::FormulaLoader, get_formula: formula)
         allow(Formulary).to receive(:loader_for).with(ref, any_args).and_return(loader)
       end
     end

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -43,20 +43,20 @@ RSpec.describe Utils::Autoremove do
 
     before do
       allow(formula_with_deps).to receive_messages(
-        installed_runtime_formula_dependencies: [first_formula_dep, second_formula_dep],
-        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
+        runtime_formula_dependencies: [first_formula_dep, second_formula_dep],
+        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
       )
       allow(first_formula_dep).to receive_messages(
-        installed_runtime_formula_dependencies: [second_formula_dep],
-        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
+        runtime_formula_dependencies: [second_formula_dep],
+        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
       )
       allow(second_formula_dep).to receive_messages(
-        installed_runtime_formula_dependencies: [],
-        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
+        runtime_formula_dependencies: [],
+        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
       )
       allow(formula_is_build_dep).to receive_messages(
-        installed_runtime_formula_dependencies: [],
-        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
+        runtime_formula_dependencies: [],
+        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
       )
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe Utils::Autoremove do
     include_context "with formulae for dependency testing"
 
     before do
-      allow(Formulary).to receive(:factory).with("three", { warn: false })
+      allow(Formulary).to receive(:factory).with("three", { prefer_stub: false, warn: false })
                                            .and_return(formula_is_build_dep)
     end
 
@@ -157,9 +157,9 @@ RSpec.describe Utils::Autoremove do
     let(:casks_multiple_deps) { [first_cask_no_deps, second_cask_no_deps, cask_multiple_deps] }
 
     before do
-      allow(Formulary).to receive(:resolve).with("zero").and_return(formula_with_deps)
-      allow(Formulary).to receive(:resolve).with("one").and_return(first_formula_dep)
-      allow(Formulary).to receive(:resolve).with("two").and_return(second_formula_dep)
+      allow(Formula).to receive("[]").with("zero").and_return(formula_with_deps)
+      allow(Formula).to receive("[]").with("one").and_return(first_formula_dep)
+      allow(Formula).to receive("[]").with("two").and_return(second_formula_dep)
     end
   end
 


### PR DESCRIPTION
There are issues with bottling in `homebrew/core`. See https://github.com/Homebrew/homebrew-core/actions/runs/17918737406/job/50948240605?pr=245265 for example.

Reverts Homebrew/brew#20603
