### PR TITLE
Fetch in parallel with `brew bundle`

### DIFF
--- a/Library/Homebrew/bundle/cask_installer.rb
+++ b/Library/Homebrew/bundle/cask_installer.rb
@@ -74,6 +74,10 @@ module Homebrew
         result
       end
 
+      def self.installable_or_upgradable?(name, no_upgrade: false, **options)
+        !cask_installed?(name) || upgrading?(no_upgrade, name, options)
+      end
+
       private_class_method def self.postinstall_change_state!(name:, options:, verbose:)
         postinstall = options.fetch(:postinstall, nil)
         return true if postinstall.blank?

--- a/Library/Homebrew/test/bundle/commands/install_spec.rb
+++ b/Library/Homebrew/test/bundle/commands/install_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
   context "when a Brewfile is found", :no_api do
     before do
       Homebrew::Bundle::CaskDumper.reset!
+      allow(Homebrew::Bundle).to receive(:brew).and_return(true)
+      allow(Homebrew::Bundle::FormulaInstaller).to receive(:formula_installed_and_up_to_date?).and_return(false)
+      allow(Homebrew::Bundle::CaskInstaller).to receive(:installable_or_upgradable?).and_return(true)
     end
 
     let(:brewfile_contents) do
@@ -86,7 +89,6 @@ RSpec.describe Homebrew::Bundle::Commands::Install do
       allow(Homebrew::Bundle::FlatpakInstaller).to receive_messages(preinstall!: true, install!: true)
       allow_any_instance_of(Pathname).to receive(:read).and_return(brewfile_contents)
 
-      expect(Homebrew::Bundle).not_to receive(:system)
       expect { described_class.run }.to raise_error(SystemExit)
     end
   end

--- a/Library/Homebrew/test/bundle/installer_spec.rb
+++ b/Library/Homebrew/test/bundle/installer_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "bundle"
+require "bundle/dsl"
+require "bundle/installer"
+
+RSpec.describe Homebrew::Bundle::Installer do
+  let(:formula_entry) { Homebrew::Bundle::Dsl::Entry.new(:brew, "mysql") }
+  let(:cask_options) { { args: {}, full_name: "homebrew/cask/google-chrome" } }
+  let(:cask_entry) { Homebrew::Bundle::Dsl::Entry.new(:cask, "google-chrome", cask_options) }
+
+  before do
+    allow(Homebrew::Bundle::Skipper).to receive(:skip?).and_return(false)
+    allow(Homebrew::Bundle::FormulaInstaller).to receive_messages(formula_upgradable?: false, install!: true)
+    allow(Homebrew::Bundle::CaskInstaller).to receive_messages(cask_upgradable?: false, install!: true)
+  end
+
+  it "prefetches installable formulae and casks before installing" do
+    allow(Homebrew::Bundle::FormulaInstaller).to receive(:formula_installed_and_up_to_date?)
+      .with("mysql", no_upgrade: false).and_return(false)
+    allow(Homebrew::Bundle::CaskInstaller).to receive(:installable_or_upgradable?)
+      .with("google-chrome", no_upgrade: false, **cask_options).and_return(true)
+
+    expect(Homebrew::Bundle).to receive(:brew)
+      .with("fetch", "mysql", "homebrew/cask/google-chrome", verbose: false)
+      .ordered
+      .and_return(true)
+    expect(Homebrew::Bundle::FormulaInstaller).to receive(:preinstall!)
+      .with("mysql", no_upgrade: false, verbose: false)
+      .ordered
+      .and_return(true)
+    expect(Homebrew::Bundle::CaskInstaller).to receive(:preinstall!)
+      .with("google-chrome", **cask_options, no_upgrade: false, verbose: false)
+      .ordered
+      .and_return(true)
+
+    described_class.install!([formula_entry, cask_entry], verbose: false, force: false, quiet: true)
+  end
+
+  it "skips fetching when no formulae or casks need installation or upgrade" do
+    allow(Homebrew::Bundle::FormulaInstaller).to receive(:formula_installed_and_up_to_date?)
+      .with("mysql", no_upgrade: true).and_return(true)
+    allow(Homebrew::Bundle::FormulaInstaller).to receive(:preinstall!).and_return(false)
+
+    expect(Homebrew::Bundle).not_to receive(:brew).with("fetch", any_args)
+
+    described_class.install!([formula_entry], no_upgrade: true, quiet: true)
+  end
+end


### PR DESCRIPTION
Run `brew fetch` before `brew install`

This will parallelise fetching of formulae and casks in `brew bundle`

Note dependencies are not properly handled yet but that could be a future extension if someone cares enough.

Fixes https://github.com/Homebrew/brew/issues/21140