### PR TITLE
bundle: allow preinstalled mas

### DIFF
--- a/Library/Homebrew/bundle.rb
+++ b/Library/Homebrew/bundle.rb
@@ -41,7 +41,12 @@ module Homebrew
 
       sig { returns(T::Boolean) }
       def mas_installed?
-        @mas_installed ||= which_formula?("mas")
+        @mas_installed ||= which_mas.present?
+      end
+
+      sig { returns(T.nilable(Pathname)) }
+      def which_mas
+        @which_mas ||= which("mas", ORIGINAL_PATHS)
       end
 
       sig { returns(T::Boolean) }
@@ -160,6 +165,7 @@ module Homebrew
 
       sig { void }
       def reset!
+        @which_mas = T.let(nil, T.nilable(Pathname))
         @mas_installed = T.let(nil, T.nilable(T::Boolean))
         @vscode_installed = T.let(nil, T.nilable(T::Boolean))
         @which_vscode = T.let(nil, T.nilable(Pathname))

--- a/Library/Homebrew/bundle/mac_app_store_dumper.rb
+++ b/Library/Homebrew/bundle/mac_app_store_dumper.rb
@@ -15,7 +15,8 @@ module Homebrew
       def self.apps
         @apps ||= T.let(nil, T.nilable(T::Array[[String, String]]))
         @apps ||= if Bundle.mas_installed?
-          `mas list 2>/dev/null`.split("\n").map do |app|
+          mas = T.must(Bundle.which_mas)
+          `#{mas} list 2>/dev/null`.split("\n").map do |app|
             app_details = app.match(/\A\s*(?<id>\d+)\s+(?<name>.*?)\s+\((?<version>[\d.]*)\)\Z/)
 
             # Only add the application details should we have a valid match.

--- a/Library/Homebrew/bundle/mac_app_store_installer.rb
+++ b/Library/Homebrew/bundle/mac_app_store_installer.rb
@@ -44,14 +44,16 @@ module Homebrew
 
         if app_id_installed?(id)
           puts "Upgrading #{name} app. It is installed but not up-to-date." if verbose
-          return false unless Bundle.system "mas", "upgrade", id.to_s, verbose: verbose
+          mas = T.must(Bundle.which_mas)
+          return false unless Bundle.system mas, "upgrade", id.to_s, verbose: verbose
 
           return true
         end
 
         puts "Installing #{name} app. It is not currently installed." if verbose
 
-        return false unless Bundle.system "mas", "get", id.to_s, verbose: verbose
+        mas = T.must(Bundle.which_mas)
+        return false unless Bundle.system mas, "get", id.to_s, verbose: verbose
 
         installed_app_ids << id
         true
@@ -85,7 +87,8 @@ module Homebrew
       def self.outdated_app_ids
         @outdated_app_ids ||= T.let(
           if Bundle.mas_installed?
-            `mas outdated 2>/dev/null`.split("\n").map do |app|
+            mas = T.must(Bundle.which_mas)
+            `#{mas} outdated 2>/dev/null`.split("\n").map do |app|
               app.split(" ", 2).first.to_i
             end
           else

--- a/Library/Homebrew/test/bundle/bundle_spec.rb
+++ b/Library/Homebrew/test/bundle/bundle_spec.rb
@@ -41,9 +41,14 @@ RSpec.describe Homebrew::Bundle do
   end
 
   context "when checking for mas", :needs_macos do
+    before do
+      described_class.instance_variable_set(:@mas_installed, nil)
+      described_class.instance_variable_set(:@which_mas, nil)
+    end
+
     it "finds it when present" do
-      stub_formula_loader formula("mas") { url "mas-1.0" }
-      allow(described_class).to receive(:which).and_return(true)
+      allow(described_class).to receive(:which).with("mas",
+                                                     ORIGINAL_PATHS).and_return(Pathname("/opt/homebrew/bin/mas"))
       expect(described_class.mas_installed?).to be(true)
     end
   end

--- a/Library/Homebrew/test/bundle/mac_app_store_dumper_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_dumper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreDumper do
   context "when there is no apps" do
     before do
       described_class.reset!
-      allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(true)
+      allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
       allow(described_class).to receive(:`).and_return("")
     end
 
@@ -40,7 +40,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreDumper do
   context "when apps `foo`, `bar` and `baz` are installed" do
     before do
       described_class.reset!
-      allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(true)
+      allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
       allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreDumper do
   context "when apps `foo`, `bar`, `baz` and `qux` are installed including right-justified IDs" do
     before do
       described_class.reset!
-      allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(true)
+      allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
       allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)")
       allow(described_class).to receive(:`).and_return("123 foo (1.0)\n456 bar (2.0)\n789 baz (3.0)\n 10 qux (4.0)")
     end
@@ -137,7 +137,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreDumper do
 
     before do
       described_class.reset!
-      allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(true)
+      allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
       allow(described_class).to receive(:`).and_return(invalid_mas_output)
     end
 
@@ -169,7 +169,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreDumper do
 
     before do
       described_class.reset!
-      allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(true)
+      allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
       allow(described_class).to receive(:`).and_return(new_mas_output)
     end
 

--- a/Library/Homebrew/test/bundle/mac_app_store_installer_spec.rb
+++ b/Library/Homebrew/test/bundle/mac_app_store_installer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Homebrew::Bundle::MacAppStoreInstaller do
 
   context "when mas is installed" do
     before do
-      allow(Homebrew::Bundle).to receive(:mas_installed?).and_return(true)
+      allow(Homebrew::Bundle).to receive_messages(mas_installed?: true, which_mas: Pathname.new("mas"))
     end
 
     describe ".outdated_app_ids" do
@@ -72,7 +72,8 @@ RSpec.describe Homebrew::Bundle::MacAppStoreInstaller do
       end
 
       it "upgrades" do
-        expect(Homebrew::Bundle).to receive(:system).with("mas", "upgrade", "123", verbose: false).and_return(true)
+        expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "upgrade", "123", verbose: false)
+                                                    .and_return(true)
         expect(described_class.preinstall!("foo", 123)).to be(true)
         expect(described_class.install!("foo", 123)).to be(true)
       end
@@ -84,7 +85,8 @@ RSpec.describe Homebrew::Bundle::MacAppStoreInstaller do
       end
 
       it "installs app" do
-        expect(Homebrew::Bundle).to receive(:system).with("mas", "get", "123", verbose: false).and_return(true)
+        expect(Homebrew::Bundle).to receive(:system).with(Pathname("mas"), "get", "123", verbose: false)
+                                                    .and_return(true)
         expect(described_class.preinstall!("foo", 123)).to be(true)
         expect(described_class.install!("foo", 123)).to be(true)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used `codex` to help discover the correct fix.

-----

This PR aligns the handling of `mas` with other external dependencies for `brew bundle`, allowing the use of an externally installed binary, such as `mas` installed via upstream's package installer. The only downside I can see is that it is possible that the provided package could be use an interface that is incompatible if it is running an old version, but I'm not sure it is worth the extra effort to include version detection here, and this issue is not unique to `mas`.