### PR TITLE
Replace `T.any(..., NilClass, ...)` with `T.nilable(...)`

### DIFF
--- a/Library/Homebrew/api/json_download.rb
+++ b/Library/Homebrew/api/json_download.rb
@@ -6,7 +6,7 @@ require "downloadable"
 module Homebrew
   module API
     class JSONDownloadStrategy < AbstractDownloadStrategy
-      sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+      sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
       def initialize(url, name, version, **meta)
         super
         @target = T.let(meta.fetch(:target), Pathname)

--- a/Library/Homebrew/bundle_version.rb
+++ b/Library/Homebrew/bundle_version.rb
@@ -59,7 +59,7 @@ module Homebrew
       raise ArgumentError, "`short_version` and `version` cannot both be `nil` or empty"
     end
 
-    sig { params(other: BundleVersion).returns(T.any(Integer, NilClass)) }
+    sig { params(other: BundleVersion).returns(T.nilable(Integer)) }
     def <=>(other)
       return super unless instance_of?(other.class)
 

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -323,7 +323,7 @@ module Cask
     LIVECHECK_REFERENCE_URL = "https://docs.brew.sh/Cask-Cookbook#stanza-livecheck"
     private_constant :LIVECHECK_REFERENCE_URL
 
-    sig { params(livecheck_result: T.any(NilClass, T::Boolean, Symbol)).void }
+    sig { params(livecheck_result: T.nilable(T.any(T::Boolean, Symbol))).void }
     def audit_hosting_with_livecheck(livecheck_result: audit_livecheck_version)
       return if cask.deprecated? || cask.disabled?
       return if cask.version&.latest?
@@ -734,7 +734,7 @@ module Cask
       end
     end
 
-    sig { returns(T.any(NilClass, T::Boolean, Symbol)) }
+    sig { returns(T.nilable(T.any(T::Boolean, Symbol))) }
     def audit_livecheck_version
       return unless online?
       return unless cask.version

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -67,7 +67,7 @@ module Cask
       downloaded_path
     end
 
-    sig { params(timeout: T.any(Float, Integer, NilClass)).returns([T.nilable(Time), Integer]) }
+    sig { params(timeout: T.nilable(T.any(Float, Integer))).returns([T.nilable(Time), Integer]) }
     def time_file_size(timeout: nil)
       raise ArgumentError, "not supported for this download strategy" unless downloader.is_a?(CurlDownloadStrategy)
 

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -31,7 +31,7 @@ module Cask
     sig { returns(T.nilable(T.any(Symbol, String))) }
     attr_reader :user_agent
 
-    sig { returns(T.any(T::Class[AbstractDownloadStrategy], Symbol, NilClass)) }
+    sig { returns(T.nilable(T.any(T::Class[AbstractDownloadStrategy], Symbol))) }
     attr_reader :using
 
     sig { returns(T.nilable(String)) }
