### PR TITLE
os/mac/xcode: remove obsolete PKGID

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -244,9 +244,7 @@ module OS
     module CLT
       extend Utils::Output::Mixin
 
-      # The original Mavericks CLT package ID
       EXECUTABLE_PKG_ID = "com.apple.pkg.CLTools_Executables"
-      MAVERICKS_NEW_PKG_ID = "com.apple.pkg.CLTools_Base" # obsolete
       PKG_PATH = "/Library/Developer/CommandLineTools"
 
       # Returns true even if outdated tools are installed.
@@ -408,10 +406,8 @@ module OS
       sig { returns(T.nilable(String)) }
       def self.detect_version
         version = T.let(nil, T.nilable(String))
-        [EXECUTABLE_PKG_ID, MAVERICKS_NEW_PKG_ID].each do |id|
-          next unless File.exist?("#{PKG_PATH}/usr/bin/clang")
-
-          version = MacOS.pkgutil_info(id)[/version: (.+)$/, 1]
+        if File.exist?("#{PKG_PATH}/usr/bin/clang")
+          version = MacOS.pkgutil_info(EXECUTABLE_PKG_ID)[/version: (.+)$/, 1]
           return version if version
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Based on da56a4502597a7ea6380e9443ecb70411d59650b, the PKGID was changed in Mavericks and then reverted in Yosemite.
