### PR TITLE
linux/cask/artifact/relocated: fix type error.

### DIFF
--- a/Library/Homebrew/extend/os/linux/cask/artifact/relocated.rb
+++ b/Library/Homebrew/extend/os/linux/cask/artifact/relocated.rb
@@ -10,7 +10,7 @@ module OS
 
           requires_ancestor { ::Cask::Artifact::Relocated }
 
-          sig { params(file: Pathname, altname: Pathname, command: T.class_of(SystemCommand)).returns(T.nilable(SystemCommand::Result)) }
+          sig { params(file: ::Pathname, altname: ::Pathname, command: T.class_of(SystemCommand)).returns(T.nilable(SystemCommand::Result)) }
           def add_altname_metadata(file, altname, command:)
             # no-op on Linux: /usr/bin/xattr for setting extended attributes is not available there.
           end


### PR DESCRIPTION
We need to fully qualify the Pathname class to avoid runtime Sorbet errors.

Fixes #21147