### PR TITLE
download_strategy: fallback to Content-Range for file size

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -616,6 +616,15 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
                 .flat_map { |headers| [*headers["content-length"]&.to_i] }
                 .last
 
+    # Fallback to content-range header if content-length is not available.
+    # Content-Range format: "bytes start-end/total" or "bytes */total" or "bytes start-end/*"
+    if file_size.nil? || file_size.zero?
+      file_size = parsed_headers
+                  .flat_map { |headers| [*headers["content-range"]] }
+                  .filter_map { |range| Integer(range.split("/").last, 10, exception: false) }
+                  .last
+    end
+
     content_type = parsed_headers
                    .flat_map { |headers| [*headers["content-type"]] }
                    .last


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
## Summary
- Extract file size from `Content-Range` header when `Content-Length` is missing
- Add tests for Content-Range header parsing

## Why
Some file storage servers return `Content-Range` header instead of `Content-Length` in HEAD responses. This causes the download progress bar to not display the total file size during concurrent downloads.

**Example:** 
```bash 
$ curl -I 'https://cdn.crabnebula.app/asset/01KFBYACJVQEXTVPRRV97DCNPV'
# HTTP/2 200
# content-range: bytes 0-191050769/191050770
# content-disposition: attachment; filename="Conductor.app.tar.gz" 
# Note: no Content-Length header
```

## Solution
Fallback to parsing total size from Content-Range header when Content-Length is missing or zero.

According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Range, the header has these formats:
- `bytes <start>-<end>/<size> → extract <size>`
- `bytes */<size> (416 response) → extract <size>`
- `bytes <start>-<end>/* (unknown size) → return nil