### PR TITLE
formula_auditor: remove unused postgresql audit

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -499,21 +499,6 @@ module Homebrew
       problem "Formulae in homebrew/core should not have a Linux-only dependency on GCC."
     end
 
-    def audit_postgresql
-      return if formula.name != "postgresql"
-      return unless @core_tap
-
-      major_version = formula.version.major.to_i
-      previous_major_version = major_version - 1
-      previous_formula_name = "postgresql@#{previous_major_version}"
-      begin
-        Formula[previous_formula_name]
-      rescue FormulaUnavailableError
-        problem "Versioned #{previous_formula_name} in homebrew/core must be created for " \
-                "`brew postgresql-upgrade-database` and `pg_upgrade` to work."
-      end
-    end
-
     def audit_glibc
       return unless @core_tap
       return if formula.name != "glibc"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We no longer have unversioned `postgresql` so this audit always hits:
```
return if formula.name != "postgresql"
```

Since moving to versioned formulae, it is guaranteed that `n-1` would exist already.