### PR TITLE
extend/os/linux/extend/pathname: fix typing issue

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/pathname.rb
+++ b/Library/Homebrew/extend/os/linux/extend/pathname.rb
@@ -31,8 +31,6 @@ module OS
         sig { void }
         def activate_extensions!
           super
-
-          prepend(ELFShim)
         end
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This is an attempt at fixing https://github.com/Homebrew/brew/issues/21147
A recent change to the way `ELFShim` is applied caused all Pathnames on Linux to be assigned a different type than expected.
