### PR TITLE
Bump test-prof to 1.5.1

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
       yard-sorbet
-    test-prof (1.5.0)
+    test-prof (1.5.1)
     thor (1.5.0)
     tsort (0.2.0)
     unicode-display_width (3.2.0)

--- a/Library/Homebrew/sorbet/rbi/gems/test-prof@1.5.1.rbi
+++ b/Library/Homebrew/sorbet/rbi/gems/test-prof@1.5.1.rbi
@@ -105,6 +105,146 @@ module Process
   end
 end
 
+module RuboCop; end
+module RuboCop::Cop; end
+module RuboCop::Cop::RSpec; end
+
+class RuboCop::Cop::RSpec::AggregateExamples < ::RuboCop::Cop::Base
+  include ::RuboCop::Cop::RSpec::AggregateExamples::Its
+  include ::RuboCop::Cop::RSpec::Language
+  include ::RuboCop::Cop::RSpec::AggregateExamples::MatchersWithSideEffects
+  include ::RuboCop::Cop::RangeHelp
+  include ::RuboCop::Cop::RSpec::AggregateExamples::LineRangeHelpers
+  include ::RuboCop::Cop::RSpec::AggregateExamples::MetadataHelpers
+  include ::RuboCop::Cop::RSpec::AggregateExamples::NodeMatchers
+  extend ::RuboCop::Cop::AutoCorrector
+
+  def on_block(node); end
+
+  private
+
+  def aggregated_example(examples, metadata); end
+  def drop_example(corrector, example); end
+  def example_clusters(all_examples); end
+  def example_clusters_for_autocorrect(example_node); end
+  def message_for(example, first_example); end
+  def new_body(node); end
+  def transform_body(node, base_indent); end
+end
+
+module RuboCop::Cop::RSpec::AggregateExamples::Its
+  extend ::RuboCop::AST::NodePattern::Macros
+
+  def example_for_autocorrect?(param0 = T.unsafe(nil)); end
+  def its_with_multi_element_array_argument?(param0 = T.unsafe(nil)); end
+  def its_with_send_or_var_argument?(param0 = T.unsafe(nil)); end
+
+  private
+
+  def example_metadata(example); end
+  def its?(node); end
+  def new_body(node); end
+  def transform_its(body, arguments); end
+end
+
+module RuboCop::Cop::RSpec::AggregateExamples::LineRangeHelpers
+  include ::RuboCop::Cop::RangeHelp
+
+  private
+
+  def adjacent?(range, another_range); end
+  def range_for_replace(examples); end
+end
+
+RuboCop::Cop::RSpec::AggregateExamples::MSG = T.let(T.unsafe(nil), String)
+
+module RuboCop::Cop::RSpec::AggregateExamples::MatchersWithSideEffects
+  include ::RuboCop::Cop::RSpec::Language
+  extend ::RuboCop::AST::NodePattern::Macros
+
+  def example_for_autocorrect?(param0 = T.unsafe(nil)); end
+  def example_with_side_effects?(param0 = T.unsafe(nil)); end
+  def expectation_with_side_effects?(param0 = T.unsafe(nil)); end
+  def matcher_with_side_effects?(param0); end
+
+  private
+
+  def matcher_with_side_effects_name?(matcher_name); end
+  def matcher_with_side_effects_names; end
+  def message_for(example, first_example); end
+end
+
+RuboCop::Cop::RSpec::AggregateExamples::MatchersWithSideEffects::MSG_FOR_EXPECTATIONS_WITH_SIDE_EFFECTS = T.let(T.unsafe(nil), String)
+
+module RuboCop::Cop::RSpec::AggregateExamples::MetadataHelpers
+  private
+
+  def add_aggregate_failures_metadata?; end
+  def example_metadata(example); end
+  def metadata_for_aggregated_example(metadata); end
+  def metadata_pairs_without_aggegate_failures(metadata); end
+  def metadata_symbols_without_aggregate_failures(metadata); end
+  def metadata_without_aggregate_failures(example); end
+end
+
+module RuboCop::Cop::RSpec::AggregateExamples::NodeMatchers
+  include ::RuboCop::Cop::RSpec::Language
+  extend ::RuboCop::AST::NodePattern::Macros
+
+  def example_for_autocorrect?(param0 = T.unsafe(nil)); end
+  def example_group_with_several_examples(param0 = T.unsafe(nil)); end
+  def example_has_title?(param0 = T.unsafe(nil)); end
+  def example_with_expectations_only?(param0 = T.unsafe(nil)); end
+  def expectation?(param0 = T.unsafe(nil)); end
+  def single_expectation?(param0 = T.unsafe(nil)); end
+  def subject_with_no_args?(param0 = T.unsafe(nil)); end
+
+  private
+
+  def contains_heredoc?(node); end
+  def example_method?(method_name); end
+end
+
+module RuboCop::Cop::RSpec::Language; end
+module RuboCop::Cop::RSpec::Language::ExampleGroups; end
+RuboCop::Cop::RSpec::Language::ExampleGroups::ALL = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::ExampleGroups::FOCUSED = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::ExampleGroups::GROUPS = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::ExampleGroups::SKIPPED = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+module RuboCop::Cop::RSpec::Language::Examples; end
+RuboCop::Cop::RSpec::Language::Examples::ALL = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::Examples::EXAMPLES = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::Examples::FOCUSED = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::Examples::PENDING = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::Examples::SKIPPED = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+RuboCop::Cop::RSpec::Language::RSPEC = T.let(T.unsafe(nil), String)
+module RuboCop::Cop::RSpec::Language::Runners; end
+RuboCop::Cop::RSpec::Language::Runners::ALL = T.let(T.unsafe(nil), RuboCop::Cop::RSpec::Language::SelectorSet)
+
+class RuboCop::Cop::RSpec::Language::SelectorSet
+  def initialize(selectors); end
+
+  def +(other); end
+  def ==(other); end
+  def block_pattern; end
+  def include?(selector); end
+  def node_pattern; end
+  def node_pattern_union; end
+  def send_pattern; end
+
+  protected
+
+  def selectors; end
+end
+
+module RuboCop::TestProf; end
+
+class RuboCop::TestProf::Plugin < ::LintRoller::Plugin
+  def about; end
+  def rules(_context); end
+  def supported?(context); end
+end
+
 module TestProf
   extend ::TestProf::Logging
 

