### PR TITLE
Restore Style/RedundantLineContinuation following upstream fix

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -436,11 +436,6 @@ Style/OptionalBooleanParameter:
     - respond_to?
     - respond_to_missing?
 
-# Broken in RuboCop 1.68.0 so tries to fix line continuations in inline patch blocks:
-# https://github.com/Homebrew/brew/actions/runs/11653110391/job/32460881827?pr=18682
-Style/RedundantLineContinuation:
-  Enabled: false
-
 # Rescuing `StandardError` is an understood default.
 Style/RescueStandardError:
   EnforcedStyle: implicit

--- a/Library/Homebrew/bundle/brewfile.rb
+++ b/Library/Homebrew/bundle/brewfile.rb
@@ -29,7 +29,7 @@ module Homebrew
             end
             user_config_home_brewfile = "#{user_config_home}/Brewfile"
 
-            if user_config_home.present? && Dir.exist?(user_config_home) && \
+            if user_config_home.present? && Dir.exist?(user_config_home) &&
                (File.exist?(user_config_home_brewfile) || !File.exist?(home_brewfile))
               user_config_home_brewfile
             else

--- a/Library/Homebrew/cask/upgrade.rb
+++ b/Library/Homebrew/cask/upgrade.rb
@@ -90,7 +90,7 @@ module Cask
     )
       quarantine = true if quarantine.nil?
 
-      outdated_casks = \
+      outdated_casks =
         self.outdated_casks(casks, args:, greedy:, greedy_latest:, greedy_auto_updates:, force:, quiet:)
 
       manual_installer_casks = outdated_casks.select do |cask|

--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -216,9 +216,9 @@ module Homebrew
         verbose = args.verbose?
 
         puts "Querying pull requests for #{person} in #{organisation}..." if args.verbose?
-        organisation_merged_prs = \
+        organisation_merged_prs =
           GitHub.search_merged_pull_requests_in_user_or_organisation(organisation, person, from:, to:)
-        organisation_approved_reviews = \
+        organisation_approved_reviews =
           GitHub.search_approved_pull_requests_in_user_or_organisation(organisation, person, from:, to:)
 
         require "utils/git"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
I noticed this one when putting together https://github.com/Homebrew/brew/pull/20969

I believe that the underlying issue has been fixed: https://github.com/rubocop/rubocop/issues/13412