### PR TITLE
Fix regressions from deprecation commit

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -631,7 +631,7 @@ then
   if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "${HOMEBREW_MACOS_OLDEST_ALLOWED_NUMERIC}" ]]
   then
     printf "ERROR: Your version of macOS (%s) is too old to run Homebrew!\\n" "${HOMEBREW_MACOS_VERSION}" >&2
-    if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "101500" ]]
+    if [[ "${HOMEBREW_MACOS_VERSION_NUMERIC}" -lt "100700" ]]
     then
       printf "         For 10.4 - 10.6 support see: https://github.com/mistydemeo/tigerbrew\\n" >&2
     fi

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -38,7 +38,12 @@ module OS
     # @api internal
     sig { returns(MacOSVersion) }
     def self.full_version
-      @full_version ||= T.let(MacOSVersion.new(VERSION), T.nilable(MacOSVersion))
+      @full_version ||= T.let(nil, T.nilable(MacOSVersion))
+      @full_version ||= if (fake_macos = ENV.fetch("HOMEBREW_FAKE_MACOS", nil)) # for Portable Ruby building
+        MacOSVersion.new(fake_macos)
+      else
+        MacOSVersion.new(VERSION)
+      end
     end
 
     sig { params(version: String).void }


### PR DESCRIPTION
Reverts small parts of c7c9c12620b3826616cd4da806a2987dfde5163c.

The `HOMEBREW_FAKE_MACOS` is needed for Portable Ruby building.
Showing the 10.4-10.6 message to 10.7-10.15 also doesn't makes sense.

Alternative option for the latter is to just remove that message entirely.