### PR TITLE
Add more documentation for the fake macOS version.

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -171,6 +171,7 @@ class GitHubRunnerMatrix
       x86_64_macos_version = MacOSVersion.new("10.15")
       @runners << create_runner(:macos, :x86_64, x86_64_spec, x86_64_macos_version)
 
+      # odisabled: remove support for Big Sur September (or later) 2027
       arm64_spec = MacOSRunnerSpec.new(
         name:    "macOS 11-arm64-cross",
         runner:  "11-arm64-cross-#{github_run_id}",

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -39,7 +39,10 @@ module OS
     sig { returns(MacOSVersion) }
     def self.full_version
       @full_version ||= T.let(nil, T.nilable(MacOSVersion))
-      @full_version ||= if (fake_macos = ENV.fetch("HOMEBREW_FAKE_MACOS", nil)) # for Portable Ruby building
+      # HOMEBREW_FAKE_MACOS is set system-wide in the macOS 11-arm64-cross image
+      # for building a macOS 11 Portable Ruby on macOS 12
+      # odisabled: remove support for Big Sur September (or later) 2027
+      @full_version ||= if (fake_macos = ENV.fetch("HOMEBREW_FAKE_MACOS", nil))
         MacOSVersion.new(fake_macos)
       else
         MacOSVersion.new(VERSION)


### PR DESCRIPTION
And make clear that it and `11-arm64-cross` can be removed September (or later) 2027