### PR TITLE
Fix issue with missing `ruby_soruce_checksum` in `CaskStruct`

### DIFF
--- a/Library/Homebrew/api/cask/cask_struct_generator.rb
+++ b/Library/Homebrew/api/cask/cask_struct_generator.rb
@@ -53,7 +53,7 @@ module Homebrew
 
           hash["ruby_source_checksum"] = {
             sha256: hash.dig("ruby_source_checksum", :sha256),
-          }
+          }.compact
 
           hash["ruby_source_path"] = hash["ruby_source_path"]&.to_s
 

--- a/Library/Homebrew/api/cask_struct.rb
+++ b/Library/Homebrew/api/cask_struct.rb
@@ -77,7 +77,7 @@ module Homebrew
       const :languages, T::Array[String], default: []
       const :names, T::Array[String], default: []
       const :renames, T::Array[[String, String]], default: []
-      const :ruby_source_checksum, T::Hash[Symbol, String]
+      const :ruby_source_checksum, T::Hash[Symbol, T.nilable(String)], default: { sha256: nil }
       const :ruby_source_path, T.nilable(String)
       const :sha256, T.any(String, Symbol)
       const :tap_string, T.nilable(String)


### PR DESCRIPTION
Fixes #21652

I think what happened in the issue is an old installed cask didn't have `ruby_source_checksum`, and so the type verification in `CaskStruct` didn't work. I've checked, and I believe it's fine to have this field be nilable, so let's fallback to a blank `{ sha256: nil }` for cases where this value isn't available.
