### PR TITLE
dev-cmd/tests: remove HOMEBREW_USE_INTERNAL_API from test environment.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -230,6 +230,9 @@ module Homebrew
           ENV.delete(env)
         end
 
+        # Tests go boom right now with internal API enabled.
+        ENV.delete("HOMEBREW_USE_INTERNAL_API")
+
         # Fetch JSON API files if needed.
         require "api"
         Homebrew::API.fetch_api_files!


### PR DESCRIPTION
Tests are very broken with internal API enabled for now.