### PR TITLE
cleanup: fix file descriptor leak in cleanup_lockfiles

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -549,12 +549,15 @@ module Homebrew
 
       lockfiles.each do |file|
         next unless file.readable?
-        next unless file.open(File::RDWR).flock(File::LOCK_EX | File::LOCK_NB)
 
-        begin
-          file.unlink
-        ensure
-          file.open(File::RDWR).flock(File::LOCK_UN) if file.exist?
+        file.open(File::RDWR) do |lockfile|
+          next unless lockfile.flock(File::LOCK_EX | File::LOCK_NB)
+
+          begin
+            file.unlink
+          ensure
+            lockfile.flock(File::LOCK_UN) if file.exist?
+          end
         end
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
cleanup_lockfiles leaks file descriptors by calling `file.open` without saving or closing the handle. Fixed by storing the handle and closing it on all code paths.