### PR TITLE
test_bot/formulae: fix portable attestations.

### DIFF
--- a/Library/Homebrew/test_bot/formulae.rb
+++ b/Library/Homebrew/test_bot/formulae.rb
@@ -639,9 +639,7 @@ report_analytics: true)
         bottled_deps, deps = deps.partition { |dep| bottled_dep_allowlist.match?(dep) }
 
         # Install bottled dependencies.
-        if bottled_deps.present?
-          test "brew", "install", *bottled_deps
-        end
+        test "brew", "install", *bottled_deps if bottled_deps.present?
 
         # Build bottles for all other dependencies.
         test "brew", "install", "--build-bottle", *deps


### PR DESCRIPTION
Can't resolve attestations properly on old macOS versions: https://github.com/Homebrew/homebrew-core/actions/runs/18503877202/job/52728070257?pr=249551