### PR TITLE
formatter: move formatting methods from kernel

### DIFF
--- a/Library/Homebrew/cask/info.rb
+++ b/Library/Homebrew/cask/info.rb
@@ -72,7 +72,7 @@ module Cask
       tab = Tab.for_cask(cask)
 
       info = ["Installed"]
-      info << "#{versioned_staged_path} (#{disk_usage_readable(path_details)})"
+      info << "#{versioned_staged_path} (#{Formatter.disk_usage_readable(path_details)})"
       info << "  #{tab}" if tab.tabfile&.exist?
       info.join("\n")
     end

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -52,7 +52,7 @@ module Homebrew
         cleanup.clean!(quiet: args.quiet?, periodic: false)
 
         unless cleanup.disk_cleanup_size.zero?
-          disk_space = disk_usage_readable(cleanup.disk_cleanup_size)
+          disk_space = Formatter.disk_usage_readable(cleanup.disk_cleanup_size)
           if args.dry_run?
             ohai "This operation would free approximately #{disk_space} of disk space."
           else

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -338,8 +338,8 @@ module Homebrew
               bottle.fetch_tab(quiet: !args.debug?) if args.fetch_manifest?
               bottle_size = bottle.bottle_size
               installed_size = bottle.installed_size
-              puts "Bottle Size: #{disk_usage_readable(bottle_size)}" if bottle_size
-              puts "Installed Size: #{disk_usage_readable(installed_size)}" if installed_size
+              puts "Bottle Size: #{Formatter.disk_usage_readable(bottle_size)}" if bottle_size
+              puts "Installed Size: #{Formatter.disk_usage_readable(installed_size)}" if installed_size
             rescue RuntimeError => e
               odebug e
             end
@@ -432,14 +432,16 @@ module Homebrew
         ohai title
 
         total_size = items.sum(&:size)
-        total_size_str = disk_usage_readable(total_size)
+        total_size_str = Formatter.disk_usage_readable(total_size)
 
         name_width = (items.map { |item| item.name.length } + [5]).max
-        size_width = (items.map { |item| disk_usage_readable(item.size).length } + [total_size_str.length]).max
+        size_width = (items.map do |item|
+ Formatter.disk_usage_readable(item.size).length
+        end + [total_size_str.length]).max
 
         items.each do |item|
           puts format("%-#{name_width}s %#{size_width}s", item.name,
-                      disk_usage_readable(item.size))
+                      Formatter.disk_usage_readable(item.size))
         end
 
         puts format("%-#{name_width}s %#{size_width}s", "Total", total_size_str)

--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -301,14 +301,14 @@ module Homebrew
       size_length = 5
       unit_length = 2
       size_formatting_string = "%<size>#{size_length}.#{precision}f%<unit>#{unit_length}s"
-      size, unit = disk_usage_readable_size_unit(fetched_size, precision:)
+      size, unit = Formatter.disk_usage_readable_size_unit(fetched_size, precision:)
       formatted_fetched_size = format(size_formatting_string, size:, unit:)
 
       total_size = downloadable.total_size
       formatted_total_size = if future.fulfilled?
         formatted_fetched_size
       elsif total_size
-        size, unit = disk_usage_readable_size_unit(total_size, precision:)
+        size, unit = Formatter.disk_usage_readable_size_unit(total_size, precision:)
         format(size_formatting_string, size:, unit:)
       else
         # fill in the missing spaces for the size if we don't have it yet.

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -692,7 +692,7 @@ class ErrorDuringExecution < RuntimeError
       status.termsig
     end
 
-    redacted_cmd = redact_secrets(cmd.shelljoin.gsub('\=', "="), secrets)
+    redacted_cmd = Formatter.redact_secrets(cmd.shelljoin.gsub('\=', "="), secrets)
 
     reason = if exitstatus
       "exited with #{exitstatus}"

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -195,42 +195,6 @@ module Kernel
     Formulary.factory_stub(formula_name).ensure_installed!(reason:, latest:).opt_bin/name
   end
 
