### PR TITLE
test_bot: more fixes for building portable Ruby.

### DIFF
--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -22,6 +22,9 @@ module Homebrew
         verify_local_bottles
 
         with_env(HOMEBREW_DISABLE_LOAD_FORMULA: "1") do
+          # Portable Ruby bottles are rebuilt every time.
+          next if tap&.core_tap? && @testing_formulae.include?("portable-ruby")
+
           # TODO: move to extend/os
           # rubocop:todo Homebrew/MoveToExtendOS
           bottle_specifier = if OS.linux?

--- a/Library/Homebrew/test_bot/formulae_detect.rb
+++ b/Library/Homebrew/test_bot/formulae_detect.rb
@@ -148,10 +148,12 @@ module Homebrew
         if args.test_default_formula?
           # Build the default test formulae.
           modified_formulae << "libfaketime" << "xz"
-        elsif @added_formulae.any? { |formula| formula.start_with?("portable-") }
+        elsif @added_formulae.all? { |formula| formula.start_with?("portable-") }
           @added_formulae = ["portable-ruby"]
-        elsif modified_formulae.any? { |formula| formula.start_with?("portable-") }
+        elsif modified_formulae.all? { |formula| formula.start_with?("portable-") }
           modified_formulae = ["portable-ruby"]
+        elsif modified_formulae.any? { |formula| formula.start_with?("portable-") }
+          odie "Portable Ruby (and related formulae) cannot be tested in the same job as other formulae!"
         end
 
         @testing_formulae += @added_formulae + modified_formulae


### PR DESCRIPTION
- Skip downloading existing portable Ruby bottles.
- Improve error handling when building portable Ruby alongside other formulae.

More attempts to get https://github.com/Homebrew/homebrew-core/pull/245971 🟢 and add some better error handling