### PR TITLE
formula: default to cache for `Dependency#expand` usage

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2431,8 +2431,11 @@ class Formula
   # @api internal
   sig { params(block: T.nilable(T.proc.params(arg0: Formula, arg1: Dependency).void)).returns(T::Array[Dependency]) }
   def recursive_dependencies(&block)
-    cache_key = "Formula#recursive_dependencies" unless block
+    cache_key = "Formula#recursive_dependencies"
+    cache_key += "-#{full_name}-#{Time.now.to_f}" if block
     Dependency.expand(self, cache_key:, &block)
+  ensure
+    Dependency.cache.delete(cache_key) if block
   end
 
   # The full set of {Requirements} for this formula's dependency tree.
@@ -3000,7 +3003,8 @@ class Formula
   # Returns a list of {Dependency} objects that are declared in the formula.
   sig { returns(T::Array[Dependency]) }
   def declared_runtime_dependencies
-    cache_key = "Formula#declared_runtime_dependencies" unless build.any_args_or_options?
+    cache_key = "Formula#declared_runtime_dependencies"
+    cache_key += "-#{full_name}-#{Time.now.to_f}" if build.any_args_or_options?
     Dependency.expand(self, cache_key:) do |_, dependency|
       Dependency.prune if dependency.build?
       next if dependency.required?
@@ -3011,6 +3015,8 @@ class Formula
         Dependency.prune
       end
     end
+  ensure
+    Dependency.cache.delete(cache_key) if build.any_args_or_options?
   end
 
   # Returns a list of {Dependency} objects that are not declared in the formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Performance can be very slow without the cache to prune the duplicate parts of the dependency tree so use the cache by default when running `Formula#recursive_dependencies`. All other usage of `Dependency#expand` in Homebrew/brew already uses the cache.

---

For blocks, I decided to create a temporary cache entry and purge it to avoid unnecessary memory consumption. Used the same naming scheme as FormulaInstaller. Not sure if any chance of collision (if so could add a `SecureRandom.uuid` or something else)
https://github.com/Homebrew/brew/blob/7c21e4163e7a3408f30f734023e2a4dc296b64fd/Library/Homebrew/formula_installer.rb#L762

This should help with another slow down seen in:
- https://github.com/Homebrew/homebrew-core/pull/246844

---

Even on macOS with smaller dependency tree, there is a noticeable impact:
```
Benchmark 1: git checkout formula-recursive-dependencies-cache && brew reinstall -sv qt
  Time (mean ± σ):     14.824 s ±  1.606 s    [User: 10.861 s, System: 1.654 s]
  Range (min … max):   13.263 s … 18.121 s    10 runs

Benchmark 2: git checkout main && brew reinstall -sv qt
  Time (mean ± σ):     51.123 s ±  0.774 s    [User: 42.229 s, System: 6.600 s]
  Range (min … max):   49.952 s … 52.388 s    10 runs

Summary
  git checkout formula-recursive-dependencies-cache && brew reinstall -sv qt ran
    3.45 ± 0.38 times faster than git checkout main && brew reinstall -sv qt
```