### PR TITLE
gems: remove arm-linux from Gemfile.lock.

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -167,7 +167,6 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm-linux
   arm64-darwin
   x86_64-darwin
   x86_64-linux

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -51,7 +51,7 @@ module Homebrew
           # Workaround Bundler 2.4.21 issue where platforms may be removed.
           # Although we don't use 2.4.21, Dependabot does as it currently ignores your lockfile version.
           # https://github.com/rubygems/rubygems/issues/7169
-          run_bundle "lock", "--add-platform", "aarch64-linux", "arm-linux"
+          run_bundle "lock", "--add-platform", "aarch64-linux"
           system "git", "add", "Gemfile.lock" unless args.no_commit?
 
           if args.non_bundler_gems?


### PR DESCRIPTION
Sorbet have dropped it so we have to too.

Needed for https://github.com/Homebrew/brew/pull/21062