### PR TITLE
system_command: avoid modifying Context.current

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -346,7 +346,7 @@ class SystemCommand
     thread_done_queue = Queue.new
     line_thread = Thread.new do
       # Ensure the new thread inherits the current context.
-      Context.current = thread_context
+      Thread.current[:context] = thread_context
 
       Thread.handle_interrupt(ProcessTerminatedInterrupt => :never) do
         thread_ready_queue << true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

May need to know if original code was intentional. But at least seems to fix reported issue for me:

Before
```console
❯ rm -rf "$(brew --cache)/api" && HOMEBREW_DOWNLOAD_CONCURRENCY=auto brew outdated
✔︎ JSON API formula_tap_migrations.jws.json
✔︎ JSON API cask_tap_migrations.jws.json
✔︎ JSON API cask.jws.json
✔︎ JSON API formula.jws.json
ca-certificates
clang-format
gh
libomp
openexr
```

After
```console
❯ rm -rf "$(brew --cache)/api" && HOMEBREW_DOWNLOAD_CONCURRENCY=auto brew outdated
✔︎ JSON API formula_tap_migrations.jws.json
✔︎ JSON API cask_tap_migrations.jws.json
✔︎ JSON API cask.jws.json
✔︎ JSON API formula.jws.json
ca-certificates (2025-09-09) < 2025-11-04
clang-format (21.1.4) < 21.1.5
gh (2.82.1) < 2.83.0
libomp (21.1.4) < 21.1.5
openexr (3.4.2_1) < 3.4.3
```
---
MikeMcQuaid edit: fixes https://github.com/Homebrew/brew/issues/20954