### PR TITLE
dependency: skip `use_macos_install?` checks if `current_os == :macos`

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -337,6 +337,10 @@ class UsesFromMacOSDependency < Dependency
       since_os_bounds = bounds[:since]
       return true if since_os_bounds.blank?
 
+      # Assume the oldest macOS version when simulating a generic macOS version.
+      # If `since_os_bounds` is not empty we should use brewed dependencies on such system
+      return false if Homebrew::SimulateSystem.current_os == :macos
+
       # When installing a bottle built on an older macOS version, use that version
       # to determine if the dependency should come from macOS or Homebrew
       effective_os = if bottle_os_version.present? &&


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Skip `use_macos_install?` checks if `current_os == :macos` to prevent `MacOSVersion.from_symbol` runtime error. This should fix `tap_audit` job failures in core tap
https://github.com/Homebrew/homebrew-core/actions/runs/18692771346/job/53302362144#step:5:31
https://github.com/Homebrew/homebrew-core/actions/runs/18693883960/job/53306163232#step:5:31
https://github.com/Homebrew/homebrew-core/actions/runs/18693889555/job/53306182716#step:5:31
...
and so on