### PR TITLE
Add `Dependency#to_installed_formula` to access installed formula deps with `Formulary::resolve`

### DIFF
--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -32,7 +32,7 @@ class CaskDependent
 
   sig { returns(T::Array[Dependency]) }
   def runtime_dependencies
-    deps.flat_map { |dep| [dep, *dep.to_formula.runtime_dependencies] }.uniq
+    deps.flat_map { |dep| [dep, *dep.to_installed_formula.runtime_dependencies] }.uniq
   end
 
   sig { returns(T::Array[Dependency]) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -722,7 +722,7 @@ module Homebrew
       # Remove formulae listed in HOMEBREW_NO_CLEANUP_FORMULAE and their dependencies.
       if Homebrew::EnvConfig.no_cleanup_formulae.present?
         formulae -= formulae.select { skip_clean_formula?(_1) }
-                            .flat_map { |f| [f, *f.runtime_formula_dependencies] }
+                            .flat_map { |f| [f, *f.installed_runtime_formula_dependencies] }
       end
       casks = Cask::Caskroom.casks
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -231,7 +231,6 @@ module Homebrew
               dep_names = CaskDependent.new(cask)
                                        .runtime_dependencies
                                        .reject(&:installed?)
-                                       .map(&:to_formula)
                                        .map(&:name)
               next if dep_names.blank?
 

--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -24,9 +24,9 @@ module Homebrew
 
       sig { override.void }
       def run
-        leaves_list = Formula.installed - Formula.installed.flat_map(&:runtime_formula_dependencies)
+        leaves_list = Formula.installed - Formula.installed.flat_map(&:installed_runtime_formula_dependencies)
         casks_runtime_dependencies = Cask::Caskroom.casks.flat_map do |cask|
-          CaskDependent.new(cask).runtime_dependencies.map(&:to_formula)
+          CaskDependent.new(cask).runtime_dependencies.map(&:to_installed_formula)
         end
         leaves_list -= casks_runtime_dependencies
         leaves_list.select! { |leaf| installed_on_request?(leaf) } if args.installed_on_request?

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -36,8 +36,14 @@ class Dependency
     [name, tags].hash
   end
 
-  def to_formula(prefer_stub: false)
-    formula = Formulary.factory(name, warn: false, prefer_stub:)
+  def to_installed_formula
+    formula = Formulary.resolve(name)
+    formula.build = BuildOptions.new(options, formula.options)
+    formula
+  end
+
+  def to_formula
+    formula = Formulary.factory(name, warn: false)
     formula.build = BuildOptions.new(options, formula.options)
     formula
   end
@@ -48,7 +54,7 @@ class Dependency
   }
   def installed?(minimum_version: nil, minimum_revision: nil, minimum_compatibility_version: nil)
     formula = begin
-      to_formula(prefer_stub: true)
+      to_installed_formula
     rescue FormulaUnavailableError
       nil
     end
@@ -101,7 +107,7 @@ class Dependency
   end
 
   def missing_options(inherited_options)
-    formula = to_formula(prefer_stub: true)
+    formula = to_installed_formula
     required = options
     required |= inherited_options
     required &= formula.options.to_a

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -21,7 +21,7 @@ module Homebrew
 
     sig {
       params(formulae: T::Array[Formula], hide: T::Array[String], _block: T.nilable(
-        T.proc.params(formula_name: String, missing_dependencies: T::Array[Formula]).void,
+        T.proc.params(formula_name: String, missing_dependencies: T::Array[Dependency]).void,
       )).returns(T::Hash[String, T::Array[String]])
     }
     def self.missing_deps(formulae, hide = [], &_block)

--- a/Library/Homebrew/installed_dependents.rb
+++ b/Library/Homebrew/installed_dependents.rb
@@ -44,10 +44,10 @@ module InstalledDependents
     dependents_to_check.each do |dependent|
       required = case dependent
       when Formula
-        dependent.missing_dependencies(hide: keg_names)
+        dependent.missing_dependencies(hide: keg_names).map(&:to_installed_formula)
       when Cask::Cask
         # When checking for cask dependents, we don't care about missing or non-runtime dependencies
-        CaskDependent.new(dependent).runtime_dependencies.map(&:to_formula)
+        CaskDependent.new(dependent).runtime_dependencies.map(&:to_installed_formula)
       end
 
       required_kegs = required.filter_map do |f|

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe Homebrew::Cmd::Leaves do
 
   context "when there are only installed Formulae without dependencies", :integration_test do
     it "prints all installed Formulae" do
