### PR TITLE
cask: show accurate log messages for in-place upgrades

### DIFF
--- a/Library/Homebrew/cask/artifact/moved.rb
+++ b/Library/Homebrew/cask/artifact/moved.rb
@@ -105,6 +105,7 @@ module Cask
         Utils.gain_permissions_mkpath(target.dirname, command:) unless target.dirname.exist?
 
         if target.directory? && Quarantine.app_management_permissions_granted?(app: target, command:)
+          ohai "Moving #{self.class.english_name} contents of '#{source.basename}' into '#{target}'"
           if target.writable?
             source.children.each { |child| FileUtils.move(child, target/child.basename) }
           else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code (claude-opus-4-6) was used to trace the upgrade code path in `cask/artifact/moved.rb` and identify the misleading log messages. The actual fix was authored and reviewed by the submitter. Style and type checks were run locally.

-----

## What

When Homebrew has App Management or Full Disk Access permissions, cask upgrades use an in-place content replacement strategy (PR #15138, #15483) that preserves the `.app` directory inode. macOS then retains Dock position, notification settings, and granted permissions.

However, the `ohai` log messages in `Cask::Artifact::Moved#delete` and `#move` were printed unconditionally *before* the strategy branch, so the output always showed:

```
==> Removing App '/Applications/Signal.app'
==> Moving App 'Signal.app' to '/Applications/Signal.app'
```

even when the app was never actually removed.

## Fix

Move the `ohai` calls into the respective branches:

- **In-place** (App Management / FDA granted): prints a single `Upgrading App '/Applications/Signal.app' in-place`
- **Full replacement** (no permissions): prints `Removing App` and `Moving App` as before — no change in behavior

No tests added — this is a log-message-only change with no logic change. No existing tests cover these messages.