### PR TITLE
Make auto-update hint message copy-pastable

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -765,7 +765,7 @@ EOS
           # shellcheck disable=SC2016
           echo 'Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with' >&2
           # shellcheck disable=SC2016
-          echo '`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).' >&2
+          echo '`HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).' >&2
         fi
       else
         ohai 'Updating Homebrew...' >&2


### PR DESCRIPTION
You cannot run `$HOMEBREW_NO_AUTO_UPDATE=1` since `HOMEBREW_NO_AUTO_UPDATE` will be expanded prior to assignment.  This commit removes the `$` to make it copy-pastable

Alternative ideas:
- `$ HOMEBREW_NO_AUTO_UPDATE=1 brew` (the $ is used to indicate this is a shell command)
- `export HOMEBREW_NO_AUTO_UPDATE=1` (now it's truly copy-pastable on its own)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
