### PR TITLE
Fix `brew doctor` warning for missing dependencies

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -698,7 +698,7 @@ module Homebrew
         <<~EOS
           Some installed formulae are missing dependencies.
           You should `brew install` the missing dependencies:
-            brew install #{missing.sort_by(&:full_name) * " "}
+            brew install #{missing.map(&:to_installed_formula).sort_by(&:full_name) * " "}
 
           Run `brew missing` for more details.
         EOS


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/20901

Changing the return type of `Formula#missing_dependencies` caused this breakage, and `brew typecheck` didn't catch it because it's called with the `&:method` syntax :sob:
