### PR TITLE
curl_args: support :curl user_agent

### DIFF
--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -437,6 +437,10 @@ RSpec.describe "Utils::Curl" do
       expect(curl_args(*args, referer: nil).join(" ")).not_to include("--referer")
     end
 
+    it "omits `--user-agent` when `:user_agent` is `:curl`" do
+      expect(curl_args(*args, user_agent: :curl).join(" ")).not_to include("--user-agent")
+    end
+
     it "uses HOMEBREW_USER_AGENT_FAKE_SAFARI when `:user_agent` is `:browser` or `:fake`" do
       expect(curl_args(*args, user_agent: :browser).join(" "))
         .to include("--user-agent #{HOMEBREW_USER_AGENT_FAKE_SAFARI}")
@@ -457,7 +461,7 @@ RSpec.describe "Utils::Curl" do
 
     it "errors when `:user_agent` is not a String or supported Symbol" do
       expect { curl_args(*args, user_agent: :an_unsupported_symbol) }
-        .to raise_error(TypeError, ":user_agent must be :browser/:fake, :default, or a String")
+        .to raise_error(TypeError, ":user_agent must be :browser/:fake, :default, :curl, or a String")
       expect { curl_args(*args, user_agent: 123) }.to raise_error(TypeError)
     end
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -113,15 +113,17 @@ module Utils
 
       args << "--show-error" if show_error
 
-      args << "--user-agent" << case user_agent
-      when :browser, :fake
-        HOMEBREW_USER_AGENT_FAKE_SAFARI
-      when :default, nil
-        HOMEBREW_USER_AGENT_CURL
-      when String
-        user_agent
-      else
-        raise TypeError, ":user_agent must be :browser/:fake, :default, or a String"
+      if user_agent != :curl
+        args << "--user-agent" << case user_agent
+        when :browser, :fake
+          HOMEBREW_USER_AGENT_FAKE_SAFARI
+        when :default, nil
+          HOMEBREW_USER_AGENT_CURL
+        when String
+          user_agent
+        else
+          raise TypeError, ":user_agent must be :browser/:fake, :default, :curl, or a String"
+        end
       end
 
       args << "--header" << "Accept-Language: en"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

A small number of casks require the default curl user agent, `curl/8.7.1`, for requests to work with an upstream server. Though livecheck doesn't support a `user_agent` parameter yet (this is [forthcoming](https://github.com/Homebrew/brew/pull/21253)), I know of a similar number of casks that require a curl user agent to work as well (there's some overlap). In these cases, neither `:browser`/`:fake` nor the default Homebrew user agent works.

We've already been using `user_agent: "curl/8.7.1"` for these casks for some time, so this change simply adds support for  `user_agent: :curl` to avoid hardcoding a specific version. This works by omitting the `--user-agent` option when `:curl` is used, so curl will use the default `curl/8.7.1` user agent. Outside of manual testing to verify the behavior (e.g., making a request and checking the access log), I tested this by replacing some `user_agent` arguments in related casks and checking to make sure they continue to work as expected.