### PR TITLE
utils/gems: run `setup_gem_environment!`

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -214,11 +214,9 @@ module Homebrew
     invalid_groups = groups - valid_gem_groups
     raise ArgumentError, "Invalid gem groups: #{invalid_groups.join(", ")}" unless invalid_groups.empty?
 
+    setup_gem_environment!
     # Tests should not modify the state of the repository.
-    if ENV["HOMEBREW_TESTS"]
-      setup_gem_environment!
-      return
-    end
+    return if ENV["HOMEBREW_TESTS"]
 
     # Combine the passed groups with the ones stored in settings.
     groups |= (user_gem_groups & valid_gem_groups)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This was previously done by `install_bundler!` before d562e44c88b8fc0140981f6b4b312c0011d20c7f

---

I don't know about other places we were running `install_bundler!` but the removal of this at below (originally line 244) seems to cause  issues:
- https://github.com/Homebrew/brew/commit/d562e44c88b8fc0140981f6b4b312c0011d20c7f#diff-a1a5395d198aee1fb8c45c74bf9dd49ef5734887a17ee84000badc7d58b82e98L244


Prior to change, strange errors like 
- if brew Ruby is installed and on PATH, gems link to that one. Need to purge old gems to get brew to work again.
- brew tries running on system Ruby 2
