### PR TITLE
Remove leftover `go_resource`s

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -42,7 +42,7 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = T.let([
   [{ name: :cxxstdlib_check, type: :method_call }],
   [{ name: :link_overwrite, type: :method_call }],
   [{ name: :fails_with, type: :method_call }, { name: :fails_with, type: :block_call }],
-  [{ name: :go_resource, type: :block_call }, { name: :resource, type: :block_call }],
+  [{ name: :resource, type: :block_call }],
   [{ name: :patch, type: :method_call }, { name: :patch, type: :block_call }],
   [{ name: :needs, type: :method_call }],
   [{ name: :allow_network_access!, type: :method_call }],

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -135,10 +135,6 @@ module RuboCop
         def audit_formula(formula_nodes)
           return if (body_node = formula_nodes.body_node).nil?
 
-          find_method_with_args(body_node, :go_resource) do
-            problem "`go_resource`s are deprecated. Please ask upstream to implement Go vendoring"
-          end
-
           find_method_with_args(body_node, :env, :userpaths) do
             problem "`env :userpaths` in homebrew/core formulae is deprecated"
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

go_resource was removed in c9a7b62b1d589c2c8a09ee46a85279519ab3271e so cleaning up some leftovers