### PR TITLE
cask/upgrade: don't uninstall before upgrade

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -423,6 +423,7 @@ module Cask
         "disable_reason"                  => disable_reason,
         "disable_replacement_formula"     => disable_replacement_formula,
         "disable_replacement_cask"        => disable_replacement_cask,
+        "uninstall_on_upgrade"            => uninstall_on_upgrade?,
         "tap_git_head"                    => tap_git_head,
         "languages"                       => languages,
         "ruby_source_path"                => ruby_source_path,

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -434,6 +434,8 @@ module Cask
             container(**container_hash)
           end
 
+          uninstall_on_upgrade! if json_cask[:uninstall_on_upgrade]
+
           json_cask[:artifacts]&.each do |artifact|
             # convert generic string replacements into actual ones
             artifact = cask.loader.from_h_gsubs(artifact, appdir)

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -88,6 +88,8 @@ module Cask
       :rename,
       :sha256,
       :staged_path,
+      :uninstall_on_upgrade!,
+      :uninstall_on_upgrade?,
       :url,
       :version,
       :appdir,
@@ -143,6 +145,7 @@ module Cask
       @container_set_in_block = T.let(false, T::Boolean)
       @depends_on = T.let(DSL::DependsOn.new, DSL::DependsOn)
       @depends_on_set_in_block = T.let(false, T::Boolean)
+      @uninstall_on_upgrade = T.let(false, T::Boolean)
       @deprecated = T.let(false, T::Boolean)
       @deprecation_date = T.let(nil, T.nilable(Date))
       @deprecation_reason = T.let(nil, T.nilable(T.any(String, Symbol)))
@@ -557,6 +560,19 @@ module Cask
     # @api public
     def auto_updates(auto_updates = nil)
       set_unique_stanza(:auto_updates, auto_updates.nil?) { auto_updates }
+    end
+
+    # Forces the uninstall to run during upgrades and reinstalls even when
+    # `HOMEBREW_NO_UNINSTALL_ON_CASK_UPGRADE` is set.
+    #
+    # @api public
+    def uninstall_on_upgrade!
+      @uninstall_on_upgrade = true
+    end
+
+    # Is uninstall_on_upgrade! method defined?
+    def uninstall_on_upgrade?
+      @uninstall_on_upgrade == true
     end
 
     # Automatically fetch the latest version of a cask from changelogs.

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -444,6 +444,11 @@ module Homebrew
                      "outdated.",
         boolean:     true,
       },
+      HOMEBREW_NO_UNINSTALL_ON_CASK_UPGRADE:     {
+        description: "If set, `brew upgrade` will not run the uninstall script during cask upgrades and will " \
+                     "install over the top instead.",
+        boolean:     true,
+      },
       HOMEBREW_NO_UPDATE_REPORT_NEW:             {
         description: "If set, `brew update` will not show the list of newly added formulae/casks.",
         boolean:     true,

--- a/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/cask/cask.rbi
@@ -193,6 +193,12 @@ class Cask::Cask
   def uninstall(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def uninstall_on_upgrade!(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
+  def uninstall_on_upgrade?(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def uninstall_postflight(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -263,6 +263,9 @@ module Homebrew::EnvConfig
     def no_proxy; end
 
     sig { returns(T::Boolean) }
+    def no_uninstall_on_cask_upgrade?; end
+
+    sig { returns(T::Boolean) }
     def no_update_report_new?; end
 
     sig { returns(T::Boolean) }

--- a/Library/Homebrew/test/api/cask_spec.rb
+++ b/Library/Homebrew/test/api/cask_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Homebrew::API::Cask do
     it "specifies the correct URL and sha256" do
       expect(Homebrew::API::SourceDownload).to receive(:new).with(
         "https://raw.githubusercontent.com/Homebrew/homebrew-cask/abcdef1234567890abcdef1234567890abcdef12/Casks/everything.rb",
-        Checksum.new("d3c19b564ee5a17f22191599ad795a6cc9c4758d0e1269f2d13207155b378dea"),
+        Checksum.new("d4799fe58288f669de4688e57eb9f568b7c48d04abddfaaf8aa0a21beba0f2d3"),
         any_args,
       ).and_call_original
       described_class.source_download(cask)

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/everything.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/everything.rb
@@ -26,6 +26,8 @@ cask "everything" do
   rename "Foobar.app", "Foo.app"
   rename "Foo.app", "Bar.app"
 
+  uninstall_on_upgrade!
+
   app "Everything.app"
   installer script: {
     executable:   "~/just/another/path/install.sh",

--- a/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything-with-variations.json
@@ -115,6 +115,7 @@
   "disable_reason": null,
   "disable_replacement_formula": null,
   "disable_replacement_cask": null,
+  "uninstall_on_upgrade": true,
   "tap_git_head": "abcdef1234567890abcdef1234567890abcdef12",
   "languages": [
     "en",
@@ -122,7 +123,7 @@
   ],
   "ruby_source_path": "Casks/everything-with-variations.rb",
   "ruby_source_checksum": {
-    "sha256": "d3c19b564ee5a17f22191599ad795a6cc9c4758d0e1269f2d13207155b378dea"
+    "sha256": "d4799fe58288f669de4688e57eb9f568b7c48d04abddfaaf8aa0a21beba0f2d3"
   },
   "variations": {
     "arm64_monterey": {

--- a/Library/Homebrew/test/support/fixtures/cask/everything.json
+++ b/Library/Homebrew/test/support/fixtures/cask/everything.json
@@ -115,6 +115,7 @@
   "disable_reason": null,
   "disable_replacement_formula": null,
   "disable_replacement_cask": null,
+  "uninstall_on_upgrade": true,
   "tap_git_head": "abcdef1234567890abcdef1234567890abcdef12",
   "languages": [
     "en",
@@ -122,6 +123,6 @@
   ],
   "ruby_source_path": "Casks/everything.rb",
   "ruby_source_checksum": {
-    "sha256": "d3c19b564ee5a17f22191599ad795a6cc9c4758d0e1269f2d13207155b378dea"
+    "sha256": "d4799fe58288f669de4688e57eb9f568b7c48d04abddfaaf8aa0a21beba0f2d3"
   }
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is an initial pass at trying to skip the `uninstall` step when running `brew upgrade` and `brew reinstall`.
I have also added a simple dsl `uninstall_on_upgrade!` that would cause the uninstall to always run, for use in cases where it may be required.

This is currently only accessible behind an ENV variable - `HOMEBREW_NO_UNINSTALL_ON_CASK_UPGRADE=1`.

I have tested this with simple applications so far and it seems to work ok, but have not completed any testing with `pkg` or `script` installers yet. 

One blindside we may have here is that we do not test `brew upgrade` on CI, which means any future issues would only be surfaced by users, unless we had a way of running the upgrade on PRs.