### PR TITLE
Xml: expand test coverage

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -78,7 +78,6 @@ module Homebrew
         def self.items_from_content(content)
           require "rexml/document"
           xml = Xml.parse_xml(content)
-          return [] if xml.blank?
 
           # Remove prefixes, so we can reliably identify elements and attributes
           xml.root&.each_recursive do |node|

--- a/Library/Homebrew/livecheck/strategy/xml.rb
+++ b/Library/Homebrew/livecheck/strategy/xml.rb
@@ -54,8 +54,8 @@ module Homebrew
 
         # Parses XML text and returns an `REXML::Document` object.
         # @param content [String] the XML text to parse
-        # @return [REXML::Document, nil]
-        sig { params(content: String).returns(T.nilable(REXML::Document)) }
+        # @return [REXML::Document]
+        sig { params(content: String).returns(REXML::Document) }
         def self.parse_xml(content)
           parsing_tries = 0
           begin
@@ -117,9 +117,8 @@ module Homebrew
         def self.versions_from_content(content, regex = nil, &block)
           return [] if content.blank? || !block_given?
 
-          require "rexml"
+          require "rexml/document"
           xml = parse_xml(content)
-          return [] if xml.blank?
 
           block_return_value = if regex.present?
             yield(xml, regex)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This expands test coverage for livecheck's `Xml` strategy, bringing it to 100% coverage for lines and branches.

To achieve this, it was necessary to strengthen the return type of `parse_xml` and remove a related guard in `versions_from_content` that can never be true. `parse_xml` should only ever return an `REXML::Document` or raise an error, so it can't return `nil`.

Like https://github.com/Homebrew/brew/pull/21476, this is part of some overarching work to ensure that all strategy `find_versions` methods have a `content` parameter (except `ExtractPlist`) and to increase test coverage for all the strategies to 100%. Changing the `parse_xml` return type felt a little out of scope, so I split this into a separate PR.