### PR TITLE
Remove unused inherited_options

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -387,7 +387,7 @@ module Homebrew
       sig { params(dependencies: T::Array[Dependency]).returns(String) }
       def decorate_dependencies(dependencies)
         deps_status = dependencies.map do |dep|
-          if dep.satisfied?([])
+          if dep.satisfied?
             pretty_installed(dep_display_s(dep))
           else
             pretty_uninstalled(dep_display_s(dep))

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -104,16 +104,15 @@ class Dependency
     end
   end
 
-  def satisfied?(inherited_options = [], minimum_version: nil, minimum_revision: nil,
+  def satisfied?(minimum_version: nil, minimum_revision: nil,
                  minimum_compatibility_version: nil, bottle_os_version: nil)
     installed?(minimum_version:, minimum_revision:, minimum_compatibility_version:, bottle_os_version:) &&
-      missing_options(inherited_options).empty?
+      missing_options.empty?
   end
 
-  def missing_options(inherited_options)
+  def missing_options
     formula = to_installed_formula
     required = options
-    required |= inherited_options
     required &= formula.options.to_a
     required -= Tab.for_formula(formula).used_options
     required

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1632,9 +1632,6 @@ class Formula
     false
   end
 
-  sig { returns(T::Boolean) }
-  def require_universal_deps? = false
-
   sig { void }
   def patch
     return if patchlist.empty?

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -425,7 +425,7 @@ module Homebrew
       sig {
         params(
           formula:      Formula,
-          dependencies: T::Array[[Dependency, Options]],
+          dependencies: T::Array[Dependency],
           _block:       T.proc.params(arg0: Formula).returns(String),
         ).void
       }
@@ -434,7 +434,7 @@ module Homebrew
 
         ohai "Would install #{Utils.pluralize("dependency", dependencies.count, include_count: true)} " \
              "for #{formula.name}:"
-        formula_names = dependencies.map { |(dep, _options)| yield dep.to_formula }
+        formula_names = dependencies.map { |dep| yield dep.to_formula }
         puts formula_names.join(" ")
       end
 

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Dependency do
     subject(:dependency) { described_class.new("foo") }
 
     it "accepts bottle_os_version parameter" do
-      expect { dependency.satisfied?([], bottle_os_version: "macOS 14") }.not_to raise_error
+      expect { dependency.satisfied?(bottle_os_version: "macOS 14") }.not_to raise_error
     end
 
     it "accepts Ubuntu bottle_os_version parameter" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

inherited_options feature was originally added to support cascading `option :univeral` back in 793d6de6c3211ffea112770081e788e760806366.

This is now dead code given `:universal` support was removed.

