### PR TITLE
formula_auditor: check `fails_with` specs in `audit_gcc_dependency`

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -493,6 +493,16 @@ module Homebrew
       # https://github.com/nghttp2/nghttp2/issues/2194
       return if formula.tap&.audit_exception(:linux_only_gcc_dependency_allowlist, formula.name)
 
+      # Allow to depend on brewed GCC if formula fails to build with the
+      # minimal supported version
+      min_gcc_version = CompilerConstants::GNU_GCC_VERSIONS.map(&:to_i).min
+      min_gcc = CompilerSelector::Compiler.new(
+        type:    :gcc,
+        name:    "gcc-#{min_gcc_version}",
+        version: Version.parse("#{min_gcc_version}.999"),
+      )
+      return if formula.stable.compiler_failures.any? { |c| c.fails_with?(min_gcc) }
+
       problem "Formulae in homebrew/core should not have a Linux-only dependency on GCC."
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Right now, audit fails on Linux if GCC build dependency is used, even if `fails_with :gcc { version "x" }` is set (https://github.com/Homebrew/homebrew-core/pull/258187)

There's audit exception `linux_only_gcc_dependency_allowlist` but I'd prefer not to use it in such cases