### PR TITLE
dev-cmd/formula-analytics: prettier macOS analytics.

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -372,7 +372,10 @@ module Homebrew
                              .gsub(/ \(.+\)$/, "")
 
         begin
-          return ::MacOSVersion.new(dimension).pretty_name
+          macos_version = ::MacOSVersion.new(dimension)
+          if macos_version.pretty_name.presence && macos_version.to_sym != :dunno
+            return "macOS #{macos_version.pretty_name}"
+          end
         rescue MacOSVersion::Error
           nil
         end
@@ -390,6 +393,11 @@ module Homebrew
         when /Red Hat Enterprise Linux CoreOS (\d+\.\d+)[-.\d]*/
           "Red Hat Enterprise Linux CoreOS #{Regexp.last_match(1)}"
         when /([A-Za-z ]+)\s+(\d+)\.\d{8}[.\d]*/ then "#{Regexp.last_match(1)} #{Regexp.last_match(2)}"
+        # odisabled: add new entries when removing support, remove entries when no longer in the data
+        when /^10\.14[.\d]*/ then "macOS Mojave"
+        when /^10\.13[.\d]*/ then "macOS High Sierra"
+        when /^10\.12[.\d]*/ then "macOS Sierra"
+        when /^10\.(\d+)/ then "macOS 10.#{Regexp.last_match(1)}"
         else dimension
         end
       end


### PR DESCRIPTION
- We weren't rendering the pretty name nicely with a macOS prefix.
- We intentionally dropped the names for old versions but let's add them back as a simple regex while they are still in the data.