### PR TITLE
fix: suppress error message of broken pipe

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -657,7 +657,7 @@ else
   if [[ -r "/proc/cpuinfo" ]] &&
      [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]]
   then
-    if ! grep -E "^(flags|Features)" /proc/cpuinfo | grep -q "ssse3"
+    if ! grep -E "^(flags|Features)" /proc/cpuinfo 2>/dev/null | grep -q "ssse3"
     then
       odie "Homebrew's x86_64 support on Linux requires a CPU with SSSE3 support!"
     fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

An error `grep: write error: Broken pipe` can occur intermittently due to an underlying race condition in the pipe use, `grep ... | grep ...` (found [here][code]). This happens only when the second `grep` command exits earlier, and we can safely suppress the error message: `grep -E "^(flags|Features)" /proc/cpuinfo 2>/dev/null | grep -q "ssse3"`.

[code]: https://github.com/Homebrew/brew/blob/7c34e4bfdee8bf30a40d1f884a612db61ed707a3/Library/Homebrew/brew.sh#L660