### PR TITLE
Fix formula reporter inconsistencies

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -216,7 +216,7 @@ module Homebrew
       names_path = HOMEBREW_CACHE_API/"#{type}_names.txt"
       if !names_path.exist? || regenerate
         names_path.unlink if names_path.exist?
-        names_path.write(names.join("\n"))
+        names_path.write(names.sort.join("\n"))
         return true
       end
 
@@ -231,7 +231,7 @@ module Homebrew
           "#{alias_name}|#{real_name}"
         end
         aliases_path.unlink if aliases_path.exist?
-        aliases_path.write(aliases_text.join("\n"))
+        aliases_path.write(aliases_text.sort.join("\n"))
         return true
       end
 


### PR DESCRIPTION
I've noticed that occasionally, `brew update` tells me that a formula I have installed has been deleted, even though it hasn't:

```console
$ brew update
==> Updating Homebrew...
==> Updated Homebrew from 71bf64f85d to b30a52a0e4.
Updated 2 taps (homebrew/core and homebrew/cask).
==> New Formulae
==> Downloading https://formulae.brew.sh/api/formula.jws.json
hexhog: Hex viewer/editor
intelli-shell: Like IntelliSense, but for shells
ktea: Kafka TUI client
tscriptify: Golang struct to TypeScript class/interface converter
tuios: Terminal UI OS (Terminal Multiplexer)
==> New Casks
==> Downloading https://formulae.brew.sh/api/cask.jws.json
nkoda: Digital sheet music app
==> Deleted Installed Formulae
glib ✘                                   gnupg ✘
```

It turns out, occasionally, the order for formulae in the `formula_names.txt` and `formula_names.before.txt` files are different, and so the `git diff` output treats the formulae as "moved". However, since this appears as an addition on one line and a deletion on another, our reporter logic ends up treating it as a deletion.

To fix this, I've made two changes:

First, sort the output before writing to the names files to ensure consistent ordering.

Also, when analyzing the `git diff` output, keep track of the total number of times a given formula appears. If it appears as "added" more times than "deleted", assume it's a new formula. If it appears as "deleted" more than "added", assume it's been deleted. If it appears the same number of times as an addition and deletion, treat it as no change.

Realistically, a formula should appear at most twice (one addition and one deletion in a move) and not more than that, so I'm not super worried about edge cases with multiple occurrences.
