### PR TITLE
linuxbrew-core-migration: remove unneeded formulae

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -10,7 +10,6 @@ require "descriptions"
 require "cleanup"
 require "description_cache_store"
 require "settings"
-require "linuxbrew-core-migration"
 require "reinstall"
 
 module Homebrew
@@ -153,6 +152,7 @@ module Homebrew
              Settings.read("linuxbrewmigrated") != "true"
             ohai "Migrating formulae from linuxbrew-core to homebrew-core"
 
+            require "linuxbrew-core-migration"
             LINUXBREW_CORE_MIGRATION_LIST.each do |name|
               begin
                 formula = Formula[name]

--- a/Library/Homebrew/linuxbrew-core-migration.rb
+++ b/Library/Homebrew/linuxbrew-core-migration.rb
@@ -1,126 +1,39 @@
-# typed: strict
+# typed: strong
 # frozen_string_literal: true
+
+# Hash of formulae with their old linuxbrew-core pkg_version strings.
+# These formulae had a revision in linuxbrew-core that was different
+# than in homebrew-core.
+LINUXBREW_CORE_MIGRATION_OLD_PKG_VERSIONS = T.let({
+  "apng2gif"         => "1.8_2",
+  "argon2"           => "20190702_2",
+  "csvtomd"          => "0.3.0_4",
+  "cvs"              => "1.12.13_5",
+  "cxxtest"          => "4.4_4",
+  "datetime-fortran" => "1.7.0_1",
+  "docbook2x"        => "0.8.8_3",
+  "exif"             => "0.6.22_1",
+  "ftgl"             => "2.1.3-rc5_1",
+  "gflags"           => "2.2.2_2",
+  "glew"             => "2.2.0_2",
+  "glui"             => "2.37_2",
+  "gtkmm"            => "2.24.5_9",
+  "intltool"         => "0.51.0_3",
+  "io"               => "2017.09.06_2",
+  "jed"              => "0.99-19_1",
+  "mecab"            => "0.996_1",
+  "openmotif"        => "2.3.8_3",
+  "osmfilter"        => "0.9_1",
+  "pius"             => "3.0.0_4",
+  "plotutils"        => "2.6_5",
+  "plplot"           => "5.15.0_4",
+  "softhsm"          => "2.6.1_1",
+  "tasksh"           => "1.2.0_2",
+  "xclip"            => "0.13_4",
+}.freeze, T::Hash[String, String])
 
 # List of formulae that had a revision in linuxbrew-core
 # that was different than in homebrew-core
 # We will use this list to modify the version_scheme
 # during the migration from linuxbrew-core to homebrew-core.
-
-LINUXBREW_CORE_MIGRATION_LIST = %w[
-  afuse
-  apng2gif
-  apr-util
-  archivemount
-  argon2
-  arpack
-  asciinema
-  atdtool
-  augustus
-  avfs
-  bandcamp-dl
-  cairo
-  ccls
-  codemod
-  cquery
-  credstash
-  csvtomd
-  cvs
-  cxxtest
-  datetime-fortran
-  ddd
-  diceware
-  docbook2x
-  docker-squash
-  doitlive
-  double-conversion
-  exif
-  expect
-  fades
-  fastme
-  fbi-servefiles
-  foma
-  fontconfig
-  freeglut
-  ftgl
-  gcc@5
-  gettext
-  gflags
-  ghc@8.6
-  ghc@8.8
-  git-remote-hg
-  gitfs
-  gitless
-  gitup
-  glade
-  glew
-  glui
-  goolabs
-  gperftools
-  grip
-  gtkmm
-  hdf5@1.8
-  htop
-  intltool
-  io
-  jed
-  jinja2-cli
-  legit
-  libebml
-  libexif
-  libffi
-  libgetdata
-  libhttpseverywhere
-  libproxy
-  libtool
-  libxslt
-  literate-git
-  llvm@11
-  llvm@7
-  llvm@8
-  llvm@9
-  lua
-  lua@5.1
-  lua@5.3
-  magic-wormhole
-  mecab
-  mosh
-  mps-youtube
-  ncview
-  notifiers
-  openmotif
-  osmfilter
-  pachi
-  packmol
-  passpie
-  pius
-  pkg-config
-  plotutils
-  plplot
-  postgresql@9.4
-  postgresql@9.5
-  pssh
-  pup
-  pyvim
-  ratfor
-  remarshal
-  reprepro
-  rtv
-  s3cmd
-  scalapack
-  securefs
-  softhsm
-  statik
-  stormssh
-  superlu
-  tasksh
-  termtosvg
-  tinyxml
-  vsts-cli
-  xclip
-  xerces-c
-  xmlto
-  xmltoman
-  xmount
-  xxhash
-  zabbix-cli
-].freeze
+LINUXBREW_CORE_MIGRATION_LIST = T.let(LINUXBREW_CORE_MIGRATION_OLD_PKG_VERSIONS.keys.freeze, T::Array[String])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This change removes formulae that:
* have newer versions or revisions in Homebrew/core
* have been removed or disabled

The last pkg-version string is added for remaining formulae to check when `Formula[key].pkg_version > PkgVersion.parse(value)`

---

Alternatively could just drop Linuxbrew migration handling. 