### PR TITLE
github_runner_matrix: enable arm64 linux dep tests when not self-hosted

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -184,8 +184,9 @@ class GitHubRunnerMatrix
     end
 
     if !@all_supported || ENV.key?("HOMEBREW_LINUX_RUNNER")
+      self_hosted_deps = @dependent_matrix && ENV["HOMEBREW_LINUX_RUNNER"] == SELF_HOSTED_LINUX_RUNNER
       @runners << create_runner(:linux, :x86_64)
-      @runners << create_runner(:linux, :arm64) unless @dependent_matrix
+      @runners << create_runner(:linux, :arm64) unless self_hosted_deps
     end
 
     long_timeout       = ENV.fetch("HOMEBREW_MACOS_LONG_TIMEOUT", "false") == "true"

--- a/Library/Homebrew/test/github_runner_matrix_spec.rb
+++ b/Library/Homebrew/test/github_runner_matrix_spec.rb
@@ -285,6 +285,10 @@ RSpec.describe GitHubRunnerMatrix, :no_api do
               allow(Formula).to receive(:all).and_return([testball, testball_depender_linux].map(&:formula))
 
               matrix = described_class.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
+              expect(get_runner_names(matrix)).to eq(["Linux x86_64", "Linux arm64"])
+
+              allow(ENV).to receive(:[]).with("HOMEBREW_LINUX_RUNNER").and_return("linux-self-hosted-1")
+              matrix = described_class.new([testball], ["deleted"], all_supported: false, dependent_matrix: true)
               expect(get_runner_names(matrix)).to eq(["Linux x86_64"])
             end
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Increase arm64 Linux testing to now run on dependents as long as `CI-linux-self-hosted-deps` is not used.

As far as I can tell, arm64 Linux is faster than Intel Linux so should be able to finish within same time frame.

This should make our arm64 Linux support closer to complete "Tier 1" status. The remainder of CI either needs self-hosted runner or adding support for splitting dependent tests across separate jobs.