### PR TITLE
Add link to homebrew-changelog repository

### DIFF
--- a/docs/Interesting-Taps-and-Forks.md
+++ b/docs/Interesting-Taps-and-Forks.md
@@ -38,6 +38,8 @@ Your taps are Git repositories located at `$(brew --repository)/Library/Taps`. A
 
 * [apple/apple](https://github.com/apple/homebrew-apple): Formulae from Apple, including the Game Porting Toolkit.
 
+* [pavel-voronin/homebrew-changelog](https://github.com/pavel-voronin/homebrew-changelog): Find upstream changelogs for Homebrew packages
+
 ## Unsupported interesting forks
 
 * [mistydemeo/tigerbrew](https://github.com/mistydemeo/tigerbrew): Experimental Tiger/Leopard PowerPC version.


### PR DESCRIPTION
`brew changelog` parses the formula or cask, looks at the upstream repo, and tries to locate changelog-like files: CHANGELOG, NEWS, HISTORY, etc. Then it either prints the changelog to terminal or opens it in your browser.

```
brew changelog <formula|cask>
brew changelog --help
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
