### PR TITLE
Add add'l rescue for Utils.gain_permissions_rmdir

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -582,7 +582,7 @@ module Cask
 
           begin
             Utils.gain_permissions_rmdir(resolved_path, command:)
-          rescue Errno::ENOTEMPTY
+          rescue Errno::ENOTEMPTY, ErrorDuringExecution
             next false
           end
 

--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -104,7 +104,7 @@ module Cask
           #       before using `sudo` and `chown`.
           ohai "Using sudo to gain ownership of path '#{path}'"
           command.run("chown",
-                      args: command_args + ["--", User.current, path],
+                      args: command_args + ["--", User.current.to_s, path],
                       sudo: true)
           tried_ownership = true
           # retry chflags/chmod after chown

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -169,7 +169,7 @@ module Homebrew
           resource_version = bottle.resource.version
           return false unless resource_version
 
-          return resource_version != GitHubPackages.version_rebuild(resource_version, bottle.rebuild)
+          return version != GitHubPackages.version_rebuild(resource_version, bottle.rebuild)
         end
 
         return false if formula.blank?

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -445,20 +445,51 @@ RSpec.describe Homebrew::Cleanup do
       end
     end
 
-    it "does not remove bottle manifests for the latest installed version when using GitHub Packages" do
-      manifest = HOMEBREW_CACHE/"foo_bottle_manifest--1.0.json"
-      FileUtils.touch manifest
+    context "when the cache path is a bottle manifest file" do
+      let(:bottle_manifest_path) { (HOMEBREW_CACHE/"testball_bottle_manifest--1.0.bottle_manifest.json") }
 
-      resource = instance_double(Resource, version: Version.new("1.0.arm64_sonoma"))
-      bottle   = instance_double(Bottle, resource:, rebuild: 0)
-      formula  = instance_double(Formula, latest_version_installed?: true, bottle:)
+      before do
+        HOMEBREW_CACHE.mkpath
+        FileUtils.touch bottle_manifest_path
+        (HOMEBREW_CELLAR/"testball"/"0.1/bin").mkpath
+        FileUtils.touch(CoreTap.instance.new_formula_path("testball"))
+      end
 
-      allow(Formulary).to receive(:from_rack).and_return(nil, formula)
-      allow(described_class).to receive(:excluded_versions_from_cleanup).with(formula).and_return([])
+      it "does not remove the file when bottle resource version is nil" do
+        allow(Formulary).to receive(:from_rack).with(HOMEBREW_CELLAR/"testball_bottle_manifest").and_return(nil)
+        allow(Formulary).to receive(:from_rack).and_call_original
+        allow(Formulary).to receive(:from_rack).with(HOMEBREW_CELLAR/"testball").and_wrap_original do |m, *args|
+          formula = m.call(*args)
+          if formula
+            bottle_nil_version = instance_double(Bottle,
+                                                 resource: instance_double(Resource, version: nil),
+                                                 rebuild:  0)
+            allow(formula).to receive(:bottle).and_return(bottle_nil_version)
+          end
+          formula
+        end
+        cleanup.cleanup_cache([{ path: bottle_manifest_path, type: nil }])
+        expect(bottle_manifest_path).to exist
+      end
 
-      cleanup.cleanup_cache
-
-      expect(manifest).to exist
+      it "removes the file when path version differs from bottle version_rebuild" do
+        pathname_mismatch = (HOMEBREW_CACHE/"testball_bottle_manifest--2.0.bottle_manifest.json")
+        FileUtils.touch pathname_mismatch
+        allow(Formulary).to receive(:from_rack).with(HOMEBREW_CELLAR/"testball_bottle_manifest").and_return(nil)
+        allow(Formulary).to receive(:from_rack).and_call_original
+        allow(Formulary).to receive(:from_rack).with(HOMEBREW_CELLAR/"testball").and_wrap_original do |m, *args|
+          formula = m.call(*args)
+          if formula
+            bottle_double = instance_double(Bottle,
+                                            resource: instance_double(Resource, version: Version.new("1.0")),
+                                            rebuild:  0)
+            allow(formula).to receive(:bottle).and_return(bottle_double)
+          end
+          formula
+        end
+        cleanup.cleanup_cache([{ path: pathname_mismatch, type: nil }])
+        expect(pathname_mismatch).not_to exist
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----
Partial revert of https://github.com/Homebrew/brew/pull/21499/

Intended to resolve https://github.com/Homebrew/brew/issues/21507