### PR TITLE
linkage_checker: treat indirect deps as general test failure

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -88,9 +88,9 @@ class LinkageChecker
     display_items("Broken dependencies", @broken_deps, puts_output:)
     display_items("Unwanted system libraries", @unwanted_system_dylibs, puts_output:)
     display_items("Conflicting libraries", @version_conflict_deps, puts_output:)
+    display_items("Indirect dependencies with linkage", @indirect_deps, puts_output:)
     return unless strict
 
-    display_items("Indirect dependencies with linkage", @indirect_deps, puts_output:)
     display_items("Undeclared dependencies with linkage", @undeclared_deps, puts_output:)
     display_items("Unexpected linkage for no_linkage dependencies", @unexpected_linkage_deps, puts_output:)
     display_items("Files with missing rpath", @files_missing_rpaths, puts_output:)
@@ -103,9 +103,9 @@ class LinkageChecker
 
     issues = [@broken_deps, @broken_dylibs]
     if test
-      issues += [@unwanted_system_dylibs, @version_conflict_deps]
+      issues += [@unwanted_system_dylibs, @version_conflict_deps, @indirect_deps]
       if strict
-        issues += [@indirect_deps, @undeclared_deps, @unexpected_linkage_deps,
+        issues += [@undeclared_deps, @unexpected_linkage_deps,
                    @files_missing_rpaths, @executable_path_dylibs]
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
We've fixed a large number indirect dependencies with linkage in Homebrew/core. Let's move this to be a general failure so we can start catching the remaining ones.