### PR TITLE
formula_creator: use `pnpm` instead of `npm`

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -196,6 +196,7 @@ module Homebrew
           depends_on "meson" => :build
           depends_on "ninja" => :build
         <% elsif @mode == :node %>
+          depends_on "pnpm" => :build
           depends_on "node"
         <% elsif @mode == :perl %>
           uses_from_macos "perl"
@@ -242,7 +243,7 @@ module Homebrew
             system "meson", "compile", "-C", "build", "--verbose"
             system "meson", "install", "-C", "build"
         <% elsif @mode == :node %>
-            system "npm", "install", *std_npm_args
+            system "pnpm", "install", *std_npm_args
             bin.install_symlink Dir["\#{libexec}/bin/*"]
         <% elsif @mode == :perl %>
             ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
In the aftermath of [Sha1-Hulud 2.0](https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack), we've discussed using `pnpm` rather than `npm` for formulae moving forward. This PR is a first step.