### PR TITLE
bundle/go_dumper: skip dummy command-line-arguments package

### DIFF
--- a/Library/Homebrew/bundle/go_dumper.rb
+++ b/Library/Homebrew/bundle/go_dumper.rb
@@ -37,7 +37,14 @@ module Homebrew
             # Extract the package path (second field after splitting by tab)
             # The line format is: "\tpath\tgithub.com/user/repo"
             parts = path_line.split("\t")
-            parts[2]&.strip if parts.length >= 3
+            path = parts[2]&.strip if parts.length >= 3
+
+            # `command-line-arguments` is a dummy package name for binaries built
+            # from a list of source files instead of a specific package name.
+            # https://github.com/golang/go/issues/36043
+            next if path == "command-line-arguments"
+
+            path
           end.compact.uniq
         else
           []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`command-line-arguments` is a dummy package name for binaries built from a list of source files instead of a specific package name [^1], so we should skip it.

Fixes https://github.com/Homebrew/brew/issues/20867.

[^1]: https://github.com/golang/go/issues/36043
