### PR TITLE
add `full_name` to test cask objects

### DIFF
--- a/Library/Homebrew/bundle/cask_dumper.rb
+++ b/Library/Homebrew/bundle/cask_dumper.rb
@@ -37,10 +37,9 @@ module Homebrew
       sig { params(describe: T::Boolean).returns(String) }
       def self.dump(describe: false)
         casks.map do |cask|
-          name = cask.respond_to?(:full_name) ? cask.full_name : cask.to_s
           description = "# #{cask.desc}\n" if describe && cask.desc.present?
           config = ", args: { #{explicit_s(cask.config)} }" if cask.config.present? && cask.config.explicit.present?
-          "#{description}cask \"#{name}\"#{config}"
+          "#{description}cask \"#{cask.full_name}\"#{config}"
         end.join("\n")
       end
 

--- a/Library/Homebrew/test/bundle/cask_dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/cask_dumper_spec.rb
@@ -43,13 +43,14 @@ RSpec.describe Homebrew::Bundle::CaskDumper do
   end
 
   context "when casks `foo`, `bar` and `baz` are installed, with `baz` being a formula requirement" do
-    let(:foo) { instance_double(Cask::Cask, to_s: "foo", desc: nil, config: nil) }
-    let(:baz) { instance_double(Cask::Cask, to_s: "baz", desc: "Software", config: nil) }
+    let(:foo) { instance_double(Cask::Cask, to_s: "foo", full_name: "foo", desc: nil, config: nil) }
+    let(:baz) { instance_double(Cask::Cask, to_s: "baz", full_name: "baz", desc: "Software", config: nil) }
     let(:bar) do
       instance_double(
-        Cask::Cask, to_s:   "bar",
-                    desc:   nil,
-                    config: instance_double(
+        Cask::Cask, to_s:      "bar",
+                    full_name: "bar",
+                    desc:      nil,
+                    config:    instance_double(
                       Cask::Config,
                       explicit: {
                         fontdir:   "/Library/Fonts",


### PR DESCRIPTION
Followup to #21417. This removes the needs for `respond_to?` gymnastics.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?
