### PR TITLE
formula_auditor: only run conflict check in `--strict`

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -173,15 +173,6 @@ module Homebrew
       end
 
       return unless @core_tap
-
-      cask_tokens = CoreCaskTap.instance.cask_tokens.presence
-      cask_tokens ||= Homebrew::API.cask_tokens
-
-      if cask_tokens.include?(name)
-        problem "Formula name conflicts with an existing Homebrew/cask cask's token."
-        return
-      end
-
       return unless @strict
 
       problem "'#{name}' is not allowed in homebrew/core." if MissingFormula.disallowed_reason(name)
@@ -195,6 +186,9 @@ module Homebrew
         problem "'#{name}' is reserved as the old name of #{oldname} in homebrew/core."
         return
       end
+
+      cask_tokens = CoreCaskTap.instance.cask_tokens.presence
+      cask_tokens ||= Homebrew::API.cask_tokens
 
       if cask_tokens.include?(name)
         problem "Formula name conflicts with an existing Homebrew/cask cask's token."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Looks like the check is done twice. Let's remove the one without `--strict` as we migrated duplicates within official repos already.

I think this will trigger for `--new` formulae and maybe can be bypassed with `test-bot --skip-new --skip-new-strict`.
