### PR TITLE
Replace sdk_path_if_needed with sdk_path

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -82,6 +82,7 @@ Style/Documentation:
     - livecheck/strategy/xorg.rb
     - livecheck/strategy/yaml.rb
     - os.rb
+    - os/mac.rb
     - resource.rb
     - startup/config.rb
     - utils/inreplace.rb

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -57,7 +57,7 @@ module OS
         delete("CPATH")
         remove "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 
-        sdk = self["SDKROOT"] || MacOS.sdk_path_if_needed(version)
+        sdk = self["SDKROOT"] || MacOS.sdk_path(version)
         return unless sdk
 
         delete("SDKROOT")
@@ -107,7 +107,7 @@ module OS
       # Some configure scripts won't find libxml2 without help.
       # This is a no-op with macOS SDK 10.15.4 and later.
       def libxml2
-        sdk = self["SDKROOT"] || MacOS.sdk_path_if_needed
+        sdk = self["SDKROOT"] || MacOS.sdk_path
         # Use the includes from the sdk
         append "CPPFLAGS", "-I#{sdk}/usr/include/libxml2" unless Pathname("#{sdk}/usr/include/libxml").directory?
       end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -132,6 +132,9 @@ module OS
       sdk_locator.sdk_if_applicable(version)
     end
 
+    # Returns the path to the SDK needed based on the formula's requirements.
+    #
+    # @api public
     sig {
       params(
         formula:                         Formula,
@@ -154,6 +157,8 @@ module OS
     end
 
     # Returns the path to an SDK or nil, following the rules set by {sdk}.
+    #
+    # @api public
     sig { params(version: T.nilable(MacOSVersion)).returns(T.nilable(Pathname)) }
     def self.sdk_path(version = nil)
       s = sdk(version)
@@ -164,6 +169,8 @@ module OS
     # Expected results:
     # 1. On Xcode-only systems, return the Xcode SDK.
     # 2. On CLT-only systems, return the CLT SDK.
+    #
+    # @api public
     sig { params(version: T.nilable(MacOSVersion)).returns(T.nilable(Pathname)) }
     def self.sdk_path_if_needed(version = nil)
       sdk_path(version)

--- a/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
+++ b/Library/Homebrew/test/os/mac/pkgconfig_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "pkg-config", :needs_ci, type: :system do
     version
   end
 
-  let(:sdk) { MacOS.sdk_path_if_needed }
+  let(:sdk) { MacOS.sdk_path }
 
   it "returns the correct version for bzip2" do
     version = File.foreach("#{sdk}/usr/include/bzlib.h")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

sdk_path_if_needed is now just an alias for sdk_path. Also mark sdk_for_formula, sdk_path and sdk_path_if_needed as public API due to usage in Homebrew/core formulae.

---

https://github.com/Homebrew/brew/blob/0b8a8532e6e0e3e26330d2fd8e44268303b38188/Library/Homebrew/os/mac.rb#L168-L170