### PR TITLE
patch: deprecate old HOMEBREW_PREFIX placeholder

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -32,6 +32,8 @@ end
 
 # An abstract class representing a patch embedded into a formula.
 class EmbeddedPatch
+  include Utils::Output::Mixin
+
   attr_writer :owner
   attr_reader :strip
 
@@ -49,8 +51,8 @@ class EmbeddedPatch
   def apply
     data = contents.gsub("@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX)
     if data.gsub!("HOMEBREW_PREFIX", HOMEBREW_PREFIX)
-      # Utils::Output.odeprecated "patch with HOMEBREW_PREFIX placeholder",
-      #                           "patch with @@HOMEBREW_PREFIX@@ placeholder"
+      odeprecated "patch with HOMEBREW_PREFIX placeholder",
+                  "patch with @@HOMEBREW_PREFIX@@ placeholder"
     end
     args = %W[-g 0 -f -#{strip}]
     Utils.safe_popen_write("patch", *args) { |p| p.write(data) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Uncomment deprecation for next release