### PR TITLE
workflows/docker: stop pushing to Docker Hub, remove 20.04 image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - master
   merge_group:
   release:
     types:
@@ -79,13 +78,11 @@ jobs:
                 )
               fi
             elif [[ "${GITHUB_EVENT_NAME}" == "push" &&
-                    ("${GITHUB_REF}" == "refs/heads/master" || "${GITHUB_REF}" == "refs/heads/main") &&
+                    ("${GITHUB_REF}" == "refs/heads/main") &&
                     "${version}" == "22.04" ]]; then
               tags+=(
                 "ghcr.io/homebrew/brew:main"
-                "ghcr.io/homebrew/brew:master"
                 "ghcr.io/homebrew/ubuntu${version}:main"
-                "ghcr.io/homebrew/ubuntu${version}:master"
               )
             fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We've decided to stop pushing to Docker Hub due to reliability issues. This PR also removes the 20.04 image in preparation for Homebrew 4.7.0.