### PR TITLE
utils/linkage: allow checking non-brew libraries

### DIFF
--- a/Library/Homebrew/test/utils/linkage_spec.rb
+++ b/Library/Homebrew/test/utils/linkage_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe Utils do
                                                            HOMEBREW_PREFIX/"lib/libbrewbar#{suffix}")
         expect(result).to be false
       end
+
+      it "can check if the binary is linked to a non-brew library" do
+        non_brew_library = "/usr/lib/libtest#{suffix}"
+        shim = OS.mac? ? MachOShim : ELFShim
+        allow_any_instance_of(shim).to receive(:dynamically_linked_libraries).and_return([non_brew_library])
+        result = described_class.binary_linked_to_library?(HOMEBREW_PREFIX/"bin/brewtest", non_brew_library)
+        expect(result).to be true
+      end
     end
   end
 end

--- a/Library/Homebrew/utils/linkage.rb
+++ b/Library/Homebrew/utils/linkage.rb
@@ -6,10 +6,12 @@ module Utils
     params(binary: T.any(String, Pathname), library: T.any(String, Pathname)).returns(T::Boolean)
   }
   def self.binary_linked_to_library?(binary, library)
-    Pathname.new(binary).dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
+    library = library.to_s
+    library = File.realpath(library) if library.start_with?(HOMEBREW_PREFIX.to_s)
 
-      File.realpath(dll) == File.realpath(Pathname.new(library))
+    Pathname.new(binary).dynamically_linked_libraries.any? do |dll|
+      dll = File.realpath(dll) if dll.start_with?(HOMEBREW_PREFIX.to_s)
+      dll == library
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This allows replacing some Homebrew/core system library checks where we are using `Pathname#dynamically_linked_libraries` (which will break if we stop monkey-patching Pathname).

For example
- https://github.com/Homebrew/homebrew-core/blob/c7150571f364c08554c028cb561e6871bb104636/Formula/z/zig.rb#L123-L124

The previous code skipped over non-Homebrew libraries and would always run realpath which is not guaranteed to exist for macOS system libraries.

---

This won't handle checking a symlinked system library. However, this feature isn't needed as it would only be used for Linux libraries but we already audit unwanted system library linkage.

If there is ever a case we want to check symlinked system library, could add an `exist?` check and then run `realpath`.