### PR TITLE
ExtractPlist: add content parameter

### DIFF
--- a/Library/Homebrew/bundle_version.rb
+++ b/Library/Homebrew/bundle_version.rb
@@ -116,5 +116,13 @@ module Homebrew
       [short_version, version].compact
     end
     private :nice_parts
+
+    sig { returns(T::Hash[Symbol, String]) }
+    def to_h
+      {
+        short_version:,
+        version:,
+      }.compact
+    end
   end
 end

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -47,4 +47,15 @@ RSpec.describe Homebrew::BundleVersion do
       end
     end
   end
+
+  describe "#to_h" do
+    it "returns a hash containing non-nil instance variables" do
+      expect(described_class.new("1.2.3", "3000").to_h)
+        .to eq({ short_version: "1.2.3", version: "3000" })
+      expect(described_class.new(nil, "3000").to_h)
+        .to eq({ version: "3000" })
+      expect(described_class.new("1.2.3", nil).to_h)
+        .to eq({ short_version: "1.2.3" })
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This adds a `content` parameter to `ExtractPlist#find_versions`, to align it with other strategies and allow caching in the future. The existing parameter name in other strategies is `provided_content` but `ExtractPlist` will always use `override(allow_incompatible: true)` because its `find_versions` method has a `cask` parameter and `url` is nilable, so I'm using the forthcoming `content` name here to save myself the trouble of updating it in an upcoming PR. The `content` parameter is only used in tests right now, so this should be fine.

One thing to note is that the "content" here is a hash of versions found in Plist files in an app bundle by `UnversionedCaskChecker` and subsequently stored in `Item` structs. To cache the `items` hash, we have to serialize it and this uses `JSON.generate` for that. However, this doesn't work out of the box, so this also adds `#to_h` methods to `BundleVersion` and `ExtractPlist::Item` as a way of converting the objects into a format that JSON can handle. We then use the values when deserializing to recreate the `Item` and `BundleVersion` objects.

This also renames `versions_from_items` to `versions_from_content` to align with other strategies.