### PR TITLE
Updated example for listing taps with note saying that nothing is shown after fresh install.

### DIFF
--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -11,14 +11,14 @@ but the command isn't limited to any one location.
 ## The `brew tap` command
 
 * `brew tap` without arguments lists all currently tapped repositories. For
-  example:
+  example with one installed tap which is called `petere/postgresql`:
 
   ```console
   $ brew tap
-  homebrew/cask
-  homebrew/core
   petere/postgresql
   ```
+
+* It should be noted: `brew tap` will not output anything if no taps were added yet. That is the case after a fresh install of homebrew.
 
 * `brew tap <user>/<repo>` makes a clone of the repository at
   `https://github.com/<user>/homebrew-<repo>` into `$(brew --repository)/Library/Taps`.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

## Note about the checklist
>  Have you written new tests for your changes? 

My addition are just in the docs so no tests are needed

## Reason for this change

This update to the documentation should reduce confusion for user learning about taps. The previous example is outdated in my view. Back then even the official repositories of formulas were listed as taps. Nowadays this is not the case anymore. Only external taps added after a install are listed now.

It was also commented by a maintainer that this part should be updated in the following [discussion](https://github.com/orgs/Homebrew/discussions/5594). 
