### PR TITLE
Update some block returns to use type_parameter

### DIFF
--- a/Library/Homebrew/api.rb
+++ b/Library/Homebrew/api.rb
@@ -362,14 +362,19 @@ module Homebrew
     end
   end
 
-  sig { params(block: T.proc.returns(T.untyped)).returns(T.untyped) }
+  sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
   def self.with_no_api_env(&block)
     return yield if Homebrew::EnvConfig.no_install_from_api?
 
     with_env(HOMEBREW_NO_INSTALL_FROM_API: "1", HOMEBREW_AUTOMATICALLY_SET_NO_INSTALL_FROM_API: "1", &block)
   end
 
-  sig { params(condition: T::Boolean, block: T.proc.returns(T.untyped)).returns(T.untyped) }
+  sig {
+    type_parameters(:U).params(
+      condition: T::Boolean,
+      block:     T.proc.returns(T.type_parameter(:U)),
+    ).returns(T.type_parameter(:U))
+  }
   def self.with_no_api_env_if_needed(condition, &block)
     return yield unless condition
 

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -28,14 +28,14 @@ module EnvActivation
   end
 
   sig {
-    params(
+    type_parameters(:U).params(
       env:           T.nilable(String),
       cc:            T.nilable(String),
       build_bottle:  T::Boolean,
       bottle_arch:   T.nilable(String),
       debug_symbols: T.nilable(T::Boolean),
-      _block:        T.proc.returns(T.untyped),
-    ).returns(T.untyped)
+      _block:        T.proc.returns(T.type_parameter(:U)),
+    ).returns(T.type_parameter(:U))
   }
   def with_build_environment(env: nil, cc: nil, build_bottle: false, bottle_arch: nil, debug_symbols: false, &_block)
     old_env = to_hash.dup

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1301,7 +1301,12 @@ class Formula
   end
 
   # Runs a block with the given log type in effect for its duration.
-  sig { params(log_type: String, _block: T.proc.void).void }
+  sig {
+    type_parameters(:U).params(
+      log_type: String,
+      _block:   T.proc.returns(T.type_parameter(:U)),
+    ).returns(T.type_parameter(:U))
+  }
   def with_logging(log_type, &_block)
     old_log_type = @active_log_type
     @active_log_type = T.let(log_type, T.nilable(String))
@@ -3330,12 +3335,12 @@ class Formula
   # or calling `do |staging| ... staging.retain!` in the block will skip
   # the deletion and retain the temporary directory's contents.
   sig {
-    params(
+    type_parameters(:U).params(
       prefix:          String,
       retain:          T::Boolean,
       retain_in_cache: T::Boolean,
-      block:           T.proc.params(arg0: Mktemp).void,
-    ).void
+      block:           T.proc.params(arg0: Mktemp).returns(T.type_parameter(:U)),
+    ).returns(T.type_parameter(:U))
   }
   def mktemp(prefix = name, retain: false, retain_in_cache: false, &block)
     Mktemp.new(prefix, retain:, retain_in_cache:).run(&block)

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -51,7 +51,12 @@ class Mktemp
     "[Mktemp: #{tmpdir} retain=#{@retain} quiet=#{@quiet}]"
   end
 
-  sig { params(chdir: T::Boolean, _block: T.proc.params(arg0: Mktemp).void).void }
+  sig {
+    type_parameters(:U).params(
+      chdir:  T::Boolean,
+      _block: T.proc.params(arg0: Mktemp).returns(T.type_parameter(:U)),
+    ).returns(T.type_parameter(:U))
+  }
   def run(chdir: true, &_block)
     prefix_name = @prefix.tr "@", "AT"
     @tmpdir = if retain_in_cache?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This provides better type checking than T.untyped.

For places where void is replaced, this restores support for original return where the final output was propagated out of blocks.