### PR TITLE
Cask::Audit: prioritize main bundle Info.plist

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -860,6 +860,12 @@ module Cask
 
           info_plist_paths = Dir.glob("#{path}/**/Contents/Info.plist")
 
+          # Ensure the main `Info.plist` file is checked first, as this can
+          # sometimes use the min_os version from a framework instead
+          if info_plist_paths.delete("#{path}/Contents/Info.plist")
+            info_plist_paths.insert(0, "#{path}/Contents/Info.plist")
+          end
+
           info_plist_paths.each do |plist_path|
             next unless File.exist?(plist_path)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Cask::Audit.cask_bundle_min_os` checks `Info.plist` files throughout an app but it doesn't prioritize the main `Contents/Info.plist` file, so the audit can mistakenly return the minimum macOS version for something else within the app. This is an issue with a [recent release of the `calibre` cask](https://github.com/Homebrew/homebrew-cask/pull/232606), as the main `Info.plist` file declares a minimum macOS version of Ventura (13.3) but `brew audit` is returning Monterey (12) from a `QtWebEngineProcess.app` in
`QtWebEngineCore.framework`. The `Frameworks` directory comes before `Info.plist` alphabetically, so the audit never checks the main `Info.plist` file because it already found a `min_os` value.

This addresses the issue by moving the main `Contents/Info.plist` path (if any) to the start of `info_plist_paths`, so it's checked before any other `Info.plist` files. This approach maintains the existing behavior (where it can check multiple files) but it will only fall back to checking other files if it's unable to get a `min_os` value from the main `Info.plist` file.