### PR TITLE
Add URL fallbacks for deprecated formula and cask checks

### DIFF
--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -130,4 +130,142 @@ RSpec.describe Homebrew::Diagnostic::Checks do
 
     expect(checks.check_for_unnecessary_cask_tap).to match("unnecessary local Cask tap")
   end
+
+  describe "#formula_tap_url" do
+    let(:tap) do
+      instance_double(Tap, remote: "https://github.com/Homebrew/homebrew-core",
+                           path:   Pathname.new("/tap/path"))
+    end
+
+    it "returns nil when tap is nil" do
+      formula = instance_double(Formula, tap: nil)
+      expect(checks.formula_tap_url(formula)).to be_nil
+    end
+
+    it "returns nil when tap remote is blank" do
+      tap_no_remote = instance_double(Tap, remote: nil)
+      formula = instance_double(Formula, tap: tap_no_remote)
+      expect(checks.formula_tap_url(formula)).to be_nil
+    end
+
+    it "returns URL when tap has remote" do
+      formula = instance_double(Formula, tap: tap, path: Pathname.new("/tap/path/Formula/w/wget.rb"))
+      expect(checks.formula_tap_url(formula))
+        .to eq "https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/w/wget.rb"
+    end
+  end
+
+  describe "#cask_tap_url" do
+    let(:tap) do
+      instance_double(Tap, remote: "https://github.com/Homebrew/homebrew-cask")
+    end
+
+    before do
+      allow(tap).to receive(:relative_cask_path).with("firefox").and_return("Casks/f/firefox.rb")
+    end
+
+    it "returns nil when tap is nil" do
+      cask = instance_double(Cask::Cask, tap: nil)
+      expect(checks.cask_tap_url(cask)).to be_nil
+    end
+
+    it "returns nil when tap remote is blank" do
+      tap_no_remote = instance_double(Tap, remote: nil)
+      cask = instance_double(Cask::Cask, tap: tap_no_remote)
+      expect(checks.cask_tap_url(cask)).to be_nil
+    end
+
+    it "returns URL using remote and relative_cask_path" do
+      cask = instance_double(Cask::Cask, tap: tap, token: "firefox")
+      expect(checks.cask_tap_url(cask))
+        .to eq "https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/f/firefox.rb"
+    end
+  end
+
+  describe "#check_deprecated_disabled" do
+    let(:tap) do
+      instance_double(Tap, remote: "https://github.com/Homebrew/homebrew-core",
+                           path:   Pathname.new("/tap/path"))
+    end
+    let(:head_spec) { instance_double(HeadSoftwareSpec, url: "https://github.com/example/repo.git") }
+
+    it "returns nil when no formulae are deprecated or disabled" do
+      allow(Formula).to receive(:installed).and_return([])
+      expect(checks.check_deprecated_disabled).to be_nil
+    end
+
+    it "includes deprecated formula with homepage URL" do
+      formula = instance_double(Formula, deprecated?: true, disabled?: false,
+                                full_name: "deprecated-formula",
+                                homepage: "https://example.com/deprecated",
+                                head: nil, tap: tap,
+                                path: Pathname.new("/tap/path/Formula/d/deprecated-formula.rb"))
+      allow(Formula).to receive(:installed).and_return([formula])
+
+      result = checks.check_deprecated_disabled
+      expect(result).to match("deprecated-formula")
+      expect(result).to match("https://example.com/deprecated")
+    end
+
+    it "falls back to head URL when homepage is nil" do
+      formula = instance_double(Formula, deprecated?: false, disabled?: true,
+                                full_name: "disabled-head-formula",
+                                homepage: nil, head: head_spec, tap: tap,
+                                path: Pathname.new("/tap/path/Formula/d/disabled-head-formula.rb"))
+      allow(Formula).to receive(:installed).and_return([formula])
+
+      result = checks.check_deprecated_disabled
+      expect(result).to match("disabled-head-formula")
+      expect(result).to match("https://github.com/example/repo.git")
+    end
+
+    it "falls back to tap URL when homepage and head are nil" do
+      formula = instance_double(Formula, deprecated?: false, disabled?: true,
+                                full_name: "disabled-formula",
+                                homepage: nil, head: nil, tap: tap,
+                                path: Pathname.new("/tap/path/Formula/d/disabled-formula.rb"))
+      allow(Formula).to receive(:installed).and_return([formula])
+
+      result = checks.check_deprecated_disabled
+      expect(result).to match("disabled-formula")
+      expect(result).to match("https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/d/disabled-formula.rb")
+    end
+  end
+
+  describe "#check_cask_deprecated_disabled" do
+    let(:tap) do
+      instance_double(Tap, remote: "https://github.com/Homebrew/homebrew-cask")
+    end
+
+    before do
+      allow(tap).to receive(:relative_cask_path).with("deprecated-cask").and_return("Casks/d/deprecated-cask.rb")
+      allow(tap).to receive(:relative_cask_path).with("disabled-cask").and_return("Casks/d/disabled-cask.rb")
+    end
+
+    it "returns nil when no casks are deprecated or disabled" do
+      allow(Cask::Caskroom).to receive(:casks).and_return([])
+      expect(checks.check_cask_deprecated_disabled).to be_nil
+    end
+
+    it "includes deprecated cask with homepage URL" do
+      cask = instance_double(Cask::Cask, deprecated?: true, disabled?: false,
+                             token: "deprecated-cask",
+                             homepage: "https://example.com/deprecated-cask", tap: tap)
+      allow(Cask::Caskroom).to receive(:casks).and_return([cask])
+
+      result = checks.check_cask_deprecated_disabled
+      expect(result).to match("deprecated-cask")
+      expect(result).to match("https://example.com/deprecated-cask")
+    end
+
+    it "falls back to cask tap URL when homepage is nil" do
+      cask = instance_double(Cask::Cask, deprecated?: false, disabled?: true,
+                             token: "disabled-cask", homepage: nil, tap: tap)
+      allow(Cask::Caskroom).to receive(:casks).and_return([cask])
+
+      result = checks.check_cask_deprecated_disabled
+      expect(result).to match("disabled-cask")
+      expect(result).to match("https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/d/disabled-cask.rb")
+    end
+  end
 end


### PR DESCRIPTION
I find it it a bit frustrating having to do a brew info on each deprecated cask or formula to investigate why things are deprecated, so it would be nice to include URLs, but I didn't want to overload the list, so it will try to pick the best URL to show with the following fallbacks: 

Formulas
`homepage` → `head.url (git repo)` → `tap file URL` 

Casks
`homepage` → `tap file URL`


> What's the existing output? 
```
brew doctor                  

Warning: Some installed casks are deprecated or disabled.
You should find replacements for the following casks:
  syntax-highlight 
```


> What's the new output? 

```
brew doctor                  

Warning: Some installed casks are deprecated or disabled.
You should find replacements for the following casks:
  syntax-highlight (https://github.com/sbarex/SourceCodeSyntaxHighlight)
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/seivan/brew/blob/feature/deprecated_url/Library/Homebrew/test/diagnostic_checks_spec.rb#L134-L265).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
