### PR TITLE
hardware: add `arm64?`

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -82,7 +82,7 @@ module OS
         sig { returns(T.nilable(String)) }
         def check_supported_architecture
           return if ::Hardware::CPU.intel?
-          return if ::Hardware::CPU.arm? && ::Hardware::CPU.is_64_bit?
+          return if ::Hardware::CPU.arm64?
 
           <<~EOS
             Your CPU architecture (#{::Hardware::CPU.arch}) is not supported. We only support

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -45,19 +45,19 @@ module OS
         self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(@formula)
         m4_path_deps = ["libtool", "bison"]
         self["M4"] = "#{HOMEBREW_PREFIX}/opt/m4/bin/m4" if deps.any? { m4_path_deps.include?(_1.name) }
-        if ::Hardware::CPU.arch == :arm64
-          # Build jemalloc-sys rust crate on ARM64/AArch64 with support for page sizes up to 64K.
-          self["JEMALLOC_SYS_WITH_LG_PAGE"] = "16"
+        return unless ::Hardware::CPU.arm64?
 
-          # Workaround patchelf.rb bug causing segfaults and preventing bottling on ARM64/AArch64
-          # https://github.com/Homebrew/homebrew-core/issues/163826
-          self["CGO_ENABLED"] = "0"
-        end
+        # Build jemalloc-sys rust crate on ARM64/AArch64 with support for page sizes up to 64K.
+        self["JEMALLOC_SYS_WITH_LG_PAGE"] = "16"
+
+        # Workaround patchelf.rb bug causing segfaults and preventing bottling on ARM64/AArch64
+        # https://github.com/Homebrew/homebrew-core/issues/163826
+        self["CGO_ENABLED"] = "0"
 
         # Pointer authentication and BTI are hardening techniques most distros
         # use by default on their packages. arm64 Linux we're packaging
         # everything from scratch so the entire dependency tree can have it.
-        append_to_cccfg "b" if ::Hardware::CPU.arch == :arm64 && ::DevelopmentTools.gcc_version("gcc") >= 9
+        append_to_cccfg "b" if ::DevelopmentTools.gcc_version("gcc") >= 9
       end
 
       sig { returns(T::Array[Pathname]) }

--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -12,7 +12,7 @@ module OS
           else
             MacOS.version
           end
-          if ::Hardware::CPU.arch == :arm64
+          if ::Hardware::CPU.arm64?
             :arm_vortex_tempest
           # This cannot use a newer CPU e.g. haswell because Rosetta 2 does not
           # support AVX instructions in bottles:

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -163,6 +163,12 @@ module Hardware
         type == :arm
       end
 
+      # Check whether the CPU architecture is 64-bit ARM.
+      sig { returns(T::Boolean) }
+      def arm64?
+        arm? && is_64_bit?
+      end
+
       sig { returns(T::Boolean) }
       def little_endian?
         !big_endian?

--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -21,7 +21,7 @@ class ArchRequirement < Requirement
   satisfy(build_env: false) do
     case @arch
     when :x86_64 then Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
-    when :arm64 then Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    when :arm64 then Hardware::CPU.arm64?
     when :arm, :intel, :ppc then Hardware::CPU.type == @arch
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Provide a single method to check arm64. This should replace usage of both:
- `Hardware::CPU.arm? && Hardware::CPU.is_64_bit?`
- `Hardware::CPU.arch == :arm64`

And maybe other variations that we use to detect this given Linux arm32 is still considered supported at a lower tier.

Mainly want to reduce variations and line length on Homebrew/core side for a common check