### PR TITLE
cmd/update-report: handle cask-to-formula tap migration with rename

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -606,7 +606,7 @@ class Reporter
 
       # This means it is a cask
       if Array(report[:DC]).include? full_name
-        next unless (HOMEBREW_PREFIX/"Caskroom"/new_name).exist?
+        next unless (HOMEBREW_PREFIX/"Caskroom"/name).exist?
 
         new_tap = Tap.fetch(new_tap_name)
         new_tap.ensure_installed!
@@ -617,11 +617,8 @@ class Reporter
         next if (HOMEBREW_CELLAR/new_name.split("/").last).directory?
 
         ohai "Installing #{new_name}..."
-        system HOMEBREW_BREW_FILE, "install", new_full_name
         begin
-          unless Formulary.factory(new_full_name).keg_only?
-            system HOMEBREW_BREW_FILE, "link", new_full_name, "--overwrite"
-          end
+          system HOMEBREW_BREW_FILE, "install", "--overwrite", new_full_name
         # Rescue any possible exception types.
         rescue Exception => e # rubocop:disable Lint/RescueException
           if Homebrew::EnvConfig.developer?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Fix a bug in tap migration from homebrew-cask to homebrew-core when combined with a rename.

Previously it skipped installing formula as looking for wrong name of Cask.

Changing name allowed installation to continue, but would fail to link at install time since Cask already owns symlink. Two options here:
1. change in PR to `--overwrite` at install time
2. run install with `--skip-link` and then let this be handled in existing `brew link` step.

Not sure if there is a specific reason we were doing latter so just used simpler `brew install --overwrite`