### PR TITLE
workflows/tests: tweak behaviour.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -212,10 +212,10 @@ jobs:
           brew update-test --commit=HEAD
 
   tests:
-    if: github.event_name != 'push'
     name: ${{ matrix.name }}
     needs: syntax
     runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:


### PR DESCRIPTION
- Run on `push` events so that parallel tests files are cached correctly and used to speedup the suites.
- Set a conservative timeout for tests to avoid them running for hours sometimes.