### PR TITLE
test: remove false return handling

### DIFF
--- a/Library/Homebrew/debrew.rb
+++ b/Library/Homebrew/debrew.rb
@@ -17,7 +17,7 @@ module Debrew
       Debrew.debrew { super }
     end
 
-    sig { returns(T.nilable(T::Boolean)) }
+    sig { void }
     def test
       Debrew.debrew { super }
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2975,7 +2975,7 @@ class Formula
     self.class.on_system_blocks_exist? || @on_system_blocks_exist
   end
 
-  sig { params(keep_tmp: T::Boolean).returns(T.untyped) }
+  sig { params(keep_tmp: T::Boolean).void }
   def run_test(keep_tmp: false)
     @prefix_returns_versioned_prefix = T.let(true, T.nilable(T::Boolean))
 
@@ -3020,7 +3020,7 @@ class Formula
     method(:test).owner != Formula
   end
 
-  sig { returns(T.nilable(T::Boolean)) }
+  sig { void }
   def test; end
 
   sig { params(file: T.any(Pathname, String)).returns(Pathname) }
@@ -4436,13 +4436,12 @@ class Formula
     # end
     # ```
     #
-    # The test will fail if it returns false, or if an exception is raised.
+    # The test will fail if an exception is raised.
     # Failed assertions and failed `system` commands will raise exceptions.
     #
     # @see https://docs.brew.sh/Formula-Cookbook#add-a-test-to-the-formula Tests
-    # @return [Boolean]
     # @api public
-    sig { params(block: T.proc.returns(T.untyped)).returns(T.untyped) }
+    sig { params(block: T.proc.void).void }
     def test(&block) = define_method(:test, &block)
 
     # {Livecheck} can be used to check for newer versions of the software.

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -49,14 +49,13 @@ begin
   ENV.setup_build_environment(formula:, testing_formula: true)
   Pathname.activate_extensions!
 
-  # tests can also return false to indicate failure
-  run_test = proc { |_| raise "test returned false" if formula.run_test(keep_tmp: args.keep_tmp?) == false }
+  keep_tmp = args.keep_tmp?
   if args.debug? # --debug is interactive
-    run_test.call(nil)
+    formula.run_test(keep_tmp:)
   else
     # HOMEBREW_TEST_TIMEOUT_SECS is private API and subject to change.
     timeout = ENV["HOMEBREW_TEST_TIMEOUT_SECS"]&.to_i || DEFAULT_TEST_TIMEOUT_SECONDS
-    Timeout.timeout(timeout, &run_test)
+    Timeout.timeout(timeout) { formula.run_test(keep_tmp:) }
   end
 # Any exceptions during the test run are reported.
 rescue Exception => e # rubocop:disable Lint/RescueException


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

False return handling is currently broken due to some Sorbet typing resulting in void returns. Although we can fix it, there doesn't seem to be any use case where `return false` is worth using when compared to alternatives like `Formula#system`, Minitest, `odie`, `raise`, etc.

So we can instead simplify the code and remove handling of false return. This has some advantages for Sorbet. For example, we can remove some T.untyped and replace proc with block.