### PR TITLE
resource_auditor: skip ftp.gnu.org audit

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -152,7 +152,7 @@ module Homebrew
           raise HomebrewCurlDownloadStrategyError, url if
             strategy <= HomebrewCurlDownloadStrategy && !Formula["curl"].any_version_installed?
 
-          # Skip ftp.gnu.org audit
+          # Skip ftp.gnu.org audit, upstream has asked us to reduce load.
           # See issue: https://github.com/Homebrew/brew/issues/20456
           next if url.match?(%r{^https?://ftp\.gnu\.org/.+})
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

These are either slow or rate limited as frequently hit failures in CI. Also upstream requested we minimize load on ftp.gnu.org so should just stop curl-ing mirror in our audit checks (we run these on every runner so at least 6 times per PR in a short time period) 

We do something similar for homepage audit but that still runs on self-hosted runners:
https://github.com/Homebrew/brew/blob/f9553b6e0922842fe12114e4ad86bac0cc3c43d2/Library/Homebrew/formula_auditor.rb#L552-L555