### PR TITLE
cask-cookbook: clarify `desktop` and `launcher` suffix in tokens

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -1323,9 +1323,9 @@ Details of software names and brands will inevitably be lost in the conversion t
 
 * If the version number is arranged to occur in the middle of the App name, it should also be removed.
 
-* Remove from the end: “Launcher”, “Quick Launcher”.
+* Remove from the end: “Launcher”, “Quick Launcher”, "Desktop", "for Desktop".
 
-* Remove from the end: strings such as “Desktop”, “for Desktop”.
+  * Exception: when the suffix is an intrinsic part of the product name, as in [Docker Desktop.app](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/d/docker-desktop.rb).
 
 * Remove from the end: strings such as “Mac”, “for Mac”, “for OS X”, “macOS”, “for macOS”. These terms are generally added to ported software such as “MAME OS X.app”.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

I don't believe there is any reason to require the omission of `-desktop` or `-launcher` from a cask token when it is an intrinsic part of the product name, such as `docker-desktop`. There has been room for some maintainer discretion here in the past, so I think loosening the specific guidelines makes sense to me.