### PR TITLE
dev-cmd/bottle: change mtime if the date is before 1970

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -520,7 +520,11 @@ module Homebrew
             cd cellar do
               sudo_purge
               # Tar then gzip for reproducible bottles.
-              tar_mtime = tab.source_modified_time.strftime("%Y-%m-%d %H:%M:%S")
+              # GNU tar fails to create a bottle if modification time is unsigned integer
+              # (i.e. before 1970)
+              time_at_epoch = Time.at(1)
+              tab_source_modified_time = [time_at_epoch, tab.source_modified_time].max
+              tar_mtime = tab_source_modified_time.strftime("%Y-%m-%d %H:%M:%S")
               tar, tar_args = setup_tar_and_args!(tar_mtime, default_tar: formula.name == "gnu-tar")
               safe_system tar, "--create", "--numeric-owner",
                           *tar_args,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
GNU tar fails to create a bottle if date before 1970 is passed to `--mtime=` parameter, f.e.:

```
/opt/homebrew/opt/gnu-tar/bin/gtar --numeric-owner --mtime=1677-09-20
19:12:43 --sort=name --owner=0 --group=0 --numeric-owner --format=pax
--pax-option=globexthdr.name=/GlobalHead.%n,exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime
--file
/Users/brew/actions-runner/_work/homebrew-core/homebrew-core/bottles/neo4j--2025.09.0.arm64_sequoia.bottle.tar
neo4j/2025.09.0
Error: integer -9223372037 too small to convert to 'unsigned int'
```

Related:
https://github.com/Homebrew/homebrew-core/pull/246155
https://github.com/Homebrew/homebrew-core/actions/runs/18090483016/job/51470097819?pr=246155