### PR TITLE
workflows/command-not-found-db-update: update token

### DIFF
--- a/.github/workflows/command-not-found-db-update.yml
+++ b/.github/workflows/command-not-found-db-update.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Log in to GitHub Packages
         if: github.ref == 'refs/heads/main'
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io --username brewtestbot --password-stdin
+        run: echo "${{ secrets.HOMEBREW_BREW_GITHUB_PACKAGES_TOKEN }}" | oras login ghcr.io --username brewtestbot --password-stdin
 
       - name: Push to GitHub Packages
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

Trying to fix https://github.com/Homebrew/brew/actions/runs/18795031295/job/53633198297, which is failing to push to ghcr with `Error response from registry: denied: permission_denied: write_package`
