### PR TITLE
Fix race condition in concurrent downloads for duplicate URLs

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -31,7 +31,6 @@ module Homebrew
       @spinner = T.let(nil, T.nilable(Spinner))
       @symlink_targets = T.let({}, T::Hash[Pathname, T::Set[Downloadable]])
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
-      @downloadable_to_location = T.let({}, T::Hash[Downloadable, Pathname])
     end
 
     sig {
@@ -47,8 +46,6 @@ module Homebrew
       targets = @symlink_targets.fetch(cached_location)
       targets << downloadable
 
-      @downloadable_to_location[downloadable] = cached_location
-
       @downloads_by_location[cached_location] ||= Concurrent::Promises.future_on(
         pool, RetryableDownload.new(downloadable, tries:, pour:),
         force, quiet, check_attestation
@@ -60,41 +57,40 @@ module Homebrew
         end
         create_symlinks_for_shared_download(cached_location)
       end
+
+      downloads[downloadable] = @downloads_by_location.fetch(cached_location)
     end
 
     sig { void }
     def fetch
-      return if @downloads_by_location.empty?
+      return if downloads.empty?
 
       context_before_fetch = Context.current
 
       if concurrency == 1
-        @downloads_by_location.each do |cached_location, promise|
+        downloads.each do |downloadable, promise|
           promise.wait!
         rescue ChecksumMismatchError => e
-          downloadable = @symlink_targets[cached_location]&.first
-          ofail "#{downloadable&.download_queue_type || "Download"} reports different checksum: #{e.expected}"
+          ofail "#{downloadable.download_queue_type} reports different checksum: #{e.expected}"
         rescue => e
-          downloadable = @symlink_targets[cached_location]&.first
-          raise e if downloadable.nil? || !bottle_manifest_error?(downloadable, e)
+          raise e unless bottle_manifest_error?(downloadable, e)
         end
       else
-        message_length_max = @downloads_by_location.keys.map { |location| location.basename.to_s.length }.max || 0
-        remaining_downloads = @downloads_by_location.dup.to_a
+        message_length_max = downloads.keys.map { |download| download.download_queue_message.length }.max || 0
+        remaining_downloads = downloads.dup.to_a
         previous_pending_line_count = 0
 
         begin
           stdout_print_and_flush_if_tty Tty.hide_cursor
 
-          output_message = lambda do |cached_location, future, last|
+          output_message = lambda do |downloadable, future, last|
             status = status_from_future(future)
             exception = future.reason if future.rejected?
-            downloadable = @symlink_targets[cached_location]&.first
-            next 1 if downloadable && bottle_manifest_error?(downloadable, exception)
+            next 1 if bottle_manifest_error?(downloadable, exception)
 
-            message = cached_location.basename.to_s
+            message = downloadable.download_queue_message
             if tty
-              message = message_with_progress(cached_location, future, message, message_length_max)
+              message = message_with_progress(downloadable, future, message, message_length_max)
               stdout_print_and_flush "#{status} #{message}#{"\n" unless last}"
             elsif status
               $stderr.puts "#{status} #{message}"
@@ -102,15 +98,15 @@ module Homebrew
 
             if future.rejected?
               if exception.is_a?(ChecksumMismatchError)
-                actual = Digest::SHA256.file(cached_location).hexdigest
-                download_type = downloadable&.download_queue_type || "Download"
-                actual_message, expected_message = align_checksum_mismatch_message(download_type)
+                actual = Digest::SHA256.file(downloadable.cached_download).hexdigest
+                actual_message, expected_message = align_checksum_mismatch_message(downloadable.download_queue_type)
 
                 ofail "#{actual_message} #{exception.expected}"
                 puts "#{expected_message} #{actual}"
                 next 2
               elsif exception.is_a?(CannotInstallFormulaError)
-                cached_location.unlink if cached_location.exist?
+                cached_download = downloadable.cached_download
+                cached_download.unlink if cached_download&.exist?
                 raise exception
               else
                 message = future.reason.to_s
@@ -130,20 +126,20 @@ module Homebrew
                 finished_states.include?(future.state)
               end
 
-              finished_downloads.each do |cached_location, future|
+              finished_downloads.each do |downloadable, future|
                 previous_pending_line_count -= 1
                 stdout_print_and_flush_if_tty Tty.clear_to_end
-                output_message.call(cached_location, future, false)
+                output_message.call(downloadable, future, false)
               end
 
               previous_pending_line_count = 0
               max_lines = [concurrency, Tty.height].min
-              remaining_downloads.each_with_index do |(cached_location, future), i|
+              remaining_downloads.each_with_index do |(downloadable, future), i|
                 break if previous_pending_line_count >= max_lines
 
                 stdout_print_and_flush_if_tty Tty.clear_to_end
                 last = i == max_lines - 1 || i == remaining_downloads.count - 1
-                previous_pending_line_count += output_message.call(cached_location, future, last)
+                previous_pending_line_count += output_message.call(downloadable, future, last)
               end
 
               if previous_pending_line_count.positive?
@@ -179,9 +175,9 @@ module Homebrew
       # Restore the pre-parallel fetch context to avoid e.g. quiet state bleeding out from threads.
       Context.current = context_before_fetch
 
+      downloads.clear
       @downloads_by_location.clear
       @symlink_targets.clear
-      @downloadable_to_location.clear
     end
 
     sig { params(message: String).void }
@@ -253,6 +249,11 @@ module Homebrew
     sig { returns(T::Boolean) }
     attr_reader :tty
 
+    sig { returns(T::Hash[Downloadable, Concurrent::Promises::Future]) }
+    def downloads
+      @downloads ||= T.let({}, T.nilable(T::Hash[Downloadable, Concurrent::Promises::Future]))
+    end
+
     sig { params(future: Concurrent::Promises::Future).returns(T.nilable(String)) }
     def status_from_future(future)
       case future.state
@@ -292,15 +293,12 @@ module Homebrew
       @spinner ||= Spinner.new
     end
 
-    sig { params(cached_location: Pathname, future: Concurrent::Promises::Future, message: String, message_length_max: Integer).returns(String) }
-    def message_with_progress(cached_location, future, message, message_length_max)
+    sig { params(downloadable: Downloadable, future: Concurrent::Promises::Future, message: String, message_length_max: Integer).returns(String) }
+    def message_with_progress(downloadable, future, message, message_length_max)
       tty_width = Tty.width
       return message unless tty_width.positive?
 
       available_width = tty_width - 2
-      downloadable = @symlink_targets[cached_location]&.first
-      return message[0, available_width].to_s if downloadable.nil?
-
       fetched_size = downloadable.fetched_size
       return message[0, available_width].to_s if fetched_size.blank?
 


### PR DESCRIPTION
Fix race condition in concurrent downloads for duplicate URLs

Root Cause:
The race condition occurs because download_queue.rb creates separate download futures for each Downloadable object. In the docbook formula, the same URL (docbook-5.2.zip) appears both as the main formula download and as a resource. Even though they point to the same file, they create different Downloadable objects, so both attempt to download simultaneously and lock the same .incomplete file.

Solution Approach:
Instead of tracking downloads by Downloadable object (which treats the formula and resource as separate downloads), I've implemented deduplication based on cached_location (the actual file path). This ensures that when multiple downloadables need the same file, they share a single download operation.

Result:
The docbook formula and its xml52 resource both need docbook-5.2.zip, but now only one download is initiated and both share it. No more lock conflicts!

When `HOMEBREW_DOWNLOAD_CONCURRENCY` is enabled and a formula has the same URL listed both as the main download and as a resource (e.g., docbook), concurrent download attempts would try to lock the same `.incomplete` file, causing an "operation in progress" error.

The issue was that `download_queue.rb` created separate download futures for each `Downloadable` object, even when multiple downloadables shared the same `cached_location` (file path). This resulted in race conditions when downloading identical files.

This commit fixes the issue by:
- Adding `@downloads_by_location` hash to track downloads by file path
- Deduplicating downloads based on `cached_location` instead of `Downloadable` object identity
- Ensuring multiple downloadables sharing the same file reuse the same download future

When the same file is needed by multiple downloadables, they now share a single download operation, preventing concurrent lock attempts on the same `.incomplete` file.

Fixes #21425

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?