### PR TITLE
Prefer `it` default params to numbered default params

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -96,11 +96,6 @@ Layout/ArgumentAlignment:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-# currently bugged and as relevant/urgent in taps:
-# https://github.com/rubocop/rubocop/issues/14443
-Layout/EmptyLinesAfterModuleInclusion:
-  Enabled: false
-
 # significantly less indentation involved; more consistent
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
@@ -411,9 +406,9 @@ Style/InvertibleUnlessCondition:
     :zero?:
     :blank?: :present?
 
-# Reconsider once sorbet supports "it": https://github.com/sorbet/sorbet/issues/8375
+# It's confusing to the ruby novice to support both `it` and `_1`
 Style/ItBlockParameter:
-  Enabled: false
+  EnforcedStyle: only_numbered_parameters
 
 Style/MutableConstant:
   # would rather freeze too much than too little

--- a/Library/Homebrew/PATH.rb
+++ b/Library/Homebrew/PATH.rb
@@ -76,7 +76,7 @@ class PATH
 
   sig { returns(T.nilable(T.self_type)) }
   def existing
-    existing_path = select { File.directory?(_1) }
+    existing_path = select { File.directory?(it) }
     # return nil instead of empty PATH, to unset environment variables
     existing_path unless existing_path.empty?
   end

--- a/Library/Homebrew/abstract_command.rb
+++ b/Library/Homebrew/abstract_command.rb
@@ -39,7 +39,7 @@ module Homebrew
 
       # @return the AbstractCommand subclass associated with the brew CLI command name.
       sig { params(name: String).returns(T.nilable(T.class_of(AbstractCommand))) }
-      def command(name) = subclasses.find { _1.command_name == name }
+      def command(name) = subclasses.find { it.command_name == name }
 
       sig { returns(T::Boolean) }
       def dev_cmd? = T.must(name).start_with?("Homebrew::DevCmd")

--- a/Library/Homebrew/bundle/commands/cleanup.rb
+++ b/Library/Homebrew/bundle/commands/cleanup.rb
@@ -199,7 +199,7 @@ module Homebrew
           require "bundle/tap_dumper"
 
           @dsl ||= Brewfile.read(global:, file:)
-          kept_formulae = self.kept_formulae(global:, file:).filter_map { lookup_formula(_1) }
+          kept_formulae = self.kept_formulae(global:, file:).filter_map { lookup_formula(it) }
           kept_taps = @dsl.entries.select { |e| e.type == :tap }.map(&:name)
           kept_taps += kept_formulae.filter_map(&:tap).map(&:name)
           current_taps = Homebrew::Bundle::TapDumper.tap_names

--- a/Library/Homebrew/bundle/formula_dumper.rb
+++ b/Library/Homebrew/bundle/formula_dumper.rb
@@ -40,7 +40,7 @@ module Homebrew
         @formulae_by_full_name ||= {}
 
         if name.nil?
-          formulae = Formula.installed.map { add_formula(_1) }
+          formulae = Formula.installed.map { add_formula(it) }
           sort!(formulae)
           return @formulae_by_full_name
         end

--- a/Library/Homebrew/cask/artifact/app.rb
+++ b/Library/Homebrew/cask/artifact/app.rb
@@ -31,7 +31,7 @@ module Cask
       )
         super
 
-        return if target.ascend.none? { OS::Mac.system_dir?(_1) }
+        return if target.ascend.none? { OS::Mac.system_dir?(it) }
 
         odebug "Fixing up '#{target}' permissions for installation to '#{target.parent}'"
         # Ensure that globally installed applications can be accessed by all users.

--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -147,7 +147,7 @@ module Cask
       # @api public
       sig { returns(T::Array[Version]) } # Only top-level T.self_type is supported https://sorbet.org/docs/self-type
       def csv
-        split(",").map { self.class.new(_1) }
+        split(",").map { self.class.new(it) }
       end
 
       # The version part before the first comma.

--- a/Library/Homebrew/cask/list.rb
+++ b/Library/Homebrew/cask/list.rb
@@ -23,9 +23,9 @@ module Cask
       elsif full_name
         puts output.map(&:full_name).sort(&tap_and_name_comparison)
       elsif versions
-        puts output.map { format_versioned(_1) }
+        puts output.map { format_versioned(it) }
       elsif !output.empty? && casks.any?
