### PR TITLE
Remove unnecessary `T.let` from literal declarations

### DIFF
--- a/Library/Homebrew/dev-cmd/contributions.rb
+++ b/Library/Homebrew/dev-cmd/contributions.rb
@@ -17,8 +17,8 @@ module Homebrew
         committer:          "commit author or committer",
         coauthor:           "commit coauthor",
       }.freeze, T::Hash[Symbol, String])
-      MAX_COMMITS = T.let(1000, Integer)
-      MAX_PR_SEARCH = T.let(100, Integer)
+      MAX_COMMITS = 1000
+      MAX_PR_SEARCH = 100
 
       cmd_args do
         usage_banner "`contributions` [`--user=`] [`--repositories=`] [`--quarter=`] [`--from=`] [`--to=`] [`--csv`]"

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -139,7 +139,7 @@ module OS
         end
       end
 
-      VARIABLE_REFERENCE_RX = T.let(/^@(loader_|executable_|r)path/, Regexp)
+      VARIABLE_REFERENCE_RX = /^@(loader_|executable_|r)path/
 
       sig { params(file: MachOShim, linkage_type: Symbol, resolve_variable_references: T::Boolean, block: T.proc.params(arg0: String).void).void }
       def each_linkage_for(file, linkage_type, resolve_variable_references: false, &block)
@@ -265,7 +265,7 @@ module OS
 
       private
 
