### PR TITLE
dev-cmd/vendor-gems: restore setting up gem environment

### DIFF
--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -25,6 +25,7 @@ module Homebrew
 
       sig { override.void }
       def run
+        Homebrew.setup_gem_environment!
         ENV["BUNDLE_WITH"] = Homebrew.valid_gem_groups.join(":")
 
         ohai "cd #{HOMEBREW_LIBRARY_PATH}"


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This used to run `Homebrew.install_bundler!` which would run `Homebrew.setup_gem_environment!` and modify the environment variables. Restore this behavior to find `bundler`
