### PR TITLE
Cleanup partial download queue installations on error/interrupt

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -593,17 +593,7 @@ on_request: installed_on_request?, options:)
         pour
       # Catch any other types of exceptions as they leave us with nothing installed.
       rescue Exception # rubocop:disable Lint/RescueException
-        ignore_interrupts do
-          begin
-            FileUtils.rm_r(formula.prefix) if formula.prefix.directory?
-          rescue Errno::EACCES, Errno::ENOTEMPTY
-            odie <<~EOS
-              Could not remove #{formula.prefix.basename} keg! Do so manually:
-                sudo rm -rf #{formula.prefix}
-            EOS
-          end
-          formula.rack.rmdir_if_possible
-        end
+        Keg.new(formula.prefix).ignore_interrupts_and_uninstall!
         raise
       else
         @poured_bottle = true

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -279,6 +279,7 @@ class Keg
     opt_record.parent.rmdir_if_possible
   end
 
+  sig { params(raise_failures: T::Boolean).void }
   def uninstall(raise_failures: false)
     CacheStoreDatabase.use(:linkage) do |db|
       break unless db.created?
@@ -299,6 +300,13 @@ class Keg
       Could not remove #{name} keg! Do so manually:
         sudo rm -rf #{path}
     EOS
+  end
+
+  sig { void }
+  def ignore_interrupts_and_uninstall!
+    ignore_interrupts do
+      uninstall
+    end
   end
 
   def unlink(verbose: false, dry_run: false)


### PR DESCRIPTION
This will port the similar logic from `formula_installer.rb` that handles errors or manual user interrupts from producing partial installations.

I noticed this code is almost identical (with some missing edge-cases) in `formula_installer.rb` to `Keg#uninstall` so I added a new `Keg#uninstall_ignore_interrupts_and_raise_failures!` method and made both `formula_installer.rb` and `retryable_download.rb` use it.

@cho-m can you try this out and see if it fixes the issue? I cannot reliably reproduce this so I've had to hack together something a little.
