### PR TITLE
Don't clear progress bar before overwriting it

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -136,8 +136,8 @@ module Homebrew
 
               finished_downloads.each do |downloadable, future|
                 previous_pending_line_count -= 1
-                stdout_print_and_flush_if_tty Tty.clear_to_end
                 output_message.call(downloadable, future, false)
+                stdout_print_and_flush_if_tty Tty.clear_to_end
               end
 
               previous_pending_line_count = 0
@@ -145,9 +145,9 @@ module Homebrew
               remaining_downloads.each_with_index do |(downloadable, future), i|
                 break if previous_pending_line_count >= max_lines
 
-                stdout_print_and_flush_if_tty Tty.clear_to_end
                 last = i == max_lines - 1 || i == remaining_downloads.count - 1
                 previous_pending_line_count += output_message.call(downloadable, future, last)
+                stdout_print_and_flush_if_tty Tty.clear_to_end
               end
 
               if previous_pending_line_count.positive?


### PR DESCRIPTION
This makes sure there is never an empty line which should reduce flickering in some terminals.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I am using tmux and the progress indicator flickers quite heavily under some circumstances for me. The old code cleared the entire line before writing the new progress indicator. With my change, the old progress indicator is overwritten by the new indicator. That way there is never an empty line so less visual flickering. After the indicator is written, the remainder of the line is still cleared. This ensures that nothing from the old indicator will remain visible if the new indicator is shorter or some other weird things happen. On modern terminals without multiplexer this should not have any impact – there was no visible flickering before anyways. But with tmux this significantly reduces the flickering for me.