### PR TITLE
utils/wrapper: fix infinite loop installing Portable Ruby

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -190,7 +190,7 @@ esac
 # Check `HOMEBREW_FORCE_BREW_WRAPPER` for all non-trivial commands
 # (i.e. not defined above this line e.g. formulae or --cellar).
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/wrapper.sh"
-check-brew-wrapper
+check-brew-wrapper "$1"
 
 # commands that take a single or no arguments and need to write to HOMEBREW_PREFIX.
 # HOMEBREW_LIBRARY set by bin/brew

--- a/Library/Homebrew/utils/wrapper.sh
+++ b/Library/Homebrew/utils/wrapper.sh
@@ -44,8 +44,9 @@ check-brew-wrapper() {
   fi
 
   # If HOMEBREW_FORCE_BREW_WRAPPER and HOMEBREW_DISABLE_NO_FORCE_BREW_WRAPPER are set,
-  # verify that the path to our parent process is the same as the value of HOMEBREW_FORCE_BREW_WRAPPER,
-  if [[ -n "${HOMEBREW_DISABLE_NO_FORCE_BREW_WRAPPER:-}" ]]
+  # verify that the path to our parent process is the same as the value of HOMEBREW_FORCE_BREW_WRAPPER.
+  # We can't check this for `brew vendor-install` as this would cause an infinite loop on macOS.
+  if [[ -n "${HOMEBREW_DISABLE_NO_FORCE_BREW_WRAPPER:-}" && "$1" != "vendor-install" ]]
   then
     local HOMEBREW_BREW_CALLER HOMEBREW_BREW_CALLER_CHECK_EXIT_CODE
 


### PR DESCRIPTION
`setup-ruby-path` calls `brew vendor-install` but that would just call `setup-ruby-path` again before installing.

Fixes #20770