-        output.map { list_artifacts(_1) }
+        output.map { list_artifacts(it) }
       elsif !output.empty?
         puts Formatter.columns(output.map(&:to_s))
       end

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -78,7 +78,7 @@ module Cask
 
     sig { returns(T::Array[Pathname]) }
     def pkgutil_bom_specials
-      @pkgutil_bom_specials ||= T.let(pkgutil_bom_all.select { special?(_1) }, T.nilable(T::Array[Pathname]))
+      @pkgutil_bom_specials ||= T.let(pkgutil_bom_all.select { special?(it) }, T.nilable(T::Array[Pathname]))
     end
 
     sig { returns(T::Array[Pathname]) }

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -175,7 +175,7 @@ module Homebrew
 
         stable = formula.stable
         if resource_name == "patch"
-          patch_hashes = stable&.patches&.filter_map { T.cast(_1, ExternalPatch).resource.version if _1.external? }
+          patch_hashes = stable&.patches&.filter_map { T.cast(it, ExternalPatch).resource.version if it.external? }
           return true unless patch_hashes&.include?(Checksum.new(version.to_s))
         elsif resource_name && stable && (resource_version = stable.resources[resource_name]&.version)
           return true if resource_version != version
@@ -770,7 +770,7 @@ module Homebrew
       formulae = Formula.installed
       # Remove formulae listed in HOMEBREW_NO_CLEANUP_FORMULAE and their dependencies.
       if Homebrew::EnvConfig.no_cleanup_formulae.present?
-        formulae -= formulae.select { skip_clean_formula?(_1) }
+        formulae -= formulae.select { skip_clean_formula?(it) }
                             .flat_map { |f| [f, *f.installed_runtime_formula_dependencies] }
       end
       casks = Cask::Caskroom.casks

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -70,8 +70,8 @@ module Homebrew
         @processed_options += processed_options
         @processed_options.freeze
 
-        @options_only = cli_args.select { _1.start_with?("-") }.freeze
-        @flags_only = cli_args.select { _1.start_with?("--") }.freeze
+        @options_only = cli_args.select { it.start_with?("-") }.freeze
+        @flags_only = cli_args.select { it.start_with?("--") }.freeze
       end
 
       sig { returns(NamedArgs) }

--- a/Library/Homebrew/cli/error.rb
+++ b/Library/Homebrew/cli/error.rb
@@ -20,7 +20,7 @@ module Homebrew
     class OptionConflictError < UsageError
       sig { params(args: T::Array[String]).void }
       def initialize(args)
-        args_list = args.map { Formatter.option(_1) }.join(" and ")
+        args_list = args.map { Formatter.option(it) }.join(" and ")
         super "Options #{args_list} are mutually exclusive."
       end
     end

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -663,9 +663,9 @@ module Homebrew
           end
 
           select_cli_arg = violations.count - env_var_options.count == 1
-          raise OptionConflictError, violations.map { name_to_option(_1) } unless select_cli_arg
+          raise OptionConflictError, violations.map { name_to_option(it) } unless select_cli_arg
 
-          env_var_options.each { disable_switch(_1) }
+          env_var_options.each { disable_switch(it) }
         end
       end
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -207,7 +207,7 @@ module Homebrew
 
         begin
           formulae, casks = T.cast(
-            args.named.to_formulae_and_casks(warn: false).partition { _1.is_a?(Formula) },
+            args.named.to_formulae_and_casks(warn: false).partition { it.is_a?(Formula) },
             [T::Array[Formula], T::Array[Cask::Cask]],
           )
         rescue FormulaOrCaskUnavailableError, Cask::CaskUnavailableError

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -83,7 +83,7 @@ class DescriptionCacheStore < CacheStore
   def delete_from_formula_names!(formula_names)
     return if database.empty?
 
-    formula_names.each { delete!(_1) }
+    formula_names.each { delete!(it) }
   end
   alias delete_from_cask_tokens! delete_from_formula_names!
 

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -96,7 +96,7 @@ module Homebrew
 
             # Only run bump on the first formula in each synced group
             if args.bump_synced? && args.formula?
-              synced_formulae = Set.new(tap.synced_versions_formulae.flat_map { _1.drop(1) })
+              synced_formulae = Set.new(tap.synced_versions_formulae.flat_map { it.drop(1) })
             end
 
             autobump_list.filter_map do |name|

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -61,7 +61,7 @@ module Homebrew
         end
 
         if args.print_path?
-          paths.each { puts _1 }
+          paths.each { puts it }
           return
         end
 

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -34,7 +34,7 @@ module Homebrew
 
       sig { override.void }
       def run
