### PR TITLE
Add `homebrew.code-workspace` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,6 +204,7 @@
 !/.sublime
 /.sublime/homebrew.sublime-workspace
 !/.vscode
+!/homebrew.code-workspace
 
 # Unignore AI configuration
 !/.cursor

--- a/homebrew.code-workspace
+++ b/homebrew.code-workspace
@@ -1,0 +1,55 @@
+{
+	"folders": [
+		{
+			"path": ".",
+      "name": "brew"
+		},
+		{
+			"path": "Library/Taps/homebrew/homebrew-core",
+      "name": "homebrew-core"
+		},
+		{
+			"path": "Library/Taps/homebrew/homebrew-cask",
+      "name": "homebrew-cask"
+		}
+	],
+	"settings": {
+    "files.exclude": {
+      "Library/Taps": true,
+      // Exclude all files in bin except for brew
+      "bin/[^b]*": true,
+      "bin/b[^r]*": true,
+      "bin/br[^e]*": true,
+      "bin/bre[^w]*": true,
+      // brew aliases are in the form brew-*
+      "bin/brew-*": true,
+    },
+		"rubyLsp.rubyVersionManager": {
+			"identifier": "custom"
+		},
+		"rubyLsp.customRubyCommand": "source /opt/homebrew/.vscode/ruby-lsp-activate.sh",
+		"rubyLsp.bundleGemfile": "Library/Homebrew/Gemfile",
+		"rubyLsp.formatter": "rubocop",
+		"sorbet.enabled": true,
+		"sorbet.lspConfigs": [
+			{
+				"id": "default",
+				"name": "Brew Typecheck",
+				"description": "Default configuration",
+				"command": [
+					"./bin/brew",
+					"typecheck",
+					"--lsp"
+				]
+			}
+		],
+		"sorbet.selectedLspConfigId": "default",
+		"shellformat.effectLanguages": [
+			"shellscript"
+		],
+		"shellformat.path": "${workspaceFolder}/Library/Homebrew/utils/shfmt.sh",
+		"shellformat.flag": "-i 2 -ci -ln bash",
+		"simplecov-vscode.path": "Library/Homebrew/test/coverage/.resultset.json",
+    "simplecov-vscode.enabled": false,
+	}
+}


### PR DESCRIPTION
Testing out creating a multi-root workspace for vscode

To test this out, run `code $(brew --repo)/homebrew.code-workspace`

The good news is that it seems to work fine for the `brew` repo.
For formulae and casks, command-click to view definition of formula DSLs seems to work fine, but the sorbet requirement still stands which is unfortunate.

Also, when opening a formula or cask, I get this weird error:

```
Automatic Ruby environment activation with custom failed: spawn /opt/homebrew/bin/zsh ENOENT
```

Which is odd because that path does exist, and seems to work fine for files in `brew`, just not in core or cask...
