### PR TITLE
test-bot: fix Pathname and artifact cache regressions

### DIFF
--- a/Library/Homebrew/test_bot/test_cleanup.rb
+++ b/Library/Homebrew/test_bot/test_cleanup.rb
@@ -101,9 +101,9 @@ module Homebrew
         end
 
         if tap
-          checkout_branch_if_needed(HOMEBREW_REPOSITORY)
-          reset_if_needed(HOMEBREW_REPOSITORY)
-          clean_if_needed(HOMEBREW_REPOSITORY)
+          checkout_branch_if_needed(HOMEBREW_REPOSITORY.to_s)
+          reset_if_needed(HOMEBREW_REPOSITORY.to_s)
+          clean_if_needed(HOMEBREW_REPOSITORY.to_s)
         end
 
         # Keep all "brew" invocations after HOMEBREW_REPOSITORY operations

--- a/Library/Homebrew/test_bot/test_formulae.rb
+++ b/Library/Homebrew/test_bot/test_formulae.rb
@@ -174,8 +174,9 @@ module Homebrew
         end
         return if wanted_artifacts.empty?
 
+        downloaded_for_sha = @downloaded_artifacts.fetch(sha) { |k| @downloaded_artifacts[k] = [] }
         if (attempted_artifact = wanted_artifacts.find do |artifact|
-              @downloaded_artifacts.fetch(sha).include?(artifact.fetch("name"))
+              downloaded_for_sha.include?(artifact.fetch("name"))
             end)
           opoo "Already tried #{attempted_artifact.fetch("name")} from #{sha}, giving up"
           return
@@ -191,7 +192,7 @@ module Homebrew
           wanted_artifacts.each do |artifact|
             name = artifact.fetch("name")
             ohai "Downloading artifact #{name} from #{sha}"
-            @downloaded_artifacts.fetch(sha) << name
+            downloaded_for_sha << name
 
             download_url = artifact.fetch("archive_download_url")
             artifact_id = artifact.fetch("id")


### PR DESCRIPTION
seeing 

```
==> git -C /opt/homebrew/Library/Taps/chenrui333/homebrew-tap clean -ff -dx
Error: Parameter 'repository': Expected type String, got type Pathname with value #<Pathname:/opt/homebrew>
Caller: /opt/homebrew/Library/Homebrew/test_bot/test_cleanup.rb:104
Definition: /opt/homebrew/Library/Homebrew/test_bot/test_cleanup.rb:148 (Homebrew::TestBot::TestCleanup#checkout_branch_if_needed)
```

```
Error: key not found: "8e624f21ac73d02a609cfec1ce620ccfee3aa97c"
/opt/homebrew/Library/Homebrew/test_bot/test_formulae.rb:178:in 'Hash#fetch'
/opt/homebrew/Library/Homebrew/test_bot/test_formulae.rb:178:in 'block in Homebrew::TestBot::TestFormulae#download_artifacts_from_previous_run!'
```

in the tap run after https://github.com/Homebrew/brew/pull/21506