### PR TITLE
array_alphabetization: update to check `conflicts_with` methods

### DIFF
--- a/Library/Homebrew/rubocops/cask/array_alphabetization.rb
+++ b/Library/Homebrew/rubocops/cask/array_alphabetization.rb
@@ -9,7 +9,7 @@ module RuboCop
 
         sig { params(node: RuboCop::AST::SendNode).void }
         def on_send(node)
-          return unless [:zap, :uninstall].include?(node.method_name)
+          return unless [:conflicts_with, :uninstall, :zap].include?(node.method_name)
 
           node.each_descendant(:pair).each do |pair|
             symbols = pair.children.select(&:sym_type?).map(&:value)

--- a/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/array_alphabetization_spec.rb
@@ -87,6 +87,71 @@ RSpec.describe RuboCop::Cop::Cask::ArrayAlphabetization, :config do
     CASK
   end
 
+  it "reports an offense when a single cask is specified in an array" do
+    expect_offense(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        conflicts_with cask: ["bar"]
+                             ^^^^^^^ Avoid single-element arrays by removing the []
+      end
+    CASK
+
+    expect_correction(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        conflicts_with cask: "bar"
+      end
+    CASK
+  end
+
+  it "reports an offense when a single cask is specified in a multi-line array" do
+    expect_offense(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        conflicts_with cask: [
+                             ^ Avoid single-element arrays by removing the []
+          "bar"
+        ]
+      end
+    CASK
+
+    expect_correction(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        conflicts_with cask: "bar"
+      end
+    CASK
+  end
+
+  it "autocorrects alphabetization in `conflicts_with` methods" do
+    expect_offense(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        conflicts_with cask: [
+                             ^ The array elements should be ordered alphabetically
+          "something",
+          "other",
+        ]
+      end
+    CASK
+
+    expect_correction(<<~CASK)
+      cask "foo" do
+        url "https://example.com/foo.zip"
+
+        conflicts_with cask: [
+          "other",
+          "something",
+        ]
+      end
+    CASK
+  end
+
   it "autocorrects alphabetization in `uninstall` methods" do
     expect_offense(<<~CASK)
       cask "foo" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

During a Cask update, someone had introduced a single item array in a `conflicts_with` block, but wasn't caught by `brew style` and fixed in the same way that `zap` and `uninstall` methods are.

This updates the Rubocop to also check on `conflicts_with` and treat alphabetization and single-item arrays the same way as `zap` and `uninstall`.
