### PR TITLE
Exit with failure on tap-info for unknown tap

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -93,8 +93,11 @@ module Homebrew
 
       sig { params(taps: T::Array[Tap]).void }
       def print_tap_json(taps)
-        taps.each { |tap| Homebrew.failed = true unless tap.installed? }
-        puts JSON.pretty_generate(taps.map(&:to_hash))
+        taps_hashes = taps.map do |tap|
+          Homebrew.failed = true unless tap.installed?
+          tap.to_hash
+        end
+        puts JSON.pretty_generate(taps_hashes)
       end
     end
   end


### PR DESCRIPTION
This applies the change for https://github.com/Homebrew/brew/issues/21301

the top-level comment for tap-info is unneccessary, but the linter complained that it was missing, so applying the boyscout-rule here, even if it's unrelated to the PR.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
