### PR TITLE
livecheck/strategy/extract_plist: enable livecheck url options

### DIFF
--- a/Library/Homebrew/livecheck/strategy/extract_plist.rb
+++ b/Library/Homebrew/livecheck/strategy/extract_plist.rb
@@ -103,17 +103,27 @@ module Homebrew
           match_data = { matches: {}, regex:, url: }
 
           unversioned_cask_checker = if url.present? && url != cask.url.to_s
-            # Create a copy of the `cask` that uses the `livecheck` block URL
+            # Create a copy of the `cask` to use the `livecheck` block URL
             cask_copy = Cask::CaskLoader.load(cask.sourcefile_path)
             cask_copy.allow_reassignment = true
-            cask_copy.url url
 
-            cask.livecheck.options.to_h.each_key do |options_key|
-              next unless cask_copy.url.specs.key?(options_key)
+            # Collect the `Cask::URL` initializer keyword parameter symbols
+            @cask_url_kw_params ||= T.let(
+              T::Utils.signature_for_method(
+                Cask::URL.instance_method(:initialize),
+              ).parameters.filter_map { |type, sym| (type == :key) ? sym : nil },
+              T.nilable(T::Array[Symbol]),
+            )
 
-              value = cask.livecheck.options.public_send(options_key)
-              cask_copy.url.specs[options_key] = value if value
+            # Use `livecheck` block URL options that correspond to a `Cask::URL`
+            # keyword parameter
+            url_kwargs = {}
+            cask.livecheck.options.url_options.compact.each_key do |option_key|
+              next unless @cask_url_kw_params.include?(option_key)
+
+              url_kwargs[option_key] = cask.livecheck.options.public_send(option_key)
             end
+            cask_copy.url(url, **url_kwargs)
 
             UnversionedCaskChecker.new(cask_copy)
           else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This change ensures that any `livecheck.url.options` are passed through to the `ExtractPlist` strategy when the `livecheck` block is given a different url. I have tried to use a robust approach that should automatically pick up any additional keys that may be provided in future, by checking the `livecheck.url.options` keys against the `cask.url.specs` to see if they respond.

CC: @samford 