### PR TITLE
caskroom: filter out casks without valid installation metadata

### DIFF
--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -71,7 +71,7 @@ module Cask
       rescue
         # Don't blow up because of a single unavailable cask.
         nil
-      end
+      end.select(&:installed?)
     end
   end
 end

--- a/Library/Homebrew/test/installed_dependents_spec.rb
+++ b/Library/Homebrew/test/installed_dependents_spec.rb
@@ -191,6 +191,14 @@ RSpec.describe InstalledDependents do
     def setup_test_cask(name, version, dependency)
       c = stub_cask_name(name, version, dependency)
       Cask::Caskroom.path.join(name, c.version).mkpath
+      Cask::Caskroom.path.join(name, ".metadata", c.version, "0", "Casks").tap(&:mkpath)
+                    .join("#{name}.rb").open("w") do |caskfile|
+                      caskfile.puts <<~RUBY
+                        cask "#{name}" do
+                          version "#{version}"
+                        end
+                      RUBY
+                    end
       c
     end
 


### PR DESCRIPTION
## Summary

- `Caskroom.casks` now filters results with `.select(&:installed?)` to exclude cask directories that lack valid `.metadata`, preventing `brew info --installed --json=v2` from returning casks with `installed: null`
- Updated `installed_dependents_spec.rb` test to properly create `.metadata` directory structure so test casks are recognized as installed

## Motivation

When a cask directory exists in the Caskroom (e.g. `/opt/homebrew/Caskroom/arq/`) but its `.metadata` directory is missing or corrupt, `Caskroom.casks` still includes it. This causes `brew info --installed --json=v2` to output casks with `"installed": null`, which breaks tooling that parses the JSON output.

The fix adds `.select(&:installed?)` after the `filter_map` block in `Caskroom.casks`, which checks for a valid `installed_caskfile` — the same condition `installed_version` relies on. This matches the method's documented purpose of "Get all installed casks".

## Test plan

- [x] `brew typecheck` passes
- [x] `brew style --fix Library/Homebrew/cask/caskroom.rb Library/Homebrew/test/installed_dependents_spec.rb` — no offenses
- [x] `brew tests --only=installed_dependents` — all 13 specs pass
- [x] `brew tests --only=cmd/--caskroom` — all specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)