### PR TITLE
cask/audit: adjust signing failure error message

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -557,7 +557,7 @@ module Cask
 
           if cask.tap.official?
             signing_failure_message += <<~EOS
-              Homebrew/cask requires all casks to be signed and notarized by Apple.
+              The homebrew/cask tap requires all casks to be signed and notarized by Apple.
               Please contact the upstream developer and ask them to sign and notarize their software.
             EOS
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
"macOS on ARM requires software to be signed." is misleading for the checks we're running. This PR adjusts the messaging for signing failures to better distinguish between Homebrew/cask and third-party taps. `url.location` also doesn't provide anything meaningful for this audit, so I've removed that to reduce noise.

Before:
```
 - Signature verification failed:
Progress: 356/356
Scan completed, but failed because the software is not signed by a distributor that meets the system Gatekeeper requirements.

macOS on ARM requires software to be signed.
Please contact the upstream developer to let them know they should sign and notarize their software.
foo
  * line 5, col 2: Signature verification failed:
Progress: 356/356
    Scan completed, but failed because the software is not signed by a distributor that meets the system Gatekeeper requirements.

    macOS on ARM requires software to be signed.
    Please contact the upstream developer to let them know they should sign and notarize their software.
Error: 1 problem in 1 cask detected.
```

After:
```
 - Signature verification failed:
Progress: 356/356
Scan completed, but failed because the software is not signed by a distributor that meets the system Gatekeeper requirements.

Homebrew/cask requires all casks to be signed and notarized by Apple.
Please contact the upstream developer and ask them to sign and notarize their software.
foo
  * Signature verification failed:
Progress: 356/356
    Scan completed, but failed because the software is not signed by a distributor that meets the system Gatekeeper requirements.

    Homebrew/cask requires all casks to be signed and notarized by Apple.
    Please contact the upstream developer and ask them to sign and notarize their software.
Error: 1 problem in 1 cask detected.
```