### PR TITLE
Add `source` command to open formulae source repositories

### DIFF
--- a/Library/Homebrew/cmd/source.rb
+++ b/Library/Homebrew/cmd/source.rb
@@ -1,0 +1,155 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "abstract_command"
+require "formula"
+
+module Homebrew
+  module Cmd
+    class Source < AbstractCommand
+      cmd_args do
+        description <<~EOS
+          Open a <formula>'s source repository in a browser, or open
+          Homebrew's own repository if no argument is provided.
+
+          The repository URL is determined from the formula's head URL,
+          stable URL, or homepage. Supports GitHub, GitLab, Bitbucket, Codeberg, and
+          SourceHut repositories.
+        EOS
+
+        named_args :formula
+      end
+
+      sig { override.void }
+      def run
+        if args.no_named?
+          exec_browser "https://github.com/Homebrew/brew"
+          return
+        end
+
+        formulae = args.named.to_formulae
+        repo_urls = formulae.filter_map do |formula|
+          repo_url = extract_repo_url(formula)
+          if repo_url
+            puts "Opening repository for #{formula.name}"
+            repo_url
+          else
+            opoo "Could not determine repository URL for #{formula.name}"
+            nil
+          end
+        end
+
+        return if repo_urls.empty?
+
+        exec_browser(*repo_urls)
+      end
+
+      private
+
+      sig { params(formula: Formula).returns(T.nilable(String)) }
+      def extract_repo_url(formula)
+        urls_to_check = [
+          formula.head&.url,
+          formula.stable&.url,
+          formula.homepage,
+        ]
+
+        urls_to_check.each do |url|
+          next if url.nil?
+
+          repo_url = url_to_repo(url)
+          return repo_url if repo_url
+        end
+
+        nil
+      end
+
+      sig { params(url: String).returns(T.nilable(String)) }
+      def url_to_repo(url)
+        github_repo_url(url) ||
+          gitlab_repo_url(url) ||
+          bitbucket_repo_url(url) ||
+          codeberg_repo_url(url) ||
+          sourcehut_repo_url(url)
+      end
+
+      sig { params(url: String).returns(T.nilable(String)) }
+      def github_repo_url(url)
+        regex = %r{
+          https?://github\.com/
+          (?<user>[\w.-]+)/
+          (?<repo>[\w.-]+)
+          (?:/.*)?
+        }x
+        match = url.match(regex)
+        return unless match
+
+        user = match[:user]
+        repo = match[:repo]&.delete_suffix(".git")
+        "https://github.com/#{user}/#{repo}"
+      end
+
+      sig { params(url: String).returns(T.nilable(String)) }
+      def gitlab_repo_url(url)
+        regex = %r{
+          https?://gitlab\.com/
+          (?<path>(?:[\w.-]+/)*?[\w.-]+)
+          (?:/-/|\.git|/archive/)
+        }x
+        match = url.match(regex)
+        return unless match
+
+        path = match[:path]&.delete_suffix(".git")
+        "https://gitlab.com/#{path}"
+      end
+
+      sig { params(url: String).returns(T.nilable(String)) }
+      def bitbucket_repo_url(url)
+        regex = %r{
+          https?://bitbucket\.org/
+          (?<user>[\w.-]+)/
+          (?<repo>[\w.-]+)
+          (?:/.*)?
+        }x
+        match = url.match(regex)
+        return unless match
+
+        user = match[:user]
+        repo = match[:repo]&.delete_suffix(".git")
+        "https://bitbucket.org/#{user}/#{repo}"
+      end
+
+      sig { params(url: String).returns(T.nilable(String)) }
+      def codeberg_repo_url(url)
+        regex = %r{
+          https?://codeberg\.org/
+          (?<user>[\w.-]+)/
+          (?<repo>[\w.-]+)
+          (?:/.*)?
+        }x
+        match = url.match(regex)
+        return unless match
+
+        user = match[:user]
+        repo = match[:repo]&.delete_suffix(".git")
+        "https://codeberg.org/#{user}/#{repo}"
+      end
+
+      sig { params(url: String).returns(T.nilable(String)) }
+      def sourcehut_repo_url(url)
+        regex = %r{
+          https?://(?:git\.)?sr\.ht/
+          ~(?<user>[\w.-]+)/
+          (?<repo>[\w.-]+)
+          (?:/.*)?
+        }x
+        match = url.match(regex)
+        return unless match
+
+        user = match[:user]
+        repo = match[:repo]&.delete_suffix(".git")
+        "https://sr.ht/~#{user}/#{repo}"
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/cmd/source_spec.rb
+++ b/Library/Homebrew/test/cmd/source_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "cmd/source"
+require "cmd/shared_examples/args_parse"
+
+RSpec.describe Homebrew::Cmd::Source do
+  it_behaves_like "parseable arguments"
+
+  it "opens the Homebrew repo when no formula is specified", :integration_test do
+    expect { brew "source", "HOMEBREW_BROWSER" => "echo" }
+      .to output(%r{https://github\.com/Homebrew/brew}).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  describe "#github_repo_url" do
+    it "extracts repository URL from GitHub URL" do
+      expect(described_class.new([]).send(:github_repo_url, "https://github.com/Homebrew/brew.git"))
+        .to eq("https://github.com/Homebrew/brew")
+    end
+
+    it "handles GitHub archive URLs" do
+      expect(described_class.new([]).send(:github_repo_url, "https://github.com/Homebrew/testball/archive/refs/tags/v0.1.tar.gz"))
+        .to eq("https://github.com/Homebrew/testball")
+    end
+
+    it "returns nil for non-GitHub URLs" do
+      expect(described_class.new([]).send(:github_repo_url, "https://example.com/repo.git"))
+        .to be_nil
+    end
+  end
+
+  describe "#gitlab_repo_url" do
+    it "extracts repository URL from GitLab URL with nested groups" do
+      expect(described_class.new([]).send(:gitlab_repo_url, "https://gitlab.com/group/subgroup/project/-/archive/v1.0/project-v1.0.tar.gz"))
+        .to eq("https://gitlab.com/group/subgroup/project")
+    end
+
+    it "handles GitLab .git URLs" do
+      expect(described_class.new([]).send(:gitlab_repo_url, "https://gitlab.com/user/repo.git"))
+        .to eq("https://gitlab.com/user/repo")
+    end
+
+    it "returns nil for non-GitLab URLs" do
+      expect(described_class.new([]).send(:gitlab_repo_url, "https://example.com/repo.git"))
+        .to be_nil
+    end
+  end
+
+  describe "#bitbucket_repo_url" do
+    it "extracts repository URL from Bitbucket URL" do
+      expect(described_class.new([]).send(:bitbucket_repo_url, "https://bitbucket.org/user/repo/get/v1.0.tar.gz"))
+        .to eq("https://bitbucket.org/user/repo")
+    end
+
+    it "handles Bitbucket .git URLs" do
+      expect(described_class.new([]).send(:bitbucket_repo_url, "https://bitbucket.org/user/repo.git"))
+        .to eq("https://bitbucket.org/user/repo")
+    end
+
+    it "returns nil for non-Bitbucket URLs" do
+      expect(described_class.new([]).send(:bitbucket_repo_url, "https://example.com/repo.git"))
+        .to be_nil
+    end
+  end
+
+  describe "#codeberg_repo_url" do
+    it "extracts repository URL from Codeberg URL" do
+      expect(described_class.new([]).send(:codeberg_repo_url, "https://codeberg.org/user/repo/archive/v1.0.tar.gz"))
+        .to eq("https://codeberg.org/user/repo")
+    end
+
+    it "handles Codeberg .git URLs" do
+      expect(described_class.new([]).send(:codeberg_repo_url, "https://codeberg.org/user/repo.git"))
+        .to eq("https://codeberg.org/user/repo")
+    end
+
+    it "returns nil for non-Codeberg URLs" do
+      expect(described_class.new([]).send(:codeberg_repo_url, "https://example.com/repo.git"))
+        .to be_nil
+    end
+  end
+
+  describe "#sourcehut_repo_url" do
+    it "extracts repository URL from SourceHut URL" do
+      expect(described_class.new([]).send(:sourcehut_repo_url, "https://git.sr.ht/~user/repo/archive/v1.0.tar.gz"))
+        .to eq("https://sr.ht/~user/repo")
+    end
+
+    it "handles sr.ht URLs without git subdomain" do
+      expect(described_class.new([]).send(:sourcehut_repo_url, "https://sr.ht/~user/repo"))
+        .to eq("https://sr.ht/~user/repo")
+    end
+
+    it "returns nil for non-SourceHut URLs" do
+      expect(described_class.new([]).send(:sourcehut_repo_url, "https://example.com/repo.git"))
+        .to be_nil
+    end
+  end
+
+  describe "#url_to_repo" do
+    it "returns GitHub repo URL for GitHub URLs" do
+      expect(described_class.new([]).send(:url_to_repo, "https://github.com/Homebrew/brew"))
+        .to eq("https://github.com/Homebrew/brew")
+    end
+
+    it "returns GitLab repo URL for GitLab URLs" do
+      expect(described_class.new([]).send(:url_to_repo, "https://gitlab.com/user/repo.git"))
+        .to eq("https://gitlab.com/user/repo")
+    end
+
+    it "returns nil for unsupported URLs" do
+      expect(described_class.new([]).send(:url_to_repo, "https://example.com/repo.tar.gz"))
+        .to be_nil
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
This PR adds a new `source` command to open source repositories similar to how `home` opens homepages. Formulae homepages are often upstream marketing sites or documentation pages, which require extra work to get to the repository. The command extracts the repository URL from the formula's head URL, stable URL, or homepage. This initial implementation supports GitHub, GitLab, Bitbucket, Codeberg, and SourceHut.