### PR TITLE
Remove computable elements from `FormulaStruct`

### DIFF
--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -21,7 +21,7 @@ module Homebrew
         :disable,
         :head,
         :keg_only,
-        :no_autobump_message,
+        :no_autobump,
         :pour_bottle,
         :service,
         :service_run,
@@ -117,7 +117,6 @@ module Homebrew
       const :pour_bottle_args, T::Hash[Symbol, Symbol], default: {}
       const :revision, Integer, default: 0
       const :ruby_source_checksum, String
-      const :ruby_source_path, String
       const :service_args, T::Array[[Symbol, BasicObject]], default: []
       const :service_name_args, T::Hash[Symbol, String], default: {}
       const :service_run_args, T::Array[Homebrew::Service::RunParam], default: []
@@ -125,7 +124,6 @@ module Homebrew
       const :stable_checksum, T.nilable(String)
       const :stable_url_args, [String, T::Hash[Symbol, T.anything]]
       const :stable_version, String
-      const :tap_git_head, String
       const :version_scheme, Integer, default: 0
       const :versioned_formulae, T::Array[String], default: []
 

--- a/Library/Homebrew/sorbet/rbi/dsl/homebrew/api/formula_struct.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/homebrew/api/formula_struct.rbi
@@ -22,7 +22,7 @@ class Homebrew::API::FormulaStruct
   def keg_only?; end
 
   sig { returns(T::Boolean) }
-  def no_autobump_message?; end
+  def no_autobump?; end
 
   sig { returns(T::Boolean) }
   def pour_bottle?; end


### PR DESCRIPTION
This PR removes `tap_git_head` and `ruby_source_path` from `FormulaStruct`.

`tap_git_head` is not formula-specific, so we don't want to waste space storing it for each formula (especially since it's the same for all formulae at any given time). Eventually, with the internal API, this will be a part of the top-level `formula.json` file with all homebrew/core data. Until then, we can manually extract it from the raw JSON data.

`ruby_source_path` is predictable for all homebrew/core formulae, so we can compute it with `Tap#new_formula_path` and save space in `FormulaStruct`.
