### PR TITLE
tap-new: fix default cleanup action

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -107,7 +107,7 @@ module Homebrew
                     key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
                     restore-keys: ${{ matrix.os }}-rubygems-
 
-                - run: brew test-bot --only-cleanup-before
+                - run: brew test-bot --cleanup --only-cleanup-before
 
                 - run: brew test-bot --only-setup
 


### PR DESCRIPTION
The [test-bot docs](https://docs.brew.sh/Manpage#test-bot-options-formula) say `--only-cleanup-before` requires `--cleanup`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