-  sig {
-    params(
-      size_in_bytes: T.any(Integer, Float),
-      precision:     T.nilable(Integer),
-    ).returns([T.any(Integer, Float), String])
-  }
-  def disk_usage_readable_size_unit(size_in_bytes, precision: nil)
-    size = size_in_bytes
-    unit = "B"
-    %w[KB MB GB].each do |next_unit|
-      break if (precision ? size.abs.round(precision) : size.abs) < 1000
-
-      size /= 1000.0
-      unit = next_unit
-    end
-    [size, unit]
-  end
-
-  sig { params(size_in_bytes: T.any(Integer, Float)).returns(String) }
-  def disk_usage_readable(size_in_bytes)
-    size, unit = disk_usage_readable_size_unit(size_in_bytes)
-    # avoid trailing zero after decimal point
-    if ((size * 10).to_i % 10).zero?
-      "#{size.to_i}#{unit}"
-    else
-      "#{format("%<size>.1f", size:)}#{unit}"
-    end
-  end
-
-  sig { params(number: Integer).returns(String) }
-  def number_readable(number)
-    numstr = number.to_i.to_s
-    (numstr.size - 3).step(1, -3) { |i| numstr.insert(i.to_i, ",") }
-    numstr
-  end
-
   # Calls the given block with the passed environment variables
   # added to `ENV`, then restores `ENV` afterwards.
   #
@@ -280,12 +244,5 @@ module Kernel
         a <=> b
       end
     end
-  end
-
-  sig { params(input: String, secrets: T::Array[String]).returns(String) }
-  def redact_secrets(input, secrets)
-    secrets.compact
-           .reduce(input) { |str, secret| str.gsub secret, "******" }
-           .freeze
   end
 end

--- a/Library/Homebrew/extend/pathname/disk_usage_extension.rb
+++ b/Library/Homebrew/extend/pathname/disk_usage_extension.rb
@@ -1,6 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
+require "utils/formatter"
+
 module DiskUsageExtension
   extend T::Helpers
 
@@ -28,8 +30,8 @@ module DiskUsageExtension
   def abv
     out = +""
     @file_count, @disk_usage = compute_disk_usage
-    out << "#{number_readable(@file_count)} files, " if @file_count > 1
-    out << disk_usage_readable(@disk_usage).to_s
+    out << "#{Formatter.number_readable(@file_count)} files, " if @file_count > 1
+    out << Formatter.disk_usage_readable(@disk_usage).to_s
     out.freeze
   end
 

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -451,10 +451,10 @@ module Homebrew
 
         puts "#{::Utils.pluralize("Formula", formulae.count)} \
 (#{formulae.count}): #{formulae.join(", ")}\n\n"
-        puts "Download Size: #{disk_usage_readable(sizes.fetch(:download))}"
-        puts "Install Size:  #{disk_usage_readable(sizes.fetch(:installed))}"
+        puts "Download Size: #{Formatter.disk_usage_readable(sizes.fetch(:download))}"
+        puts "Install Size:  #{Formatter.disk_usage_readable(sizes.fetch(:installed))}"
         if (net_install_size = sizes[:net]) && net_install_size != 0
-          puts "Net Install Size: #{disk_usage_readable(net_install_size)}"
+          puts "Net Install Size: #{Formatter.disk_usage_readable(net_install_size)}"
         end
 
         ask_input

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -132,7 +132,7 @@ class SystemCommand
 
   sig { returns(SystemCommand::Result) }
   def run!
-    $stderr.puts redact_secrets(command.shelljoin.gsub('\=', "="), @secrets) if verbose? && debug?
+    $stderr.puts Formatter.redact_secrets(command.shelljoin.gsub('\=', "="), @secrets) if verbose? && debug?
 
     @output = T.let([], T.nilable(T::Array[[Symbol, String]]))
     @output = T.must(@output)
@@ -142,17 +142,17 @@ class SystemCommand
       when :stdout
         case @print_stdout
         when true
-          $stdout << redact_secrets(line, @secrets)
+          $stdout << Formatter.redact_secrets(line, @secrets)
         when :debug
-          $stderr << redact_secrets(line, @secrets) if debug?
+          $stderr << Formatter.redact_secrets(line, @secrets) if debug?
         end
         @output << [:stdout, line]
       when :stderr
         case @print_stderr
         when true
-          $stderr << redact_secrets(line, @secrets)
+          $stderr << Formatter.redact_secrets(line, @secrets)
         when :debug
-          $stderr << redact_secrets(line, @secrets) if debug?
+          $stderr << Formatter.redact_secrets(line, @secrets) if debug?
         end
         @output << [:stderr, line]
       end

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -57,23 +57,6 @@ RSpec.describe Kernel do
     expect(which_editor).to eq("vemate -w")
   end
 
