### PR TITLE
Fix Bash commands not recognizing global options

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -114,29 +114,43 @@ then
   HOMEBREW_TEMP="${HOMEBREW_DEFAULT_TEMP}"
 fi
 
-# commands that take a single or no arguments.
-# HOMEBREW_LIBRARY set by bin/brew
-# shellcheck disable=SC2154
-# doesn't need a default case as other arguments handled elsewhere.
-# shellcheck disable=SC2249
-case "$1" in
-  formulae)
-    source "${HOMEBREW_LIBRARY}/Homebrew/cmd/formulae.sh"
-    homebrew-formulae
-    exit 0
-    ;;
-  casks)
-    source "${HOMEBREW_LIBRARY}/Homebrew/cmd/casks.sh"
-    homebrew-casks
-    exit 0
-    ;;
-  shellenv)
-    source "${HOMEBREW_LIBRARY}/Homebrew/cmd/shellenv.sh"
-    shift
-    homebrew-shellenv "$1"
-    exit 0
-    ;;
-esac
+for arg in "$@"
+do
+  [[ "${arg}" == "--" ]] && break
+
+  if [[ "${arg}" == "--help" || "${arg}" == "-h" || "${arg}" == "--usage" || "${arg}" == "-?" ]]
+  then
+    export HOMEBREW_HELP="1"
+    break
+  fi
+done
+
+if [[ -z "${HOMEBREW_HELP}" ]]
+then
+  # commands that take a single or no arguments.
+  # HOMEBREW_LIBRARY set by bin/brew
+  # shellcheck disable=SC2154
+  # doesn't need a default case as other arguments handled elsewhere.
+  # shellcheck disable=SC2249
+  case "$1" in
+    formulae)
+      source "${HOMEBREW_LIBRARY}/Homebrew/cmd/formulae.sh"
+      homebrew-formulae
+      exit 0
+      ;;
+    casks)
+      source "${HOMEBREW_LIBRARY}/Homebrew/cmd/casks.sh"
+      homebrew-casks
+      exit 0
+      ;;
+    shellenv)
+      source "${HOMEBREW_LIBRARY}/Homebrew/cmd/shellenv.sh"
+      shift
+      homebrew-shellenv "$1"
+      exit 0
+      ;;
+  esac
+fi
 
 source "${HOMEBREW_LIBRARY}/Homebrew/help.sh"
 
@@ -192,19 +206,22 @@ esac
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/wrapper.sh"
 check-brew-wrapper "$1"
 
-# commands that take a single or no arguments and need to write to HOMEBREW_PREFIX.
-# HOMEBREW_LIBRARY set by bin/brew
-# shellcheck disable=SC2154
-# doesn't need a default case as other arguments handled elsewhere.
-# shellcheck disable=SC2249
-case "$1" in
-  setup-ruby)
-    source "${HOMEBREW_LIBRARY}/Homebrew/cmd/setup-ruby.sh"
-    shift
-    homebrew-setup-ruby "$1"
-    exit 0
-    ;;
-esac
+if [[ -z "${HOMEBREW_HELP}" ]]
+then
+  # commands that take a single or no arguments and need to write to HOMEBREW_PREFIX.
+  # HOMEBREW_LIBRARY set by bin/brew
+  # shellcheck disable=SC2154
+  # doesn't need a default case as other arguments handled elsewhere.
+  # shellcheck disable=SC2249
+  case "$1" in
+    setup-ruby)
+      source "${HOMEBREW_LIBRARY}/Homebrew/cmd/setup-ruby.sh"
+      shift
+      homebrew-setup-ruby "$1"
+      exit 0
+      ;;
+  esac
+fi
 
 #####
 ##### Next, define all other helper functions.
@@ -852,17 +869,6 @@ EOS
   fi
 fi
 
-for arg in "$@"
-do
-  [[ "${arg}" == "--" ]] && break
-
-  if [[ "${arg}" == "--help" || "${arg}" == "-h" || "${arg}" == "--usage" || "${arg}" == "-?" ]]
-  then
-    export HOMEBREW_HELP="1"
-    break
-  fi
-done
-
 HOMEBREW_ARG_COUNT="$#"
 HOMEBREW_COMMAND="$1"
 shift
@@ -1077,7 +1083,7 @@ unset SUDO
 # Remove internal variables
 unset HOMEBREW_INTERNAL_ALLOW_PACKAGES_FROM_PATHS
 
-if [[ -n "${HOMEBREW_BASH_COMMAND}" ]]
+if [[ -n "${HOMEBREW_BASH_COMMAND}" ]] && [[ -z "${HOMEBREW_HELP}" ]]
 then
   # source rather than executing directly to ensure the entire file is read into
   # memory before it is run. This makes running a Bash script behave more like

--- a/Library/Homebrew/cmd/--repository.sh
+++ b/Library/Homebrew/cmd/--repository.sh
@@ -31,8 +31,19 @@ tap_path() {
 
 homebrew---repository() {
   local tap
+  local taps=()
 
-  if [[ "$#" -eq 0 ]]
+  for arg in "$@"
+  do
+    case "${arg}" in
+      -d | --debug | -q | --quiet | -v | --verbose) ;;
+      *)
+        taps+=("${arg}")
+        ;;
+    esac
+  done
+
+  if [[ "${#taps[@]}" -eq 0 ]]
   then
     echo "${HOMEBREW_REPOSITORY}"
     return
@@ -40,7 +51,7 @@ homebrew---repository() {
 
   (
     shopt -s extglob
-    for tap in "$@"
+    for tap in "${taps[@]}"
     do
       tap_path "${tap}"
     done

--- a/Library/Homebrew/cmd/--version.sh
+++ b/Library/Homebrew/cmd/--version.sh
@@ -36,3 +36,7 @@ homebrew-version() {
     echo "Homebrew/homebrew-cask $(version_string "${HOMEBREW_CASK_REPOSITORY}")"
   fi
 }
+
+homebrew---version() {
+  homebrew-version
+}

--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -74,6 +74,9 @@ homebrew-which-formula() {
   while [[ "$#" -gt 0 ]]
   do
     case "$1" in
+      -d | --debug | -q | --quiet | -v | --verbose)
+        shift
+        ;;
       --explain)
         HOMEBREW_EXPLAIN=1
         shift

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -119,7 +119,7 @@ If there's no Homebrew Portable Ruby available for your processor:
 
   unset HOMEBREW_RUBY_PATH
 
-  if [[ "${HOMEBREW_COMMAND}" == "vendor-install" ]]
+  if [[ "${HOMEBREW_COMMAND}" == "vendor-install" && -z "${HOMEBREW_HELP}" ]]
   then
     return 0
   fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some Bash commands don't recognize global options like `--help`, `--debug`, etc. For `--help`, we fix this in `brew.sh` by redirecting to the Ruby code path when `--help` is detected. For the remaining global options, we add handling for them in the respective shell commands.
