### PR TITLE
download_queue: implement cooperative cancellation

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -36,8 +36,6 @@ module Homebrew
       @spinner = T.let(nil, T.nilable(Spinner))
       @symlink_targets = T.let({}, T::Hash[Pathname, T::Set[Downloadable]])
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
-
-      # Cooperative cancellation flag
       @cancelled = T.let(Concurrent::AtomicBoolean.new(false), Concurrent::AtomicBoolean)
     end
 
@@ -48,6 +46,7 @@ module Homebrew
       ).void
     }
     def enqueue(downloadable, check_attestation: false)
+      @cancelled.make_false
       cached_location = downloadable.cached_download
 
       @symlink_targets[cached_location] ||= Set.new


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

GitHub Copilot (Claude Opus 4.5) assisted with implementing cooperative cancellation. Verification: `brew typecheck`, `brew style --changed`. Manually tested cancellation with `HOMEBREW_DOWNLOAD_CONCURRENCY=2 brew fetch wget --force` + Ctrl+C.

-----
## Summary
Implements graceful cooperative cancellation for parallel downloads, replacing `pool.kill` with a thread-safe `AtomicBoolean` flag. Resolves the FIXME comments in `download_queue.rb`.

## Changes
- Added `CancelledDownloadError` exception class
- Added `@cancelled` AtomicBoolean flag checked at safe points in downloads
- Updated `cancel` method to set the flag instead of killing the thread pool

