### PR TITLE
Allow using dashes (`-`) in tap names

### DIFF
--- a/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
+++ b/Library/Homebrew/rubocops/cask/mixin/cask_help.rb
@@ -60,7 +60,7 @@ module RuboCop
 
         sig { returns(T.nilable(String)) }
         def cask_tap
-          return unless (match_obj = @file_path&.match(%r{/(homebrew-[\w-]+)/}))
+          return unless (match_obj = @file_path&.match(%r{(?:/Taps/[\w-]+|^)/(homebrew-[\w-]+)/}))
 
           match_obj[1]
         end

--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -183,7 +183,7 @@ module RuboCop
       # Returns the formula tap.
       sig { returns(T.nilable(String)) }
       def formula_tap
-        return unless (match_obj = @file_path&.match(%r{/(homebrew-[\w-]+)/}))
+        return unless (match_obj = @file_path&.match(%r{(?:/Taps/[\w-]+|^)/(homebrew-[\w-]+)/}))
 
         match_obj[1]
       end


### PR DESCRIPTION
This allows for tap repositories to contain dashes anywhere in name not only in the `homebrew-` prefix.

This bring it on par with `TestBot.HOMEBREW_TAP_REGEX` (see https://github.com/Homebrew/brew/blob/110b93e/Library/Homebrew/test_bot.rb#L24) and `Bundle.Dsl.Entry.HOMEBREW_TAP_ARGS_REGEX` (see https://github.com/Homebrew/brew/blob/110b93e/Library/Homebrew/bundle/dsl.rb#L114).

I have stumbled upon it when wanted to add my formulae to `runtime_cpu_detection_allowlist.json` in `pkryger/homebrew-emacsmacport-exp` tap, and `brew audit --strict` has been not accepting my exceptions (see https://github.com/orgs/Homebrew/discussions/6656).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
