### PR TITLE
test-bot: clarify cleanup flag usage

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -77,7 +77,7 @@ module Homebrew
         switch "--skip-revision-audit",
                description: "Don't audit the revision."
         switch "--only-cleanup-before",
-               description: "Only run the pre-cleanup step. Needs `--cleanup`."
+               description: "Only run the pre-cleanup step. Needs `--cleanup`, except in GitHub Actions."
         switch "--only-setup",
                description: "Only run the local system setup check step."
         switch "--only-tap-syntax",
@@ -97,7 +97,7 @@ module Homebrew
                             "to be run on a single machine. The bottle commit to be tested must be on the tested " \
                             "branch."
         switch "--only-cleanup-after",
-               description: "Only run the post-cleanup step. Needs `--cleanup`."
+               description: "Only run the post-cleanup step. Needs `--cleanup`, except in GitHub Actions."
         comma_array "--testing-formulae=",
                     description: "Use these testing formulae rather than running the formulae detection steps."
         comma_array "--added-formulae=",


### PR DESCRIPTION
As noted in https://github.com/Homebrew/brew/pull/21030#issuecomment-3520666050, `test-bot` assumes `--cleanup` in GitHub Actions.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

Full disclosure: I ran `brew lgtm` instead of the last three commands mentioned above. 😀 