### PR TITLE
shellenv: prefer lsof to ps to read the command for a process

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -14,6 +14,11 @@ homebrew-shellenv() {
   if [[ -n "$1" ]]
   then
     HOMEBREW_SHELL_NAME="$1"
+  elif [[ -n "${HOMEBREW_MACOS}" ]]
+  then
+    # Prefer lsof to ps to get the command for the parent process. Because lsof
+    # is not setuid, it can be run under Seatbelt without a special exemption.
+    HOMEBREW_SHELL_NAME="$(/usr/sbin/lsof -p "${PPID}" -a -d cwd -Fc | /usr/bin/sed -n "s/^c//p")"
   else
     HOMEBREW_SHELL_NAME="$(/bin/ps -p "${PPID}" -c -o comm=)"
   fi


### PR DESCRIPTION

Currently, `shellenv.sh` is frequently run as part of a user's `~/.zprofile`,
which includes the following line:

```shell
HOMEBREW_SHELL_NAME="$(/bin/ps -p "${PPID}" -c -o comm=)"
```

Indeed, if I run the following from `zsh`, this reports `zsh` (or `-zsh`), as expected:

```shell
$ bash -c '/bin/ps -p "${PPID}" -c -o comm='
-zsh
```

Though `/bin/ps` is a setuid binary:

```shell
$ stat -f "%Sp" /bin/ps
-rwsr-xr-x
```

Which means that it cannot be run under macOS Seatbelt unless explicit support
is added to the Seatbelt policy to run it outside of the sandbox:

```
(allow process-exec (path "/bin/ps") (with no-sandbox))
```

Though this is somewhat undesirable because `/bin/ps` makes it possible to
dump environment variables from processes, which often includes sensitive
information such as API keys.

By comparison, `/usr/sbin/lsof` is _not_ setuid:

```shell
$ stat -f "%Sp" /usr/sbin/lsof
-rwxr-xr-x
```

And the proposed change yields the same information (without the leading hyphen):

```shell
$ bash -c '/usr/sbin/lsof -p "$PPID" -a -d cwd -Fc | /usr/bin/sed -n "s/^c//p"'
zsh
```

Overall, this would make it possible to invoke `zsh -lc` under Seatbelt for
users who run `shellenv.sh` in their `~/.zprofile` without having to use a less
restrictive Seatbelt policy.
