### PR TITLE
`brew determine-test-runners`: allow running locally.

### DIFF
--- a/Library/Homebrew/dev-cmd/determine-test-runners.rb
+++ b/Library/Homebrew/dev-cmd/determine-test-runners.rb
@@ -51,7 +51,14 @@ module Homebrew
 
         ohai "Runners", JSON.pretty_generate(runners)
 
-        github_output = ENV.fetch("GITHUB_OUTPUT")
+        # gracefully handle non-GitHub Actions environments
+        github_output = if ENV.key?("GITHUB_ACTIONS")
+          ENV.fetch("GITHUB_OUTPUT")
+        else
+          ENV.fetch("GITHUB_OUTPUT", nil)
+        end
+        return unless github_output
+
         File.open(github_output, "a") do |f|
           f.puts("runners=#{runners.to_json}")
           f.puts("runners_present=#{runners.present?}")

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -159,7 +159,13 @@ class GitHubRunnerMatrix
       end
     end
 
-    github_run_id      = ENV.fetch("GITHUB_RUN_ID")
+    # gracefully handle non-GitHub Actions environments
+    github_run_id = if ENV.key?("GITHUB_ACTIONS")
+      ENV.fetch("GITHUB_RUN_ID")
+    else
+      ENV.fetch("GITHUB_RUN_ID", "")
+    end
+
     long_timeout       = ENV.fetch("HOMEBREW_MACOS_LONG_TIMEOUT", "false") == "true"
     use_github_runner  = ENV.fetch("HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER", "false") == "true"
 


### PR DESCRIPTION
Handle missing `GITHUB_*` variables.