### PR TITLE
workflows/docker: add Docker Hub push fallback

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -317,14 +317,22 @@ jobs:
               echo "[$(date -u)] imagetools create failed after 3 attempts. Falling back to manual push..." >&2
 
               for image in "${image_args[@]}"; do
-                docker pull "$image"
+                if ! docker pull "$image"; then
+                  echo "[$(date -u)] docker pull failed for $image" >&2
+                  exit 1
+                fi
               done
               for tag in "${tag_args[@]}"; do
                 tag_clean="${tag#--tag=}"
-                docker manifest create "$tag_clean" "${image_args[@]}"
-                docker manifest push "$tag_clean"
+                if ! docker manifest create "$tag_clean" "${image_args[@]}"; then
+                  echo "[$(date -u)] docker manifest create failed for $tag_clean" >&2
+                  exit 1
+                fi
+                if ! docker manifest push "$tag_clean"; then
+                  echo "[$(date -u)] docker manifest push failed for $tag_clean" >&2
+                  exit 1
+                fi
               done
-
               break
             fi
             delay=$((2 ** attempts))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We often get [400 errors](https://github.com/Homebrew/brew/actions/runs/18352506375/job/52276692523) even with retries when using `docker buildx imagetools` to push to Docker Hub. Let's try to fall back to a manual push in case that happens.