### PR TITLE
docs/Support-Tiers: rewrite for more clarity

### DIFF
--- a/docs/Support-Tiers.md
+++ b/docs/Support-Tiers.md
@@ -67,7 +67,7 @@ Tier 2 configurations include:
 
 - macOS prerelease versions before they are promoted to Tier 1
 - Linux systems with `glibc` versions between 2.13 and 2.34 (Homebrew’s own `glibc` formula will be installed automatically)
-- Homebrew installed outside the default prefix, requiring source builds for official packages (e.g. non-standard installs of `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew/.linuxbrew`)
+- Homebrew installed outside the default prefix, requiring source builds for official packages (i.e. installing outside `/opt/homebrew`, `/usr/local`, or `/home/linuxbrew/.linuxbrew`)
 - Architectures not yet officially supported by Homebrew
 - Macs using OpenCore Legacy Patcher with a Westmere or newer Intel CPU
 
@@ -79,7 +79,7 @@ The following conditions typically apply:
 
 - Homebrew may work, but with a poor and unstable experience
 - Migration to a Tier 1 or 2 configuration, or to a non-Homebrew tool, is strongly recommended
-- Pull requests must meet a very high bar: they must resolve an issue (not merely work around it) and must not introduce high ongoing maintenance cost (e.g. no custom patches that haven't been already merged upstream)
+- Pull requests must meet a very high bar: they must resolve an issue (not merely work around it) and must not introduce high ongoing maintenance cost (e.g. patches must already be merged upstream)
 - Homebrew maintainers do not commit to fixing bugs affecting these systems
 - Functionality may regress intentionally if it benefits supported configurations
 - Loud configuration warnings will be printed at runtime


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR is an attempt to standardize language, reduce implied guarantees, clarify future support.

I also noticed we call out Ubuntu as Tier 1, but other Linux systems are now recommending Homebrew, so we may want to address those somewhere in this doc.