### PR TITLE
Suppress warning from lsof

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -18,7 +18,7 @@ homebrew-shellenv() {
   then
     # Prefer lsof to ps to get the command for the parent process. Because lsof
     # is not setuid, it can be run under Seatbelt without a special exemption.
-    HOMEBREW_SHELL_NAME="$(/usr/sbin/lsof -p "${PPID}" -a -d cwd -Fc | /usr/bin/sed -n "s/^c//p")"
+    HOMEBREW_SHELL_NAME="$(/usr/sbin/lsof -w -p "${PPID}" -a -d cwd -Fc | /usr/bin/sed -n "s/^c//p")"
   else
     HOMEBREW_SHELL_NAME="$(/bin/ps -p "${PPID}" -c -o comm=)"
   fi


### PR DESCRIPTION
lsof in shellenv will leak warnings like `WARNING can't stat() smbfs filesystem`. Add `-w` to suppress the warnings.

lsof is only used to get the name of the shell so suppressing filesystem warning shouldn't be an issue.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