-      CELLAR_RX = T.let(%r{\A#{HOMEBREW_CELLAR}/(?<formula_name>[^/]+)/[^/]+}, Regexp)
+      CELLAR_RX = %r{\A#{HOMEBREW_CELLAR}/(?<formula_name>[^/]+)/[^/]+}
       private_constant :CELLAR_RX
 
       # Replace HOMEBREW_CELLAR references with HOMEBREW_PREFIX/opt references

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -6,17 +6,17 @@ require "utils/output"
 class Keg
   extend Utils::Output::Mixin
 
-  PREFIX_PLACEHOLDER = T.let("@@HOMEBREW_PREFIX@@", String)
-  CELLAR_PLACEHOLDER = T.let("@@HOMEBREW_CELLAR@@", String)
-  REPOSITORY_PLACEHOLDER = T.let("@@HOMEBREW_REPOSITORY@@", String)
-  LIBRARY_PLACEHOLDER = T.let("@@HOMEBREW_LIBRARY@@", String)
-  PERL_PLACEHOLDER = T.let("@@HOMEBREW_PERL@@", String)
-  JAVA_PLACEHOLDER = T.let("@@HOMEBREW_JAVA@@", String)
-  NULL_BYTE = T.let("\x00", String)
-  NULL_BYTE_STRING = T.let("\\x00", String)
+  PREFIX_PLACEHOLDER = "@@HOMEBREW_PREFIX@@"
+  CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@"
+  REPOSITORY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@"
+  LIBRARY_PLACEHOLDER = "@@HOMEBREW_LIBRARY@@"
+  PERL_PLACEHOLDER = "@@HOMEBREW_PERL@@"
+  JAVA_PLACEHOLDER = "@@HOMEBREW_JAVA@@"
+  NULL_BYTE = "\x00"
+  NULL_BYTE_STRING = "\\x00"
 
   class Relocation
-    RELOCATABLE_PATH_REGEX_PREFIX = T.let(/(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))/, Regexp)
+    RELOCATABLE_PATH_REGEX_PREFIX = /(?:(?<=-F|-I|-L|-isystem)|(?<![a-zA-Z0-9]))/
 
     sig { void }
     def initialize

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -36,11 +36,11 @@ module Homebrew
         NICE_NAME = "GNU"
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = T.let(%r{
+        URL_MATCH_REGEX = %r{
           ^https?://
           (?:(?:[^/]+?\.)*gnu\.org/(?:gnu|software)/(?<project_name>[^/]+)/
           |(?<project_name>[^/]+)\.gnu\.org/?$)
-        }ix, Regexp)
+        }ix
 
         # Whether the strategy can be applied to the provided URL.
         #

--- a/Library/Homebrew/mcp_server.rb
+++ b/Library/Homebrew/mcp_server.rb
@@ -15,9 +15,9 @@ module Homebrew
   class McpServer
     HOMEBREW_BREW_FILE = T.let(ENV.fetch("HOMEBREW_BREW_FILE").freeze, String)
     HOMEBREW_VERSION = T.let(ENV.fetch("HOMEBREW_VERSION").freeze, String)
-    JSON_RPC_VERSION = T.let("2.0", String)
-    MCP_PROTOCOL_VERSION = T.let("2025-03-26", String)
-    ERROR_CODE = T.let(-32601, Integer)
+    JSON_RPC_VERSION = "2.0"
+    MCP_PROTOCOL_VERSION = "2025-03-26"
+    ERROR_CODE = -32601
 
     SERVER_INFO = T.let({
       name:    "brew-mcp-server",

--- a/Library/Homebrew/rubocops/cask/uninstall_methods_order.rb
+++ b/Library/Homebrew/rubocops/cask/uninstall_methods_order.rb
@@ -12,7 +12,7 @@ module RuboCop
         extend AutoCorrector
         include HelperFunctions
 
-        MSG = T.let("`%<method>s` method out of order", String)
+        MSG = "`%<method>s` method out of order"
 
         # These keys are ignored when checking method order.
         # Mirrors AbstractUninstall::METADATA_KEYS.
@@ -21,15 +21,10 @@ module RuboCop
           T::Array[Symbol],
         )
 
-        USELESS_METADATA_MSG = T.let(
-          "`on_upgrade` has no effect without matching `uninstall quit:` or `uninstall signal:` directives",
-          String,
-        )
+        USELESS_METADATA_MSG =
+          "`on_upgrade` has no effect without matching `uninstall quit:` or `uninstall signal:` directives"
 
-        PARTIAL_METADATA_MSG = T.let(
-          "`on_upgrade` lists %<symbols>s without matching `uninstall` directives",
-          String,
-        )
+        PARTIAL_METADATA_MSG = "`on_upgrade` lists %<symbols>s without matching `uninstall` directives"
 
         sig { params(node: AST::SendNode).void }
         def on_send(node)

--- a/Library/Homebrew/services/system.rb
+++ b/Library/Homebrew/services/system.rb
@@ -9,11 +9,8 @@ module Homebrew
     module System
       extend Utils::Output::Mixin
 
-      LAUNCHCTL_DOMAIN_ACTION_NOT_SUPPORTED = T.let(125, Integer)
-      MISSING_DAEMON_MANAGER_EXCEPTION_MESSAGE = T.let(
-        "`brew services` is supported only on macOS or Linux (with systemd)!",
-        String,
-      )
+      LAUNCHCTL_DOMAIN_ACTION_NOT_SUPPORTED = 125
+      MISSING_DAEMON_MANAGER_EXCEPTION_MESSAGE = "`brew services` is supported only on macOS or Linux (with systemd)!"
 
       # Path to launchctl binary.
       sig { returns(T.nilable(Pathname)) }

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -2,51 +2,35 @@
 # frozen_string_literal: true
 
 # Match a formula name.
-HOMEBREW_TAP_FORMULA_NAME_REGEX = T.let(/(?<name>[\w+\-.@]+)/, Regexp)
+HOMEBREW_TAP_FORMULA_NAME_REGEX = /(?<name>[\w+\-.@]+)/
 # Match taps' formulae, e.g. `someuser/sometap/someformula`.
-HOMEBREW_TAP_FORMULA_REGEX = T.let(
-  %r{\A(?<user>[^/]+)/(?<repository>[^/]+)/#{HOMEBREW_TAP_FORMULA_NAME_REGEX.source}\Z},
-  Regexp,
-)
+HOMEBREW_TAP_FORMULA_REGEX =
+  %r{\A(?<user>[^/]+)/(?<repository>[^/]+)/#{HOMEBREW_TAP_FORMULA_NAME_REGEX.source}\Z}
 # Match default formula taps' formulae, e.g. `homebrew/core/someformula` or `someformula`.
-HOMEBREW_DEFAULT_TAP_FORMULA_REGEX = T.let(
-  %r{\A(?:[Hh]omebrew/(?:homebrew-)?core/)?(?<name>#{HOMEBREW_TAP_FORMULA_NAME_REGEX.source})\Z},
-  Regexp,
-)
+HOMEBREW_DEFAULT_TAP_FORMULA_REGEX =
+  %r{\A(?:[Hh]omebrew/(?:homebrew-)?core/)?(?<name>#{HOMEBREW_TAP_FORMULA_NAME_REGEX.source})\Z}
 # Match taps' remote repository, e.g. `someuser/somerepo`.
-HOMEBREW_TAP_REPOSITORY_REGEX = T.let(
-  %r{\A.+[/:](?<remote_repository>[^/:]+/[^/:]+?(?=\.git/*\Z|/*\Z))},
-  Regexp,
-)
+HOMEBREW_TAP_REPOSITORY_REGEX =
+  %r{\A.+[/:](?<remote_repository>[^/:]+/[^/:]+?(?=\.git/*\Z|/*\Z))}
 
 # Match a cask token.
-HOMEBREW_TAP_CASK_TOKEN_REGEX = T.let(/(?<token>[\w+\-.@]+)/, Regexp)
+HOMEBREW_TAP_CASK_TOKEN_REGEX = /(?<token>[\w+\-.@]+)/
 # Match taps' casks, e.g. `someuser/sometap/somecask`.
-HOMEBREW_TAP_CASK_REGEX = T.let(
-  %r{\A(?<user>[^/]+)/(?<repository>[^/]+)/#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z},
-  Regexp,
-)
+HOMEBREW_TAP_CASK_REGEX =
+  %r{\A(?<user>[^/]+)/(?<repository>[^/]+)/#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z}
 # Match default cask taps' casks, e.g. `homebrew/cask/somecask` or `somecask`.
-HOMEBREW_DEFAULT_TAP_CASK_REGEX = T.let(
-  %r{\A(?:[Hh]omebrew/(?:homebrew-)?cask/)?#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z},
-  Regexp,
-)
+HOMEBREW_DEFAULT_TAP_CASK_REGEX =
+  %r{\A(?:[Hh]omebrew/(?:homebrew-)?cask/)?#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z}
 
 # Match taps' directory paths, e.g. `HOMEBREW_LIBRARY/Taps/someuser/sometap`.
-HOMEBREW_TAP_DIR_REGEX = T.let(
-  %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/(?<user>[^/]+)/(?<repository>[^/]+)},
-  Regexp,
-)
+HOMEBREW_TAP_DIR_REGEX =
+  %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/(?<user>[^/]+)/(?<repository>[^/]+)}
 # Match taps' formula paths, e.g. `HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula`.
 HOMEBREW_TAP_PATH_REGEX = T.let(Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{(?:/.*)?\Z}.source).freeze, Regexp)
 # Match official cask taps, e.g `homebrew/cask`.
-HOMEBREW_CASK_TAP_REGEX = T.let(
-  %r{(?:([Cc]askroom)/(cask)|([Hh]omebrew)/(?:homebrew-)?(cask|cask-[\w-]+))},
-  Regexp,
-)
+HOMEBREW_CASK_TAP_REGEX =
+  %r{(?:([Cc]askroom)/(cask)|([Hh]omebrew)/(?:homebrew-)?(cask|cask-[\w-]+))}
 # Match official taps' casks, e.g. `homebrew/cask/somecask`.
-HOMEBREW_CASK_TAP_CASK_REGEX = T.let(
-  %r{\A#{HOMEBREW_CASK_TAP_REGEX.source}/#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z},
-  Regexp,
-)
-HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX = T.let(/\A(home|linux)brew-/, Regexp)
+HOMEBREW_CASK_TAP_CASK_REGEX =
+  %r{\A#{HOMEBREW_CASK_TAP_REGEX.source}/#{HOMEBREW_TAP_CASK_TOKEN_REGEX.source}\Z}
+HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX = /\A(home|linux)brew-/

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -15,7 +15,7 @@ module GitHub
   extend SystemCommand::Mixin
   extend Utils::Output::Mixin
 
-  MAX_PER_PAGE = T.let(100, Integer)
+  MAX_PER_PAGE = 100
 
   def self.issues(repo:, **filters)
     uri = url_to("repos", repo, "issues")

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -18,12 +18,12 @@ module GitHub
     EOS
   end
 
-  API_URL = T.let("https://api.github.com", String)
-  API_MAX_PAGES = T.let(50, Integer)
+  API_URL = "https://api.github.com"
+  API_MAX_PAGES = 50
   private_constant :API_MAX_PAGES
-  API_MAX_ITEMS = T.let(5000, Integer)
+  API_MAX_ITEMS = 5000
   private_constant :API_MAX_ITEMS
-  PAGINATE_RETRY_COUNT = T.let(3, Integer)
+  PAGINATE_RETRY_COUNT = 3
   private_constant :PAGINATE_RETRY_COUNT
 
   CREATE_GIST_SCOPES = T.let(["gist"].freeze, T::Array[String])
@@ -32,7 +32,7 @@ module GitHub
   ALL_SCOPES = T.let((CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES + CREATE_WORKFLOW_SCOPES).freeze,
                      T::Array[String])
   private_constant :ALL_SCOPES
-  GITHUB_PERSONAL_ACCESS_TOKEN_REGEX = T.let(/^(?:[a-f0-9]{40}|(?:gh[pousr]|github_pat)_\w{36,251})$/, Regexp)
+  GITHUB_PERSONAL_ACCESS_TOKEN_REGEX = /^(?:[a-f0-9]{40}|(?:gh[pousr]|github_pat)_\w{36,251})$/
   private_constant :GITHUB_PERSONAL_ACCESS_TOKEN_REGEX
 
   # Helper functions for accessing the GitHub API.
@@ -96,7 +96,7 @@ module GitHub
       Regexp,
     )
 
-    NO_CREDENTIALS_MESSAGE = T.let <<~MESSAGE.freeze, String
+    NO_CREDENTIALS_MESSAGE = T.let(<<~MESSAGE.freeze, String)
       No GitHub credentials found in macOS Keychain, GitHub CLI or the environment.
       #{GitHub.pat_blurb}
     MESSAGE


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
At some point, Sorbet became able to infer the types of simple literals, and it was no longer necessary to use `T.let`, even at `typed: strict`. I worked with a coding agent to remove T.let declarations that were not necessary for type checking to succeed:

- Remove T.let from regexp literals in tap_constants, keg_relocate, extend/os/mac/keg_relocate, utils/github/api, livecheck/strategy/gnu (keep T.let for Regexp.new/union)
- Remove T.let from string constants in keg_relocate placeholders, utils/github/api (API_URL, etc.), services/system, mcp_server, rubocops/cask/uninstall_methods_order
- Remove T.let from integer constants in utils/github, services/system, dev-cmd/contributions, mcp_server
- Skip collection literals (arrays, hashes) and T::Boolean, as these require `T.let` declarations