### PR TITLE
checksum, version: improve `.inspect` output

### DIFF
--- a/Library/Homebrew/checksum.rb
+++ b/Library/Homebrew/checksum.rb
@@ -13,6 +13,11 @@ class Checksum
     @hexdigest = T.let(hexdigest.downcase, String)
   end
 
+  sig { returns(String) }
+  def inspect
+    "#<Checksum #{hexdigest}>"
+  end
+
   delegate [:empty?, :to_s, :length, :[]] => :@hexdigest
 
   sig { params(other: T.any(String, Checksum, Symbol)).returns(T::Boolean) }

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -746,7 +746,7 @@ class Version
   def inspect
     return "#<Version::NULL>" if null?
 
-    super
+    "#<Version #{self}>"
   end
 
   sig { returns(T.self_type) }


### PR DESCRIPTION
This makes them much nicer to read in `brew irb` or with `p`/`pp`.