### PR TITLE
Load installed formulae from kegs

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -953,7 +953,7 @@ module Formulary
       # The formula file in `.brew` will use the canonical name, whereas `ref` can be an alias.
       # Use `Keg#name` to get the canonical name.
       keg = Keg.new(keg_directory)
-      return unless (keg_formula = HOMEBREW_PREFIX/"opt/#{ref}/.brew/#{keg.name}.rb").file?
+      return unless (keg_formula = keg_directory/".brew/#{keg.name}.rb").file?
 
       new(keg.name, keg_formula, tap: keg.tab.tap)
     end


### PR DESCRIPTION
Final part extracted from https://github.com/Homebrew/brew/pull/20830

This PR actually makes the fundamental change to `Formulary::resolve` to attempt to load formulae from their kegs (and therefore, their install receipts).

I've marked this as a draft for now, because I want to gate this with an environment variable. For now, I'm thinking I'll just do `HOMEBREW_USE_INTERNAL_API`, but let me know if a separate one is preferred.
