### PR TITLE
cmd/bundle: disable whalebrew dumping by default.

### DIFF
--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -215,7 +215,7 @@ module Homebrew
             formulae:   args.formulae? || no_type_args,
             casks:      args.casks? || no_type_args,
             mas:        args.mas? || no_type_args,
-            whalebrew:  args.whalebrew? || no_type_args,
+            whalebrew:  args.whalebrew?,
             vscode:
           )
         when "edit"


### PR DESCRIPTION
This avoids printing the disabled message just because it's installed.

Fixes https://github.com/Homebrew/brew/issues/20758