### PR TITLE
Remove legacy CLI parser fallbacks and streamline command handling

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -101,9 +101,9 @@ begin
       Utils::Analytics.report_command_run(command_instance)
       command_instance.run
     else
-      Utils::Output.odeprecated "Calling `brew #{cmd}` without subclassing `AbstractCommand`",
-                                "subclassing of `Homebrew::AbstractCommand` " \
-                                "(see https://docs.brew.sh/External-Commands)"
+      # Utils::Output.odeprecated "Calling `brew #{cmd}` without subclassing `AbstractCommand`",
+      #                           "subclassing of `Homebrew::AbstractCommand` " \
+      #                           "(see https://docs.brew.sh/External-Commands)"
       begin
         Homebrew.public_send Commands.method_name(cmd)
       rescue NoMethodError => e


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
add `Utils::Output.odeprecated` to `Calling brew #{cmd} without subclassing AbstractCommand`