### PR TITLE
Add `String#to_string_or_symbol` extension

### DIFF
--- a/Library/Homebrew/api/formula.rb
+++ b/Library/Homebrew/api/formula.rb
@@ -171,7 +171,7 @@ module Homebrew
           files = hash.dig("bottle", "stable", "files") || {}
           files.map do |tag, bottle_spec|
             {
-              cellar: Formulary.convert_to_string_or_symbol(bottle_spec.fetch("cellar")),
+              cellar: Utils.convert_to_string_or_symbol(bottle_spec.fetch("cellar")),
               tag.to_sym => bottle_spec.fetch("sha256"),
             }
           end
@@ -214,7 +214,7 @@ module Homebrew
         end
 
         if (keg_only_hash = hash["keg_only_reason"])
-          reason = Formulary.convert_to_string_or_symbol(keg_only_hash.fetch("reason"))
+          reason = Utils.convert_to_string_or_symbol(keg_only_hash.fetch("reason"))
           explanation = keg_only_hash["explanation"]
           hash["keg_only_args"] = [reason, explanation].compact
         end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -467,13 +467,6 @@ module Formulary
     class_name
   end
 
-  sig { params(string: String).returns(T.any(String, Symbol)) }
-  def self.convert_to_string_or_symbol(string)
-    return T.must(string[1..]).to_sym if string.start_with?(":")
-
-    string
-  end
-
   # A {FormulaLoader} returns instances of formulae.
   # Subclasses implement loaders for particular sources of formulae.
   class FormulaLoader

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -748,16 +748,6 @@ RSpec.describe Formulary do
     end
   end
 
-  describe "::convert_to_string_or_symbol" do
-    it "returns the original string if it doesn't start with a colon" do
-      expect(described_class.convert_to_string_or_symbol("foo")).to eq "foo"
-    end
-
-    it "returns a symbol if the original string starts with a colon" do
-      expect(described_class.convert_to_string_or_symbol(":foo")).to eq :foo
-    end
-  end
-
   describe "::loader_for" do
     context "when given a relative path with two slashes" do
       it "returns a `FromPathLoader`" do

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -117,4 +117,11 @@ RSpec.describe Utils do
       end
     end
   end
+
+  describe ".convert_to_string_or_symbol" do
+    specify(:aggregate_failures) do
+      expect(described_class.convert_to_string_or_symbol(":example")).to eq(:example)
+      expect(described_class.convert_to_string_or_symbol("example")).to eq("example")
+    end
+  end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -220,4 +220,16 @@ module Utils
   def self.safe_filename(basename)
     basename.gsub(SAFE_FILENAME_REGEX, "")
   end
+
+  # Converts a string starting with `:` to a symbol, otherwise returns the
+  # string itself.
+  #
+  #   convert_to_string_or_symbol(":example") # => :example
+  #   convert_to_string_or_symbol("example")  # => "example"
+  sig { params(string: String).returns(T.any(String, Symbol)) }
+  def self.convert_to_string_or_symbol(string)
+    return T.must(string[1..]).to_sym if string.start_with?(":")
+
+    string
+  end
 end


### PR DESCRIPTION
Currently, there is a method in `Formulary` to convert strings to symbols if they begin with `:`. This functionality isn't specific to formulae, so extracting this out lets it be used in casks and other places where it might be useful.

I opted for patching `String` to define this method since it's not overriding an existing method and seems potentially useful for any string, but I'm sure there's another place this can go if preferred to avoid the monkey patch.
