### PR TITLE
Fix `uses_from_macos` checks with unsupported macOS versions and the internal API

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -352,7 +352,13 @@ class UsesFromMacOSDependency < Dependency
         MacOSVersion.from_symbol(Homebrew::SimulateSystem.current_os)
       end
 
-      since_os = MacOSVersion.from_symbol(since_os_bounds)
+      since_os = begin
+        MacOSVersion.from_symbol(since_os_bounds)
+      rescue MacOSVersion::Error
+        # If we can't parse the bound, it means it's an unsupported macOS version
+        # so let's default to the oldest possible macOS version
+        Version::NULL
+      end
       return true if effective_os >= since_os
     end
 


### PR DESCRIPTION
When running with `HOMEBREW_USE_INTERNAL_API`, it's possible to load an old keg formula file that includes `uses_from_macos since:` bound that is no longer supported.
If this happens, `MacOSVersion::from_symbol` will raise an exception. Instead, treat this case as if no `since` bound was passed, and assume the oldest macOS version.

To reproduce the issue, run the following with `HOMEBREW_USE_INTERNAL_API` (although there's a newer version of `curl`, so if you've recently upgraded this may not be a problem)

```console
$ brew ruby -e 'puts Formulary.resolve("curl").deps'
/opt/homebrew/Library/Homebrew/macos_version.rb:50:in 'block in MacOSVersion.from_symbol': unknown or unsupported macOS version: :sierra (MacOSVersion::Error)
	from /opt/homebrew/Library/Homebrew/macos_version.rb:50:in 'Hash#fetch'
	from /opt/homebrew/Library/Homebrew/macos_version.rb:50:in 'MacOSVersion.from_symbol'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/call_validation_2_7.rb:427:in 'UnboundMethod#bind_call'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/call_validation_2_7.rb:427:in 'block in MacOSVersion.create_validator_method_skip_return_fast1'
	from /opt/homebrew/Library/Homebrew/dependency.rb:355:in 'UsesFromMacOSDependency#use_macos_install?'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/call_validation.rb:179:in 'UnboundMethod#bind_call'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/call_validation.rb:179:in 'T::Private::Methods::CallValidation.validate_call_skip_block_type'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/call_validation.rb:121:in 'block in UsesFromMacOSDependency#create_validator_slow_skip_block_type'
	from /opt/homebrew/Library/Homebrew/dependencies.rb:35:in 'block in Dependencies#dup_without_system_deps'
	from /opt/homebrew/Library/Homebrew/dependencies.rb:35:in 'Array#reject'
	from /opt/homebrew/Library/Homebrew/dependencies.rb:35:in 'Dependencies#dup_without_system_deps'
	from /opt/homebrew/Library/Homebrew/software_spec.rb:273:in 'SoftwareSpec#deps'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12689/lib/types/private/methods/_methods.rb:259:in 'block in SoftwareSpec#_on_method_added'
	from /opt/homebrew/Library/Homebrew/vendor/portable-ruby/3.4.5/lib/ruby/3.4.0/forwardable.rb:240:in 'Formula#deps'
	from -e:1:in '<main>'
```