### PR TITLE
bundle: auto-tap formulae or casks in `brew bundle`

### DIFF
--- a/Library/Homebrew/bundle/formula_installer.rb
+++ b/Library/Homebrew/bundle/formula_installer.rb
@@ -77,6 +77,11 @@ module Homebrew
       end
 
       def install_change_state!(no_upgrade:, verbose:, force:)
+        if (tap_with_name = Tap.with_formula_name(@full_name))
+          tap, = tap_with_name
+          tap.ensure_installed!
+        end
+
         return false unless resolve_conflicts!(verbose:)
 
         if installed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [x] AI was used to generate or assist with generating this PR.

Used AI to write this, but checked that the auto-tapping worked manually before opening the PR.

-----

When you `brew install org/tap/formula-name`, it automatically taps the
repo if not present. However `brew bundle` doesn't do this. This changes
`brew bundle install` to work the same way as `brew install`.