--- a/Library/Homebrew/test/rubocop_spec.rb
+++ b/Library/Homebrew/test/rubocop_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe "RuboCop" do
     end
 
     it "loads all Formula cops without errors" do
-      # TODO: Remove these args once TestProf fixes their RuboCop plugin.
+      # Work around the test-prof plugin's RuboCop version check, which is incompatible with Homebrew's ruby setup.
       test_prof_rubocop_args = [
         # Require "sorbet-runtime" to bring T into scope for warnings.rb
         "-r", "sorbet-runtime",
         # Require "extend/module" to include T::Sig in Module for warnings.rb
         "-r", HOMEBREW_LIBRARY_PATH/"extend/module.rb",
-        # Work around TestProf RuboCop plugin issues
+        # Load the test-prof RuboCop plugin manually to avoid issues with auto-loading (see test_prof_rubocop_stub.rb)
         "-r", HOMEBREW_LIBRARY_PATH/"utils/test_prof_rubocop_stub.rb"
       ]
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -31,8 +31,7 @@ Warnings.ignore :parser_syntax do
   require "rubocop"
 end
 
-# TODO: Remove this workaround once TestProf fixes their RuboCop plugin.
-# This is needed because the RuboCop RSpec plugin attempts to load TestProf's RuboCop plugin.
+# Load the test-prof RuboCop plugin manually to avoid issues with auto-loading (see test_prof_rubocop_stub.rb)
 require "utils/test_prof_rubocop_stub"
 
 require "rspec/github"

--- a/Library/Homebrew/utils/rubocop.rb
+++ b/Library/Homebrew/utils/rubocop.rb
@@ -9,7 +9,7 @@ Warnings.ignore :parser_syntax do
   require "rubocop"
 end
 
-# TODO: Remove this workaround once TestProf fixes their RuboCop plugin.
+# Load the test-prof RuboCop plugin manually to avoid issues with auto-loading (see test_prof_rubocop_stub.rb)
 require_relative "test_prof_rubocop_stub"
 
 exit RuboCop::CLI.new.run

