### PR TITLE
rubydoc: fix index page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,7 +12,8 @@ exclude:
   - Rakefile
   - vale-styles
   - vendor
-
+include:
+  - _*.html
 plugins:
   - jekyll-optional-front-matter
   - jekyll-redirect-from


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

As mentioned https://github.com/Homebrew/brew/pull/21589#issuecomment-3947684975 the index page did return a 404.

This was because there was no index page, since the index page is `_index.html` Jekyll excluded it, so I made a include in the config file, and now it works.