### PR TITLE
Use `#present?` instead of `#empty?` to check presence in `CaskStruct`

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -249,7 +249,7 @@ module Homebrew
         hash["caveats_present"] = hash["caveats"].present?
         hash["conflicts_present"] = hash["conflicts_with"].present?
         hash["container_present"] = hash["container"].present?
-        hash["depends_on_present"] = !hash["depends_on_args"].empty?
+        hash["depends_on_present"] = hash["depends_on_args"].present?
         hash["deprecate_present"] = hash["deprecate_args"].present?
         hash["desc_present"] = hash["desc"].present?
         hash["disable_present"] = hash["disable_args"].present?


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/21348

Let's use `#present?` instead of negating `#empty?` to in case we call these on `nil`. `[].present?` and `{}.present?` return `false`, which gives us the same result.
