### PR TITLE
audit_min_os: only use sparkle_min_os as fallback

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -774,7 +774,7 @@ module Cask
       bundle_min_os = cask_bundle_min_os
       sparkle_min_os = cask_sparkle_min_os
 
-      app_min_os = [bundle_min_os, sparkle_min_os].compact.max
+      app_min_os = bundle_min_os || sparkle_min_os
       debug_messages = []
       debug_messages << "from artifact: #{bundle_min_os.to_sym}" if bundle_min_os
       debug_messages << "from upstream: #{sparkle_min_os.to_sym}" if sparkle_min_os


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Cask::Audit#audit_min_os` uses the minimum macOS version requirement from the app bundle and newest item in the Sparkle feed but these values are treated equally in the code. [We recently came across a cask](https://github.com/Homebrew/homebrew-cask/pull/230766) where the app specified High Sierra (10.13) as the minimum macOS version but the Sparkle appcast used 26.0.0 (Tahoe) as the `minimumSystemVersion` value, so this audit incorrectly requires `depends_on macos: ">= :tahoe"` in the cask. The app and the upstream website both advertise the 10.13 macOS requirement, so the appcast value needs to be fixed.

However, this highlighted a shortcoming in the audit logic, as we probably shouldn't allow the Sparkle minimum macOS value to override what's specified in the app. This updates the logic to only fall back to the `sparkle_min_os` value when `bundle_min_os` isn't `nil`, so it won't override `bundle_min_os` when the Sparkle value is higher.