### PR TITLE
.github/actionlint: remove upstream supported labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   # Labels of self-hosted or not-yet-known-upstream runner in array of strings.
-  labels: [macos-15-intel, macos-26]
+  labels: []
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.
 # Empty array means no configuration variable is allowed.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

actionlint v1.7.8 supports `macos-15-intel` and `macos-26` [^1] so this is no longer needed after Homebrew/homebrew-core#248932.

See also: https://github.com/Homebrew/homebrew-cask/pull/231842.

[^1]: https://github.com/rhysd/actionlint/releases/tag/v1.7.8
