### PR TITLE
Improve `Tab.for_name` to use keg where possible.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -1098,12 +1098,10 @@ module Formulary
       alias_path:   T.nilable(T.any(Pathname, String)),
       force_bottle: T::Boolean,
       flags:        T::Array[String],
+      keg:          T.nilable(Keg),
     ).returns(Formula)
   }
-  def self.from_rack(rack, spec = nil, alias_path: nil, force_bottle: false, flags: [])
-    kegs = rack.directory? ? rack.subdirs.map { |d| Keg.new(d) } : []
-    keg = kegs.find(&:linked?) || kegs.find(&:optlinked?) || kegs.max_by(&:scheme_and_version)
-
+  def self.from_rack(rack, spec = nil, alias_path: nil, force_bottle: false, flags: [], keg: Keg.from_rack(rack))
     options = {
       alias_path:,
       force_bottle:,

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -121,6 +121,14 @@ class Keg
     raise NotAKegError, "#{original_path} is not inside a keg"
   end
 
+  sig { params(rack: Pathname).returns(T.nilable(Keg)) }
+  def self.from_rack(rack)
+    return unless rack.directory?
+
+    kegs = rack.subdirs.map { |d| new(d) }
+    kegs.find(&:linked?) || kegs.find(&:optlinked?) || kegs.max_by(&:scheme_and_version)
+  end
+
   sig { returns(T::Array[Keg]) }
   def self.all
     Formula.racks.flat_map(&:subdirs).map { |d| new(d) }

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -291,7 +291,12 @@ class Tab < AbstractTab
   # or a fake one if the formula is not installed.
   sig { params(name: String).returns(T.attached_class) }
   def self.for_name(name)
-    for_formula(Formulary.factory(name))
+    rack = HOMEBREW_CELLAR/name
+    if (keg = Keg.from_rack(rack))
+      for_keg(keg)
+    else
+      for_formula(Formulary.from_rack(rack, keg:))
+    end
   end
 
   def self.remap_deprecated_options(deprecated_options, options)


### PR DESCRIPTION
I noticed a tiny performance improvement here when reviewing https://github.com/Homebrew/brew/pull/21351 where we can avoid creating a `Formula` when loading a Tab from a name/rack path.