### PR TITLE
Various fixes to `Formula#latest_formula`

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -93,10 +93,10 @@ module Homebrew
 
             if verbose?
               outdated_kegs = f.outdated_kegs(fetch_head: args.fetch_HEAD?)
+              latest_formula = f.latest_formula(prefer_stub: true)
 
-              current_version = if f.alias_changed? && !f.latest_formula.latest_version_installed?
-                latest = f.latest_formula
-                "#{latest.name} (#{latest.pkg_version})"
+              current_version = if f.alias_changed? && !latest_formula.latest_version_installed?
+                "#{latest_formula.name} (#{latest_formula.pkg_version})"
               elsif f.head?
                 latest_head_version = f.latest_head_pkg_version(fetch_head: args.fetch_HEAD?)
                 if outdated_kegs.any? { |k| k.version.to_s == latest_head_version.to_s }
@@ -106,7 +106,7 @@ module Homebrew
                   latest_head_version.to_s
                 end
               else
-                f.latest_formula.pkg_version.to_s
+                latest_formula.pkg_version.to_s
               end
 
               outdated_versions = outdated_kegs.group_by { |keg| Formulary.from_keg(keg).full_name }


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/20959

First, this PR ensures that all changes made to `latest_formula` are scoped to `HOMEBREW_USE_INTERNAL_API` and also only for core formulae. This fixes issues like the one in the linked PR for most users.

Additionally, for `HOMEBREW_USE_INTERNAL_API` users, this fixes the way `brew outdated`, `brew reinstall`, and `brew upgrade` work to actually determine the correct formula to install/reference.

We now pass along `spec` and other relevant information so the returned "latest" formula actually matches the "old" formula.

Additionally, we can optionally fetch a stub of the latest formula, which is useful for printing results in `brew outdated`. We still need the non-stub version for `brew reinstall` and `brew upgrade` where we do actually want to fetch the latest file.