### PR TITLE
workflows/command-not-found-db-update: don't run on all PRs.

### DIFF
--- a/.github/workflows/command-not-found-db-update.yml
+++ b/.github/workflows/command-not-found-db-update.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - .github/workflows/command-not-found-db-update.yml
+      - Library/Homebrew/dev-cmd/which-update.rb
+      - Library/Homebrew/executables_db.rb
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:


### PR DESCRIPTION
Let's be more selective about when we run this.