### PR TITLE
Cleanup some more residual `test-prof` workarounds

### DIFF
--- a/Library/Homebrew/test/rubocop_spec.rb
+++ b/Library/Homebrew/test/rubocop_spec.rb
@@ -19,14 +19,7 @@ RSpec.describe "RuboCop" do
     end
 
     it "loads all Formula cops without errors" do
-      stdout, stderr, status = Open3.capture3(
-        RUBY_PATH, "-W0", "-S", "rubocop", TEST_FIXTURE_DIR/"testball.rb",
-        # Require "sorbet-runtime" to bring T into scope for warnings.rb
-        "-r", "sorbet-runtime",
-        # Require "extend/module" to include T::Sig in Module for warnings.rb
-        "-r", HOMEBREW_LIBRARY_PATH/"extend/module.rb",
-        "-r", "rubocop/test_prof"
-      )
+      stdout, stderr, status = Open3.capture3(RUBY_PATH, "-W0", "-S", "rubocop", TEST_FIXTURE_DIR/"testball.rb")
       expect(stderr).to be_empty
       expect(stdout).to include("no offenses detected")
       expect(status).to be_a_success

--- a/Library/Homebrew/utils/rubocop.rb
+++ b/Library/Homebrew/utils/rubocop.rb
@@ -9,6 +9,4 @@ Warnings.ignore :parser_syntax do
   require "rubocop"
 end
 
-require "rubocop/test_prof"
-
 exit RuboCop::CLI.new.run


### PR DESCRIPTION
Follow-up to #21564

There are a few more residual `test-prof` references that are no longer needed now that their bundler setup is fixed.
