### PR TITLE
Serialize `FormulaStruct`s in the internal API

### DIFF
--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -29,6 +29,16 @@ module Homebrew
         :stable,
       ].freeze
 
+      SKIP_SERIALIZATION = [
+        # Bottle checksums have special serialization done by the serialize_bottle method
+        :bottle_checksums,
+      ].freeze
+
+      SPECS = [:head, :stable].freeze
+
+      # :any_skip_relocation is the most common in homebrew/core
+      DEFAULT_CELLAR = :any_skip_relocation
+
       DependsOnArgs = T.type_alias do
         T.any(
           # Dependencies
@@ -83,7 +93,7 @@ module Homebrew
       const :desc, String
       const :disable_args, T::Hash[Symbol, T.nilable(T.any(String, Symbol))], default: {}
       const :head_dependencies, T::Array[DependsOnArgs], default: []
-      const :head_url_args, [String, T::Hash[Symbol, T.anything]]
+      const :head_url_args, [String, T::Hash[Symbol, T.anything]], default: ["", {}]
       const :head_uses_from_macos, T::Array[UsesFromMacOSArgs], default: []
       const :homepage, String
       const :keg_only_args, T::Array[T.any(String, Symbol)], default: []
@@ -101,11 +111,201 @@ module Homebrew
       const :service_run_kwargs, T::Hash[Symbol, Homebrew::Service::RunParam], default: {}
       const :stable_dependencies, T::Array[DependsOnArgs], default: []
       const :stable_checksum, T.nilable(String)
-      const :stable_url_args, [String, T::Hash[Symbol, T.anything]]
+      const :stable_url_args, [String, T::Hash[Symbol, T.anything]], default: ["", {}]
       const :stable_uses_from_macos, T::Array[UsesFromMacOSArgs], default: []
       const :stable_version, String
       const :version_scheme, Integer, default: 0
       const :versioned_formulae, T::Array[String], default: []
+
+      sig { params(bottle_tag: ::Utils::Bottles::Tag).returns(T.nilable(T::Hash[String, T.untyped])) }
+      def serialize_bottle(bottle_tag: ::Utils::Bottles.tag)
+        bottle_collector = ::Utils::Bottles::Collector.new
+        bottle_checksums.each do |bottle_info|
+          bottle_info = bottle_info.dup
+          cellar = bottle_info.delete(:cellar) || :any
+          tag = T.must(bottle_info.keys.first)
+          checksum = T.cast(bottle_info.values.first, String)
+
+          bottle_collector.add(
+            ::Utils::Bottles::Tag.from_symbol(tag),
+            checksum: Checksum.new(checksum),
+            cellar:,
+          )
+        end
+        return unless (bottle_spec = bottle_collector.specification_for(bottle_tag))
+
+        tag = (bottle_spec.tag if bottle_spec.tag != bottle_tag)
+        cellar = (bottle_spec.cellar if bottle_spec.cellar != DEFAULT_CELLAR)
+
+        {
+          "bottle_tag"      => tag&.to_sym,
+          "bottle_cellar"   => cellar,
+          "bottle_checksum" => bottle_spec.checksum.to_s,
+        }
+      end
+
+      sig { params(bottle_tag: ::Utils::Bottles::Tag).returns(T::Hash[String, T.untyped]) }
+      def serialize(bottle_tag: ::Utils::Bottles.tag)
+        hash = self.class.decorator.all_props.filter_map do |prop|
+          next if PREDICATES.any? { |predicate| prop == :"#{predicate}_present" }
+          next if SKIP_SERIALIZATION.include?(prop)
+
+          [prop.to_s, send(prop)]
+        end.to_h
+
+        if (bottle_hash = serialize_bottle(bottle_tag:))
+          hash = hash.merge(bottle_hash)
+        end
+
+        hash = self.class.deep_stringify_symbols(hash)
+        self.class.deep_compact_blank(hash)
+      end
+
+      sig { params(hash: T::Hash[String, T.untyped], bottle_tag: ::Utils::Bottles::Tag).returns(FormulaStruct) }
+      def self.deserialize(hash, bottle_tag: ::Utils::Bottles.tag)
+        hash = deep_unstringify_symbols(hash)
+
+        # Items that don't follow the `hash["foo_present"] = hash["foo_args"].present?` pattern are overridden below
+        PREDICATES.each do |name|
+          hash["#{name}_present"] = hash["#{name}_args"].present?
+        end
+
+        if (bottle_checksum = hash["bottle_checksum"])
+          tag = hash.fetch("bottle_tag", bottle_tag.to_sym)
+          cellar = hash.fetch("bottle_cellar", DEFAULT_CELLAR)
+
+          hash["bottle_present"] = true
+          hash["bottle_checksums"] = [{ cellar: cellar, tag => bottle_checksum }]
+        else
+          hash["bottle_present"] = false
+        end
+
+        # *_url_args need to be in [String, Hash] format, but the hash may have been dropped if empty
+        SPECS.each do |key|
+          if (url_args = hash["#{key}_url_args"])
+            hash["#{key}_present"] = true
+            hash["#{key}_url_args"] = format_arg_pair(url_args, last: {})
+          else
+            hash["#{key}_present"] = false
+          end
+
+          next unless (uses_from_macos = hash["#{key}_uses_from_macos"])
+
+          hash["#{key}_uses_from_macos"] = uses_from_macos.map do |args|
+            format_arg_pair(args, last: {})
+          end
+        end
+
+        hash["service_args"] = if (service_args = hash["service_args"])
+          service_args.map { |service_arg| format_arg_pair(service_arg, last: nil) }
+        end
+
+        hash["conflicts"] = if (conflicts = hash["conflicts"])
+          conflicts.map { |conflict| format_arg_pair(conflict, last: {}) }
+        end
+
+        from_hash(hash)
+      end
+
+      # Format argument pairs into proper [first, last] format if serialization has removed some elements.
+      # Pass a default value for last to be used when only one element is present.
+      #
+      #  format_arg_pair(["foo"], last: {})                       # => ["foo", {}]
+      #  format_arg_pair([{ "foo" => :build }], last: {})         # => [{ "foo" => :build }, {}]
+      #  format_arg_pair(["foo", { since: :catalina }], last: {}) # => ["foo", { since: :catalina }]
+      sig {
+        type_parameters(:U, :V)
+          .params(
+            args: T.any([T.type_parameter(:U)], [T.type_parameter(:U), T.type_parameter(:V)]),
+            last: T.type_parameter(:V),
+          ).returns([T.type_parameter(:U), T.type_parameter(:V)])
+      }
+      def self.format_arg_pair(args, last:)
+        args = case args
+        in [elem]
+          [elem, last]
+        in [elem1, elem2]
+          [elem1, elem2]
+        end
+
+        # The case above is exhaustive so args will never be nil, but sorbet cannot infer that.
+        T.must(args)
+      end
+
+      # Converts a symbol to a string starting with `:`, otherwise returns the input.
+      #
+      #   stringify_symbol(:example)  # => ":example"
+      #   stringify_symbol("example") # => "example"
+      sig { params(value: T.any(String, Symbol)).returns(T.nilable(String)) }
+      def self.stringify_symbol(value)
+        return ":#{value}" if value.is_a?(Symbol)
+
+        value
+      end
+
+      sig { params(obj: T.untyped).returns(T.untyped) }
+      def self.deep_stringify_symbols(obj)
+        case obj
+        when String
+          # Escape leading : or \ to avoid confusion with stringified symbols
+          # ":foo" -> "\:foo"
+          # "\foo" -> "\\foo"
+          if obj.start_with?(":", "\\")
+            "\\#{obj}"
+          else
+            obj
+          end
+        when Symbol
+          ":#{obj}"
+        when Hash
+          obj.to_h { |k, v| [deep_stringify_symbols(k), deep_stringify_symbols(v)] }
+        when Array
+          obj.map { |v| deep_stringify_symbols(v) }
+        else
+          obj
+        end
+      end
+
+      sig { params(obj: T.untyped).returns(T.untyped) }
+      def self.deep_unstringify_symbols(obj)
+        case obj
+        when String
+          if obj.start_with?("\\")
+            obj[1..]
+          elsif obj.start_with?(":")
+            T.must(obj[1..]).to_sym
+          else
+            obj
+          end
+        when Hash
+          obj.to_h { |k, v| [deep_unstringify_symbols(k), deep_unstringify_symbols(v)] }
+        when Array
+          obj.map { |v| deep_unstringify_symbols(v) }
+        else
+          obj
+        end
+      end
+
+      sig {
+        type_parameters(:U)
+          .params(obj: T.all(T.type_parameter(:U), Object))
+          .returns(T.nilable(T.type_parameter(:U)))
+      }
+      def self.deep_compact_blank(obj)
+        obj = case obj
+        when Hash
+          obj.transform_values { |v| deep_compact_blank(v) }
+             .compact
+        when Array
+          obj.filter_map { |v| deep_compact_blank(v) }
+        else
+          obj
+        end
+
+        return if obj.blank? || (obj.is_a?(Numeric) && obj.zero?)
+
+        obj
+      end
     end
   end
 end

--- a/Library/Homebrew/test/api/formula_struct_spec.rb
+++ b/Library/Homebrew/test/api/formula_struct_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "api"
+
+RSpec.describe Homebrew::API::FormulaStruct do
+  describe "#serialize_bottle" do
+    def build_formula_struct(checksums)
+      Homebrew::API::FormulaStruct.new(
+        desc:                 "sample formula",
+        homepage:             "https://example.com",
+        license:              "MIT",
+        ruby_source_checksum: "abc123",
+        stable_version:       "1.0.0",
+        bottle_checksums:     checksums,
+      )
+    end
+
+    specify :aggregate_failures, :needs_macos do
+      struct = build_formula_struct([
+        { cellar: :any, arm64_sequoia: "checksum1" },
+        { cellar: :any_skip_relocation, sequoia: "checksum2" },
+        { cellar: "/opt/homebrew/Cellar", arm64_sonoma: "checksum3" },
+      ])
+
+      arm64_tahoe = Utils::Bottles::Tag.from_symbol(:arm64_tahoe)
+      arm64_sequoia = Utils::Bottles::Tag.from_symbol(:arm64_sequoia)
+      sequoia = Utils::Bottles::Tag.from_symbol(:sequoia)
+      arm64_sonoma = Utils::Bottles::Tag.from_symbol(:arm64_sonoma)
+      x86_64_linux = Utils::Bottles::Tag.from_symbol(:x86_64_linux)
+
+      expect(struct.serialize_bottle(bottle_tag: arm64_tahoe)).to eq(
+        {
+          "bottle_tag"      => :arm64_sequoia,
+          "bottle_cellar"   => :any,
+          "bottle_checksum" => "checksum1",
+        },
+      )
+
+      expect(struct.serialize_bottle(bottle_tag: arm64_sequoia)).to eq(
+        {
+          "bottle_tag"      => nil,
+          "bottle_cellar"   => :any,
+          "bottle_checksum" => "checksum1",
+        },
+      )
+
+      expect(struct.serialize_bottle(bottle_tag: sequoia)).to eq(
+        {
+          "bottle_tag"      => nil,
+          "bottle_cellar"   => nil,
+          "bottle_checksum" => "checksum2",
+        },
+      )
+
+      expect(struct.serialize_bottle(bottle_tag: arm64_sonoma)).to eq(
+        {
+          "bottle_tag"      => nil,
+          "bottle_cellar"   => "/opt/homebrew/Cellar",
+          "bottle_checksum" => "checksum3",
+        },
+      )
+
+      expect(struct.serialize_bottle(bottle_tag: x86_64_linux)).to be_nil
+    end
+
+    it "serializes bottle with all tag" do
+      all_struct = build_formula_struct([{ cellar: :any_skip_relocation, all: "checksum1" }])
+      all_struct_result = {
+        "bottle_tag"      => :all,
+        "bottle_cellar"   => nil,
+        "bottle_checksum" => "checksum1",
+      }
+
+      [:arm64_tahoe, :sequoia, :x86_64_linux].each do |tag_sym|
+        bottle_tag = Utils::Bottles::Tag.from_symbol(tag_sym)
+        expect(all_struct.serialize_bottle(bottle_tag: bottle_tag)).to eq(all_struct_result)
+      end
+    end
+  end
+
+  describe "::format_arg_pair" do
+    specify(:aggregate_failures) do
+      expect(described_class.format_arg_pair(["foo"], last: {})).to eq ["foo", {}]
+      expect(described_class.format_arg_pair([{ "foo" => :build }], last: {}))
+        .to eq [{ "foo" => :build }, {}]
+      expect(described_class.format_arg_pair([{ "foo" => :build, since: :catalina }], last: {}))
+        .to eq [{ "foo" => :build, since: :catalina }, {}]
+      expect(described_class.format_arg_pair(["foo", { since: :catalina }], last: {}))
+        .to eq ["foo", { since: :catalina }]
+
+      expect(described_class.format_arg_pair([:foo], last: nil)).to eq [:foo, nil]
+      expect(described_class.format_arg_pair([:foo, :bar], last: nil)).to eq [:foo, :bar]
+    end
+  end
+
+  describe "::stringify_symbol" do
+    specify(:aggregate_failures) do
+      expect(described_class.stringify_symbol(:example)).to eq(":example")
+      expect(described_class.stringify_symbol("example")).to eq("example")
+    end
+  end
+
+  describe "::deep_stringify_symbols and #deep_unstringify_symbols" do
+    it "converts all symbols in nested hashes and arrays", :aggregate_failures do
+      with_symbols = {
+        a: :symbol_a,
+        b: {
+          c: :symbol_c,
+          d: ["string_d", :symbol_d],
+        },
+        e: [:symbol_e1, { f: :symbol_f }],
+        g: "string_g",
+        h: ":not_a_symbol",
+        i: "\\also not a symbol", # literal: "\also not a symbol"
+      }
+
+      without_symbols = {
+        ":a" => ":symbol_a",
+        ":b" => {
+          ":c" => ":symbol_c",
+          ":d" => ["string_d", ":symbol_d"],
+        },
+        ":e" => [":symbol_e1", { ":f" => ":symbol_f" }],
+        ":g" => "string_g",
+        ":h" => "\\:not_a_symbol",       # literal: "\:not_a_symbol"
+        ":i" => "\\\\also not a symbol", # literal: "\\also not a symbol"
+      }
+
+      expect(described_class.deep_stringify_symbols(with_symbols)).to eq(without_symbols)
+      expect(described_class.deep_unstringify_symbols(without_symbols)).to eq(with_symbols)
+    end
+  end
+
+  describe "::deep_compact_blank" do
+    it "removes blank values from nested hashes and arrays" do
+      input = {
+        a: "",
+        b: [],
+        c: {},
+        d: {
+          e: "value",
+          f: nil,
+          g: {
+            h: "",
+            i: true,
+            j: {
+              k: nil,
+              l: "",
+            },
+          },
+          m: ["", nil],
+        },
+        n: [nil, "", 2, [], { o: nil }],
+        p: false,
+        q: 0,
+        r: 0.0,
+      }
+
+      expected_output = {
+        d: {
+          e: "value",
+          g: {
+            i: true,
+          },
+        },
+        n: [2],
+      }
+
+      expect(described_class.deep_compact_blank(input)).to eq(expected_output)
+    end
+  end
+end


### PR DESCRIPTION
This is a cleaner attempt of #21429.

I've added `serialize` and `deserialize` methods to `FormulaStruct` to efficiently store formula data in JSON format. After the simplifications made in #21455, the code needed to accomplish this is pretty straightforward.

The goal is that the only special handling needed in `FormulaStruct#serialize` and `FormulaStruct#deserialize` is for cases where there is a simpler way to store the data than is needed by `Formulary`. At the moment, the only two customizations needed are:

- bottle data: only need to store the relevant checksum (and can leave information like the bottle tag, cellar, and rebuild if they are the default values)
- dependency/`uses_from_macos` information: deduplicate dependencies that are both stable and head deps by storing shared dependencies separately

I also added a handful of methods to `Utils` so they can, eventually, be used by `CaskStruct`. I've added tests for all of these methods.
