### PR TITLE
docs: fix permissions and privilege explanation in FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -122,7 +122,7 @@ We use the macOS sandbox to stop this but this doesn't work when run as the `roo
 
 Did you `chown root /Applications/TextMate.app`? Probably not. So is it that important to `chown root wget`?
 
-If you need to run Homebrew in a multi-user environment, consider creating a separate user account specifically for use of Homebrew.
+Note: Homebrew is primarily designed for single-user use and does not work well in multi-user configurations.
 
 ## What is the default ownership and permissions used by Homebrew?
 
@@ -132,9 +132,11 @@ Ownership on macOS, all subdirectories and files use a forced default of `admin`
 
 Ownership on Linux, all subdirectories and files default to the current user and the user group that executed the installation.
 
-By default, permissions for Homebrew-managed directories and files are `0755 (u=rwx,g=rx,o=rx)` on both macOS and Linux. This means that only the owning user (typically the installing user) can modify or replace files within the Homebrew prefix, while all users are allowed to read and execute installed binaries. On multi-user systems, Homebrew recommends managing the installation from a dedicated user account rather than running `brew` as multiple users.
+By default, permissions for Homebrew-managed directories and files are `0755 (u=rwx,g=rx,o=rx)` on both macOS and Linux. This means that only the owning user (typically the installing user) can modify or replace files within the Homebrew prefix, while all users are allowed to read and execute installed binaries.
 
 When a Homebrew-installed binary is executed, it runs with the privileges of the user who launched it.
+
+Note: Homebrew is primarily designed for single-user use and does not work well in multi-user configurations.
 
 ## Why isn’t a particular command documented?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Follow-up to Homebrew discussion: https://github.com/orgs/Homebrew/discussions/6617.

This PR updates the newly added FAQ section "What is the default ownership and permissions used by Homebrew" (introduced in https://github.com/Homebrew/brew/pull/20946) to avoid two misleading statements:

* Clarifies that Homebrew-installed binaries run with the invoking user's privileges. Removes and adjusts wording implying binaries "inherit" admin permissions or can read/modify system locations by default.
* Fixes wording that discourages a dedicated Homebrew user account, aligning it with existing FAQ guidance that recommends a dedicated account for multi-user environments (see "Why does Homebrew say sudo is bad?": [https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad](https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad)).
