### PR TITLE
cask/artifact/moved: use `mv` instead of `cp` and `rm`

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -167,15 +167,13 @@ module Cask
         # This may fail and need sudo if the source has files with restricted permissions.
         [!source.parent.writable?, true].uniq.each do |sudo|
           result = command.run(
-            "/bin/cp",
-            args:         ["-pR", target, source],
+            "/bin/mv",
+            args:         [target, source.dirname],
             must_succeed: sudo,
             sudo:,
           )
           break if result.success?
         end
-
-        delete(target, force:, command:, **options)
       end
 
       def delete(target, force: false, successor: nil, command: nil, **_)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As mentioned internally, this PR is an attempt at trying to use `mv` to backup cask artifacts on upgrade/reinstall instead of using `cp` and `rm`.