### PR TITLE
Internal API: re-fetch formula json when stub shows update

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -23,10 +23,10 @@ module Homebrew
         cache.fetch("formula_json").fetch(name)
       end
 
-      sig { params(name: String, download_queue: T.nilable(DownloadQueue)).void }
-      def self.fetch_formula_json!(name, download_queue: nil)
+      sig { params(name: String, download_queue: T.nilable(DownloadQueue), stale_seconds: T.nilable(Integer)).void }
+      def self.fetch_formula_json!(name, download_queue: nil, stale_seconds: nil)
         endpoint = "formula/#{name}.json"
-        json_formula, updated = Homebrew::API.fetch_json_api_file endpoint, download_queue: download_queue
+        json_formula, updated = Homebrew::API.fetch_json_api_file(endpoint, download_queue:, stale_seconds:)
         return if download_queue
 
         json_formula = JSON.parse((HOMEBREW_CACHE_API/endpoint).read) unless updated


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Helps fix #21084

Not too sure if this is the best place to handle it but at least fixes `brew upgrade` when using internal API. Maybe other commands need to invalidate cache too.

An alternate idea is to download a new file whenever older than the internal JSON file but this would result in extra downloads. However, may be safer if a non-revision bump change went in.