### PR TITLE
dev-cmd/formula-analytics: fix non-standard prefix display

### DIFF
--- a/Library/Homebrew/dev-cmd/formula-analytics.rb
+++ b/Library/Homebrew/dev-cmd/formula-analytics.rb
@@ -170,6 +170,7 @@ module Homebrew
           when :homebrew_prefixes
             dimension_key = "prefix"
             groups = [:prefix, :os, :arch]
+            standard_prefixes = %w[/opt/homebrew /usr/local /home/linuxbrew/.linuxbrew]
           when :homebrew_versions
             dimension_key = "version"
             groups = [:version]
@@ -229,10 +230,11 @@ module Homebrew
                   "#{record["os"]} #{record["arch"]}"
                 end
               when :homebrew_prefixes
-                if record["prefix"] == "custom-prefix"
-                  "#{record["prefix"]} (#{record["os"]} #{record["arch"]})"
+                prefix = record["prefix"].to_s
+                if T.must(standard_prefixes).none? { |std| std.casecmp?(prefix) }
+                  "custom-prefix (#{record["os"]} #{record["arch"]})"
                 else
-                  record["prefix"].to_s
+                  prefix
                 end
               when :os_versions
                 format_os_version_dimension(record["os_name_and_version"])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
This PR adjusts the logic for sanitizing non-standard prefixes. Our current analytics data has a number of non-standard prefixes showing up.
