### PR TITLE
dev-cmd/bump-cask-pr: add audit exceptions

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -340,7 +340,6 @@ module Homebrew
         if args.no_audit?
           ohai "Skipping `brew audit`"
         else
-          odebug "Running `brew audit --cask --online #{cask.full_name} --except=#{audit_exceptions.join(",")}`"
           system HOMEBREW_BREW_FILE, "audit", "--cask", "--online", cask.full_name,
                  "--except=#{audit_exceptions.join(",")}"
           failed_audit = !$CHILD_STATUS.success?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR introduces the ability to set audit exceptions for the autobump workflow in `homebrew/cask`. There are some audit failures that are easily remedied, and it should be easier from a maintainability point of view to fix them in a PR with 🟥 CI than having to discover them in the autobump workflow logs.

An alternative could be to collect the exceptions from an environment variable that is set in the workflow, which could make it easier to update the list without having to find it in the `homebrew/Brew` code. I can update if this is preferable.