### PR TITLE
Fix typo in test cleanup: replace `pgrep -9` with `pkill -9`

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -70,7 +70,7 @@ ensure
     $stderr.puts "Killing child processes..."
     system pkill, "-P", pid
     sleep 1
-    system pgrep, "-9", "-P", pid
+    system pkill, "-9", "-P", pid
   end
   exit! 1 if e
 end


### PR DESCRIPTION
The cleanup logic was attempting to use `pgrep` with the -9 flag, which is invalid. This switches the command to `pkill` to correctly send SIGKILL to remaining child processes.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
