### PR TITLE
Set `FormulaStruct#deprecate?` based on `deprecate_args` (and same for `disable`)

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -281,8 +281,8 @@ module Homebrew
 
         # Should match FormulaStruct::PREDICATES
         hash["bottle_present"] = hash["bottle"].present?
-        hash["deprecated_present"] = hash["deprecation_date"].present?
-        hash["disabled_present"] = hash["disable_date"].present?
+        hash["deprecate_present"] = hash["deprecate_args"].present?
+        hash["disable_present"] = hash["disable_args"].present?
         hash["head_present"] = hash.dig("urls", "head").present?
         hash["keg_only_present"] = hash["keg_only_reason"].present?
         hash["no_autobump_message_present"] = hash["no_autobump_message"].present?

--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -9,8 +9,8 @@ module Homebrew
     class FormulaStruct < T::Struct
       PREDICATES = [
         :bottle,
-        :deprecated,
-        :disabled,
+        :deprecate,
+        :disable,
         :head,
         :keg_only,
         :no_autobump_message,

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -287,8 +287,8 @@ module Formulary
 
       keg_only(*formula_struct.keg_only_args) if formula_struct.keg_only?
 
-      deprecate!(**formula_struct.deprecate_args) if formula_struct.deprecated?
-      disable!(**formula_struct.disable_args) if formula_struct.disabled?
+      deprecate!(**formula_struct.deprecate_args) if formula_struct.deprecate?
+      disable!(**formula_struct.disable_args) if formula_struct.disable?
 
       formula_struct.conflicts.each do |name, args|
         conflicts_with(name, **args)

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/api/formula_struct.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/api/formula_struct.rbi
@@ -10,10 +10,10 @@ class Homebrew::API::FormulaStruct
   def bottle?; end
 
   sig { returns(T::Boolean) }
-  def deprecated?; end
+  def deprecate?; end
 
   sig { returns(T::Boolean) }
-  def disabled?; end
+  def disable?; end
 
   sig { returns(T::Boolean) }
   def head?; end


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/21215

Now that we have `deprecate_args` and `disable_args` in the formula JSON, we should use their presence to determine whether to call `deprecate!` and `disable!`.

I changed the predicate methods to `deprecate?` and `disable?` to match the other predicates that generally match the DSL method name. Alternately, they could be changed to `deprecate_args?` and `disable_args?` if that's more clear.

CC: @Bo98