### PR TITLE
formula_auditor: get casks from API if not tapped

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -174,7 +174,10 @@ module Homebrew
 
       return unless @core_tap
 
-      if CoreCaskTap.instance.cask_tokens.include?(name)
+      cask_tokens = CoreCaskTap.instance.cask_tokens
+      cask_tokens = Homebrew::API.cask_tokens if cask_tokens.empty? && Homebrew::EnvConfig.no_install_from_api?
+
+      if cask_tokens.include?(name)
         problem "Formula name conflicts with an existing Homebrew/cask cask's token."
         return
       end
@@ -193,7 +196,7 @@ module Homebrew
         return
       end
 
-      if CoreCaskTap.instance.cask_tokens.include?(name)
+      if cask_tokens.include?(name)
         problem "Formula name conflicts with an existing Homebrew/cask cask's token."
         return
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`CoreCaskTap.instance.cask_tokens` handles 2 scenarios:
- API
- no API with Homebrew/cask tapped

Homebrew/core CI runs in a 3rd scenario, i.e. no API without Homebrew/cask tapped.

---

This does mean a network fetch may occur during `brew audit` even when no API is used. As a developer command and conditioned only for Homebrew/core formulae, I think this is okay.

Could put it under `@online` but that seems to be for slower audits and isn't needed in CI where we've already fetched the JSON API in an earlier step.

Could restrict to CI only if preferred?