### PR TITLE
formula_versions: fix tracking previous versions of formulae

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -20,7 +20,7 @@ class FormulaVersions
   sig { params(formula: Formula).void }
   def initialize(formula)
     @name = formula.name
-    @path = formula.tap_path
+    @path = formula.path
     @repository = T.must(formula.tap).path
     @relative_path = @path.relative_path_from(repository).to_s
     # Also look at e.g. older homebrew-core paths before sharding.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This broke in fa68f3d30f (#20895). Since `Formula#tap_path` returns the theoretical/canonical location within a tap that a formula will live, it may not correspond to the actual location of the formula file (e.g., when a non-official tap is sharded). Using `Formula#path` instead correctly tracks the actual file location.

Fixes #20917.
