### PR TITLE
cask/cask_loader: fix future disable reason

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -378,14 +378,15 @@ module Cask
           desc json_cask[:desc]
           homepage json_cask[:homepage]
 
-          if (deprecation_date = json_cask[:deprecation_date].presence)
-            reason = DeprecateDisable.to_reason_string_or_symbol json_cask[:deprecation_reason], type: :cask
-            deprecate! date: deprecation_date, because: reason
+          if (date = json_cask[:deprecation_date].presence)
+            because = DeprecateDisable.to_reason_string_or_symbol json_cask[:deprecation_reason], type: :cask
+            deprecate! date:, because:
           end
 
-          if (disable_date = json_cask[:disable_date].presence)
-            reason = DeprecateDisable.to_reason_string_or_symbol json_cask[:disable_reason], type: :cask
-            disable! date: disable_date, because: reason
+          if (date = json_cask[:disable_date].presence)
+            disable_reason = json_cask[:disable_reason].presence || json_cask[:deprecation_reason]
+            because = DeprecateDisable.to_reason_string_or_symbol disable_reason, type: :cask
+            disable! date:, because:
           end
 
           auto_updates json_cask[:auto_updates] unless json_cask[:auto_updates].nil?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When a cask is loaded via the API, if only a `disable!` stanza was provided with a date in the future, the "reason" was not being displayed correctly. This is because DeprecateDisable sees it as a "deprecation reason" until the disable date is reached. This PR should correctly re-assemble the cask to be read from the API.

Discovered in: https://github.com/orgs/Homebrew/discussions/6433#discussioncomment-14522001