### PR TITLE
cmd/which-formula: use simpler check for performance

### DIFF
--- a/Library/Homebrew/cmd/which-formula.sh
+++ b/Library/Homebrew/cmd/which-formula.sh
@@ -9,7 +9,7 @@ DATABASE_FILE="${HOMEBREW_CACHE}/api/${ENDPOINT}"
 
 is_formula_installed() {
   local name="$1"
-  if brew list --formula "${name}" &>/dev/null
+  if [[ -d "${HOMEBREW_CELLAR}/${name}" ]]
   then
     return 0
   else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

`brew list <name>` outputs all files in Cellar and hits Ruby code making it slow to run in a bash script. Could possibly use `brew list --formula | grep <name>` but that has more overhead than just a directory check while doing essentially the same check.

For example, when checking `ruby` command (with `ruby` formula installed), this is a 10x difference (5s vs 0.5s):

Before:
```console
❯ time (brew which-formula --skip-update --explain ruby)
The program 'ruby' can be found in the following formulae:
  * jruby
  * portable-ruby
  * ruby@3.1
  * ruby@3.2
  * ruby@3.3
Try: brew install <selected formula>
( brew which-formula --skip-update --explain ruby; )  3.16s user 1.73s system 93% cpu 5.246 total
```

After:
```console
❯ time (brew which-formula --skip-update --explain ruby)
The program 'ruby' can be found in the following formulae:
  * jruby
  * portable-ruby
  * ruby@3.1
  * ruby@3.2
  * ruby@3.3
Try: brew install <selected formula>
( brew which-formula --skip-update --explain ruby; )  0.25s user 0.15s system 73% cpu 0.545 total
```