### PR TITLE
Avoid consecutive spaces in a message

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -629,7 +629,7 @@ module GitHub
 
     confidence = version ? "are" : "might be"
     duplicates_message = <<~EOS
-      These #{state} pull requests #{confidence} duplicates:
+      These #{"#{state} " if state}pull requests #{confidence} duplicates:
       #{pull_requests.map { |pr| "#{pr["title"]} #{pr["html_url"]}" }.join("\n")}
     EOS
     error_message = <<~EOS


### PR DESCRIPTION
Avoid consecutive spaces if `state` is `nil`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

**Background**

I spot consecutive spaces in a warning raised by `brew bump-formula-pr`

```
Warning: These  pull requests are duplicates:
               ^
```

Steps to reproduce
```
$ brew tap muzimuzhi/beta
$ brew bump-formula-pr --version=6.0.4 gnuplot-lite
Warning: These  pull requests are duplicates:
gnuplot-lite 6.0.4 https://github.com/muzimuzhi/homebrew-beta/pull/115
Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://downloads.sourceforge.net/project/gnuplot/gnuplot/6.0.4/gnuplot-6.0.4.tar.gz
```

First I searched for words in that message and successfully found the responsible file line.

Then I asked Copilot about how to avoid the consecutive spaces if `state` is `nil`, got the suggested change, and checked that `#{state ? "#{state} " : ""}` works in Ruby repl (`irb`) locally.