### PR TITLE
Deprecate `no_autobump! because: :requires_manual_review`

### DIFF
--- a/Library/Homebrew/autobump_constants.rb
+++ b/Library/Homebrew/autobump_constants.rb
@@ -6,10 +6,19 @@ NO_AUTOBUMP_REASONS_INTERNAL = T.let({
   latest_version: "`version` is set to `:latest`",
 }.freeze, T::Hash[Symbol, String])
 
+NO_AUTOBUMP_REASONS_DEPRECATED = T.let({
+  requires_manual_review: "a manual review of this package is required for inclusion in autobump",
+}.freeze, T::Hash[Symbol, String])
+
 # The valid symbols for passing to `no_autobump!` in a `Formula` or `Cask`.
 # @api public
-NO_AUTOBUMP_REASONS_LIST = T.let({
-  incompatible_version_format: "the package has a version format that can only be updated manually",
-  bumped_by_upstream:          "updates to the package are handled by the upstream developers",
-  requires_manual_review:      "a manual review of this package is required for inclusion in autobump",
-}.merge(NO_AUTOBUMP_REASONS_INTERNAL).freeze, T::Hash[Symbol, String])
+NO_AUTOBUMP_REASONS_LIST = T.let(
+  {
+    incompatible_version_format: "the package has a version format that can only be updated manually",
+    bumped_by_upstream:          "updates to the package are handled by the upstream developers",
+  }
+    .merge(NO_AUTOBUMP_REASONS_INTERNAL)
+    .merge(NO_AUTOBUMP_REASONS_DEPRECATED)
+    .freeze,
+  T::Hash[Symbol, String],
+)

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -1242,15 +1242,6 @@ module Cask
       add_error error if error
     end
 
-    sig { void }
-    def audit_no_autobump
-      return if cask.autobump?
-      return unless new_cask?
-
-      error = SharedAudits.no_autobump_new_package_message(cask.no_autobump_message)
-      add_error error if error
-    end
-
     sig {
       params(
         url_to_check: T.any(String, URL),

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -594,6 +594,8 @@ module Cask
         raise CaskInvalidError.new(cask, "'no_autobump_defined' stanza may only appear once.")
       end
 
+      odeprecated "no_autobump! because: :requires_manual_review" if because == :requires_manual_review
+
       @no_autobump_defined = true
       @no_autobump_message = because
       @autobump = false

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -4618,6 +4618,8 @@ class Formula
         raise ArgumentError, "'because' argument should use valid symbol or a string!"
       end
 
+      odeprecated "no_autobump! because: :requires_manual_review" if because == :requires_manual_review
+
       @no_autobump_defined = T.let(true, T.nilable(T::Boolean))
       @no_autobump_message = T.let(because, T.nilable(T.any(String, Symbol)))
       @autobump = T.let(false, T.nilable(T::Boolean))

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -1079,15 +1079,6 @@ module Homebrew
       problem error if error
     end
 
-    def audit_no_autobump
-      return if formula.autobump?
-
-      return unless @new_formula_inclusive
-
-      error = SharedAudits.no_autobump_new_package_message(formula.no_autobump_message)
-      new_formula_problem error if error
-    end
-
     def quote_dep(dep)
       dep.is_a?(Symbol) ? dep.inspect : "'#{dep}'"
     end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -1303,53 +1303,5 @@ RSpec.describe Cask::Audit, :cask do
         end
       end
     end
-
-    describe "checking `no_autobump!` message" do
-      let(:new_cask) { true }
-      let(:only) { ["no_autobump"] }
-      let(:cask_token) { "test-cask" }
-
-      context "when `no_autobump!` reason is not suitable for new cask" do
-        let(:cask) do
-          tmp_cask cask_token.to_s, <<~RUBY
-            cask '#{cask_token}' do
-              version "1.0"
-              sha256 "8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a"
-              url "https://brew.sh/foo.zip"
-              name "Audit"
-              desc "Cask Auditor"
-              homepage "https://brew.sh/"
-              app "Audit.app"
-              no_autobump! because: :requires_manual_review
-            end
-          RUBY
-        end
-
-        it "fails" do
-          expect(run).to error_with(/use a different reason instead/)
-        end
-      end
-
-      context "when `no_autobump!` reason is allowed" do
-        let(:cask) do
-          tmp_cask cask_token.to_s, <<~RUBY
-            cask '#{cask_token}' do
-              version "1.0"
-              sha256 "8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a"
-              url "https://brew.sh/foo.zip"
-              name "Audit"
-              desc "Cask Auditor"
-              homepage "https://brew.sh/"
-              app "Audit.app"
-              no_autobump! because: "foo bar"
-            end
-          RUBY
-        end
-
-        it "passes" do
-          expect(run).to pass
-        end
-      end
-    end
   end
 end

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1739,34 +1739,4 @@ RSpec.describe Homebrew::FormulaAuditor do
       expect(fa.problems).to be_empty
     end
   end
-
-  describe "#audit_no_autobump" do
-    it "warns when autobump exclusion reason is not suitable for new formula" do
-      fa = formula_auditor "foo", <<~RUBY, new_formula: true
-        class Foo < Formula
-          url "https://brew.sh/foo-1.0.tgz"
-
-          no_autobump! because: :requires_manual_review
-        end
-      RUBY
-
-      fa.audit_no_autobump
-      expect(fa.new_formula_problems.first[:message])
-        .to match("`:requires_manual_review` is a temporary reason intended for existing packages, " \
-                  "use a different reason instead.")
-    end
-
-    it "does not warn when autobump exclusion reason is allowed" do
-      fa = formula_auditor "foo", <<~RUBY, new_formula: true
-        class Foo < Formula
-          url "https://brew.sh/foo-1.0.tgz"
-
-          no_autobump! because: "foo bar"
-        end
-      RUBY
-
-      fa.audit_no_autobump
-      expect(fa.new_formula_problems).to be_empty
-    end
-  end
 end

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -367,11 +367,4 @@ module SharedAudits
 
     "#{reason} is not a valid deprecate! or disable! reason" unless reasons.include?(reason)
   end
-
-  sig { params(message: T.any(String, Symbol)).returns(T.nilable(String)) }
-  def self.no_autobump_new_package_message(message)
-    return if message.is_a?(String) || message != :requires_manual_review
-
-    "`:requires_manual_review` is a temporary reason intended for existing packages, use a different reason instead."
-  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
I skipped cask auditor as there is no casks that use `:requires_manual_review`