### PR TITLE
Revert "Revert "Use installed keg formula files when referencing installed formulae/dependencies""

### DIFF
--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -32,7 +32,7 @@ class CaskDependent
 
   sig { returns(T::Array[Dependency]) }
   def runtime_dependencies
-    deps.flat_map { |dep| [dep, *dep.to_formula.runtime_dependencies] }.uniq
+    deps.flat_map { |dep| [dep, *dep.to_installed_formula.runtime_dependencies] }.uniq
   end
 
   sig { returns(T::Array[Dependency]) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -722,7 +722,7 @@ module Homebrew
       # Remove formulae listed in HOMEBREW_NO_CLEANUP_FORMULAE and their dependencies.
       if Homebrew::EnvConfig.no_cleanup_formulae.present?
         formulae -= formulae.select { skip_clean_formula?(_1) }
-                            .flat_map { |f| [f, *f.runtime_formula_dependencies] }
+                            .flat_map { |f| [f, *f.installed_runtime_formula_dependencies] }
       end
       casks = Cask::Caskroom.casks
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -231,7 +231,6 @@ module Homebrew
               dep_names = CaskDependent.new(cask)
                                        .runtime_dependencies
                                        .reject(&:installed?)
-                                       .map(&:to_formula)
                                        .map(&:name)
               next if dep_names.blank?
 

--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -24,9 +24,9 @@ module Homebrew
 
       sig { override.void }
       def run
-        leaves_list = Formula.installed - Formula.installed.flat_map(&:runtime_formula_dependencies)
+        leaves_list = Formula.installed - Formula.installed.flat_map(&:installed_runtime_formula_dependencies)
         casks_runtime_dependencies = Cask::Caskroom.casks.flat_map do |cask|
-          CaskDependent.new(cask).runtime_dependencies.map(&:to_formula)
+          CaskDependent.new(cask).runtime_dependencies.map(&:to_installed_formula)
         end
         leaves_list -= casks_runtime_dependencies
         leaves_list.select! { |leaf| installed_on_request?(leaf) } if args.installed_on_request?

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -101,7 +101,7 @@ module Homebrew
                 # There is a newer HEAD but the version number has not changed.
                 "latest HEAD"
               else
-                f.pkg_version.to_s
+                f.latest_formula.pkg_version.to_s
               end
 
               outdated_versions = outdated_kegs.group_by { |keg| Formulary.from_keg(keg).full_name }

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -141,7 +141,7 @@ module Homebrew
             end
             Migrator.migrate_if_needed(formula, force: args.force?)
             Homebrew::Reinstall.build_install_context(
-              formula,
+              formula.latest_formula,
               flags:                      args.flags_only,
               force_bottle:               args.force_bottle?,
               build_from_source_formulae: args.build_from_source_formulae,

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -36,8 +36,14 @@ class Dependency
     [name, tags].hash
   end
 
-  def to_formula(prefer_stub: false)
-    formula = Formulary.factory(name, warn: false, prefer_stub:)
+  def to_installed_formula
+    formula = Formulary.resolve(name)
+    formula.build = BuildOptions.new(options, formula.options)
+    formula
+  end
+
+  def to_formula
+    formula = Formulary.factory(name, warn: false)
     formula.build = BuildOptions.new(options, formula.options)
     formula
   end
@@ -45,7 +51,7 @@ class Dependency
   sig { params(minimum_version: T.nilable(Version), minimum_revision: T.nilable(Integer)).returns(T::Boolean) }
   def installed?(minimum_version: nil, minimum_revision: nil)
     formula = begin
-      to_formula(prefer_stub: true)
+      to_installed_formula
     rescue FormulaUnavailableError
       nil
     end
@@ -86,7 +92,7 @@ class Dependency
   end
 
   def missing_options(inherited_options)
-    formula = to_formula(prefer_stub: true)
+    formula = to_installed_formula
     required = options
     required |= inherited_options
     required &= formula.options.to_a

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -21,7 +21,7 @@ module Homebrew
 
     sig {
       params(formulae: T::Array[Formula], hide: T::Array[String], _block: T.nilable(
-        T.proc.params(formula_name: String, missing_dependencies: T::Array[Formula]).void,
+        T.proc.params(formula_name: String, missing_dependencies: T::Array[Dependency]).void,
       )).returns(T::Hash[String, T::Array[String]])
     }
     def self.missing_deps(formulae, hide = [], &_block)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1702,14 +1702,15 @@ class Formula
     Formula.cache[:outdated_kegs][cache_key] ||= begin
       all_kegs = []
       current_version = T.let(false, T::Boolean)
+      latest = latest_formula
 
       installed_kegs.each do |keg|
         all_kegs << keg
         version = keg.version
         next if version.head?
 
-        next if version_scheme > keg.version_scheme && pkg_version != version
-        next if version_scheme == keg.version_scheme && pkg_version > version
+        next if latest.version_scheme > keg.version_scheme && latest.pkg_version != version
+        next if latest.version_scheme == keg.version_scheme && latest.pkg_version > version
 
         # don't consider this keg current if there's a newer formula available
         next if follow_installed_alias? && new_formula_available?
@@ -1767,7 +1768,7 @@ class Formula
   # Otherwise, return self.
   sig { returns(Formula) }
   def latest_formula
-    installed_alias_target_changed? ? T.must(current_installed_alias_target) : self
+    installed_alias_target_changed? ? T.must(current_installed_alias_target) : Formulary.factory(name)
   end
 
   sig { returns(T::Array[Formula]) }
@@ -2478,23 +2479,28 @@ class Formula
   # @api internal
   sig { params(read_from_tab: T::Boolean, undeclared: T::Boolean).returns(T::Array[Dependency]) }
   def runtime_dependencies(read_from_tab: true, undeclared: true)
-    deps = if read_from_tab && undeclared &&
-              (tab_deps = any_installed_keg&.runtime_dependencies)
-      tab_deps.filter_map do |d|
-        full_name = d["full_name"]
-        next unless full_name
+    cache_key = "#{full_name}-#{read_from_tab}-#{undeclared}"
 
-        Dependency.new full_name
+    Formula.cache[:runtime_dependencies] ||= {}
+    Formula.cache[:runtime_dependencies][cache_key] ||= begin
+      deps = if read_from_tab && undeclared &&
+                (tab_deps = any_installed_keg&.runtime_dependencies)
+        tab_deps.filter_map do |d|
+          full_name = d["full_name"]
+          next unless full_name
+
+          Dependency.new full_name
+        end
       end
+      begin
+        deps ||= declared_runtime_dependencies unless undeclared
+        deps ||= (declared_runtime_dependencies | undeclared_runtime_dependencies)
+      rescue FormulaUnavailableError
+        onoe "Could not get runtime dependencies from #{path}!"
+        deps ||= []
+      end
+      deps
     end
-    begin
-      deps ||= declared_runtime_dependencies unless undeclared
-      deps ||= (declared_runtime_dependencies | undeclared_runtime_dependencies)
-    rescue FormulaUnavailableError
-      onoe "Could not get runtime dependencies from #{path}!"
-      deps ||= []
-    end
-    deps
   end
 
   # Returns a list of {Formula} objects that are required at runtime.
@@ -2513,6 +2519,22 @@ class Formula
     end
   end
 
+  # Returns a list of installed {Formula} objects that are required at runtime.
+  sig { params(read_from_tab: T::Boolean, undeclared: T::Boolean).returns(T::Array[Formula]) }
+  def installed_runtime_formula_dependencies(read_from_tab: true, undeclared: true)
+    cache_key = "#{full_name}-#{read_from_tab}-#{undeclared}"
+
+    Formula.cache[:installed_runtime_formula_dependencies] ||= {}
+    Formula.cache[:installed_runtime_formula_dependencies][cache_key] ||= runtime_dependencies(
+      read_from_tab:,
+      undeclared:,
+    ).filter_map do |d|
+      d.to_installed_formula
+    rescue FormulaUnavailableError
+      nil
+    end
+  end
+
   sig { returns(T::Array[Formula]) }
   def runtime_installed_formula_dependents
     # `any_installed_keg` and `runtime_dependencies` `select`s ensure
@@ -2523,7 +2545,7 @@ class Formula
                                                                                .select(&:any_installed_keg)
                                                                                .select(&:runtime_dependencies)
                                                                                .select do |f|
-      f.runtime_formula_dependencies.any? do |dep|
+      f.installed_runtime_formula_dependencies.any? do |dep|
         full_name == dep.full_name
       rescue
         name == dep.name
@@ -2533,10 +2555,10 @@ class Formula
 
   # Returns a list of formulae depended on by this formula that aren't
   # installed.
-  sig { params(hide: T::Array[String]).returns(T::Array[Formula]) }
+  sig { params(hide: T::Array[String]).returns(T::Array[Dependency]) }
   def missing_dependencies(hide: [])
-    runtime_formula_dependencies.select do |f|
-      hide.include?(f.name) || f.installed_prefixes.empty?
+    runtime_dependencies(read_from_tab: true, undeclared: true).select do |f|
+      hide.include?(f.name) || f.to_installed_formula.installed_prefixes.none?
     end
   # If we're still getting unavailable formulae at this stage the best we can
   # do is just return no results.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -738,6 +738,15 @@ module Formulary
       return unless path.expand_path.exist?
       return unless ::Utils::Path.loadable_package_path?(path, :formula)
 
+      # If the path is for an installed keg, use FromKegLoader instead
+      begin
+        keg = Keg.for(path)
+        loader = FromKegLoader.try_new(keg.name, from:, warn:)
+        return T.cast(loader, T.attached_class)
+      rescue NotAKegError
+        # Not a keg path, continue
+      end
+
       if (tap = Tap.from_path(path))
         # Only treat symlinks in taps as aliases.
         if path.symlink?

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -936,9 +936,15 @@ module Formulary
     def self.try_new(ref, from: nil, warn: false)
       ref = ref.to_s
 
-      return unless (keg_formula = HOMEBREW_PREFIX/"opt/#{ref}/.brew/#{ref}.rb").file?
+      keg_directory = HOMEBREW_PREFIX/"opt/#{ref}"
+      return unless keg_directory.directory?
 
-      new(ref, keg_formula)
+      # The formula file in `.brew` will use the canonical name, whereas `ref` can be an alias.
+      # Use `Keg#name` to get the canonical name.
+      keg = Keg.new(keg_directory)
+      return unless (keg_formula = HOMEBREW_PREFIX/"opt/#{ref}/.brew/#{keg.name}.rb").file?
+
+      new(keg.name, keg_formula, tap: keg.tab.tap)
     end
   end
 
@@ -1054,7 +1060,12 @@ module Formulary
 
     sig { overridable.params(flags: T::Array[String]).void }
     def load_from_api(flags:)
-      json_formula = Homebrew::API::Formula.all_formulae[name]
+      json_formula = if Homebrew::EnvConfig.use_internal_api?
+        Homebrew::API::Formula.formula_json(name)
+      else
+        Homebrew::API::Formula.all_formulae[name]
+      end
+
       raise FormulaUnavailableError, name if json_formula.nil?
 
       Formulary.load_formula_from_json!(name, json_formula, flags:)
@@ -1223,7 +1234,16 @@ module Formulary
       flags:,
     }.compact
 
-    f = if tap.nil?
+    loader = FromKegLoader.try_new(keg.name, warn: false)
+    f = if loader.present?
+      begin
+        loader.get_formula(spec, alias_path:, force_bottle:, flags:, ignore_errors: true)
+      rescue FormulaUnreadableError
+        nil
+      end
+    end
+
+    f ||= if tap.nil?
       factory(formula_name, spec, **options)
     else
       begin

--- a/Library/Homebrew/installed_dependents.rb
+++ b/Library/Homebrew/installed_dependents.rb
@@ -44,10 +44,10 @@ module InstalledDependents
     dependents_to_check.each do |dependent|
       required = case dependent
       when Formula
-        dependent.missing_dependencies(hide: keg_names)
+        dependent.missing_dependencies(hide: keg_names).map(&:to_installed_formula)
       when Cask::Cask
         # When checking for cask dependents, we don't care about missing or non-runtime dependencies
-        CaskDependent.new(dependent).runtime_dependencies.map(&:to_formula)
+        CaskDependent.new(dependent).runtime_dependencies.map(&:to_installed_formula)
       end
 
       required_kegs = required.filter_map do |f|

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe Homebrew::Cmd::Leaves do
 
   context "when there are only installed Formulae without dependencies", :integration_test do
     it "prints all installed Formulae" do
-      setup_test_formula "foo"
+      setup_test_formula "foo", tab_attributes: { installed_on_request: true }
       setup_test_formula "bar"
-      (HOMEBREW_CELLAR/"foo/0.1/somedir").mkpath
 
       expect { brew "leaves" }
         .to output("foo\n").to_stdout

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -875,6 +875,8 @@ RSpec.describe Formula do
 
       expect(f3.runtime_dependencies.map(&:name)).to eq(["baz/qux/f2"])
 
+      described_class.clear_cache
+
       f1_path = Tap.fetch("foo", "bar").path/"Formula/f1.rb"
       stub_formula_loader(formula("f1", path: f1_path) { url("f1-1.0") }, "foo/bar/f1")
 
@@ -960,6 +962,7 @@ RSpec.describe Formula do
         sha256 cellar: :any, Utils::Bottles.tag.to_sym => TEST_SHA256
       end
     end
+    stub_formula_loader(f1)
 
     h = f1.to_hash
 
@@ -1270,6 +1273,8 @@ RSpec.describe Formula do
     let(:alias_path) { CoreTap.instance.alias_dir/alias_name }
 
     before do
+      stub_formula_loader(f)
+      stub_formula_loader(new_formula)
       allow(described_class).to receive(:installed).and_return([f])
 
       f.build = tab
@@ -1361,6 +1366,12 @@ RSpec.describe Formula do
 
     let(:alias_name) { "bar" }
     let(:alias_path) { f.tap.alias_dir/alias_name }
+
+    before do
+      stub_formula_loader(f)
+      stub_formula_loader(old_formula)
+      stub_formula_loader(new_formula)
+    end
 
     def setup_tab_for_prefix(prefix, options = {})
       prefix.mkpath

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe Migrator do
 
   before do |example|
     allow(new_formula).to receive(:oldnames).and_return(["oldname"])
+    allow(Formulary).to receive(:factory).with("homebrew/core/oldname", any_args).and_return(old_formula)
+    allow(Formulary).to receive(:factory).with("oldname", any_args).and_return(old_formula)
+    allow(Formulary).to receive(:factory).with("newname", any_args).and_return(new_formula)
 
     # do not create directories for error tests
     next if example.metadata[:description].start_with?("raises an error")

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -15,7 +15,7 @@ module Test
       def stub_formula_loader(formula, ref = formula.full_name, call_original: false)
         allow(Formulary).to receive(:loader_for).and_call_original if call_original
 
-        loader = instance_double(Formulary::FormulaLoader, get_formula: formula)
+        loader = instance_double(Formulary::FormulaLoader, get_formula: formula, name: formula.name)
         allow(Formulary).to receive(:loader_for).with(ref, any_args).and_return(loader)
       end
     end

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -43,20 +43,20 @@ RSpec.describe Utils::Autoremove do
 
     before do
       allow(formula_with_deps).to receive_messages(
-        runtime_formula_dependencies: [first_formula_dep, second_formula_dep],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [first_formula_dep, second_formula_dep],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
       allow(first_formula_dep).to receive_messages(
-        runtime_formula_dependencies: [second_formula_dep],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [second_formula_dep],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
       allow(second_formula_dep).to receive_messages(
-        runtime_formula_dependencies: [],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
       allow(formula_is_build_dep).to receive_messages(
-        runtime_formula_dependencies: [],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe Utils::Autoremove do
     include_context "with formulae for dependency testing"
 
     before do
-      allow(Formulary).to receive(:factory).with("three", { prefer_stub: false, warn: false })
+      allow(Formulary).to receive(:factory).with("three", { warn: false })
                                            .and_return(formula_is_build_dep)
     end
 
@@ -157,9 +157,9 @@ RSpec.describe Utils::Autoremove do
     let(:casks_multiple_deps) { [first_cask_no_deps, second_cask_no_deps, cask_multiple_deps] }
 
     before do
-      allow(Formula).to receive("[]").with("zero").and_return(formula_with_deps)
-      allow(Formula).to receive("[]").with("one").and_return(first_formula_dep)
-      allow(Formula).to receive("[]").with("two").and_return(second_formula_dep)
+      allow(Formulary).to receive(:resolve).with("zero").and_return(formula_with_deps)
+      allow(Formulary).to receive(:resolve).with("one").and_return(first_formula_dep)
+      allow(Formulary).to receive(:resolve).with("two").and_return(second_formula_dep)
     end
   end
 

--- a/Library/Homebrew/utils/autoremove.rb
+++ b/Library/Homebrew/utils/autoremove.rb
@@ -23,10 +23,16 @@ module Utils
       # @private
       sig { params(casks: T::Array[Cask::Cask]).returns(T::Array[Formula]) }
       def formulae_with_cask_dependents(casks)
-        casks.flat_map { |cask| cask.depends_on[:formula] }
-             .compact
-             .map { |f| Formula[f] }
-             .flat_map { |f| [f, *f.runtime_formula_dependencies].compact }
+        casks.flat_map { |cask| cask.depends_on[:formula] }.compact.flat_map do |name|
+          f = begin
+            Formulary.resolve(name)
+          rescue FormulaUnavailableError
+            nil
+          end
+          next [] unless f
+
+          [f, *f.installed_runtime_formula_dependencies].compact
+        end
       end
 
       # An array of all installed bottled {Formula} without runtime {Formula}
@@ -37,7 +43,7 @@ module Utils
       def bottled_formulae_with_no_formula_dependents(formulae)
         formulae_to_keep = T.let([], T::Array[Formula])
         formulae.each do |formula|
-          formulae_to_keep += formula.runtime_formula_dependencies
+          formulae_to_keep += formula.installed_runtime_formula_dependencies
 
           if (tab = formula.any_installed_keg&.tab)
             # Ignore build dependencies when the formula is a bottle


### PR DESCRIPTION
Reverts Homebrew/brew#20753

Retry https://github.com/Homebrew/brew/pull/20603

The issue was that `brew bottle` loads a formula from the path `/opt/homebrew/opt/foo/.brew/foo.rb`, but that doesn't include tap information. We write the tap information to the formula tab, so the information is indeed available.

Now, inside `FromPathLoader`, if we detect that the path is a keg path, use `FromKegLoader` instead, which reads information from the tab and fills the tap information correctly.

---

I double checked that this works with the following:

```console
$ brew install --build-bottle hello
==> Fetching downloads for: hello
✔︎ API Source hello.rb
✔︎ Formula hello (2.12.2)
==> ./configure --disable-silent-rules
==> make install
==> Not running 'post_install' as we're building a bottle
You can run it manually using:
  brew postinstall hello
🍺  /opt/homebrew/Cellar/hello/2.12.2: 56 files, 355.0KB, built in 30 seconds
==> Running `brew cleanup hello`...

$ brew bottle --json hello --only-json-tab
==> Determining hello bottle rebuild...
==> Bottling hello--2.12.2.arm64_tahoe.bottle.tar.gz...
./hello--2.12.2.arm64_tahoe.bottle.tar.gz
  bottle do
    sha256 arm64_tahoe: "45b9d5dbc87e6cf7509c4e5e099ff7889d65c1e1710c2ef57d1e3d9b5896deaf"
  end

$ brew bottle --merge --write --no-commit --no-all-checks ./hello*.json
==> hello
  bottle do
    sha256 arm64_tahoe: "45b9d5dbc87e6cf7509c4e5e099ff7889d65c1e1710c2ef57d1e3d9b5896deaf"
  end
```