### PR TITLE
dev-cmd/generate-cask-ci-matrix: fix Ubuntu runner label

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
+++ b/Library/Homebrew/dev-cmd/generate-cask-ci-matrix.rb
@@ -17,7 +17,7 @@ module Homebrew
         { symbol: :sequoia, name: "macos-15-intel", arch: :intel } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       X86_LINUX_RUNNERS = T.let({
-        { symbol: :linux, name: "ubuntu-24.04", arch: :intel } => 1.0,
+        { symbol: :linux, name: "ubuntu-22.04", arch: :intel } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       ARM_MACOS_RUNNERS = T.let({
         { symbol: :sonoma,  name: "macos-14", arch: :arm } => 0.0,
@@ -25,7 +25,7 @@ module Homebrew
         { symbol: :tahoe,   name: "macos-26", arch: :arm } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       ARM_LINUX_RUNNERS = T.let({
-        { symbol: :linux, name: "ubuntu-24.04-arm", arch: :arm } => 1.0,
+        { symbol: :linux, name: "ubuntu-22.04-arm", arch: :arm } => 1.0,
       }.freeze, T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])
       MACOS_RUNNERS = T.let(X86_MACOS_RUNNERS.merge(ARM_MACOS_RUNNERS).freeze,
                             T::Hash[T::Hash[Symbol, T.any(Symbol, String)], Float])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We're using Ubuntu 22.04 containers: https://github.com/Homebrew/brew/pull/20789