### PR TITLE
rubocops/urls: collect all livecheck urls

### DIFF
--- a/Library/Homebrew/rubocops/cask/url.rb
+++ b/Library/Homebrew/rubocops/cask/url.rb
@@ -37,7 +37,7 @@ module RuboCop
           url_stanza = stanza_node.first_argument
           hash_node = stanza_node.last_argument
 
-          audit_url(:cask, [stanza.stanza_node], [], livecheck_url: false)
+          audit_url(:cask, [stanza.stanza_node], [], livecheck_urls: [])
 
           # Check for http:// URLs in homebrew-cask (skip deprecated/disabled casks)
           # TODO: Remove the deprecated/disabled check after Homebrew/cask has no more

--- a/Library/Homebrew/rubocops/shared/url_helper.rb
+++ b/Library/Homebrew/rubocops/shared/url_helper.rb
@@ -20,6 +20,8 @@ module RuboCop
             url_string = url_node.source
           else
             url_string_node = parameters(url_node).first
+            next unless url_string_node
+
             url_string = string_content(url_string_node)
           end
 
@@ -32,7 +34,7 @@ module RuboCop
         end
       end
 
-      def audit_url(type, urls, mirrors, livecheck_url: false)
+      def audit_url(type, urls, mirrors, livecheck_urls: [])
         @type = type
 
         # URLs must be ASCII; IDNs must be punycode
