### PR TITLE
Remove portable ruby bin from PATH

### DIFF
--- a/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
+++ b/Library/Homebrew/test/utils/ruby_check_version_script_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Utils do
       Bundler.with_unbundled_env do
         ENV.delete_if { |key,| key.start_with?("HOMEBREW_") }
         ENV.update(homebrew_env)
-        quiet_system "#{HOMEBREW_LIBRARY_PATH}/utils/ruby_check_version_script.rb", required_ruby_version
+        # We intentionally don't use the shebang in this script as portable Ruby
+        # is usually not in PATH. This aligns with how we run the script in brew.
+        quiet_system RUBY_PATH, "#{HOMEBREW_LIBRARY_PATH}/utils/ruby_check_version_script.rb", required_ruby_version
       end
     end
 

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -173,7 +173,6 @@ If there's no Homebrew Portable Ruby available for your processor:
   then
     "${homebrew_ruby_bin}/gem" install bundler -v "${HOMEBREW_BUNDLER_VERSION}"
   fi
-  PATH="${homebrew_ruby_bin}:${PATH}"
 
   export HOMEBREW_RUBY_PATH HOMEBREW_BOOTSNAP_GEM_PATH
   [[ -n "${HOMEBREW_LINUX}" && -n "${TERMINFO_DIRS}" ]] && export TERMINFO_DIRS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Fixes #21109

This PR removes portable Ruby from PATH as parts of brew are written expecting only system paths like
https://github.com/Homebrew/brew/blob/07a983c338fe0df4409d75c04318c81f654805a4/Library/Homebrew/extend/os/linux/cleanup.rb#L15

I am not entirely sure on `setup_gem_environment!` change, but it restores original behavior before https://github.com/Homebrew/brew/commit/60fa3682364e8a65582ff808089e77eab1983baa#diff-a1a5395d198aee1fb8c45c74bf9dd49ef5734887a17ee84000badc7d58b82e98L43 (called via `install_bundler!`)

This mainly is used to avoid a failing test (utils/ruby_check_version_script_spec.rb).

Though maybe the test shouldn't be using Ruby from PATH as that is not how we interact with the script. We usually call the script like `<path/to/ruby> ruby_check_version_script_spec.rb ...` so it doesn't matter whether or not portable Ruby is on the PATH.

---

EDIT: After thinking over above, will just adjust test rather than adding `setup_gem_environment!`. Also in line with the Copilot review that `setup_gem_environment!` has side effects that we may not have intended.

May need to keep an eye out for unexpected failures though if any code is expecting portable Ruby on PATH. 