### PR TITLE
attestation: remove `T.must`

### DIFF
--- a/Library/Homebrew/attestation.rb
+++ b/Library/Homebrew/attestation.rb
@@ -81,11 +81,9 @@ module Homebrew
       # NOTE: We set HOMEBREW_NO_VERIFY_ATTESTATIONS when installing `gh` itself,
       #       to prevent a cycle during bootstrapping. This can eventually be resolved
       #       by vendoring a pure-Ruby Sigstore verifier client.
-      with_env(HOMEBREW_NO_VERIFY_ATTESTATIONS: "1") do
-        @gh_executable = ensure_executable!("gh", reason: "verifying attestations", latest: true)
+      @gh_executable = with_env(HOMEBREW_NO_VERIFY_ATTESTATIONS: "1") do
+        ensure_executable!("gh", reason: "verifying attestations", latest: true)
       end
-
-      T.must(@gh_executable)
     end
 
     # Prioritize installing `gh` first if it's in the formula list

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -185,8 +185,8 @@ module Kernel
     out.close
   end
 
-  # Ensure the given executable is exist otherwise install the brewed version
-  sig { params(name: String, formula_name: T.nilable(String), reason: String, latest: T::Boolean).returns(T.nilable(Pathname)) }
+  # Ensure the given executable exists otherwise install the brewed version
+  sig { params(name: String, formula_name: T.nilable(String), reason: String, latest: T::Boolean).returns(Pathname) }
   def ensure_executable!(name, formula_name = nil, reason: "", latest: false)
     formula_name ||= name
 
@@ -197,8 +197,8 @@ module Kernel
       # path where available, since the former is stable during upgrades.
       HOMEBREW_PREFIX/"opt/#{formula_name}/bin/#{name}",
       HOMEBREW_PREFIX/"bin/#{name}",
-    ].compact.first
-    return executable if executable.exist?
+    ].compact.find(&:exist?)
+    return executable if executable
 
     require "formula"
     Formulary.factory_stub(formula_name).ensure_installed!(reason:, latest:).opt_bin/name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This updates `ensure_executable!` return to drop nil and uses the `with_env` return so that Sorbet can infer the type.

Also search all guesses for `ensure_executable!` prior to installing formula.

---

Change is done as usually better to avoid `T.must` as it adds some overhead for all users (as an extra function call even when Sorbet is disabled for non-developers) and is often a sign that code needs refactoring