### PR TITLE
Add aliases and renames to internal API

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-formula-api.rb
+++ b/Library/Homebrew/dev-cmd/generate-formula-api.rb
@@ -77,8 +77,10 @@ module Homebrew
 
             json_contents = {
               formulae:,
-              tap_git_head:   CoreTap.instance.git_head,
-              tap_migrations: CoreTap.instance.tap_migrations,
+              aliases:        tap.alias_table,
+              renames:        tap.formula_renames,
+              tap_git_head:   tap.git_head,
+              tap_migrations: tap.tap_migrations,
             }
 
             File.write("api/internal/formula.#{bottle_tag}.json", JSON.generate(json_contents)) unless args.dry_run?


### PR DESCRIPTION
Follow-up to #21456

I realized that aliases and renames _are_ actually required here, because that information isn't reflected in `FormulaStruct`s. It does make file sizes slightly bigger, but still substantially better:

Uncompressed:

```console
$ dua api/internal/
   5.46 MB formula.catalina.json
   5.49 MB formula.arm64_big_sur.json
   5.49 MB formula.big_sur.json
   5.54 MB formula.arm64_monterey.json
   5.54 MB formula.monterey.json
   5.67 MB formula.arm64_ventura.json
   5.67 MB formula.ventura.json
   6.00 MB formula.arm64_linux.json
   6.00 MB formula.x86_64_linux.json
   6.04 MB formula.sonoma.json
   6.04 MB formula.arm64_sonoma.json
   6.05 MB formula.arm64_sequoia.json
   6.05 MB formula.arm64_tahoe.json
   6.20 MB formula.sequoia.json
   6.20 MB formula.tahoe.json
  87.43 MB total
```

Compressed:

```console
$ dua
   1.57 MB formula.catalina.json.gz
   1.58 MB formula.arm64_big_sur.json.gz
   1.58 MB formula.big_sur.json.gz
   1.60 MB formula.arm64_monterey.json.gz
   1.60 MB formula.monterey.json.gz
   1.66 MB formula.arm64_ventura.json.gz
   1.66 MB formula.ventura.json.gz
   1.82 MB formula.arm64_linux.json.gz
   1.82 MB formula.x86_64_linux.json.gz
   1.83 MB formula.arm64_sequoia.json.gz
   1.83 MB formula.arm64_sonoma.json.gz
   1.83 MB formula.arm64_tahoe.json.gz
   1.83 MB formula.sonoma.json.gz
   1.83 MB formula.sequoia.json.gz
   1.83 MB formula.tahoe.json.gz
  25.87 MB total
```
