### PR TITLE
shims/super/cc: use canonical_path on `<sysroot>/usr/lib`

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -410,7 +410,7 @@ class Cmd
   end
 
   def system_library_paths
-    paths = ["#{sysroot}/usr/lib"]
+    paths = [canonical_path("#{sysroot}/usr/lib")]
     paths << "/usr/local/lib" if !sysroot && !ENV["SDKROOT"]
     paths
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

system_library_paths is used by refurbished_args to detect duplicate/unneeded `-L<path>` flags; however, the shim does comparisons to `canonical_path(<path>)`. This means an SDK path like `/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk` won't work as it is a symlink to MacOSX26.0.sdk

The old behavior can cause issues if build is run with `-L` to SDK path as it can find wrong libraries to be linked. The usage of SDK path is often an issue elsewhere (e.g. seen in PHP formula) but this PR allows the shim to handle particular scenario better.

---

The alternative is workarounds like https://github.com/Homebrew/homebrew-core/blob/a41bd1a9053482dcdce96ab83b7f3e81f03d6ec3/Formula/p/php%408.4.rb#L133-L135
```rb
      # PHP build system incorrectly links system libraries: https://github.com/php/php-src/issues/10680
      # Homebrew's superenv can only discard these if using realpath of SDK
      ENV["HOMEBREW_SDKROOT"] = sdk_path.realpath
```