### PR TITLE
dev-cmd/test-bot: remove unused `--concurrent-downloads`

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -20,9 +20,6 @@ module Homebrew
                description: "Print what would be done rather than doing it."
         switch "--cleanup",
                description: "Clean all state from the Homebrew directory. Use with care!"
-        # TODO: remove this when concurrent downloads are enabled by default.
-        switch "--concurrent-downloads",
-               hidden: true
         switch "--skip-setup",
                description: "Don't check if the local system is set up correctly."
         switch "--build-from-source",

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/test_bot_cmd.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/cmd/test_bot_cmd.rbi
@@ -23,9 +23,6 @@ class Homebrew::Cmd::TestBotCmd::Args < Homebrew::CLI::Args
   sig { returns(T::Boolean) }
   def cleanup?; end
 
-  sig { returns(T::Boolean) }
-  def concurrent_downloads?; end
-
   sig { returns(T.nilable(T::Array[String])) }
   def deleted_formulae; end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

`--concurrent-downloads` is currently a no-op as it is now enabled by default.
