### PR TITLE
Cpan: update generated url

### DIFF
--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -26,7 +26,7 @@ module Homebrew
 
         # The `Regexp` used to determine if the strategy applies to the URL.
         URL_MATCH_REGEX = %r{
-          ^https?://cpan\.metacpan\.org
+          ^https?://(?:cpan\.metacpan\.org|www\.cpan\.org)
           (?<path>/authors/id(?:/[^/]+){3,}/) # Path before the filename
           (?<prefix>[^/]+) # Filename text before the version
           -v?\d+(?:\.\d+)* # The numeric version
@@ -55,7 +55,7 @@ module Homebrew
           return values if match.blank?
 
           # The directory listing page where the archive files are found
-          values[:url] = "https://cpan.metacpan.org#{match[:path]}"
+          values[:url] = "https://www.cpan.org#{match[:path]}"
 
           regex_prefix = Regexp.escape(T.must(match[:prefix])).gsub("\\-", "-")
 

--- a/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/cpan_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
 
   let(:cpan_urls) do
     {
-      no_subdirectory:   "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/Brew-v1.2.3.tar.gz",
-      with_subdirectory: "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/brew/brew-v1.2.3.tar.gz",
+      no_subdirectory:       "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/Brew-v1.2.3.tar.gz",
+      with_subdirectory:     "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/brew/brew-v1.2.3.tar.gz",
+      no_subdirectory_www:   "https://www.cpan.org/authors/id/H/HO/HOMEBREW/Brew-v1.2.3.tar.gz",
+      with_subdirectory_www: "https://www.cpan.org/authors/id/H/HO/HOMEBREW/brew/brew-v1.2.3.tar.gz",
     }
   end
   let(:non_cpan_url) { "https://brew.sh/test" }
@@ -16,11 +18,11 @@ RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
   let(:generated) do
     {
       no_subdirectory:   {
-        url:   "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/",
+        url:   "https://www.cpan.org/authors/id/H/HO/HOMEBREW/",
         regex: /href=.*?Brew[._-]v?(\d+(?:\.\d+)*)\.t/i,
       },
       with_subdirectory: {
-        url:   "https://cpan.metacpan.org/authors/id/H/HO/HOMEBREW/brew/",
+        url:   "https://www.cpan.org/authors/id/H/HO/HOMEBREW/brew/",
         regex: /href=.*?brew[._-]v?(\d+(?:\.\d+)*)\.t/i,
       },
     }
@@ -30,6 +32,8 @@ RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
     it "returns true for a CPAN URL" do
       expect(cpan.match?(cpan_urls[:no_subdirectory])).to be true
       expect(cpan.match?(cpan_urls[:with_subdirectory])).to be true
+      expect(cpan.match?(cpan_urls[:no_subdirectory_www])).to be true
+      expect(cpan.match?(cpan_urls[:with_subdirectory_www])).to be true
     end
 
     it "returns false for a non-CPAN URL" do
@@ -41,6 +45,8 @@ RSpec.describe Homebrew::Livecheck::Strategy::Cpan do
     it "returns a hash containing url and regex for a CPAN URL" do
       expect(cpan.generate_input_values(cpan_urls[:no_subdirectory])).to eq(generated[:no_subdirectory])
       expect(cpan.generate_input_values(cpan_urls[:with_subdirectory])).to eq(generated[:with_subdirectory])
+      expect(cpan.generate_input_values(cpan_urls[:no_subdirectory_www])).to eq(generated[:no_subdirectory])
+      expect(cpan.generate_input_values(cpan_urls[:with_subdirectory_www])).to eq(generated[:with_subdirectory])
     end
 
     it "returns an empty hash for a non-CPAN URL" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Generated URLs from the `Cpan` livecheck strategy currently use cpan.metacpan.org but they are redirecting to www.cpan.org, so this updates the strategy to resolve the redirection. This also modifies `URL_MATCH_REGEX` to support www.cpan.org URLs using the same path format, in case we encounter URLs like this in the future.

For what it's worth, I tested this with the 10 formulae using the `Cpan` strategy and they all worked as expected.