### PR TITLE
cmd/shellenv: more shell detection fixes.

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -11,10 +11,19 @@ homebrew-shellenv() {
     return
   fi
 
-  if [[ -n "$1" ]]
+  # Use specified shell name parameter, if available.
+  HOMEBREW_SHELL_NAME="${1:-}"
+
+  # Use the parent process name, if possible.
+  # This is known to fail under some sandboxes.
+  if [[ -z "${HOMEBREW_SHELL_NAME}" ]]
   then
-    HOMEBREW_SHELL_NAME="$1"
-  else
+    HOMEBREW_SHELL_NAME="$(/bin/ps -p "${PPID}" -c -o comm= 2>/dev/null)"
+  fi
+
+  # Fall back to the (login) shell name from the environment.
+  if [[ -z "${HOMEBREW_SHELL_NAME}" ]]
+  then
     HOMEBREW_SHELL_NAME="${SHELL##*/}"
   fi
 


### PR DESCRIPTION
Relying on `SHELL` is not reliable enough to detect e.g. `fish` given how some of our users do it.

Let's fall back to using `ps` and instead add a fallback for sandboxes.

@maschwenk @bolinfest The needs of Fish, the macOS sandbox and e.g. Cursor here contradict so we're going to move back to the original `ps` method that has worked well for years. If that's not working for you, hopefully the fallback here will work or you can just use e.g. `brew shellenv zsh` to bypass it all (and speed it up at little).

Fixes https://github.com/Homebrew/brew/issues/21388
Fixes https://github.com/Homebrew/install/issues/1069
Fixes https://github.com/Homebrew/brew/issues/21382

See also https://github.com/Homebrew/brew/pull/21157, https://github.com/Homebrew/brew/issues/21284, https://github.com/Homebrew/brew/pull/21374