-        if (tap_with_name = args.named.first&.then { Tap.with_formula_name(_1) })
+        if (tap_with_name = args.named.first&.then { Tap.with_formula_name(it) })
           source_tap, name = tap_with_name
         else
           name = args.named.fetch(0).downcase

--- a/Library/Homebrew/dev-cmd/formula.rb
+++ b/Library/Homebrew/dev-cmd/formula.rb
@@ -23,7 +23,7 @@ module Homebrew
                                        .any?(&:exist?)
           odie "Found casks but did not find formulae!"
         end
-        formula_paths.each { puts _1 }
+        formula_paths.each { puts it }
       end
     end
   end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1048,7 +1048,7 @@ module Homebrew
 
       sig { returns(T.nilable(String)) }
       def check_cask_load_path
-        paths = $LOAD_PATH.map { user_tilde(_1) }
+        paths = $LOAD_PATH.map { user_tilde(it) }
 
         add_info "$LOAD_PATHS", paths.presence || none_string
 

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -39,7 +39,7 @@ module OS
         self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path
         self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(formula)
         m4_path_deps = ["libtool", "bison"]
-        self["M4"] = "#{HOMEBREW_PREFIX}/opt/m4/bin/m4" if deps.any? { m4_path_deps.include?(_1.name) }
+        self["M4"] = "#{HOMEBREW_PREFIX}/opt/m4/bin/m4" if deps.any? { m4_path_deps.include?(it.name) }
         return unless ::Hardware::CPU.arm64?
 
         # Build jemalloc-sys rust crate on ARM64/AArch64 with support for page sizes up to 64K.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -730,7 +730,7 @@ class Formula
   def aliases
     @aliases ||= T.let(
       if (tap = self.tap)
-        tap.alias_reverse_table.fetch(full_name, []).map { _1.split("/").fetch(-1) }
+        tap.alias_reverse_table.fetch(full_name, []).map { it.split("/").fetch(-1) }
       else
         []
       end, T.nilable(T::Array[String])

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -810,10 +810,10 @@ on_request: installed_on_request?, options:)
     elsif !deps.empty?
       if deps.length > 1
         oh1 "Installing dependencies for #{formula.full_name}: " \
-            "#{deps.map { Formatter.identifier(_1) }.to_sentence}",
+            "#{deps.map { Formatter.identifier(it) }.to_sentence}",
             truncate: false
       end
-      deps.each { install_dependency(_1) }
+      deps.each { install_dependency(it) }
     end
 
     @show_header = true if deps.length > 1
@@ -1382,7 +1382,7 @@ on_request: installed_on_request?, options:)
           truncate: false
     end
 
-    deps.each { fetch_dependency(_1) }
+    deps.each { fetch_dependency(it) }
   end
 
   sig { returns(T.nilable(Formula)) }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -211,7 +211,7 @@ class Keg
     files ||= text_files | libtool_files
 
     changed_files = T.let([], T::Array[Pathname])
-    files.map { path.join(_1) }.group_by { |f| f.stat.ino }.each_value do |first, *rest|
+    files.map { path.join(it) }.group_by { |f| f.stat.ino }.each_value do |first, *rest|
       first = T.must(first)
       s = first.open("rb", &:read)
 

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -61,7 +61,7 @@ module Homebrew
 
       other_taps.each_value do |tap|
         tap_strategy_path = "#{tap.path}/livecheck/strategy"
-        Dir["#{tap_strategy_path}/*.rb"].each { require(_1) } if Dir.exist?(tap_strategy_path)
+        Dir["#{tap_strategy_path}/*.rb"].each { require(it) } if Dir.exist?(tap_strategy_path)
       end
     end
 

--- a/Library/Homebrew/manpages.rb
+++ b/Library/Homebrew/manpages.rb
@@ -78,7 +78,7 @@ module Homebrew
       man_page_lines = []
 
       # preserve existing manpage order
-      cmd_paths.sort_by { sort_key_for_path(_1) }
+      cmd_paths.sort_by { sort_key_for_path(it) }
                .each do |cmd_path|
         cmd_man_page_lines = if (cmd_parser = Homebrew::CLI::Parser.from_cmd_path(cmd_path))
           next if cmd_parser.hide_from_man_page

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -107,7 +107,7 @@ module MachOShim
     lcs = macho.dylib_load_commands
     lcs.reject! { |lc| lc.flag?(except) } if except != :none
     names = lcs.map { |lc| lc.name.to_s }.uniq
