### PR TITLE
cmd/shellenv: improve detection of shell name. 

### DIFF
--- a/Library/Homebrew/cmd/shellenv.rb
+++ b/Library/Homebrew/cmd/shellenv.rb
@@ -20,11 +20,12 @@ module Homebrew
           querying them multiple times.
           To help guarantee idempotence, this command produces no output when Homebrew's `bin` and `sbin` directories
           are first and second respectively in your `$PATH`. Consider adding evaluation of this command's output to
-          your dotfiles (e.g. `~/.bash_profile` or ~/.zprofile` on macOS and ~/.bashrc` or ~/.zshrc` on Linux) with:
-            `eval "$(brew shellenv)"`
+          your dotfiles (e.g. `~/.bash_profile` or ~/.zprofile` on macOS and ~/.bashrc` or ~/.zshrc` on Linux)
+          with e.g.:
+            `eval "$(brew shellenv zsh)"` or `eval "$(brew shellenv bash)"`
 
-          The shell can be specified explicitly with a supported shell name parameter. Unknown shells will output
-          POSIX exports.
+          The shell should be specified explicitly with a supported shell name parameter but will be detected
+          automatically if not provided (but this may not be correct). Unknown shells will output POSIX exports.
         EOS
 
         named_args :shell

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -15,7 +15,7 @@ homebrew-shellenv() {
   then
     HOMEBREW_SHELL_NAME="$1"
   else
-    HOMEBREW_SHELL_NAME="$(/bin/ps -p "${PPID}" -c -o comm=)"
+    HOMEBREW_SHELL_NAME="${SHELL##*/}"
   fi
 
   if [[ -n "${HOMEBREW_MACOS}" ]] &&

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1526,11 +1526,13 @@ are also exported to avoid querying them multiple times. To help guarantee
 idempotence, this command produces no output when Homebrew's `bin` and `sbin`
 directories are first and second respectively in your `$PATH`. Consider adding
 evaluation of this command's output to your dotfiles (e.g. `~/.bash_profile` or
-~/.zprofile` on macOS and ~/.bashrc` or ~/.zshrc` on Linux) with:
-  `eval "$(brew shellenv)"\`
+~/.zprofile` on macOS and ~/.bashrc` or ~/.zshrc` on Linux)
+with e.g.:
+  `eval "$(brew shellenv zsh)"` or `eval "$(brew shellenv bash)"\`
 
-The shell can be specified explicitly with a supported shell name parameter.
-Unknown shells will output POSIX exports.
+The shell should be specified explicitly with a supported shell name parameter
+but will be detected automatically if not provided (but this may not be
+correct). Unknown shells will output POSIX exports.
 
 ### `source` \[*`formula`* ...\]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -951,9 +951,9 @@ Valid shells: bash|csh|fish|pwsh|sh|tcsh|zsh
 .P
 Print export statements\. When run in a shell, this installation of Homebrew will be added to your \fB$PATH\fP, \fB$MANPATH\fP, and \fB$INFOPATH\fP\&\.
 .P
-The variables \fB$HOMEBREW_PREFIX\fP, \fB$HOMEBREW_CELLAR\fP and \fB$HOMEBREW_REPOSITORY\fP are also exported to avoid querying them multiple times\. To help guarantee idempotence, this command produces no output when Homebrew\[u2019]s \fBbin\fP and \fBsbin\fP directories are first and second respectively in your \fB$PATH\fP\&\. Consider adding evaluation of this command\[u2019]s output to your dotfiles (e\.g\. \fB~/\.bash_profile\fP or ~/\.zprofile\fB on macOS and ~/\.bashrc\fP or ~/\.zshrc\fB on Linux) with: \fPeval \[u201c]$(brew shellenv)\[u201d]`
+The variables \fB$HOMEBREW_PREFIX\fP, \fB$HOMEBREW_CELLAR\fP and \fB$HOMEBREW_REPOSITORY\fP are also exported to avoid querying them multiple times\. To help guarantee idempotence, this command produces no output when Homebrew\[u2019]s \fBbin\fP and \fBsbin\fP directories are first and second respectively in your \fB$PATH\fP\&\. Consider adding evaluation of this command\[u2019]s output to your dotfiles (e\.g\. \fB~/\.bash_profile\fP or ~/\.zprofile\fB on macOS and ~/\.bashrc\fP or ~/\.zshrc\fB on Linux) with e\.g\.: \fPeval \[u201c]$(brew shellenv zsh)\[u201d]\fB or \fPeval \[u201c]$(brew shellenv bash)\[u201d]`
 .P
-The shell can be specified explicitly with a supported shell name parameter\. Unknown shells will output POSIX exports\.
+The shell should be specified explicitly with a supported shell name parameter but will be detected automatically if not provided (but this may not be correct)\. Unknown shells will output POSIX exports\.
 .SS "\fBsource\fP \fR[\fIformula\fP \.\.\.]"
 Open a \fIformula\fP\[u2019]s source repository in a browser, or open Homebrew\[u2019]s own repository if no argument is provided\.
 .P


### PR DESCRIPTION
Let's just use the simplest method (that we use in the installer) to detect the shell.

Let's just tell users to set the shell name explicitly if this detection is wrong.

This is done by many other tools and avoids us fighting with stupid checks that don't work reliably or speedily under sandboxes etc.

Fixes https://github.com/Homebrew/brew/issues/21284