### PR TITLE
bundle: add -g flag as alias for --global

### DIFF
--- a/Library/Homebrew/cmd/bundle.rb
+++ b/Library/Homebrew/cmd/bundle.rb
@@ -67,7 +67,7 @@ module Homebrew
         flag   "--file=",
                description: "Read from or write to the `Brewfile` from this location. " \
                             "Use `--file=-` to pipe to stdin/stdout."
-        switch "--global",
+        switch "-g", "--global",
                description: "Read from or write to the `Brewfile` from `$HOMEBREW_BUNDLE_FILE_GLOBAL` (if set), " \
                             "`${XDG_CONFIG_HOME}/homebrew/Brewfile` (if `$XDG_CONFIG_HOME` is set), " \
                             "`~/.homebrew/Brewfile` or `~/.Brewfile` otherwise."


### PR DESCRIPTION
This restores behavior that this command had for years prior to the addition of --go flag.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
