### PR TITLE
fix(caveats): avoid showing Rosetta 2 caveat on Intel machines

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -175,6 +175,13 @@ module Cask
       @dsl.os.present?
     end
 
+    # Mark that this cask has architecture-specific behavior,
+    # which triggers variation computation for different architectures.
+    sig { void }
+    def mark_on_system_blocks_exist!
+      @dsl.instance_variable_set(:@on_system_blocks_exist, true)
+    end
+
     # The caskfile is needed during installation when there are
     # `*flight` blocks or the cask has multiple languages
     def caskfile_only?

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -141,6 +141,7 @@ module Cask
       end
 
       caveat :requires_rosetta do
+        @cask.mark_on_system_blocks_exist!
         next if Homebrew::SimulateSystem.current_arch != :arm
 
         <<~EOS


### PR DESCRIPTION
## Summary

When a cask uses the `requires_rosetta` built-in caveat, mark `on_system_blocks_exist` on the DSL so that architecture variations are properly computed during API JSON generation.

## Problem

Intel Mac users see the Rosetta 2 caveat when installing casks via the API, even though Rosetta 2 is only needed on Apple Silicon Macs. This happens because:

1. The API JSON is generated while simulating ARM architecture
2. The `requires_rosetta` caveat includes the Rosetta warning in the base JSON
3. Variations for Intel architecture are NOT computed because `on_system_blocks_exist?` is `false` (the `requires_rosetta` caveat didn't set it)
4. When an Intel user installs the cask, they get the pre-computed ARM caveats without the Intel variation override

## Solution

Call `@cask.mark_on_system_blocks_exist!` in the `requires_rosetta` caveat to ensure architecture variations are computed. This means:
- ARM: Rosetta caveat is included (correct)
- Intel variation: Rosetta caveat is `nil` (correct - will override the base)

When the cask is loaded on an Intel machine via the API, `merge_variations` will apply the Intel variation which has no Rosetta caveat.

## Test

All changed-file tests pass with `brew tests --changed`.

Fixes #18365