### PR TITLE
help.sh: avoid heredoc for sandbox compatibility

### DIFF
--- a/Library/Homebrew/help.sh
+++ b/Library/Homebrew/help.sh
@@ -8,9 +8,7 @@
 #       and concision is important. If more help is needed we should start
 #       specialising help like the gem command does.
 # NOTE: Keep lines less than 80 characters! Wrapping is just not cricket.
-HOMEBREW_HELP_MESSAGE=$(
-  cat <<'EOS'
-Example usage:
+HOMEBREW_HELP_MESSAGE='Example usage:
   brew search TEXT|/REGEX/
   brew info [FORMULA|CASK...]
   brew install FORMULA|CASK...
@@ -32,9 +30,7 @@ Further help:
   brew commands
   brew help [COMMAND]
   man brew
-  https://docs.brew.sh
-EOS
-)
+  https://docs.brew.sh'
 
 homebrew-help() {
   if [[ -z "$*" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). (N/A)
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Heredocs create temporary files internally, which fails under sandbox restrictions:

```
/opt/homebrew/Library/Homebrew/help.sh: line 38: cannot create temp file for here document: Operation not permitted
```

Replace with a quoted string containing literal newlines.

## Related

- #21175 - `brew.sh`: avoid here-string for sandbox compatibility
- #21157 - `shellenv`: prefer lsof to ps for sandbox-compatible shell detection
