### PR TITLE
formula_auditor: move `RELICENSED_FORMULAE_VERSIONS` list to tap

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -510,25 +510,12 @@ module Homebrew
               "which allows them to use our Linux bottles, which were compiled against system glibc on CI."
     end
 
-    RELICENSED_FORMULAE_VERSIONS = {
-      "boundary"           => "0.14",
-      "consul"             => "1.17",
-      "liquibase"          => "5.0.0",
-      "nomad"              => "1.7",
-      "packer"             => "1.10",
-      "terraform"          => "1.6",
-      "vagrant"            => "2.4",
-      "vagrant-completion" => "2.4",
-      "vault"              => "1.15",
-      "waypoint"           => "0.12",
-    }.freeze
-
     def audit_relicensed_formulae
-      return unless RELICENSED_FORMULAE_VERSIONS.key? formula.name
       return unless @core_tap
 
-      relicensed_version = Version.new(RELICENSED_FORMULAE_VERSIONS[formula.name])
-      return if formula.version < relicensed_version
+      relicensed_version = formula.tap&.audit_exception :relicensed_formulae_versions, formula.name
+      return unless relicensed_version
+      return if formula.version < Version.new(relicensed_version)
 
       problem "#{formula.name} was relicensed to a non-open-source license from version #{relicensed_version}. " \
               "It must not be upgraded to version #{relicensed_version} or newer."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Moving it for convenience (it is easier for Homebrew/core contributors to modify a JSON rather than look for the hash table somewhere in brew source code) and consistency (other audit exception lists are already in a tap)

This PR depends on Homebrew/homebrew-core#246437, merge it first