### PR TITLE
build: skip libexec metafiles if prefix already has some

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -207,7 +207,11 @@ class Build
 
             # Find and link metafiles
             formula.prefix.install_metafiles T.must(formula.buildpath)
-            formula.prefix.install_metafiles formula.libexec if formula.libexec.exist?
+            if formula.libexec.exist?
+              require "metafiles"
+              no_metafiles = formula.prefix.children.none? { |p| p.file? && Metafiles.copy?(p.basename.to_s) }
+              formula.prefix.install_metafiles formula.libexec if no_metafiles
+            end
 
             normalize_pod2man_outputs!(formula)
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

libexec can contain resources and installing metafiles can override the correct metafiles (e.g. readme and license).

Also, this provides a way to prevent brew from moving files that we want to retain within libexec.

---

This provides an alternative approach to following issue, rather than modifying `skip_clean` logic:
- #20922

Closes #20922 (MikeMcQuaid edit)