### PR TITLE
utils/ruby: ensure `utils/helpers` is `source`d

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -124,6 +124,9 @@ If there's no Homebrew Portable Ruby available for your processor:
     return 0
   fi
 
+  # Needed for `brew` and `odie`.
+  source "${HOMEBREW_LIBRARY}/Homebrew/utils/helpers.sh"
+
   if [[ -x "${vendor_ruby_path}" ]]
   then
     HOMEBREW_RUBY_PATH="${vendor_ruby_path}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This can be called before `utils/helpers` is `source`d (e.g. when
Portable Ruby is updated), which results in the calls to `brew` and
`odie` to error out.

Let's fix that by ensuring that these functions are defined when they're
needed.
