### PR TITLE
chore(brew doctor): Suppress the bold disclaimer when `-q`/`--quiet` is passed

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -59,7 +59,7 @@ module Homebrew
           out = checks.send(method)
           next if out.blank?
 
-          if first_warning
+          if first_warning && !args.quiet?
             $stderr.puts <<~EOS
               #{Tty.bold}Please note that these warnings are just used to help the Homebrew maintainers
               with debugging if you file an issue. If everything you use Homebrew for is


### PR DESCRIPTION
The `-q`/`--quiet` flag already exists and governs the "You're ready to brew" message. I'd suggest it also govern this message, which is boilerplate.

I'm planning to use e.g. `brew doctor check_clt_up_to_date --quiet` for preflight checks in scenarios when we know we'll be installing an unbottled formula. I'd for it to either print the warning and fail or print nothing and succeed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
