### PR TITLE
cask/audit: don't expand full pkg in min_os audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -888,7 +888,7 @@ module Cask
           if artifact.is_a?(Artifact::Pkg)
             pkg_expanded_dir = tmpdir/"pkg-expanded"
             begin
-              system_command!("pkgutil", args: ["--expand-full", path.to_s, pkg_expanded_dir.to_s])
+              system_command!("pkgutil", args: ["--expand", path.to_s, pkg_expanded_dir.to_s])
 
               distribution_file = pkg_expanded_dir/"Distribution"
               if File.exist?(distribution_file)
@@ -900,8 +900,6 @@ module Cask
               end
             rescue
               break
-            ensure
-              FileUtils.remove_entry(pkg_expanded_dir) if pkg_expanded_dir.exist?
             end
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

We don't need to fully expand the `pkg` with `pkgutil` to access the Distribution file, so use the slimmer `--expand` option.
We also shouldn't need to clean up the files here as there is a global finaliser that handles the whole `tmpdir` in the `extract_artifacts` function.

This will also resolve: https://github.com/Homebrew/homebrew-cask/pull/246493