### PR TITLE
Guard scheduled issue jobs to upstream repo

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -96,7 +96,7 @@ jobs:
 
   issue:
     needs: sbom
-    if: always() && github.event_name == 'schedule'
+    if: always() && github.event_name == 'schedule' && github.repository == 'Homebrew/brew'
     runs-on: ubuntu-slim
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -116,7 +116,7 @@ jobs:
 
   issue:
     needs: tapioca
-    if: always() && github.event_name == 'schedule'
+    if: always() && github.event_name == 'schedule' && github.repository == 'Homebrew/brew'
     runs-on: ubuntu-slim
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -90,7 +90,7 @@ jobs:
 
   issue:
     needs: spdx
-    if: always() && github.event_name == 'schedule'
+    if: always() && github.event_name == 'schedule' && github.repository == 'Homebrew/brew'
     runs-on: ubuntu-slim
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/sponsors-maintainers-man-completions.yml
+++ b/.github/workflows/sponsors-maintainers-man-completions.yml
@@ -140,7 +140,7 @@ jobs:
 
   issue:
     needs: updates
-    if: always() && github.event_name == 'schedule'
+    if: always() && github.event_name == 'schedule' && github.repository == 'Homebrew/brew'
     runs-on: ubuntu-slim
     env:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
  - N/A
- [X] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Adds upstream-repo guards to the scheduled `issue` jobs in:
- `sbom.yml`
- `sorbet.yml`
- `spdx.yml`
- `sponsors-maintainers-man-completions.yml`

These workflows already skip their main scheduled jobs on forks, but the companion `issue` jobs still ran on `schedule` and treated `skipped` as actionable, causing failing scheduled runs on forks. (e.g., https://github.com/shaanmajid/brew/actions/runs/22424596092, https://github.com/shaanmajid/brew/actions/runs/22424360798)
