### PR TITLE
dev-cmd/vendor-gems: fix permissions for Linux GitHub Actions.

### DIFF
--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -42,6 +42,11 @@ module Homebrew
           ohai "bundle install --standalone"
           run_bundle "install", "--standalone"
 
+          if GitHub::Actions.env_set? && HOMEBREW_PREFIX.to_s == HOMEBREW_LINUX_DEFAULT_PREFIX
+            ohai "chmod +t -R /home/linuxbrew/"
+            system "sudo", "chmod", "+t", "-R", "/home/linuxbrew/"
+          end
+
           ohai "bundle pristine"
           run_bundle "pristine"
 


### PR DESCRIPTION
`bundle` can refuse to install with the weird permissions situation that we can end up with.

Needed for https://github.com/Homebrew/brew/pull/21062