### PR TITLE
Improve warning message for `no-quarantine`

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -157,9 +157,7 @@ module Cask
       oh1 "Installing Cask #{Formatter.identifier(@cask)}"
       # GitHub Actions globally disables Gatekeeper.
       unless quarantine?
-        opoo_outside_github_actions(
-          "You are overriding your security settings to install an app from an unidentified developer.",
-        )
+        opoo_outside_github_actions "macOS security controls are being overridden by use of --no-quarantine"
       end
       stage
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -156,7 +156,11 @@ module Cask
 
       oh1 "Installing Cask #{Formatter.identifier(@cask)}"
       # GitHub Actions globally disables Gatekeeper.
-      opoo_outside_github_actions "macOS's Gatekeeper has been disabled for this Cask" unless quarantine?
+      unless quarantine?
+        opoo_outside_github_actions(
+          "You are overriding your security settings to install an app from an unidentified developer.",
+        )
+      end
       stage
 
       @cask.config = @cask.default_config.merge(old_config)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- Have you successfully run `brew tests` with your changes locally?

-----

The current warning shown when using `--no-quarantine` is not sufficiently informative or serious.

This PR updates the message to make it clearer and more direct:
