### PR TITLE
extend/os/linux/linkage_checker: `typed: strict`

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -20,7 +20,10 @@ class LinkageChecker
   attr_reader :store
 
   sig { returns(T::Array[String]) }
-  attr_reader :undeclared_deps
+  attr_reader :indirect_deps, :undeclared_deps, :unwanted_system_dylibs
+
+  sig { returns(T::Set[String]) }
+  attr_reader :system_dylibs
 
   sig { params(keg: Keg, formula: T.nilable(Formula), cache_db: CacheStoreDatabase, rebuild_cache: T::Boolean).void }
   def initialize(keg, formula = nil, cache_db:, rebuild_cache: false)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Part of #17297

Not sure if there is a better way to allow prepend-ed module to access instance variables without Sorbet complaining.

May be related to Sorbet's known limitations - https://sorbet.org/docs/unsupported#prepend

For now, using `attr_reader` and `requires_ancestor` to expose variables.