### PR TITLE
bundle: use `mas get` instead of `mas install` for Mac App Store apps

### DIFF
--- a/Library/Homebrew/bundle/mac_app_store_installer.rb
+++ b/Library/Homebrew/bundle/mac_app_store_installer.rb
@@ -51,7 +51,7 @@ module Homebrew
 
         puts "Installing #{name} app. It is not currently installed." if verbose
 
-        return false unless Bundle.system "mas", "install", id.to_s, verbose: verbose
+        return false unless Bundle.system "mas", "get", id.to_s, verbose: verbose
 
         installed_app_ids << id
         true

--- a/Library/Homebrew/test/bundle/mac_app_store_installer_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_installer_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreInstaller do
       end
 
       it "installs app" do
-        expect(Homebrew::Bundle).to receive(:system).with("mas", "install", "123", verbose: false).and_return(true)
+        expect(Homebrew::Bundle).to receive(:system).with("mas", "get", "123", verbose: false).and_return(true)
         expect(described_class.preinstall!("foo", 123)).to be(true)
         expect(described_class.install!("foo", 123)).to be(true)
       end


### PR DESCRIPTION
## Summary
- Replace `mas install` with `mas get` in `MacAppStoreInstaller` for installing new Mac App Store apps
- `mas install` only re-downloads apps previously associated with the Apple Account, failing with "Redownload Unavailable" on fresh accounts
- `mas get` handles both fresh installs and re-downloads, making Brewfiles work on new machines without manual workarounds

Closes #21559

## Test plan
- [x] Updated existing test expectation to verify `mas get` is called instead of `mas install`
- [x] All 8 existing `mac_app_store_installer_spec.rb` tests pass
- [x] `brew style` passes with no offenses