### PR TITLE
test/cask/dsl_spec: use cask installer stub

### DIFF
--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -470,8 +470,8 @@ RSpec.describe Cask::DSL, :cask, :no_api do
       Cask::CaskLoader.load(cask_path("with-conflicts-with"))
     end
 
-    it "installs the dependency of a Cask and the Cask itself" do
-      Cask::Installer.new(local_caffeine).install
+    it "raises an error when a conflicting cask is already installed" do
+      InstallHelper.stub_cask_installation(local_caffeine)
 
       expect(local_caffeine).to be_installed
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

This PR adds an additional usage of the new cask installer stub function for testing. For this specific test, a full installation is not required. This will significantly reduce the time this test takes.