### PR TITLE
Symbolize dependency hash in `FormulaStruct`

### DIFF
--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -74,11 +74,13 @@ module Homebrew
             T.any(
               # Formula name: "foo"
               String,
-              # Hash like { "foo" => "build" } or { :foo => ["build", "test"] }
+              # Hash like { "foo" => :build } or { "foo" => [:build, :test] }
               T::Hash[
                 String,
-                T.any(String, T::Array[String]),
+                T.any(Symbol, T::Array[Symbol]),
               ],
+              # Hash like { since: :catalina } for uses_from_macos_bounds
+              T::Hash[Symbol, Symbol],
             ),
           ],
         ]
@@ -97,7 +99,6 @@ module Homebrew
 
       # Changes to this struct must be mirrored in Homebrew::API::Formula.generate_formula_struct_hash
       const :aliases, T::Array[String], default: []
-      const :bottle, T::Hash[String, T.anything], default: {}
       const :bottle_checksums, T::Array[T::Hash[Symbol, T.anything]], default: []
       const :bottle_rebuild, Integer, default: 0
       const :caveats, T.nilable(String)

--- a/Library/Homebrew/test/api/formula_spec.rb
+++ b/Library/Homebrew/test/api/formula_spec.rb
@@ -63,4 +63,45 @@ RSpec.describe Homebrew::API::Formula do
       expect(aliases_output).to eq formulae_aliases
     end
   end
+
+  specify "::symbolize_dependency_hash" do
+    input = {
+      "dependencies"           => [
+        "foo",
+        { "bar" => "build" },
+        { "baz" => ["build", "test"] },
+      ],
+      "uses_from_macos"        => [
+        "abc",
+        { "def" => "build" },
+        { "ghi" => ["build", "test"] },
+      ],
+      "uses_from_macos_bounds" => [
+        {},
+        { "since" => "catalina" },
+        {},
+      ],
+    }
+
+    expected_output = {
+      "dependencies"           => [
+        "foo",
+        { "bar" => :build },
+        { "baz" => [:build, :test] },
+      ],
+      "uses_from_macos"        => [
+        "abc",
+        { "def" => :build },
+        { "ghi" => [:build, :test] },
+      ],
+      "uses_from_macos_bounds" => [
+        {},
+        { since: :catalina },
+        {},
+      ],
+    }
+
+    output = described_class.symbolize_dependency_hash(input)
+    expect(output).to eq expected_output
+  end
 end


### PR DESCRIPTION
This PR fixes a typing issue in `FormulaStruct` where, in certain cases, strings needed to be turned into symbols.

For example, `depends_on` expects dependency types like `{ "foo" => :build }` where `:build` is a symbol. Also, `uses_from_macos` can accept conditions like `{ since: :catalina }` where both the key and the value are symbols.
