### PR TITLE
Add `--ruby` option to `brew sh`

### DIFF
--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -4,6 +4,8 @@
 require "abstract_command"
 require "extend/ENV"
 require "formula"
+require "utils/gems"
+require "utils/shell"
 
 module Homebrew
   module DevCmd
@@ -15,17 +17,65 @@ module Homebrew
           and even your `gem install` succeed. Especially handy if you run Homebrew
           in an Xcode-only configuration since it adds tools like `make` to your `$PATH`
           which build systems would not find otherwise.
+
+          With `--ruby`, enter an interactive shell for Homebrew's Ruby environment.
+          This sets up the correct Ruby paths, `$GEM_HOME`, and bundle
+          configuration used by Homebrew's development tools.
+          The environment includes gems from the installed groups,
+          making tools like RuboCop, Sorbet, and RSpec available via `bundle exec`.
         EOS
-        flag "--env=",
-             description: "Use the standard `$PATH` instead of superenv's when `std` is passed."
-        flag "-c=", "--cmd=",
-             description: "Execute commands in a non-interactive shell."
+        switch "-r", "--ruby",
+               description: "Set up Homebrew's Ruby environment."
+        flag   "--env=",
+               description: "Use the standard `$PATH` instead of superenv's when `std` is passed."
+        flag   "-c=", "--cmd=",
+               description: "Execute commands in a non-interactive shell."
+
+        conflicts "--ruby", "--env="
 
         named_args :file, max: 1
       end
 
       sig { override.void }
       def run
+        prompt, notice = if args.ruby?
+          setup_ruby_environment!
+        else
+          setup_build_environment!
+        end
+
+        preferred_path = Utils::Shell.preferred_path(default: "/bin/bash")
+
+        if args.cmd.present?
+          safe_system(preferred_path, "-c", args.cmd)
+        elsif args.named.present?
+          safe_system(preferred_path, args.named.first)
+        else
+          system Utils::Shell.shell_with_prompt(prompt, preferred_path:, notice:)
+        end
+      end
+
+      private
+
+      sig { returns([String, T.nilable(String)]) }
+      def setup_ruby_environment!
+        Homebrew.install_bundler_gems!(setup_path: true)
+
+        notice = unless Homebrew::EnvConfig.no_env_hints?
+          <<~EOS
+            Your shell has been configured to use Homebrew's Ruby environment.
+            This includes the correct Ruby version, GEM_HOME, and bundle configuration.
+            Tools like RuboCop, Sorbet, and RSpec are available via `bundle exec`.
+            Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
+            When done, type `exit`.
+          EOS
+        end
+
+        ["brew ruby", notice]
+      end
+
+      sig { returns([String, T.nilable(String)]) }
+      def setup_build_environment!
         ENV.activate_extensions!(env: args.env)
 
         if superenv?(args.env)
@@ -41,26 +91,19 @@ module Homebrew
 
         ENV["VERBOSE"] = "1" if args.verbose?
 
-        preferred_path = Utils::Shell.preferred_path(default: "/bin/bash")
-
-        if args.cmd.present?
-          safe_system(preferred_path, "-c", args.cmd)
-        elsif args.named.present?
-          safe_system(preferred_path, args.named.first)
-        else
-          notice = unless Homebrew::EnvConfig.no_env_hints?
-            <<~EOS
-              Your shell has been configured to use Homebrew's build environment;
-              this should help you build stuff. Notably though, the system versions of
-              gem and pip will ignore our configuration and insist on using the
-              environment they were built under (mostly). Sadly, scons will also
-              ignore our configuration.
-              Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
-              When done, type `exit`.
-            EOS
-          end
-          system Utils::Shell.shell_with_prompt("brew", preferred_path:, notice:)
+        notice = unless Homebrew::EnvConfig.no_env_hints?
+          <<~EOS
+            Your shell has been configured to use Homebrew's build environment;
+            this should help you build stuff. Notably though, the system versions of
+            gem and pip will ignore our configuration and insist on using the
+            environment they were built under (mostly). Sadly, scons will also
+            ignore our configuration.
+            Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
+            When done, type `exit`.
+          EOS
         end
+
+        ["brew", notice]
       end
     end
   end

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/sh.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/dev_cmd/sh.rbi
@@ -19,4 +19,10 @@ class Homebrew::DevCmd::Sh::Args < Homebrew::CLI::Args
 
   sig { returns(T.nilable(String)) }
   def env; end
+
+  sig { returns(T::Boolean) }
+  def r?; end
+
+  sig { returns(T::Boolean) }
+  def ruby?; end
 end

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -163,7 +163,7 @@ module Utils
         zdotdir.mkpath
         FileUtils.chmod_R(0700, zdotdir)
         FileUtils.cp(HOMEBREW_LIBRARY_PATH/"utils/zsh/brew-sh-prompt-zshrc.zsh", zdotdir/".zshrc")
-        %w[.zcompdump .zsh_history .zsh_sessions].each do |file|
+        %w[.zshenv .zcompdump .zsh_history .zsh_sessions].each do |file|
           FileUtils.ln_sf("#{home}/#{file}", zdotdir/file)
         end
         <<~ZSH.strip


### PR DESCRIPTION
Sometimes I want to be able to interact with Homebrew `ruby` and `bundle` directly to do various things.

This PR adds a `--ruby` option to `brew sh` that starts an interactive shell with Homebrew's `ruby` and `bundle` set up so you can run `bundle exec` and other commands directly.

```console
$ bundle exec rubocop --version
Source locally installed gems is ignoring #<Bundler::StubSpecification name=vernier version=1.9.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=stackprof version=0.2.27 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=ruby-prof version=1.7.2 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=redcarpet version=3.6.1 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=rbs version=4.0.0.dev.4 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=racc version=1.8.1 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=pycall version=1.5.2 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=prism version=1.6.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=json version=2.16.0 platform=ruby> because it is missing extensions
Source locally installed gems is ignoring #<Bundler::StubSpecification name=bigdecimal version=3.3.1 platform=ruby> because it is missing extensions
bundler: failed to load command: rubocop (/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/bin/rubocop)
/Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/rubygems_integration.rb:236:in 'block in Gem.replace_bin_path': can't find executable rubocop for gem rubocop. rubocop is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/site_ruby/3.4.0/rubygems.rb:237:in 'Gem.find_and_activate_spec_for_exe'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/site_ruby/3.4.0/rubygems.rb:318:in 'Gem.activate_bin_path'
	from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/bin/rubocop:25:in '<top (required)>'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli/exec.rb:61:in 'Kernel.load'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli/exec.rb:61:in 'Bundler::CLI::Exec#kernel_load'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli/exec.rb:24:in 'Bundler::CLI::Exec#run'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli.rb:494:in 'Bundler::CLI#exec'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/exe/bundle:28:in 'block in <top (required)>'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/lib/bundler/friendly_errors.rb:118:in 'Bundler.with_friendly_errors'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/bundler-4.0.0/exe/bundle:20:in '<top (required)>'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/site_ruby/3.4.0/rubygems.rb:303:in 'Kernel#load'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/lib/ruby/site_ruby/3.4.0/rubygems.rb:303:in 'Gem.activate_and_load_bin_path'
	from /Users/rylanpolster/.rbenv/versions/3.4.7/bin/bundle:25:in '<main>'

$ brew sh --ruby --cmd='bundle exec rubocop --version'
1.81.7
```