### PR TITLE
Respect `SimulateSystem` in `FormulaStructGenerator`

### DIFF
--- a/Library/Homebrew/api/formula/formula_struct_generator.rb
+++ b/Library/Homebrew/api/formula/formula_struct_generator.rb
@@ -38,7 +38,7 @@ module Homebrew
         end
 
         sig { params(hash: T::Hash[String, T.untyped], bottle_tag: Utils::Bottles::Tag).returns(FormulaStruct) }
-        def generate_formula_struct_hash(hash, bottle_tag: Utils::Bottles.tag)
+        def generate_formula_struct_hash(hash, bottle_tag: Homebrew::SimulateSystem.current_tag)
           hash = Homebrew::API.merge_variations(hash, bottle_tag:).dup
 
           if (caveats = hash["caveats"])


### PR DESCRIPTION
Fixes #21543

`brew unbottled` uses `Homebrew::SimulateSystem` to control formula loading, but `Homebrew::API::Formula::FormulaStructGenerator` did not respect these settings. Before, the `bottle_tag` argument defaulted to `Utils::Bottle.tag`, but this always represents the real system. Instead, by defaulting to `Homebrew::SimulateSystem.current_tag`, we now respect any simulated configurations.

---

On Linux:

Before:

```console
$ brew unbottled ruby --tag arm64_sequoia
==> Populating dependency tree...
==> :arm64_sequoia bottle status
ruby: requires Linux
```

After:

```console
$ brew unbottled ruby --tag arm64_sequoia
==> Populating dependency tree...
==> :arm64_sequoia bottle status
ruby: already bottled
```