### PR TITLE
compilers: add comment on older GCC usage

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 module CompilerConstants
+  # GCC 7 - Ubuntu 18.04 (ESM ends 2028-04-01)
+  # GCC 8 - RHEL 8       (ELS ends 2032-05-31)
   GNU_GCC_VERSIONS = %w[7 8 9 10 11 12 13 14 15].freeze
   GNU_GCC_REGEXP = /^gcc-(#{GNU_GCC_VERSIONS.join("|")})$/
   COMPILER_SYMBOL_MAP = T.let({


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This provides some context on why we may want to keep some of the older GCC versions around. These are not hard dates for us so can still remove support for older versions if there is a reason to do so.

References:
- https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/gcc/
- https://endoflife.date/ubuntu
- https://access.redhat.com/solutions/19458
- https://endoflife.date/rhel

---

Mainly added as I was checking on whether we should keep these around or not given we no longer provide `gcc@7` or `gcc@8` formulae.

Ubuntu 18.04 is off standard support but still has ESM so may wait until that ends before moving up minimum to GCC 8. 