### PR TITLE
Fix internal API service handling

### DIFF
--- a/Library/Homebrew/api/formula/formula_struct_generator.rb
+++ b/Library/Homebrew/api/formula/formula_struct_generator.rb
@@ -39,7 +39,7 @@ module Homebrew
 
         sig { params(hash: T::Hash[String, T.untyped], bottle_tag: Utils::Bottles::Tag).returns(FormulaStruct) }
         def generate_formula_struct_hash(hash, bottle_tag: Homebrew::SimulateSystem.current_tag)
-          hash = Homebrew::API.merge_variations(hash, bottle_tag:).dup
+          hash = Homebrew::API.merge_variations(hash, bottle_tag:).dup.deep_stringify_keys
 
           if (caveats = hash["caveats"])
             hash["caveats"] = Formulary.replace_placeholders(caveats)

--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -605,7 +605,7 @@ module Homebrew
 
       hash[:run] =
         case api_hash["run"]
-        when String
+        when String, Pathname
           replace_placeholders(api_hash["run"])
         when Array
           api_hash["run"].map { replace_placeholders(it) }
@@ -662,9 +662,10 @@ module Homebrew
     end
 
     # Replace API path placeholders with local paths.
-    sig { params(string: String).returns(String) }
+    sig { params(string: T.any(String, Pathname)).returns(String) }
     def self.replace_placeholders(string)
-      string.gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+      string.to_s
+            .gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
             .gsub(HOMEBREW_CELLAR_PLACEHOLDER, HOMEBREW_CELLAR)
             .gsub(HOMEBREW_HOME_PLACEHOLDER, Dir.home)
     end


### PR DESCRIPTION
Service blocks were accidentally left out of the internal API due to a type mismatch. `Formula#to_hash_with_variations` returns different types based on whether running via `HOMEBREW_NO_INSTALL_FROM_API` or not. If using the API, it returns JSON-ified values (i.e. everything is a string), but if not using the API, it returns a mix of symbols, pathnames, etc. This ultimately resulted in a mismatch where `Homebrew::Service::from_hash` attempted to search for the key `"run"` and turned up blank, because what it was looking for was listed under `:run`.

To solve this, let's stringify the keys before processing the variations hash into a `FormulaStruct`, that way keys throughout the hash are consistently strings. Note that values can still be non-strings, so I had to make another small change to process `Pathname`s correctly.

Unfortunately, this will require re-installing any affected formulae (once the API is regenerated) to actually install the service files.
