### PR TITLE
workflows/release: create an unversioned `.pkg`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,11 +276,10 @@ jobs:
             --generate-notes \
             --fail-on-no-commits
 
-      - name: Copy installer to unversioned path
-        if: github.event_name == 'workflow_dispatch'
+      - name: Rename installer to unversioned path
         env:
           INSTALLER_PATH: ${{ needs.build.outputs.installer_path }}
-        run: cp "${INSTALLER_PATH}" Homebrew.pkg
+        run: mv "${INSTALLER_PATH}" Homebrew.pkg
 
       - name: Upload installer to GitHub release
         if: github.event_name == 'workflow_dispatch'
@@ -290,4 +289,4 @@ jobs:
         run: |
           VERSION="${INSTALLER_PATH#Homebrew-}"
           VERSION="${VERSION%.pkg}"
-          gh release upload --repo Homebrew/brew "${VERSION}" "${INSTALLER_PATH}" Homebrew.pkg
+          gh release upload --repo Homebrew/brew "${VERSION}" Homebrew.pkg


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
This will allow us to have `https://github.com/Homebrew/brew/releases/latest/download/Homebrew.pkg` consistently offer the latest release. This will allow users to script installs, while preserving the versioned `.pkg`.

Closes https://github.com/Homebrew/brew/issues/21445.