### PR TITLE
test/bundle/formula_installer_spec: avoid slow `brew link`

### DIFF
--- a/Library/Homebrew/test/bundle/formula_installer_spec.rb
+++ b/Library/Homebrew/test/bundle/formula_installer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Homebrew::Bundle::FormulaInstaller do
       before do
         allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
         allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
+        allow(Homebrew::Bundle).to receive(:brew).with("link", formula_name, verbose: false).and_return(true)
       end
 
       context "when service is already running" do
@@ -78,6 +79,7 @@ RSpec.describe Homebrew::Bundle::FormulaInstaller do
       before do
         allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
         allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
+        allow(Homebrew::Bundle).to receive(:brew).with("link", formula_name, verbose: false).and_return(true)
       end
 
       context "with a successful installation" do
@@ -230,6 +232,7 @@ RSpec.describe Homebrew::Bundle::FormulaInstaller do
       before do
         allow_any_instance_of(described_class).to receive(:install_change_state!).and_return(true)
         allow_any_instance_of(described_class).to receive(:installed?).and_return(true)
+        allow(Homebrew::Bundle).to receive(:brew).with("link", formula_name, verbose: false).and_return(true)
       end
 
       context "when formula has changed" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

We probably should look into improving performance here as `brew bundle` can now directly interact with `Homebrew::Cmd::Link`. So it should no longer need to create another `brew` instance, which requires subshell and then another Ruby adding a noticeable overhead.

---

However, in the mean time, we can avoid running this code for testcases that aren't verifying link behavior providing a significant speed up on one of slowest test files:

Before:
```
Top 3 slowest examples (15.17 seconds, 26.6% of total time):
  Homebrew::Bundle::FormulaInstaller when the formula is installed when the postinstall option is provided when formula has changed reports a failure
    5.13 seconds ./test/bundle/formula_installer_spec.rb:246
  Homebrew::Bundle::FormulaInstaller when the formula is installed with an always restart_service option with a skipped installation restart service
    5.02 seconds ./test/bundle/formula_installer_spec.rb:93
  Homebrew::Bundle::FormulaInstaller when the formula is installed when the postinstall option is provided when formula has changed runs the postinstall command
    5.02 seconds ./test/bundle/formula_installer_spec.rb:240

Took 58 seconds
```

After:
```
Top 3 slowest examples (1.3 seconds, 8.2% of total time):
  Homebrew::Bundle::FormulaInstaller.outdated_formulae calls Homebrew
    0.49262 seconds ./test/bundle/formula_installer_spec.rb:317
  Homebrew::Bundle::FormulaInstaller#restart_service_needed? is false by default
    0.46559 seconds ./test/bundle/formula_installer_spec.rb:559
  Homebrew::Bundle::FormulaInstaller#start_service_needed? when a service is already started is false with {restart_service: :always}
    0.34286 seconds ./test/bundle/formula_installer_spec.rb:502

Took 16 seconds
```