### PR TITLE
workflows/tests: run brew style on both official taps in one step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,11 +106,8 @@ jobs:
           key: tap-syntax-style-cache-${{ github.sha }}
           restore-keys: tap-syntax-style-cache-
 
-      - name: Run brew style on homebrew-core
-        run: brew style homebrew/core
-
-      - name: Run brew style on homebrew-cask
-        run: brew style homebrew/cask
+      - name: Run brew style on official taps
+        run: brew style homebrew/core homebrew/cask
 
   formula-audit:
     name: formula audit


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Rather than running brew style on Homebrew/core and Homebrew/cask in separate workflow steps, this PR combines them into a single step.

When run separately, the job often fails on issues in Homebrew/core, which are fixed, only for reruns to surface similar issues in Homebrew/cask. Because the first failure stops the job, we don’t get a complete view of style issues across both taps in one run.

Unifying the checks allows all style violations to be reported at once and addressed together.