### PR TITLE
Update rexml to version 3.3.6

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       logger
     redcarpet (3.6.0)
     regexp_parser (2.9.2)
-    rexml (3.3.4)
+    rexml (3.3.6)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -156,7 +156,6 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm-linux
   arm64-darwin
   x86_64-darwin
   x86_64-linux


### PR DESCRIPTION
Upgrade the `rexml` dependency from version 3.3.4 to 3.3.6 to incorporate the latest improvements and fixes.

