### PR TITLE
test: deprecate `return false` in test

### DIFF
--- a/Library/Homebrew/debrew.rb
+++ b/Library/Homebrew/debrew.rb
@@ -17,7 +17,10 @@ module Debrew
       Debrew.debrew { super }
     end
 
-    sig { returns(T.nilable(T::Boolean)) }
+    sig {
+      # TODO: replace `returns(BasicObject)` with `void` after dropping `return false` handling in test
+      returns(BasicObject)
+    }
     def test
       Debrew.debrew { super }
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2995,7 +2995,10 @@ class Formula
     self.class.on_system_blocks_exist? || @on_system_blocks_exist
   end
 
-  sig { params(keep_tmp: T::Boolean).returns(T.untyped) }
+  sig {
+    # TODO: replace `returns(BasicObject)` with `void` after dropping `return false` handling in test
+    params(keep_tmp: T::Boolean).returns(BasicObject)
+  }
   def run_test(keep_tmp: false)
     @prefix_returns_versioned_prefix = T.let(true, T.nilable(T::Boolean))
 
@@ -3040,7 +3043,10 @@ class Formula
     method(:test).owner != Formula
   end
 
-  sig { returns(T.nilable(T::Boolean)) }
+  sig {
+    # TODO: replace `returns(BasicObject)` with `void` after dropping `return false` handling in test
+    returns(BasicObject)
+  }
   def test; end
 
   sig { params(file: T.any(Pathname, String)).returns(Pathname) }
@@ -4460,9 +4466,11 @@ class Formula
     # Failed assertions and failed `system` commands will raise exceptions.
     #
     # @see https://docs.brew.sh/Formula-Cookbook#add-a-test-to-the-formula Tests
-    # @return [Boolean]
     # @api public
-    sig { params(block: T.proc.returns(T.untyped)).returns(T.untyped) }
+    sig {
+      # TODO: replace `returns(BasicObject)` with `void` after dropping `return false` handling in test
+      params(block: T.proc.returns(BasicObject)).returns(BasicObject)
+    }
     def test(&block) = define_method(:test, &block)
 
     # {Livecheck} can be used to check for newer versions of the software.

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -50,7 +50,15 @@ begin
   Pathname.activate_extensions!
 
   # tests can also return false to indicate failure
-  run_test = proc { |_| raise "test returned false" if formula.run_test(keep_tmp: args.keep_tmp?) == false }
+  run_test = proc do |_|
+    # TODO: Replace proc usage with direct `formula.run_test` when removing this.
+    # Also update formula.rb 'TODO: replace `returns(BasicObject)` with `void`'
+    if formula.run_test(keep_tmp: args.keep_tmp?) == false
+      require "utils/output"
+      Utils::Output.odeprecated "`return false` in test", "`raise \"<reason for failure>\"`"
+      raise "test returned false"
+    end
+  end
   if args.debug? # --debug is interactive
     run_test.call(nil)
   else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Replacement for #21291 to allow odeprecate cycle.

Using BasicObject as we have no control over what a formula test block returns and we need something that supports `==`.