### PR TITLE
Improve Cask upgrades

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -247,9 +247,7 @@ module Homebrew
         upgradeable.reject! { |f| FormulaInstaller.installed.include?(f) }
 
         # Print the upgradable dependents.
-        if upgradeable.blank?
-          ohai "No outdated dependents to upgrade!" unless dry_run
-        else
+        if upgradeable.present?
           installed_formulae = (dry_run ? formulae : FormulaInstaller.installed.to_a).dup
           formula_plural = Utils.pluralize("formula", installed_formulae.count)
           upgrade_verb = dry_run ? "Would upgrade" : "Upgrading"


### PR DESCRIPTION
- Don't download unnecessary casks with download queue
- Don't show "no outdated dependents to upgrade" message
- Skip some messages/work if there's no outdated casks

Fixes https://github.com/Homebrew/brew/issues/20745