### PR TITLE
github_runner_matrix: check requirement on simulated system

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -285,10 +285,10 @@ class GitHubRunnerMatrix
       macos_version = runner.macos_version
 
       @testing_formulae.select do |formula|
-        next false if macos_version && !formula.compatible_with?(macos_version)
-
         Homebrew::SimulateSystem.with(os: platform, arch: Homebrew::SimulateSystem.arch_symbols.fetch(arch)) do
           simulated_formula = TestRunnerFormula.new(Formulary.factory(formula.name))
+          next false if macos_version && !simulated_formula.compatible_with?(macos_version)
+
           simulated_formula.public_send(:"#{platform}_compatible?") &&
             simulated_formula.public_send(:"#{arch}_compatible?")
         end
@@ -306,10 +306,10 @@ class GitHubRunnerMatrix
       compatible_testing_formulae(runner).select do |formula|
         compatible_dependents = formula.dependents(platform:, arch:, macos_version: macos_version&.to_sym)
                                        .select do |dependent_f|
-          next false if macos_version && !dependent_f.compatible_with?(macos_version)
-
           Homebrew::SimulateSystem.with(os: platform, arch: Homebrew::SimulateSystem.arch_symbols.fetch(arch)) do
             simulated_dependent_f = TestRunnerFormula.new(Formulary.factory(dependent_f.name))
+            next false if macos_version && !simulated_dependent_f.compatible_with?(macos_version)
+
             simulated_dependent_f.public_send(:"#{platform}_compatible?") &&
               simulated_dependent_f.public_send(:"#{arch}_compatible?")
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Otherwise requirements will be checked on the local architecture leading to incorrect runners.

Seen in `dotnet@8` - https://github.com/Homebrew/homebrew-core/pull/253273/files

Before
```
❯ arch -x86_64 brew determine-test-runners dotnet@8 | rg name
    "name": "Linux x86_64",
    "name": "Linux arm64",
```

After
```
❯ arch -x86_64 brew determine-test-runners dotnet@8 | rg name
    "name": "Linux x86_64",
    "name": "Linux arm64",
    "name": "macOS 26-arm64",
    "name": "macOS 15-arm64",
    "name": "macOS 14-arm64",
```