### PR TITLE
downloadable: show "Verified" status after successful checksum verification

### DIFF
--- a/Library/Homebrew/downloadable.rb
+++ b/Library/Homebrew/downloadable.rb
@@ -31,6 +31,10 @@ module Downloadable
   sig { void }
   def downloaded! = (@phase = :downloaded)
   sig { void }
+  def verifying! = (@phase = :verifying)
+  sig { void }
+  def verified! = (@phase = :verified)
+  sig { void }
   def extracting! = (@phase = :extracting)
 
   sig { void }
@@ -146,11 +150,12 @@ module Downloadable
 
   sig { overridable.params(filename: Pathname).void }
   def verify_download_integrity(filename)
-    @phase = :verifying
+    verifying!
 
     if filename.file?
       ohai "Verifying checksum for '#{filename.basename}'" if verbose?
       filename.verify_checksum(checksum)
+      verified!
     end
   rescue ChecksumMissingError
     return if silence_checksum_missing_error?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

### What & Why

This PR fixes a bug where the download verification phase never transitions to "Verified" status after successful checksum verification. Currently, users see the status stuck at "Verifying" even after verification completes successfully, making it unclear whether the process finished successfully.

**User-visible impact:** Download progress now properly shows the complete flow:
```
Downloading → Downloaded → Verifying → Verified 
```

### Changes

Added `verifying!` and `verified!` phase methods (matching existing `downloading!`, `downloaded!`, `extracting!` pattern) and updated `verify_download_integrity()` to call `verified!` when verification actually succeeds