### PR TITLE
HeaderMatch: add content parameter, expand tests

### DIFF
--- a/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/header_match_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
   let(:http_url) { "https://brew.sh/blog/" }
   let(:non_http_url) { "ftp://brew.sh/" }
 
-  let(:versions) do
-    versions = {
-      content_disposition: ["1.2.3"],
-      location:            ["1.2.4"],
+  let(:regexes) do
+    {
+      archive: /filename=brew[._-]v?(\d+(?:\.\d+)+)\.t/i,
+      latest:  %r{.*?/tag/v?(\d+(?:\.\d+)+)$}i,
+      loose:   /v?(\d+(?:\.\d+)+)/i,
     }
-    versions[:content_disposition_and_location] = versions[:content_disposition] + versions[:location]
-
-    versions
   end
 
   let(:headers) do
@@ -24,26 +22,32 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
         "date"                => "Fri, 01 Jan 2021 01:23:45 GMT",
         "content-type"        => "application/x-gzip",
         "content-length"      => "120",
-        "content-disposition" => "attachment; filename=brew-#{versions[:content_disposition].first}.tar.gz",
+        "content-disposition" => "attachment; filename=brew-1.2.3.tar.gz",
       },
       location:            {
         "date"           => "Fri, 01 Jan 2021 01:23:45 GMT",
         "content-type"   => "text/html; charset=utf-8",
-        "location"       => "https://github.com/Homebrew/brew/releases/tag/#{versions[:location].first}",
+        "location"       => "https://github.com/Homebrew/brew/releases/tag/1.2.4",
         "content-length" => "117",
       },
     }
     headers[:content_disposition_and_location] = headers[:content_disposition].merge(headers[:location])
+    headers[:no_version] = headers[:content_disposition_and_location].merge({
+      "content-disposition" => "attachment; filename=brew.tar.gz",
+      "location"            => http_url,
+    })
 
     headers
   end
 
-  let(:regexes) do
-    {
-      archive: /filename=brew[._-]v?(\d+(?:\.\d+)+)\.t/i,
-      latest:  %r{.*?/tag/v?(\d+(?:\.\d+)+)$}i,
-      loose:   /v?(\d+(?:\.\d+)+)/i,
+  let(:matches) do
+    matches = {
+      content_disposition: ["1.2.3"],
+      location:            ["1.2.4"],
     }
+    matches[:content_disposition_and_location] = matches[:content_disposition] + matches[:location]
+
+    matches
   end
 
   describe "::match?" do
@@ -56,61 +60,123 @@ RSpec.describe Homebrew::Livecheck::Strategy::HeaderMatch do
     end
   end
 
-  describe "::versions_from_headers" do
+  describe "::versions_from_content" do
     it "returns an empty array if headers hash is empty" do
-      expect(header_match.versions_from_headers({})).to eq([])
+      expect(header_match.versions_from_content({})).to eq([])
+    end
+
+    it "returns an empty array if checked headers do not contain versions" do
+      expect(header_match.versions_from_content(headers[:no_version])).to eq([])
     end
 
     it "returns an array of version strings when given headers" do
-      expect(header_match.versions_from_headers(headers[:content_disposition])).to eq(versions[:content_disposition])
-      expect(header_match.versions_from_headers(headers[:location])).to eq(versions[:location])
-      expect(header_match.versions_from_headers(headers[:content_disposition_and_location]))
-        .to eq(versions[:content_disposition_and_location])
+      expect(header_match.versions_from_content(headers[:content_disposition])).to eq(matches[:content_disposition])
+      expect(header_match.versions_from_content(headers[:location])).to eq(matches[:location])
+      expect(header_match.versions_from_content(headers[:content_disposition_and_location]))
+        .to eq(matches[:content_disposition_and_location])
 
-      expect(header_match.versions_from_headers(headers[:content_disposition], regexes[:archive]))
-        .to eq(versions[:content_disposition])
-      expect(header_match.versions_from_headers(headers[:location], regexes[:latest])).to eq(versions[:location])
-      expect(header_match.versions_from_headers(headers[:content_disposition_and_location], regexes[:latest]))
-        .to eq(versions[:location])
+      expect(header_match.versions_from_content(headers[:content_disposition], regexes[:archive]))
+        .to eq(matches[:content_disposition])
+      expect(header_match.versions_from_content(headers[:location], regexes[:latest])).to eq(matches[:location])
+      expect(header_match.versions_from_content(headers[:content_disposition_and_location], regexes[:latest]))
+        .to eq(matches[:location])
     end
 
     it "returns an array of version strings when given headers and a block" do
       # Returning a string from block, no regex.
       expect(
-        header_match.versions_from_headers(headers[:location]) do |headers|
+        header_match.versions_from_content(headers[:location]) do |headers|
           v = Version.parse(headers["location"], detected_from_url: true)
           v.null? ? nil : v.to_s
         end,
-      ).to eq(versions[:location])
+      ).to eq(matches[:location])
 
       # Returning a string from block, explicit regex.
       expect(
-        header_match.versions_from_headers(headers[:location], regexes[:latest]) do |headers, regex|
+        header_match.versions_from_content(headers[:location], regexes[:latest]) do |headers, regex|
           headers["location"] ? headers["location"][regex, 1] : nil
         end,
-      ).to eq(versions[:location])
+      ).to eq(matches[:location])
 
       # Returning an array of strings from block.
       #
       # NOTE: Strategies runs `#compact` on an array from a block, so nil values
       #       are filtered out without needing to use `#compact` in the block.
       expect(
-        header_match.versions_from_headers(
+        header_match.versions_from_content(
           headers[:content_disposition_and_location],
           regexes[:loose],
         ) do |headers, regex|
           headers.transform_values { |header| header[regex, 1] }.values
         end,
-      ).to eq(versions[:content_disposition_and_location])
+      ).to eq(matches[:content_disposition_and_location])
     end
 
     it "allows a nil return from a block" do
