### PR TITLE
cask/cask_loader: discard invalid macOS versions earlier

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -412,15 +412,16 @@ module Cask
 
               dep_type = dep_value.keys.first
               if dep_type == :==
-                version_symbols = dep_value[dep_type].map do |version|
-                  MacOSVersion::SYMBOLS.key(version) || version
+                version_symbols = dep_value[dep_type].filter_map do |version|
+                  MacOSVersion::SYMBOLS.key(version)
                 end
-                next [dep_key, version_symbols]
+                next [dep_key, version_symbols.presence]
               end
 
               version_symbol = dep_value[dep_type].first
-              version_symbol = MacOSVersion::SYMBOLS.key(version_symbol) || version_symbol
-              [dep_key, "#{dep_type} :#{version_symbol}"]
+              version_symbol = MacOSVersion::SYMBOLS.key(version_symbol)
+              version_dep = "#{dep_type} :#{version_symbol}" if version_symbol
+              [dep_key, version_dep]
             end.compact
             begin
               depends_on(**dep_hash)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `rescue MacOSVersion::Error` never triggered as we convert the error to RuntimeError in
https://github.com/Homebrew/brew/blob/6f4acdad339a4a0f62154f20116f1fc1e6d102ff/Library/Homebrew/cask/dsl/depends_on.rb#L71-L72

Try handling this earlier to retain the `depends_on` parts that are valid.

Need to test this out.