### PR TITLE
Set `HOMEBREW_DOWNLOAD_CONCURRENCY=auto` by default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -345,7 +345,6 @@ jobs:
     env:
       HOMEBREW_TEST_BOT_ANALYTICS: 1
       HOMEBREW_ENFORCE_SBOM: 1
-      HOMEBREW_DOWNLOAD_CONCURRENCY: auto
     steps:
       - name: Install Homebrew and Homebrew's dependencies
         # All other images are built from our Homebrew Dockerfile.

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -999,13 +999,6 @@ if [[ -n "${HOMEBREW_DEVELOPER}" || -n "${HOMEBREW_DEV_CMD_RUN}" ]]
 then
   # Always run with Sorbet for Homebrew developers or when a Homebrew developer command has been run.
   export HOMEBREW_SORBET_RUNTIME="1"
-
-  # Enable concurrent downloads for Homebrew developers or when a Homebrew developer command has been
-  # run who haven't explicitly set a value.
-  if [[ -z "${HOMEBREW_DOWNLOAD_CONCURRENCY}" ]]
-  then
-    export HOMEBREW_DOWNLOAD_CONCURRENCY="auto"
-  fi
 fi
 
 # Provide a (temporary, undocumented) way to disable Sorbet globally if needed

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -20,8 +20,9 @@ module Homebrew
                description: "Print what would be done rather than doing it."
         switch "--cleanup",
                description: "Clean all state from the Homebrew directory. Use with care!"
+        # TODO: remove this when concurrent downloads are enabled by default.
         switch "--concurrent-downloads",
-               description: "Invoke `brew` with `HOMEBREW_DOWNLOAD_CONCURRENCY=auto`."
+               hidden: true
         switch "--skip-setup",
                description: "Don't check if the local system is set up correctly."
         switch "--build-from-source",

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -191,11 +191,11 @@ module Homebrew
                      "Preferred over `$HOMEBREW_DOCKER_REGISTRY_BASIC_AUTH_TOKEN`.",
       },
       HOMEBREW_DOWNLOAD_CONCURRENCY:             {
-        description: "If set, Homebrew will download in parallel using this many concurrent connections. " \
-                     "Setting to `auto` will use twice the number of available CPU cores " \
+        description: "Homebrew will download in parallel using this many concurrent connections. " \
+                     "The default, `auto`, will use twice the number of available CPU cores " \
                      "(what our benchmarks showed to produce the best performance). " \
-                     "If set to `1` (the default), Homebrew will download in serial.",
-        default:     1,
+                     "If set to `1`, Homebrew will download in serial.",
+        default:     "auto",
       },
       HOMEBREW_EDITOR:                           {
         description:  "Use this editor when editing a single formula, or several formulae in the " \
@@ -709,7 +709,7 @@ module Homebrew
 
     sig { returns(Integer) }
     def download_concurrency
-      concurrency = ENV.fetch("HOMEBREW_DOWNLOAD_CONCURRENCY", 1)
+      concurrency = ENV.fetch("HOMEBREW_DOWNLOAD_CONCURRENCY", "auto")
       concurrency = if concurrency == "auto"
         require "os"
         require "hardware"

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Cask::Reinstall, :cask do
     Cask::Installer.new(caffeine).install
 
     output = Regexp.new <<~EOS
-      ==> Downloading file:.*caffeine.zip
-      Already downloaded: .*--caffeine.zip
+      ==> Fetching downloads for:.*caffeine
+      .* Cask .*caffeine .*
       ==> Uninstalling Cask local-caffeine
       ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
@@ -32,8 +32,8 @@ RSpec.describe Cask::Reinstall, :cask do
     Cask::Installer.new(caffeine).install
 
     output = Regexp.new <<~EOS
-      ==> Downloading file:.*caffeine.zip
-      Already downloaded: .*--caffeine.zip
+      ==> Fetching downloads for:.*caffeine
+      .* Cask .*caffeine .*
       ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Dispatching zap stanza

--- a/Library/Homebrew/test_bot.rb
+++ b/Library/Homebrew/test_bot.rb
@@ -60,7 +60,6 @@ module Homebrew
         raise UsageError, "cannot use --cleanup from HOMEBREW_PREFIX as it will delete all output."
       end
 
-      ENV["HOMEBREW_DOWNLOAD_CONCURRENCY"] = "auto" if args.concurrent_downloads?
       ENV["HOMEBREW_DEVELOPER"] = "1"
       ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
       ENV["HOMEBREW_NO_EMOJI"] = "1"


### PR DESCRIPTION
This rolls out the concurrent downloads feature to all users, as we said we'd do in Homebrew 4.7.0.