### PR TITLE
Fix `Formula#tap_path` to only use real formula paths

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -438,8 +438,10 @@ class Formula
   sig { returns(Pathname) }
   def tap_path
     return path unless (t = tap)
+    return Formulary.core_path(name) if t.core_tap?
+    return path unless t.installed?
 
-    t.new_formula_path(name)
+    t.formula_files_by_name[name] || path
   end
 
   # The path that was specified to find this formula.

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -20,7 +20,7 @@ class FormulaVersions
   sig { params(formula: Formula).void }
   def initialize(formula)
     @name = formula.name
-    @path = formula.path
+    @path = formula.tap_path
     @repository = T.must(formula.tap).path
     @relative_path = @path.relative_path_from(repository).to_s
     # Also look at e.g. older homebrew-core paths before sharding.


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/20926

This PR re-tries https://github.com/Homebrew/brew/commit/fa68f3d30f3176aa5cce9928d1d43bfa37085edc using a more reliable method for finding the tap files. It now respects sharded/unsharded third party taps as discussed in https://github.com/Homebrew/brew/pull/20921 (which this PR reverts).

I've tested this on both sharded and non-sharded third-party taps, as well as homebrew/core.