### PR TITLE
Normalize `HOMEBREW_CELLAR` for immutable Fedora

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -79,7 +79,7 @@ realpath() {
 
 # Support systems where HOMEBREW_PREFIX is the default,
 # but a parent directory is a symlink.
-# Example: Fedora Silverblue symlinks /home -> var/home
+# Example: Fedora Silverblue symlinks /home -> /var/home
 if [[ "${HOMEBREW_PREFIX}" != "${HOMEBREW_DEFAULT_PREFIX}" && "$(realpath "${HOMEBREW_DEFAULT_PREFIX}")" == "${HOMEBREW_PREFIX}" ]]
 then
   HOMEBREW_PREFIX="${HOMEBREW_DEFAULT_PREFIX}"


### PR DESCRIPTION
Fedora immutable systems use `/home` as a symlink to `/var/home`. Homebrew has code in `brew.sh` (lines 76-94) to normalize `HOMEBREW_PREFIX` and `HOMEBREW_REPOSITORY` for this situation, but it didn't normalize `HOMEBREW_CELLAR`. This caused a path mismatch when creating symlinks; for example:

- Destination: `/home/linuxbrew/.linuxbrew/opt/gum` (using symlink)
- Source: `/var/home/linuxbrew/.linuxbrew/Cellar/gum/0.17.0` (using real path)

Ruby's `relative_path_from` then generated broken symlinks like `../../../../var/home/linuxbrew/.linuxbrew/Cellar/gum/0.17.0`.

The commit adds normalization for `HOMEBREW_CELLAR` in `Library/Homebrew/brew.sh` to ensure it uses `/home` consistently with `HOMEBREW_PREFIX`.


**Without the patch**

```
$ brew install jq
✔︎ JSON API cask.jws.json
✔︎ JSON API formula.jws.json
==> Fetching downloads for: jq
✔︎ Bottle Manifest jq (1.8.1)
✔︎ Bottle Manifest oniguruma (6.9.10)
✔︎ Bottle oniguruma (6.9.10)
✔︎ Bottle jq (1.8.1)
==> Installing jq dependency: oniguruma
==> Pouring oniguruma--6.9.10.x86_64_linux.bottle.tar.gz
Error: No such file or directory @ rb_sysopen - /home/linuxbrew/.linuxbrew/opt/oniguruma/.sbom.spdx.json20251105-58550-9j303o

$ ls -la /home/linuxbrew/.linuxbrew/var/homebrew/linked/
total 36
drwxr-xr-x. 1 max  max       100 Nov  5 14:22 .
drwxrwxr-x. 1 root linuxbrew  22 Nov  5 13:02 ..
lrwxrwxrwx. 1 max  max        71 Nov  5 14:22 oniguruma -> ../../../../../../var/home/linuxbrew/.linuxbrew/Cellar/oniguruma/6.9.10
```


**With the patch**

```
$ brew install jq
==> Fetching downloads for: jq
✔︎ Bottle Manifest jq (1.8.1)
✔︎ Bottle Manifest oniguruma (6.9.10)
✔︎ Bottle oniguruma (6.9.10)
✔︎ Bottle jq (1.8.1)
==> Installing jq dependency: oniguruma
==> Pouring oniguruma--6.9.10.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/oniguruma/6.9.10: 16 files, 1.7MB
==> Pouring jq--1.8.1.x86_64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/jq/1.8.1: 21 files, 1.4MB
==> Running `brew cleanup jq`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
$ jq
jq - commandline JSON processor [version 1.8.1]
```


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
