### PR TITLE
Remove API placeholders in `FormulaStruct` and `CaskStruct`

### DIFF
--- a/Library/Homebrew/api/cask_struct.rb
+++ b/Library/Homebrew/api/cask_struct.rb
@@ -8,6 +8,7 @@ module Homebrew
       def self.from_hash(cask_hash, ignore_types: false)
         return super(cask_hash) if ignore_types
 
+        cask_hash = ::Cask::Cask.deep_remove_placeholders(cask_hash)
         cask_hash = cask_hash.transform_keys(&:to_sym)
                              .slice(*decorator.all_props)
                              .compact_blank

--- a/Library/Homebrew/api/formula_struct.rb
+++ b/Library/Homebrew/api/formula_struct.rb
@@ -9,6 +9,7 @@ module Homebrew
     class FormulaStruct < T::Struct
       sig { params(formula_hash: T::Hash[String, T.untyped]).returns(FormulaStruct) }
       def self.from_hash(formula_hash)
+        formula_hash = ::Formula.deep_remove_placeholders(formula_hash)
         formula_hash = formula_hash.transform_keys(&:to_sym)
                                    .slice(*decorator.all_props)
                                    .compact_blank

--- a/Library/Homebrew/api_hashable.rb
+++ b/Library/Homebrew/api_hashable.rb
@@ -38,4 +38,24 @@ module APIHashable
     @generating_hash ||= false
     @generating_hash == true
   end
+
+  sig { type_parameters(:U).params(value: T.type_parameter(:U)).returns(T.type_parameter(:U)) }
+  def deep_remove_placeholders(value)
+    return value if generating_hash?
+
+    value = case value
+    when Hash
+      value.transform_values { |v| deep_remove_placeholders(v) }
+    when Array
+      value.map { |v| deep_remove_placeholders(v) }
+    when String
+      value.gsub(HOMEBREW_HOME_PLACEHOLDER, Dir.home)
+           .gsub(HOMEBREW_PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
+           .gsub(HOMEBREW_CELLAR_PLACEHOLDER, HOMEBREW_CELLAR)
+    else
+      value
+    end
+
+    T.cast(value, T.type_parameter(:U))
+  end
 end


### PR DESCRIPTION
When generating the API, we replace `HOMEBREW_PREFIX` and `Dir.home` with placeholder values, but we don't actually replace the placeholders with the real values when loading from `FormulaStruct` (or `CaskStruct`). This PR adds the replacement logic to the `APIHashable` module so it's included by default anywhere the module is used.
