### PR TITLE
cask/artifact/app: fix up permissions for globally installed apps

### DIFF
--- a/Library/Homebrew/cask/artifact/app.rb
+++ b/Library/Homebrew/cask/artifact/app.rb
@@ -10,7 +10,7 @@ module Cask
       sig {
         params(
           adopt:        T::Boolean,
-          auto_updates: T::Boolean,
+          auto_updates: T.nilable(T::Boolean),
           force:        T::Boolean,
           verbose:      T::Boolean,
           predecessor:  T.nilable(Cask),


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Some casks (e.g. `sourcetree`) install `app` artifacts with permissions
that make them accessible only to the user that installed them. This is
problematic on multi-user systems when the app is installed into a
global location like `/Applications`.

Let's handle that by fixing up permissions appropriately when we install
an app artifact into a global location.

I've had to make this `typed: true` to match the code it inherits from
the `Moved` class, which also used `typed: true` instead of
`typed: strict`.