-      expect(header_match.versions_from_headers(headers[:location]) { next }).to eq([])
+      expect(header_match.versions_from_content(headers[:location]) { next }).to eq([])
     end
 
     it "errors on an invalid return type from a block" do
-      expect { header_match.versions_from_headers(headers) { 123 } }
-        .to raise_error(TypeError, /Parameter 'headers': Expected type T::Hash\[String, String\]/o)
+      expect { header_match.versions_from_content(headers[:location]) { 123 } }
+        .to raise_error(TypeError, Homebrew::Livecheck::Strategy::INVALID_BLOCK_RETURN_VALUE_MSG)
+    end
+  end
+
+  describe "::find_versions" do
+    let(:content) do
+      require "json"
+      JSON.generate([headers[:location]])
+    end
+    let(:match_data) do
+      base = {
+        matches: matches[:location].to_h { |v| [v, Version.new(v)] },
+        regex:   nil,
+        url:     http_url,
+      }
+
+      {
+        fetched:        base.merge({ content: }),
+        cached:         base.merge({ cached: true }),
+        cached_default: base.merge({ matches: {}, cached: true }),
+      }
+    end
+
+    it "finds versions in fetched content" do
+      allow(Homebrew::Livecheck::Strategy).to receive(:page_headers).and_return([headers[:location]])
+
+      expect(header_match.find_versions(url: http_url)).to eq(match_data[:fetched])
+    end
+
+    it "finds versions in provided content" do
+      expect(header_match.find_versions(url: http_url, provided_content: content))
+        .to eq(match_data[:cached])
+
+      # This `strategy` block is unnecessary but it's intended to test using a
+      # regex in a `strategy` block.
+      expect(
+        header_match.find_versions(
+          url:              http_url,
+          regex:            regexes[:latest],
+          provided_content: content,
+        ) do |headers, regex|
+          match = headers["location"]&.match(regex)
+          next if match.blank?
+
+          match[1]
+        end,
+      ).to eq(match_data[:cached].merge({ regex: regexes[:latest] }))
+    end
+
+    it "returns default match_data when url is blank" do
+      expect(header_match.find_versions(url: "", provided_content: content))
+        .to eq(match_data[:cached_default].merge({ url: "" }))
+    end
+
+    it "returns default match_data when content is blank" do
+      expect(header_match.find_versions(url: http_url, provided_content: "[]"))
+        .to eq(match_data[:cached_default])
+      expect(header_match.find_versions(url: http_url, provided_content: "[{}]"))
+        .to eq(match_data[:cached_default])
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This adds a `provided_content` parameter to `HeaderMatch#find_versions` and expands test coverage to 100% for both lines and branches. One thing to note is that the `content` returned from `Strategy.page_headers` is an array of header hashes, so we have to serialize the object to use it as cached content and this uses `JSON.generate` for that. Header hashes have a string key and value, so `content` is easily converted to/from JSON.

I decided to use the original value from `page_headers` (from before `content.reduce(&:merge)` is called) as the returned `content` value instead of `merged_headers` as it allows for more flexibility. For example, we may need to check specific response headers in a series of redirections in a `strategy` block (instead of only the last values) and this setup would make that easier to implement in the future.

This also renames `versions_from_headers` to `versions_from_content` to align with other strategies.