### PR TITLE
rubocop/cask: allow depends_on in `on_(arm|intel)` blocks

### DIFF
--- a/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/no_overrides_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe RuboCop::Cop::Cask::NoOverrides, :config do
     CASK
   end
 
-  it "reports an offense when `on_*` blocks contain a `depends_on macos:` stanza" do
+  it "reports an offense when `on_*` blocks contain the samne `depends_on macos:` stanza" do
     expect_offense <<~CASK
       cask 'foo' do
         version '1.2.3'
@@ -208,6 +208,25 @@ RSpec.describe RuboCop::Cop::Cask::NoOverrides, :config do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use a `depends_on macos:` stanza inside an `on_{system}` block. Add it once to specify the oldest macOS supported by any version in the cask.
         end
 
+        name 'Foo'
+      end
+    CASK
+  end
+
+  it "accepts when multiple `on_*` blocks contain different `depends_on macos:` stanzas" do
+    expect_no_offenses <<~CASK
+      cask "foo" do
+        version "1.2.3"
+
+        on_arm do
+          depends_on macos: ">= :monterey"
+        end
+        on_intel do
+          depends_on macos: ">= :ventura"
+        end
+
+        sha256 "aaa"
+        url "https://brew.sh/foo-mac.dmg"
         name 'Foo'
       end
     CASK


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It is possible for Casks to have a different minimum os dependency on different architectures, as seen in https://github.com/Homebrew/homebrew-cask/blob/817d9b808ee39bdae5dab49b761f5570b5d54586/Casks/c/copyq.rb

In this instance the `arm` version of the cask requires `monterey`, and the `intel` version requires `ventura`, but we do not allow for this case with our current rubocop setup.

This PR allows for this specific instance to pass `brew style`.