### PR TITLE
`HOMEBREW_NO_INSTALL_FROM_API` disables `HOMEBREW_USE_INTERNAL_API`

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -575,6 +575,7 @@ module Homebrew
       :HOMEBREW_CASK_OPTS,
       :HOMEBREW_FORBID_PACKAGES_FROM_PATHS,
       :HOMEBREW_DOWNLOAD_CONCURRENCY,
+      :HOMEBREW_USE_INTERNAL_API,
     ]).freeze, T::Set[Symbol])
 
     FALSY_VALUES = T.let(%w[false no off nil 0].freeze, T::Array[String])
@@ -678,6 +679,14 @@ module Homebrew
       end
 
       [concurrency, 1].max
+    end
+
+    sig { returns(T::Boolean) }
+    def use_internal_api?
+      return false if Homebrew::EnvConfig.no_install_from_api?
+
+      use_internal_api = ENV.fetch("HOMEBREW_USE_INTERNAL_API", nil)
+      use_internal_api.present? && FALSY_VALUES.exclude?(use_internal_api.downcase)
     end
   end
 end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/env_config.rbi
@@ -317,9 +317,6 @@ module Homebrew::EnvConfig
     def upgrade_greedy_casks; end
 
     sig { returns(T::Boolean) }
-    def use_internal_api?; end
-
-    sig { returns(T::Boolean) }
     def verbose?; end
 
     sig { returns(T::Boolean) }


### PR DESCRIPTION
Since setting `HOMEBREW_NO_INSTALL_FROM_API` is meant to disable all API actions, it should not be possible to have `HOMEBREW_NO_INSTALL_FROM_API` set while also having `HOMEBREW_USE_INTERNAL_API` set. If that happens, treat `HOMEBREW_USE_INTERNAL_API` as unset.
