### PR TITLE
Add all `deprecate!` and `disable!` arguments to the formula API

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1591,6 +1591,13 @@ class Formula
   # @see .deprecate!
   delegate deprecation_replacement_cask: :"self.class"
 
+  # The arguments that were used to deprecate this {Formula}.
+  # Returns `nil` if `deprecate!` was not called.
+  # @!method deprecate_args
+  # @return [Hash<Symbol, Object>]
+  # @api private
+  delegate deprecate_args: :"self.class"
+
   # Whether this {Formula} is disabled (i.e. cannot be installed).
   # Defaults to false.
   # @!method disabled?
@@ -1625,6 +1632,13 @@ class Formula
   # @return [String]
   # @see .disable!
   delegate disable_replacement_cask: :"self.class"
+
+  # The arguments that were used to disable this {Formula}.
+  # Returns `nil` if `disable!` was not called.
+  # @!method disable_args
+  # @return [Hash<Symbol, Object>]
+  # @api private
+  delegate disable_args: :"self.class"
 
   sig { returns(T::Boolean) }
   def skip_cxxstdlib_check?
@@ -2700,11 +2714,13 @@ class Formula
       "deprecation_reason"              => deprecation_reason,
       "deprecation_replacement_formula" => deprecation_replacement_formula,
       "deprecation_replacement_cask"    => deprecation_replacement_cask,
+      "deprecate_args"                  => deprecate_args,
       "disabled"                        => disabled?,
       "disable_date"                    => disable_date,
       "disable_reason"                  => disable_reason,
       "disable_replacement_formula"     => disable_replacement_formula,
       "disable_replacement_cask"        => disable_replacement_cask,
+      "disable_args"                    => disable_args,
       "post_install_defined"            => post_install_defined?,
       "service"                         => (service.to_hash if service?),
       "tap_git_head"                    => tap_git_head,
@@ -4624,13 +4640,18 @@ class Formula
         )
       end
 
+      @deprecate_args = T.let(
+        { date:, because:, replacement_formula:, replacement_cask: },
+        T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))]),
+      )
+
       @deprecation_date = T.let(Date.parse(date), T.nilable(Date))
       return if T.must(@deprecation_date) > Date.today
 
       @deprecation_reason = T.let(because, T.nilable(T.any(String, Symbol)))
       @deprecation_replacement_formula = T.let(replacement_formula.presence || replacement, T.nilable(String))
       @deprecation_replacement_cask = T.let(replacement_cask.presence || replacement, T.nilable(String))
-      T.must(@deprecated = T.let(true, T.nilable(T::Boolean)))
+      @deprecated = T.let(true, T.nilable(T::Boolean))
     end
 
     # Whether this {Formula} is deprecated (i.e. warns on installation).
@@ -4669,6 +4690,14 @@ class Formula
     # @see .deprecate!
     sig { returns(T.nilable(String)) }
     attr_reader :deprecation_replacement_cask
+
+    # The arguments that were passed to deprecate!.
+    #
+    # @return [nil] if deprecate! was not called.
+    # @see .deprecate!
+    # @api private
+    sig { returns(T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))])) }
+    attr_reader :deprecate_args
 
     # Disables a {Formula} (on the given date) so it cannot be
     # installed. If the date has not yet passed the formula
@@ -4712,9 +4741,14 @@ class Formula
       if replacement
         odeprecated(
           "disable!(:replacement)",
-          "disable!(:replacement_formula) or deprecate!(:replacement_cask)",
+          "disable!(:replacement_formula) or disable!(:replacement_cask)",
         )
       end
+
+      @disable_args = T.let(
+        { date:, because:, replacement_formula:, replacement_cask: },
+        T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))]),
+      )
 
       @disable_date = T.let(Date.parse(date), T.nilable(Date))
 
@@ -4768,6 +4802,14 @@ class Formula
     # @see .disable!
     sig { returns(T.nilable(String)) }
     attr_reader :disable_replacement_cask
+
+    # The arguments that were passed to disable!.
+    #
+    # @return [nil] if disable! was not called.
+    # @see .disable!
+    # @api private
+    sig { returns(T.nilable(T::Hash[Symbol, T.nilable(T.any(String, Symbol))])) }
+    attr_reader :disable_args
 
     # Permit overwriting certain files while linking.
     #

--- a/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
@@ -42,6 +42,9 @@ class Formula
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def deny_network_access!(*args, &block); end
 
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def deprecate_args(*args, &block); end
+
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
   def deprecated?(*args, &block); end
 
@@ -68,6 +71,9 @@ class Formula
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def desc(*args, &block); end
+
+  sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
+  def disable_args(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }
   def disable_date(*args, &block); end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -390,6 +390,7 @@ RSpec.describe Formulary do
           "deprecation_reason"              => "repo_archived",
           "deprecation_replacement_formula" => nil,
           "deprecation_replacement_cask"    => nil,
+          "deprecate_args"                  => { date: "2022-06-15", because: :repo_archived },
         }
       end
 
@@ -400,6 +401,7 @@ RSpec.describe Formulary do
           "disable_reason"              => "requires something else",
           "disable_replacement_formula" => nil,
           "disable_replacement_cask"    => nil,
+          "disable_args"                => { date: "2022-06-15", because: "requires something else" },
         }
       end
 
@@ -500,6 +502,8 @@ RSpec.describe Formulary do
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.deprecated?).to be true
+        expect(formula.deprecation_date).to eq(Date.parse("2022-06-15"))
+        expect(formula.deprecation_reason).to eq :repo_archived
         expect do
           formula.install
         end.to raise_error("Cannot build from source from abstract formula.")
@@ -511,6 +515,8 @@ RSpec.describe Formulary do
         formula = described_class.factory(formula_name)
         expect(formula).to be_a(Formula)
         expect(formula.disabled?).to be true
+        expect(formula.disable_date).to eq(Date.parse("2022-06-15"))
+        expect(formula.disable_reason).to eq("requires something else")
         expect do
           formula.install
         end.to raise_error("Cannot build from source from abstract formula.")


### PR DESCRIPTION
I noticed that we don't include all of the `deprecate` and `disable!` arguments in the formula API, we only include them if the deprecation/disable date is active (i.e. before today).

This PR adds `deprecate_args` and `disable_args` fields to the API that contain all of the arguments passed to `deprecate!` and `disable!`, regardless of whether the deprecation/disable is active. This will allow the API to replicate the exact `deprecate!`/`disable!` call that is used in the formula file. I have a follow-up PR ready to handle this once this change is merged and makes it through the API generation.
