### PR TITLE
Add Homebrew's ruby to `PATH` for VSCode Ruby LSP setup

### DIFF
--- a/.vscode/ruby-lsp-activate.sh
+++ b/.vscode/ruby-lsp-activate.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+# This might be sourced from zsh, so support both
 if [[ -n "${BASH_SOURCE[0]}" ]]; then
     SCRIPT_PATH="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION}" ]]; then
+    # This is zsh-specific syntax.
+    # shellcheck disable=SC2296
     SCRIPT_PATH="${(%):-%x}"
 else
     SCRIPT_PATH="$0"
@@ -13,9 +16,13 @@ export HOMEBREW_BREW_FILE="${HOMEBREW_PREFIX}/bin/brew"
 export HOMEBREW_LIBRARY="${HOMEBREW_PREFIX}/Library"
 export BUNDLE_WITH="style:typecheck:vscode"
 
-# shellcheck disable=SC1091
+# shellcheck source=../Library/Homebrew/utils/ruby.sh
 source "${HOMEBREW_PREFIX}/Library/Homebrew/utils/ruby.sh"
 
 setup-ruby-path
 setup-gem-home-bundle-gemfile
 ensure-bundle-dependencies
+
+# setup-ruby-path doesn't add Homebrew's ruby to PATH
+homebrew_ruby_bin="$(dirname "${HOMEBREW_RUBY_PATH}")"
+export PATH="${homebrew_ruby_bin}:${PATH}"


### PR DESCRIPTION
After https://github.com/Homebrew/brew/pull/21111, Homebrew's ruby was no longer added to the PATH in the `ruby-lsp-setup.sh` file. This meant that all subsequent setup steps were using the wrong Ruby, leading to the wrong Gem setup being used. This PR adds ruby back to the PATH to (mostly) fix vscode.

Unfortunately, the `test-prof` issues (see https://github.com/Homebrew/brew/pull/21220) are preventing RuboCop from working out of the box, so vscode is still slightly broken. The workaround is to comment out the `test-prof` plugin in `.rubocop.yml` temporarily. That shouldn't be necessary once the next version of `test-prof` is released and gets merged in.
