### PR TITLE
lazy_object: update block parameter to fix Ruby warning

### DIFF
--- a/Library/Homebrew/lazy_object.rb
+++ b/Library/Homebrew/lazy_object.rb
@@ -13,8 +13,8 @@ class LazyObject < Delegator
     super(callable)
   end
 
-  sig { returns(T.untyped) }
-  def __getobj__
+  sig { params(_blk: T.untyped).returns(T.untyped) }
+  def __getobj__(&_blk)
     return @__getobj__ if @getobj_set
 
     @__getobj__ = T.must(@__callable__).call


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Followup to https://github.com/Homebrew/brew/pull/21263.

Fixes `/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.6.12815/lib/types/private/methods/call_validation.rb:282: warning: the block passed to 'LazyObject#__getobj__' defined at /opt/homebrew/Library/Homebrew/lazy_object.rb:17 may be ignored`