### PR TITLE
Remove deprecation check in autobump logic

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1037,7 +1037,6 @@ class Tap
 
     @autobump ||= T.let(autobump_packages.select do |_, p|
       next if p["disabled"]
-      next if p["deprecated"] && p["deprecation_reason"] != "fails_gatekeeper_check"
       next if p["skip_livecheck"]
 
       p["autobump"] == true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
See https://github.com/Homebrew/homebrew-core/pull/269618

Since deprecated formula can still receive updates they should not be kept out of the autobump flow unless it's marked as skipping the livecheck (which is a separate line).