### PR TITLE
Detect outdated formulae using only the minimal API

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1721,7 +1721,11 @@ class Formula
     Formula.cache[:outdated_kegs][cache_key] ||= begin
       all_kegs = []
       current_version = T.let(false, T::Boolean)
-      latest = latest_formula
+      latest = if core_formula? && Homebrew::EnvConfig.use_internal_api?
+        Homebrew::API::Internal.formula_stub(full_name)
+      else
+        latest_formula
+      end
 
       installed_kegs.each do |keg|
         all_kegs << keg

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -559,7 +559,7 @@ module Formulary
       end
     else
       rack = to_rack(name)
-      alias_path = factory(name, force_bottle:, flags:, prefer_stub:).alias_path
+      alias_path = factory(name, force_bottle:, flags:, prefer_stub: true).alias_path
       f = from_rack(rack, *spec, alias_path:, force_bottle:, flags:)
     end
 


### PR DESCRIPTION
We're now at a point where we can detect whether a formula is outdated or not using only the minimal API, so let's enable this for `HOMEBREW_USE_INTERNAL_API`.

Now, running `brew outdated` (and `brew upgrade`) won't download any unnecessary formula JSON files.

There are still a few special cases (e.g. `gh` and `pkgconf`) that are occasionally downloaded, but many of these can probably be minimized in a follow-up PR.
