### PR TITLE
download_strategy: make hardcoded commit hash length a constant

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -822,7 +822,7 @@ module GitHub
     pr_data["labels"].map { |label| label["name"] }
   end
 
-  def self.last_commit(user, repo, ref, version)
+  def self.last_commit(user, repo, ref, version, length: nil)
     return if Homebrew::EnvConfig.no_github_api?
 
     require "utils/curl"
@@ -837,16 +837,17 @@ module GitHub
     commit = result.stdout[/^ETag: "(\h+)"/i, 1]
     return if commit.blank?
 
-    github_graphql_abbreviated_oid_length = 7
-    return if commit.length < github_graphql_abbreviated_oid_length
+    if length
+      return if commit.length < length
 
-    # Just guess 7 characters for `git rev-parse --short=7`, which is the same
-    # as what GitHub uses for GraphQL abbreviatedOid. If this fails, then just
-    # return nil as we currently don't have a way to determine the reason for
-    # the failure. This means we can't distinguish a GitHub API rate limit from
-    # an actual non-unique short commit where the latter needs 8 or more characters.
-    commit = commit[0, github_graphql_abbreviated_oid_length]
-    return if multiple_short_commits_exist?(user, repo, commit)
+      commit = commit[0, length]
+
+      # We return nil if the following fails as we currently don't have a way to
+      # determine the reason for the failure. This means we can't distinguish a
+      # GitHub API rate limit from a non-unique short commit where the latter
+      # needs (n+1) or more characters to match `git rev-parse --short=n`.
+      return if multiple_short_commits_exist?(user, repo, commit)
+    end
 
     version.update_commit(commit)
     commit


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Updates my previous change to avoid multiple hardcoded `7` values in code and instead use a constant.