### PR TITLE
xcode_requirement: fix unversioned requirement

### DIFF
--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -18,7 +18,7 @@ class XcodeRequirement < Requirement
   sig { params(tags: T::Array[T.any(String, Symbol)]).void }
   def initialize(tags = [])
     version = tags.shift if tags.first.to_s.match?(/(\d\.)+\d/)
-    @version = T.let(version.to_s, T.nilable(String))
+    @version = T.let(version&.to_s, T.nilable(String))
     super
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`@version = nil` is used to handle `depends_on :xcode` or `depends_on xcode: :build`.

Converting this to empty string (`""`) causes 
```
Error: Version must not be empty
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/version.rb:499:in 'Version#initialize'
/opt/homebrew/Library/Homebrew/requirements/xcode_requirement.rb:40:in 'Class#new'
/opt/homebrew/Library/Homebrew/requirements/xcode_requirement.rb:40:in 'XcodeRequirement#message'
```