### PR TITLE
test_bot: remove `session-manager-plugin`

### DIFF
--- a/Library/Homebrew/test_bot/cleanup_before.rb
+++ b/Library/Homebrew/test_bot/cleanup_before.rb
@@ -27,6 +27,7 @@ module Homebrew
             delete_or_move bad_paths, sudo: true
           elsif OS.mac?
             delete_or_move HOMEBREW_CELLAR.glob("*")
+            delete_or_move HOMEBREW_CASKROOM.glob("session-manager-plugin")
 
             frameworks_dir = Pathname("/Library/Frameworks")
             frameworks = %w[


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Seeing if possible to remove deprecated cask via test-bot to unblock CI. May need to also either discuss deprecation with GitHub side, and/or see if it can be migrated elsewhere.

There is an issue for aws tap to provide their own `session-manager-plugin` and another issue in upstream to sign/notarize binary. Depending on license, could check if possible to make a Formula.

Also trying to see if `HOMEBREW_CASKROOM` from `startup/config.rb` works rather than needing to use `Cask::Caskroom.path` (which adds an extra require)
