### PR TITLE
utiluti (new formula) 1.3

### DIFF
--- a/Formula/u/utiluti.rb
+++ b/Formula/u/utiluti.rb
@@ -1,0 +1,20 @@
+class Utiluti < Formula
+  desc "macOS command-line to work with default apps"
+  homepage "https://github.com/scriptingosx/utiluti"
+  url "https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.3.tar.gz"
+  sha256 "98d72888421cf048d157da3b64dcc4bdc165c4899de987636a1cac022e5bd7ff"
+  license "Apache-2.0"
+  head "https://github.com/scriptingosx/utiluti.git", branch: "main"
+
+  depends_on :macos
+  uses_from_macos "swift"
+
+  def install
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    bin.install ".build/release/utiluti"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/utiluti --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

A note on the last task: I do receive the following offense, but this seems to be the same way other source-based formulas reference GitHub. If I'm misinterpretting how to do this, would a maintainer please advise?

```sh
==> brew typecheck homebrew/core
No errors! Great job.

==> brew style --changed --fix
Taps/homebrew/homebrew-core/Formula/u/utiluti.rb:4:3: C: FormulaAudit/Urls: https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.3.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
  url "https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.3.tar.gz"
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
Error: Failure while executing; `/opt/homebrew/bin/brew style --changed --fix` exited with 1.
```

---

Thanks for considering this addition.

closes https://github.com/scriptingosx/utiluti/issues/6
