### PR TITLE
cask/installer: add workaround for language URLs

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -855,7 +855,15 @@ on_request: true)
       download_queue = @download_queue
       return if download_queue.nil?
 
-      Homebrew::API::Cask.source_download(@cask, download_queue:) if cask_from_source_api?
+      # FIXME: We need to load Cask source before enqueuing to support
+      # language-specific URLs, but this will block the main process.
+      if cask_from_source_api?
+        if @cask.languages.any?
+          load_cask_from_source_api!
+        else
+          Homebrew::API::Cask.source_download(@cask, download_queue:)
+        end
+      end
 
       download_queue.enqueue(downloader)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

For now, just add a quick fix to support concurrent installs using JSON API for casks with language specific URLs.

Leaving a FIXME comment as this blocks the main process while downloading Cask source which doesn't align with our usage of download queue.

Ideally should be handled asynchronously.

---

Fixes #21094