### PR TITLE
rubocop: Ignore `.github/copilot-instructions.md` under `AllCops`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -31,6 +31,7 @@ AllCops:
     - "Homebrew/bin/*"
     - "Homebrew/vendor/**/*"
     - "Taps/*/*/vendor/**/*"
+    - "**/.github/copilot-instructions.md" # This should be treated the same as the `docs/` files.
   SuggestExtensions:
     rubocop-minitest: false
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- We use the `rubocop-md` extension to lint the Ruby within our Markdown files. It parses Ruby code snippets out of Markdown files and runs RuboCop on them.
- The `docs/` directory has its own RuboCop configuration to handle which rules we enforce.
- Copilot's instructions are made up of all our docs. Instead of adding a separate RuboCop config in places where we want Copilot instructions files to exist but not spew linting errors (say, `Taps/homebrew/homebrew-core/.github/.rubocop.yml`), let's ignore this Markdown file entirely.
- Needed for https://github.com/Homebrew/homebrew-core/pull/250521 to pass `brew style homebrew/core`.