### PR TITLE
Use decimal prefixes for bytes, fix concurrent download progress output edge cases

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -263,16 +263,17 @@ module Homebrew
       fetched_size = downloadable.fetched_size
       return message[0, available_width].to_s if fetched_size.blank?
 
+      precision = 1
       size_length = 5
       unit_length = 2
-      size_formatting_string = "%<size>#{size_length}.1f%<unit>#{unit_length}s"
-      size, unit = disk_usage_readable_size_unit(fetched_size, per_thousand: true)
+      size_formatting_string = "%<size>#{size_length}.#{precision}f%<unit>#{unit_length}s"
+      size, unit = disk_usage_readable_size_unit(fetched_size, precision:)
       formatted_fetched_size = format(size_formatting_string, size:, unit:)
 
       formatted_total_size = if future.fulfilled?
         formatted_fetched_size
       elsif (total_size = downloadable.total_size)
-        size, unit = disk_usage_readable_size_unit(total_size, per_thousand: true)
+        size, unit = disk_usage_readable_size_unit(total_size, precision:)
         format(size_formatting_string, size:, unit:)
       else
         # fill in the missing spaces for the size if we don't have it yet.

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -204,20 +204,20 @@ module Kernel
     Formulary.factory_stub(formula_name).ensure_installed!(reason:, latest:).opt_bin/name
   end
 
-  sig { params(size_in_bytes: T.any(Integer, Float)).returns([T.any(Integer, Float), String]) }
-  def disk_usage_readable_size_unit(size_in_bytes)
-    if size_in_bytes.abs >= 1_048_576_000
-      size = size_in_bytes.to_f / 1_073_741_824
-      unit = "GB"
-    elsif size_in_bytes.abs >= 1_024_000
-      size = size_in_bytes.to_f / 1_048_576
-      unit = "MB"
-    elsif size_in_bytes.abs >= 1_000
-      size = size_in_bytes.to_f / 1_024
-      unit = "KB"
-    else
-      size = size_in_bytes
-      unit = "B"
+  sig {
+    params(
+      size_in_bytes: T.any(Integer, Float),
+      precision:     T.nilable(Integer),
+    ).returns([T.any(Integer, Float), String])
+  }
+  def disk_usage_readable_size_unit(size_in_bytes, precision: nil)
+    size = size_in_bytes
+    unit = "B"
+    %w[KB MB GB].each do |next_unit|
+      break if (precision ? size.abs.round(precision) : size.abs) < 1000
+
+      size /= 1000.0
+      unit = next_unit
     end
     [size, unit]
   end

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -71,11 +71,11 @@ RSpec.describe Kernel do
 
   specify "#disk_usage_readable" do
     expect(disk_usage_readable(1)).to eq("1B")
-    expect(disk_usage_readable(1000)).to eq("1000B")
-    expect(disk_usage_readable(1024)).to eq("1KB")
+    expect(disk_usage_readable(999)).to eq("999B")
+    expect(disk_usage_readable(1000)).to eq("1KB")
     expect(disk_usage_readable(1025)).to eq("1KB")
-    expect(disk_usage_readable(4_404_020)).to eq("4.2MB")
-    expect(disk_usage_readable(4_509_715_660)).to eq("4.2GB")
+    expect(disk_usage_readable(4_404_020)).to eq("4.4MB")
+    expect(disk_usage_readable(4_509_715_660)).to eq("4.5GB")
   end
 
   describe "#number_readable" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

~~IEC binary prefixes (KiB, MiB and GiB) can help avoid confusion.~~

EDIT: switched to decimal prefixes for alignment with defaults on macOS and Ubuntu.

Our current output of KB, MB and GB can be mistaken for SI/decimal prefixes given this is how more groups have standardized the prefixes. 

---

For formatting changes, one example prior to change is:
```rb
brew(main):001> disk_usage_readable_size_unit(1040000)
=> [1015.625, "KB"]
```

Which can cause formatted output to shift around like:
```
 [Downloading 999.0KB/500.0MB]
[Downloading 1000.0KB/500.0MB]
[Downloading 1015.6KB/500.0MB]
 [Downloading   1.0MB/500.0MB]
```
