### PR TITLE
Remove unneeded T.let

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -39,7 +39,7 @@ class Build
   def initialize(formula, options, args:)
     @formula = formula
     @formula.build = BuildOptions.new(options, formula.options)
-    @args = T.let(args, Homebrew::Cmd::InstallCmd::Args)
+    @args = args
     @deps = T.let([], T::Array[Dependency])
     @reqs = T.let(Requirements.new, Requirements)
 

--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -5,8 +5,8 @@
 class BuildOptions
   sig { params(args: Options, options: Options).void }
   def initialize(args, options)
-    @args = T.let(args, Options)
-    @options = T.let(options, Options)
+    @args = args
+    @options = options
   end
 
   # True if a {Formula} is being built with a specific option.

--- a/Library/Homebrew/cask/dsl/base.rb
+++ b/Library/Homebrew/cask/dsl/base.rb
@@ -18,7 +18,7 @@ module Cask
 
       sig { params(cask: Cask, command: T.class_of(SystemCommand)).void }
       def initialize(cask, command = SystemCommand)
-        @cask = T.let(cask, Cask)
+        @cask = cask
         @command = T.let(command, T.class_of(SystemCommand))
       end
 

--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -89,7 +89,7 @@ module Cask
       specs[:only_path]  = @only_path  = T.let(only_path, T.nilable(String))
 
       @specs = T.let(specs.compact, T::Hash[Symbol, T.untyped])
-      @caller_location = T.let(caller_location, Thread::Backtrace::Location)
+      @caller_location = caller_location
     end
 
     sig { returns(Homebrew::SourceLocation) }

--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -17,7 +17,7 @@ class CaskDependent
 
   sig { params(cask: Cask::Cask).void }
   def initialize(cask)
-    @cask = T.let(cask, Cask::Cask)
+    @cask = cask
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -61,7 +61,7 @@ module Homebrew
 
       sig { params(verbose: T::Boolean).void }
       def initialize(verbose: true)
-        @verbose = T.let(verbose, T::Boolean)
+        @verbose = verbose
         @found = T.let([], T::Array[String])
         @seen_prefix_bin = T.let(false, T::Boolean)
         @seen_prefix_sbin = T.let(false, T::Boolean)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -250,10 +250,10 @@ class Formula
     # Now that we have an instance, it's too late to make any changes to the class-level definition.
     self.class.freeze
 
-    @name = T.let(name, String)
-    @unresolved_path = T.let(path, Pathname)
+    @name = name
+    @unresolved_path = path
     @path = T.let(path.resolved_path, Pathname)
-    @alias_path = T.let(alias_path, T.nilable(Pathname))
+    @alias_path = alias_path
     @alias_name = T.let((File.basename(alias_path) if alias_path), T.nilable(String))
     @revision = T.let(self.class.revision || 0, Integer)
     @version_scheme = T.let(self.class.version_scheme || 0, Integer)
@@ -264,7 +264,7 @@ class Formula
     @autobump = T.let(true, T::Boolean)
     @no_autobump_message = T.let(nil, T.nilable(T.any(String, Symbol)))
 
-    @force_bottle = T.let(force_bottle, T::Boolean)
+    @force_bottle = force_bottle
 
     @tap = T.let(tap, T.nilable(Tap))
     @tap ||= if path == Formulary.core_path(name)

--- a/Library/Homebrew/formula_info.rb
+++ b/Library/Homebrew/formula_info.rb
@@ -9,7 +9,7 @@ class FormulaInfo
 
   sig { params(info: T::Hash[String, T.untyped]).void }
   def initialize(info)
-    @info = T.let(info, T::Hash[String, T.untyped])
+    @info = info
   end
 
   # Looks up formula on disk and reads its info.

--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -58,10 +58,10 @@ class GitHubRunnerMatrix
       raise ArgumentError, "all_supported is mutually exclusive to other arguments"
     end
 
