### PR TITLE
language/node: replace `-ddd` with long form

### DIFF
--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -67,7 +67,7 @@ module Language
 
       # npm install args for global style module format installed into libexec
       args = %W[
-        -ddd
+        --loglevel=silly
         --global
         --build-from-source
         --#{npm_cache_config}
@@ -85,7 +85,7 @@ module Language
       setup_npm_environment
       # npm install args for local style module format
       %W[
-        -ddd
+        --loglevel=silly
         --build-from-source
         --#{npm_cache_config}
       ]

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -68,6 +68,6 @@ RSpec.describe Language::Node do
 
   specify "#local_npm_install_args" do
     resp = described_class.local_npm_install_args
-    expect(resp).to include("-ddd", "--build-from-source", "--cache=#{HOMEBREW_CACHE}/npm_cache")
+    expect(resp).to include("--loglevel=silly", "--build-from-source", "--cache=#{HOMEBREW_CACHE}/npm_cache")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

npm switched abbreviated form from `-ddd` to `--ddd` in v7 and now complains that:

> npm warn -ddd is not a valid single-hyphen cli flag and will be
> removed in the future

Instead we can just use the long form `--loglevel silly`[^1] which works with all npm versions.

[^1]: https://docs.npmjs.com/cli/v11/using-npm/config#shorthands-and-other-cli-niceties