-    names.map! { resolve_variable_name(_1) } if resolve_variable_references
+    names.map! { resolve_variable_name(it) } if resolve_variable_references
 
     names
   end

--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
@@ -31,6 +31,7 @@ module RuboCop
           cask_block = RuboCop::Cask::AST::CaskBlock.new(block_node, comments)
           on_cask(cask_block)
         end
+        alias on_itblock on_block
 
         sig {
           params(

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -608,11 +608,11 @@ module Homebrew
         when String
           replace_placeholders(api_hash["run"])
         when Array
-          api_hash["run"].map { replace_placeholders(_1) }
+          api_hash["run"].map { replace_placeholders(it) }
         when Hash
           api_hash["run"].to_h do |key, elem|
             run_cmd = if elem.is_a?(Array)
-              elem.map { replace_placeholders(_1) }
+              elem.map { replace_placeholders(it) }
             else
               replace_placeholders(elem)
             end

--- a/Library/Homebrew/sorbet/tapioca/compilers/args.rb
+++ b/Library/Homebrew/sorbet/tapioca/compilers/args.rb
@@ -9,7 +9,7 @@ module Tapioca
     class Args < Tapioca::Dsl::Compiler
       GLOBAL_OPTIONS = T.let(
         Homebrew::CLI::Parser.global_options.map do |short_option, long_option, _|
-          [short_option, long_option].map { "#{Homebrew::CLI::Parser.option_to_name(_1)}?" }
+          [short_option, long_option].map { "#{Homebrew::CLI::Parser.option_to_name(it)}?" }
         end.flatten.freeze, T::Array[String]
       )
 
@@ -19,7 +19,7 @@ module Tapioca
       def self.gather_constants
         # require all the commands to ensure the command subclasses are defined
         ["cmd", "dev-cmd"].each do |dir|
-          Dir[File.join(__dir__, "../../../#{dir}", "*.rb")].each { require(_1) }
+          Dir[File.join(__dir__, "../../../#{dir}", "*.rb")].each { require(it) }
         end
         Homebrew::AbstractCommand.subclasses
       end

--- a/Library/Homebrew/sorbet/tapioca/require.rb
+++ b/Library/Homebrew/sorbet/tapioca/require.rb
@@ -25,7 +25,7 @@ definition.resolve.for(definition.current_dependencies).each do |spec|
 
   name = dependency_require_map[name] if dependency_require_map.key?(name)
   require name
-  additional_requires_map[name]&.each { require(_1) }
+  additional_requires_map[name]&.each { require(it) }
 rescue LoadError
   raise unless name.include?("-")
 

--- a/Library/Homebrew/sorbet/tapioca/utils.rb
+++ b/Library/Homebrew/sorbet/tapioca/utils.rb
@@ -23,11 +23,11 @@ module Homebrew
       }
       def self.methods_from_file(mod, file_name, class_methods: false)
         methods = if class_methods
-          mod.methods(false).map { mod.method(_1) }
+          mod.methods(false).map { mod.method(it) }
         else
-          mod.instance_methods(false).map { mod.instance_method(_1) }
+          mod.instance_methods(false).map { mod.instance_method(it) }
         end
-        methods.select { _1.source_location&.first&.end_with?(file_name) }
+        methods.select { it.source_location&.first&.end_with?(file_name) }
       end
 
       sig { params(mod: T::Module[T.anything]).returns(T::Array[T::Module[T.anything]]) }

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -49,7 +49,7 @@ module Homebrew
       ruby_files = T.let([], T::Array[Pathname])
       shell_files = T.let([], T::Array[Pathname])
       actionlint_files = T.let([], T::Array[Pathname])
-      Array(files).map { Pathname(_1) }
+      Array(files).map { Pathname(it) }
                   .each do |path|
         case path.extname
         when ".rb"

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -424,7 +424,7 @@ class SystemCommand
 
   sig { params(raw_stdin: IO).void }
   def write_input_to(raw_stdin)
-    input.each { raw_stdin.write(_1) }
+    input.each { raw_stdin.write(it) }
   end
 
   sig { params(sources: T::Array[IO], _block: T.proc.params(type: Symbol, line: String).void).void }

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -467,12 +467,12 @@ class Tab < AbstractTab
 
   sig { returns(T.nilable(Version)) }
   def stable_version
-    versions["stable"]&.then { Version.new(_1) }
+    versions["stable"]&.then { Version.new(it) }
   end
 
   sig { returns(T.nilable(Version)) }
   def head_version
-    versions["head"]&.then { Version.new(_1) }
+    versions["head"]&.then { Version.new(it) }
   end
 
   sig { returns(Integer) }

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -836,7 +836,7 @@ class Tap
   # An array of all {Formula} names of this {Tap}.
   sig { overridable.returns(T::Array[String]) }
   def formula_names
-    @formula_names ||= T.let(formula_files.map { formula_file_to_name(_1) }, T.nilable(T::Array[String]))
+    @formula_names ||= T.let(formula_files.map { formula_file_to_name(it) }, T.nilable(T::Array[String]))
   end
 
   # A hash of all {Formula} name prefixes to versioned {Formula} in this {Tap}.
@@ -852,7 +852,7 @@ class Tap
   # An array of all {Cask} tokens of this {Tap}.
   sig { returns(T::Array[String]) }
   def cask_tokens
-    @cask_tokens ||= T.let(cask_files.map { formula_file_to_name(_1) }, T.nilable(T::Array[String]))
+    @cask_tokens ||= T.let(cask_files.map { formula_file_to_name(it) }, T.nilable(T::Array[String]))
   end
 
   # Path to the directory of all alias files for this {Tap}.
@@ -1126,7 +1126,7 @@ class Tap
   sig { returns(T::Array[Tap]) }
   def self.installed
     cache[:installed] ||= if HOMEBREW_TAP_DIRECTORY.directory?
-      HOMEBREW_TAP_DIRECTORY.subdirs.flat_map(&:subdirs).map { from_path(_1) }
+      HOMEBREW_TAP_DIRECTORY.subdirs.flat_map(&:subdirs).map { from_path(it) }
     else
       []
     end

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Cask::List, :cask do
     let(:casks) { [caffeine, transmission] }
 
     it "lists the installed files for those Casks" do
-      casks.each { InstallHelper.install_without_artifacts_with_caskfile(_1) }
+      casks.each { InstallHelper.install_without_artifacts_with_caskfile(it) }
 
       transmission.artifacts.select { |a| a.is_a?(Cask::Artifact::App) }.each do |artifact|
         artifact.install_phase(command: NeverSudoSystemCommand, force: false)

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe Tab do
       tab = described_class.from_file(path)
       source_path = "/usr/local/Library/Taps/homebrew/homebrew-core/Formula/foo.rb"
       runtime_dependencies = [{ "full_name" => "foo", "version" => "1.0" }]
-      changed_files = %w[INSTALL_RECEIPT.json bin/foo].map { Pathname.new(_1) }
+      changed_files = %w[INSTALL_RECEIPT.json bin/foo].map { Pathname.new(it) }
 
       expect(tab.used_options.sort).to eq(used_options.sort)
       expect(tab.unused_options.sort).to eq(unused_options.sort)
@@ -295,7 +295,7 @@ RSpec.describe Tab do
       tab = described_class.from_file_content(path.read, path)
       source_path = "/usr/local/Library/Taps/homebrew/homebrew-core/Formula/foo.rb"
       runtime_dependencies = [{ "full_name" => "foo", "version" => "1.0" }]
-      changed_files = %w[INSTALL_RECEIPT.json bin/foo].map { Pathname.new(_1) }
+      changed_files = %w[INSTALL_RECEIPT.json bin/foo].map { Pathname.new(it) }
 
       expect(tab.used_options.sort).to eq(used_options.sort)
       expect(tab.unused_options.sort).to eq(unused_options.sort)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
This is a bit of an opinionated PR. The rationale is:
- We already enforced a max limit of `_1`, via `Style/NumberedParametersLimit`, so the numbering isn't useful. Additionally, `it` has better readability (IMO).
- Mixing `it` and `_1` presents unnecessary confusion to novice ruby coders
- Supporting both styles requires more technical lift (for instance, rubocop-ast has separate node [types](https://docs.rubocop.org/rubocop-ast/node_types.html) for `itblock` and `numblock`
- We previously avoided `it` because sorbet didn't support it. This was fixed in https://github.com/sorbet/sorbet/pull/9443.

(Note that there are some subtle behavior differences between `it` and `_1`, elaborated [here](https://rubyreferences.github.io/rubychanges/3.4.html#standalone-it-in-blocks-became-anonymous-argument), so this is not a safe autocorrect (though the differences should be unlikely to matter).)