### PR TITLE
Bundle: use full formula name for upgrade checks

### DIFF
--- a/Library/Homebrew/bundle/formula_installer.rb
+++ b/Library/Homebrew/bundle/formula_installer.rb
@@ -242,7 +242,7 @@ module Homebrew
       end
 
       def upgradable?
-        FormulaInstaller.formula_upgradable?(@name)
+        FormulaInstaller.formula_upgradable?(@full_name)
       end
 
       def conflicts_with


### PR DESCRIPTION
This PR fixes a bug where `brew bundle` fails to upgrade tapped formulae when they shadow a homebrew-core formula name.

**The Problem:**
The `upgradable?` method in `formula_installer.rb` was using `@name` (short name like "tart") instead of `@full_name` (full name like "cirruslabs/cli/tart") when checking if a formula can be upgraded. This caused `Formula[formula]` to resolve to the deprecated homebrew-core formula instead of the intended tapped formula.

**The Fix:**
Changed line 237 to use `@full_name` instead of `@name`, ensuring `Formula[]` resolves to the correct tapped formula.

Fixes #21521

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
