### PR TITLE
item: do not remove `lib` formulae/casks

### DIFF
--- a/Library/Homebrew/items.sh
+++ b/Library/Homebrew/items.sh
@@ -27,7 +27,7 @@ homebrew-items() {
       -regex "${find_exclude_filter}" -o \
       -name cmd -o \
       -name .github -o \
-      -name lib -o \
+      \( -name lib -a ! -path '*/Formula/*' -a ! -path '*/Casks/*' \) -o \
       -name spec -o \
       -name vendor -o \
       -name .git \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
I noticed this problem with shell completions where it doesn't suggest anything that starts with `lib`. `brew formulae | grew '^lib'` doesn't show anything either. We should keep `lib/*` path if it is inside `Formula` or `Casks` directory