### PR TITLE
download_queue: extract bottle to temporary cellar.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -328,6 +328,7 @@ module Homebrew
         cleanup_empty_api_source_directories
         cleanup_bootsnap
         cleanup_logs
+        cleanup_temp_cellar
         cleanup_lockfiles
         cleanup_python_site_packages
         prune_prefix_symlinks_and_directories
@@ -404,6 +405,14 @@ module Homebrew
 
       HOMEBREW_LOGS.subdirs.each do |dir|
         cleanup_path(dir) { FileUtils.rm_r(dir) } if self.class.prune?(dir, logs_days)
+      end
+    end
+
+    def cleanup_temp_cellar
+      return unless HOMEBREW_TEMP_CELLAR.directory?
+
+      HOMEBREW_TEMP_CELLAR.each_child do |child|
+        cleanup_path(child) { FileUtils.rm_r(child) }
       end
     end
 

--- a/Library/Homebrew/startup/config.rb
+++ b/Library/Homebrew/startup/config.rb
@@ -56,6 +56,9 @@ HOMEBREW_PINNED_KEGS = (HOMEBREW_PREFIX/"var/homebrew/pinned").freeze
 # Where we store lock files
 HOMEBREW_LOCKS = (HOMEBREW_PREFIX/"var/homebrew/locks").freeze
 
+# Where we store temporary cellar files that must be in the prefix
+HOMEBREW_TEMP_CELLAR = (HOMEBREW_PREFIX/"var/homebrew/tmp/.cellar").freeze
+
 # Where we store Casks
 HOMEBREW_CASKROOM = Pathname(ENV.fetch("HOMEBREW_CASKROOM")).freeze
 

--- a/Library/Homebrew/test/support/lib/startup/config.rb
+++ b/Library/Homebrew/test/support/lib/startup/config.rb
@@ -32,6 +32,7 @@ HOMEBREW_CACHE_FORMULA = (HOMEBREW_PREFIX.parent/"formula_cache").freeze
 HOMEBREW_LINKED_KEGS   = (HOMEBREW_PREFIX/"var/homebrew/linked").freeze
 HOMEBREW_PINNED_KEGS   = (HOMEBREW_PREFIX/"var/homebrew/pinned").freeze
 HOMEBREW_LOCKS         = (HOMEBREW_PREFIX/"var/homebrew/locks").freeze
+HOMEBREW_TEMP_CELLAR   = (HOMEBREW_PREFIX/"var/homebrew/tmp/.cellar").freeze
 HOMEBREW_CELLAR        = (HOMEBREW_PREFIX/"Cellar").freeze
 HOMEBREW_LOGS          = (HOMEBREW_PREFIX.parent/"logs").freeze
 HOMEBREW_TEMP          = (HOMEBREW_PREFIX.parent/"temp").freeze


### PR DESCRIPTION
Extracts are slow and moves are fast so let's extract the bottle _somewhere_ rather than in the `Cellar` and then we can move it later.

This avoids the issue with temporary kegs being left behind if an installation is interrupted and massively simplifies the cleanup process both with a user interrupt and with `brew cleanup`.

CC @cho-m in particular as I think this is a much cleaner fix to the issues you were describing.

Fixes https://github.com/Homebrew/brew/issues/18278