### PR TITLE
unpack_strategy: replace T.untyped, narrow types

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -631,7 +631,9 @@ module Cask
         }.compact
 
         Homebrew::Install.perform_preinstall_checks_once
-        formula_installers = primary_container.dependencies.map do |dep|
+        formula_installers = primary_container.dependencies.filter_map do |dep|
+          next unless dep.is_a?(Formula)
+
           FormulaInstaller.new(
             dep,
             **install_options,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Narrowing some types to be more accurate. This includes replace T.untyped so static type checking coverage increases.