### PR TITLE
dev-cmd/bump-cask-pr: add autobump audit exceptions

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -167,7 +167,7 @@ module Homebrew
                                          silent:        args.quiet?)
 
         audit_exceptions = []
-        audit_exceptions << "min_os" if ENV["HOMEBREW_TEST_BOT_AUTOBUMP"].present?
+        audit_exceptions << ["min_os", "rosetta", "signing"] if ENV["HOMEBREW_TEST_BOT_AUTOBUMP"].present?
         run_cask_audit(cask, old_contents, audit_exceptions)
         run_cask_style(cask, old_contents)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

For `homebrew-cask`, the rosetta and signing audits are easily resolved, and would benefit from the same logic as the minimum OS audit, where we allow autobump PRs to be created by @BrewTestBot with certain failing audits. These issues can easily resolved using the GitHub editor in the PR and saves maintainers the time to create these PRs manually/locally.