### PR TITLE
extend/os/mac/system_config: check for Metal Toolchain

### DIFF
--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -45,12 +45,25 @@ module OS
           dump_tap_config(CoreCaskTap.instance, out)
         end
 
+        sig { returns(T.nilable(String)) }
+        def metal_toolchain
+          @metal_toolchain ||= T.let(if MacOS::Xcode.installed? || MacOS::CLT.installed?
+                                       result = SystemCommand.run("xcrun", args: ["metal", "-v"],
+                                       print_stderr: false, print_stdout: false)
+                                       "present" if result.success?
+          end, T.nilable(String))
+        end
+
         sig { params(out: T.any(File, StringIO, IO)).void }
         def dump_verbose_config(out = $stdout)
           super
           out.puts "macOS: #{MacOS.full_version}-#{kernel}"
           out.puts "CLT: #{clt || "N/A"}"
           out.puts "Xcode: #{xcode || "N/A"}"
+          # Metal Toolchain is a separate install starting with Xcode 26.
+          if MacOS::Xcode.installed? && MacOS::Xcode.version >= "26.0"
+            out.puts "Metal Toolchain: #{metal_toolchain || "N/A"}"
+          end
           out.puts "Rosetta 2: #{::Hardware::CPU.in_rosetta2?}" if ::Hardware::CPU.physical_cpu_arm64?
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Starting with Xcode 26 the Metal Toolchain is no longer bundled. We're starting to see [formulae](https://github.com/Homebrew/homebrew-core/pull/255173) that depend on the presence of the Metal Toolchain. This PR adds a check to `brew config` to output if the toolchain is installed to help us verify inevitable reports. If we start identifying enough formulae we may want to add `depends_on :metal_toolchain`, but I don't think that's necessary yet.