@@ -48,7 +48,7 @@ module Cask
       params(
         uri:             T.any(URI::Generic, String),
         verified:        T.nilable(String),
-        using:           T.any(T::Class[AbstractDownloadStrategy], Symbol, NilClass),
+        using:           T.nilable(T.any(T::Class[AbstractDownloadStrategy], Symbol)),
         tag:             T.nilable(String),
         branch:          T.nilable(String),
         revisions:       T.nilable(T::Hash[T.any(Symbol, String), String]),
@@ -74,7 +74,7 @@ module Cask
 
       specs = {}
       specs[:verified]   = @verified   = T.let(verified, T.nilable(String))
-      specs[:using]      = @using      = T.let(using, T.any(T::Class[AbstractDownloadStrategy], Symbol, NilClass))
+      specs[:using]      = @using      = T.let(using, T.nilable(T.any(T::Class[AbstractDownloadStrategy], Symbol)))
       specs[:tag]        = @tag        = T.let(tag, T.nilable(String))
       specs[:branch]     = @branch     = T.let(branch, T.nilable(String))
       specs[:revisions]  = @revisions  = T.let(revisions, T.nilable(T::Hash[T.any(Symbol, String), String]))

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -569,7 +569,7 @@ module Homebrew
       sig {
         params(
           ref: String, loaded_type: String,
-          package: T.any(T::Array[T.any(Formula, Keg)], Cask::Cask, Formula, Keg, NilClass)
+          package: T.nilable(T.any(T::Array[T.any(Formula, Keg)], Cask::Cask, Formula, Keg))
         ).returns(String)
       }
       def package_conflicts_message(ref, loaded_type, package)

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -17,7 +17,7 @@ module Homebrew
     class Parser
       include Utils::Output::Mixin
 
-      ArgType = T.type_alias { T.any(NilClass, Symbol, T::Array[String], T::Array[Symbol]) }
+      ArgType = T.type_alias { T.nilable(T.any(Symbol, T::Array[String], T::Array[Symbol])) }
       HIDDEN_DESC_PLACEHOLDER = "@@HIDDEN@@"
       SYMBOL_TO_USAGE_MAPPING = T.let({
         text_or_regex: "<text>|`/`<regex>`/`",
@@ -265,7 +265,7 @@ module Homebrew
       end
 
       sig {
-        params(names: String, description: T.nilable(String), replacement: T.any(Symbol, String, NilClass),
+        params(names: String, description: T.nilable(String), replacement: T.nilable(T.any(Symbol, String)),
                depends_on: T.nilable(String), hidden: T::Boolean).void
       }
       def flag(*names, description: nil, replacement: nil, depends_on: nil, hidden: false)
@@ -745,7 +745,7 @@ module Homebrew
         argv.include?("--casks") || argv.include?("--cask")
       end
 
-      sig { params(env: T.any(NilClass, String, Symbol)).returns(T.untyped) }
+      sig { params(env: T.nilable(T.any(String, Symbol))).returns(T.untyped) }
       def value_for_env(env)
         return if env.blank?
 

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -135,7 +135,7 @@ class DependencyCollector
 
   sig {
     params(spec: T.any(String, Resource, Symbol, Requirement, Dependency, Class),
-           tags: T::Array[T.any(String, Symbol)]).returns(T.any(Dependency, Requirement, Array, NilClass))
+           tags: T::Array[T.any(String, Symbol)]).returns(T.nilable(T.any(Dependency, Requirement, Array)))
   }
   def parse_spec(spec, tags)
     raise ArgumentError, "Implicit dependencies cannot be manually specified" if tags.include?(:implicit)

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -232,7 +232,7 @@ module Homebrew
       sig {
         params(
           cask:              Cask::Cask,
-          new_hash:          T.any(NilClass, String, Symbol),
+          new_hash:          T.nilable(T.any(String, Symbol)),
           new_version:       BumpVersionParser,
           replacement_pairs: T::Array[[T.any(Regexp, String), T.any(Pathname, String)]],
         ).returns(T::Array[[T.any(Regexp, String), T.any(Pathname, String)]])

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -47,12 +47,12 @@ class AbstractDownloadStrategy
   sig { returns(String) }
   attr_reader :name
 
-  sig { returns(T.any(NilClass, String, Version)) }
+  sig { returns(T.nilable(T.any(String, Version))) }
   attr_reader :version
 
   private :meta, :name, :version
 
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     @cached_location = T.let(nil, T.nilable(Pathname))
     @ref_type = T.let(nil, T.nilable(Symbol))
@@ -68,7 +68,7 @@ class AbstractDownloadStrategy
   # Download and cache the resource at {#cached_location}.
   #
   # @api public
-  sig { overridable.params(timeout: T.any(Float, Integer, NilClass)).void }
+  sig { overridable.params(timeout: T.nilable(T.any(Float, Integer))).void }
   def fetch(timeout: nil); end
 
   # Location of the cached download.
@@ -201,7 +201,7 @@ class VCSDownloadStrategy < AbstractDownloadStrategy
 
   REF_TYPES = [:tag, :branch, :revisions, :revision].freeze
 
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     extracted_ref = extract_ref(meta)
@@ -214,7 +214,7 @@ class VCSDownloadStrategy < AbstractDownloadStrategy
   # Download and cache the repository at {#cached_location}.
   #
   # @api public
-  sig { override.params(timeout: T.any(Float, Integer, NilClass)).void }
+  sig { override.params(timeout: T.nilable(T.any(Float, Integer))).void }
   def fetch(timeout: nil)
     end_time = Time.now + timeout if timeout
 
@@ -419,7 +419,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   sig { returns(T::Array[String]) }
   attr_reader :mirrors
 
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     @try_partial = T.let(true, T::Boolean)
     @mirrors = T.let(meta.fetch(:mirrors, []), T::Array[String])
@@ -436,7 +436,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   # Download and cache the file at {#cached_location}.
   #
   # @api public
-  sig { override.params(timeout: T.any(Float, Integer, NilClass)).void }
+  sig { override.params(timeout: T.nilable(T.any(Float, Integer))).void }
   def fetch(timeout: nil)
     end_time = Time.now + timeout if timeout
 
@@ -518,7 +518,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     rm_rf(temporary_path)
   end
 
-  sig { params(timeout: T.any(Float, Integer, NilClass)).returns([T.nilable(Time), Integer]) }
+  sig { params(timeout: T.nilable(T.any(Float, Integer))).returns([T.nilable(Time), Integer]) }
   def resolved_time_file_size(timeout: nil)
     _, _, time, file_size, = resolve_url_basename_time_file_size(url, timeout:)
     [time, T.must(file_size)]
@@ -526,13 +526,13 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
   private
 
-  sig { params(timeout: T.any(Float, Integer, NilClass)).returns([String, String]) }
+  sig { params(timeout: T.nilable(T.any(Float, Integer))).returns([String, String]) }
   def resolved_url_and_basename(timeout: nil)
     resolved_url, basename, = resolve_url_basename_time_file_size(url, timeout: nil)
     [resolved_url, basename]
   end
 
-  sig { overridable.params(url: String, timeout: T.any(Float, Integer, NilClass)).returns(URLMetadata) }
+  sig { overridable.params(url: String, timeout: T.nilable(T.any(Float, Integer))).returns(URLMetadata) }
   def resolve_url_basename_time_file_size(url, timeout: nil)
     @resolved_info_cache ||= T.let({}, T.nilable(T::Hash[String, URLMetadata]))
     return @resolved_info_cache.fetch(url) if @resolved_info_cache.include?(url)
@@ -603,7 +603,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   end
 
   sig {
-    overridable.params(url: String, resolved_url: String, timeout: T.any(Float, Integer, NilClass))
+    overridable.params(url: String, resolved_url: String, timeout: T.nilable(T.any(Float, Integer)))
                .returns(T.nilable(SystemCommand::Result))
   }
   def _fetch(url:, resolved_url:, timeout:)
@@ -619,7 +619,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   end
 
   sig {
-    params(resolved_url: String, to: T.any(Pathname, String), timeout: T.any(Float, Integer, NilClass))
+    params(resolved_url: String, to: T.any(Pathname, String), timeout: T.nilable(T.any(Float, Integer)))
       .returns(T.nilable(SystemCommand::Result))
   }
   def _curl_download(resolved_url, to, timeout)
@@ -670,7 +670,7 @@ class HomebrewCurlDownloadStrategy < CurlDownloadStrategy
   private
 
   sig {
-    params(resolved_url: String, to: T.any(Pathname, String), timeout: T.any(Float, Integer, NilClass))
+    params(resolved_url: String, to: T.any(Pathname, String), timeout: T.nilable(T.any(Float, Integer)))
       .returns(T.nilable(SystemCommand::Result))
   }
   def _curl_download(resolved_url, to, timeout)
@@ -695,7 +695,7 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
   sig { params(resolved_basename: String).returns(T.nilable(String)) }
   attr_writer :resolved_basename
 
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     meta[:headers] ||= []
     # GitHub Packages authorization header.
@@ -711,7 +711,7 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
 
   private
 
-  sig { override.params(url: String, timeout: T.any(Float, Integer, NilClass)).returns(URLMetadata) }
+  sig { override.params(url: String, timeout: T.nilable(T.any(Float, Integer))).returns(URLMetadata) }
   def resolve_url_basename_time_file_size(url, timeout: nil)
     return super if @resolved_basename.blank?
 
@@ -742,7 +742,7 @@ class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy
     T.must(@combined_mirrors = T.let([*@mirrors, *backup_mirrors], T.nilable(T::Array[String])))
   end
 
-  sig { override.params(url: String, timeout: T.any(Float, Integer, NilClass)).returns(URLMetadata) }
+  sig { override.params(url: String, timeout: T.nilable(T.any(Float, Integer))).returns(URLMetadata) }
   def resolve_url_basename_time_file_size(url, timeout: nil)
     if url == self.url
       preferred = if apache_mirrors["in_attic"]
@@ -775,7 +775,7 @@ class CurlPostDownloadStrategy < CurlDownloadStrategy
   private
 
   sig {
-    override.params(url: String, resolved_url: String, timeout: T.any(Float, Integer, NilClass))
+    override.params(url: String, resolved_url: String, timeout: T.nilable(T.any(Float, Integer)))
             .returns(T.nilable(SystemCommand::Result))
   }
   def _fetch(url:, resolved_url:, timeout:)
@@ -825,7 +825,7 @@ end
 #
 # @api public
 class SubversionDownloadStrategy < VCSDownloadStrategy
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @url = @url.sub("svn+http://", "")
@@ -834,7 +834,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
   # Download and cache the repository at {#cached_location}.
   #
   # @api public
-  sig { override.params(timeout: T.any(Float, Integer, NilClass)).void }
+  sig { override.params(timeout: T.nilable(T.any(Float, Integer))).void }
   def fetch(timeout: nil)
     if @url.chomp("/") != repo_url || !silent_command("svn", args: ["switch", @url, cached_location]).success?
       clear_cache
@@ -944,7 +944,7 @@ end
 #
 # @api public
 class GitDownloadStrategy < VCSDownloadStrategy
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     # Needs to be before the call to `super`, as the VCSDownloadStrategy's
     # constructor calls `cache_tag` and sets the cache path.
@@ -1286,7 +1286,7 @@ end
 #
 # @api public
 class CVSDownloadStrategy < VCSDownloadStrategy
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @url = T.let(@url.sub(%r{^cvs://}, ""), String)
@@ -1379,7 +1379,7 @@ end
 #
 # @api public
 class MercurialDownloadStrategy < VCSDownloadStrategy
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @url = T.let(@url.sub(%r{^hg://}, ""), String)
@@ -1467,7 +1467,7 @@ end
 #
 # @api public
 class BazaarDownloadStrategy < VCSDownloadStrategy
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @url = T.let(@url.sub(%r{^bzr://}, ""), String)
@@ -1533,7 +1533,7 @@ end
 #
 # @api public
 class FossilDownloadStrategy < VCSDownloadStrategy
-  sig { params(url: String, name: String, version: T.any(NilClass, String, Version), meta: T.untyped).void }
+  sig { params(url: String, name: String, version: T.nilable(T.any(String, Version)), meta: T.untyped).void }
   def initialize(url, name, version, **meta)
     super
     @url = T.let(@url.sub(%r{^fossil://}, ""), String)
@@ -1588,7 +1588,7 @@ end
 # Helper class for detecting a download strategy from a URL.
 class DownloadStrategyDetector
   sig {
-    params(url: String, using: T.any(NilClass, Symbol, T::Class[AbstractDownloadStrategy]))
+    params(url: String, using: T.nilable(T.any(Symbol, T::Class[AbstractDownloadStrategy])))
       .returns(T::Class[AbstractDownloadStrategy])
   }
   def self.detect(url, using = nil)

--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -14,7 +14,7 @@ module Downloadable
   abstract!
   requires_ancestor { Kernel }
 
-  sig { overridable.returns(T.any(NilClass, String, URL)) }
+  sig { overridable.returns(T.nilable(T.any(String, URL))) }
   attr_reader :url
 
   sig { overridable.returns(T.nilable(Checksum)) }

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -52,9 +52,9 @@ module Kernel
   # Kernel.system but with exceptions.
   sig {
     params(
-      cmd:     T.any(NilClass, Pathname, String, [String, String], T::Hash[String, T.nilable(String)]),
-      argv0:   T.any(NilClass, Pathname, String, [String, String]),
-      args:    T.any(NilClass, Pathname, String),
+      cmd:     T.nilable(T.any(Pathname, String, [String, String], T::Hash[String, T.nilable(String)])),
+      argv0:   T.nilable(T.any(Pathname, String, [String, String])),
+      args:    T.nilable(T.any(Pathname, String)),
       options: T.untyped,
     ).void
   }
@@ -72,8 +72,8 @@ module Kernel
   # @api internal
   sig {
     params(
-      cmd:   T.any(NilClass, Pathname, String, [String, String], T::Hash[String, T.nilable(String)]),
-      argv0: T.any(NilClass, String, [String, String]),
+      cmd:   T.nilable(T.any(Pathname, String, [String, String], T::Hash[String, T.nilable(String)])),
+      argv0: T.nilable(T.any(String, [String, String])),
       args:  T.any(Pathname, String),
     ).returns(T::Boolean)
   }
@@ -287,7 +287,7 @@ module Kernel
   sig {
     type_parameters(:U)
       .params(
-        hash:   T::Hash[Object, T.any(NilClass, PATH, Pathname, String)],
+        hash:   T::Hash[Object, T.nilable(T.any(PATH, Pathname, String))],
         _block: T.proc.returns(T.type_parameter(:U)),
       ).returns(T.type_parameter(:U))
   }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3520,14 +3520,14 @@ class Formula
     # @see https://spdx.github.io/spdx-spec/latest/annexes/spdx-license-expressions/ SPDX license expression guide
     # @api public
     sig {
-      params(args: T.any(NilClass, String, Symbol, T::Hash[T.any(String, Symbol), T.anything]))
-        .returns(T.any(NilClass, String, Symbol, T::Hash[T.any(String, Symbol), T.anything]))
+      params(args: T.nilable(T.any(String, Symbol, T::Hash[T.any(String, Symbol), T.anything])))
+        .returns(T.nilable(T.any(String, Symbol, T::Hash[T.any(String, Symbol), T.anything])))
     }
     def license(args = nil)
       if args.nil?
         @licenses
       else
-        @licenses = T.let(args, T.any(NilClass, String, Symbol, T::Hash[T.any(String, Symbol), T.anything]))
+        @licenses = T.let(args, T.nilable(T.any(String, Symbol, T::Hash[T.any(String, Symbol), T.anything])))
       end
     end
 
@@ -4094,7 +4094,7 @@ class Formula
     # @see https://docs.brew.sh/Formula-Cookbook#patches Patches
     # @api public
     sig {
-      params(strip: T.any(String, Symbol), src: T.any(NilClass, String, Symbol), block: T.nilable(T.proc.void)).void
+      params(strip: T.any(String, Symbol), src: T.nilable(T.any(String, Symbol)), block: T.nilable(T.proc.void)).void
     }
     def patch(strip = :p1, src = nil, &block)
       specs.each { |spec| spec.patch(strip, src, &block) }
@@ -4474,7 +4474,7 @@ class Formula
     sig {
       params(
         date:                String,
-        because:             T.any(NilClass, String, Symbol),
+        because:             T.nilable(T.any(String, Symbol)),
         replacement:         T.nilable(String),
         replacement_formula: T.nilable(String),
         replacement_cask:    T.nilable(String),
@@ -4495,7 +4495,7 @@ class Formula
       @deprecation_date = T.let(Date.parse(date), T.nilable(Date))
       return if T.must(@deprecation_date) > Date.today
 
-      @deprecation_reason = T.let(because, T.any(NilClass, String, Symbol))
+      @deprecation_reason = T.let(because, T.nilable(T.any(String, Symbol)))
       @deprecation_replacement_formula = T.let(replacement_formula.presence || replacement, T.nilable(String))
       @deprecation_replacement_cask = T.let(replacement_cask.presence || replacement, T.nilable(String))
       T.must(@deprecated = T.let(true, T.nilable(T::Boolean)))
@@ -4521,7 +4521,7 @@ class Formula
     #
     # @return [nil] if no reason was provided or the formula is not deprecated.
     # @see .deprecate!
-    sig { returns(T.any(NilClass, String, Symbol)) }
+    sig { returns(T.nilable(T.any(String, Symbol))) }
     attr_reader :deprecation_reason
 
     # The replacement formula for a deprecated {Formula}.
@@ -4566,7 +4566,7 @@ class Formula
     sig {
       params(
         date:                String,
-        because:             T.any(NilClass, String, Symbol),
+        because:             T.nilable(T.any(String, Symbol)),
         replacement:         T.nilable(String),
         replacement_formula: T.nilable(String),
         replacement_cask:    T.nilable(String),
@@ -4587,7 +4587,7 @@ class Formula
       @disable_date = T.let(Date.parse(date), T.nilable(Date))
 
       if T.must(@disable_date) > Date.today
-        @deprecation_reason = T.let(because, T.any(NilClass, String, Symbol))
+        @deprecation_reason = T.let(because, T.nilable(T.any(String, Symbol)))
         @deprecation_replacement_formula = T.let(replacement_formula.presence || replacement, T.nilable(String))
         @deprecation_replacement_cask = T.let(replacement_cask.presence || replacement, T.nilable(String))
         @deprecated = T.let(true, T.nilable(T::Boolean))
@@ -4620,7 +4620,7 @@ class Formula
     # Returns `nil` if no reason was provided or the formula is not disabled.
     #
     # @see .disable!
-    sig { returns(T.any(NilClass, String, Symbol)) }
+    sig { returns(T.nilable(T.any(String, Symbol))) }
     attr_reader :disable_reason
 
     # The replacement formula for a disabled {Formula}.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1118,7 +1118,7 @@ module Formulary
     params(
       ref:           T.any(Pathname, String),
       spec:          Symbol,
-      alias_path:    T.any(NilClass, Pathname, String),
+      alias_path:    T.nilable(T.any(Pathname, String)),
       from:          T.nilable(Symbol),
       warn:          T::Boolean,
       force_bottle:  T::Boolean,
@@ -1161,7 +1161,7 @@ module Formulary
       rack:         Pathname,
       # Automatically resolves the formula's spec if not specified.
       spec:         T.nilable(Symbol),
-      alias_path:   T.any(NilClass, Pathname, String),
+      alias_path:   T.nilable(T.any(Pathname, String)),
       force_bottle: T::Boolean,
       flags:        T::Array[String],
     ).returns(Formula)
@@ -1197,7 +1197,7 @@ module Formulary
       keg:          Keg,
       # Automatically resolves the formula's spec if not specified.
       spec:         T.nilable(Symbol),
-      alias_path:   T.any(NilClass, Pathname, String),
+      alias_path:   T.nilable(T.any(Pathname, String)),
       force_bottle: T::Boolean,
       flags:        T::Array[String],
     ).returns(Formula)

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -41,7 +41,7 @@ class Livecheck
     @strategy = T.let(nil, T.nilable(Symbol))
     @strategy_block = T.let(nil, T.nilable(Proc))
     @throttle = T.let(nil, T.nilable(Integer))
-    @url = T.let(nil, T.any(NilClass, String, Symbol))
+    @url = T.let(nil, T.nilable(T.any(String, Symbol)))
   end
 
   # Sets the `@referenced_cask_name` instance variable to the provided `String`

--- a/Library/Homebrew/retryable_download.rb
+++ b/Library/Homebrew/retryable_download.rb
@@ -10,7 +10,7 @@ module Homebrew
     include Downloadable
     include Utils::Output::Mixin
 
-    sig { override.returns(T.any(NilClass, String, URL)) }
+    sig { override.returns(T.nilable(T.any(String, URL))) }
     def url = downloadable.url
 
     sig { override.returns(T.nilable(Checksum)) }

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -27,7 +27,7 @@ class SystemCommand
         args:         T::Array[T.any(String, Integer, Float, Pathname, URI::Generic)],
         sudo:         T::Boolean,
         sudo_as_root: T::Boolean,
-        env:          T::Hash[String, T.any(NilClass, String, T::Boolean)],
+        env:          T::Hash[String, T.nilable(T.any(String, T::Boolean))],
         input:        T.any(String, T::Array[String]),
         must_succeed: T::Boolean,
         print_stdout: T.any(T::Boolean, Symbol),
@@ -56,7 +56,7 @@ class SystemCommand
         args:         T::Array[T.any(String, Integer, Float, Pathname, URI::Generic)],
         sudo:         T::Boolean,
         sudo_as_root: T::Boolean,
-        env:          T::Hash[String, T.any(NilClass, String, T::Boolean)],
+        env:          T::Hash[String, T.nilable(T.any(String, T::Boolean))],
         input:        T.any(String, T::Array[String]),
         print_stdout: T.any(T::Boolean, Symbol),
         print_stderr: T.any(T::Boolean, Symbol),
@@ -84,7 +84,7 @@ class SystemCommand
       args:         T::Array[T.any(String, Integer, Float, Pathname, URI::Generic)],
       sudo:         T::Boolean,
       sudo_as_root: T::Boolean,
-      env:          T::Hash[String, T.any(NilClass, String, T::Boolean)],
+      env:          T::Hash[String, T.nilable(T.any(String, T::Boolean))],
       input:        T.any(String, T::Array[String]),
       must_succeed: T::Boolean,
       print_stdout: T.any(T::Boolean, Symbol),
@@ -92,7 +92,7 @@ class SystemCommand
       debug:        T.nilable(T::Boolean),
       verbose:      T.nilable(T::Boolean),
       secrets:      T.any(String, T::Array[String]),
-      chdir:        T.any(NilClass, String, Pathname),
+      chdir:        T.nilable(T.any(String, Pathname)),
       reset_uid:    T::Boolean,
       timeout:      T.nilable(T.any(Integer, Float)),
     ).returns(SystemCommand::Result)
@@ -110,7 +110,7 @@ class SystemCommand
       args:         T::Array[T.any(String, Integer, Float, Pathname, URI::Generic)],
       sudo:         T::Boolean,
       sudo_as_root: T::Boolean,
-      env:          T::Hash[String, T.any(NilClass, String, T::Boolean)],
+      env:          T::Hash[String, T.nilable(T.any(String, T::Boolean))],
       input:        T.any(String, T::Array[String]),
       must_succeed: T::Boolean,
       print_stdout: T.any(T::Boolean, Symbol),
@@ -118,7 +118,7 @@ class SystemCommand
       debug:        T.nilable(T::Boolean),
       verbose:      T.nilable(T::Boolean),
       secrets:      T.any(String, T::Array[String]),
-      chdir:        T.any(NilClass, String, Pathname),
+      chdir:        T.nilable(T.any(String, Pathname)),
       reset_uid:    T::Boolean,
       timeout:      T.nilable(T.any(Integer, Float)),
     ).returns(SystemCommand::Result)
@@ -169,7 +169,7 @@ class SystemCommand
       args:         T::Array[T.any(String, Integer, Float, Pathname, URI::Generic)],
       sudo:         T::Boolean,
       sudo_as_root: T::Boolean,
-      env:          T::Hash[String, T.any(NilClass, String, T::Boolean)],
+      env:          T::Hash[String, T.nilable(T.any(String, T::Boolean))],
       input:        T.any(String, T::Array[String]),
       must_succeed: T::Boolean,
       print_stdout: T.any(T::Boolean, Symbol),
@@ -177,7 +177,7 @@ class SystemCommand
       debug:        T.nilable(T::Boolean),
       verbose:      T.nilable(T::Boolean),
       secrets:      T.any(String, T::Array[String]),
-      chdir:        T.any(NilClass, String, Pathname),
+      chdir:        T.nilable(T.any(String, Pathname)),
       reset_uid:    T::Boolean,
       timeout:      T.nilable(T.any(Integer, Float)),
     ).void
@@ -234,10 +234,10 @@ class SystemCommand
   sig { returns(T::Array[String]) }
   attr_reader :input
 
-  sig { returns(T.any(NilClass, String, Pathname)) }
+  sig { returns(T.nilable(T.any(String, Pathname))) }
   attr_reader :chdir
 
-  sig { returns(T::Hash[String, T.any(NilClass, String, T::Boolean)]) }
+  sig { returns(T::Hash[String, T.nilable(T.any(String, T::Boolean))]) }
   attr_reader :env
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -435,7 +435,7 @@ class Tap
   sig {
     overridable.params(
       quiet:         T::Boolean,
-      clone_target:  T.any(NilClass, Pathname, String),
+      clone_target:  T.nilable(T.any(Pathname, String)),
       custom_remote: T::Boolean,
       verify:        T::Boolean,
       force:         T::Boolean,
@@ -591,7 +591,7 @@ class Tap
     end
   end
 
-  sig { params(requested_remote: T.any(NilClass, Pathname, String), quiet: T::Boolean).void }
+  sig { params(requested_remote: T.nilable(T.any(Pathname, String)), quiet: T::Boolean).void }
   def fix_remote_configuration(requested_remote: nil, quiet: false)
     if requested_remote.present?
       path.cd do
@@ -1190,7 +1190,7 @@ class Tap
   end
 
   sig {
-    overridable.params(list: Symbol, formula_or_cask: String, value: T.any(NilClass, String, Version))
+    overridable.params(list: Symbol, formula_or_cask: String, value: T.nilable(T.any(String, Version)))
                .returns(T.any(T::Boolean, String))
   }
   def audit_exception(list, formula_or_cask, value = nil)
@@ -1322,7 +1322,7 @@ class CoreTap < AbstractCoreTap
 
   # CoreTap never allows shallow clones (on request from GitHub).
   sig {
-    override.params(quiet: T::Boolean, clone_target: T.any(NilClass, Pathname, String),
+    override.params(quiet: T::Boolean, clone_target: T.nilable(T.any(Pathname, String)),
                     custom_remote: T::Boolean, verify: T::Boolean, force: T::Boolean).void
   }
   def install(quiet: false, clone_target: nil,

--- a/Library/Homebrew/url.rb
+++ b/Library/Homebrew/url.rb
@@ -7,14 +7,14 @@ class URL
   sig { returns(T::Hash[Symbol, T.untyped]) }
   attr_reader :specs
 
-  sig { returns(T.any(NilClass, Symbol, T::Class[AbstractDownloadStrategy])) }
+  sig { returns(T.nilable(T.any(Symbol, T::Class[AbstractDownloadStrategy]))) }
   attr_reader :using
 
   sig { params(url: String, specs: T::Hash[Symbol, T.untyped]).void }
   def initialize(url, specs = {})
     @url = T.let(url.freeze, String)
     @specs = T.let(specs.dup, T::Hash[Symbol, T.untyped])
-    @using = T.let(@specs.delete(:using), T.any(NilClass, Symbol, T::Class[AbstractDownloadStrategy]))
+    @using = T.let(@specs.delete(:using), T.nilable(T.any(Symbol, T::Class[AbstractDownloadStrategy])))
     @specs.freeze
   end
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -28,8 +28,8 @@ module Homebrew
   # rubocop:disable Naming/PredicateMethod
   sig {
     params(
-      cmd:     T.any(NilClass, Pathname, String, [String, String], T::Hash[String, T.nilable(String)]),
-      argv0:   T.any(NilClass, Pathname, String, [String, String]),
+      cmd:     T.nilable(T.any(Pathname, String, [String, String], T::Hash[String, T.nilable(String)])),
+      argv0:   T.nilable(T.any(Pathname, String, [String, String])),
       args:    T.any(Pathname, String),
       options: T.untyped,
       _block:  T.nilable(T.proc.void),
@@ -60,7 +60,7 @@ module Homebrew
   sig {
     params(
       cmd:     T.any(Pathname, String, [String, String], T::Hash[String, T.nilable(String)]),
-      argv0:   T.any(NilClass, Pathname, String, [String, String]),
+      argv0:   T.nilable(T.any(Pathname, String, [String, String])),
       args:    T.any(Pathname, String),
       options: T.untyped,
     ).returns(T::Boolean)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -71,13 +71,13 @@ module Utils
     sig {
       params(
         extra_args:      String,
-        connect_timeout: T.any(Integer, Float, NilClass),
-        max_time:        T.any(Integer, Float, NilClass),
+        connect_timeout: T.nilable(T.any(Integer, Float)),
+        max_time:        T.nilable(T.any(Integer, Float)),
         retries:         T.nilable(Integer),
-        retry_max_time:  T.any(Integer, Float, NilClass),
+        retry_max_time:  T.nilable(T.any(Integer, Float)),
         show_output:     T.nilable(T::Boolean),
         show_error:      T.nilable(T::Boolean),
-        user_agent:      T.any(String, Symbol, NilClass),
+        user_agent:      T.nilable(T.any(String, Symbol)),
         referer:         T.nilable(String),
       ).returns(T::Array[String])
     }

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -99,7 +99,7 @@ module Formatter
           .gsub(/(.{1,#{width}})( +|$)(?!-)\n?/, "\\1\n")
   end
 
-  sig { params(string: T.any(NilClass, String, URI::Generic)).returns(String) }
+  sig { params(string: T.nilable(T.any(String, URI::Generic))).returns(String) }
   def self.url(string)
     "#{Tty.underline}#{string}#{Tty.no_underline}"
   end

--- a/Library/Homebrew/utils/github/artifacts.rb
+++ b/Library/Homebrew/utils/github/artifacts.rb
@@ -31,7 +31,7 @@ class GitHubArtifactDownloadStrategy < AbstractFileDownloadStrategy
     @token = T.let(token, String)
   end
 
-  sig { override.params(timeout: T.any(Float, Integer, NilClass)).void }
+  sig { override.params(timeout: T.nilable(T.any(Float, Integer))).void }
   def fetch(timeout: nil)
     ohai "Downloading #{url}"
     if cached_location.exist?

--- a/Library/Homebrew/utils/timer.rb
+++ b/Library/Homebrew/utils/timer.rb
@@ -3,14 +3,14 @@
 
 module Utils
   module Timer
-    sig { params(time: T.nilable(Time)).returns(T.any(Float, Integer, NilClass)) }
+    sig { params(time: T.nilable(Time)).returns(T.nilable(T.any(Float, Integer))) }
     def self.remaining(time)
       return unless time
 
       [0, time - Time.now].max
     end
 
-    sig { params(time: T.nilable(Time)).returns(T.any(Float, Integer, NilClass)) }
+    sig { params(time: T.nilable(Time)).returns(T.nilable(T.any(Float, Integer))) }
     def self.remaining!(time)
       r = remaining(time)
       raise Timeout::Error if r && r <= 0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Changing it for better semantics and consistency. The newest version of `rubocop-sorbet` gem includes a cop that detects and corrects `T.any(NilClass)`

https://github.com/Shopify/rubocop-sorbet/pull/356