### PR TITLE
formula: add cargo `features` and `bin` options

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1881,10 +1881,25 @@ class Formula
   #
   # @api public
   sig {
-    params(root: T.any(String, Pathname), path: T.any(String, Pathname)).returns(T::Array[String])
+    params(
+      root:     T.any(String, Pathname),
+      path:     T.any(String, Pathname),
+      features: T.nilable(T.any(Symbol, String, T::Array[String])),
+      bin:      T.nilable(String),
+    ).returns(T::Array[String])
   }
-  def std_cargo_args(root: prefix, path: ".")
-    ["--jobs", ENV.make_jobs.to_s, "--locked", "--root=#{root}", "--path=#{path}"]
+  def std_cargo_args(root: prefix, path: ".", features: nil, bin: nil)
+    args = ["--jobs", ENV.make_jobs.to_s, "--locked", "--root=#{root}", "--path=#{path}"]
+    case features
+    when :all
+      args += ["--all-features"]
+    when :no_default
+      args += ["--no-default-features"]
+    else
+      args += ["--features=#{Array(features).join(",")}"] if features
+    end
+    args += ["--bin=#{bin}"] if bin
+    args
   end
 
   # Standard parameters for CMake builds.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

Add `features` and `bin` options to `std_cargo_args` for `cargo install`.

Currently, around 60 files define `features` and 6 files define `bin` separately.  By moving them into `std_cargo_args`, we can make more consistent `cargo install` usage.