### PR TITLE
Add service install dir info to Formula Cookbook

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1104,7 +1104,9 @@ Another example would be configuration files that should not be overwritten on p
 
 There are two ways to add `launchd` plists and `systemd` services to a formula, so that `brew services` can pick them up:
 
-1. If the package already provides a service file the formula can reference it by name:
+#### Package-provided service file
+
+If the package already provides a service file, it can be installed into the `prefix` directory and referenced by name:
 
 ```ruby
 service do
@@ -1113,9 +1115,11 @@ service do
 end
 ```
 
-   To find the file we append `.plist` to the `launchd` service name and `.service` to the `systemd` service name internally.
+To find the file we append `.plist` to the `launchd` service name and `.service` to the `systemd` service name internally.
 
-2. If the formula does not provide a service file you can generate one using the following stanza:
+#### Formula-defined service file
+
+If the formula does not provide a service file you can generate one using the following stanza:
 
 ```ruby
 # 1. An individual command


### PR DESCRIPTION
Adds a breief snippet to the "Service files" section describing where brew looks for source-provided launchd and systemd service files.
Also removes the numbered list elements, which don't render properly on the homebrew website due to the code blocks not being indented.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
