### PR TITLE
bump-*-pr: skip PR creation when --write-only without --commit

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -688,6 +688,7 @@ module GitHub
   def self.create_bump_pr(info, args:)
     # --write-only without --commit means don't take any git actions at all.
     return if args.write_only? && !args.commit?
+
     tap = info[:tap]
     remote = info[:remote] || "origin"
     remote_branch = info[:remote_branch] || tap.git_repository.origin_branch_name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

PR #20005 fixed `--write-only` and broke `--write-only --commit` (my bad). #20809 fixed `--write-only --commit` and broke `--write-only`. This
hopefully fixes both.

From the help:

```
--write-only                 Make the expected file modifications without
                             taking any Git actions.
--commit                     When passed with --write-only, generate a
                             new commit after writing changes to the cask
                             file.
```

So if `--write-only` is passed without `--commit`, we should skip the
whole PR creation flow. But if `--write-only --commit` is passed, we
should generate the branch and commit but not the PR.

Refs: <https://github.com/Homebrew/brew/pull/20005>
Refs: <https://github.com/Homebrew/brew/pull/20809>
Refs: <https://github.com/Homebrew/brew/pull/20818/files>