### PR TITLE
dev-cmd/contributions: Space between  `--quarter` docs sentences

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -42,7 +42,7 @@ module Homebrew
                             "The first part of the team name will be used as the organisation."
         flag   "--quarter=",
                description: "Quarter to search (1-4). " \
-                            "Omitting this flag searches the past year." \
+                            "Omitting this flag searches the past year. " \
                             "If `--from` or `--to` are set, they take precedence."
         flag   "--from=",
                description: "Date (ISO 8601 format) to start searching contributions. " \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- Only noticed this once the manpage regeneration job ran in #21079, oops.