### PR TITLE
cmd/tap-info: revert exit code changes to `--json` only

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -93,11 +93,7 @@ module Homebrew
 
       sig { params(taps: T::Array[Tap]).void }
       def print_tap_json(taps)
-        taps_hashes = taps.map do |tap|
-          Homebrew.failed = true unless tap.installed?
-          tap.to_hash
-        end
-        puts JSON.pretty_generate(taps_hashes)
+        puts JSON.pretty_generate(taps.map(&:to_hash))
       end
     end
   end


### PR DESCRIPTION
#21310 presented a good case for returning an exit code on `brew tap-info` however this shouldn't apply to `--json` for multiple reasons:

* Unlike regular `brew tap-info`, `brew tap-info --json` is designed to work on uninstalled core taps (i.e. from the API).
* `brew tap-info --json` is able to provide install locations even when taps aren't installed.
* There's already a dedicated entry for `installed` in the JSON
* Being able to differentiate between parseable JSON output and non-parseable output (e.g. Ruby error) is important.

This fixes regressions seen downstream (public example: https://github.com/rcmdnk/homebrew-file/issues/373).

The case originally presented in #21301 is still retained since that talked about the non-JSON case.