### PR TITLE
Use latest_throttled in cask livecheck audit

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -775,10 +775,15 @@ module Cask
         return @livecheck_result
       end
 
-      latest_version = Homebrew::Livecheck.latest_version(
+      result = Homebrew::Livecheck.latest_version(
         cask,
         referenced_formula_or_cask: referenced_cask,
-      )&.fetch(:latest, nil)
+      )
+      if result
+        throttle = cask.livecheck.throttle
+        throttle ||= referenced_cask.livecheck.throttle if referenced_cask
+        latest_version = throttle ? result[:latest_throttled] : result[:latest]
+      end
 
       if latest_version && (cask.version.to_s == latest_version.to_s)
         @livecheck_result = :auto_detected

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle-reference.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle-reference.rb
@@ -1,0 +1,20 @@
+cask "livecheck-throttle-reference" do
+  version "1.2.5"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-throttle-reference-#{version}.dmg"
+  name "Throttle"
+  desc "Cask for testing throttle in a referenced cask"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-throttle-reference"
+
+  # The referenced check will not work, so livecheck values need to be
+  # controlled using a test double.
+  livecheck do
+    cask "livecheck-throttle"
+  end
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-throttle.rb
@@ -1,0 +1,21 @@
+cask "livecheck-throttle" do
+  version "1.2.5"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-throttle-#{version}.dmg"
+  name "Throttle"
+  desc "Cask for testing throttle in a livecheck block"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-throttle"
+
+  # This check will not work, so livecheck values need to be controlled using a
+  # test double.
+  livecheck do
+    url "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-throttle-latest"
+    throttle 5
+  end
+
+  app "TestCask.app"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I recently modified `bump-cask-pr` to include basic throttle handling (in line with the approach for formulae) but forgot to update `audit_livecheck_version` to also handle the `latest_throttled` value from `latest_version`. As it stands, `brew audit` will fail with an error like "Version '1.2.5' differs from '1.2.6' retrieved by livecheck" when `bump-cask-pr` tries to update to a throttled version but a newer unthrottled version exists upstream, preventing the autobump workflow from updating casks that use `throttle`.

This addresses the issue by updating `audit_livecheck_version` to also handle the `:latest_throttled` value from `latest_version`, instead of checking the unthrottled `:latest` value. Casks that aren't throttled will continue to check the `:latest` value, as expected.

In the process, this expands tests for `audit_livecheck_version` to increase coverage to 100%.