### PR TITLE
pypi: keep extra packages even if they are dependencies of exclude packages

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -355,6 +355,8 @@ module PyPI
     exclude_packages.delete_if { |package| found_packages.exclude? package }
     ohai "Retrieving PyPI dependencies for excluded \"#{exclude_packages.join(" ")}\"..." if show_info
     exclude_packages = pip_report(exclude_packages, python_name:, print_stderr:)
+    # Keep extra_packages even if they are dependencies of exclude_packages
+    exclude_packages.delete_if { |package| extra_packages.include? package }
     if (main_package_name = main_package&.name)
       exclude_packages += [Package.new(main_package_name)]
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

When a package is added to `exclude_packages`, all of its dependencies are also excluded from the resource list. However, some of these dependencies may overlap with the target package's dependencies and need to be preserved.

Previously, there was no way to keep these overlapping dependencies, they would be excluded even if explicitly listed in `extra_packages`.

This change ensures that packages explicitly specified in `extra_packages` are preserved, even when they appear in the dependency tree of excluded packages.