### PR TITLE
keg_relocate: add relocation path to `#{var}/lib/#{name}`

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -113,6 +113,10 @@ class Keg
         old: "/usr/local/var/log/#{name}",
         new: "#{PREFIX_PLACEHOLDER}/var/log/#{name}",
       },
+      var_lib_name: {
+        old: "/usr/local/var/lib/#{name}",
+        new: "#{PREFIX_PLACEHOLDER}/var/lib/#{name}",
+      },
       var_run_name: {
         old: "/usr/local/var/run/#{name}",
         new: "#{PREFIX_PLACEHOLDER}/var/run/#{name}",


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Maybe we should consider using regex for `#{var}/<dir>/#{name}` paths (although I'm not sure how to do it)

Needed for https://github.com/Homebrew/homebrew-core/pull/253348