### PR TITLE
utils/pypi: don't exclude packages which are explicitly listed as an extra

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -360,6 +360,8 @@ module PyPI
       exclude_packages += [Package.new(main_package_name)]
     end
 
+    exclude_packages.delete_if { |package| extra_packages.include?(package) }
+
     new_resource_blocks = ""
     package_errors = ""
     found_packages.sort.each do |package|


### PR DESCRIPTION
…extra

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Packages which are dependencies of excluded packages end up being excluded from the formula, even if the top-level package needs them and it's explicitly listed as an extra. This PR removes extra packages from the `exclude_packages` array.

supports https://github.com/Homebrew/homebrew-core/pull/250161