### PR TITLE
formula: allow using modern bash completion dir

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1249,9 +1249,19 @@ class Formula
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with
   # `brew link` for formulae that are not keg-only.
   #
+  # By default the compatibility directory is used to support system Bash 3
+  # on macOS. Pass in `compat: false` when installing completions that need
+  # Bash >= 4 or bash-completion >= 2.
+  #
   # @api public
-  sig { returns(Pathname) }
-  def bash_completion = prefix/"etc/bash_completion.d"
+  sig { params(compat: T::Boolean).returns(Pathname) }
+  def bash_completion(compat: true)
+    if compat
+      prefix/"etc/bash_completion.d"
+    else
+      share/"bash-completion/completions"
+    end
+  end
 
   # The directory where the formula's `zsh` completion files should be
   # installed.
@@ -2273,7 +2283,7 @@ class Formula
     base_name ||= name
 
     completion_script_path_map = {
-      bash: bash_completion/base_name,
+      bash: bash_completion(compat: shell_parameter_format != :click)/base_name,
       zsh:  zsh_completion/"_#{base_name}",
       fish: fish_completion/"#{base_name}.fish",
       pwsh: pwsh_completion/"_#{base_name}.ps1",

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1942,6 +1942,7 @@ RSpec.describe Formula do
           FileUtils.chmod "+x", bin/"foo"
 
           generate_completions_from_executable(bin/"foo", "test")
+          generate_completions_from_executable(bin/"foo", base_name: "bar", shell_parameter_format: :click)
         end
       end.new
     end
@@ -1951,6 +1952,11 @@ RSpec.describe Formula do
       expect(f.bash_completion/"foo").to be_a_file
       expect(f.zsh_completion/"_foo").to be_a_file
       expect(f.fish_completion/"foo.fish").to be_a_file
+
+      expect(f.bash_completion(compat: false)/"bar").to be_a_file
+      expect(f.bash_completion/"bar").not_to exist
+      expect(f.zsh_completion/"_bar").to be_a_file
+      expect(f.fish_completion/"bar.fish").to be_a_file
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

I was previously thinking of adding a separate method:
- #14270

But I wasn't happy on naming as version number doesn't make much sense given the path will likely remain for v3, v4, etc as it is based on XDG.

This PR is a different idea for DSL of using an argument, with default to keep using compatdir path so all `bash_completion.install` usage remains the same.

---

This is needed as we recently enabled Click Bash completions
- #20188

Which are incompatible with system Bash
- https://github.com/orgs/Homebrew/discussions/6603

---

One scenario that this does not automatically support is Bash 4 without `bash-completion@2` installed. For now, users will need to manually adjust their Bash config file to load these.

We could adjust https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash but it will make the logic more complicated to detect which Bash version is running and add multiple directories to load from.

Easier response to this scenario is to tell users to install `bash-completion@2`.