### PR TITLE
Add profiling to `brew tests`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /Library/Homebrew/test/coverage
 /Library/Homebrew/test/junit
 /Library/Homebrew/test/fs_leak_log
+/Library/Homebrew/tmp/test_prof
 /Library/Homebrew/vendor/portable-ruby
 /Library/Taps
 /Library/PinnedTaps
@@ -141,6 +142,7 @@
 **/vendor/bundle/ruby/*/gems/strscan-*/
 **/vendor/bundle/ruby/*/gems/syntax_tree-*/
 **/vendor/bundle/ruby/*/gems/tapioca-*/
+**/vendor/bundle/ruby/*/gems/test-prof-*/
 **/vendor/bundle/ruby/*/gems/thor-*/
 **/vendor/bundle/ruby/*/gems/unicode-display_width-*/
 **/vendor/bundle/ruby/*/gems/unicode-emoji-*/

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -50,6 +50,9 @@ group :style, optional: true do
   gem "rubocop-rspec", require: false
   gem "rubocop-sorbet", require: false
 end
+group :style, :tests, optional: true do
+  gem "test-prof", require: false
+end
 group :tests, optional: true do
   gem "parallel_tests", require: false
   gem "rspec", require: false

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
       yard-sorbet
+    test-prof (1.4.4)
     thor (1.4.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -211,6 +212,7 @@ DEPENDENCIES
   spoom
   stackprof
   tapioca
+  test-prof
   vernier
   warning
   yard

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1157,7 +1157,8 @@ on_request: installed_on_request?, options:)
     Formula.clear_cache
 
     cask_installed_with_formula_name = begin
-      Cask::CaskLoader.load(formula.name, warn: false).installed?
+      (Cask::Caskroom.path/formula.name).exist? &&
+        Cask::CaskLoader.load(formula.name, warn: false).installed?
     rescue Cask::CaskUnavailableError, Cask::CaskInvalidError
       false
     end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/tests.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/tests.rbi
@@ -35,6 +35,15 @@ class Homebrew::DevCmd::Tests::Args < Homebrew::CLI::Args
   sig { returns(T.nilable(String)) }
   def profile; end
 
+  sig { returns(T::Boolean) }
+  def ruby_prof?; end
+
   sig { returns(T.nilable(String)) }
   def seed; end
+
+  sig { returns(T::Boolean) }
+  def stackprof?; end
+
+  sig { returns(T::Boolean) }
+  def vernier?; end
 end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -25,6 +25,8 @@ end
 require_relative "../standalone"
 require_relative "../warnings"
 
+require "test-prof"
+
 Warnings.ignore :parser_syntax do
   require "rubocop"
 end

--- a/Library/Homebrew/vendor/bundle/bundler/setup.rb
+++ b/Library/Homebrew/vendor/bundle/bundler/setup.rb
@@ -119,6 +119,7 @@ $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/yard-0.9.37/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/yard-sorbet-0.9.0/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/tapioca-0.17.9/lib")
+$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/test-prof-1.4.4/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/extensions/arm64-darwin-20/#{Gem.extension_api_version}/vernier-1.8.1")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/vernier-1.8.1/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/warning-1.5.0/lib")


### PR DESCRIPTION
Add the same profilers support as `brew prof` using `test-prof`.

While we're here, fix a `formula_installer` performance issue that added ~0.5s to every call to `FormulaInstaller#finish` which is a lot of integration tests (already our slowest types).