### PR TITLE
Fix display on "dumb" terminals

### DIFF
--- a/Library/Homebrew/download_queue.rb
+++ b/Library/Homebrew/download_queue.rb
@@ -26,6 +26,7 @@ module Homebrew
       @pour = pour
       @pool = T.let(Concurrent::FixedThreadPool.new(concurrency), Concurrent::FixedThreadPool)
       @tty = T.let($stdout.tty?, T::Boolean)
+      @dumb_tty = T.let(ENV["TERM"] == "dumb", T::Boolean)
       @spinner = T.let(nil, T.nilable(Spinner))
       @symlink_targets = T.let({}, T::Hash[Pathname, T::Set[Downloadable]])
       @downloads_by_location = T.let({}, T::Hash[Pathname, Concurrent::Promises::Future])
@@ -96,7 +97,7 @@ module Homebrew
             next 1 if bottle_manifest_error?(downloadable, exception)
 
             message = downloadable.download_queue_message
-            if tty
+            if tty_with_cursor_move_support?
               message = message_with_progress(downloadable, future, message, message_length_max)
               stdout_print_and_flush "#{status} #{message}#{"\n" unless last}"
             elsif status
@@ -193,7 +194,7 @@ module Homebrew
 
     sig { params(message: String).void }
     def stdout_print_and_flush_if_tty(message)
-      stdout_print_and_flush(message) if $stdout.tty?
+      stdout_print_and_flush(message) if tty_with_cursor_move_support?
     end
 
     sig { params(message: String).void }
@@ -260,6 +261,11 @@ module Homebrew
     sig { returns(T::Boolean) }
     attr_reader :tty
 
+    sig { returns(T::Boolean) }
+    def tty_with_cursor_move_support?
+      tty && !@dumb_tty
+    end
+
     sig { returns(T::Hash[Downloadable, Concurrent::Promises::Future]) }
     def downloads
       @downloads ||= T.let({}, T.nilable(T::Hash[Downloadable, Concurrent::Promises::Future]))
@@ -281,7 +287,7 @@ module Homebrew
           "✘"
         end
       when :pending, :processing
-        "#{Tty.blue}#{spinner}#{Tty.reset}" if tty
+        "#{Tty.blue}#{spinner}#{Tty.reset}" if tty_with_cursor_move_support?
       else
         raise future.state.to_s
       end


### PR DESCRIPTION
Hello,

I took some time understand why brew messed my Emacs shell and I ended up with this change. I don't know if you are interested in fixing this kind of display. Happy to improve it if yes.

Problem: brew does not respect "dumb" terminals.

When running brew from a dumb terminal, I have the following display (scroll horizontally to see the problem):
```
% brew reinstall caffeine
==> Fetching downloads for: caffeine
⠋ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠋ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠙ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠙ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠚ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠚ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠞ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠞ Cask caffeine (1.1.4)                                                                                          Downloading 827.6KB/-------⠖ Cask caffeine (1.1.4)                                                                                          Downloading 827.6K
[...]
```
From man term(7):

   > Older UNIX systems pre‐set a very dumb terminal type like ‘dumb’  or  ‘di‐
   alup’  on  dialup  lines.   Newer ones may pre‐set ‘vt100’, reflecting the
   prevalence of DEC VT100‐compatible terminals and personal‐computer  emula‐
   tors.

Those "dumb" terminals is are still useful nowadays. For instance, they are the default value in Emacs shell or eshell. In those terminals, we cannot use the ANSI escape sequences to move the cursor around (but I guess, today all dumb terminals supports ANSI colors escape sequences).

Solution: Detect whether brew is run from a dumb terminal and stop displaying progress in that case.

The result is:
```
  % bin/brew reinstall caffeine
  ==> Fetching downloads for: caffeine
  ✔︎ Cask caffeine (1.1.4)
  ==> Uninstalling Cask caffeine
```

Thanks in advance,

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew lgtm` (style, typechecking and tests) with your changes locally?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
