### PR TITLE
formula_auditor: only audit compatibility_version on valid platform

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -963,6 +963,7 @@ module Homebrew
 
       compatibility_increment = current_compatibility_version - previous_compatibility_version
       return if compatibility_increment.zero?
+      return unless formula.valid_platform?
 
       dependent_revision_bumps = changed_formulae_paths(tap).filter_map do |path|
         changed_formula = Formulary.factory(path)

--- a/Library/Homebrew/test/formula_auditor_spec.rb
+++ b/Library/Homebrew/test/formula_auditor_spec.rb
@@ -1453,6 +1453,19 @@ RSpec.describe Homebrew::FormulaAuditor do
 
         expect(auditor.problems).to be_empty
       end
+
+      it "ignores missing dependent revision bumps for unsupported platform" do
+        allow(target_formula).to receive(:valid_platform?).and_return(false)
+        stub_committed_info(
+          auditor,
+          default:   [{ compatibility_version: 1 }, { compatibility_version: 1 }],
+          overrides: { dependent_formula => [{ revision: 2 }, { revision: 2 }] },
+        )
+
+        auditor.audit_compatibility_version
+
+        expect(auditor.problems).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

If auditing on a platform that does not support a formula, then there will never be any dependents which will fail audit.

This was seen for macOS-only `molten-vk` on Linux CI.

---

We can still audit other stuff like increment by only 1.