### PR TITLE
cask/list: move `tap_and_name_comparison` from kernel

### DIFF
--- a/Library/Homebrew/cask/list.rb
+++ b/Library/Homebrew/cask/list.rb
@@ -5,8 +5,21 @@ require "cask/artifact/relocated"
 require "utils/output"
 
 module Cask
-  class List
+  module List
     extend ::Utils::Output::Mixin
+
+    TAP_AND_NAME_COMPARISON = T.let(
+      proc do |a, b|
+        if a.include?("/") && b.exclude?("/")
+          1
+        elsif a.exclude?("/") && b.include?("/")
+          -1
+        else
+          a <=> b
+        end
+      end.freeze,
+      T.proc.params(a: String, b: String).returns(Integer),
+    )
 
     sig { params(casks: Cask, one: T::Boolean, full_name: T::Boolean, versions: T::Boolean).void }
     def self.list_casks(*casks, one: false, full_name: false, versions: false)
@@ -21,7 +34,7 @@ module Cask
       if one
         puts output.map(&:to_s)
       elsif full_name
-        puts output.map(&:full_name).sort(&tap_and_name_comparison)
+        puts output.map(&:full_name).sort(&TAP_AND_NAME_COMPARISON)
       elsif versions
         puts output.map { format_versioned(it) }
       elsif !output.empty? && casks.any?

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -89,7 +89,7 @@ module Homebrew
              args.poured_from_bottle? || args.built_from_source?)
           unless args.cask?
             formula_names = args.no_named? ? Formula.installed : args.named.to_resolved_formulae
-            full_formula_names = formula_names.map(&:full_name).sort(&tap_and_name_comparison)
+            full_formula_names = formula_names.map(&:full_name).sort(&Cask::List::TAP_AND_NAME_COMPARISON)
             full_formula_names = Formatter.columns(full_formula_names) unless args.public_send(:"1?")
             puts full_formula_names if full_formula_names.present?
           end
@@ -101,7 +101,7 @@ module Homebrew
             end
             # The cast is because `Keg`` does not define `full_name`
             full_cask_names = T.cast(cask_names, T::Array[T.any(Formula, Cask::Cask)])
-                               .map(&:full_name).sort(&tap_and_name_comparison)
+                               .map(&:full_name).sort(&Cask::List::TAP_AND_NAME_COMPARISON)
             full_cask_names = Formatter.columns(full_cask_names) unless args.public_send(:"1?")
             puts full_cask_names if full_cask_names.present?
           end
@@ -126,7 +126,7 @@ module Homebrew
             # See https://ruby-doc.org/3.2/Kernel.html#method-i-test
             Formula.installed.sort_by { |formula| T.cast(test("M", formula.rack.to_s), Time) }.reverse!
           elsif args.full_name?
-            Formula.installed.sort { |a, b| tap_and_name_comparison.call(a.full_name, b.full_name) }
+            Formula.installed.sort { |a, b| Cask::List::TAP_AND_NAME_COMPARISON.call(a.full_name, b.full_name) }
           else
             Formula.installed.sort
           end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -232,17 +232,4 @@ module Kernel
       ENV.update(old_values)
     end
   end
-
-  sig { returns(T.proc.params(a: String, b: String).returns(Integer)) }
-  def tap_and_name_comparison
-    proc do |a, b|
-      if a.include?("/") && b.exclude?("/")
-        1
-      elsif a.exclude?("/") && b.include?("/")
-        -1
-      else
-        a <=> b
-      end
-    end
-  end
 end

--- a/Library/Homebrew/test/cask/list_spec.rb
+++ b/Library/Homebrew/test/cask/list_spec.rb
@@ -113,4 +113,33 @@ RSpec.describe Cask::List, :cask do
       EOS
     end
   end
+
+  describe "TAP_AND_NAME_COMPARISON" do
+    describe "both strings are only names" do
+      it "alphabetizes the strings" do
+        expect(%w[a b].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
+        expect(%w[b a].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a b])
+      end
+    end
+
+    describe "both strings include tap" do
+      it "alphabetizes the strings" do
+        expect(%w[a/z/z b/z/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
+        expect(%w[b/z/z a/z/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[a/z/z b/z/z])
+
+        expect(%w[z/a/z z/b/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
+        expect(%w[z/b/z z/a/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/a/z z/b/z])
+
+        expect(%w[z/z/a z/z/b].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
+        expect(%w[z/z/b z/z/a].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z/z/a z/z/b])
+      end
+    end
+
+    describe "only one string includes tap" do
+      it "prefers the string without tap" do
+        expect(%w[a/z/z z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
+        expect(%w[z a/z/z].sort(&described_class::TAP_AND_NAME_COMPARISON)).to eq(%w[z a/z/z])
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test/extend/kernel_spec.rb
+++ b/Library/Homebrew/test/extend/kernel_spec.rb
@@ -86,33 +86,4 @@ RSpec.describe Kernel do
       expect(path).not_to eq("/bin")
     end
   end
-
-  describe "#tap_and_name_comparison" do
-    describe "both strings are only names" do
-      it "alphabetizes the strings" do
-        expect(%w[a b].sort(&tap_and_name_comparison)).to eq(%w[a b])
-        expect(%w[b a].sort(&tap_and_name_comparison)).to eq(%w[a b])
-      end
-    end
-
-    describe "both strings include tap" do
-      it "alphabetizes the strings" do
-        expect(%w[a/z/z b/z/z].sort(&tap_and_name_comparison)).to eq(%w[a/z/z b/z/z])
-        expect(%w[b/z/z a/z/z].sort(&tap_and_name_comparison)).to eq(%w[a/z/z b/z/z])
-
-        expect(%w[z/a/z z/b/z].sort(&tap_and_name_comparison)).to eq(%w[z/a/z z/b/z])
-        expect(%w[z/b/z z/a/z].sort(&tap_and_name_comparison)).to eq(%w[z/a/z z/b/z])
-
-        expect(%w[z/z/a z/z/b].sort(&tap_and_name_comparison)).to eq(%w[z/z/a z/z/b])
-        expect(%w[z/z/b z/z/a].sort(&tap_and_name_comparison)).to eq(%w[z/z/a z/z/b])
-      end
-    end
-
-    describe "only one string includes tap" do
-      it "prefers the string without tap" do
-        expect(%w[a/z/z z].sort(&tap_and_name_comparison)).to eq(%w[z a/z/z])
-        expect(%w[z a/z/z].sort(&tap_and_name_comparison)).to eq(%w[z a/z/z])
-      end
-    end
-  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Move `tap_and_name_comparison` from `extend/kernel.rb` to `cask/list.rb` as a class method since it's only used by the list commands. Update call sites in `cmd/list.rb` and move corresponding specs.