### PR TITLE
dev-cmd/generate-cask-ci-matrix: enable container for linux runners

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -262,7 +262,7 @@ module Homebrew
             next if !native_runner_arch && !multi_os
 
             arch_args = native_runner_arch ? [] : ["--arch=#{arch}"]
-            {
+            runner_output = {
               name:         "test #{cask_token} (#{runner.fetch(:name)}, #{arch})",
               tap:          tap.name,
               cask:         {
@@ -274,6 +274,15 @@ module Homebrew
               skip_install: labels.include?("ci-skip-install") || !native_runner_arch || skip_install,
               runner:       runner.fetch(:name),
             }
+
+            if runner.fetch(:symbol) == :linux
+              runner_output[:container] = {
+                image:   "ghcr.io/homebrew/ubuntu24.04:main",
+                options: "--user=linuxbrew",
+              }
+            end
+
+            runner_output
           end
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR passes through container information for Linux cask CI runners.
We should be able to then pick it up on the Cask CI matrix side to start the runners inside the container image.