@@ -56,7 +58,7 @@ module RuboCop
 
         apache_pattern = %r{^https?://(?:[^/]*\.)?apache\.org/(?:dyn/closer\.cgi\?path=/?|dist/)(.*)}i
         audit_urls(urls, apache_pattern) do |match, url|
-          next if url == livecheck_url
+          next if livecheck_urls.include?(url)
 
           problem "#{url} should be: https://www.apache.org/dyn/closer.lua?path=#{match[1]}"
         end
@@ -160,7 +162,7 @@ module RuboCop
 
           problem "Don't use \"/download\" in SourceForge URLs (`url` is #{url})." if url.end_with?("/download")
 
-          if url.match?(%r{^https?://(sourceforge|sf)\.}) && url != livecheck_url
+          if url.match?(%r{^https?://(sourceforge|sf)\.}) && !livecheck_urls.include?(url)
             problem "Use \"https://downloads.sourceforge.net\" to get geolocation (`url` is #{url})."
           end
 

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -19,12 +19,19 @@ module RuboCop
           mirrors = find_every_func_call_by_name(body_node, :mirror)
 
           # Identify livecheck URLs, to skip some checks for them
-          livecheck_url = if (livecheck = find_every_func_call_by_name(body_node, :livecheck).first) &&
-                             (livecheck_url = find_every_func_call_by_name(livecheck.parent, :url).first)
-            string_content(parameters(livecheck_url).first)
+          livecheck_urls = []
+          find_every_func_call_by_name(body_node, :livecheck).each do |livecheck_node|
+            livecheck_url = find_every_func_call_by_name(livecheck_node.parent, :url).first
+            next unless livecheck_url
+
+            livecheck_url_argument = parameters(livecheck_url).first
+            next unless livecheck_url_argument
+            next if livecheck_url_argument.type == :sym
+
+            livecheck_urls << string_content(livecheck_url_argument)
           end
 
-          audit_url(:formula, urls, mirrors, livecheck_url:)
+          audit_url(:formula, urls, mirrors, livecheck_urls:)
 
           return if formula_tap != "homebrew-core"
 
@@ -53,20 +60,26 @@ module RuboCop
           # deprecated/disabled formulae using http:// URLs
           return if method_called_ever?(body_node, :deprecate!) || method_called_ever?(body_node, :disable!)
 
-          urls = find_every_func_call_by_name(body_node, :url)
+          # Identify livecheck URLs, to skip checking them
+          livecheck_urls = []
+          find_every_func_call_by_name(body_node, :livecheck).each do |livecheck_node|
+            livecheck_url = find_every_func_call_by_name(livecheck_node.parent, :url).first
+            next unless livecheck_url
 
-          # Identify livecheck URL to skip checking it (symbols like :homepage are implicitly skipped)
-          livecheck_url = if (livecheck = find_every_func_call_by_name(body_node, :livecheck).first) &&
-                             (livecheck_url_node = find_every_func_call_by_name(livecheck.parent, :url).first)
-            string_content(parameters(livecheck_url_node).first)
+            livecheck_url_argument = parameters(livecheck_url).first
+            next unless livecheck_url_argument
+            next if livecheck_url_argument.type == :sym
+
+            livecheck_urls << string_content(livecheck_url_argument)
           end
 
-          urls.each do |url_node|
+          find_every_func_call_by_name(body_node, :url).each do |url_node|
             url_string_node = parameters(url_node).first
-            url_string = string_content(url_string_node)
+            next unless url_string_node
 
+            url_string = string_content(url_string_node)
             next unless url_string.start_with?("http://")
-            next if url_string == livecheck_url
+            next if livecheck_urls.include?(url_string)
 
             offending_node(url_string_node)
             problem "Formulae in homebrew/core should not use http:// URLs" do |corrector|

--- a/Library/Homebrew/test/rubocops/urls/http_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls/http_spec.rb
@@ -80,7 +80,57 @@ RSpec.describe RuboCop::Cop::FormulaAudit::HttpUrls do
 
           livecheck do
             url "http://example.com/releases"
-            regex(/foo-(\d+(?:.\d+)+).tar.gz/i)
+            regex(/foo[._-]v?(\d+(?:.\d+)+).t/i)
+          end
+
+          resource "foo" do
+            url "https://example.com/foo-resource-1.0.tar.gz"
+
+            livecheck do
+              url "http://example.com/resource-releases"
+              regex(/foo-resource[._-]v?(\d+(?:.\d+)+).t/i)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offense for a livecheck URL symbol" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://example.com/foo-1.0.tar.gz"
+
+          livecheck do
+            url :stable
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offense when livecheck has no URL" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://example.com/foo-1.0.tar.gz"
+
+          # No URL is present when `skip` is used.
+          livecheck do
+            skip "No version information available"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offense when livecheck has a `url` call with no argument" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://example.com/foo-1.0.tar.gz"
+
+          # This shouldn't ever happen but this is simply to exercise a guard.
+          livecheck do
+            url
           end
         end
       RUBY
@@ -95,7 +145,7 @@ RSpec.describe RuboCop::Cop::FormulaAudit::HttpUrls do
 
           livecheck do
             url "http://example.com/releases"
-            regex(/foo-(\d+(?:.\d+)+).tar.gz/i)
+            regex(/foo[._-]v?(\d+(?:.\d+)+).t/i)
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -245,5 +245,61 @@ RSpec.describe RuboCop::Cop::FormulaAudit::Urls do
         end
       RUBY
     end
+
+    it "does not report offenses that are skipped for `livecheck` block URLs" do
+      source = <<~RUBY
+        class Foo < Formula
+          desc "foo"
+          url "https://brew.sh/test-0.0.1.tgz"
+
+          # This URL will trigger the 'Use "https://downloads.sourceforge.net"
+          # to get geolocation' cop unless it's skipped for the `livecheck`
+          # block URL.
+          livecheck do
+            url "https://sourceforge.net/projects/homebrew/rss?path=/brew"
+          end
+
+          resource "foo" do
+            url "https://brew.sh/foo-1.0.tar.gz"
+
+            # This URL will trigger the 'Use "https://downloads.sourceforge.net"
+            # to get geolocation' cop unless it's skipped for all `livecheck`
+            # block URLs (not just the main `livecheck` block).
+            livecheck do
+              url "https://sourceforge.net/projects/homebrew/rss?path=/resource"
+            end
+          end
+
+          resource "livecheck-url-symbol" do
+            url "https://brew.sh/livecheck-url-no-argument-1.0.tar.gz"
+
+            # URL symbols shouldn't be checked..
+            livecheck do
+              url :url
+            end
+          end
+
+          resource "livecheck-no-url" do
+            url "https://brew.sh/livecheck-no-url-1.0.tar.gz"
+
+            # No URL is present when `skip` is used.
+            livecheck do
+              skip "No version information available"
+            end
+          end
+
+          resource "livecheck-url-no-arg" do
+            url "https://brew.sh/livecheck-url-no-arg-1.0.tar.gz"
+
+            # This shouldn't ever happen but this is simply to exercise a guard.
+            livecheck do
+              url
+            end
+          end
+        end
+      RUBY
+
+      expect(inspect_source(source)).to eq([])
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`RuboCop::Cop::FormulaAudit::Urls` and `::HttpUrls` contain logic to identify the main `livecheck` block URL, which is used to ensure certain URL cops don't apply to a `livecheck` block URL. This was created at a time when formulae only contained one `livecheck` block but nowadays we also have `livecheck` blocks in resources. Since this only collects the URL from the first `livecheck` block, the cops that are skipped for the main `livecheck` block URL aren't skipped for resource `livecheck` block URLs. This addresses the issue by collecting all `livecheck` block URLs and modifying related conditions accordingly.

In the process, this also adds a guard to ensure that we skip over URL symbols (e.g., `:stable`, `:url`, `:homepage`, `:head`), as those would otherwise appear in the array like `stable`, `url`, etc. Skipping should be fine but if we run into issues in the future, we'll have to figure out a way to map the symbols to their respective URLs, which may be challenging when working with the AST (i.e., we can't use `Livecheck.url_to_string` and would have to manually identify URLs while accounting for permutations that are usually handled when a formula is parsed, like conditional arch/OS logic).

It may be worth mentioning that URL cops don't handle string interpolation (i.e., `https://example.com/#{something}` is audited as written), so the logic to collect `livecheck` block URLs uses the same approach to ensure URLs match.