### PR TITLE
Don't fail if a formula stub doesn't exist when checking `Formula#outdated?`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1743,7 +1743,7 @@ class Formula
     Formula.cache[:outdated_kegs][cache_key] ||= begin
       all_kegs = []
       current_version = T.let(false, T::Boolean)
-      latest = if core_formula? && Homebrew::EnvConfig.use_internal_api?
+      latest = if core_formula? && Homebrew::EnvConfig.use_internal_api? && Homebrew::API.formula_names.include?(full_name)
         Homebrew::API::Internal.formula_stub(full_name)
       else
         latest_formula


### PR DESCRIPTION
This fixes a bug where a core formula might not exist in the minimal JSON API.
One example of when this might occur would be if a formula was recently migrated to a different tap.

In `Formula#outdated?`, if we aren't able to get a formula stub, just fall back to the non-internal-api solution.

CC: @MikeMcQuaid
