### PR TITLE
dev-cmd/typecheck: fix Ruby version conflict in sigil bump

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -74,10 +74,16 @@ module Homebrew
             if args.suggest_typed?
               ohai "Checking if we can bump Sorbet `typed` sigils..."
               # --sorbet needed because of https://github.com/Shopify/spoom/issues/488
+              #
+              # Use the native sorbet binary directly to avoid Ruby version conflicts.
+              # spoom's exec uses Bundler.with_unbundled_env which can cause `#!/usr/bin/env ruby`
+              # scripts to use the wrong Ruby version (e.g., system Ruby 2.6 on macOS).
+              sorbet_path = Gem::Specification.find_by_name("sorbet-static").full_gem_path
+              sorbet_bin = File.join(sorbet_path, "libexec", "sorbet")
               system "bundle", "exec", "spoom", "srb", "bump", "--from", "false", "--to", "true",
-                     "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
+                     "--sorbet", sorbet_bin
               system "bundle", "exec", "spoom", "srb", "bump", "--from", "true", "--to", "strict",
-                     "--sorbet", "#{Gem.bin_path("sorbet", "srb")} tc"
+                     "--sorbet", sorbet_bin
             end
 
             return


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
When running `brew typecheck --update --suggest-typed`, spoom's exec method uses `Bundler.with_unbundled_env` which strips environment variables that ensure Homebrew's portable Ruby is used. This caused `#!/usr/bin/env ruby` in the `srb` wrapper script to resolve to the system Ruby 2.6 on macOS GitHub runners.

Lets use the native sorbet binary from sorbet-static directly instead.

Seen in https://github.com/Homebrew/brew/actions/runs/20927488069/job/60129300539:

```
==> Checking if we can bump Sorbet `typed` sigils...
Checking files...
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/lockfile_parser.rb:108:in warn_for_outdated_bundler_version': You must use Bundler 2 or greater with this lockfile. (Bundler::LockfileError)
```