### PR TITLE
cask_loader: ignore invalid macOS version dependencies

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -424,8 +424,8 @@ module Cask
             end.compact
             begin
               depends_on(**dep_hash)
-            rescue MacOSVersion::Error
-              # ignore invalid macOS version dependencies
+            rescue MacOSVersion::Error => e
+              odebug "Ignored invalid macOS version dependency in cask '#{token}': #{dep_hash.inspect} (#{e.message})"
               nil
             end
           end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-cask/issues/235325