-  specify "#disk_usage_readable" do
-    expect(disk_usage_readable(1)).to eq("1B")
-    expect(disk_usage_readable(999)).to eq("999B")
-    expect(disk_usage_readable(1000)).to eq("1KB")
-    expect(disk_usage_readable(1025)).to eq("1KB")
-    expect(disk_usage_readable(4_404_020)).to eq("4.4MB")
-    expect(disk_usage_readable(4_509_715_660)).to eq("4.5GB")
-  end
-
-  describe "#number_readable" do
-    it "returns a string with thousands separators" do
-      expect(number_readable(1)).to eq("1")
-      expect(number_readable(1_000)).to eq("1,000")
-      expect(number_readable(1_000_000)).to eq("1,000,000")
-    end
-  end
-
   describe "#with_env" do
     it "sets environment variables within the block" do
       expect(ENV.fetch("PATH")).not_to eq("/bin")

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -124,4 +124,72 @@ RSpec.describe Formatter do
       expect(described_class.truncate("this is a long string", max: 10, omission: " [...]")).to eq("this [...]")
     end
   end
+
+  describe ".disk_usage_readable_size_unit" do
+    it "returns size and unit for bytes" do
+      expect(described_class.disk_usage_readable_size_unit(500)).to eq([500, "B"])
+    end
+
+    it "converts to KB for sizes >= 1000" do
+      size, unit = described_class.disk_usage_readable_size_unit(1500)
+      expect(unit).to eq("KB")
+      expect(size).to eq(1.5)
+    end
+
+    it "converts to MB for sizes >= 1000000" do
+      size, unit = described_class.disk_usage_readable_size_unit(2_500_000)
+      expect(unit).to eq("MB")
+      expect(size).to eq(2.5)
+    end
+
+    it "converts to GB for sizes >= 1000000000" do
+      size, unit = described_class.disk_usage_readable_size_unit(3_500_000_000)
+      expect(unit).to eq("GB")
+      expect(size).to eq(3.5)
+    end
+
+    it "respects precision parameter" do
+      _, unit = described_class.disk_usage_readable_size_unit(999.5, precision: 0)
+      expect(unit).to eq("KB")
+    end
+  end
+
+  describe ".disk_usage_readable" do
+    it "formats bytes as human-readable sizes" do
+      expect(described_class.disk_usage_readable(1)).to eq("1B")
+      expect(described_class.disk_usage_readable(999)).to eq("999B")
+      expect(described_class.disk_usage_readable(1000)).to eq("1KB")
+      expect(described_class.disk_usage_readable(1025)).to eq("1KB")
+      expect(described_class.disk_usage_readable(4_404_020)).to eq("4.4MB")
+      expect(described_class.disk_usage_readable(4_509_715_660)).to eq("4.5GB")
+    end
+  end
+
+  describe ".number_readable" do
+    it "returns a string with thousands separators" do
+      expect(described_class.number_readable(1)).to eq("1")
+      expect(described_class.number_readable(1_000)).to eq("1,000")
+      expect(described_class.number_readable(1_000_000)).to eq("1,000,000")
+    end
+  end
+
+  describe ".redact_secrets" do
+    it "replaces secrets with asterisks" do
+      expect(described_class.redact_secrets("password123", ["password123"])).to eq("******")
+    end
+
+    it "replaces multiple secrets" do
+      input = "user: admin, pass: secret"
+      expect(described_class.redact_secrets(input, ["admin", "secret"])).to eq("user: ******, pass: ******")
+    end
+
+    it "handles empty secrets array" do
+      expect(described_class.redact_secrets("keep this", [])).to eq("keep this")
+    end
+
+    it "returns frozen string" do
+      result = described_class.redact_secrets("test", ["foo"])
+      expect(result).to be_frozen
+    end
+  end
 end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -269,7 +269,7 @@ module Utils
               table_output(category, days.to_s, results)
             else
               total_count = results.values.inject("+")
-              analytics << "#{number_readable(total_count)} (#{days} days)"
+              analytics << "#{Formatter.number_readable(total_count)} (#{days} days)"
             end
           end
 
@@ -322,7 +322,7 @@ module Utils
         end
 
         ohai "GitHub Packages Downloads"
-        puts "#{number_readable(thirty_day_download_count)} (30 days)"
+        puts "#{Formatter.number_readable(thirty_day_download_count)} (30 days)"
       end
 
       sig { params(formula: Formula, args: Homebrew::Cmd::Info::Args).void }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Move `disk_usage_readable_size_unit`, `disk_usage_readable`, `number_readable`, and `redact_secrets` from `extend/kernel.rb` to `utils/formatter.rb` as class methods to avoid polluting the Object namespace. These methods are formatting utilities that fit better in the Formatter module. Move specs for `disk_usage_readable` and `number_readable`. Add missing specs for `disk_usage_readable_size_unit` and `redact_secrets`.

Update all call sites and move corresponding specs to formatter_spec.rb.