--- a/Library/Homebrew/utils/test_prof_rubocop_stub.rb
+++ b/Library/Homebrew/utils/test_prof_rubocop_stub.rb
@@ -1,43 +1,8 @@
 # typed: strict
 # frozen_string_literal: true
 
-require_relative "../warnings"
-
-# TestProf's RuboCop plugin has two issues that we need to work around:
-#
-# 1. It references RuboCop::TestProf::Plugin::VERSION, which does not exist.
-#    To solve this, we define the constant ourselves, which requires creating a dummy LintRoller::Plugin class.
-#    This should be fixed in the next version of TestProf.
-#    See: https://github.com/test-prof/test-prof/commit/a151a513373563ed8fa7f8e56193138d3ee9b5e3
-#
-# 2. It checks the RuboCop version using a method that is incompatible with our RuboCop setup.
-#    To bypass this check, we need to manually require the necessary files. More details below.
-
-module LintRoller
-  # Dummy class to satisfy TestProf's reference to LintRoller::Plugin.
-  class Plugin; end # rubocop:disable Lint/EmptyClass
-end
-
-module RuboCop
-  module TestProf
-    class Plugin < LintRoller::Plugin
-      VERSION = "1.5.0"
-    end
-  end
-end
-
-# TestProf is not able to detect what version of RuboCop we're using, so we need to manually import its cops.
-# For more details, see https://github.com/test-prof/test-prof/blob/v1.5.0/lib/test_prof/rubocop.rb
-# TODO: This will change in the next version of TestProf.
-#       See: https://github.com/test-prof/test-prof/commit/a151a513373563ed8fa7f8e56193138d3ee9b5e3
-Warnings.ignore(/TestProf cops require RuboCop >= 0.51.0 to run/) do
-  # All this file does is check the RuboCop version and require the files below.
-  # If we don't require this now while the warning is ignored, we'll see the warning again later
-  # when RuboCop requires the file.
-  require "test_prof/rubocop"
-
-  # This is copied from test-prof/rubocop.rb, and is necessary because that file returns early if the RuboCop version
-  # check isn't met.
-  require "test_prof/cops/plugin"
-  require "test_prof/cops/rspec/aggregate_examples"
-end
+# TestProf attempts to check for a supported RuboCop version using a method that is incompatible with our setup.
+# We load the TestProf plugin manually (as opposed to letting RuboCop automatically load it) to prevent the version check from running.
+# The `require` calls are copied from https://github.com/test-prof/test-prof/blob/v1.5.1/lib/rubocop/test_prof.rb
+require "rubocop/test_prof/plugin"
+require "rubocop/test_prof/cops/rspec/aggregate_examples"

--- a/Library/Homebrew/vendor/bundle/bundler/setup.rb
+++ b/Library/Homebrew/vendor/bundle/bundler/setup.rb
@@ -123,7 +123,7 @@ $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/yard-0.9.38/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/yard-sorbet-0.9.0/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/tapioca-0.17.10/lib")
-$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/test-prof-1.5.0/lib")
+$:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/test-prof-1.5.1/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/extensions/arm64-darwin-20/#{Gem.extension_api_version}/vernier-1.9.0")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/vernier-1.9.0/lib")
 $:.unshift File.expand_path("#{__dir__}/../#{RUBY_ENGINE}/#{Gem.ruby_api_version}/gems/warning-1.5.0/lib")


### PR DESCRIPTION
Bump `test-prof` to `1.5.1`, which fixes (sort of) the RuboCop plugin issues.

@SMillerDev and I did some digging, and the reason `test-prof` is unable to detect our RuboCop version is that we intentionally (although I don't know the reason) use the original `Kernal.require` implementation, rather than the overloaded method provided by RubyGems. Because of this, `Gem.loaded_specs` is not updated when we run `require "rubocop"`, and `test-prof` is unable to see that we have RuboCop installed at all.

So, as a workaround, we can just manually require the plugin files. Once the plugin modules have been loaded, RuboCop can access them directly, and will not attempt to `require` the file containing the version check, effectively bypassing it.

It seems like this is going to be a long-standing patch, so I've removed the `TODO` comments.
