### PR TITLE
info: highlight formula and cask installation status (✔/✘)

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -298,7 +298,14 @@ module Homebrew
         attrs << "pinned at #{formula.pinned_version}" if formula.pinned?
         attrs << "keg-only" if formula.keg_only?
 
-        puts "#{oh1_title(formula.full_name)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
+        kegs = formula.installed_kegs
+        name_with_status = if kegs.empty?
+          pretty_uninstalled(formula.full_name)
+        else
+          pretty_installed(formula.full_name)
+        end
+
+        puts "#{oh1_title(name_with_status)}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
         puts formula.desc if formula.desc
         puts Formatter.url(formula.homepage) if formula.homepage
 
@@ -319,7 +326,6 @@ module Homebrew
           EOS
         end
 
-        kegs = formula.installed_kegs
         heads, versioned = kegs.partition { |keg| keg.version.head? }
         kegs = [
           *heads.sort_by { |keg| -keg.tab.time.to_i },

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -50,4 +50,49 @@ RSpec.describe Homebrew::Cmd::Info do
         .to eq("https://mywebsite.com/foo/bar.rb")
     end
   end
+
+  describe "#info_formula" do
+    it "displays info for an uninstalled formula", :integration_test do
+      setup_test_formula "testball"
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+      formula = Formula["testball"]
+
+      expect do
+        described_class.new([]).send(:info_formula, formula)
+      end.to output(<<~EOS).to_stdout
+        ==> testball ✘: stable 0.1
+        Some test
+        https://brew.sh/testball
+        Not installed
+        From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/testball.rb
+        ==> Options
+        --with-foo
+        \tBuild with foo
+      EOS
+    end
+
+    it "displays info for an installed formula", :integration_test do
+      install_test_formula "testball"
+      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
+
+      formula = Formula["testball"]
+      keg = formula.installed_kegs.first
+
+      expect do
+        described_class.new([]).send(:info_formula, formula)
+      end.to output(<<~EOS).to_stdout
+        ==> testball ✔: stable 0.1
+        Some test
+        https://brew.sh/testball
+        Installed
+        #{keg} (#{keg.abv}) *
+          #{keg.tab}
+        From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/testball.rb
+        ==> Options
+        --with-foo
+        \tBuild with foo
+      EOS
+    end
+  end
 end

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -50,49 +50,4 @@ RSpec.describe Homebrew::Cmd::Info do
         .to eq("https://mywebsite.com/foo/bar.rb")
     end
   end
-
-  describe "#info_formula" do
-    it "displays info for an uninstalled formula", :integration_test do
-      setup_test_formula "testball"
-      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
-
-      formula = Formula["testball"]
-
-      expect do
-        described_class.new([]).send(:info_formula, formula)
-      end.to output(<<~EOS).to_stdout
-        ==> testball ✘: stable 0.1
-        Some test
-        https://brew.sh/testball
-        Not installed
-        From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/testball.rb
-        ==> Options
-        --with-foo
-        \tBuild with foo
-      EOS
-    end
-
-    it "displays info for an installed formula", :integration_test do
-      install_test_formula "testball"
-      allow_any_instance_of(StringIO).to receive(:tty?).and_return(true)
-
-      formula = Formula["testball"]
-      keg = formula.installed_kegs.first
-
-      expect do
-        described_class.new([]).send(:info_formula, formula)
-      end.to output(<<~EOS).to_stdout
-        ==> testball ✔: stable 0.1
-        Some test
-        https://brew.sh/testball
-        Installed
-        #{keg} (#{keg.abv}) *
-          #{keg.tab}
-        From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/testball.rb
-        ==> Options
-        --with-foo
-        \tBuild with foo
-      EOS
-    end
-  end
 end


### PR DESCRIPTION
`brew info` to display installation status indicators for formulae and casks. It's not at clear as it could be now, so this would be a good improvement.

The output shows a checkmark (✔) for installed formulae and a cross (✘) for uninstalled formulae, same as already happens for its dependencies.

```bash
❯ ./bin/brew info wget
==> wget ✘: stable 1.25.0, HEAD
Internet file retriever
https://www.gnu.org/software/wget/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/w/wget.rb
License: GPL-3.0-or-later
==> Dependencies
Build: pkgconf ✔
Required: libidn2 ✘, openssl@3 ✘, gettext ✘, libunistring ✔
==> Options
--HEAD
	Install HEAD version
==> Analytics
install: 26,851 (30 days), 87,982 (90 days), 622,067 (365 days)
install-on-request: 26,639 (30 days), 87,080 (90 days), 618,174 (365 days)
build-error: 5 (30 days)
```