### PR TITLE
std_npm_args: ignore scripts optionally, by default.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1975,14 +1975,16 @@ class Formula
 
   # Standard parameters for npm builds.
   #
+  # @param prefix [String, Pathname, false] installation prefix (default: libexec)
+  # @param ignore_scripts [Boolean] whether to add --ignore-scripts flag (default: true)
   # @api public
-  sig { params(prefix: T.any(String, Pathname, FalseClass)).returns(T::Array[String]) }
-  def std_npm_args(prefix: libexec)
+  sig { params(prefix: T.any(String, Pathname, FalseClass), ignore_scripts: T::Boolean).returns(T::Array[String]) }
+  def std_npm_args(prefix: libexec, ignore_scripts: true)
     require "language/node"
 
-    return Language::Node.std_npm_install_args(Pathname(prefix)) if prefix
+    return Language::Node.std_npm_install_args(Pathname(prefix), ignore_scripts:) if prefix
 
-    Language::Node.local_npm_install_args
+    Language::Node.local_npm_install_args(ignore_scripts:)
   end
 
   # Standard parameters for pip builds.

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -56,8 +56,8 @@ module Language
       end
     end
 
-    sig { params(libexec: Pathname).returns(T::Array[String]) }
-    def self.std_npm_install_args(libexec)
+    sig { params(libexec: Pathname, ignore_scripts: T::Boolean).returns(T::Array[String]) }
+    def self.std_npm_install_args(libexec, ignore_scripts: true)
       setup_npm_environment
 
       pack = pack_for_installation
@@ -75,20 +75,25 @@ module Language
         #{Dir.pwd}/#{pack}
       ]
 
+      args << "--ignore-scripts" if ignore_scripts
       args << "--unsafe-perm" if Process.uid.zero?
 
       args
     end
 
-    sig { returns(T::Array[String]) }
-    def self.local_npm_install_args
+    sig { params(ignore_scripts: T::Boolean).returns(T::Array[String]) }
+    def self.local_npm_install_args(ignore_scripts: true)
       setup_npm_environment
       # npm install args for local style module format
-      %W[
+      args = %W[
         --loglevel=silly
         --build-from-source
         --#{npm_cache_config}
       ]
+
+      args << "--ignore-scripts" if ignore_scripts
+
+      args
     end
 
     # Mixin module for {Formula} adding shebang rewrite features.


### PR DESCRIPTION
This emulates what `pnpm` 10+ does by default.

In response to current NPM supply-side attacks.