### PR TITLE
tab: Actual booleans for `installed_{on_request,as_dependency}` values

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -57,10 +57,10 @@ class AbstractTab
     attributes.each do |key, value|
       case key.to_sym
       when :installed_as_dependency
-        @installed_as_dependency = !!value
+        @installed_as_dependency = value.nil? ? false : value
         @installed_as_dependency_present = true
       when :installed_on_request
-        @installed_on_request = !!value
+        @installed_on_request = value.nil? ? false : value
         @installed_on_request_present = true
       when :changed_files
         @changed_files = value&.map { |f| Pathname(f) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #20960.
- I don't know _why_ these would ever be nil, but they apparently sometimes are.
- When `installed_on_request=null` is found in `INSTALL_RECEIPT.json`, `brew autoremove` and `brew bundle dump` and other things fail with a Sorbet error.

```
$ brew bundle dump --file=-
Error: Return value: Expected type T::Boolean, got type NilClass
Caller: /opt/homebrew/Library/Homebrew/bundle/formula_dumper.rb:150
Definition: /opt/homebrew/Library/Homebrew/tab.rb:29 (AbstractTab#installed_on_request)
```
