### PR TITLE
Enhance bug report instructions for logs

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -3249,6 +3249,8 @@ class Formula
         if !verbose? || verbose_using_dots
           puts "Last #{log_lines} lines from #{log_filename}:"
           Kernel.system "/usr/bin/tail", "-n", log_lines.to_s, log_filename
+          puts
+          puts "IMPORTANT: If submitting a bug report, please include the full content of #{log_filename}"
         end
         log.puts
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds some logging to tell users to include the full logs when they submit bug reports to projects. While the existing logging does tell users where it is, most users do not even read the output and especially not in the middle of the output. This puts a message at the end of output that tells users to include the logs and where to get them. Maybe there is hope they will at least read the final line of the output.

Resolves https://github.com/orgs/Homebrew/discussions/6541