### PR TITLE
keg: retain pypy directories

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -460,6 +460,7 @@ class Keg
            %r{^lua/}, #  Lua, Lua51, Lua53 all need the same handling.
            %r{^guile/},
            /^postgresql@\d+/,
+           /^pypy/,
            *SHARE_PATHS
         :mkpath
       else
@@ -484,6 +485,7 @@ class Keg
            /^perl5/,
            "php",
            /^postgresql@\d+/,
+           /^pypy/,
            /^python[23]\.\d+/,
            /^R/,
            /^ruby/


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For similar reasons as Python along with share directory where user scripts are saved
- `share/pypy3.10/` https://github.com/Homebrew/homebrew-core/blob/main/Formula/p/pypy3.10.rb#L209
- `share/pypy/` https://github.com/Homebrew/homebrew-core/blob/main/Formula/p/pypy.rb#L207

Regex needs to match both `pypy` and `pypy3.X` so didn't include version part (it would need to be optional in which case it may as well be excluded).

If we want a more specific regex then maybe,
```ruby
%r{^pypy(3\.\d+)?(/|$)}
```

Would depend on how likely a non-Pypy formula uses a path like `lib/pypyfoo`.