### PR TITLE
utils/path: allow loading API source cache

### DIFF
--- a/Library/Homebrew/utils/path.rb
+++ b/Library/Homebrew/utils/path.rb
@@ -24,6 +24,10 @@ module Utils
       else
         "#{Cask::Caskroom.path}/"
       end
+      unless Homebrew::EnvConfig.no_install_from_api?
+        require "api"
+        allowed_paths << "#{Homebrew::API::HOMEBREW_CACHE_API_SOURCE}/"
+      end
 
       return true if !path_realpath.end_with?(".rb") && !path_string.end_with?(".rb")
       return true if allowed_paths.any? { |path| path_realpath.start_with?(path) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

To fix #20984

Before
```console
❯ brew install -svd rustup
==> Fetching downloads for: rustup
✔︎ API Source rustup.rb
✔︎ Bottle Manifest rust (1.91.0)
✔︎ Formula rustup (1.28.2)
✔︎ Bottle rust (1.91.0)
...
==> Cleaning
==> Finishing up
Warning: The post-install step did not complete successfully
You can try again using:
  brew postinstall rustup
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
==> Caveats
```

After
```console
❯ brew install -svd rustup
==> Fetching downloads for: rustup
✔︎ API Source rustup.rb
✔︎ Bottle Manifest rust (1.91.0)
✔︎ Formula rustup (1.28.2)
✔︎ Bottle rust (1.91.0)
...
==> Cleaning
==> Finishing up
==> Caveats
```
