### PR TITLE
Remove pre-Sierra locale workaround

### DIFF
--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -40,15 +40,6 @@ module Kernel
     with_env(PATH: PATH.new(ORIGINAL_PATHS).to_s, &block)
   end
 
-  sig {
-    type_parameters(:U)
-      .params(locale: String, block: T.proc.returns(T.type_parameter(:U)))
-      .returns(T.type_parameter(:U))
-  }
-  def with_custom_locale(locale, &block)
-    with_env(LC_ALL: locale, &block)
-  end
-
   # Kernel.system but with exceptions.
   sig {
     params(

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -21,18 +21,6 @@ RSpec.describe Kernel do
     end
   end
 
-  describe "#with_custom_locale" do
-    it "temporarily overrides the system locale" do
-      ENV["LC_ALL"] = "en_US.UTF-8"
-
-      with_custom_locale("C") do
-        expect(ENV.fetch("LC_ALL")).to eq("C")
-      end
-
-      expect(ENV.fetch("LC_ALL")).to eq("en_US.UTF-8")
-    end
-  end
-
   describe "#which" do
     let(:cmd) { dir/"foo" }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
This workaround was only needed for pre-Sierra macOS, which is no longer supported.