### PR TITLE
brew.sh: fix sporadic SIGPIPE in CPU feature check (Fixes #21365)

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -657,7 +657,7 @@ else
   if [[ -r "/proc/cpuinfo" ]] &&
      [[ "${HOMEBREW_PROCESSOR}" == "x86_64" ]]
   then
-    if ! grep -E "^(flags|Features)" /proc/cpuinfo | grep -q "ssse3"
+    if ! grep -qE '^(flags|Features).*\bssse3\b' /proc/cpuinfo
     then
       odie "Homebrew's x86_64 support on Linux requires a CPU with SSSE3 support!"
     fi


### PR DESCRIPTION
Fixes #21365
Closes #21359

The previous implementation used a pipeline:
  grep -E "^(flags|Features)" /proc/cpuinfo | grep -q "ssse3"

This caused a race condition. If the second grep (grep -q) found a match and exited early, it closed the read end of the pipe. If the first grep was still writing to that pipe (processing subsequent lines of /proc/cpuinfo), it would receive a SIGPIPE and print 'grep: write error: Broken pipe' to stderr.

This patch consolidates the logic into a single grep command:
  grep -qE '^(flags|Features).*\bssse3\b' /proc/cpuinfo

This eliminates the pipeline entirely, preventing the broken pipe error while maintaining the same logic: verifying that 'ssse3' appears on a line starting with 'flags' or 'Features'.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
