### PR TITLE
bump-*-pr: fix issue that --commit argument has no effect

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -181,7 +181,7 @@ module Homebrew
           pr_title:    commit_message,
         }
 
-        GitHub.create_bump_pr(pr_info, args:) unless args.write_only?
+        GitHub.create_bump_pr(pr_info, args:)
       end
 
       private

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -491,7 +491,7 @@ module Homebrew
           tap_remote_repo:,
           pr_message:,
         }
-        GitHub.create_bump_pr(pr_info, args:) unless args.write_only?
+        GitHub.create_bump_pr(pr_info, args:)
       end
 
       private

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -700,7 +700,7 @@ module GitHub
     username = tap.user
 
     tap.path.cd do
-      if args.no_fork?
+      if args.no_fork? || args.write_only?
         remote_url = Utils.popen_read("git", "remote", "get-url", "--push", "origin").chomp
         username = tap.user
         add_auth_token_to_url!(remote_url)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`--commit` argument has become useless since commit 97acfb9, because `--write-only` will no longer trigger `create_bump_pr` which contains `git commit` logic.