### PR TITLE
cmd/deps: clarify when `--include-test` is recursive

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -38,7 +38,7 @@ module Homebrew
         switch "--include-optional",
                description: "Include `:optional` dependencies for <formula>."
         switch "--include-test",
-               description: "Include `:test` dependencies for <formula> (non-recursive)."
+               description: "Include `:test` dependencies for <formula> (non-recursive unless `--graph` or `--tree`)."
         switch "--skip-recommended",
                description: "Skip `:recommended` dependencies for <formula>."
         switch "--include-requirements",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

We always output recursive test dependencies when running `brew deps --include-test --tree` or `--graph` so the description is incorrect in those cases.