### PR TITLE
download_queue: Output API download messages to stderr when not a TTY

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -100,7 +100,7 @@ module Homebrew
             if tty
               stdout_print_and_flush "#{status} #{message}#{"\n" unless last}"
             elsif status
-              puts "#{status} #{message}"
+              $stderr.puts "#{status} #{message}"
             end
 
             if future.rejected?

--- a/Library/Homebrew/test/cask/reinstall_spec.rb
+++ b/Library/Homebrew/test/cask/reinstall_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Cask::Reinstall, :cask do
 
     output = Regexp.new <<~EOS
       ==> Fetching downloads for:.*caffeine
-      .* Cask .*caffeine .*
       ==> Uninstalling Cask local-caffeine
       ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
@@ -33,7 +32,6 @@ RSpec.describe Cask::Reinstall, :cask do
 
     output = Regexp.new <<~EOS
       ==> Fetching downloads for:.*caffeine
-      .* Cask .*caffeine .*
       ==> Backing App 'Caffeine.app' up to '.*Caffeine.app'
       ==> Removing App '.*Caffeine.app'
       ==> Dispatching zap stanza

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
     expect { brew "install", "testball1" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}o).to_stdout
-      .and not_to_output.to_stderr
+      .and output(/✔︎.*/m).to_stderr
       .and be_a_success
     expect(HOMEBREW_CELLAR/"testball1/0.1/foo/test").not_to be_a_file
   end
@@ -23,7 +23,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
     expect { brew "install", "testball1", "--with-foo" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}o).to_stdout
-      .and not_to_output.to_stderr
+      .and output(/✔︎.*/m).to_stderr
       .and be_a_success
     expect(HOMEBREW_CELLAR/"testball1/0.1/foo/test").to be_a_file
   end
@@ -37,7 +37,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
     expect { brew "install", "testball1" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/1\.0}o).to_stdout
-      .and not_to_output.to_stderr
+      .and output(/✔︎.*/m).to_stderr
       .and be_a_success
     expect(HOMEBREW_CELLAR/"testball1/1.0/foo/test").not_to be_a_file
   end
@@ -80,7 +80,7 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
 
     expect { brew "install", "testball1", "--debug-symbols", "--build-from-source" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}o).to_stdout
-      .and not_to_output.to_stderr
+      .and output(/✔︎.*/m).to_stderr
       .and be_a_success
     expect(HOMEBREW_CELLAR/"testball1/0.1/bin/test").to be_a_file
     expect(HOMEBREW_CELLAR/"testball1/0.1/bin/test.dSYM/Contents/Resources/DWARF/test").to be_a_file if OS.mac?
@@ -90,10 +90,10 @@ RSpec.describe Homebrew::Cmd::InstallCmd do
   it "installs with asking for user prompts without installed dependent checks", :integration_test do
     setup_test_formula "testball1"
 
-    expect do
-      brew "install", "--ask", "testball1"
-    end.to output(/.*Formula\s*\(1\):\s*testball1.*/).to_stdout.and not_to_output.to_stderr
-
+    expect { brew "install", "--ask", "testball1" }
+      .to output(/.*Formula\s*\(1\):\s*testball1.*/).to_stdout
+      .and output(/✔︎.*/m).to_stderr
+      .and be_a_success
     expect(HOMEBREW_CELLAR/"testball1/0.1/bin/test").to be_a_file
   end
 

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Homebrew::Cmd::Reinstall do
 
     expect { brew "reinstall", "testball" }
       .to output(/Reinstalling testball/).to_stdout
-      .and not_to_output.to_stderr
+      .and output(/✔︎.*/m).to_stderr
       .and be_a_success
 
     expect(foo_dir).to exist
@@ -29,8 +29,8 @@ RSpec.describe Homebrew::Cmd::Reinstall do
 
     expect { brew "reinstall", "--ask", "testball" }
       .to output(/.*Formula\s*\(1\):\s*testball.*/).to_stdout
-                                                   .and not_to_output.to_stderr
-                                                                     .and be_a_success
+      .and output(/✔︎.*/m).to_stderr
+      .and be_a_success
 
     expect(foo_dir).to exist
   end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -35,15 +35,15 @@ RSpec.describe Homebrew::Cmd::UpgradeCmd do
     setup_test_formula "testball"
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 
-    expect do
-      brew "upgrade", "--ask"
-    end.to output(/.*Formula\s*\(1\):\s*testball.*/).to_stdout.and not_to_output.to_stderr
+    expect { brew "upgrade", "--ask" }
+      .to output(/.*Formula\s*\(1\):\s*testball.*/).to_stdout
+      .and output(/✔︎.*/m).to_stderr
 
     expect(HOMEBREW_CELLAR/"testball/0.1").to be_a_directory
     expect(HOMEBREW_CELLAR/"testball/0.0.1").not_to exist
   end
 
-  it "refuses to upgrades a forbidden formula", :integration_test do
+  it "refuses to upgrade a forbidden formula", :integration_test do
     setup_test_formula "testball"
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Fixes #20978.
- With `HOMEBREW_DOWNLOAD_CONCURRENCY=1` we were seeing `brew info hello --json=v2 | jq` fail to parse the JSON because the start of the string was the download messages:

```
$ brew info --json hello
✔︎ JSON API formula_tap_migrations.jws.json
✔︎ JSON API cask_tap_migrations.jws.json
[
  {
    "name": "hello",
    "full_name": "hello",
    "tap": "homebrew/core",
    ...

$ brew info hello --json=v2 | jq
jq: parse error: Invalid numeric literal at line 1, column 7
```