### PR TITLE
rubocops/components_order: allow pour_bottle? in on_system blocks

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -145,6 +145,7 @@ module RuboCop
             fails_with
             resource
             patch
+            pour_bottle?
           ]
           on_system_allowed_methods += on_system_methods.map(&:to_s)
           _, offensive_node = check_order(component_precedence_list, on_system_block.body)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Sometimes only one type of system's bottles are required to default prefix. be in the . We should allow `pour_bottle?` to be added to `on_system` blocks in order to only restrict bottle pours on those systems.

Fixes https://github.com/orgs/Homebrew/discussions/6468.