### PR TITLE
bundle: dump full cask names

### DIFF
--- a/Library/Homebrew/bundle/cask_dumper.rb
+++ b/Library/Homebrew/bundle/cask_dumper.rb
@@ -37,9 +37,10 @@ module Homebrew
       sig { params(describe: T::Boolean).returns(String) }
       def self.dump(describe: false)
         casks.map do |cask|
+          name = cask.respond_to?(:full_name) ? cask.full_name : cask.to_s
           description = "# #{cask.desc}\n" if describe && cask.desc.present?
           config = ", args: { #{explicit_s(cask.config)} }" if cask.config.present? && cask.config.explicit.present?
-          "#{description}cask \"#{cask}\"#{config}"
+          "#{description}cask \"#{name}\"#{config}"
         end.join("\n")
       end
 

--- a/Library/Homebrew/test/bundle/dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/dumper_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Homebrew::Bundle::Dumper do
     expect(dumper.build_brewfile(
              describe: false, no_restart: false, formulae: true, taps: true, casks: true, mas: true,
              vscode: true, go: true, cargo: true, flatpak: false
-           )).to eql("cask \"google-chrome\"\ncask \"java\"\ncask \"iterm2-beta\"\n")
+           )).to eql("cask \"google-chrome\"\ncask \"java\"\ncask \"homebrew/cask-versions/iterm2-beta\"\n")
   end
 
   it "determines the brewfile correctly" do


### PR DESCRIPTION
This mirrors existing 3rd-party formulae disambiguation. 

Fixes #21416.

Before:
```
% brew bundle dump --file=- | grep -E '(jq|pup|font)'
tap "colindean/fonts-nonfree"
brew "jq"
brew "gromgit/tap/pup"
cask "font-dseg"
cask "font-lato"
cask "font-microsoft-office"
```

After:
```
% brew bundle dump --file=- | grep -E '(jq|pup|font)'
tap "colindean/fonts-nonfree"
brew "jq"
brew "gromgit/tap/pup"
cask "rami3l/tap/font-dseg"
cask "font-lato"
cask "colindean/fonts-nonfree/font-microsoft-office"
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
