### PR TITLE
Display correct outdated head information

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -97,9 +97,14 @@ module Homebrew
               current_version = if f.alias_changed? && !f.latest_formula.latest_version_installed?
                 latest = f.latest_formula
                 "#{latest.name} (#{latest.pkg_version})"
-              elsif f.head? && outdated_kegs.any? { |k| k.version.to_s == f.pkg_version.to_s }
-                # There is a newer HEAD but the version number has not changed.
-                "latest HEAD"
+              elsif f.head?
+                latest_head_version = f.latest_head_pkg_version(fetch_head: args.fetch_HEAD?)
+                if outdated_kegs.any? { |k| k.version.to_s == latest_head_version.to_s }
+                  # There is a newer HEAD but the version number has not changed.
+                  "latest HEAD"
+                else
+                  latest_head_version.to_s
+                end
               else
                 f.latest_formula.pkg_version.to_s
               end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1239,21 +1239,21 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
     @repo = T.let(match_data[:repo], T.nilable(String))
   end
 
+  sig { override.returns(String) }
+  def last_commit
+    @last_commit ||= GitHub.last_commit(@user, @repo, @ref, version) || super
+  end
+
   sig { override.params(commit: T.nilable(String)).returns(T::Boolean) }
   def commit_outdated?(commit)
-    @last_commit ||= GitHub.last_commit(@user, @repo, @ref, version)
-    if @last_commit
-      return true unless commit
-      return true unless @last_commit.start_with?(commit)
+    return true unless commit
+    return true unless last_commit.start_with?(commit)
 
-      if GitHub.multiple_short_commits_exist?(@user, @repo, commit)
-        true
-      else
-        T.must(@version).update_commit(commit)
-        false
-      end
+    if GitHub.multiple_short_commits_exist?(@user, @repo, commit)
+      true
     else
-      super
+      T.must(@version).update_commit(commit)
+      false
     end
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -841,6 +841,17 @@ class Formula
     end
   end
 
+  sig { params(fetch_head: T::Boolean).returns(PkgVersion) }
+  def latest_head_pkg_version(fetch_head: false)
+    return pkg_version unless (latest_version = latest_head_version)
+    return latest_version unless head_version_outdated?(latest_version, fetch_head:)
+
+    downloader = T.must(head).downloader
+    with_context quiet: true do
+      PkgVersion.new(Version.new("HEAD-#{downloader.last_commit}"), revision)
+    end
+  end
+
   # The latest prefix for this formula. Checks for {#head} and then {#stable}'s {#prefix}.
   sig { returns(Pathname) }
   def latest_installed_prefix


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/20934

This PR updates `brew outdated` to properly display the latest HEAD version when `--fetch-HEAD` is passed.

CC @carlocab can you double check that this works as expected for you? I've tested it based on your issue, but I don't use HEAD formulae myself so I'm not 100% sure I'm covering the case that would print `latest HEAD`.