### PR TITLE
kernel extension: move `truncate_text_to_approximate_size` to gist-logs

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -39,6 +39,39 @@ module Homebrew
         gistify_logs(formula)
       end
 
+      # Truncates a text string to fit within a byte size constraint,
+      # preserving character encoding validity. The returned string will
+      # be not much longer than the specified max_bytes, though the exact
+      # shortfall or overrun may vary.
+      sig { params(str: String, max_bytes: Integer, options: T::Hash[Symbol, T.untyped]).returns(String) }
+      def self.truncate_text_to_approximate_size(str, max_bytes, options = {})
+        front_weight = options.fetch(:front_weight, 0.5)
+        raise "opts[:front_weight] must be between 0.0 and 1.0" if front_weight < 0.0 || front_weight > 1.0
+        return str if str.bytesize <= max_bytes
+
+        glue = "\n[...snip...]\n"
+        max_bytes_in = [max_bytes - glue.bytesize, 1].max
+        bytes = str.dup.force_encoding("BINARY")
+        glue_bytes = glue.encode("BINARY")
+        n_front_bytes = (max_bytes_in * front_weight).floor
+        n_back_bytes = max_bytes_in - n_front_bytes
+        if n_front_bytes.zero?
+          front = bytes[1..0]
+          back = bytes[-max_bytes_in..]
+        elsif n_back_bytes.zero?
+          front = bytes[0..(max_bytes_in - 1)]
+          back = bytes[1..0]
+        else
+          front = bytes[0..(n_front_bytes - 1)]
+          back = bytes[-n_back_bytes..]
+        end
+        out = T.must(front) + glue_bytes + T.must(back)
+        out.force_encoding("UTF-8")
+        out.encode!("UTF-16", invalid: :replace)
+        out.encode!("UTF-8")
+        out
+      end
+
       private
 
       sig { params(formula: Formula).void }
@@ -127,7 +160,7 @@ module Homebrew
               contents = file.size? ? file.read : "empty log"
               # small enough to avoid GitHub "unicorn" page-load-timeout errors
               max_file_size = 1_000_000
-              contents = truncate_text_to_approximate_size(contents, max_file_size, front_weight: 0.2)
+              contents = GistLogs.truncate_text_to_approximate_size(contents, max_file_size, front_weight: 0.2)
               logs[file.relative_path_from(basedir).to_s.tr("/", ":")] = { content: contents }
             end
           end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -231,39 +231,6 @@ module Kernel
     numstr
   end
 
-  # Truncates a text string to fit within a byte size constraint,
-  # preserving character encoding validity. The returned string will
-  # be not much longer than the specified max_bytes, though the exact
-  # shortfall or overrun may vary.
-  sig { params(str: String, max_bytes: Integer, options: T::Hash[Symbol, T.untyped]).returns(String) }
-  def truncate_text_to_approximate_size(str, max_bytes, options = {})
-    front_weight = options.fetch(:front_weight, 0.5)
-    raise "opts[:front_weight] must be between 0.0 and 1.0" if front_weight < 0.0 || front_weight > 1.0
-    return str if str.bytesize <= max_bytes
-
-    glue = "\n[...snip...]\n"
-    max_bytes_in = [max_bytes - glue.bytesize, 1].max
-    bytes = str.dup.force_encoding("BINARY")
-    glue_bytes = glue.encode("BINARY")
-    n_front_bytes = (max_bytes_in * front_weight).floor
-    n_back_bytes = max_bytes_in - n_front_bytes
-    if n_front_bytes.zero?
-      front = bytes[1..0]
-      back = bytes[-max_bytes_in..]
-    elsif n_back_bytes.zero?
-      front = bytes[0..(max_bytes_in - 1)]
-      back = bytes[1..0]
-    else
-      front = bytes[0..(n_front_bytes - 1)]
-      back = bytes[-n_back_bytes..]
-    end
-    out = T.must(front) + glue_bytes + T.must(back)
-    out.force_encoding("UTF-8")
-    out.encode!("UTF-16", invalid: :replace)
-    out.encode!("UTF-8")
-    out
-  end
-
   # Calls the given block with the passed environment variables
   # added to `ENV`, then restores `ENV` afterwards.
   #

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -5,4 +5,33 @@ require "cmd/shared_examples/args_parse"
 
 RSpec.describe Homebrew::Cmd::GistLogs do
   it_behaves_like "parseable arguments"
+
+  describe ".truncate_text_to_approximate_size" do
+    let(:glue) { "\n[...snip...]\n" } # hard-coded copy from truncate_text_to_approximate_size
+
+    it "truncates long text to approximate size" do
+      n = 20
+      long_s = "x" * 40
+
+      s = described_class.truncate_text_to_approximate_size(long_s, n)
+      expect(s.length).to eq(n)
+      expect(s).to match(/^x+#{Regexp.escape(glue)}x+$/)
+    end
+
+    it "respects front_weight: 0.0" do
+      n = 20
+      long_s = "x" * 40
+
+      s = described_class.truncate_text_to_approximate_size(long_s, n, front_weight: 0.0)
+      expect(s).to eq(glue + ("x" * (n - glue.length)))
+    end
+
+    it "respects front_weight: 1.0" do
+      n = 20
+      long_s = "x" * 40
+
+      s = described_class.truncate_text_to_approximate_size(long_s, n, front_weight: 1.0)
+      expect(s).to eq(("x" * (n - glue.length)) + glue)
+    end
+  end
 end

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -74,22 +74,6 @@ RSpec.describe Kernel do
     end
   end
 
-  specify "#truncate_text_to_approximate_size" do
-    glue = "\n[...snip...]\n" # hard-coded copy from truncate_text_to_approximate_size
-    n = 20
-    long_s = "x" * 40
-
-    s = truncate_text_to_approximate_size(long_s, n)
-    expect(s.length).to eq(n)
-    expect(s).to match(/^x+#{Regexp.escape(glue)}x+$/)
-
-    s = truncate_text_to_approximate_size(long_s, n, front_weight: 0.0)
-    expect(s).to eq(glue + ("x" * (n - glue.length)))
-
-    s = truncate_text_to_approximate_size(long_s, n, front_weight: 1.0)
-    expect(s).to eq(("x" * (n - glue.length)) + glue)
-  end
-
   describe "#with_env" do
     it "sets environment variables within the block" do
       expect(ENV.fetch("PATH")).not_to eq("/bin")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Move `truncate_text_to_approximate_size` from `extend/kernel.rb` to `cmd/gist-logs.rb` as a public class method since `gist-logs` is its only caller. Move the corresponding specs as well. No need for this method to live in every object's ancestry.