### PR TITLE
bundle/go_dumper: skip symlinks

### DIFF
--- a/Library/Homebrew/bundle/go_dumper.rb
+++ b/Library/Homebrew/bundle/go_dumper.rb
@@ -22,7 +22,9 @@ module Homebrew
 
           return [] unless File.directory?(bin_dir)
 
-          binaries = Dir.glob("#{bin_dir}/*").select { |f| File.executable?(f) && !File.directory?(f) }
+          binaries = Dir.glob("#{bin_dir}/*").select do |f|
+            File.executable?(f) && !File.directory?(f) && !File.symlink?(f)
+          end
 
           binaries.filter_map do |binary|
             output = `#{go} version -m "#{binary}" 2>/dev/null`


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

---

Symlinks in `GOBIN` wouldn't have been installed by `go install`. In my case, `GOBIN` is set to the XDG standard `~/.local/bin` and Orbstack symlinks its own go-built binaries there (mainly `orbctl`, which isn't open source)

```console
$ ls -la ~/.local/bin/ | grep orbstack
lrwxrwxrwx@  1 branch  staff        31 Dec  9  2024 orb -> /Users/branch/.orbstack/bin/orb
lrwxrwxrwx@  1 branch  staff        34 Dec  9  2024 orbctl -> /Users/branch/.orbstack/bin/orbctl
```
