### PR TITLE
patch: use `@@HOMEBREW_PREFIX@@` placeholder in all patches

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -47,7 +47,11 @@ class EmbeddedPatch
   def contents; end
 
   def apply
-    data = contents.gsub("HOMEBREW_PREFIX", HOMEBREW_PREFIX)
+    data = contents.gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX)
+    if data.gsub!("HOMEBREW_PREFIX", HOMEBREW_PREFIX)
+      # Utils::Output.odeprecated "patch with HOMEBREW_PREFIX placeholder",
+      #                           "patch with @@HOMEBREW_PREFIX@@ placeholder"
+    end
     args = %W[-g 0 -f -#{strip}]
     Utils.safe_popen_write("patch", *args) { |p| p.write(data) }
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We went with `@@HOMEBREW_PREFIX@@` for external patches and I feel this is the better option to avoid chances of collisions with actual `HOMEBREW_PREFIX` usage.

In Homebrew/core, the only formulae this impacts is:
* `libxmlsec1` - https://github.com/Homebrew/homebrew-core/blob/main/Formula/lib/libxmlsec1.rb#L65
* `pypy*` - these are incorrect inreplaces since the code is trying to fetch environment variable, but it luckily still applies patch

The latter does mean odisabled will cause issues. Will need to move patch to formula-patches to avoid this.