### PR TITLE
Remove linuxbrew automatic git repo migration

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -723,14 +723,6 @@ Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}
   fi
 
   HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION="2.13"
-
-  HOMEBREW_CORE_REPOSITORY_ORIGIN="$("${HOMEBREW_GIT}" -C "${HOMEBREW_CORE_REPOSITORY}" remote get-url origin 2>/dev/null)"
-  if [[ "${HOMEBREW_CORE_REPOSITORY_ORIGIN}" =~ (/linuxbrew|Linuxbrew/homebrew)-core(\.git)?$ ]]
-  then
-    # triggers migration code in update.sh
-    # shellcheck disable=SC2034
-    HOMEBREW_LINUXBREW_CORE_MIGRATION=1
-  fi
 fi
 
 setup_ca_certificates() {

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -49,40 +49,6 @@ module Homebrew
 
       sig { void }
       def output_update_report
-        # Run `brew update` (again) if we've got a linuxbrew-core CoreTap
-        if CoreTap.instance.installed? && CoreTap.instance.linuxbrew_core? &&
-           ENV["HOMEBREW_LINUXBREW_CORE_MIGRATION"].blank?
-          ohai "Re-running `brew update` for linuxbrew-core migration"
-
-          if Homebrew::EnvConfig.core_git_remote != HOMEBREW_CORE_DEFAULT_GIT_REMOTE
-            opoo <<~EOS
-              `$HOMEBREW_CORE_GIT_REMOTE` was set: #{Homebrew::EnvConfig.core_git_remote}.
-              It has been unset for the migration.
-              You may need to change this from a linuxbrew-core mirror to a homebrew-core one.
-
-            EOS
-          end
-          ENV.delete("HOMEBREW_CORE_GIT_REMOTE")
-
-          if Homebrew::EnvConfig.bottle_domain != HOMEBREW_BOTTLE_DEFAULT_DOMAIN
-            opoo <<~EOS
-              `$HOMEBREW_BOTTLE_DOMAIN` was set: #{Homebrew::EnvConfig.bottle_domain}.
-              It has been unset for the migration.
-              You may need to change this from a Linuxbrew package mirror to a Homebrew one.
-
-            EOS
-          end
-          ENV.delete("HOMEBREW_BOTTLE_DOMAIN")
-
-          ENV["HOMEBREW_LINUXBREW_CORE_MIGRATION"] = "1"
-          FileUtils.rm_f HOMEBREW_LOCKS/"update"
-
-          update_args = []
-          update_args << "--auto-update" if args.auto_update?
-          update_args << "--force" if args.force?
-          exec HOMEBREW_BREW_FILE, "update", *update_args
-        end
-
         if ENV["HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID"].present?
           opoo "HOMEBREW_ADDITIONAL_GOOGLE_ANALYTICS_ID is now a no-op so can be unset."
           puts "All Homebrew Google Analytics code and data was destroyed."

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -8,7 +8,7 @@
 # HOMEBREW_AUTO_UPDATE_SECS, HOMEBREW_BREW_DEFAULT_GIT_REMOTE, HOMEBREW_BREW_GIT_REMOTE, HOMEBREW_CACHE,
 # HOMEBREW_CASK_REPOSITORY, HOMEBREW_CELLAR, HOMEBREW_CORE_DEFAULT_GIT_REMOTE, HOMEBREW_CORE_GIT_REMOTE,
 # HOMEBREW_CORE_REPOSITORY, HOMEBREW_CURL, HOMEBREW_DEV_CMD_RUN, HOMEBREW_FORCE_BREWED_CA_CERTIFICATES,
-# HOMEBREW_FORCE_BREWED_CURL, HOMEBREW_FORCE_BREWED_GIT, HOMEBREW_LINUXBREW_CORE_MIGRATION,
+# HOMEBREW_FORCE_BREWED_CURL, HOMEBREW_FORCE_BREWED_GIT,
 # HOMEBREW_SYSTEM_CURL_TOO_OLD, HOMEBREW_USER_AGENT_CURL are set by brew.sh
 # shellcheck disable=SC2154
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/lock.sh"
@@ -331,13 +331,7 @@ EOS
   # make sure symlinks are saved as-is
   git config --bool core.symlinks true
 
-  if [[ "${DIR}" == "${HOMEBREW_CORE_REPOSITORY}" && -n "${HOMEBREW_LINUXBREW_CORE_MIGRATION}" ]]
-  then
-    # Don't even try to rebase/merge on linuxbrew-core migration but rely on
-    # stashing etc. above.
-    git reset --hard "${QUIET_ARGS[@]}" "${REMOTE_REF}"
-    unset HOMEBREW_LINUXBREW_CORE_MIGRATION
-  elif [[ -z "${HOMEBREW_MERGE}" ]]
+  if [[ -z "${HOMEBREW_MERGE}" ]]
   then
     # Work around bug where git rebase --quiet is not quiet
     if [[ -z "${HOMEBREW_VERBOSE}" ]]
@@ -671,8 +665,7 @@ EOS
   fi
 
   if [[ -d "${HOMEBREW_CORE_REPOSITORY}" ]] &&
-     [[ "${HOMEBREW_CORE_DEFAULT_GIT_REMOTE}" != "${HOMEBREW_CORE_GIT_REMOTE}" ||
-        -n "${HOMEBREW_LINUXBREW_CORE_MIGRATION}" ]]
+     [[ "${HOMEBREW_CORE_DEFAULT_GIT_REMOTE}" != "${HOMEBREW_CORE_GIT_REMOTE}" ]]
   then
     safe_cd "${HOMEBREW_CORE_REPOSITORY}"
     echo "HOMEBREW_CORE_GIT_REMOTE set: using ${HOMEBREW_CORE_GIT_REMOTE} as the Homebrew/homebrew-core Git remote."

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -151,7 +151,8 @@ module OS
 
           <<~EOS
             Your Linux core repository is still linuxbrew-core.
-            You must `brew update` to update to homebrew-core.
+            You must either unset `$HOMEBREW_NO_INSTALL_FROM_API` or set
+            the repository's remote to homebrew-core to update core formulae.
           EOS
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

The JSON API provides an easy alternative for any users who still haven't migrated.

---

This removes remaining Linuxbrew migration handling (other than diagnostic message) following:
- #21195
