### PR TITLE
github_runner_matrix: always deploy arm64 linux runner for bottling

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -184,11 +184,7 @@ class GitHubRunnerMatrix
 
     if !@all_supported || ENV.key?("HOMEBREW_LINUX_RUNNER")
       @runners << create_runner(:linux, :x86_64)
-
-      if !@dependent_matrix &&
-         @testing_formulae.any? { |tf| tf.formula.bottle_specification.tag?(Utils::Bottles.tag(:arm64_linux)) }
-        @runners << create_runner(:linux, :arm64)
-      end
+      @runners << create_runner(:linux, :arm64) unless @dependent_matrix
     end
 
     long_timeout       = ENV.fetch("HOMEBREW_MACOS_LONG_TIMEOUT", "false") == "true"

--- a/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/determine-test-runners_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Homebrew::DevCmd::DetermineTestRunners do
     end
 
     out << linux_runner
+    out << "#{linux_runner}-arm"
 
     out
   end

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -92,14 +92,14 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
       end
 
       context "when testing formulae require Linux" do
-        it "activates only the Linux runner" do
+        it "activates only the Linux runners" do
           runner_matrix = described_class.new([testball_depender_linux], [],
                                               all_supported:    false,
                                               dependent_matrix: false)
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
-          expect(get_runner_names(runner_matrix)).to eq(["Linux x86_64"])
+          expect(get_runner_names(runner_matrix)).to eq(["Linux x86_64", "Linux arm64"])
         end
       end
 
@@ -140,7 +140,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
       end
 
       context "when testing formulae require a macOS version" do
-        it "activates the Linux runner and suitable macOS runners" do
+        it "activates the Linux runners and suitable macOS runners" do
           _, v = newest_supported_macos
           runner_matrix = described_class.new([testball_depender_newest], [],
                                               all_supported:    false,
@@ -148,7 +148,7 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
 
           expect(runner_matrix.runners.all?(&:active)).to be(false)
           expect(runner_matrix.runners.any?(&:active)).to be(true)
-          expect(get_runner_names(runner_matrix).sort).to eq(["Linux x86_64", "macOS #{v}-arm64"])
+          expect(get_runner_names(runner_matrix).sort).to eq(["Linux arm64", "Linux x86_64", "macOS #{v}-arm64"])
         end
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Continuation of
- https://github.com/Homebrew/brew/pull/20308

I think we can always run the arm64 linux during `tests` now.

---

Could potentially run dependent tests but they are likely to time out for formulae with large number of dependents. If we want green runs, then can't enable yet. Though could just skip dependent tests when PR has `CI-linux-self-hosted-deps`