### PR TITLE
cask/audit: add arch to signing audit skiplist

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -511,8 +511,9 @@ module Cask
       end
 
       odebug "Auditing signing"
-
-      is_in_skiplist = cask.tap&.audit_exception(:signing_audit_skiplist, cask.token)
+      is_in_skiplist = cask.tap&.audit_exception(:signing_audit_skiplist, cask.token,
+                                                 Homebrew::SimulateSystem.current_arch.to_s) ||
+                       cask.tap&.audit_exception(:signing_audit_skiplist, cask.token, "all")
 
       extract_artifacts do |artifacts, tmpdir|
         is_container = artifacts.any? { |a| a.is_a?(Artifact::App) || a.is_a?(Artifact::Pkg) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This makes an adjustment to our signing audit skiplist for `homebrew-cask` to make it architecture specific. We have seen an increasing number of casks that fail only on the GitHub intel-based CI runners. Making this change allows us to skip these cases once they have been manually verified.

The alternative considered is to skip this audit entirely on the macos-15-intel runner, but I don't believe the issue is widespread enough for this to be the best option at this time.

Needed for: https://github.com/Homebrew/homebrew-cask/pull/234707