### PR TITLE
ast_constants: add preserve_rpath

### DIFF
--- a/Library/Homebrew/ast_constants.rb
+++ b/Library/Homebrew/ast_constants.rb
@@ -38,6 +38,7 @@ FORMULA_COMPONENT_PRECEDENCE_LIST = T.let([
   [{ name: :on_arm, type: :block_call }],
   [{ name: :on_intel, type: :block_call }],
   [{ name: :conflicts_with, type: :method_call }],
+  [{ name: :preserve_rpath, type: :method_call }],
   [{ name: :skip_clean, type: :method_call }],
   [{ name: :cxxstdlib_check, type: :method_call }],
   [{ name: :link_overwrite, type: :method_call }],


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before we start using this, should decide where to put stanza.

One of following seems okay:
```rb
preserve_rpath
skip_clean "bin/foo"
link_overwrite "bin/foo", "lib/bar.so"
```

or
```rb
skip_clean "bin/foo"
link_overwrite "bin/foo", "lib/bar.so"
preserve_rpath
```

Went with former as putting `preserve_rpath` and `skip_clean` near each other makes sense to me as they handle brew's internal modifications to keg files.

And having `skip_clean` next to `link_overwrite` as both take a list of files.