-    @testing_formulae = T.let(testing_formulae, T::Array[TestRunnerFormula])
-    @deleted_formulae = T.let(deleted_formulae, T::Array[String])
-    @all_supported = T.let(all_supported, T::Boolean)
-    @dependent_matrix = T.let(dependent_matrix, T::Boolean)
+    @testing_formulae = testing_formulae
+    @deleted_formulae = deleted_formulae
+    @all_supported = all_supported
+    @dependent_matrix = dependent_matrix
     @compatible_testing_formulae = T.let({}, T::Hash[GitHubRunner, T::Array[TestRunnerFormula]])
     @formulae_with_untested_dependents = T.let({}, T::Hash[GitHubRunner, T::Array[TestRunnerFormula]])
 

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -16,7 +16,7 @@ class Mktemp
   sig { params(prefix: String, retain: T::Boolean, retain_in_cache: T::Boolean).void }
   def initialize(prefix, retain: false, retain_in_cache: false)
     @prefix = prefix
-    @retain_in_cache = T.let(retain_in_cache, T::Boolean)
+    @retain_in_cache = retain_in_cache
     @retain = T.let(retain || @retain_in_cache, T::Boolean)
     @quiet = T.let(false, T::Boolean)
     @tmpdir = T.let(nil, T.nilable(Pathname))

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -187,7 +187,7 @@ module ELFShim
       require "patchelf"
       patcher = path.patchelf_patcher
 
-      @path = T.let(path, ELFShim)
+      @path = path
       @dylibs = T.let(nil, T.nilable(T::Array[String]))
       @dylib_id = T.let(nil, T.nilable(String))
       @needed = T.let([], T::Array[String])

--- a/Library/Homebrew/pkg_version.rb
+++ b/Library/Homebrew/pkg_version.rb
@@ -28,8 +28,8 @@ class PkgVersion
 
   sig { params(version: Version, revision: Integer).void }
   def initialize(version, revision)
-    @version = T.let(version, Version)
-    @revision = T.let(revision, Integer)
+    @version = version
+    @revision = revision
   end
 
   sig { returns(T::Boolean) }

--- a/Library/Homebrew/pypi_packages.rb
+++ b/Library/Homebrew/pypi_packages.rb
@@ -30,9 +30,9 @@ class PypiPackages
     exclude_packages: [],
     dependencies: []
   )
-    @package_name = T.let(package_name, T.nilable(String))
-    @extra_packages = T.let(extra_packages, T::Array[String])
-    @exclude_packages = T.let(exclude_packages, T::Array[String])
-    @dependencies = T.let(dependencies, T::Array[String])
+    @package_name = package_name
+    @extra_packages = extra_packages
+    @exclude_packages = exclude_packages
+    @dependencies = dependencies
   end
 end

--- a/Library/Homebrew/rubocops/cask/ast/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/ast/stanza.rb
@@ -19,8 +19,8 @@ module RuboCop
           ).void
         }
         def initialize(method_node, all_comments)
-          @method_node = T.let(method_node, RuboCop::AST::Node)
-          @all_comments = T.let(all_comments, T::Array[T.any(String, Parser::Source::Comment)])
+          @method_node = method_node
+          @all_comments = all_comments
         end
 
         sig { returns(RuboCop::AST::Node) }

--- a/Library/Homebrew/services/formula_wrapper.rb
+++ b/Library/Homebrew/services/formula_wrapper.rb
@@ -29,7 +29,7 @@ module Homebrew
       # Initialize a new `Service` instance with supplied formula.
       sig { params(formula: Formula).void }
       def initialize(formula)
-        @formula = T.let(formula, Formula)
+        @formula = formula
         @status_output_success_type = T.let(nil, T.nilable(StatusOutputSuccessType))
 
         return if System.launchctl? || System.systemctl?
@@ -384,9 +384,9 @@ module Homebrew
 
         sig { params(output: String, success: T::Boolean, type: Symbol).void }
         def initialize(output, success, type)
