### PR TITLE
api: increase stale seconds to 7 days.

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -18,7 +18,7 @@ module Homebrew
 
     HOMEBREW_CACHE_API = T.let((HOMEBREW_CACHE/"api").freeze, Pathname)
     HOMEBREW_CACHE_API_SOURCE = T.let((HOMEBREW_CACHE/"api-source").freeze, Pathname)
-    DEFAULT_API_STALE_SECONDS = T.let(86400, Integer) # 1 day
+    DEFAULT_API_STALE_SECONDS = T.let(7 * 24 * 60 * 60, Integer) # 7 days
 
     sig { params(endpoint: String).returns(T::Hash[String, T.untyped]) }
     def self.fetch(endpoint)


### PR DESCRIPTION
This increases the time when we will update from the API even if we're not in a command that needs auto-updates e.g. `brew services`.

We might make this higher still in future as this could technically be indefinite.

Fixes #21201