### PR TITLE
Handle more nilable cask struct attributes

### DIFF
--- a/Library/Homebrew/api/cask.rb
+++ b/Library/Homebrew/api/cask.rb
@@ -253,6 +253,7 @@ module Homebrew
         hash["deprecate_present"] = hash["deprecate_args"].present?
         hash["desc_present"] = hash["desc"].present?
         hash["disable_present"] = hash["disable_args"].present?
+        hash["homepage_present"] = hash["homepage"].present?
 
         CaskStruct.from_hash(hash)
       end

--- a/Library/Homebrew/api/cask_struct.rb
+++ b/Library/Homebrew/api/cask_struct.rb
@@ -13,6 +13,7 @@ module Homebrew
         :deprecate,
         :desc,
         :disable,
+        :homepage,
       ].freeze
 
       ArtifactArgs = T.type_alias do
@@ -43,15 +44,15 @@ module Homebrew
       const :deprecate_args, T::Hash[Symbol, T.nilable(T.any(String, Symbol))], default: {}
       const :desc, T.nilable(String)
       const :disable_args, T::Hash[Symbol, T.nilable(T.any(String, Symbol))], default: {}
-      const :homepage, String
+      const :homepage, T.nilable(String)
       const :languages, T::Array[String], default: []
       const :names, T::Array[String], default: []
       const :renames, T::Array[[String, String]], default: []
       const :ruby_source_checksum, T::Hash[Symbol, String]
-      const :ruby_source_path, String
+      const :ruby_source_path, T.nilable(String)
       const :sha256, T.any(String, Symbol)
-      const :tap_git_head, String
-      const :tap_string, String
+      const :tap_git_head, T.nilable(String)
+      const :tap_string, T.nilable(String)
       const :url_args, T::Array[String], default: []
       const :url_kwargs, T::Hash[Symbol, T.anything], default: {}
       const :version, T.any(String, Symbol)

--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -352,8 +352,11 @@ module Cask
           source:          JSON.pretty_generate(json_cask),
           config:,
           loader:          self,
-          tap:             Tap.fetch(cask_struct.tap_string),
         }
+
+        if (tap_string = cask_struct.tap_string)
+          cask_options[:tap] = Tap.fetch(tap_string)
+        end
 
         api_cask = Cask.new(token, **cask_options) do
           version cask_struct.version
@@ -364,7 +367,7 @@ module Cask
             name cask_name
           end
           desc cask_struct.desc if cask_struct.desc?
-          homepage cask_struct.homepage
+          homepage cask_struct.homepage if cask_struct.homepage?
 
           deprecate!(**cask_struct.deprecate_args) if cask_struct.deprecate?
           disable!(**cask_struct.disable_args) if cask_struct.disable?

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/api/cask_struct.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/api/cask_struct.rbi
@@ -29,4 +29,7 @@ class Homebrew::API::CaskStruct
 
   sig { returns(T::Boolean) }
   def disable?; end
+
+  sig { returns(T::Boolean) }
+  def homepage?; end
 end


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/21373

This PR removes more (and hopefully all) potential places in `CaskStruct` that could theoretically lead to a `nil` value assigned to a non-nilable field when reading old cask JSON files.

Now, aside from `sha256` and `version`, all of the fields either have a default value, are nilable. I can add fallbacks for those too if needed, but I think those should be pretty stable (?)
