### PR TITLE
dev-cmd: install ast bundler gems before `require "utils/pypi"`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -5,7 +5,6 @@ require "abstract_command"
 require "fileutils"
 require "formula"
 require "utils/inreplace"
-require "utils/pypi"
 require "utils/tar"
 
 module Homebrew
@@ -94,6 +93,9 @@ module Homebrew
 
       sig { override.void }
       def run
+        Homebrew.install_bundler_gems!(groups: ["ast"])
+        require "utils/pypi"
+
         if args.revision.present? && args.tag.nil? && args.version.nil?
           raise UsageError, "`--revision` must be passed with either `--tag` or `--version`!"
         end

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -4,7 +4,6 @@
 require "formula"
 require "formula_creator"
 require "missing_formula"
-require "utils/pypi"
 require "cask/cask_loader"
 
 module Homebrew
@@ -232,7 +231,12 @@ module Homebrew
           CoreTap.instance.clear_cache
           Formula[formula_creator.name]
         end
-        PyPI.update_python_resources! formula, ignore_non_pypi_packages: true if args.python?
+
+        if args.python?
+          Homebrew.install_bundler_gems!(groups: ["ast"])
+          require "utils/pypi"
+          PyPI.update_python_resources! formula, ignore_non_pypi_packages: true
+        end
 
         puts <<~EOS
           Please audit and test formula before submitting:

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "abstract_command"
-require "utils/pypi"
 
 module Homebrew
   module DevCmd
@@ -38,6 +37,9 @@ module Homebrew
 
       sig { override.void }
       def run
+        Homebrew.install_bundler_gems!(groups: ["ast"])
+        require "utils/pypi"
+
         args.named.to_formulae.each do |formula|
           ignore_errors = if formula.tap&.official?
             false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Since 1ab3b0c33da07242d9fedd397f7587f0599eb271 (#21105), `utils/pypi` depends on the `rubocop-ast` gem (via `utils/ast`). We need to ensure that the gem is installed before requiring `utils/pypi` in the affected developer commands.

Fixes https://github.com/orgs/Homebrew/discussions/6557.
