### PR TITLE
bundle/commands/exec: add HOMEBREW_INSIDE_BUNDLE.

### DIFF
--- a/Library/Homebrew/bundle/commands/exec.rb
+++ b/Library/Homebrew/bundle/commands/exec.rb
@@ -77,6 +77,9 @@ module Homebrew
           # Enable compiler flag filtering
           ENV.refurbish_args
 
+          # Add variable to detect being inside a `brew bundle exec` environment
+          ENV["HOMEBREW_INSIDE_BUNDLE"] = "1"
+
           # Set up `nodenv`, `pyenv` and `rbenv` if present.
           env_formulae = %w[nodenv pyenv rbenv]
           ENV.deps.each do |dep|

--- a/docs/Brew-Bundle-and-Brewfile.md
+++ b/docs/Brew-Bundle-and-Brewfile.md
@@ -208,6 +208,8 @@ If you want to start all the services in your `Brewfile` just during the executi
 brew bundle exec --services
 ```
 
+Note inside `brew bundle exec`, `brew bundle sh` and `brew bundle env` the environment variable `HOMEBREW_INSIDE_BUNDLE` is set to `1` for easy detection.
+
 ### `brew bundle sh`
 
 `brew bundle sh` is like `brew bundle exec` but it runs your interactive shell of choice, like `brew sh`:


### PR DESCRIPTION
This allows easy detection of being inside a `brew bundle exec` environment.

For example, could be used like this in a shell script:
```sh
if [[ "${HOMEBREW_INSIDE_BUNDLE:-}" != "1" ]]; then
  eval "$(brew bundle --check --install env)"
  exec "$@"
fi
```

This would ensure that the script is run in a `brew bundle exec` environment, but not if it's already inside one.