### PR TITLE
test_bot/junit: require `rexml/document` in `initialize` method 

### DIFF
--- a/Library/Homebrew/test_bot/junit.rb
+++ b/Library/Homebrew/test_bot/junit.rb
@@ -8,6 +8,8 @@ module Homebrew
     class Junit
       sig { params(tests: T::Array[Test]).void }
       def initialize(tests)
+        require "rexml/document"
+
         @tests = tests
         @xml_document = T.let(nil, T.nilable(REXML::Document))
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
This should fix CI failures caused by #21506