-      setup_test_formula "foo"
+      setup_test_formula "foo", tab_attributes: { installed_on_request: true }
       setup_test_formula "bar"
-      (HOMEBREW_CELLAR/"foo/0.1/somedir").mkpath
 
       expect { brew "leaves" }
         .to output("foo\n").to_stdout

--- a/Library/Homebrew/test/utils/autoremove_spec.rb
+++ b/Library/Homebrew/test/utils/autoremove_spec.rb
@@ -43,20 +43,20 @@ RSpec.describe Utils::Autoremove do
 
     before do
       allow(formula_with_deps).to receive_messages(
-        runtime_formula_dependencies: [first_formula_dep, second_formula_dep],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [first_formula_dep, second_formula_dep],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
       allow(first_formula_dep).to receive_messages(
-        runtime_formula_dependencies: [second_formula_dep],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [second_formula_dep],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
       allow(second_formula_dep).to receive_messages(
-        runtime_formula_dependencies: [],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
       allow(formula_is_build_dep).to receive_messages(
-        runtime_formula_dependencies: [],
-        any_installed_keg:            instance_double(Keg, tab: tab_from_keg),
+        installed_runtime_formula_dependencies: [],
+        any_installed_keg:                      instance_double(Keg, tab: tab_from_keg),
       )
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe Utils::Autoremove do
     include_context "with formulae for dependency testing"
 
     before do
-      allow(Formulary).to receive(:factory).with("three", { prefer_stub: false, warn: false })
+      allow(Formulary).to receive(:factory).with("three", { warn: false })
                                            .and_return(formula_is_build_dep)
     end
 
@@ -157,9 +157,9 @@ RSpec.describe Utils::Autoremove do
     let(:casks_multiple_deps) { [first_cask_no_deps, second_cask_no_deps, cask_multiple_deps] }
 
     before do
-      allow(Formula).to receive("[]").with("zero").and_return(formula_with_deps)
-      allow(Formula).to receive("[]").with("one").and_return(first_formula_dep)
-      allow(Formula).to receive("[]").with("two").and_return(second_formula_dep)
+      allow(Formulary).to receive(:resolve).with("zero").and_return(formula_with_deps)
+      allow(Formulary).to receive(:resolve).with("one").and_return(first_formula_dep)
+      allow(Formulary).to receive(:resolve).with("two").and_return(second_formula_dep)
     end
   end
 

--- a/Library/Homebrew/utils/autoremove.rb
+++ b/Library/Homebrew/utils/autoremove.rb
@@ -23,10 +23,16 @@ module Utils
       # @private
       sig { params(casks: T::Array[Cask::Cask]).returns(T::Array[Formula]) }
       def formulae_with_cask_dependents(casks)
-        casks.flat_map { |cask| cask.depends_on[:formula] }
-             .compact
-             .map { |f| Formula[f] }
-             .flat_map { |f| [f, *f.runtime_formula_dependencies].compact }
+        casks.flat_map { |cask| cask.depends_on[:formula] }.compact.flat_map do |name|
+          f = begin
+            Formulary.resolve(name)
+          rescue FormulaUnavailableError
+            nil
+          end
+          next [] unless f
+
+          [f, *f.installed_runtime_formula_dependencies].compact
+        end
       end
 
       # An array of all installed bottled {Formula} without runtime {Formula}
@@ -37,7 +43,7 @@ module Utils
       def bottled_formulae_with_no_formula_dependents(formulae)
         formulae_to_keep = T.let([], T::Array[Formula])
         formulae.each do |formula|
-          formulae_to_keep += formula.runtime_formula_dependencies
+          formulae_to_keep += formula.installed_runtime_formula_dependencies
 
           if (tab = formula.any_installed_keg&.tab)
             # Ignore build dependencies when the formula is a bottle


### PR DESCRIPTION
This PR extracts some of the changes from <https://github.com/Homebrew/brew/pull/20830>

This PR adds `Dependency#to_installed_formula`, which uses `Formulary::resolve` instead of `::factory`. Right now, this should not be any different because `Formulary::resolve` calls `factory` under the hood. This will be needed eventually, once `resolve` no longer calls `factory`.