### PR TITLE
Download the correct API files in `brew update`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -600,7 +600,7 @@ then
 
   if [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]
   then
-    # used in vendor-install.sh
+    # used in vendor-install.sh and update.sh
     # shellcheck disable=SC2034
     HOMEBREW_PHYSICAL_PROCESSOR="arm64"
   fi

--- a/Library/Homebrew/macos_version.rb
+++ b/Library/Homebrew/macos_version.rb
@@ -19,6 +19,7 @@ class MacOSVersion < Version
 
   # NOTE: When removing symbols here, ensure that they are added
   #       to `DEPRECATED_MACOS_VERSIONS` in `MacOSRequirement`.
+  # NOTE: Changes to this list must match `macos_version_name` in `cmd/update.sh`.
   SYMBOLS = T.let({
     tahoe:       "26",
     sequoia:     "15",


### PR DESCRIPTION
`brew update` should only download the minimal API files when `HOMEBREW_USE_INTERNAL_API` is set
