### PR TITLE
github_runner_matrix: skip newer intel CI unless exact tag

### DIFF
--- a/Library/Homebrew/github_runner_matrix.rb
+++ b/Library/Homebrew/github_runner_matrix.rb
@@ -230,7 +230,9 @@ class GitHubRunnerMatrix
 
       skip_intel_runner = !@all_supported && macos_version > NEWEST_HOMEBREW_CORE_INTEL_MACOS_RUNNER
       skip_intel_runner &&= @dependent_matrix || @testing_formulae.none? do |testing_formula|
-        testing_formula.formula.bottle_specification.tag?(Utils::Bottles.tag(macos_version.to_sym))
+        bottle_spec = testing_formula.formula.bottle_specification
+        bottle_spec.tag?(Utils::Bottles.tag(macos_version.to_sym), no_older_versions: true) &&
+          !bottle_spec.tag?(Utils::Bottles.tag(:all), no_older_versions: true)
       end
       next if skip_intel_runner
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Skips extra Intel CI runners for `:all` bottle formulae. Original all bottles were created without these runners.

Running CI on these formulae have higher chance of unexpected setup failures and also propagate bottles when run in same PR as other formulae. For latter part, really should improve handling and maybe add an explicit exception list for bottling (or skip bottling unless an existing bottle exists, with bottle creation restricted to dispatch workflow).

Certifi (all bottle) example:
* Before:
  ```
  ❯ brew determine-test-runners certifi | tail -n+2 | jq '.[].name'
  "Linux x86_64"
  "Linux arm64"
  "macOS 26-arm64"
  "macOS 26-x86_64"
  "macOS 15-arm64"
  "macOS 15-x86_64"
  "macOS 14-arm64"
  "macOS 14-x86_64"
  ```
* After:
  ```
  ❯ brew determine-test-runners certifi | tail -n+2 | jq '.[].name'
  "Linux x86_64"
  "Linux arm64"
  "macOS 26-arm64"
  "macOS 15-arm64"
  "macOS 14-arm64"
  "macOS 14-x86_64"
  ```

GCC (Sequoia/Tahoe bottle) example, both before and after same:
```
❯ brew determine-test-runners gcc | tail -n+2 | jq '.[].name'
"Linux x86_64"
"Linux arm64"
"macOS 26-arm64"
"macOS 26-x86_64"
"macOS 15-arm64"
"macOS 15-x86_64"
"macOS 14-arm64"
"macOS 14-x86_64"
```

---

`no_older_versions: true` is mainly to get same output when run on macOS for verification purposes. CI runs command on Linux so it has no impact.

Can see difference by running `brew determine-test-runners ruby` on Linux vs macOS without PR changes