### PR TITLE
formulary: leave default `ignore_errors=false` for internal API load

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1289,7 +1289,7 @@ module Formulary
 
     f = if Homebrew::EnvConfig.use_internal_api? && (loader = FromKegLoader.try_new(keg.name, warn: false))
       begin
-        loader.get_formula(spec, alias_path:, force_bottle:, flags:, ignore_errors: true)
+        loader.get_formula(spec, alias_path:, force_bottle:, flags:)
       rescue FormulaUnreadableError
         nil
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Ignoring errors disables proper exception handling which leads to unexpected code paths that can cause Sorbet errors rather than `FormulaUnreadableError`. Sorbet errors then cascade up and cause brew to not run properly.

---

Need someone to check if this was intentionally set to `ignore_errors: true`

At least helps with `brew doctor` part of 
- https://github.com/Homebrew/brew/issues/21055

e.g. reproduced with my existing install of `tmux` which was installed before we dropped Sierra from Formula
```
❯ rg on_system $(brew --prefix tmux)/.brew/tmux.rb
30:  on_system :linux, macos: :sierra_or_newer do
```

before
```
❯ HOMEBREW_USE_INTERNAL_API=1 brew doctor
Error: Passed `nil` into T.must
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
/opt/homebrew/Library/Homebrew/ignorable.rb:30:in 'block in Object#raise'
/opt/homebrew/Library/Homebrew/ignorable.rb:29:in 'Kernel#callcc'
/opt/homebrew/Library/Homebrew/ignorable.rb:29:in 'Object#raise'
/opt/homebrew/Library/Homebrew/macos_version.rb:58:in 'MacOSVersion#initialize'
```

after
```
❯ HOMEBREW_USE_INTERNAL_API=1 brew doctor
Your system is ready to brew.
```