### PR TITLE
`brew uninstall` respects the `HOMEBREW_NO_INSTALL_FROM_API` env var

### DIFF
--- a/Library/Homebrew/uninstall.rb
+++ b/Library/Homebrew/uninstall.rb
@@ -72,7 +72,11 @@ module Homebrew
 
               unversioned_name = f.name.gsub(/@.+$/, "")
               maybe_paths = Dir.glob("#{f.etc}/#{unversioned_name}*")
-              excluded_names = Homebrew::API.formula_names
+              excluded_names = if Homebrew::EnvConfig.no_install_from_api?
+                Formula.names
+              else
+                Homebrew::API.formula_names
+              end
               maybe_paths = maybe_paths.reject do |path|
                 # Remove extension only if a file
                 # (e.g. directory with name "openssl@1.1" will be trimmed to "openssl@1")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
This PR changes `brew uninstall` to respect the `HOMEBREW_NO_INSTALL_FROM_API` env var. This resolves [this](https://github.com/orgs/Homebrew/discussions/6269) discussion I opened. 