### PR TITLE
shims/shared/git: fix executing `/usr/bin/git` on Linux

### DIFF
--- a/Library/Homebrew/shims/shared/git
+++ b/Library/Homebrew/shims/shared/git
@@ -58,5 +58,11 @@ fi
 path="/Applications/Xcode.app/Contents/Developer/usr/bin/${SHIM_FILE}"
 safe_exec "${path}" "$@"
 
+if [[ -z "${popup_stub}" ]]
+then
+  path="/usr/bin/${SHIM_FILE}"
+  safe_exec "${path}" "$@"
+fi
+
 echo "You must: brew install ${SHIM_FILE}" >&2
 exit 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Without this change, the shim will never actually try to execute
`/usr/bin/git` on Linux, which results in confusing messages about `git`
being too old despite `/usr/bin/git` being new enough.

This partially restores code removed in #20973.
