### PR TITLE
rubocops: require `libsodium` when `pynacl` is present

### DIFF
--- a/Library/Homebrew/rubocops/resource_requires_dependencies.rb
+++ b/Library/Homebrew/rubocops/resource_requires_dependencies.rb
@@ -17,7 +17,7 @@ module RuboCop
           resource_nodes = find_every_method_call_by_name(body_node, :resource)
           return if resource_nodes.empty?
 
-          %w[lxml pyyaml].each do |resource_name|
+          %w[lxml pynacl pyyaml].each do |resource_name|
             found = resource_nodes.find { |node| node.arguments&.first&.str_content == resource_name }
             next unless found
 
@@ -37,6 +37,9 @@ module RuboCop
             when "lxml"
               kind = depends_on?(:linux) ? "depends_on" : "uses_from_macos"
               ["libxml2", "libxslt"]
+            when "pynacl"
+              kind = "depends_on"
+              ["libsodium"]
             when "pyyaml"
               kind = "depends_on"
               ["libyaml"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
This lets us avoid indirect linkage.