### PR TITLE
fix: Don't abort an install if a dangling tracking link exists

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -887,7 +887,7 @@ class Formula
   #
   # @api internal
   sig { returns(T::Boolean) }
-  def linked? = linked_keg.symlink?
+  def linked? = linked_keg.exist?
 
   # Is the formula linked to `opt`?
   sig { returns(T::Boolean) }


### PR DESCRIPTION
Every once in a while a user runs `brew install --overwrite FORMULA` and gets the error
```
Error: No such file or directory - /opt/homebrew/var/homebrew/linked/sq-satoolbox
```

The error is raised from [Library/Homebrew/keg.rb:105](https://github.com/Homebrew/brew/blob/51b612b63b86fbb0fe4ee39b8756c7fb05d4e964/Library/Homebrew/keg.rb#L105) which is in a call stack trying to tell you that the formula is already linked.

But I'm suggesting we should not consider it be linked when the symlink is dangling. `brew install` will [remediate the situation correectly](https://github.com/Homebrew/brew/blob/51b612b63b86fbb0fe4ee39b8756c7fb05d4e964/Library/Homebrew/formula_installer.rb#L1161-L1164) anyway.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
