### PR TITLE
Fix typo: enviroment -> environment in tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,7 +384,7 @@ jobs:
 
       - name: Setup environment variables
         run: |
-          # Set enviroment variables to bypass `brew doctor` failures on Tier >=2 configurations
+          # Set environment variables to bypass `brew doctor` failures on Tier >=2 configurations
           if [[ "${MATRIX_NAME}" == "test-bot (Linux Homebrew glibc)" ]]; then
             echo "HOMEBREW_GLIBC_TESTING=1" >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
This PR fixes a small typo: 'enviroment' -> 'environment' in the GitHub Actions workflow file.