### PR TITLE
Remove most formula stub references

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -753,7 +753,7 @@ module Homebrew
           next if arg.match?(HOMEBREW_CASK_TAP_CASK_REGEX)
 
           begin
-            Formulary.factory_stub(arg, spec, flags: argv.select { |a| a.start_with?("--") })
+            Formulary.factory(arg, spec, flags: argv.select { |a| a.start_with?("--") })
           rescue FormulaUnavailableError, FormulaSpecificationError
             nil
           end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -93,7 +93,7 @@ module Homebrew
 
             if verbose?
               outdated_kegs = f.outdated_kegs(fetch_head: args.fetch_HEAD?)
-              latest_formula = f.latest_formula(prefer_stub: true)
+              latest_formula = f.latest_formula
 
               current_version = if f.alias_changed? && !latest_formula.latest_version_installed?
                 "#{latest_formula.name} (#{latest_formula.pkg_version})"

--- a/Library/Homebrew/cmd/version-install.rb
+++ b/Library/Homebrew/cmd/version-install.rb
@@ -71,7 +71,7 @@ module Homebrew
         install_target = "#{existing_tap}/#{versioned_name}" if existing_tap
 
         versioned_formula = begin
-          Formulary.factory(versioned_ref, warn: false, prefer_stub: true)
+          Formulary.factory(versioned_ref, warn: false)
         rescue TapFormulaAmbiguityError, FormulaUnavailableError, TapFormulaUnavailableError,
                TapFormulaUnreadableError
           nil
@@ -82,7 +82,7 @@ module Homebrew
             versioned_formula.full_name
           else
             current_formula = begin
-              Formulary.factory(formula_input, warn: false, prefer_stub: true)
+              Formulary.factory(formula_input, warn: false)
             rescue FormulaUnavailableError, TapFormulaUnavailableError, TapFormulaUnreadableError
               nil
             end

--- a/Library/Homebrew/extend/kernel.rb
+++ b/Library/Homebrew/extend/kernel.rb
@@ -192,7 +192,7 @@ module Kernel
     return executable if executable
 
     require "formula"
-    Formulary.factory_stub(formula_name).ensure_installed!(reason:, latest:).opt_bin/name
+    Formula[formula_name].ensure_installed!(reason:, latest:).opt_bin/name
   end
 
   # Calls the given block with the passed environment variables

--- a/Library/Homebrew/extend/os/mac/pkgconf.rb
+++ b/Library/Homebrew/extend/os/mac/pkgconf.rb
@@ -11,7 +11,7 @@ module Homebrew
       return if OS::Mac.version.prerelease? || OS::Mac.version.outdated_release?
 
       pkgconf = begin
-        ::Formulary.factory_stub("pkgconf")
+        ::Formula["pkgconf"]
       rescue FormulaUnavailableError
         nil
       end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -490,7 +490,7 @@ class Pathname
     @which_install_info ||=
       if File.executable?("/usr/bin/install-info")
         "/usr/bin/install-info"
-      elsif (texinfo_formula = Formulary.factory_stub("texinfo")).any_version_installed?
+      elsif (texinfo_formula = Formula["texinfo"]).any_version_installed?
         (texinfo_formula.opt_bin/"install-info").to_s
       end
   end

--- a/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
+++ b/Library/Homebrew/sorbet/rbi/dsl/formula.rbi
@@ -118,9 +118,6 @@ class Formula
   def loaded_from_api?(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
-  def loaded_from_stub?(*args, &block); end
-
-  sig { params(args: T.untyped, block: T.untyped).returns(T::Boolean) }
   def network_access_allowed?(*args, &block); end
 
   sig { params(args: T.untyped, block: T.untyped).returns(T.untyped) }

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -328,21 +328,18 @@ module Homebrew
 
     def self.shellcheck
       require "formula"
-      shellcheck_stub = Formulary.factory_stub("shellcheck")
-      shellcheck_stub.ensure_installed!(latest: true, reason: "shell style checks").opt_bin/"shellcheck"
+      Formula["shellcheck"].ensure_installed!(latest: true, reason: "shell style checks").opt_bin/"shellcheck"
     end
 
     def self.shfmt
       require "formula"
-      shfmt_stub = Formulary.factory_stub("shfmt")
-      shfmt_stub.ensure_installed!(latest: true, reason: "formatting shell scripts")
+      Formula["shfmt"].ensure_installed!(latest: true, reason: "formatting shell scripts")
       HOMEBREW_LIBRARY/"Homebrew/utils/shfmt.sh"
     end
 
     def self.actionlint
       require "formula"
-      actionlint_stub = Formulary.factory_stub("actionlint")
-      actionlint_stub.ensure_installed!(latest: true, reason: "GitHub Actions checks").opt_bin/"actionlint"
+      Formula["actionlint"].ensure_installed!(latest: true, reason: "GitHub Actions checks").opt_bin/"actionlint"
     end
 
     # Collection of style offenses.

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe Homebrew::Diagnostic::Checks do
     let(:tab) { instance_double(Tab, built_on: { "os_version" => "13" }) }
 
     before do
-      allow(Formulary).to receive(:factory_stub).with("pkgconf").and_return(pkg_config_formula)
+      allow(Formula).to receive(:[]).with("pkgconf").and_return(pkg_config_formula)
       allow(Tab).to receive(:for_formula).with(pkg_config_formula).and_return(tab)
     end
 
     it "doesn't trigger when pkgconf is not installed" do
-      allow(Formulary).to receive(:factory_stub).with("pkgconf").and_raise(FormulaUnavailableError.new("pkgconf"))
+      allow(Formula).to receive(:[]).with("pkgconf").and_raise(FormulaUnavailableError.new("pkgconf"))
 
       expect(checks.check_pkgconf_macos_sdk_mismatch).to be_nil
     end


### PR DESCRIPTION
Now that we're moving away from the formula stub approach, let's remove a bunch of the code that will no longer be used.

Note that I didn't actually remove the `FormulaStub` class yet because it's still used by `Homebrew::API::Internal`. I have a follow-up PR that will switch `Homebrew::API::Internal` to understand the new API structure, and will just remove the final references then.

In addition to stubs, I also removed a few other `Homebrew::EnvConfig.use_internal_api?` references and a few other related things that won't be needed with the new setup