### PR TITLE
dev-cmd/bump-formula-pr: limit synced PR title length

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -469,7 +469,9 @@ module Homebrew
         pr_title = if args.bump_synced.nil?
           "#{formula.name} #{new_formula_version}"
         else
-          "#{Array(args.bump_synced).join(" ")} #{new_formula_version}"
+          maximum_characters_in_title = 72
+          max = maximum_characters_in_title - new_formula_version.to_s.length - 1
+          "#{Formatter.truncate(Array(args.bump_synced).join(" "), max:)} #{new_formula_version}"
         end
 
         pr_message = "Created with `brew bump-formula-pr`."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Avoid overly long PR titles. Will be needed for Qt. Arbitrarily chose 5 formulae as limit, which will impact *binutils, *gdb, folly, sqlite, kde, qt and vulkan.

Alternatively could do a character limit.