### PR TITLE
requirements/codesign_requirement: `typed: strict` and deprecate

### DIFF
--- a/Library/Homebrew/requirements/codesign_requirement.rb
+++ b/Library/Homebrew/requirements/codesign_requirement.rb
@@ -1,26 +1,31 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 # A requirement on a code-signing identity.
 class CodesignRequirement < Requirement
   fatal true
 
+  sig { returns(String) }
+  attr_reader :identity
+
+  sig { params(tags: T::Array[T.untyped]).void }
   def initialize(tags)
     options = tags.shift
     raise ArgumentError, "CodesignRequirement requires an options Hash!" unless options.is_a?(Hash)
     raise ArgumentError, "CodesignRequirement requires an identity key!" unless options.key?(:identity)
 
-    @identity = options.fetch(:identity)
-    @with = options.fetch(:with, "code signing")
-    @url = options.fetch(:url, nil)
+    @identity = T.let(options.fetch(:identity), String)
+    @with = T.let(options.fetch(:with, "code signing"), String)
+    @url = T.let(options.fetch(:url, nil), T.nilable(String))
     super
   end
 
   satisfy(build_env: false) do
     T.bind(self, CodesignRequirement)
+    odeprecated "CodesignRequirement"
     mktemp do
       FileUtils.cp "/usr/bin/false", "codesign_check"
-      quiet_system "/usr/bin/codesign", "-f", "-s", @identity,
+      quiet_system "/usr/bin/codesign", "-f", "-s", identity,
                    "--dryrun", "codesign_check"
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Deprecating CodesignRequirement as it is no longer used. The previous usage included:
* llvm - https://github.com/Homebrew/homebrew-core/issues/36278
* radare2 - https://github.com/Homebrew/homebrew-core/pull/36289

Strict typing is part of 
- #17297