### PR TITLE
bundle: use `mas get` instead of `mas install`

### DIFF
--- a/Library/Homebrew/bundle/mac_app_store_installer.rb
+++ b/Library/Homebrew/bundle/mac_app_store_installer.rb
@@ -51,7 +51,7 @@ module Homebrew
 
         puts "Installing #{name} app. It is not currently installed." if verbose
 
-        return false unless Bundle.system "mas", "install", id.to_s, verbose: verbose
+        return false unless Bundle.system "mas", "get", id.to_s, verbose: verbose
 
         installed_app_ids << id
         true

--- a/Library/Homebrew/test/bundle/mac_app_store_installer_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_installer_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreInstaller do
       end
 
       it "installs app" do
-        expect(Homebrew::Bundle).to receive(:system).with("mas", "install", "123", verbose: false).and_return(true)
+        expect(Homebrew::Bundle).to receive(:system).with("mas", "get", "123", verbose: false).and_return(true)
         expect(described_class.preinstall!("foo", 123)).to be(true)
         expect(described_class.install!("foo", 123)).to be(true)
       end


### PR DESCRIPTION
## Summary

- Replace `mas install` with `mas get` in `MacAppStoreInstaller`
- `mas install` only re-downloads previously acquired apps, failing on fresh Apple Accounts with "Redownload Unavailable"
- `mas get` works for both initial installs and re-downloads with no known downsides

Fixes #21559