### PR TITLE
GithubReleases: only check tag_name

### DIFF
--- a/Library/Homebrew/livecheck/strategy/github_releases.rb
+++ b/Library/Homebrew/livecheck/strategy/github_releases.rb
@@ -51,11 +51,6 @@ module Homebrew
         # isn't provided.
         DEFAULT_REGEX = /v?(\d+(?:\.\d+)+)/i
 
-        # Keys in the release JSON that could contain the version.
-        # The tag name is checked first, to better align with the {Git}
-        # strategy.
-        VERSION_KEYS = T.let(["tag_name", "name"].freeze, T::Array[String])
-
         # Whether the strategy can be applied to the provided URL.
         #
         # @param url [String] the URL to match against
@@ -115,14 +110,7 @@ module Homebrew
           json.compact_blank.filter_map do |release|
             next if release["draft"] || release["prerelease"]
 
-            value = T.let(nil, T.nilable(String))
-            VERSION_KEYS.find do |key|
-              match = release[key]&.match(regex)
-              next if match.blank?
-
-              value = match[1]
-            end
-            value
+            release["tag_name"]&.[](regex, 1)
           end.uniq
         end
 

--- a/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_releases_spec.rb
@@ -47,13 +47,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
           "prerelease": false
         },
         {
-          "tag_name": "no-version-tag-also",
-          "name": "1.2.2",
-          "draft": false,
-          "prerelease": false
-        },
-        {
-          "tag_name": "1.2.1",
+          "tag_name": "1.2.2",
           "name": "No version title",
           "draft": false,
           "prerelease": false
@@ -90,7 +84,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
   end
   let(:json) { JSON.parse(content) }
 
-  let(:matches) { ["1.2.3", "1.2.2", "1.2.1"] }
+  let(:matches) { ["1.2.3", "1.2.2"] }
 
   describe "::match?" do
     it "returns true for a GitHub release artifact URL" do
@@ -149,12 +143,9 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
         json.map do |release|
           next if release["draft"] || release["prerelease"]
 
-          match = release["tag_name"]&.match(regex)
-          next if match.blank?
-
-          match[1]
+          release["tag_name"]&.[](regex, 1)
         end
-      end).to eq(["1.2.3", "1.2.1"])
+      end).to eq(matches)
     end
 
     it "allows a nil return from a block" do
@@ -213,7 +204,7 @@ RSpec.describe Homebrew::Livecheck::Strategy::GithubReleases do
           end
         end,
       ).to eq(match_data[:cached].merge({
-        matches: ["1.2.3", "1.2.1"].to_h { |v| [v, Version.new(v)] },
+        matches: ["1.2.3", "1.2.2"].to_h { |v| [v, Version.new(v)] },
         regex:   brew_regex,
       }))
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `GithubReleases` livecheck strategy was originally set up to check the `tag_name` value and fall back to the release `name`. At the time, I advocated for only checking `tag_name`, as matching the version from the release name is almost never needed and could be handled in a `strategy` block. Notably, only checking `tag_name` makes it easier to switch between the `Git` and `GithubLatest` strategies (i.e., the same regex can be used for both).

This modifies `GithubReleases` to only check the `tag_name` value by default, as this behavior makes it a little easier for us to implement batch `GithubLatest` data fetching in the future (i.e., using the GitHub GraphQL API to fetch the latest release `tag_name` for 100 repositories per request). I've done comparative checks across all `GithubLatest` and `GithubReleases` `livecheck` blocks in homebrew-core and homebrew-cask to confirm that the results remain the same after this change. If we need to match against the release `name` going forward, we can check the value in a `strategy` block, as we're already doing in ~5 cases (out of ~1350 checks using `GithubLatest` or `GithubReleases`).