### PR TITLE
cmd/which-formula: create `internal` directory before fetching `executables.txt`

### DIFF
--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -53,6 +53,7 @@ download_and_cache_executables_file() {
       max_time=10
       retries=0
     fi
+    mkdir -p "${HOMEBREW_CACHE}/api/internal"
     ${HOMEBREW_CURL} \
       --compressed \
       --speed-limit "${HOMEBREW_CURL_SPEED_LIMIT}" --speed-time "${HOMEBREW_CURL_SPEED_TIME}" \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes the error described below.

After updating `brew`, `command-not-found` fails to work. When I run the following command:
```sh
brew which-formula --explain --skip-update fish
```
the following error occurs:
```
Warning: Failed to open the file
Warning: /Users/<username>/Library/Caches/Homebrew/api/internal/executables.txt:
Warning: No such file or directory
curl: (56) Failure writing output to destination, passed 16384 returned 4294967295
touch: /Users/<username>/Library/Caches/Homebrew/api/internal/executables.txt: No such file or directory
```

The reason is that the `internal` directory does not exist. This is similar to [the error in the `update` command](https://github.com/orgs/Homebrew/discussions/6448).
