### PR TITLE
env_config: disable internal API.

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -683,10 +683,8 @@ module Homebrew
 
     sig { returns(T::Boolean) }
     def use_internal_api?
-      return false if Homebrew::EnvConfig.no_install_from_api?
-
-      use_internal_api = ENV.fetch("HOMEBREW_USE_INTERNAL_API", nil)
-      use_internal_api.present? && FALSY_VALUES.exclude?(use_internal_api.downcase)
+      # TODO: re-enable this when the internal API is ready again.
+      false
     end
   end
 end


### PR DESCRIPTION
We're going to rethink and break some backwards compatibility here so let's disable it for now.

CC @Rylan12 who suggested this.