### PR TITLE
formula: use `full_name` in `latest_formula`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1759,7 +1759,7 @@ class Formula
 
   sig { returns(T.nilable(Formula)) }
   def current_installed_alias_target
-    Formulary.factory(T.must(installed_alias_name)) if installed_alias_path
+    Formulary.factory(T.must(full_installed_alias_name)) if installed_alias_path
   end
 
   # Has the target of the alias used to install this formula changed?
@@ -1787,7 +1787,7 @@ class Formula
   # Otherwise, return self.
   sig { returns(Formula) }
   def latest_formula
-    installed_alias_target_changed? ? T.must(current_installed_alias_target) : Formulary.factory(name)
+    installed_alias_target_changed? ? T.must(current_installed_alias_target) : Formulary.factory(full_name)
   end
 
   sig { returns(T::Array[Formula]) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Minor fix. Use `full_name` instead of `name` when creating a new instance of `Formulary` to prevent collisions with core (and third-party) formulae

See https://github.com/Homebrew/brew/pull/20895#issuecomment-3419999536