### PR TITLE
extend/os/linux/formula: fix `valid_platform?` for macOS requirements

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -48,7 +48,7 @@ module OS
 
       sig { returns(T::Boolean) }
       def valid_platform?
-        requirements.none?(MacOSRequirement)
+        requirements.none? { |r| r.is_a?(MacOSRequirement) && !r.version_specified? }
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Fixes https://github.com/Homebrew/brew/issues/21397.

The `valid_platform?` method on Linux was rejecting all formulas with a `MacOSRequirement`, regardless of whether it had a version specified.

`depends_on :macos` = macOS only
`depends_on macos: :monterey` = Works on Linux, but requires Monterey+ for macOS

This aligns `valid_platform?` with the `MacOSRequirement#satisfy` logic, which already returns `true` on Linux when a version is specified.