### PR TITLE
Revert "dev-cmd/formula-analytics: filter tap_name client-side"

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -151,7 +151,7 @@ module Homebrew
         category_matching_buckets = [:build_error, :cask_install, :command_run, :test_bot_test]
 
         categories.each do |category|
-          additional_where = ""
+          additional_where = all_core_formulae_json ? " AND tap_name ~ '^homebrew/(core|cask)$'" : ""
           bucket = if category_matching_buckets.include?(category)
             category
           elsif category == :command_run_options
@@ -265,11 +265,7 @@ module Homebrew
               end
               next if dimension.blank?
 
-              tap_name = record["tap_name"].presence
-              # Filter to homebrew/core and homebrew/cask client-side to avoid InfluxDB Parquet query bug
-              next if all_core_formulae_json && tap_name && %w[homebrew/core homebrew/cask].exclude?(tap_name)
-
-              if tap_name &&
+              if (tap_name = record["tap_name"].presence) &&
                  ((tap_name != "homebrew/cask" && dimension_key == :cask) ||
                   (tap_name != "homebrew/core" && dimension_key == :formula))
                 dimension = "#{tap_name}/#{dimension}"


### PR DESCRIPTION
Reverts Homebrew/brew#21403.

InfluxDB confirmed this was an issue with a recent DataFusion upgrade that's been rolled back now.