### PR TITLE
Enable strict typing in descriptions & search

### DIFF
--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -40,14 +40,14 @@ module Homebrew
       sig { override.void }
       def run
         search_type = if args.search?
-          :either
+          Descriptions::SearchField::Either
         elsif args.name?
-          :name
+          Descriptions::SearchField::Name
         elsif args.description?
-          :desc
+          Descriptions::SearchField::Description
         end
 
-        if search_type.present?
+        if search_type
           if !args.eval_all? && Homebrew::EnvConfig.no_install_from_api?
             raise UsageError, "`brew desc --search` needs `--eval-all` passed or `HOMEBREW_EVAL_ALL=1` set!"
           end

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "formula"
@@ -7,35 +7,58 @@ require "search"
 
 # Helper class for printing and searching descriptions.
 class Descriptions
+  # Enum for specifying which fields to search.
+  class SearchField < T::Enum
+    enums do
+      # enum values are not mutable, and calling .freeze on them breaks Sorbet
+      # rubocop:disable Style/MutableConstant
+      Name = new
+      Description = new
+      Either = new
+      # rubocop:enable Style/MutableConstant
+    end
+  end
+
   # Given a regex, find all formulae whose specified fields contain a match.
-  def self.search(string_or_regex, field, cache_store,
-                  eval_all = Homebrew::EnvConfig.eval_all?, cache_store_hash: false)
-    cache_store.populate_if_empty!(eval_all:) unless cache_store_hash
+  sig {
+    params(
+      string_or_regex: T.any(Regexp, String),
+      field:           SearchField,
+      cache_store:     T.any(DescriptionCacheStore, T::Hash[String, String], T::Hash[String, T::Array[T.nilable(String)]]),
+      eval_all:        T::Boolean,
+    ).returns(T.attached_class)
+  }
+  def self.search(string_or_regex, field, cache_store, eval_all = Homebrew::EnvConfig.eval_all?)
+    cache_store.populate_if_empty!(eval_all:) if cache_store.is_a?(DescriptionCacheStore)
 
     results = case field
-    when :name
+    when SearchField::Name
       Homebrew::Search.search(cache_store, string_or_regex) { |name, _| name }
-    when :desc
+    when SearchField::Description
       Homebrew::Search.search(cache_store, string_or_regex) { |_, desc| desc }
-    when :either
+    when SearchField::Either
       Homebrew::Search.search(cache_store, string_or_regex)
+    else
+      T.absurd(field)
     end
 
-    new(results)
+    new(T.cast(results, T.any(T::Hash[String, String], T::Hash[String, T::Array[String]])))
   end
 
   # Create an actual instance.
+  sig { params(descriptions: T.any(T::Hash[String, String], T::Hash[String, T::Array[String]])).void }
   def initialize(descriptions)
-    @descriptions = descriptions
+    @descriptions = T.let(descriptions, T.any(T::Hash[String, String], T::Hash[String, T::Array[String]]))
   end
 
   # Take search results -- a hash mapping formula names to descriptions -- and
   # print them.
+  sig { void }
   def print
     blank = Formatter.warning("[no description]")
     @descriptions.keys.sort.each do |full_name|
       short_name = short_names[full_name]
-      printed_name = if short_name_counts[short_name] == 1
+      printed_name = if short_name && short_name_counts[short_name] == 1
         short_name
       else
         full_name
@@ -53,15 +76,22 @@ class Descriptions
 
   private
 
+  sig { returns(T::Hash[String, String]) }
   def short_names
-    @short_names ||= @descriptions.keys.to_h { |k| [k, k.split("/").last] }
+    @short_names ||= T.let(
+      @descriptions.keys.to_h { |k| [k, k.split("/").fetch(-1)] },
+      T.nilable(T::Hash[String, String]),
+    )
   end
 
+  sig { returns(T::Hash[String, Integer]) }
   def short_name_counts
-    @short_name_counts ||=
+    @short_name_counts ||= T.let(
       short_names.values
                  .each_with_object(Hash.new(0)) do |name, counts|
         counts[name] += 1
-      end
+      end,
+      T.nilable(T::Hash[String, Integer]),
+    )
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
- Upgrade `descriptions.rb` and `search.rb` to `typed: strict`
- Add `Descriptions::SearchField` enum with `Name`, `Description`, and `Either` values to replace symbol-based field parameter
- Remove redundant `cache_store_hash` parameter by using `is_a?` check

Note that two sigs avoid the runtime component because the full type union isn't available at runtime. We could avoid this be defining an interface that those types implement (which would also make clearer the args type contract), but I didn't want to chew off too much type-based refactoring in this PR.

Contributes to #17297.