### PR TITLE
dev-cmd/formula-analytics: restore macOS version numbers

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -374,7 +374,7 @@ module Homebrew
         begin
           macos_version = ::MacOSVersion.new(dimension)
           if macos_version.pretty_name.presence && macos_version.to_sym != :dunno
-            return "macOS #{macos_version.pretty_name}"
+            return "macOS #{macos_version.pretty_name} (#{macos_version.strip_patch})"
           end
         rescue MacOSVersion::Error
           nil
@@ -394,9 +394,9 @@ module Homebrew
           "Red Hat Enterprise Linux CoreOS #{Regexp.last_match(1)}"
         when /([A-Za-z ]+)\s+(\d+)\.\d{8}[.\d]*/ then "#{Regexp.last_match(1)} #{Regexp.last_match(2)}"
         # odisabled: add new entries when removing support, remove entries when no longer in the data
-        when /^10\.14[.\d]*/ then "macOS Mojave"
-        when /^10\.13[.\d]*/ then "macOS High Sierra"
-        when /^10\.12[.\d]*/ then "macOS Sierra"
+        when /^10\.14[.\d]*/ then "macOS Mojave (10.14)"
+        when /^10\.13[.\d]*/ then "macOS High Sierra (10.13)"
+        when /^10\.12[.\d]*/ then "macOS Sierra (10.12)"
         when /^10\.(\d+)/ then "macOS 10.#{Regexp.last_match(1)}"
         else dimension
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Should restore macOS version numbers in our analytics.

Closes https://github.com/Homebrew/brew/issues/20998.