### PR TITLE
Deprecate `Formula#needs` and remove `needs :openmp` support

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -35,13 +35,6 @@ class CompilerFailure
   sig { params(_: String).void }
   def cause(_); end
 
-  sig { params(standard: Symbol).returns(T::Array[CompilerFailure]) }
-  def self.for_standard(standard)
-    COLLECTIONS.fetch(standard) do
-      raise ArgumentError, "\"#{standard}\" is not a recognized standard"
-    end
-  end
-
   sig {
     params(spec: T.any(Symbol, T::Hash[Symbol, String]), block: T.nilable(T.proc.void)).returns(T.attached_class)
   }
@@ -101,13 +94,6 @@ class CompilerFailure
   def gcc_major(version)
     Version.new(version.major.to_s)
   end
-
-  COLLECTIONS = T.let({
-    openmp: [
-      create(:clang),
-    ],
-  }.freeze, T::Hash[Symbol, T::Array[CompilerFailure]])
-  private_constant :COLLECTIONS
 end
 
 # Class for selecting a compiler for a formula.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4381,20 +4381,20 @@ class Formula
       specs.each { |spec| spec.fails_with(compiler, &block) }
     end
 
-    # Marks the {Formula} as needing a certain standard, so Homebrew
-    # will fall back to other compilers if the default compiler
-    # does not implement that standard.
+    # Used to mark the {Formula} as needing a certain standard, so Homebrew
+    # would fall back to other compilers if the default compiler
+    # did not implement that standard.
     #
-    # We generally prefer to {.depends_on} a desired compiler and to
-    # explicitly use that compiler in a formula's {#install} block,
+    # This is now a no-op as we prefer to {.depends_on} a desired compiler
+    # and explicitly use that compiler in a formula's {#install} block,
     # rather than implicitly finding a suitable compiler with `needs`.
     #
     # @see .fails_with
     #
     # @api public
-    sig { params(standards: Symbol).void }
-    def needs(*standards)
-      specs.each { |spec| spec.needs(*standards) }
+    sig { params(_standards: Symbol).void }
+    def needs(*_standards)
+      odeprecated "`needs :openmp`", '`depends_on "gcc"`'
     end
 
     # A test is required for new formulae and makes us happy.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -323,13 +323,6 @@ class SoftwareSpec
     compiler_failures << CompilerFailure.create(compiler, &block)
   end
 
-  sig { params(standards: Symbol).void }
-  def needs(*standards)
-    standards.each do |standard|
-      compiler_failures.concat CompilerFailure.for_standard(standard)
-    end
-  end
-
   sig { params(dep: Dependable).void }
   def add_dep_option(dep)
     dep.option_names.each do |name|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

The only remaining use case for `needs` DSL was `needs :openmp`, but this was somewhat deprecated via an audit on 2017-12-30 in f9b6407110d7fb98a65b470d166fc5b7be6052ee. This makes the deprecation official via `odeprecated` so we can remove the unused code in future brew release

---

It's been about 8 years since audit was added so seems safe to remove private API functionality and only make public API a no-op.