### PR TITLE
docs/_config.yml: add url to fix sitemap generation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,6 @@
 title: Homebrew Documentation
 description: Documentation for the missing package manager for macOS (or Linux).
+url: https://docs.brew.sh
 
 remote_theme: Homebrew/brew.sh
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Jekyll is generating relative paths. The `github-pages` gem used to handle this, but now we need to manually define it.

Should fix https://github.com/Homebrew/brew/issues/21577.