### PR TITLE
fix: use composite cache key for to_keys_to_casks method

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -291,11 +291,23 @@ module Homebrew
       }
       def to_kegs_to_casks(only: parent.only_formula_or_cask, ignore_unavailable: false, all_kegs: nil)
         method = all_kegs ? :kegs : :default_kegs
-        @to_kegs_to_casks ||= T.let({}, T.nilable(T::Hash[T.nilable(Symbol), [T::Array[Keg], T::Array[Cask::Cask]]]))
-        @to_kegs_to_casks[method] ||=
-          T.cast(to_formulae_and_casks(only:, ignore_unavailable:, method:)
-          .partition { |o| o.is_a?(Keg) }
-          .map(&:freeze).freeze, [T::Array[Keg], T::Array[Cask::Cask]])
+        key = [method, only, ignore_unavailable]
+
+        @to_kegs_to_casks ||= T.let(
+          {},
+          T.nilable(
+            T::Hash[
+              [T.nilable(Symbol), T.nilable(Symbol), T::Boolean],
+              [T::Array[Keg], T::Array[Cask::Cask]],
+            ],
+          ),
+        )
+        @to_kegs_to_casks[key] ||= T.cast(
+          to_formulae_and_casks(only:, ignore_unavailable:, method:)
+            .partition { |o| o.is_a?(Keg) }
+            .map(&:freeze).freeze,
+          [T::Array[Keg], T::Array[Cask::Cask]],
+        )
       end
 
       sig { returns(T::Array[Tap]) }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?
<img width="264" height="39" alt="image" src="https://github.com/user-attachments/assets/e7a4836f-26a4-48cf-b55e-ec3a03b8164b" />
<img width="229" height="28" alt="image" src="https://github.com/user-attachments/assets/78cb2785-83e4-475e-ac64-51634caee0d3" />
<img width="233" height="26" alt="image" src="https://github.com/user-attachments/assets/3f02e502-c266-40d5-9f00-8bd6a3bb4034" />

-----
Fixed cache collisions that could happen when mixing formula and cask operations. Same functionality, just more reliable caching under the hood.

Issue 1: Incomplete Cache Key
The cache was only using the method parameter as the key, ignoring other parameters that affect the result.
Example of the bug:

```
# First call - caches result with only 'method' as key
method = :some_method
only = :formulae
ignore_unavailable = true
result1 = @to_keys_to_casks[method] ||= # ... computes and caches result

# Second call - WRONG! Returns cached result1 even though parameters differ
method = :some_method        # same
only = :casks               # different!
ignore_unavailable = false  # different!
result2 = @to_keys_to_casks[method]  # incorrectly returns result1
```

Issue 2: Unsafe Type Assumptions
The partition method splits arrays based on type checking, but makes unsafe assumptions:

```
# Assume to_formulae_and_casks returns:
[key1, key2, formula1, formula2, some_other_object]

# partition { |o| o.is_a?(Key) } results in:
[
  [key1, key2],                           # Array of Key objects
  [formula1, formula2, some_other_object] # Array of NON-Key objects
]
```