### PR TITLE
.claude/settings.json: skip tests hook when no files changed

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git diff --quiet --no-ext-diff || ./bin/brew tests --changed",
+            "command": "./bin/brew tests --changed",
             "timeout": 360
           }
         ]

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -230,7 +230,8 @@ module Homebrew
       def changed_test_files
         changed_files = Utils.popen_read("git", "diff", "--name-only", "main")
 
-        raise UsageError, "No files have been changed from the `main` branch!" if changed_files.blank?
+        odebug "No files have been changed from the `main` branch." if changed_files.blank?
+        return [] if changed_files.blank?
 
         filestub_regex = %r{Library/Homebrew/([\w/-]+).rb}
         T.cast(changed_files.scan(filestub_regex), T::Array[T::Array[String]])


### PR DESCRIPTION
EDIT: I understand that this is a pretty minimal annoyance, but in the interest of token efficiency and maybe speed, it might be worth considering. It is a very small change. One down side is that the behavior of `brew tests --changed` is sort of encoded in the hook, so it's possible that it could become out of sync. If you think this is a dumb PR, I won't be offended, but I was sick of looking at the error message myself, so I thought I'd see if anyone else thought this was a good idea.

## Problem

The Stop hook runs `./bin/brew tests --changed` unconditionally. When a session ends without editing any files (e.g. read-only/analysis work), this exits non-zero:

```
Error: Invalid usage: No files have been changed from the `main` branch!
```

This surfaces as a spurious hook error at the end of every read-only session.

## Fix

Guard the command so it only runs when `git diff --name-only main...HEAD` returns results. Test failures still propagate normally when the command does run — this is not a silent ignore.

```bash
changed=$(git diff --name-only main...HEAD); [ -z "$changed" ] || ./bin/brew tests --changed
```

## Disclosure

This fix was identified and implemented with assistance from Claude Code (claude-sonnet-4-6) and reviewed/tested by me before submission.