-          @output = T.let(output, String)
-          @success = T.let(success, T::Boolean)
-          @type = T.let(type, Symbol)
+          @output = output
+          @success = success
+          @type = type
         end
       end
     end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -77,7 +77,7 @@ class SoftwareSpec
     @bottle_specification = T.let(BottleSpecification.new, BottleSpecification)
     @patches = T.let([], T::Array[T.any(EmbeddedPatch, ExternalPatch)])
     @options = T.let(Options.new, Options)
-    @flags = T.let(flags, T::Array[String])
+    @flags = flags
     @deprecated_flags = T.let([], T::Array[DeprecatedOption])
     @deprecated_options = T.let([], T::Array[DeprecatedOption])
     @build = T.let(BuildOptions.new(Options.create(@flags), options), BuildOptions)

--- a/Library/Homebrew/test_runner_formula.rb
+++ b/Library/Homebrew/test_runner_formula.rb
@@ -16,10 +16,10 @@ class TestRunnerFormula
   sig { params(formula: Formula, eval_all: T::Boolean).void }
   def initialize(formula, eval_all: Homebrew::EnvConfig.eval_all?)
     Formulary.enable_factory_cache!
-    @formula = T.let(formula, Formula)
+    @formula = formula
     @name = T.let(formula.name, String)
     @dependent_hash = T.let({}, T::Hash[Symbol, T::Array[TestRunnerFormula]])
-    @eval_all = T.let(eval_all, T::Boolean)
+    @eval_all = eval_all
     freeze
   end
 

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -135,7 +135,7 @@ module UnpackStrategy
     @path = T.let(Pathname(path).expand_path, Pathname)
     @ref_type = T.let(ref_type, T.nilable(Symbol))
     @ref = T.let(ref, T.nilable(String))
-    @merge_xattrs = T.let(merge_xattrs, T::Boolean)
+    @merge_xattrs = merge_xattrs
   end
 
   sig { abstract.params(unpack_dir: Pathname, basename: Pathname, verbose: T::Boolean).void }

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -68,7 +68,7 @@ module GitHub
     class RateLimitExceededError < Error
       sig { params(github_message: String, reset: Integer, resource: String, limit: Integer).void }
       def initialize(github_message, reset:, resource:, limit:)
-        @reset = T.let(reset, Integer)
+        @reset = reset
         new_pat_message = ", or:\n#{GitHub.pat_blurb}" if API.credentials.blank?
         message = <<~EOS
           GitHub API Error: #{github_message}

--- a/Library/Homebrew/utils/github/artifacts.rb
+++ b/Library/Homebrew/utils/github/artifacts.rb
@@ -28,7 +28,7 @@ class GitHubArtifactDownloadStrategy < AbstractFileDownloadStrategy
   def initialize(url, artifact_id, token:)
     super(url, "artifact", artifact_id)
     @cache = T.let(HOMEBREW_CACHE/"gh-actions-artifact", Pathname)
-    @token = T.let(token, String)
+    @token = token
   end
 
   sig { override.params(timeout: T.nilable(T.any(Float, Integer))).void }

--- a/Library/Homebrew/utils/shebang.rb
+++ b/Library/Homebrew/utils/shebang.rb
@@ -23,9 +23,9 @@ module Utils
 
       sig { params(regex: Regexp, max_length: Integer, replacement: T.any(String, Pathname)).void }
       def initialize(regex, max_length, replacement)
-        @regex = T.let(regex, Regexp)
-        @max_length = T.let(max_length, Integer)
-        @replacement = T.let(replacement, T.any(String, Pathname))
+        @regex = regex
+        @max_length = max_length
+        @replacement = replacement
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

When constructor argument is used directly (as opposed to a method call on the argument), Sorbet can infer the type[^1]. This allows avoiding the unnecessary function call to `T.let` which is run even when runtime checks are disabled for users.

[^1]: https://sorbet.org/docs/type-assertions#prefer-method-signatures-over-type-assertions
