### PR TITLE
cask/test: create cask installer stub

### DIFF
--- a/Library/Homebrew/test/support/helper/cask/install_helper.rb
+++ b/Library/Homebrew/test/support/helper/cask/install_helper.rb
@@ -21,6 +21,35 @@ module InstallHelper
     end
   end
 
+  # Creates a minimal stub installation without downloading or extracting.
+  # This is useful for tests that only need to check installation state
+  # (installed?, installed_version) and artifact paths without performing
+  # actual file operations.
+  #
+  # @param cask [Cask::Cask] the cask to stub install
+  # @param create_app_dirs [Boolean] whether to create stub app directories in appdir
+  def self.stub_cask_installation(cask, create_app_dirs: true)
+    # Create the caskroom path
+    cask.caskroom_path.mkpath
+
+    # Create the staged_path (version directory)
+    cask.staged_path.mkpath
+
+    # Create metadata directory structure and save caskfile
+    # This makes installed? and installed_version work
+    Cask::Installer.new(cask).save_caskfile
+
+    return unless create_app_dirs
+
+    # Create stub app directories in appdir so path existence checks pass
+    cask.artifacts.each do |artifact|
+      next unless artifact.is_a?(Cask::Artifact::App)
+
+      target_path = cask.config.appdir.join(artifact.target.basename)
+      target_path.mkpath
+    end
+  end
+
   def install_without_artifacts(cask)
     Cask::Installer.new(cask).tap do |i|
       i.download


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This PR creates a new test method for using an installer stub for cask installs.
There are a number of tests that require an "installation" to exist but they don't actually make use of the installed files. The stub method creates a minimal installation that is detected for use in these instances.

The `cask/upgrade` test suite time has been reduced by 55% according to my testing.


Note: I use `claude-code` to help with the methodology for creating this new method. I had tried to optimise this test a few times unsuccessfully in the past, but this approach makes a lot of sense to me.
