### PR TITLE
Fix `rubocop` in vscode and simplify `brew install-bundler-gems` calls

### DIFF
--- a/.vscode/ruby-lsp-activate.sh
+++ b/.vscode/ruby-lsp-activate.sh
@@ -8,7 +8,14 @@ else
 fi
 HOMEBREW_PREFIX="$(cd "$(dirname "${SCRIPT_PATH}")"/../ && pwd)"
 
-"${HOMEBREW_PREFIX}/bin/brew" install-bundler-gems --add-groups=style,typecheck,vscode >/dev/null 2>&1
-
-export PATH="${HOMEBREW_PREFIX}/Library/Homebrew/vendor/portable-ruby/current/bin:${PATH}"
+# These are used by the functions needed from utils/ruby.sh
+export HOMEBREW_BREW_FILE="${HOMEBREW_PREFIX}/bin/brew"
+export HOMEBREW_LIBRARY="${HOMEBREW_PREFIX}/Library"
 export BUNDLE_WITH="style:typecheck:vscode"
+
+# shellcheck disable=SC1091
+source "${HOMEBREW_PREFIX}/Library/Homebrew/utils/ruby.sh"
+
+setup-ruby-path
+setup-gem-home-bundle-gemfile
+ensure-bundle-dependencies

--- a/Library/Homebrew/cmd/setup-ruby.sh
+++ b/Library/Homebrew/cmd/setup-ruby.sh
@@ -34,8 +34,5 @@ homebrew-setup-ruby() {
 
   setup-gem-home-bundle-gemfile
 
-  if ! bundle check &>/dev/null
-  then
-    "${HOMEBREW_BREW_FILE}" install-bundler-gems
-  fi
+  ensure-bundle-dependencies
 }

--- a/Library/Homebrew/dev-cmd/rubocop.sh
+++ b/Library/Homebrew/dev-cmd/rubocop.sh
@@ -12,10 +12,7 @@ homebrew-rubocop() {
   BUNDLE_WITH="style"
   export BUNDLE_WITH
 
-  if ! bundle check &>/dev/null
-  then
-    "${HOMEBREW_BREW_FILE}" install-bundler-gems --add-groups="${BUNDLE_WITH}"
-  fi
+  ensure-bundle-dependencies
 
   export PATH="${GEM_HOME}/bin:${PATH}"
 

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -187,3 +187,18 @@ setup-gem-home-bundle-gemfile() {
   export GEM_HOME
   export BUNDLE_GEMFILE
 }
+
+ensure-bundle-dependencies() {
+  local install_args=()
+
+  if ! bundle check &>/dev/null
+  then
+    if [[ -n "${BUNDLE_WITH}" ]]
+    then
+      # Convert colon-separated BUNDLE_WITH to comma-separated for --add-groups
+      local groups_for_flag="${BUNDLE_WITH//:/,}"
+      install_args+=("--add-groups=${groups_for_flag}")
+    fi
+    "${HOMEBREW_BREW_FILE}" install-bundler-gems "${install_args[@]}"
+  fi
+}


### PR DESCRIPTION
This fixes an issue I was having with `rubocop` in vscode.

The ruby lsp setup in vscode is now much simpler, since it uses the same ruby setup commands we use for other shell commands, so hopefully future changes will be less destructive.

As part of this, I added a new ruby helper function to run `brew install-bundler-gems` if needed, which is used a few times by shell commands and the ruby lsp setup
