### PR TITLE
utils/pypi: skip excluded packages message when empty

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -353,8 +353,10 @@ module PyPI
     found_packages = pip_report(input_packages, python_name:, print_stderr:)
     # Resolve the dependency tree of excluded packages to prune the above
     exclude_packages.delete_if { |package| found_packages.exclude? package }
-    ohai "Retrieving PyPI dependencies for excluded \"#{exclude_packages.join(" ")}\"..." if show_info
-    exclude_packages = pip_report(exclude_packages, python_name:, print_stderr:)
+    if exclude_packages.present?
+      ohai "Retrieving PyPI dependencies for excluded \"#{exclude_packages.join(" ")}\"..." if show_info
+      exclude_packages = pip_report(exclude_packages, python_name:, print_stderr:)
+    end
     # Keep extra_packages even if they are dependencies of exclude_packages
     exclude_packages.delete_if { |package| extra_packages.include? package }
     if (main_package_name = main_package&.name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
I noticed while creating a new formula that we're printing an empty line here:

Before:
```
==> Retrieving PyPI dependencies for "https://github.com/<foo>/v0.4.0.tar.gz"...
==> Retrieving PyPI dependencies for excluded ""...
==> Getting PyPI info for "aiohappyeyeballs==2.6.1"
```

After:
```
==> Retrieving PyPI dependencies for "https://github.com/<foo>/v0.4.0.tar.gz"...
==> Getting PyPI info for "aiohappyeyeballs==2.6.1"
```