### PR TITLE
Document that not supporting macOS versions can get a cask rejected

### DIFF
--- a/docs/Acceptable-Casks.md
+++ b/docs/Acceptable-Casks.md
@@ -124,7 +124,7 @@ Common reasons to reject a cask entirely:
 * App is both open-source and CLI-only (i.e. it only uses the `binary` artifact). In that case, and [in the spirit of deduplication](https://github.com/Homebrew/homebrew-cask/issues/15603), submit it first to [homebrew/core](https://github.com/Homebrew/homebrew-core) as a formula that builds from source. If it is rejected, you may then try again as a cask (link to the issue from your pull request so we can see the discussion and reasoning for rejection).
 * App is open-source and has a GUI but no compiled versions (or only old ones) are provided. It’s better to have them in [homebrew/core](https://github.com/Homebrew/homebrew-core) so users don’t get perpetually outdated versions. See [`gedit`](https://github.com/Homebrew/homebrew-cask/pull/23360) for example.
 * We have strong reasons to believe including the cask can put the whole project at risk. Happened only once so far, [with Popcorn Time](https://github.com/Homebrew/homebrew-cask/pull/3954).
-* Casks that do not work for modern macOS versions will be rejected, [when Apple drops support for Rosetta with macOS 28](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment/) this will include x86-only software.
+* Casks that do not work on the latest macOS version will be rejected e.g. [when Apple drops support for Rosetta with macOS 28](https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment/) this will include x86-only software.
 
 ### Adult Content
 


### PR DESCRIPTION
Added a note regarding casks that do not work for modern macOS versions, specifically mentioning the impact of Apple's dropping support for Rosetta.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Not sure if this is the best place to document this, but I think it's good to have a note about the support for Rosetta.