### PR TITLE
Support upcoming mas 3.0.0 right-justified app/ADAM IDs from `mas list` when called from brew bundle

### DIFF
--- a/Library/Homebrew/bundle/mac_app_store_dumper.rb
+++ b/Library/Homebrew/bundle/mac_app_store_dumper.rb
@@ -16,7 +16,7 @@ module Homebrew
         @apps ||= T.let(nil, T.nilable(T::Array[[String, String]]))
         @apps ||= if Bundle.mas_installed?
           `mas list 2>/dev/null`.split("\n").map do |app|
-            app_details = app.match(/\A(?<id>\d+)\s+(?<name>.*?)\s+\((?<version>[\d.]*)\)\Z/)
+            app_details = app.match(/\A\s*(?<id>\d+)\s+(?<name>.*?)\s+\((?<version>[\d.]*)\)\Z/)
 
             # Only add the application details should we have a valid match.
             # Strip unprintable characters

--- a/Library/Homebrew/test/bundle/mac_app_store_dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_dumper_spec.rb
@@ -49,6 +49,19 @@ RSpec.describe Homebrew::Bundle::MacAppStoreDumper do
     end
   end
 
+  context "when apps `foo`, `bar`, `baz` and `qux` are installed including right-justified IDs" do
+    before do
+      described_class.reset!
+      allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(true)
+      allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
+      allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)\n 10 qux (4.0)")
+    end
+
+    it "returns list %w[foo bar baz qux]" do
+      expect(dumper.apps).to eql([["123", "foo"], ["456", "bar"], ["789", "baz"], ["10", "qux"]])
+    end
+  end
+
   context "with invalid app details" do
     let(:invalid_mas_output) do
       <<~HEREDOC


### PR DESCRIPTION
Support upcoming mas 3.0.0 right-justified app/ADAM IDs from `mas list` when called from brew bundle.

Resolve #20881

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
