### PR TITLE
test: prefer system pgrep/pkill to avoid proctools conflict

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -64,11 +64,13 @@ rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe&.close
 ensure
   pid = Process.pid.to_s
-  if system("/usr/bin/pgrep", "-P", pid, out: File::NULL)
+  pkill = "/usr/bin/pkill"
+  pgrep = "/usr/bin/pgrep"
+  if File.executable?(pkill) && File.executable?(pgrep) && system(pgrep, "-P", pid, out: File::NULL)
     $stderr.puts "Killing child processes..."
-    system "/usr/bin/pkill", "-P", pid
+    system pkill, "-P", pid
     sleep 1
-    system "/usr/bin/pkill", "-9", "-P", pid
+    system pgrep, "-9", "-P", pid
   end
   exit! 1 if e
 end


### PR DESCRIPTION
When `proctools` is installed, `brew test` fails with a SIGTERM during cleanup. This happens because `proctools` provides `pgrep`/`pkill` binaries in `HOMEBREW_PREFIX/bin`, which behave differently than system binaries on macOS.

~~This fix forces the use of system binaries by prepending `/usr/bin` and `/bin` to `PATH` within the `system` call. It invokes commands via `/usr/bin/env` to bypass Ruby's internal command resolution, ensuring the modified `PATH` is respected during lookup.~~

This fix forces the use of system binaries in `/usr/bin` within the `system` call.

Fixes #21242

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
