### PR TITLE
[WIP] cask/artifact: enable Sorbet `typed: strict`

### DIFF
--- a/Library/Homebrew/bundle.rb
+++ b/Library/Homebrew/bundle.rb
@@ -101,7 +101,7 @@ module Homebrew
         which(name).present?
       end
 
-      sig { params(block: T.proc.returns(T.anything)).returns(T.untyped) }
+      sig { type_parameters(:U).params(block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
       def exchange_uid_if_needed!(&block)
         euid = Process.euid
         uid = Process.uid

--- a/Library/Homebrew/cache_store.rb
+++ b/Library/Homebrew/cache_store.rb
@@ -22,9 +22,9 @@ class CacheStoreDatabase
       .returns(T.type_parameter(:U))
   }
   def self.use(type, &_blk)
-    @db_type_reference_hash ||= T.let({}, T.nilable(T::Hash[T.untyped, T.untyped]))
-    @db_type_reference_hash[type] ||= {}
-    type_ref = @db_type_reference_hash[type]
+    @db_type_reference_hash ||= T.let({}, T.nilable(T::Hash[Symbol, { count: Integer, db: CacheStoreDatabase }]))
+    @db_type_reference_hash[type] ||= { count: 0, db: CacheStoreDatabase.new(type) }
+    type_ref = @db_type_reference_hash.fetch(type)
 
     type_ref[:count] ||= 0
     type_ref[:count]  += 1

--- a/Library/Homebrew/cask/artifact/app.rb
+++ b/Library/Homebrew/cask/artifact/app.rb
@@ -8,7 +8,7 @@ module Cask
     # Artifact corresponding to the `app` stanza.
     class App < Moved
       sig {
-        params(
+        override.params(
           adopt:        T::Boolean,
           auto_updates: T.nilable(T::Boolean),
           force:        T::Boolean,

--- a/Library/Homebrew/cask/artifact/artifact.rb
+++ b/Library/Homebrew/cask/artifact/artifact.rb
@@ -12,20 +12,21 @@ module Cask
         "Generic Artifact"
       end
 
-      sig { params(cask: Cask, args: T.untyped).returns(T.attached_class) }
-      def self.from_args(cask, *args)
-        source, options = args
-
+      sig { params(cask: Cask, source: T.nilable(String), target_hash: T.anything).returns(Relocated) }
+      def self.from_args(cask, source = nil, **target_hash)
         raise CaskInvalidError.new(cask.token, "No source provided for #{english_name}.") if source.blank?
 
-        unless options&.key?(:target)
+        unless target_hash.key?(:target)
           raise CaskInvalidError.new(cask.token, "#{english_name} '#{source}' requires a target.")
         end
 
-        new(cask, source, **options)
+        new(cask, source, **target_hash)
       end
 
-      sig { params(target: T.any(String, Pathname)).returns(Pathname) }
+      # FIXME: This is a pre-existing violation
+      # rubocop:disable Sorbet/AllowIncompatibleOverride
+      sig { override(allow_incompatible: true).params(target: T.any(String, Pathname)).returns(Pathname) }
+      # rubocop:enable Sorbet/AllowIncompatibleOverride
       def resolve_target(target)
         super(target, base_dir: nil)
       end

--- a/Library/Homebrew/cask/artifact/bashcompletion.rb
+++ b/Library/Homebrew/cask/artifact/bashcompletion.rb
@@ -7,7 +7,10 @@ module Cask
   module Artifact
     # Artifact corresponding to the `bash_completion` stanza.
     class BashCompletion < ShellCompletion
-      sig { params(target: T.any(String, Pathname)).returns(Pathname) }
+      # FIXME: This is a pre-existing violation
+      # rubocop:disable Sorbet/AllowIncompatibleOverride
+      sig { override(allow_incompatible: true).params(target: T.any(String, Pathname)).returns(Pathname) }
+      # rubocop:enable Sorbet/AllowIncompatibleOverride
       def resolve_target(target)
         name = if File.extname(target).nil?
           target

--- a/Library/Homebrew/cask/artifact/binary.rb
+++ b/Library/Homebrew/cask/artifact/binary.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/symlinked"
@@ -7,7 +7,8 @@ module Cask
   module Artifact
     # Artifact corresponding to the `binary` stanza.
     class Binary < Symlinked
-      def link(command: nil, **options)
+      sig { override.params(command: T.class_of(SystemCommand), force: T::Boolean, adopt: T::Boolean, _options: T.anything).void }
+      def link(command:, force: false, adopt: false, **_options)
         super
         return if source.executable?
 

--- a/Library/Homebrew/cask/artifact/fishcompletion.rb
+++ b/Library/Homebrew/cask/artifact/fishcompletion.rb
@@ -7,7 +7,10 @@ module Cask
   module Artifact
     # Artifact corresponding to the `fish_completion` stanza.
     class FishCompletion < ShellCompletion
-      sig { params(target: T.any(String, Pathname)).returns(Pathname) }
+      # FIXME: This is a pre-existing violation
+      # rubocop:disable Sorbet/AllowIncompatibleOverride
+      sig { override(allow_incompatible: true).params(target: T.any(String, Pathname)).returns(Pathname) }
+      # rubocop:enable Sorbet/AllowIncompatibleOverride
       def resolve_target(target)
         name = if target.to_s.end_with? ".fish"
           target

--- a/Library/Homebrew/cask/artifact/keyboard_layout.rb
+++ b/Library/Homebrew/cask/artifact/keyboard_layout.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/moved"
@@ -7,19 +7,22 @@ module Cask
   module Artifact
     # Artifact corresponding to the `keyboard_layout` stanza.
     class KeyboardLayout < Moved
-      def install_phase(**options)
+      sig { override.params(command: T.class_of(SystemCommand), options: T.anything).void }
+      def install_phase(command:, **options)
         super
         delete_keyboard_layout_cache(**options)
       end
 
-      def uninstall_phase(**options)
+      sig { override.params(command: T.class_of(SystemCommand), options: T.anything).void }
+      def uninstall_phase(command:, **options)
         super
         delete_keyboard_layout_cache(**options)
       end
 
       private
 
-      def delete_keyboard_layout_cache(command: nil, **_)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def delete_keyboard_layout_cache(command:, **_options)
         command.run!(
           "/bin/rm",
           args:         ["-f", "--", "/System/Library/Caches/com.apple.IntlDataCache.le*"],

--- a/Library/Homebrew/cask/artifact/manpage.rb
+++ b/Library/Homebrew/cask/artifact/manpage.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/symlinked"
@@ -7,9 +7,11 @@ module Cask
   module Artifact
     # Artifact corresponding to the `manpage` stanza.
     class Manpage < Symlinked
+      sig { returns(String) }
       attr_reader :section
 
-      def self.from_args(cask, source)
+      sig { params(cask: Cask, source: String, _target_hash: T.anything).returns(Manpage) }
+      def self.from_args(cask, source, **_target_hash)
         section = source.to_s[/\.([1-8]|n|l)(?:\.gz)?$/, 1]
 
         raise CaskInvalidError, "'#{source}' is not a valid man page name" unless section
@@ -17,12 +19,17 @@ module Cask
         new(cask, source, section)
       end
 
+      sig { params(cask: Cask, source: String, section: String).void }
       def initialize(cask, source, section)
         @section = section
 
         super(cask, source)
       end
 
+      # FIXME: This is a pre-existing violation
+      # rubocop:disable Sorbet/AllowIncompatibleOverride
+      sig { override(allow_incompatible: true).params(target: T.any(String, Pathname)).returns(Pathname) }
+      # rubocop:enable Sorbet/AllowIncompatibleOverride
       def resolve_target(target)
         config.manpagedir.join("man#{section}", target)
       end

--- a/Library/Homebrew/cask/artifact/mdimporter.rb
+++ b/Library/Homebrew/cask/artifact/mdimporter.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/moved"
@@ -12,14 +12,36 @@ module Cask
         "Spotlight metadata importer"
       end
 
-      def install_phase(**options)
+      sig {
+        override.params(
+          adopt:        T::Boolean,
+          auto_updates: T.nilable(T::Boolean),
+          force:        T::Boolean,
+          verbose:      T::Boolean,
+          predecessor:  T.nilable(Cask),
+          successor:    T.nilable(Cask),
+          reinstall:    T::Boolean,
+          command:      T.class_of(SystemCommand),
+        ).void
+      }
+      def install_phase(
+        adopt: false,
+        auto_updates: false,
+        force: false,
+        verbose: false,
+        predecessor: nil,
+        successor: nil,
+        reinstall: false,
+        command: SystemCommand
+      )
         super
-        reload_spotlight(**options)
+        reload_spotlight(command:)
       end
 
       private
 
-      def reload_spotlight(command: nil, **_)
+      sig { params(command: T.class_of(SystemCommand)).void }
+      def reload_spotlight(command:)
         command.run!("/usr/bin/mdimport", args: ["-r", target])
       end
     end

--- a/Library/Homebrew/cask/artifact/qlplugin.rb
+++ b/Library/Homebrew/cask/artifact/qlplugin.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/moved"
@@ -12,19 +12,22 @@ module Cask
         "Quick Look Plugin"
       end
 
-      def install_phase(**options)
+      sig { override.params(command: T.class_of(SystemCommand), options: T.anything).void }
+      def install_phase(command:, **options)
         super
-        reload_quicklook(**options)
+        reload_quicklook(command:, **options)
       end
 
-      def uninstall_phase(**options)
+      sig { override.params(command: T.class_of(SystemCommand), options: T.anything).void }
+      def uninstall_phase(command:, **options)
         super
-        reload_quicklook(**options)
+        reload_quicklook(command:, **options)
       end
 
       private
 
-      def reload_quicklook(command: nil, **_)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def reload_quicklook(command:, **_options)
         command.run!("/usr/bin/qlmanage", args: ["-r"])
       end
     end

--- a/Library/Homebrew/cask/artifact/shellcompletion.rb
+++ b/Library/Homebrew/cask/artifact/shellcompletion.rb
@@ -6,8 +6,13 @@ require "cask/artifact/symlinked"
 module Cask
   module Artifact
     class ShellCompletion < Symlinked
-      sig { params(_: T.any(String, Pathname)).returns(Pathname) }
-      def resolve_target(_)
+      sig {
+        override
+          .overridable
+          .params(_target: T.any(String, Pathname), base_dir: T.nilable(Pathname))
+          .returns(T.noreturn)
+      }
+      def resolve_target(_target, base_dir: nil)
         raise CaskInvalidError, "Shell completion without shell info"
       end
     end

--- a/Library/Homebrew/cask/artifact/stage_only.rb
+++ b/Library/Homebrew/cask/artifact/stage_only.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/abstract_artifact"
@@ -7,8 +7,9 @@ module Cask
   module Artifact
     # Artifact corresponding to the `stage_only` stanza.
     class StageOnly < AbstractArtifact
-      def self.from_args(cask, *args, **kwargs)
-        if (args != [true] && args != ["true"]) || kwargs.present?
+      sig { params(cask: Cask, arg: T.any(String, TrueClass)).returns(StageOnly) }
+      def self.from_args(cask, arg)
+        unless [true, "true"].include?(arg)
           raise CaskInvalidError.new(cask.token, "'stage_only' takes only a single argument: true")
         end
 

--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/relocated"
@@ -17,14 +17,17 @@ module Cask
         "#{english_name} #{link_type_english_name}s"
       end
 
+      sig { params(options: T.anything).void }
       def install_phase(**options)
         link(**options)
       end
 
+      sig { params(options: T.anything).void }
       def uninstall_phase(**options)
         unlink(**options)
       end
 
+      sig { returns(String) }
       def summarize_installed
         if target.symlink? && target.exist? && target.readlink.exist?
           "#{printable_target} -> #{target.readlink} (#{target.readlink.abv})"
@@ -41,7 +44,8 @@ module Cask
 
       private
 
-      def link(force: false, adopt: false, command: nil, **_options)
+      sig { overridable.params(command: T.class_of(SystemCommand), force: T::Boolean, adopt: T::Boolean, _options: T.anything).void }
+      def link(command:, force: false, adopt: false, **_options)
         unless source.exist?
           raise CaskError,
                 "It seems the #{self.class.link_type_english_name.downcase} " \
@@ -68,7 +72,8 @@ module Cask
         create_filesystem_link(command)
       end
 
-      def unlink(command: nil, **)
+      sig { params(command: T.class_of(SystemCommand), _options: T.anything).void }
+      def unlink(command:, **_options)
         return unless target.symlink?
 
         ohai "Unlinking #{self.class.english_name} '#{target}'"

--- a/Library/Homebrew/cask/artifact/uninstall.rb
+++ b/Library/Homebrew/cask/artifact/uninstall.rb
@@ -1,4 +1,4 @@
-# typed: true # rubocop:todo Sorbet/StrictSigil
+# typed: strict
 # frozen_string_literal: true
 
 require "cask/artifact/abstract_uninstall"
@@ -9,10 +9,8 @@ module Cask
     class Uninstall < AbstractUninstall
       UPGRADE_REINSTALL_SKIP_DIRECTIVES = [:quit, :signal].freeze
 
-      def uninstall_phase(**options)
-        upgrade   = options.fetch(:upgrade, false)
-        reinstall = options.fetch(:reinstall, false)
-
+      sig { params(upgrade: T::Boolean, reinstall: T::Boolean, options: T.anything).void }
+      def uninstall_phase(upgrade: false, reinstall: false, **options)
         raw_on_upgrade = directives[:on_upgrade]
         on_upgrade_syms =
           case raw_on_upgrade
@@ -42,6 +40,7 @@ module Cask
         end
       end
 
+      sig { params(options: T.anything).void }
       def post_uninstall_phase(**options)
         dispatch_uninstall_directive(:rmdir, **options)
       end

--- a/Library/Homebrew/cask/artifact/zshcompletion.rb
+++ b/Library/Homebrew/cask/artifact/zshcompletion.rb
@@ -7,7 +7,10 @@ module Cask
   module Artifact
     # Artifact corresponding to the `zsh_completion` stanza.
     class ZshCompletion < ShellCompletion
-      sig { params(target: T.any(String, Pathname)).returns(Pathname) }
+      # FIXME: This is a pre-existing violation
+      # rubocop:disable Sorbet/AllowIncompatibleOverride
+      sig { override(allow_incompatible: true).params(target: T.any(String, Pathname)).returns(Pathname) }
+      # rubocop:enable Sorbet/AllowIncompatibleOverride
       def resolve_target(target)
         name = if target.to_s.start_with? "_"
           target

--- a/Library/Homebrew/cask/artifact_set.rb
+++ b/Library/Homebrew/cask/artifact_set.rb
@@ -8,7 +8,7 @@ module Cask
 
     Elem = type_member(:out) { { fixed: Artifact::AbstractArtifact } }
 
-    sig { params(block: T.nilable(T.proc.params(arg0: Elem).returns(T.untyped))).void }
+    sig { override.params(block: T.nilable(T.proc.params(arg0: Elem).returns(BasicObject))).returns(T.untyped) }
     def each(&block)
       return enum_for(T.must(__method__)) { size } unless block
 

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -104,9 +104,12 @@ module Cask
       @root ||= T.let(Pathname.new(info.fetch("volume")).join(info.fetch("install-location")), T.nilable(Pathname))
     end
 
-    sig { returns(T.untyped) }
+    sig { returns(T::Hash[String, T.untyped]) }
     def info
-      @info ||= T.let(@command.run!("/usr/sbin/pkgutil", args: ["--pkg-info-plist", package_id]).plist, T.untyped)
+      @info ||= T.let(
+        @command.run!("/usr/sbin/pkgutil", args: ["--pkg-info-plist", package_id]).plist,
+        T.nilable(T::Hash[String, T.untyped]),
+      )
     end
 
     private

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -172,7 +172,7 @@ module Homebrew
         with_monkey_patch { Formulary.from_contents(name, file, contents, ignore_errors: true) }
       end
 
-      sig { params(_block: T.proc.void).returns(T.untyped) }
+      sig { type_parameters(:U).params(_block: T.proc.returns(T.type_parameter(:U))).returns(T.type_parameter(:U)) }
       def with_monkey_patch(&_block)
         # Since `method_defined?` is not a supported type guard, the use of `alias_method` below is not typesafe:
         BottleSpecification.class_eval do


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Enable strict typing for the remaining classes under `Cask::Artifact`.

This adds proper type signatures to all methods and updates the typing level from `typed: true` to `typed: strict`.

Advances https://github.com/Homebrew/brew/issues/17297